### PR TITLE
fix(ci): use linux.bundle() to add credentials

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -100,7 +100,7 @@ pipeline {
         GANACHE_NETWORK_RPC_URL = "http://localhost:${env.GANACHE_RPC_PORT}"
       }
       steps { script {
-        sh 'make nim_status_client'
+        linux.bundle('nim_status_client')
       } }
     }
 


### PR DESCRIPTION
Otherwise none of these credentials are present:
https://github.com/status-im/status-jenkins-lib/blob/master/vars/linux.groovy