### PR TITLE
StatusQ: Generic proxy models `RolesRenamingModel` and `LeftJoinModel`

### DIFF
--- a/storybook/pages/LeftJoinModelPage.qml
+++ b/storybook/pages/LeftJoinModelPage.qml
@@ -1,0 +1,283 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+
+Item {
+    id: root
+
+    readonly property var colors: [
+        "red", "green", "purple", "orange","gray", "ping", "brown", "blue"
+    ]
+
+    ListModel {
+        id: leftModel
+
+        ListElement {
+            title: "Token 1"
+            communityId: "1"
+        }
+        ListElement {
+            title: "Token 2"
+            communityId: "1"
+        }
+        ListElement {
+            title: "Token 3"
+            communityId: "2"
+        }
+        ListElement {
+            title: "Token 4"
+            communityId: "3"
+        }
+        ListElement {
+            title: "Token 5"
+            communityId: ""
+        }
+        ListElement {
+            title: "Token 6"
+            communityId: "1"
+        }
+    }
+
+    ListModel {
+        id: rightModel
+
+        ListElement {
+            communityId: "1"
+            name: "Community 1"
+            color: "red"
+
+        }
+        ListElement {
+            communityId: "2"
+            name: "Community 2"
+            color: "green"
+        }
+        ListElement {
+            communityId: "3"
+            name: "Community 3"
+            color: "blue"
+        }
+    }
+
+    LeftJoinModel {
+        id: leftJoinModel
+
+        leftModel: leftModel
+        rightModel: rightModel
+
+        joinRole: "communityId"
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 40
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            clip: true
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                border.color: "gray"
+
+                ListView {
+                    anchors.fill: parent
+
+                    model: leftModel
+
+                    header: Label {
+                        height: implicitHeight * 2
+                        text: `Left model (${leftModel.count})`
+
+                        font.bold: true
+
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Label {
+                        width: ListView.view.width
+
+                        text: `${model.title}, community id: ${model.communityId || "-"}`
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                border.color: "gray"
+
+                ListView {
+                    anchors.fill: parent
+
+                    model: rightModel
+
+                    header: Label {
+                        height: implicitHeight * 2
+                        text: `Right model (${rightModel.count})`
+
+                        font.bold: true
+
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: RowLayout {
+                        width: ListView.view.width - 10
+
+                        Label {
+                            Layout.fillWidth: true
+
+                            text: `${model.name}, community id: ${model.communityId}`
+                        }
+
+                        Rectangle {
+                            Layout.preferredWidth: parent.height
+                            Layout.preferredHeight: parent.height
+
+                            color: model.color
+
+                            MouseArea {
+                                anchors.fill: parent
+
+                                onClicked: {
+                                    const colorIndex = root.colors.indexOf(
+                                                         model.color)
+                                    const nextIndex = (colorIndex + 1)
+                                                    % root.colors.length
+
+                                    rightModel.setProperty(index, "color",
+                                                           root.colors[nextIndex])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                border.color: "gray"
+
+                ListView {
+                    id: leftJoinListView
+
+                    anchors.fill: parent
+
+                    model: leftJoinModel
+
+                    header: Label {
+                        height: implicitHeight * 2
+                        text: `Left Join model (${leftJoinListView.count})`
+
+                        font.bold: true
+
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: RowLayout {
+                        id: row
+
+                        width: ListView.view.width - 10
+
+                        readonly property bool hasCommunity: model.communityId.length
+
+                        Label {
+                            Layout.fillWidth: true
+
+                            text: model.title + (row.hasCommunity
+                                  ? `, community id: ${model.communityId}, name: ${model.name}`
+                                  : "")
+                        }
+
+                        Rectangle {
+                            Layout.preferredWidth: parent.height
+                            Layout.preferredHeight: parent.height
+
+                            color: model.color || "transparent"
+                        }
+                    }
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Label {
+                text: "Left model count: " + leftModel.count
+            }
+
+            Label {
+                text: "Right model count: " + rightModel.count
+            }
+
+            Button {
+                text: "add 100 left model items"
+
+                onClicked: {
+                    for (let i = 0; i < 100; i++) {
+
+                        const count = leftModel.count
+
+                        const entry = {
+                            title: "Token " + (count + 1),
+                            communityId: (Math.floor(Math.random() * rightModel.count) + 1).toString()
+                        }
+
+                        leftModel.append(entry)
+                    }
+                }
+            }
+
+            Button {
+                text: "add 10 right model items"
+
+                onClicked: {
+                    for (let i = 0; i < 10; i++) {
+                        const count = rightModel.count
+
+                        const entry = {
+                            communityId: count.toString(),
+                            name: "Community " + count,
+                            color: root.colors[Math.floor(Math.random() * colors.length)]
+                        }
+
+                        rightModel.append(entry)
+                    }
+                }
+            }
+
+            Button {
+                text: "shuffle"
+
+                onClicked: {
+                    const count = leftModel.count
+                    const iterations = count / 2
+
+                    for (let i = 0; i < iterations; i++) {
+                        leftModel.move(Math.floor(Math.random() * (count - 1)),
+                                       Math.floor(Math.random() * (count - 1)),
+                                       Math.floor(Math.random() * 2) + 1)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// category: Models

--- a/storybook/pages/LeftJoinRenamingSfpmPage.qml
+++ b/storybook/pages/LeftJoinRenamingSfpmPage.qml
@@ -1,0 +1,121 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import SortFilterProxyModel 0.2
+
+Control {
+    font.pixelSize: 15
+
+    ListModel {
+        id: leftBaseModel
+
+        Component.onCompleted: {
+            const items = []
+
+            for (let i = 0; i < 1000; i++)
+                items.push({ name: `base name (${i})`, foreignId: i % 15 })
+
+            append(items)
+        }
+    }
+
+    ListModel {
+        id: rightBaseModel
+
+        Component.onCompleted: {
+            const items = []
+
+            for (let i = 0; i < 20; i++)
+                items.push({ id: i, name: `foreign name (${i})` })
+
+            append(items)
+        }
+    }
+
+    RolesRenamingModel {
+        id: leftModelRenamed
+
+        sourceModel: leftBaseModel
+
+        mapping: RoleRename {
+            from: "name"
+            to: "baseName"
+        }
+    }
+
+    RolesRenamingModel {
+        id: rightModelRenamed
+
+        sourceModel: rightBaseModel
+
+        mapping: RoleRename {
+            from: "id"
+            to: "foreignId"
+        }
+    }
+
+    LeftJoinModel {
+        id: joinModel
+
+        leftModel: leftModelRenamed
+        rightModel: rightModelRenamed
+
+        joinRole: "foreignId"
+    }
+
+    SortFilterProxyModel {
+        id: filteringModel
+
+        sourceModel: joinModel
+
+        filters: ValueFilter {
+            roleName: "foreignId"
+            value: searchTextField.text
+
+            enabled: searchTextField.length
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 10
+
+        Label {
+            Layout.fillWidth: true
+
+            text: "Simple example showing how to compose custom model from two "
+                  + "source models using RolesRenamingModel, LeftJoinModel "
+                  + "and SortFilterProxyModel"
+
+            font.bold: true
+            wrapMode: Text.Wrap
+        }
+
+        TextField {
+            id: searchTextField
+
+            Layout.fillWidth: true
+            placeholderText: "Filter by foreign id"
+        }
+
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            ScrollBar.vertical: ScrollBar {}
+
+            model: filteringModel
+            clip: true
+
+            delegate: Label {
+                width: ListView.view.height
+
+                text: `${model.baseName}, ${model.name} (id: ${model.foreignId})`
+            }
+        }
+    }
+}
+
+// category: Research / Examples

--- a/storybook/pages/RolesRenamingModelPage.qml
+++ b/storybook/pages/RolesRenamingModelPage.qml
@@ -1,0 +1,156 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+
+Item {
+    id: root
+
+    RolesRenamingModel {
+        id: renamedModel
+
+        sourceModel: sourceModel
+
+        mapping: [
+            RoleRename {
+                from: "tokenId"
+                to: "id"
+            },
+            RoleRename {
+                from: "title"
+                to: "name"
+            }
+        ]
+    }
+
+    ListModel {
+        id: sourceModel
+
+        ListElement {
+            tokenId: "1"
+            title: "Token 1"
+            communityId: "1"
+        }
+        ListElement {
+            tokenId: "2"
+            title: "Token 2"
+            communityId: "1"
+        }
+        ListElement {
+            tokenId: "3"
+            title: "Token 3"
+            communityId: "2"
+        }
+        ListElement {
+            tokenId: "4"
+            title: "Token 4"
+            communityId: "3"
+        }
+        ListElement {
+            tokenId: "5"
+            title: "Token 5"
+            communityId: ""
+        }
+        ListElement {
+            tokenId: "6"
+            title: "Token 6"
+            communityId: "1"
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 40
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            clip: true
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                border.color: "gray"
+
+                ListView {
+                    anchors.fill: parent
+
+                    model: sourceModel
+
+                    header: Label {
+                        height: implicitHeight * 2
+                        text: `Left model (${sourceModel.count})`
+
+                        font.bold: true
+
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Label {
+                        width: ListView.view.width
+
+                        text: `token id: ${model.tokenId}, ${model.title}, community id: ${model.communityId || "-"}`
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                border.color: "gray"
+
+                ListView {
+                    id: renamedListView
+
+                    anchors.fill: parent
+
+                    model: renamedModel
+
+                    header: Label {
+                        height: implicitHeight * 2
+                        text: `Renamed model (${renamedListView.count})`
+
+                        font.bold: true
+
+                        verticalAlignment: Text.AlignVCenter
+                    }
+
+                    ScrollBar.vertical: ScrollBar {}
+
+                    delegate: Label {
+                        width: ListView.view.width
+
+                        text: `id: ${model.id}, ${model.name}, community id: ${model.communityId || "-"}`
+                    }
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Button {
+                text: "shuffle"
+
+                onClicked: {
+                    const count = sourceModel.count
+                    const iterations = count / 2
+
+                    for (let i = 0; i < iterations; i++) {
+                        sourceModel.move(Math.floor(Math.random() * (count - 1)),
+                                         Math.floor(Math.random() * (count - 1)),
+                                         Math.floor(Math.random() * 2) + 1)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// category: Models

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 add_library(StatusQ SHARED
         ${STATUSQ_QRC_COMPILED}
         include/StatusQ/QClipboardProxy.h
+        include/StatusQ/leftjoinmodel.h
         include/StatusQ/modelutilsinternal.h
         include/StatusQ/permissionutilsinternal.h
         include/StatusQ/rolesrenamingmodel.h
@@ -97,6 +98,7 @@ add_library(StatusQ SHARED
         include/StatusQ/statuswindow.h
         include/StatusQ/stringutilsinternal.h
         src/QClipboardProxy.cpp
+        src/leftjoinmodel.cpp
         src/modelutilsinternal.cpp
         src/permissionutilsinternal.cpp
         src/plugin.cpp

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -13,8 +13,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Although SHARED libraries set this to ON by default,
-# all static libraries, that are built into this SHARED, 
-# (which is qzxing in our case) should also be build with -fPIC. 
+# all static libraries, that are built into this SHARED,
+# (which is qzxing in our case) should also be build with -fPIC.
 # This fixes it.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -91,6 +91,7 @@ add_library(StatusQ SHARED
         include/StatusQ/QClipboardProxy.h
         include/StatusQ/modelutilsinternal.h
         include/StatusQ/permissionutilsinternal.h
+        include/StatusQ/rolesrenamingmodel.h
         include/StatusQ/rxvalidator.h
         include/StatusQ/statussyntaxhighlighter.h
         include/StatusQ/statuswindow.h
@@ -99,13 +100,14 @@ add_library(StatusQ SHARED
         src/modelutilsinternal.cpp
         src/permissionutilsinternal.cpp
         src/plugin.cpp
+        src/rolesrenamingmodel.cpp
         src/rxvalidator.cpp
         src/statussyntaxhighlighter.cpp
         src/statuswindow.cpp
         src/stringutilsinternal.cpp
         )
 
-set_target_properties(StatusQ PROPERTIES 
+set_target_properties(StatusQ PROPERTIES
     ADDITIONAL_CLEAN_FILES bin/StatusQ/qmldir
     RUNTIME_OUTPUT_DIRECTORY ${STATUSQ_MODULE_PATH}
     RUNTIME_OUTPUT_DIRECTORY_DEBUG ${STATUSQ_MODULE_PATH}
@@ -144,7 +146,7 @@ target_link_libraries(StatusQ PRIVATE
         qzxing
         )
 
-target_include_directories(StatusQ PRIVATE include)
+target_include_directories(StatusQ PUBLIC include)
 
 install(TARGETS StatusQ
         RUNTIME DESTINATION StatusQ

--- a/ui/StatusQ/include/StatusQ/leftjoinmodel.h
+++ b/ui/StatusQ/include/StatusQ/leftjoinmodel.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QIdentityProxyModel>
+
+class LeftJoinModel : public QIdentityProxyModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QAbstractItemModel* leftModel READ leftModel
+               WRITE setLeftModel NOTIFY leftModelChanged)
+
+    Q_PROPERTY(QAbstractItemModel* rightModel READ rightModel
+               WRITE setRightModel NOTIFY rightModelChanged)
+
+    Q_PROPERTY(QString joinRole READ joinRole
+               WRITE setJoinRole NOTIFY joinRoleChanged)
+
+public:
+    explicit LeftJoinModel(QObject* parent = nullptr);
+
+    void setLeftModel(QAbstractItemModel* model);
+    QAbstractItemModel* leftModel() const;
+
+    void setRightModel(QAbstractItemModel* model);
+    QAbstractItemModel* rightModel() const;
+
+    void setJoinRole(const QString& joinRole);
+    const QString& joinRole() const;
+
+    QHash<int, QByteArray> roleNames() const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    void setSourceModel(QAbstractItemModel* newSourceModel) override;
+
+signals:
+    void leftModelChanged();
+    void rightModelChanged();
+    void joinRoleChanged();
+
+private:
+    void initializeIfReady();
+    void initialize();
+
+    int m_rightModelRolesOffset = 0;
+    QHash<int, QByteArray> m_roleNames;
+    QVector<int> m_joinedRoles;
+
+    QString m_joinRole;
+    int m_leftModelJoinRole = 0;
+    int m_rightModelJoinRole = 0;
+
+    QAbstractItemModel* m_leftModel = nullptr;
+    QAbstractItemModel* m_rightModel = nullptr;
+
+    bool m_leftModelDestroyed = false;
+    bool m_rightModelDestroyed = false;
+
+    mutable QPersistentModelIndex m_lastUsedRightModelIndex;
+};

--- a/ui/StatusQ/include/StatusQ/rolesrenamingmodel.h
+++ b/ui/StatusQ/include/StatusQ/rolesrenamingmodel.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QIdentityProxyModel>
+#include <QQmlListProperty>
+
+class RoleRename : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString from READ from WRITE setFrom NOTIFY fromChanged)
+    Q_PROPERTY(QString to READ to WRITE setTo NOTIFY toChanged)
+
+public:
+    explicit RoleRename(QObject* parent = nullptr);
+
+    void setFrom(const QString& from);
+    const QString& from() const;
+
+    void setTo(const QString& to);
+    const QString& to() const;
+
+signals:
+    void fromChanged();
+    void toChanged();
+
+private:
+    QString m_from;
+    QString m_to;
+};
+
+class RolesRenamingModel : public QIdentityProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QQmlListProperty<RoleRename> mapping READ mapping CONSTANT)
+
+public:
+    explicit RolesRenamingModel(QObject* parent = nullptr);
+
+    QQmlListProperty<RoleRename> mapping();
+    QHash<int, QByteArray> roleNames() const override;
+
+private:
+    mutable bool m_rolesFetched = false;
+    QList<RoleRename*> m_mapping;
+};

--- a/ui/StatusQ/src/leftjoinmodel.cpp
+++ b/ui/StatusQ/src/leftjoinmodel.cpp
@@ -1,0 +1,240 @@
+#include "StatusQ/leftjoinmodel.h"
+
+#include <QDebug>
+
+#include <algorithm>
+
+LeftJoinModel::LeftJoinModel(QObject* parent)
+    : QIdentityProxyModel{parent}
+{
+}
+
+void LeftJoinModel::initializeIfReady()
+{
+    if (m_leftModel && m_rightModel && !m_joinRole.isEmpty()
+            && !m_leftModel->roleNames().empty()
+            && !m_rightModel->roleNames().empty())
+        initialize();
+}
+
+void LeftJoinModel::initialize()
+{
+    auto leftRoleNames = m_leftModel->roleNames();
+    auto rightRoleNames = m_rightModel->roleNames();
+
+    if (leftRoleNames.isEmpty() || rightRoleNames.isEmpty()) {
+        qWarning() << "Both left and right models have to contain some roles!";
+        return;
+    }
+
+    auto leftModelJoinRoleList = leftRoleNames.keys(m_joinRole.toUtf8());
+    auto rightModelJoinRoleList = rightRoleNames.keys(m_joinRole.toUtf8());
+
+    if (leftModelJoinRoleList.size() != 1
+            || rightModelJoinRoleList.size() != 1) {
+        qWarning().noquote() << QString("Both left and right models have to "
+                                        "contain join role %1!").arg(m_joinRole);
+        return;
+    }
+
+    m_leftModelJoinRole = leftModelJoinRoleList.at(0);
+    m_rightModelJoinRole = rightModelJoinRoleList.at(0);
+
+    auto leftRoles = leftRoleNames.keys();
+    auto maxLeftRole = std::max_element(leftRoles.cbegin(), leftRoles.cend());
+    auto rightRolesOffset = *maxLeftRole + 1;
+    auto roleNames = leftRoleNames;
+
+    auto i = rightRoleNames.constBegin();
+    while (i != rightRoleNames.constEnd()) {
+        if (i.value() != m_joinRole) {
+            auto roleWithOffset = i.key() + rightRolesOffset;
+            roleNames.insert(roleWithOffset, i.value());
+            m_joinedRoles.append(roleWithOffset);
+        }
+        ++i;
+    }
+
+    m_rightModelRolesOffset = rightRolesOffset;
+    m_roleNames = roleNames;
+
+    connect(m_rightModel, &QAbstractItemModel::dataChanged, this,
+            [this](auto& topLeft, auto& bottomRight, auto& roles) {
+        QVector<int> rolesTranslated;
+
+        if (roles.contains(m_rightModelJoinRole)) {
+            rolesTranslated = m_joinedRoles;
+        } else {
+            rolesTranslated = roles;
+
+            for (auto& role : rolesTranslated)
+                role += m_rightModelRolesOffset;
+        }
+
+        emit dataChanged(index(0, 0), index(rowCount() - 1, 0), rolesTranslated);
+    });
+
+    disconnect(m_leftModel, &QAbstractItemModel::rowsInserted,
+               this, &LeftJoinModel::initializeIfReady);
+    disconnect(m_rightModel, &QAbstractItemModel::rowsInserted,
+               this, &LeftJoinModel::initializeIfReady);
+
+    auto emitJoinedRolesChanged = [this] {
+        emit dataChanged(index(0, 0), index(rowCount() - 1, 0), m_joinedRoles);
+    };
+
+    connect(m_rightModel, &QAbstractItemModel::rowsRemoved, this,
+            emitJoinedRolesChanged);
+    connect(m_rightModel, &QAbstractItemModel::rowsInserted, this,
+            emitJoinedRolesChanged);
+    connect(m_rightModel, &QAbstractItemModel::modelReset, this,
+            emitJoinedRolesChanged);
+    connect(m_rightModel, &QAbstractItemModel::layoutChanged, this,
+            emitJoinedRolesChanged);
+
+    connect(this, &QAbstractItemModel::dataChanged, this,
+            [this](auto& topLeft, auto& bottomRight, auto& roles) {
+        if (roles.contains(m_leftModelJoinRole))
+            emit dataChanged(topLeft, bottomRight, m_joinedRoles);
+    });
+
+    QIdentityProxyModel::setSourceModel(m_leftModel);
+}
+
+QVariant LeftJoinModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid())
+        return {};
+
+    auto idx = m_leftModel->index(index.row(), index.column());
+
+    if (role < m_rightModelRolesOffset)
+        return m_leftModel->data(idx, role);
+
+    if (m_rightModelDestroyed)
+        return {};
+
+    QVariant joinRoleLeftValue = m_leftModel->data(idx, m_leftModelJoinRole);
+
+    if (m_lastUsedRightModelIndex.isValid()
+            && m_rightModel->data(m_lastUsedRightModelIndex,
+                                  m_rightModelJoinRole) == joinRoleLeftValue)
+    {
+        return m_rightModel->data(m_lastUsedRightModelIndex,
+                                  role - m_rightModelRolesOffset);
+    }
+
+    int rightModelCount = m_rightModel->rowCount();
+
+    for (int i = 0; i < rightModelCount; i++) {
+        auto rightModelIdx =  m_rightModel->index(i, 0);
+        auto rightJointRoleValue = m_rightModel->data(rightModelIdx,
+                                                      m_rightModelJoinRole);
+
+        if (joinRoleLeftValue == rightJointRoleValue) {
+            m_lastUsedRightModelIndex = rightModelIdx;
+
+            return m_rightModel->data(rightModelIdx,
+                                      role - m_rightModelRolesOffset);
+        }
+    }
+
+    return {};
+}
+
+void LeftJoinModel::setLeftModel(QAbstractItemModel* model)
+{
+    if (m_leftModel == model)
+        return;
+
+    if (m_leftModel != nullptr || m_leftModelDestroyed) {
+        qWarning("Changing left model is not supported!");
+        return;
+    }
+
+    m_leftModel = model;
+
+    // Some models may have roles undefined until first row is inserted,
+    // like ListModel, therefore in such cases initialization must be deferred
+    // until first insertion.
+    connect(m_leftModel, &QAbstractItemModel::rowsInserted,
+            this, &LeftJoinModel::initializeIfReady);
+
+    connect(m_leftModel, &QObject::destroyed, this, [this] {
+        this->m_leftModel = nullptr;
+        this->m_leftModelDestroyed = true;
+    });
+
+    emit leftModelChanged();
+
+    initializeIfReady();
+}
+
+QAbstractItemModel* LeftJoinModel::leftModel() const
+{
+    return m_leftModel;
+}
+
+void LeftJoinModel::setRightModel(QAbstractItemModel* model)
+{
+    if (m_rightModel == model)
+        return;
+
+    if (m_rightModel != nullptr || m_rightModelDestroyed) {
+        qWarning("Changing right model is not supported!");
+        return;
+    }
+
+    m_rightModel = model;
+
+    // see: LeftJoinModel::setLeftModel
+    connect(m_rightModel, &QAbstractItemModel::rowsInserted,
+            this, &LeftJoinModel::initializeIfReady);
+
+    connect(m_rightModel, &QObject::destroyed, this, [this] {
+        this->m_rightModel = nullptr;
+        this->m_rightModelDestroyed = true;
+    });
+
+    emit rightModelChanged();
+
+    initializeIfReady();
+}
+
+QAbstractItemModel* LeftJoinModel::rightModel() const
+{
+    return m_rightModel;
+}
+
+void LeftJoinModel::setJoinRole(const QString& joinRole)
+{
+    if (m_joinRole.isEmpty() && joinRole.isEmpty())
+        return;
+
+    if (!m_joinRole.isEmpty()) {
+        qWarning("Changing join role is not supported!");
+        return;
+    }
+
+    m_joinRole = joinRole;
+
+    emit joinRoleChanged();
+
+    initializeIfReady();
+}
+
+const QString& LeftJoinModel::joinRole() const
+{
+    return m_joinRole;
+}
+
+void LeftJoinModel::setSourceModel(QAbstractItemModel* newSourceModel)
+{
+    qWarning() << "Source model is not intended to be set directly on this model."
+                  " Use setLeftModel and setRightModel instead!";
+}
+
+QHash<int, QByteArray> LeftJoinModel::roleNames() const
+{
+    return m_roleNames;
+}

--- a/ui/StatusQ/src/plugin.cpp
+++ b/ui/StatusQ/src/plugin.cpp
@@ -4,6 +4,7 @@
 #include <qqmlsortfilterproxymodeltypes.h>
 
 #include "StatusQ/QClipboardProxy.h"
+#include "StatusQ/leftjoinmodel.h"
 #include "StatusQ/modelutilsinternal.h"
 #include "StatusQ/permissionutilsinternal.h"
 #include "StatusQ/rolesrenamingmodel.h"
@@ -25,6 +26,7 @@ public:
         qmlRegisterType<StatusSyntaxHighlighter>("StatusQ", 0, 1, "StatusSyntaxHighlighter");
         qmlRegisterType<RXValidator>("StatusQ", 0, 1, "RXValidator");
 
+        qmlRegisterType<LeftJoinModel>("StatusQ", 0, 1, "LeftJoinModel");
         qmlRegisterType<RolesRenamingModel>("StatusQ", 0, 1, "RolesRenamingModel");
         qmlRegisterType<RoleRename>("StatusQ", 0, 1, "RoleRename");
 

--- a/ui/StatusQ/src/plugin.cpp
+++ b/ui/StatusQ/src/plugin.cpp
@@ -6,6 +6,7 @@
 #include "StatusQ/QClipboardProxy.h"
 #include "StatusQ/modelutilsinternal.h"
 #include "StatusQ/permissionutilsinternal.h"
+#include "StatusQ/rolesrenamingmodel.h"
 #include "StatusQ/rxvalidator.h"
 #include "StatusQ/statussyntaxhighlighter.h"
 #include "StatusQ/statuswindow.h"
@@ -23,6 +24,9 @@ public:
         qmlRegisterType<StatusWindow>("StatusQ", 0, 1, "StatusWindow");
         qmlRegisterType<StatusSyntaxHighlighter>("StatusQ", 0, 1, "StatusSyntaxHighlighter");
         qmlRegisterType<RXValidator>("StatusQ", 0, 1, "RXValidator");
+
+        qmlRegisterType<RolesRenamingModel>("StatusQ", 0, 1, "RolesRenamingModel");
+        qmlRegisterType<RoleRename>("StatusQ", 0, 1, "RoleRename");
 
         qmlRegisterSingletonType<QClipboardProxy>("StatusQ", 0, 1, "QClipboardProxy", &QClipboardProxy::qmlInstance);
 

--- a/ui/StatusQ/src/rolesrenamingmodel.cpp
+++ b/ui/StatusQ/src/rolesrenamingmodel.cpp
@@ -13,7 +13,8 @@ void RoleRename::setFrom(const QString& from)
         return;
 
     if (!m_from.isEmpty()) {
-        qWarning() << "RoleRename: property \"from\" is inteded to be initialized once and not changed!";
+        qWarning() << "RoleRename: property \"from\" is intended to be "
+                      "initialized once and not changed!";
         return;
     }
 
@@ -32,7 +33,8 @@ void RoleRename::setTo(const QString& to)
         return;
 
     if (!m_to.isEmpty()) {
-        qWarning() << "RoleRename: property \"to\" is inteded to be initialized once and not changed!";
+        qWarning() << "RoleRename: property \"to\" is intended to be "
+                      "initialized once and not changed!";
         return;
     }
 
@@ -63,7 +65,8 @@ QQmlListProperty<RoleRename> RolesRenamingModel::mapping()
                     listProperty->object);
 
         if (model->m_rolesFetched) {
-            qWarning() << "RolesRenamingModel: role names mapping cannot be modified after fetching role names!";
+            qWarning() << "RolesRenamingModel: role names mapping cannot be "
+                          "modified after fetching role names!";
             return;
         }
 
@@ -102,7 +105,8 @@ QHash<int, QByteArray> RolesRenamingModel::roleNames() const
     }
 
     if (roles.size() != roleNamesSet.size()) {
-        qWarning() << "RolesRenamingModel: model cannot contain duplicated role names!";
+        qWarning() << "RolesRenamingModel: model cannot contain duplicated "
+                      "role names!";
         return {};
     }
 

--- a/ui/StatusQ/src/rolesrenamingmodel.cpp
+++ b/ui/StatusQ/src/rolesrenamingmodel.cpp
@@ -1,0 +1,117 @@
+#include "StatusQ/rolesrenamingmodel.h"
+
+#include <QDebug>
+
+RoleRename::RoleRename(QObject* parent)
+    : QObject{parent}
+{
+}
+
+void RoleRename::setFrom(const QString& from)
+{
+    if (m_from == from)
+        return;
+
+    if (!m_from.isEmpty()) {
+        qWarning() << "RoleRename: property \"from\" is inteded to be initialized once and not changed!";
+        return;
+    }
+
+    m_from = from;
+    emit fromChanged();
+}
+
+const QString& RoleRename::from() const
+{
+    return m_from;
+}
+
+void RoleRename::setTo(const QString& to)
+{
+    if (m_to == to)
+        return;
+
+    if (!m_to.isEmpty()) {
+        qWarning() << "RoleRename: property \"to\" is inteded to be initialized once and not changed!";
+        return;
+    }
+
+    m_to = to;
+    emit toChanged();
+}
+
+const QString& RoleRename::to() const
+{
+    return m_to;
+}
+
+RolesRenamingModel::RolesRenamingModel(QObject* parent)
+    : QIdentityProxyModel{parent}
+{
+}
+
+QQmlListProperty<RoleRename> RolesRenamingModel::mapping()
+{
+    QQmlListProperty<RoleRename> list(this, &m_mapping);
+
+    list.replace = nullptr;
+    list.clear = nullptr;
+    list.removeLast = nullptr;
+
+    list.append = [](auto listProperty, auto element) {
+        RolesRenamingModel* model = qobject_cast<RolesRenamingModel*>(
+                    listProperty->object);
+
+        if (model->m_rolesFetched) {
+            qWarning() << "RolesRenamingModel: role names mapping cannot be modified after fetching role names!";
+            return;
+        }
+
+        model->m_mapping.append(element);
+    };
+
+    return list;
+}
+
+QHash<int, QByteArray> RolesRenamingModel::roleNames() const
+{
+    QHash<int, QByteArray> roles = sourceModel()
+            ? sourceModel()->roleNames()
+            : QHash<int, QByteArray>{};
+
+    if (roles.empty())
+        return roles;
+
+    QHash<QString, RoleRename*> renameMap;
+
+    for (const auto rename : m_mapping)
+        renameMap.insert(rename->from(), rename);
+
+    QHash<int, QByteArray> remapped;
+    remapped.reserve(roles.size());
+
+    QSet<QByteArray> roleNamesSet;
+    roleNamesSet.reserve(roles.size());
+
+    for (auto i = roles.cbegin(), end = roles.cend(); i != end; ++i) {
+        RoleRename* rename = renameMap.take(i.value());
+        QByteArray roleName = rename ? rename->to().toUtf8() : i.value();
+
+        remapped.insert(i.key(), roleName);
+        roleNamesSet.insert(roleName);
+    }
+
+    if (roles.size() != roleNamesSet.size()) {
+        qWarning() << "RolesRenamingModel: model cannot contain duplicated role names!";
+        return {};
+    }
+
+    if (renameMap.size()) {
+        qWarning().nospace()
+                << "RolesRenamingModel: specified source roles not found: "
+                << renameMap.keys() << "!";
+    }
+
+    m_rolesFetched = true;
+    return remapped;
+}

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -44,3 +44,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 add_executable(RolesRenamingModelTest tst_RolesRenamingModel.cpp)
 target_link_libraries(RolesRenamingModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
 add_test(RolesRenamingModelTest COMMAND RolesRenamingModelTest)
+
+add_executable(LeftJoinModelTest tst_LeftJoinModel.cpp)
+target_link_libraries(LeftJoinModelTest PRIVATE Qt5::Test StatusQ)
+add_test(LeftJoinModelTest COMMAND LeftJoinModelTest)

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -16,7 +16,9 @@ add_definitions(-DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_executable(${PROJECT_NAME} main.cpp)
 
-add_test(NAME ${PROJECT_NAME} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME} -input "${CMAKE_CURRENT_SOURCE_DIR}")
+add_test(NAME ${PROJECT_NAME} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME} -input "${CMAKE_CURRENT_SOURCE_DIR}")
+
 add_custom_target("Run_${PROJECT_NAME}" COMMAND ${CMAKE_CTEST_COMMAND} --test-dir "${CMAKE_CURRENT_BINARY_DIR}")
 add_dependencies("Run_${PROJECT_NAME}" ${PROJECT_NAME})
 
@@ -38,3 +40,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
         STATUSQ_MODULE_PATH="${STATUSQ_MODULE_PATH}"
         STATUSQ_MODULE_IMPORT_PATH="${STATUSQ_MODULE_IMPORT_PATH}"
         )
+
+add_executable(RolesRenamingModelTest tst_RolesRenamingModel.cpp)
+target_link_libraries(RolesRenamingModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
+add_test(RolesRenamingModelTest COMMAND RolesRenamingModelTest)

--- a/ui/StatusQ/tests/tst_LeftJoinModel.cpp
+++ b/ui/StatusQ/tests/tst_LeftJoinModel.cpp
@@ -1,0 +1,626 @@
+#include <QSignalSpy>
+#include <QTest>
+
+#include <memory>
+
+#include <StatusQ/leftjoinmodel.h>
+
+namespace {
+
+class TestSourceModel : public QAbstractListModel {
+
+public:
+
+    explicit TestSourceModel(QList<QPair<QString, QVariantList>> data)
+        : m_data(std::move(data))
+    {
+        m_roles.reserve(m_data.size());
+
+        for (auto i = 0; i < m_data.size(); i++)
+            m_roles.insert(i, m_data.at(i).first.toUtf8());
+    }
+
+    int rowCount(const QModelIndex& parent) const override
+    {
+        assert(m_data.size());
+        return m_data.first().second.size();
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!index.isValid())
+            return {};
+
+        const auto row = index.row();
+
+        if (role >= m_data.length() || row >= m_data.at(0).second.length())
+            return {};
+
+        return m_data.at(role).second.at(row);
+    }
+
+    void insert(int index, QVariantList row)
+    {
+        beginInsertRows(QModelIndex{}, index, index);
+
+        assert(row.size() == m_data.size());
+
+        for (int i = 0; i < m_data.size(); i++) {
+            auto& roleVariantList = m_data[i].second;
+            assert(index <= roleVariantList.size());
+            roleVariantList.insert(index, row.at(i));
+        }
+
+        endInsertRows();
+    }
+
+    void update(int index, int role, QVariant value)
+    {
+        assert(role < m_data.size() && index < m_data[role].second.size());
+        m_data[role].second[index].setValue(std::move(value));
+
+        emit dataChanged(this->index(index, 0), this->index(index, 0), { role });
+    }
+
+    void remove(int index)
+    {
+        beginRemoveRows(QModelIndex{}, index, index);
+
+        for (int i = 0; i < m_data.size(); i++) {
+            auto& roleVariantList = m_data[i].second;
+            assert(index < roleVariantList.size());
+            roleVariantList.removeAt(index);
+        }
+
+        endRemoveRows();
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        return m_roles;
+    }
+
+private:
+    QList<QPair<QString, QVariantList>> m_data;
+    QHash<int, QByteArray> m_roles;
+};
+
+}
+
+class TestLeftJoinModel: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    void emptyModelTest() {
+        LeftJoinModel model;
+
+        QCOMPARE(model.rowCount(), 0);
+        QCOMPARE(model.roleNames(), {});
+    }
+
+    void initializationTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+
+        QCOMPARE(model.rowCount(), 0);
+        QCOMPARE(model.roleNames(), {});
+
+        model.setRightModel(&rightModel);
+
+        QCOMPARE(model.rowCount(), 0);
+        QCOMPARE(model.roleNames(), {});
+
+        model.setJoinRole("communityId");
+
+        QCOMPARE(model.rowCount(), 2);
+
+        QHash<int, QByteArray> roles{{0, "title" }, {1, "communityId"}, {2, "name"}};
+        QCOMPARE(model.roleNames(), roles);
+    }
+
+    void setSourceModelDirectlyTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Source model is not intended to be set directly "
+                             "on this model. Use setLeftModel and setRightModel instead!");
+        model.setSourceModel(&leftModel);
+
+        QCOMPARE(model.rowCount(), 0);
+        QCOMPARE(model.roleNames(), {});
+    }
+
+    void noJoinRoleTest()
+    {
+        {
+            TestSourceModel leftModel({
+               { "title", { "Token 1", "Token 2" }},
+               { "communityId", { "community_1", "community_2" }}
+            });
+
+            TestSourceModel rightModel({
+               { "name", { "Community 1", "Community 2" }},
+               { "communityId", { "community_1", "community_2" }}
+            });
+
+            LeftJoinModel model;
+            model.setLeftModel(&leftModel);
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+
+            model.setRightModel(&rightModel);
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+
+            QTest::ignoreMessage(QtWarningMsg,
+                                 "Both left and right models have to contain "
+                                 "join role someRole!");
+
+            model.setJoinRole("someRole");
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+        }
+        {
+            TestSourceModel leftModel({
+               { "title", { "Token 1", "Token 2" }},
+               { "communityId", { "community_1", "community_2" }}
+            });
+
+            TestSourceModel rightModel({
+               { "name", { "Community 1", "Community 2" }},
+               { "communityId", { "community_1", "community_2" }}
+            });
+
+            LeftJoinModel model;
+            model.setLeftModel(&leftModel);
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+
+            model.setRightModel(&rightModel);
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+
+            QTest::ignoreMessage(QtWarningMsg,
+                                 "Both left and right models have to contain "
+                                 "join role title!");
+
+            model.setJoinRole("title");
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+        }
+        {
+            TestSourceModel leftModel({
+               { "title", { "Token 1", "Token 2" }},
+               { "communityId", { "community_1", "community_2" }}
+            });
+
+            TestSourceModel rightModel({
+               { "name", { "Community 1", "Community 2" }},
+               { "communityId", { "community_1", "community_2" }}
+            });
+
+            LeftJoinModel model;
+            model.setLeftModel(&leftModel);
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+
+            model.setRightModel(&rightModel);
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+
+            QTest::ignoreMessage(QtWarningMsg,
+                                 "Both left and right models have to contain "
+                                 "join role name!");
+
+            model.setJoinRole("name");
+
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(model.roleNames(), {});
+        }
+    }
+
+    void basicAccesTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        QCOMPARE(model.rowCount(), 2);
+        QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+        QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+        QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+    }
+
+    void changesPropagationTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }},
+           { "color", { "red", "green" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        {
+            QSignalSpy dataChangedSpy(&model, &LeftJoinModel::dataChanged);
+
+            rightModel.update(0, 0, "Community 1 Updated");
+            QCOMPARE(dataChangedSpy.count(), 1);
+
+            QCOMPARE(dataChangedSpy.first().at(0), model.index(0, 0));
+            QCOMPARE(dataChangedSpy.first().at(1), model.index(model.rowCount() - 1, 0));
+            QCOMPARE(dataChangedSpy.first().at(2).value<QVector<int>>(), {2});
+
+            QCOMPARE(model.rowCount(), 2);
+            QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+            QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+            QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+            QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+            QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1 Updated"));
+            QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+        }
+        {
+            QSignalSpy dataChangedSpy(&model, &LeftJoinModel::dataChanged);
+
+            leftModel.update(1, 0, "Token 2 Updated");
+            QCOMPARE(dataChangedSpy.count(), 1);
+
+            QCOMPARE(dataChangedSpy.first().at(0), model.index(1, 0));
+            QCOMPARE(dataChangedSpy.first().at(1), model.index(1, 0));
+            QCOMPARE(dataChangedSpy.first().at(2).value<QVector<int>>(), {0});
+
+            QCOMPARE(model.rowCount(), 2);
+            QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+            QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2 Updated"));
+            QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+            QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+            QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1 Updated"));
+            QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+        }
+    }
+
+    void rightModelJoinRoleChangesPropagationTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        QSignalSpy dataChangedSpy(&model, &LeftJoinModel::dataChanged);
+
+        rightModel.update(1, 1, "community_3");
+        QCOMPARE(dataChangedSpy.count(), 1);
+
+        QCOMPARE(dataChangedSpy.first().at(0), model.index(0, 0));
+        QCOMPARE(dataChangedSpy.first().at(1), model.index(model.rowCount() - 1, 0));
+        QCOMPARE(dataChangedSpy.first().at(2).value<QVector<int>>(), {2});
+
+        QCOMPARE(model.rowCount(), 2);
+        QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+        QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+        QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(1, 0), 2), {});
+    }
+
+    void rightModelRemovalPropagationTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        QSignalSpy dataChangedSpy(&model, &LeftJoinModel::dataChanged);
+
+        rightModel.remove(1);
+        QCOMPARE(dataChangedSpy.count(), 1);
+
+        QCOMPARE(dataChangedSpy.first().at(0), model.index(0, 0));
+        QCOMPARE(dataChangedSpy.first().at(1), model.index(model.rowCount() - 1, 0));
+        QCOMPARE(dataChangedSpy.first().at(2).value<QVector<int>>(), {2});
+
+        QCOMPARE(model.rowCount(), 2);
+        QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+        QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+        QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(1, 0), 2), {});
+    }
+
+    void rightModelAdditionPropagationTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_3" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        QSignalSpy dataChangedSpy(&model, &LeftJoinModel::dataChanged);
+
+        rightModel.insert(2, {"Community 3", "community_3"});
+        QCOMPARE(dataChangedSpy.count(), 1);
+
+        QCOMPARE(dataChangedSpy.first().at(0), model.index(0, 0));
+        QCOMPARE(dataChangedSpy.first().at(1), model.index(model.rowCount() - 1, 0));
+        QCOMPARE(dataChangedSpy.first().at(2).value<QVector<int>>(), {2});
+
+        QCOMPARE(model.rowCount(), 3);
+        QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+        QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+        QCOMPARE(model.data(model.index(2, 0), 0), QString("Token 3"));
+        QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+        QCOMPARE(model.data(model.index(2, 0), 1), QString("community_3"));
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+        QCOMPARE(model.data(model.index(2, 0), 2), QString("Community 3"));
+    }
+
+    void leftModelJoinRoleChangesPropagationTest()
+    {
+        TestSourceModel leftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_1" }}
+        });
+
+        TestSourceModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        LeftJoinModel model;
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+        model.setJoinRole("communityId");
+
+        QSignalSpy dataChangedSpy(&model, &LeftJoinModel::dataChanged);
+
+        leftModel.update(1, 1, "community_1");
+        QCOMPARE(dataChangedSpy.count(), 2);
+
+        QCOMPARE(dataChangedSpy.first().at(0), model.index(1, 0));
+        QCOMPARE(dataChangedSpy.first().at(1), model.index(1, 0));
+        QCOMPARE(dataChangedSpy.first().at(2).value<QVector<int>>(), {2});
+
+        QCOMPARE(dataChangedSpy.at(1).at(0), model.index(1, 0));
+        QCOMPARE(dataChangedSpy.at(1).at(1), model.index(1, 0));
+        QCOMPARE(dataChangedSpy.at(1).at(2).value<QVector<int>>(), {1});
+
+        QCOMPARE(model.rowCount(), 3);
+        QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+        QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+        QCOMPARE(model.data(model.index(2, 0), 0), QString("Token 3"));
+        QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(1, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(2, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(2, 0), 2), QString("Community 1"));
+    }
+
+    void modelsDeletedBeforeInitializationTest()
+    {
+        auto leftModel = std::make_unique<TestSourceModel>(
+                    QList<QPair<QString, QVariantList>>{
+                        { "title", { "Token 1", "Token 2", "Token 3"}},
+                        { "communityId", { "community_1", "community_2", "community_1" }}
+                    });
+
+        auto rightModel = std::make_unique<TestSourceModel>(
+                    QList<QPair<QString, QVariantList>>{
+                        { "name", { "Community 1", "Community 2" }},
+                        { "communityId", { "community_1", "community_2" }}
+                    });
+
+        LeftJoinModel model;
+        model.setLeftModel(leftModel.get());
+        model.setRightModel(rightModel.get());
+
+        leftModel.reset();
+        rightModel.reset();
+
+        model.setJoinRole("communityId");
+
+        QCOMPARE(model.roleNames(), {});
+        QCOMPARE(model.rowCount(), 0);
+        QCOMPARE(model.data(model.index(0, 0), 0), {});
+        QCOMPARE(model.data(model.index(0, 0), 2), {});
+
+        TestSourceModel newLeftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_1" }}
+        });
+
+        TestSourceModel newRightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Changing left model is not supported!");
+        model.setLeftModel(&newLeftModel);
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Changing right model is not supported!");
+        model.setRightModel(&newRightModel);
+    }
+
+    void modelsDeletedAfterInitializationTest()
+    {
+        auto leftModel = std::make_unique<TestSourceModel>(
+                    QList<QPair<QString, QVariantList>>{
+                        { "title", { "Token 1", "Token 2", "Token 3"}},
+                        { "communityId", { "community_1", "community_2", "community_1" }}
+                    });
+
+        auto rightModel = std::make_unique<TestSourceModel>(
+                    QList<QPair<QString, QVariantList>>{
+                        { "name", { "Community 1", "Community 2" }},
+                        { "communityId", { "community_1", "community_2" }}
+                    });
+
+        LeftJoinModel model;
+        model.setLeftModel(leftModel.get());
+        model.setRightModel(rightModel.get());
+
+        model.setJoinRole("communityId");
+
+        leftModel.reset();
+        rightModel.reset();
+
+        QHash<int, QByteArray> roles{{0, "title" }, {1, "communityId"}, {2, "name"}};
+        QCOMPARE(model.roleNames(), roles);
+        QCOMPARE(model.rowCount(), 0);
+        QCOMPARE(model.data(model.index(0, 0), 0), {});
+        QCOMPARE(model.data(model.index(0, 0), 2), {});
+
+        TestSourceModel newLeftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_1" }}
+        });
+
+        TestSourceModel newRightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Changing left model is not supported!");
+        model.setLeftModel(&newLeftModel);
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Changing right model is not supported!");
+        model.setRightModel(&newRightModel);
+    }
+
+    void rightModelDeletedAfterInitializationTest()
+    {
+        auto leftModel = std::make_unique<TestSourceModel>(
+                    QList<QPair<QString, QVariantList>>{
+                        { "title", { "Token 1", "Token 2", "Token 3"}},
+                        { "communityId", { "community_1", "community_2", "community_1" }}
+                    });
+
+        auto rightModel = std::make_unique<TestSourceModel>(
+                    QList<QPair<QString, QVariantList>>{
+                        { "name", { "Community 1", "Community 2" }},
+                        { "communityId", { "community_1", "community_2" }}
+                    });
+
+        LeftJoinModel model;
+        model.setLeftModel(leftModel.get());
+        model.setRightModel(rightModel.get());
+
+        model.setJoinRole("communityId");
+
+        rightModel.reset();
+
+        QHash<int, QByteArray> roles{{0, "title" }, {1, "communityId"}, {2, "name"}};
+        QCOMPARE(model.roleNames(), roles);
+        QCOMPARE(model.rowCount(), 3);
+        QCOMPARE(model.data(model.index(0, 0), 0), "Token 1");
+        QCOMPARE(model.data(model.index(0, 0), 1), "community_1");
+        QCOMPARE(model.data(model.index(0, 0), 2), {});
+
+        TestSourceModel newLeftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_1" }}
+        });
+
+        TestSourceModel newRightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }}
+        });
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Changing left model is not supported!");
+        model.setLeftModel(&newLeftModel);
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "Changing right model is not supported!");
+        model.setRightModel(&newRightModel);
+    }
+};
+
+QTEST_MAIN(TestLeftJoinModel)
+#include "tst_LeftJoinModel.moc"

--- a/ui/StatusQ/tests/tst_RolesRenamingModel.cpp
+++ b/ui/StatusQ/tests/tst_RolesRenamingModel.cpp
@@ -1,0 +1,212 @@
+#include <QSignalSpy>
+#include <QTest>
+
+#include <memory>
+
+#include <StatusQ/rolesrenamingmodel.h>
+
+namespace {
+
+class TestSourceModel : public QAbstractListModel {
+
+public:
+    explicit TestSourceModel(QList<QString> roles)
+        : m_roles(std::move(roles))
+    {
+    }
+
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if(!index.isValid() || index.row() >= capacity)
+            return {};
+
+        return 42;
+    }
+
+    int rowCount(const QModelIndex& parent) const override
+    {
+        return capacity;
+    }
+
+    QHash<int, QByteArray> roleNames() const override
+    {
+        QHash<int, QByteArray> roles;
+        roles.remove(m_roles.size());
+
+        for (auto i = 0; i < m_roles.size(); i++)
+            roles.insert(i, m_roles.at(i).toUtf8());
+
+        return roles;
+    }
+
+private:
+    static constexpr auto capacity = 5;
+    QList<QString> m_roles;
+};
+
+}
+
+class TestRolesRenamingModel: public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initializationTest()
+    {
+        RolesRenamingModel model;
+
+        QQmlListProperty<RoleRename> mapping = model.mapping();
+
+        RoleRename rename;
+        rename.setFrom("someIdFrom");
+        rename.setTo("someIdTo");
+
+        mapping.append(&mapping, &rename);
+
+        QTest::ignoreMessage(QtWarningMsg, "RolesRenamingModel: specified source roles not found: (\"someIdFrom\")!");
+
+        QCOMPARE(model.roleNames(), {});
+    }
+
+    void remappingTest()
+    {
+        TestSourceModel sourceModel({"id", "name", "color"});
+        RolesRenamingModel model;
+
+        QQmlListProperty<RoleRename> mapping = model.mapping();
+
+        RoleRename rename_1;
+        rename_1.setFrom("id");
+        rename_1.setTo("tokenId");
+        mapping.append(&mapping, &rename_1);
+
+        RoleRename rename_2;
+        rename_2.setFrom("name");
+        rename_2.setTo("tokenName");
+        mapping.append(&mapping, &rename_2);
+
+        model.setSourceModel(&sourceModel);
+
+        QHash<int, QByteArray> expectedRoles = {{0, "tokenId"}, {1, "tokenName"}, {2, "color"}};
+        QCOMPARE(model.roleNames(), expectedRoles);
+    }
+
+    void addMappingAfterFetchingRoleNamesTest()
+    {
+        TestSourceModel sourceModel({"id", "name", "color"});
+        RolesRenamingModel model;
+
+        QQmlListProperty<RoleRename> mapping = model.mapping();
+
+        RoleRename rename_1;
+        rename_1.setFrom("id");
+        rename_1.setTo("tokenId");
+        mapping.append(&mapping, &rename_1);
+
+        model.setSourceModel(&sourceModel);
+
+        QHash<int, QByteArray> expectedRoles = {{0, "tokenId"}, {1, "name"}, {2, "color"}};
+        QCOMPARE(model.roleNames(), expectedRoles);
+
+        RoleRename rename_2;
+        rename_2.setFrom("name");
+        rename_2.setTo("tokenName");
+
+        QTest::ignoreMessage(QtWarningMsg, "RolesRenamingModel: role names mapping cannot be modified after fetching role names!");
+        mapping.append(&mapping, &rename_2);
+
+        QCOMPARE(model.roleNames(), expectedRoles);
+    }
+
+    void duplicatedNamesTest()
+    {
+        TestSourceModel sourceModel({"id", "name", "color"});
+        RolesRenamingModel model;
+
+        QQmlListProperty<RoleRename> mapping = model.mapping();
+
+        RoleRename rename_1;
+        rename_1.setFrom("id");
+        rename_1.setTo("name");
+        mapping.append(&mapping, &rename_1);
+
+        model.setSourceModel(&sourceModel);
+
+        QTest::ignoreMessage(QtWarningMsg, "RolesRenamingModel: model cannot contain duplicated role names!");
+
+        QCOMPARE(model.roleNames(), {});
+    }
+
+    void resettingFromToPropertiesTest()
+    {
+        RoleRename rename;
+
+        rename.setFrom("id");
+        QCOMPARE(rename.from(), "id");
+        QCOMPARE(rename.to(), "");
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             "RoleRename: property \"from\" is inteded to be initialized once and not changed!");
+        rename.setFrom("id2");
+        QCOMPARE(rename.from(), "id");
+        QCOMPARE(rename.to(), "");
+
+        rename.setTo("myId");
+        QCOMPARE(rename.from(), "id");
+        QCOMPARE(rename.to(), "myId");
+
+        QTest::ignoreMessage(QtWarningMsg, "RoleRename: property \"to\" is inteded to be initialized once and not changed!");
+        rename.setTo("myId2");
+        QCOMPARE(rename.from(), "id");
+        QCOMPARE(rename.to(), "myId");
+    }
+
+    void sourceModelDeletedTest()
+    {
+        auto sourceModel = std::make_unique<TestSourceModel>(
+                    QList<QString>{"id", "name", "color"});
+        RolesRenamingModel model;
+
+        QQmlListProperty<RoleRename> mapping = model.mapping();
+
+        RoleRename rename_1;
+        rename_1.setFrom("id");
+        rename_1.setTo("tokenId");
+        mapping.append(&mapping, &rename_1);
+
+        RoleRename rename_2;
+        rename_2.setFrom("name");
+        rename_2.setTo("tokenName");
+        mapping.append(&mapping, &rename_2);
+
+        model.setSourceModel(sourceModel.get());
+
+        QHash<int, QByteArray> expectedRoles = {
+            {0, "tokenId"}, {1, "tokenName"}, {2, "color"}
+        };
+        QCOMPARE(model.roleNames(), expectedRoles);
+        QCOMPARE(model.rowCount(), 5);
+
+        QCOMPARE(model.data(model.index(0, 0), 0), 42);
+        QCOMPARE(model.data(model.index(0, 0), 1), 42);
+        QCOMPARE(model.data(model.index(5, 0), 0), {});
+        QCOMPARE(model.data(model.index(5, 0), 1), {});
+
+        QSignalSpy destroyedSpy(sourceModel.get(), &QObject::destroyed);
+        sourceModel.reset();
+
+        QCOMPARE(destroyedSpy.size(), 1);
+
+        QCOMPARE(model.roleNames(), {});
+        QCOMPARE(model.rowCount(), 0);
+
+        QCOMPARE(model.roleNames(), {});
+        QCOMPARE(model.data(model.index(0, 0), 0), {});
+        QCOMPARE(model.data(model.index(0, 0), 1), {});
+        QCOMPARE(model.data(model.index(5, 0), 0), {});
+        QCOMPARE(model.data(model.index(5, 0), 1), {});
+    }
+};
+
+QTEST_MAIN(TestRolesRenamingModel)
+#include "tst_RolesRenamingModel.moc"

--- a/ui/StatusQ/tests/tst_RolesRenamingModel.cpp
+++ b/ui/StatusQ/tests/tst_RolesRenamingModel.cpp
@@ -51,8 +51,9 @@ class TestRolesRenamingModel: public QObject
     Q_OBJECT
 
 private slots:
-    void initializationTest()
+    void initializationWithBrokenMappingTest()
     {
+        TestSourceModel sourceModel({"id", "name", "color"});
         RolesRenamingModel model;
 
         QQmlListProperty<RoleRename> mapping = model.mapping();
@@ -63,9 +64,16 @@ private slots:
 
         mapping.append(&mapping, &rename);
 
-        QTest::ignoreMessage(QtWarningMsg, "RolesRenamingModel: specified source roles not found: (\"someIdFrom\")!");
+        model.setSourceModel(&sourceModel);
 
-        QCOMPARE(model.roleNames(), {});
+        QTest::ignoreMessage(QtWarningMsg,
+                             "RolesRenamingModel: specified source roles not "
+                             "found: (\"someIdFrom\")!");
+
+        QHash<int, QByteArray> expectedRoles = {
+            {0, "id"}, {1, "name"}, {2, "color"}
+        };
+        QCOMPARE(model.roleNames(), expectedRoles);
     }
 
     void remappingTest()
@@ -87,7 +95,9 @@ private slots:
 
         model.setSourceModel(&sourceModel);
 
-        QHash<int, QByteArray> expectedRoles = {{0, "tokenId"}, {1, "tokenName"}, {2, "color"}};
+        QHash<int, QByteArray> expectedRoles = {
+            {0, "tokenId"}, {1, "tokenName"}, {2, "color"}
+        };
         QCOMPARE(model.roleNames(), expectedRoles);
     }
 
@@ -105,14 +115,18 @@ private slots:
 
         model.setSourceModel(&sourceModel);
 
-        QHash<int, QByteArray> expectedRoles = {{0, "tokenId"}, {1, "name"}, {2, "color"}};
+        QHash<int, QByteArray> expectedRoles = {
+            {0, "tokenId"}, {1, "name"}, {2, "color"}
+        };
         QCOMPARE(model.roleNames(), expectedRoles);
 
         RoleRename rename_2;
         rename_2.setFrom("name");
         rename_2.setTo("tokenName");
 
-        QTest::ignoreMessage(QtWarningMsg, "RolesRenamingModel: role names mapping cannot be modified after fetching role names!");
+        QTest::ignoreMessage(QtWarningMsg,
+                             "RolesRenamingModel: role names mapping cannot be "
+                             "modified after fetching role names!");
         mapping.append(&mapping, &rename_2);
 
         QCOMPARE(model.roleNames(), expectedRoles);
@@ -132,7 +146,9 @@ private slots:
 
         model.setSourceModel(&sourceModel);
 
-        QTest::ignoreMessage(QtWarningMsg, "RolesRenamingModel: model cannot contain duplicated role names!");
+        QTest::ignoreMessage(QtWarningMsg,
+                             "RolesRenamingModel: model cannot contain "
+                             "duplicated role names!");
 
         QCOMPARE(model.roleNames(), {});
     }
@@ -146,7 +162,8 @@ private slots:
         QCOMPARE(rename.to(), "");
 
         QTest::ignoreMessage(QtWarningMsg,
-                             "RoleRename: property \"from\" is inteded to be initialized once and not changed!");
+                             "RoleRename: property \"from\" is intended to be "
+                             "initialized once and not changed!");
         rename.setFrom("id2");
         QCOMPARE(rename.from(), "id");
         QCOMPARE(rename.to(), "");
@@ -155,7 +172,9 @@ private slots:
         QCOMPARE(rename.from(), "id");
         QCOMPARE(rename.to(), "myId");
 
-        QTest::ignoreMessage(QtWarningMsg, "RoleRename: property \"to\" is inteded to be initialized once and not changed!");
+        QTest::ignoreMessage(QtWarningMsg,
+                             "RoleRename: property \"to\" is intended to be "
+                             "initialized once and not changed!");
         rename.setTo("myId2");
         QCOMPARE(rename.from(), "id");
         QCOMPARE(rename.to(), "myId");


### PR DESCRIPTION
### What does the PR do

It introduces two generic proxy models:
1. `RolesRenamingModel` - it allows to change role names of existing model.
2. `LeftJoinModel` - this proxy takes two source models as an input (`rightMode` and `leftModel`). The idea is to mimic SQL's left join but in a dynamic way.

When joining two models via `LeftJoinModel` it may be needed to change role names to avoid conflicts (same names in both models) and adjust role names to meet expectations of the view. Because of that need `RolesRenamingModel` has been introduces as a complementary proxy model for `LeftJoinModel`.

Closes: https://github.com/status-im/status-desktop/issues/12502

### Affected areas
`StatusQ`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00051.webm](https://github.com/status-im/status-desktop/assets/20650004/2d5cdd36-6954-4433-a2a4-4633d9869001)
