### PR TITLE
feat: info msg if owner is not awailable after community ownership change

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -304,10 +304,10 @@ proc init*(self: Controller) =
       if args.communityId == self.sectionId:
        self.delegate.setPermissionsToJoinCheckOngoing(false)
 
-    self.events.on(SIGNAL_CONTROL_NODE_OFFLINE) do(e: Args):
+    self.events.on(SIGNAL_WAITING_ON_NEW_COMMUNITY_OWNER_TO_CONFIRM_REQUEST_TO_REJOIN) do(e: Args):
       let args = CommunityIdArgs(e)
       if args.communityId == self.sectionId:
-        self.delegate.onControlNodeOffline()
+        self.delegate.onWaitingOnNewCommunityOwnerToConfirmRequestToRejoin()
 
     self.events.on(SignalType.Wallet.event, proc(e: Args) =
       var data = WalletSignal(e)
@@ -683,5 +683,5 @@ proc collectCommunityMetricsMessagesTimestamps*(self: Controller, intervals: str
 proc collectCommunityMetricsMessagesCount*(self: Controller, intervals: string) =
   self.communityService.collectCommunityMetricsMessagesCount(self.getMySectionId(), intervals)
 
-proc isCommunityRequestAwaitingAddress*(self: Controller, communityId: string): bool =
-  self.communityService.isCommunityRequestAwaitingAddress(communityId)
+proc waitingOnNewCommunityOwnerToConfirmRequestToRejoin*(self: Controller, communityId: string): bool =
+  self.communityService.waitingOnNewCommunityOwnerToConfirmRequestToRejoin(communityId)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -67,7 +67,7 @@ proc newController*(delegate: io_interface.AccessInterface, sectionId: string, i
   result.walletAccountService = walletAccountService
   result.tokenService = tokenService
   result.communityTokensService = communityTokensService
-  
+
 proc delete*(self: Controller) =
   self.events.disconnect()
 
@@ -303,6 +303,11 @@ proc init*(self: Controller) =
       let args = CheckChannelsPermissionsErrorArgs(e)
       if args.communityId == self.sectionId:
        self.delegate.setPermissionsToJoinCheckOngoing(false)
+
+    self.events.on(SIGNAL_CONTROL_NODE_OFFLINE) do(e: Args):
+      let args = CommunityIdArgs(e)
+      if args.communityId == self.sectionId:
+        self.delegate.onControlNodeOffline()
 
     self.events.on(SignalType.Wallet.event, proc(e: Args) =
       var data = WalletSignal(e)
@@ -677,3 +682,6 @@ proc collectCommunityMetricsMessagesTimestamps*(self: Controller, intervals: str
 
 proc collectCommunityMetricsMessagesCount*(self: Controller, intervals: string) =
   self.communityService.collectCommunityMetricsMessagesCount(self.getMySectionId(), intervals)
+
+proc isCommunityRequestAwaitingAddress*(self: Controller, communityId: string): bool =
+  self.communityService.isCommunityRequestAwaitingAddress(communityId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -406,5 +406,5 @@ method setChannelsPermissionsCheckOngoing*(self: AccessInterface, value: bool) {
 method getChannelsPermissionsCheckOngoing*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onControlNodeOffline*(self: AccessInterface) {.base.} =
+method onWaitingOnNewCommunityOwnerToConfirmRequestToRejoin*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -405,3 +405,6 @@ method setChannelsPermissionsCheckOngoing*(self: AccessInterface, value: bool) {
 
 method getChannelsPermissionsCheckOngoing*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onControlNodeOffline*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -339,6 +339,7 @@ method onChatsLoaded*(
   else:
     let community = self.controller.getMyCommunity()
     self.view.setAmIMember(community.joined)
+    self.view.setIsControlNodeOffline(self.controller.isCommunityRequestAwaitingAddress(community.id))
     self.initCommunityTokenPermissionsModel(channelGroup)
     self.onCommunityCheckAllChannelsPermissionsResponse(channelGroup.channelPermissions)
     self.controller.asyncCheckPermissionsToJoin()
@@ -889,9 +890,12 @@ method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, checkAllCha
 
 method onKickedFromCommunity*(self: Module) =
   self.view.setAmIMember(false)
+  let communityId = self.controller.getMySectionId()
+  self.view.setIsControlNodeOffline(self.controller.isCommunityRequestAwaitingAddress(communityId))
 
 method onJoinedCommunity*(self: Module) =
   self.view.setAmIMember(true)
+  self.view.setIsControlNodeOffline(false)
 
 method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
   self.updateBadgeNotifications(chat, hasUnreadMessages=false, unviewedMentionsCount=0)
@@ -1342,3 +1346,6 @@ method setChannelsPermissionsCheckOngoing*(self: Module, value: bool) =
   for chatId, cModule in self.chatContentModules:
     if self.view.chatsModel().getItemPermissionsRequired(chatId):
       cModule.setPermissionsCheckOngoing(true)
+
+method onControlNodeOffline*(self: Module) =
+  self.view.setIsControlNodeOffline(true)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -339,7 +339,7 @@ method onChatsLoaded*(
   else:
     let community = self.controller.getMyCommunity()
     self.view.setAmIMember(community.joined)
-    self.view.setIsControlNodeOffline(self.controller.isCommunityRequestAwaitingAddress(community.id))
+    self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(self.controller.waitingOnNewCommunityOwnerToConfirmRequestToRejoin(community.id))
     self.initCommunityTokenPermissionsModel(channelGroup)
     self.onCommunityCheckAllChannelsPermissionsResponse(channelGroup.channelPermissions)
     self.controller.asyncCheckPermissionsToJoin()
@@ -891,11 +891,11 @@ method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, checkAllCha
 method onKickedFromCommunity*(self: Module) =
   self.view.setAmIMember(false)
   let communityId = self.controller.getMySectionId()
-  self.view.setIsControlNodeOffline(self.controller.isCommunityRequestAwaitingAddress(communityId))
+  self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(self.controller.waitingOnNewCommunityOwnerToConfirmRequestToRejoin(communityId))
 
 method onJoinedCommunity*(self: Module) =
   self.view.setAmIMember(true)
-  self.view.setIsControlNodeOffline(false)
+  self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(false)
 
 method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
   self.updateBadgeNotifications(chat, hasUnreadMessages=false, unviewedMentionsCount=0)
@@ -1347,5 +1347,5 @@ method setChannelsPermissionsCheckOngoing*(self: Module, value: bool) =
     if self.view.chatsModel().getItemPermissionsRequired(chatId):
       cModule.setPermissionsCheckOngoing(true)
 
-method onControlNodeOffline*(self: Module) =
-  self.view.setIsControlNodeOffline(true)
+method onWaitingOnNewCommunityOwnerToConfirmRequestToRejoin*(self: Module) =
+  self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(true)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -29,6 +29,7 @@ QtObject:
       chatsLoaded: bool
       communityMetrics: string # NOTE: later this should be replaced with QAbstractListModel-based model
       permissionsCheckOngoing: bool
+      isControlNodeOffline: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -67,6 +68,7 @@ QtObject:
     result.requiresTokenPermissionToJoin = false
     result.chatsLoaded = false
     result.communityMetrics = "[]"
+    result.isControlNodeOffline = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -389,6 +391,7 @@ QtObject:
   proc amIMemberChanged*(self: View) {.signal.}
 
   proc setAmIMember*(self: View, value: bool) =
+    writeStackTrace()
     if (value == self.amIMember):
       return
     self.amIMember = value
@@ -446,3 +449,18 @@ QtObject:
       return
     self.permissionsCheckOngoing = value
     self.permissionsCheckOngoingChanged()
+
+  proc getIsControlNodeOffline*(self: View): bool {.slot.} =
+    return self.isControlNodeOffline
+
+  proc isControlNodeOfflineChanged*(self: View) {.signal.}
+
+  proc setIsControlNodeOffline*(self: View, value: bool) =
+    if (value == self.isControlNodeOffline):
+      return
+    self.isControlNodeOffline = value
+    self.isControlNodeOfflineChanged()
+
+  QtProperty[bool] isControlNodeOffline:
+    read = getIsControlNodeOffline
+    notify = isControlNodeOfflineChanged

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -29,7 +29,7 @@ QtObject:
       chatsLoaded: bool
       communityMetrics: string # NOTE: later this should be replaced with QAbstractListModel-based model
       permissionsCheckOngoing: bool
-      isControlNodeOffline: bool
+      isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -68,7 +68,7 @@ QtObject:
     result.requiresTokenPermissionToJoin = false
     result.chatsLoaded = false
     result.communityMetrics = "[]"
-    result.isControlNodeOffline = false
+    result.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -391,7 +391,6 @@ QtObject:
   proc amIMemberChanged*(self: View) {.signal.}
 
   proc setAmIMember*(self: View, value: bool) =
-    writeStackTrace()
     if (value == self.amIMember):
       return
     self.amIMember = value
@@ -450,17 +449,17 @@ QtObject:
     self.permissionsCheckOngoing = value
     self.permissionsCheckOngoingChanged()
 
-  proc getIsControlNodeOffline*(self: View): bool {.slot.} =
-    return self.isControlNodeOffline
+  proc getWaitingOnNewCommunityOwnerToConfirmRequestToRejoin*(self: View): bool {.slot.} =
+    return self.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin
 
-  proc isControlNodeOfflineChanged*(self: View) {.signal.}
+  proc isWaitingOnNewCommunityOwnerToConfirmRequestToRejoinChanged*(self: View) {.signal.}
 
-  proc setIsControlNodeOffline*(self: View, value: bool) =
-    if (value == self.isControlNodeOffline):
+  proc setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin*(self: View, value: bool) =
+    if (value == self.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin):
       return
-    self.isControlNodeOffline = value
-    self.isControlNodeOfflineChanged()
+    self.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin = value
+    self.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoinChanged()
 
-  QtProperty[bool] isControlNodeOffline:
-    read = getIsControlNodeOffline
-    notify = isControlNodeOfflineChanged
+  QtProperty[bool] isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin:
+    read = getWaitingOnNewCommunityOwnerToConfirmRequestToRejoin
+    notify = isWaitingOnNewCommunityOwnerToConfirmRequestToRejoinChanged

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -543,3 +543,4 @@ proc asyncGetRevealedAccountsForAllMembers*(self: Controller, communityId: strin
 
 proc asyncReevaluateCommunityMembersPermissions*(self: Controller, communityId: string) =
   self.communityService.asyncReevaluateCommunityMembersPermissions(communityId)
+  

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1155,12 +1155,13 @@ method onRemoteDestructed*[T](self: Module[T], communityId: string, chainId: int
 method onRequestReevaluateMembersPermissionsIfRequired*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string) =
   let communityDto = self.controller.getCommunityById(communityId)
   for _, tokenPermission in communityDto.tokenPermissions.pairs:
-    for tokenCriteria in tokenPermission.tokenCriteria:
-      if tokenCriteria.contractAddresses.hasKey(chainId):
-        let actualAddress = tokenCriteria.contractAddresses[chainId]
-        if actualAddress == contractAddress:
-          self.controller.asyncReevaluateCommunityMembersPermissions(communityId)
-          return
+    if tokenPermission.type != TokenPermissionType.BecomeTokenOwner:
+      for tokenCriteria in tokenPermission.tokenCriteria:
+        if tokenCriteria.contractAddresses.hasKey(chainId):
+          let actualAddress = tokenCriteria.contractAddresses[chainId]
+          if actualAddress == contractAddress:
+            self.controller.asyncReevaluateCommunityMembersPermissions(communityId)
+            return
 
 method onAcceptRequestToJoinLoading*[T](self: Module[T], communityId: string, memberKey: string) =
   let item = self.view.model().getItemById(communityId)

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -11,12 +11,14 @@ const asyncLoadCommunitiesDataTask: Task = proc(argEncoded: string) {.gcsafe, ni
     let responseCommunities = status_go.getAllCommunities()
     let responseSettings = status_go.getCommunitiesSettings()
     let responseMyPendingRequestsToJoin = status_go.myPendingRequestsToJoin()
+    let responseMyAwaitingRequestsToJoin = status_go.myAwaitingRequestsToJoin()
 
     arg.finish(%* {
       "tags": responseTags,
       "communities": responseCommunities,
       "settings": responseSettings,
       "myPendingRequestsToJoin": responseMyPendingRequestsToJoin,
+      "myAwaitingRequestsToJoin": responseMyAwaitingRequestsToJoin,
       "error": "",
     })
   except Exception as e:

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -11,14 +11,14 @@ const asyncLoadCommunitiesDataTask: Task = proc(argEncoded: string) {.gcsafe, ni
     let responseCommunities = status_go.getAllCommunities()
     let responseSettings = status_go.getCommunitiesSettings()
     let responseMyPendingRequestsToJoin = status_go.myPendingRequestsToJoin()
-    let responseMyAwaitingRequestsToJoin = status_go.myAwaitingRequestsToJoin()
+    let responseMyAwaitingAddressesRequestsToJoin = status_go.myAwaitingAddressesRequestsToJoin()
 
     arg.finish(%* {
       "tags": responseTags,
       "communities": responseCommunities,
       "settings": responseSettings,
       "myPendingRequestsToJoin": responseMyPendingRequestsToJoin,
-      "myAwaitingRequestsToJoin": responseMyAwaitingRequestsToJoin,
+      "myAwaitingAddressesRequestsToJoin": responseMyAwaitingAddressesRequestsToJoin,
       "error": "",
     })
   except Exception as e:

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -17,6 +17,7 @@ type RequestToJoinType* {.pure.}= enum
   Canceled = 4,
   AcceptedPending = 5,
   DeclinedPending = 6,
+  AwaitingAddress = 7,
 
 type MutedType* {.pure.}= enum
   For15min = 1,

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -98,6 +98,9 @@ proc checkAllCommunityChannelsPermissions*(communityId: string, addresses: seq[s
 proc myPendingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result =  callPrivateRPC("myPendingRequestsToJoin".prefix)
 
+proc myAwaitingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result =  callPrivateRPC("myAwaitingRequestsToJoin".prefix)
+
 proc myCanceledRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result =  callPrivateRPC("myCanceledRequestsToJoin".prefix)
 
@@ -467,3 +470,6 @@ proc getCommunityPublicKeyFromPrivateKey*(communityPrivateKey: string,): RpcResp
 
 proc getCommunityMembersForWalletAddresses*(communityId: string, chainId: int): RpcResponse[JsonNode] {.raises: [Exception].} =
   return callPrivateRPC("getCommunityMembersForWalletAddresses".prefix, %* [communityId, chainId])
+
+proc promoteSelfToControlNode*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  return callPrivateRPC("promoteSelfToControlNode".prefix, %* [communityId])

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -8,7 +8,7 @@ export response_type
 
 proc getCommunityTags*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("communityTags".prefix)
-  
+
 proc muteCategory*(communityId: string, categoryId: string, interval: int): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("muteCommunityCategory".prefix, %* [
     {
@@ -82,7 +82,7 @@ proc reevaluateCommunityMembersPermissions*(
   result = callPrivateRPC("reevaluateCommunityMembersPermissions".prefix, %*[{
     "communityId": communityId
   }])
-  
+
 proc checkCommunityChannelPermissions*(communityId: string, chatId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("checkCommunityChannelPermissions".prefix, %*[{
     "communityId": communityId,
@@ -98,8 +98,8 @@ proc checkAllCommunityChannelsPermissions*(communityId: string, addresses: seq[s
 proc myPendingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result =  callPrivateRPC("myPendingRequestsToJoin".prefix)
 
-proc myAwaitingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
-  result =  callPrivateRPC("myAwaitingRequestsToJoin".prefix)
+proc myAwaitingAddressesRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result =  callPrivateRPC("myAwaitingAddressesRequestsToJoin".prefix)
 
 proc myCanceledRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result =  callPrivateRPC("myCanceledRequestsToJoin".prefix)
@@ -258,7 +258,7 @@ proc deleteCommunityTokenPermission*(communityId: string, permissionId: string):
     "communityId": communityId,
     "permissionId": permissionId
   }])
-  
+
 proc requestCancelDiscordCommunityImport*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("requestCancelDiscordCommunityImport".prefix, %*[communityId])
 
@@ -426,9 +426,9 @@ proc unbanUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[J
   }])
 
 proc setCommunityMuted*(communityId: string, mutedType: int): RpcResponse[JsonNode] {.raises: [Exception].}  =
-  return callPrivateRPC("setCommunityMuted".prefix, %*[{ 
-    "communityId": communityId, 
-    "mutedType": mutedType 
+  return callPrivateRPC("setCommunityMuted".prefix, %*[{
+    "communityId": communityId,
+    "mutedType": mutedType
   }])
 
 proc shareCommunityToUsers*(communityId: string, pubKeys: seq[string], inviteMessage: string): RpcResponse[JsonNode] {.raises: [Exception].} =

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -57,8 +57,8 @@ StackLayout {
 
         sourceComponent: {
             if (chatItem.isCommunity() && !chatItem.amIMember) {
-                if (chatItem.isControlNodeOffline) {
-                    return controlNodeOffline
+                if (chatItem.isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin) {
+                    return controlNodeOfflineComponent
                 } else if (chatItem.requiresTokenPermissionToJoin) {
                     return joinCommunityViewComponent
                 }
@@ -336,9 +336,9 @@ StackLayout {
     }
 
     Component {
-        id: controlNodeOffline
+        id: controlNodeOfflineComponent
         ControlNodeOfflineCommunityView {
-            id: joinCommunityView
+            id: controlNodeOfflineView
             readonly property var communityData: sectionItemModel
             readonly property string communityId: communityData.id
             name: communityData.name
@@ -346,25 +346,11 @@ StackLayout {
             color: communityData.color
             image: communityData.image
             membersCount: communityData.members.count
-            joinCommunity: true
-            amISectionAdmin: communityData.memberRole === Constants.memberRole.owner ||
-                             communityData.memberRole === Constants.memberRole.admin ||
-                             communityData.memberRole === Constants.memberRole.tokenMaster
             communityItemsModel: root.rootStore.communityItemsModel
             notificationCount: activityCenterStore.unreadNotificationsCount
             hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
-            openCreateChat: rootStore.openCreateChat
             onNotificationButtonClicked: Global.openActivityCenterPopup()
             onAdHocChatButtonClicked: rootStore.openCloseCreateChatView()
-
-            Connections {
-                target: root.rootStore.communitiesModuleInst
-                function onCommunityAccessRequested(communityId: string) {
-                    if (communityId === joinCommunityView.communityId) {
-                        joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityId)
-                    }
-                }
-            }
         }
     }
     // End of components related to transfer community ownership flow.

--- a/ui/app/AppLayouts/Communities/panels/ControlNodeOfflineCenterPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ControlNodeOfflineCenterPanel.qml
@@ -1,0 +1,144 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtGraphicalEffects 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Layout 0.1
+
+ColumnLayout {
+    id: root
+
+    property string name
+    property string chatDateTimeText
+    property string listUsersText
+    property var messagesModel
+
+    spacing: 0
+
+    // Blur background:
+    Item {
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.min(
+                                    centralPanelData.implicitHeight,
+                                    parent.height)
+
+        ColumnLayout {
+            id: centralPanelData
+            width: parent.width
+            layer.enabled: true
+            layer.effect: fastBlur
+
+            StatusBaseText {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: 30
+                Layout.bottomMargin: 30
+                text: root.chatDateTimeText
+                font.pixelSize: 13
+                color: Theme.palette.baseColor1
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignHCenter
+
+                StatusBaseText {
+                    text: root.listUsersText
+                    font.pixelSize: 13
+                }
+
+                StatusBaseText {
+                    text: qsTr("joined the channel")
+                    font.pixelSize: 13
+                    color: Theme.palette.baseColor1
+                }
+            }
+
+            ListView {
+                Layout.fillWidth: true
+                Layout.preferredHeight: childrenRect.height + spacing
+                Layout.topMargin: 16
+                spacing: 16
+                model: root.messagesModel
+                delegate: StatusMessage {
+                    width: ListView.view.width
+                    timestamp: model.timestamp
+                    enabled: false
+                    messageDetails: StatusMessageDetails {
+                        messageText: model.message
+                        contentType: model.contentType
+                        sender.displayName: model.senderDisplayName
+                        sender.isContact: model.isContact
+                        sender.trustIndicator: model.trustIndicator
+                        sender.profileImage: StatusProfileImageSettings {
+                            width: 40
+                            height: 40
+                            name: model.profileImage || ""
+                            colorId: model.colorId
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // User information content
+    Rectangle {
+        id: panelBase
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+        gradient: Gradient {
+            GradientStop {
+                position: 0.000
+                color: "transparent"
+            }
+            GradientStop {
+                position: 0.180
+                color: panelBase.color
+            }
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 0
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            StatusBaseText {
+                Layout.maximumWidth: 405
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                font.weight: Font.Bold
+                font.pixelSize: Constants.onboarding.titleFontSize
+                text: qsTr("%1 will be right back!").arg(root.name)
+                wrapMode: Text.WordWrap
+            }
+
+            StatusBaseText {
+                Layout.maximumWidth: 405
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: Constants.onboarding.titleFontSize
+                text: qsTr("You will automatically re-enter the community and be able to view and post as normal as soon as the community’s control node comes back online.")
+                wrapMode: Text.WordWrap
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+        }
+    }
+
+    Component {
+        id: fastBlur
+
+        FastBlur {
+            radius: 32
+            transparentBorder: true
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/panels/ControlNodeOfflineCenterPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ControlNodeOfflineCenterPanel.qml
@@ -47,12 +47,6 @@ ColumnLayout {
                     text: root.listUsersText
                     font.pixelSize: 13
                 }
-
-                StatusBaseText {
-                    text: qsTr("joined the channel")
-                    font.pixelSize: 13
-                    color: Theme.palette.baseColor1
-                }
             }
 
             ListView {

--- a/ui/app/AppLayouts/Communities/panels/qmldir
+++ b/ui/app/AppLayouts/Communities/panels/qmldir
@@ -5,6 +5,7 @@ ChannelsAndCategoriesBannerPanel 1.0 ChannelsAndCategoriesBannerPanel.qml
 ChatPermissionQualificationPanel 1.0 ChatPermissionQualificationPanel.qml
 ColorPanel 1.0 ColorPanel.qml
 ColumnHeaderPanel 1.0 ColumnHeaderPanel.qml
+ControlNodeOfflineCenterPanel 1.0 ControlNodeOfflineCenterPanel.qml
 EditSettingsPanel 1.0 EditSettingsPanel.qml
 FeesBox 1.0 FeesBox.qml
 FeesPanel 1.0 FeesPanel.qml

--- a/ui/app/AppLayouts/Communities/views/ControlNodeOfflineCommunityView.qml
+++ b/ui/app/AppLayouts/Communities/views/ControlNodeOfflineCommunityView.qml
@@ -20,14 +20,11 @@ StatusSectionLayout {
     id: root
 
     // General properties:
-    property bool amISectionAdmin: false
-    property bool openCreateChat: false
     property string name
     property string communityDesc
     property color color
     property string channelName
     property string channelDesc
-    property bool joinCommunity: true // Otherwise it means join channel action
 
     // Blur view properties:
     property int membersCount
@@ -37,7 +34,6 @@ StatusSectionLayout {
     property string listUsersText
     property var messagesModel
 
-    signal infoButtonClicked
     signal adHocChatButtonClicked
 
 
@@ -48,7 +44,6 @@ StatusSectionLayout {
     }
 
     headerContent: JoinCommunityHeaderPanel {
-        joinCommunity: root.joinCommunity
         color: root.color
         name: root.name
         channelName: root.channelName
@@ -66,16 +61,15 @@ StatusSectionLayout {
             membersCount: root.membersCount
             image: root.image
             color: root.color
-            amISectionAdmin: root.amISectionAdmin
-            openCreateChat: root.openCreateChat
-            onInfoButtonClicked: if(root.amISectionAdmin) root.infoButtonClicked()
+            amISectionAdmin: false
+            openCreateChat: false
             onAdHocChatButtonClicked: root.adHocChatButtonClicked()
         }
 
         ColumnLayout {
             Layout.fillWidth: true
             Layout.margins: Style.current.halfPadding
-            layer.enabled: root.joinCommunity
+            layer.enabled: true
             layer.effect: fastBlur
 
             Repeater {

--- a/ui/app/AppLayouts/Communities/views/ControlNodeOfflineCommunityView.qml
+++ b/ui/app/AppLayouts/Communities/views/ControlNodeOfflineCommunityView.qml
@@ -1,0 +1,123 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtGraphicalEffects 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import AppLayouts.Communities.panels 1.0
+import AppLayouts.Chat.views 1.0
+
+import StatusQ.Layout 0.1
+
+import utils 1.0
+import shared.popups 1.0
+
+StatusSectionLayout {
+    id: root
+
+    // General properties:
+    property bool amISectionAdmin: false
+    property bool openCreateChat: false
+    property string name
+    property string communityDesc
+    property color color
+    property string channelName
+    property string channelDesc
+    property bool joinCommunity: true // Otherwise it means join channel action
+
+    // Blur view properties:
+    property int membersCount
+    property url image
+    property var communityItemsModel
+    property string chatDateTimeText
+    property string listUsersText
+    property var messagesModel
+
+    signal infoButtonClicked
+    signal adHocChatButtonClicked
+
+
+    QtObject {
+        id: d
+
+        readonly property int blurryRadius: 32
+    }
+
+    headerContent: JoinCommunityHeaderPanel {
+        joinCommunity: root.joinCommunity
+        color: root.color
+        name: root.name
+        channelName: root.channelName
+        communityDesc: root.communityDesc
+        channelDesc: root.channelDesc
+    }
+
+    // Blur background:
+    leftPanel: ColumnLayout {
+        anchors.fill: parent
+
+        ColumnHeaderPanel {
+            Layout.fillWidth: true
+            name: root.name
+            membersCount: root.membersCount
+            image: root.image
+            color: root.color
+            amISectionAdmin: root.amISectionAdmin
+            openCreateChat: root.openCreateChat
+            onInfoButtonClicked: if(root.amISectionAdmin) root.infoButtonClicked()
+            onAdHocChatButtonClicked: root.adHocChatButtonClicked()
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.margins: Style.current.halfPadding
+            layer.enabled: root.joinCommunity
+            layer.effect: fastBlur
+
+            Repeater {
+                model: root.communityItemsModel
+                delegate: StatusChatListItem {
+                    enabled: false
+                    name: model.name
+                    asset.color: root.color
+                    selected: model.selected
+                    type: StatusChatListItem.Type.CommunityChat
+                    notificationsCount: model.notificationsCount
+                    hasUnreadMessages: model.hasUnreadMessages
+                }
+            }
+        }
+
+        Item {
+            // filler
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
+    }
+
+    // Blur background + Control node offline information content:
+    centerPanel: ControlNodeOfflineCenterPanel {
+        id: joinCommunityCenterPanel
+
+        anchors.fill: parent
+        name: root.name
+        chatDateTimeText: root.chatDateTimeText
+        listUsersText: root.listUsersText
+        messagesModel: root.messagesModel
+    }
+
+    showRightPanel: false
+
+    Component {
+        id: fastBlur
+
+        FastBlur {
+            radius: d.blurryRadius
+            transparentBorder: true
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/views/qmldir
+++ b/ui/app/AppLayouts/Communities/views/qmldir
@@ -3,6 +3,7 @@ CommunityColumnView 1.0 CommunityColumnView.qml
 CommunitiesGridView 1.0 CommunitiesGridView.qml
 CommunitySettingsView 1.0 CommunitySettingsView.qml
 CommunityTokenView 1.0 CommunityTokenView.qml
+ControlNodeOfflineCommunityView 1.0 ControlNodeOfflineCommunityView.qml
 EditAirdropView 1.0 EditAirdropView.qml
 EditPermissionView 1.0 EditPermissionView.qml
 EditCommunityTokenView 1.0 EditCommunityTokenView.qml


### PR DESCRIPTION
### What does the PR do

When the community ownership changes, the new owner will kick out all members and they must reveal their address in order to rejoin the community. As soon, as they will do it - they will automatically rejoin by the control node.
If the control node will not be online to accept them, the appropriate info msg will be displayed

Closes: https://github.com/status-im/status-desktop/issues/11969

status-go PR: https://github.com/status-im/status-go/pull/4187

### Affected areas

Ownership change

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/117639195/a64d28fd-4f68-4738-9e77-0876535972c5

