### PR TITLE
fix(pairing): fix pairing error on too fast login

### DIFF
--- a/src/app_service/service/devices/dto/local_pairing_event.nim
+++ b/src/app_service/service/devices/dto/local_pairing_event.nim
@@ -16,6 +16,7 @@ type
     EventProcessSuccess
     EventProcessError
     EventReceivedKeystoreFiles
+    EventCompletedAndNodeReady
 
 type
   Action* {.pure.} = enum

--- a/src/app_service/service/devices/dto/local_pairing_status.nim
+++ b/src/app_service/service/devices/dto/local_pairing_status.nim
@@ -78,7 +78,7 @@ proc update*(self: LocalPairingStatus, data: LocalPairingEventArgs) =
         self.state = LocalPairingState.Finished
 
   if self.mode == LocalPairingMode.Receiver and
-    data.eventType == EventTransferSuccess:
+    data.eventType == EventCompletedAndNodeReady:
       if self.pairingType == PairingType.AppSync and
         data.action == ActionPairingInstallation or
         self.pairingType == PairingType.KeypairSync:

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -81,7 +81,6 @@ QtObject:
     self.localPairingStatus.update(data)
     self.events.emit(SIGNAL_LOCAL_PAIRING_STATUS_UPDATE, self.localPairingStatus)
 
-
   proc doConnect(self: Service) =
     self.events.on(SignalType.Message.event) do(e:Args):
       let receivedData = MessageSignal(e)
@@ -175,6 +174,12 @@ QtObject:
     let response = responseJson.parseJson
     let errorDescription = response["error"].getStr
     if len(errorDescription) == 0:
+      let data = LocalPairingEventArgs(
+        eventType: EventCompletedAndNodeReady,
+        action: ActionPairingInstallation,
+        accountData: LocalPairingAccountData(),
+        error: "")
+      self.updateLocalPairingStatus(data)
       return
     error "failed to start bootstrapping device", errorDescription
     let data = LocalPairingEventArgs(


### PR DESCRIPTION
Fixes #12550

The problem was that we used the pairing event saying "Finished" to show the Login button, however, when that event is received, the Node hasn't started fully yet, so we might try to login when the accounts are still empty in the cache.

The solution is to use the return from the async task, since that one returns at the very end when the process is over and the node is ready. Obviously, if that returns an error, we still use the error instead.

