### PR TITLE
fix(@desktop/sendModel): Use tab to focus to next field

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -309,6 +309,8 @@ StatusDialog {
 
                             formatCurrencyAmount: d.currencyStore.formatCurrencyAmount
                             onReCalculateSuggestedRoute: popup.recalculateRoutesAndFees()
+                            input.input.tabNavItem: recipientLoader.item
+                            Keys.onTabPressed: event.accepted = true
                         }
 
                         // Horizontal spacer

--- a/ui/imports/shared/popups/send/views/RecipientView.qml
+++ b/ui/imports/shared/popups/send/views/RecipientView.qml
@@ -199,6 +199,7 @@ Loader {
                     }
                 }
             }
+            Keys.onTabPressed: event.accepted = true
             Keys.onReleased: {
                 let plainText =  store.plainText(input.edit.text)
                 if(!plainText) {


### PR DESCRIPTION
closes #12507

### What does the PR do

Instead of adding tabulation to input focus on the next field

### Affected areas

Send Modal

### Screenshot of functionality (including design for comparison)



https://github.com/status-im/status-desktop/assets/11396062/6553b932-fa78-4262-8358-f6e5a03e9401

