### PR TITLE
fix(@desktop/wallet): Prevent nil conversion to qvariant

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -119,6 +119,7 @@ QtObject:
       return currencyAmountToItem(self.currencyService.parseCurrencyValue(symbol, amount),
                                     self.currencyService.getCurrencyFormat(symbol))
 
+    self.activityDetails = nil
     let entry = self.model.getEntry(entryIndex)
     if entry == nil:
       error "failed to find entry with index: ", entryIndex
@@ -127,11 +128,12 @@ QtObject:
     try:
       self.activityDetails = newActivityDetails(entry.getMetadata(), amountToCurrencyConvertor)
     except Exception as e:
-      let errDescription = e.msg
-      error "error: ", errDescription
+      error "error: ", e.msg
       return
 
   proc getActivityDetails(self: Controller): QVariant {.slot.} =
+    if self.activityDetails == nil:
+      return newQVariant()
     return newQVariant(self.activityDetails)
 
   QtProperty[QVariant] activityDetails:

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -467,7 +467,7 @@ Item {
                             Layout.fillHeight: true
                             Layout.fillWidth: true
                             title: qsTr("Token format")
-                            subTitle: root.isTransactionValid ? d.details.tokenType.toUpperCase() : ""
+                            subTitle: d.isDetailsValid ? d.details.tokenType.toUpperCase() : ""
                             visible: !!subTitle
                         }
                         TransactionDataTile {

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -52,7 +52,7 @@ StatusListItem {
     readonly property int transactionStatus: isModelDataValid ? modelData.status : Constants.TransactionStatus.Pending
     readonly property bool isMultiTransaction: isModelDataValid && modelData.isMultiTransaction
     readonly property string currentCurrency: rootStore.currentCurrency
-    readonly property double cryptoValue: isModelDataValid && !isMultiTransaction ? modelData.amount : 0.0
+    readonly property double cryptoValue: isModelDataValid ? modelData.amount : 0.0
     readonly property double fiatValue: isModelDataValid && !isMultiTransaction ? rootStore.getFiatValue(cryptoValue, modelData.symbol, currentCurrency) : 0.0
     readonly property double inCryptoValue: isModelDataValid ? modelData.inAmount : 0.0
     readonly property double inFiatValue: isModelDataValid && isMultiTransaction ? rootStore.getFiatValue(inCryptoValue, modelData.inSymbol, currentCurrency): 0.0


### PR DESCRIPTION
fixes #12498

### What does the PR do

* Crash on clicking sent Bridge. It was caused  by failed fetch details and further conversion nil to QVariant.
* Fixed 0 amount for multi tx send (send from Status desktop)

### Affected areas

Wallet / activity

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/8a2a65cf-d50f-479d-a6dc-3bcfe74c312f)

![image](https://github.com/status-im/status-desktop/assets/11396062/dbef05a4-4ecf-4627-8bbf-dc655d8b90b7)

