### PR TITLE
feat(ci): trigger E2E from meta build for releases

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -8,7 +8,7 @@ pipeline {
     timestamps()
     disableConcurrentBuilds()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 60, unit: 'MINUTES')
+    timeout(time: 90, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
       numToKeepStr: '30',
@@ -28,20 +28,30 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-        stage('Linux/E2E') { steps { script {
-          linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e')
-        } } }
         stage('Linux/x86_64') { steps { script {
-          linux_x86_64 = jenkins.Build('status-desktop/systems/linux/x86_64/package')
+          linux_x86_64 =   jenkins.Build('status-desktop/systems/linux/x86_64/package')
         } } }
         stage('Windows/x86_64') { steps { script {
           windows_x86_64 = jenkins.Build('status-desktop/systems/windows/x86_64/package')
         } } }
         stage('MacOS/x86_64') { steps { script {
-          macos_x86_64 = jenkins.Build('status-desktop/systems/macos/x86_64/package')
+          macos_x86_64 =   jenkins.Build('status-desktop/systems/macos/x86_64/package')
         } } }
         stage('MacOS/aarch64') { steps { script {
-          macos_aarch64 = jenkins.Build('status-desktop/systems/macos/aarch64/package')
+          macos_aarch64 =  jenkins.Build('status-desktop/systems/macos/aarch64/package')
+        } } }
+      }
+    }
+    stage('Tests') {
+      parallel {
+        stage('Linux/E2E/old') { steps { script {
+          linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e-old')
+        } } }
+        stage('Linux/E2E/new') { steps { script {
+          linux_e2e = build(
+              job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
+              parameters: jenkins.mapToParams([BUILD_SOURCE: linux_x86_64.fullProjectName]),
+          )
         } } }
       }
     }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -107,10 +107,10 @@ pipeline {
     }
 
     stage('E2E') {
-      when { expression { getE2EBuildType() != null } }
+      when { expression { utils.isPRBuild() } }
       steps { script {
         build(
-          job: "status-desktop/e2e/${getE2EBuildType()}",
+          job: 'status-desktop/e2e/prs',
           parameters: jenkins.mapToParams([BUILD_SOURCE: JOB_NAME]),
           wait: false
         )
@@ -129,14 +129,6 @@ def getArch() {
   for (def arch in ['x86_64', 'aarch64']) {
     if (tokens.contains(arch)) { return arch }
   }
-}
-
-def getE2EBuildType() {
-  if (utils.isPRBuild()) { return 'prs' }
-  def parent = utils.parentOrCurrentBuild()
-  if (parent == null) { return null }
-  if (parent.getFullDisplayName() =~ /nightly/) { return 'nightly' }
-  return null
 }
 
 def getMockedKeycardLibDefault() {


### PR DESCRIPTION
The method of triggering new E2E builds from the Linux build makes sense for PRs, but doesn't make as much sense for nightly or release builds.

By triggering it this way we will see the result as part of the whole build that includes all platforms and all tests.