### PR TITLE
fix `ImportCommunityPopup` issues, remove private key importing

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -85,7 +85,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_COMMUNITY_LOAD_DATA_FAILED) do(e: Args):
     let args = CommunityArgs(e)
-    self.delegate.onImportCommunityErrorOccured(args.communityId, args.error)
+    self.delegate.communityInfoRequestFailed(args.communityId, args.error)
 
   self.events.on(SIGNAL_COMMUNITY_INFO_ALREADY_REQUESTED) do(e: Args):
     self.delegate.communityInfoAlreadyRequested()

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -108,6 +108,9 @@ method communityImported*(self: AccessInterface, community: CommunityDto) {.base
 method communityDataImported*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityInfoRequestFailed*(self: AccessInterface, communityId: string, errorMsg: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onImportCommunityErrorOccured*(self: AccessInterface, communityId: string, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -346,6 +346,10 @@ method communityImported*(self: Module, community: CommunityDto) =
 
 method communityDataImported*(self: Module, community: CommunityDto) = 
   self.view.addItem(self.getCommunityItem(community))
+  self.view.emitCommunityInfoRequestCompleted(community.id, "")
+
+method communityInfoRequestFailed*(self: Module, communityId: string, errorMsg: string) =
+  self.view.emitCommunityInfoRequestCompleted(communityId, errorMsg)
 
 method importCommunity*(self: Module, communityId: string) =
   self.view.emitImportingCommunityStateChangedSignal(communityId, ImportCommunityState.ImportingInProgress.int, errorMsg = "")

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -546,6 +546,10 @@ QtObject:
   proc emitImportingCommunityStateChangedSignal*(self: View, communityId: string, state: int, errorMsg: string) =
     self.importingCommunityStateChanged(communityId, state, errorMsg)
 
+  proc communityInfoRequestCompleted*(self: View, communityId: string, errorMsg: string) {.signal.}
+  proc emitCommunityInfoRequestCompleted*(self: View, communityId: string, errorMsg: string) =
+    self.communityInfoRequestCompleted(communityId, errorMsg)
+
   proc isMemberOfCommunity*(self: View, communityId: string, pubKey: string): bool {.slot.} =
     let sectionItem = self.model.getItemById(communityId)
     if (section_item.id == ""):

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -141,6 +141,20 @@ ApplicationWindow {
                     }
 
                     CheckBox {
+                        id: windowAlwaysOnTopCheckBox
+
+                        Layout.fillWidth: true
+
+                        text: "Always on top"
+                        onCheckedChanged: {
+                            if (checked)
+                                root.flags |= Qt.WindowStaysOnTopHint
+                            else
+                                root.flags &= ~Qt.WindowStaysOnTopHint
+                        }
+                    }
+
+                    CheckBox {
                         id: darkModeCheckBox
 
                         Layout.fillWidth: true
@@ -346,6 +360,7 @@ Tips:
         property alias darkMode: darkModeCheckBox.checked
         property alias hotReloading: hotReloaderControls.enabled
         property alias figmaToken: settingsLayout.figmaToken
+        property alias windowAlwaysOnTop: windowAlwaysOnTopCheckBox.checked
     }
 
     Shortcut {

--- a/storybook/pages/ImportCommunityPopupPage.qml
+++ b/storybook/pages/ImportCommunityPopupPage.qml
@@ -1,0 +1,328 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Communities.popups 1.0
+
+import utils 1.0
+import shared.popups 1.0
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    orientation: Qt.Vertical
+
+    QtObject {
+        id: d
+
+        readonly property alias dialog: loader.item
+
+        property bool utilsReady: false
+
+        readonly property string newCommunityLink: "https://status.app/c/Cw6AChsKBnlveW95bxIGeW95b3lvGAEiByM4OEIwRkYD#zQ3shwHXstcword5gUtJCWVi55ZxPsdtfTQitnWNEAR1p3Gzd"
+        readonly property string newCommunityPublicKey: "0x03f751777ab35759f98ad241150f4329b9cc13aa42052ef64d16e9d474b9677bea"
+        readonly property string newCommunityCompressedPublicKey: "zQ3shwHXstcword5gUtJCWVi55ZxPsdtfTQitnWNEAR1p3Gzd"
+
+        readonly property var newCommunityDetails: QtObject {
+            readonly property string id: "0x039c47e9837a1a7dcd00a6516399d0eb521ab0a92d512ca20a44ac6278bfdbb5c5"
+            readonly property string name: "test-1"
+            readonly property int memberRole: 0
+            readonly property bool isControlNode: false
+            readonly property string description: "test"
+            readonly property string introMessage: "123"
+            readonly property string outroMessage: "342"
+            readonly property string image: ModelsData.icons.superRare
+            readonly property string bannerImageData: ModelsData.banners.superRare
+            readonly property string icon: ""
+            readonly property string color: "#4360DF"
+            readonly property string tags: "null"
+            readonly property bool hasNotification: false
+            readonly property int notificationsCount: 0
+            readonly property bool active: false
+            readonly property bool enabled: true
+            readonly property bool joined: false
+            readonly property bool spectated: false
+            readonly property bool canJoin: true
+            readonly property bool canManageUsers: false
+            readonly property bool canRequestAccess: false
+            readonly property bool isMember: false
+            readonly property bool amIBanned: false
+            readonly property int access: 1
+            readonly property bool ensOnly: false
+            readonly property int nbMembers: 42
+            readonly property bool encrypted: false
+        }
+
+        readonly property string knownCommunityLink: "https://status.app/c/CwyAChcKBHRlc3QSBHRlc3QYAiIHIzQzNjBERgM=#zQ3shqAAKxRroS2BE4FgLjjombivfU7XgeNqVFj1eRZ4GHuAU"
+        readonly property string knownCommunityPublicKey: "0x03c892238f64e9b74cefbaaaf5d557fee401a20d6fb52da126de45755b2a2b8166"
+        readonly property string knownCommunityCompressedPublicKey: "zQ3shqAAKxRroS2BE4FgLjjombivfU7XgeNqVFj1eRZ4GHuAU"
+
+        readonly property var knownCommunityDetails: QtObject {
+            readonly property string id: "0x03c892238f64e9b74cefbaaaf5d557fee401a20d6fb52da126de45755b2a2b8166"
+            readonly property string name: "test-2"
+            readonly property int memberRole: 0
+            readonly property bool isControlNode: false
+            readonly property string description: "test"
+            readonly property string introMessage: "123"
+            readonly property string outroMessage: "342"
+            readonly property string image: ModelsData.icons.status
+            readonly property string bannerImageData: ModelsData.banners.status
+            readonly property string icon: ""
+            readonly property string color: "#4360DF"
+            readonly property string tags: "null"
+            readonly property bool hasNotification: false
+            readonly property int notificationsCount: 0
+            readonly property bool active: false
+            readonly property bool enabled: true
+            readonly property bool joined: false
+            readonly property bool spectated: false
+            readonly property bool canJoin: true
+            readonly property bool canManageUsers: false
+            readonly property bool canRequestAccess: false
+            readonly property bool isMember: false
+            readonly property bool amIBanned: false
+            readonly property int access: 1
+            readonly property bool ensOnly: false
+            readonly property int nbMembers: 15
+            readonly property bool encrypted: false
+        }
+
+        property bool currenKeyIsPublic: false
+        property string currentKey: ""
+    }
+
+    QtObject {
+        id: communityStoreMock
+
+        property bool newCommunityFetched: false
+
+        signal communityInfoRequestCompleted(string communityId, string errorMsg)
+
+        function getCommunityDetails(publicKey, importing, requestWhenNotFound) {
+            if (publicKey === d.knownCommunityPublicKey) {
+                return d.knownCommunityDetails
+            }
+            if (publicKey === d.newCommunityPublicKey && newCommunityFetched)
+                return d.newCommunityDetails
+            return null
+        }
+
+        function requestCommunityInfo(communityId) {
+            // Dynamically create a timer to be able to simulate overlapping requests
+            let timer = Qt.createQmlObject("import QtQuick 2.0; Timer {}", root)
+            timer.interval = 1000
+            timer.repeat = false
+            timer.triggered.connect(() => {
+                const communityFound = (communityId === d.knownCommunityPublicKey || communityId === d.newCommunityPublicKey)
+                const error = communityFound ? "" : "communtiy not found"
+                if (communityId === d.newCommunityPublicKey) {
+                    newCommunityFetched = true
+                }
+                communityStoreMock.communityInfoRequestCompleted(communityId, error)
+            })
+            timer.start()
+        }
+    }
+    QtObject {
+        id: utilsMock
+
+        function getContactDetailsAsJson(arg1, arg2) {
+            return JSON.stringify({
+                displayName: "Mock user",
+                displayIcon: Style.png("tokens/AST"),
+                publicKey: 123456789,
+                name: "",
+                ensVerified: false,
+                alias: "",
+                lastUpdated: 0,
+                lastUpdatedLocally: 0,
+                localNickname: "",
+                thumbnailImage: "",
+                largeImage: "",
+                isContact: false,
+                isAdded: false,
+                isBlocked: false,
+                requestReceived: false,
+                isSyncing: false,
+                removed: false,
+                trustStatus: Constants.trustStatus.unknown,
+                verificationStatus: Constants.verificationStatus.unverified,
+                incomingVerificationStatus: Constants.verificationStatus.unverified
+            })
+        }
+
+        function isCompressedPubKey(key) {
+            return d.dialog.text === d.knownCommunityCompressedPublicKey ||
+                    d.dialog.text === d.newCommunityCompressedPublicKey
+        }
+
+        function changeCommunityKeyCompression(key) {
+            if (key === d.knownCommunityCompressedPublicKey)
+                return d.knownCommunityPublicKey
+            if (key === d.newCommunityCompressedPublicKey)
+                return d.newCommunityPublicKey
+            if (key === d.knownCommunityPublicKey)
+                return d.knownCommunityCompressedPublicKey
+            if (key === d.newCommunityPublicKey)
+                return d.newCommunityCompressedPublicKey
+            return ""
+        }
+
+        function getCommunityDataFromSharedLink(link) {
+            return d.knownCommunityDetails
+        }
+
+        function getCompressedPk(publicKey) {
+            return d.knownCommunityCompressedPublicKey
+        }
+
+        signal importingCommunityStateChanged(string communityId, int state, string errorMsg)
+
+        // sharedUrlsModuleInst
+
+        function parseCommunitySharedUrl(link) {
+            if (link === d.knownCommunityLink)
+                return JSON.stringify({ communityId: d.knownCommunityPublicKey })
+            if (link === d.newCommunityLink)
+                return JSON.stringify({ communityId: d.newCommunityPublicKey })
+            return null
+        }
+
+        Component.onCompleted: {
+            Utils.sharedUrlsModuleInst = this
+            Utils.globalUtilsInst = this
+            d.utilsReady = true
+        }
+        Component.onDestruction: {
+            d.utilsReady = false
+            Utils.sharedUrlsModuleInst = {}
+            Utils.globalUtilsInst = {}
+        }
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            id: popupBg
+            anchors.fill: parent
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+                onClicked: loader.item.open()
+            }
+        }
+
+        Loader {
+            id: loader
+            active: d.utilsReady
+            anchors.fill: parent
+
+            sourceComponent: ImportCommunityPopup {
+                anchors.centerIn: parent
+                modal: false
+                closePolicy: Popup.NoAutoClose
+                destroyOnClose: false
+
+                store: communityStoreMock
+
+                Component.onCompleted: open()
+
+                onJoinCommunityRequested: (communityId, communityDetails) => {
+                    logs.logEvent("onJoinCommunity", ["communityId", "communityDetails"], communityId, communityDetails)
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        GridLayout {
+            columns: 4
+
+            Button {
+                text: "Reset communities storage"
+                Layout.fillWidth: false
+                Layout.columnSpan: 4
+                Layout.alignment: Qt.AlignRight
+                onClicked: {
+                    communityStoreMock.newCommunityFetched = false
+                    const prevText = d.dialog.text
+                    d.dialog.text = ""
+                    d.dialog.text = prevText
+                }
+            }
+
+            Label {
+                text: "Known community"
+            }
+
+            Button {
+                checked: d.dialog && d.dialog.text === d.knownCommunityLink
+                text: "Link"
+                onClicked: {
+                    d.dialog.text = d.knownCommunityLink
+                }
+            }
+
+            Button {
+                checked: d.dialog && d.dialog.text === d.knownCommunityPublicKey
+                text: "Public key"
+                onClicked: {
+                    d.dialog.text = d.knownCommunityPublicKey
+                }
+            }
+
+            Button {
+                checked: d.dialog && d.dialog.text === d.knownCommunityCompressedPublicKey
+                text: "Compressed public key"
+                onClicked: {
+                    d.dialog.text = d.knownCommunityCompressedPublicKey
+                }
+            }
+
+            Label {
+                text: "Never fetched community"
+            }
+
+            Button {
+                checked: d.dialog && d.dialog.text === d.newCommunityLink
+                text: "Link"
+                onClicked: {
+                    d.dialog.text = d.newCommunityLink
+                }
+            }
+
+            Button {
+                checked: d.dialog && d.dialog.text === d.newCommunityPublicKey
+                text: "Public key"
+                onClicked: {
+                    d.dialog.text = d.newCommunityPublicKey
+                }
+            }
+
+            Button {
+                checked: d.dialog && d.dialog.text === d.newCommunityCompressedPublicKey
+                text: "Compressed public key"
+                onClicked: {
+                    d.dialog.text = d.newCommunityCompressedPublicKey
+                }
+            }
+
+        }
+    }
+}
+
+// category: Popups

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -62,6 +62,8 @@ QtObject {
 
     signal communityInfoAlreadyRequested()
 
+    signal communityInfoRequestCompleted(string communityId, string errorMsg)
+
     function createCommunity(args = {
                                 name: "",
                                 description: "",
@@ -120,19 +122,14 @@ QtObject {
         root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey);
     }
 
-    function getCommunityDetails(communityId, importing = false) {
+    function getCommunityDetails(communityId) {
         const publicKey = Utils.isCompressedPubKey(communityId)
                             ? Utils.changeCommunityKeyCompression(communityId)
                             : communityId
         try {
             const communityJson = root.communitiesList.getSectionByIdJson(publicKey)
-
-            if (!communityJson) {
-                root.requestCommunityInfo(publicKey, importing)
-                return null
-            }
-
-            return JSON.parse(communityJson);
+            if (!!communityJson)
+                return JSON.parse(communityJson)
         } catch (e) {
             console.error("Error parsing community", e)
         }
@@ -250,6 +247,10 @@ QtObject {
 
         function onCommunityInfoAlreadyRequested() {
           root.communityInfoAlreadyRequested()
+        }
+
+        function onCommunityInfoRequestCompleted(communityId, erorrMsg) {
+            root.communityInfoRequestCompleted(communityId, erorrMsg)
         }
     }
 }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -504,7 +504,7 @@ QtObject {
             id: importCommunitiesPopupComponent
             ImportCommunityPopup {
                 store: root.communitiesStore
-                onJoinCommunity: {
+                onJoinCommunityRequested: {
                     close()
                     openCommunityIntroPopup(communityId,
                                             communityDetails.name,

--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -28,7 +28,7 @@ StatusDialog {
         id: d
         property string importErrorMessage
 
-        property bool communityFound: !!d.communityDetails && !!d.communityDetails.name
+        readonly property bool communityFound: !!d.communityDetails && !!d.communityDetails.name
         property var communityDetails: null
 
         property var requestedCommunityDetails: null
@@ -79,12 +79,6 @@ StatusDialog {
         }
     }
 
-    Timer {
-        interval: 20000  // 20s
-        onTriggered: {
-        }
-    }
-
     Connections {
         target: root.store
 
@@ -95,7 +89,7 @@ StatusDialog {
             d.communityInfoRequested = false
 
             if (errorMsg !== "") {
-                d.importErrorMessage = "Couldn't find community"
+                d.importErrorMessage = qsTr("Couldn't find community")
                 return
             }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12465
Fixes https://github.com/status-im/status-desktop/issues/12542
Drops the usage of `parseCommunitySharedUrl` (https://github.com/status-im/status-desktop/issues/12356)

### What does the PR do

1. Correctly show result of `requestCommunityInfo` call
2. Remove QML timeout, trust status-go timeout instead
3. Remove support for private key importing
4. Remove automatic call for `reuestCommunityInfo` from `getCommunityDetails`. 
Because the former returns nothing and requires binding to nim signals.
5. Update status-go to include https://github.com/status-im/status-go/pull/4194
6. storybook page for `ImportCommunityPopup`

### Affected areas

ImportCommunityPopup

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/acc37804-a043-4652-abfc-25ed68f2c286

https://github.com/status-im/status-desktop/assets/25482501/28e61e4a-5c6d-4221-a881-32afeb1f2ba7
