### PR TITLE
fix(LinkPreviews): Fix link preview settings

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -238,14 +238,10 @@ proc loadLinkPreviews*(self: Controller, urls: seq[string]) =
     self.messageService.asyncUnfurlUrls(urls)
 
 proc setLinkPreviewEnabled*(self: Controller, enabled: bool) =
-  if enabled and self.settingsService.saveUrlUnfurlingMode(UrlUnfurlingMode.Enabled):
-    self.linkPreviewPersistentSetting = UrlUnfurlingMode.Enabled
-    self.linkPreviewCurrentMessageSetting = UrlUnfurlingMode.Enabled
-  elif not enabled and self.settingsService.saveUrlUnfurlingMode(UrlUnfurlingMode.Disabled):
-    self.linkPreviewPersistentSetting = UrlUnfurlingMode.Disabled
-    self.linkPreviewCurrentMessageSetting = UrlUnfurlingMode.Disabled
-
-  self.delegate.setAskToEnableLinkPreview(false)
+  if enabled:
+    discard self.settingsService.saveUrlUnfurlingMode(UrlUnfurlingMode.Enabled)
+    return
+  discard self.settingsService.saveUrlUnfurlingMode(UrlUnfurlingMode.Disabled)
 
 proc onUnfurlingModeChanged(self: Controller, value: UrlUnfurlingMode) =
   self.linkPreviewPersistentSetting = value

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -248,13 +248,9 @@ QtObject:
   
   proc enableLinkPreview(self: View) {.slot.} =
     self.delegate.setLinkPreviewEnabled(true)
-    let links = self.linkPreviewModel.getLinks()
-    self.linkPreviewModel.clearItems()
-    self.loadLinkPreviews(links)
   
   proc disableLinkPreview(self: View) {.slot.} =
     self.delegate.setLinkPreviewEnabled(false)
-    self.linkPreviewModel.removeAllPreviewData()
   
   proc setLinkPreviewEnabledForCurrentMessage(self: View, enabled: bool) {.slot.} =
     self.delegate.setLinkPreviewEnabledForThisMessage(enabled)


### PR DESCRIPTION
### What does the PR do

Removing link preview settings leftovers after resolving conflicts.

The link preview settings change is event based. The previous logic needs to be removed.