### PR TITLE
fix(@wallet): sending big number

### DIFF
--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -61,7 +61,8 @@ QtObject {
     }
 
     function suggestedRoutes(amount) {
-        walletSectionSendInst.suggestedRoutes(amount)
+        const value = AmountsArithmetic.fromNumber(amount)
+        walletSectionSendInst.suggestedRoutes(value.toFixed())
     }
 
     function resolveENS(value) {


### PR DESCRIPTION
fixes #12497

JS format long string with scientific notation. This is prevented by big.js toFixed
Also we only send integer so tofixed is fine