### PR TITLE
chore(@AccountView.qml): add object name for confirmation popup

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -300,6 +300,7 @@ ColumnLayout {
 
         ConfirmationDialog {
             id: confirmationPopup
+            objectName: "deleteAccountConfirmationPopup"
             confirmButtonObjectName: "confirmDeleteAccountButton"
             headerSettings.title: qsTr("Confirm %1 Removal").arg(!!root.account? root.account.name : "")
             confirmationText: qsTr("You will not be able to restore viewing access to this account in the future unless you enter this account’s address again.")


### PR DESCRIPTION
### What does the PR do

add object name for confirmation popup

### Affected areas

`ui/app/AppLayouts/Profile/views/wallet/AccountView.qml`