### PR TITLE
chore(LeftJoinModel): Minor improvements and tests amendments

### DIFF
--- a/ui/StatusQ/src/leftjoinmodel.cpp
+++ b/ui/StatusQ/src/leftjoinmodel.cpp
@@ -129,7 +129,7 @@ QVariant LeftJoinModel::data(const QModelIndex& index, int role) const
     if (m_rightModelDestroyed)
         return {};
 
-    QVariant joinRoleLeftValue = m_leftModel->data(idx, m_leftModelJoinRole);
+    auto joinRoleLeftValue = m_leftModel->data(idx, m_leftModelJoinRole);
 
     if (m_lastUsedRightModelIndex.isValid()
             && m_rightModel->data(m_lastUsedRightModelIndex,
@@ -139,22 +139,15 @@ QVariant LeftJoinModel::data(const QModelIndex& index, int role) const
                                   role - m_rightModelRolesOffset);
     }
 
-    int rightModelCount = m_rightModel->rowCount();
+    QModelIndexList match = m_rightModel->match(
+                m_rightModel->index(0, 0), m_rightModelJoinRole,
+                joinRoleLeftValue, 1, Qt::MatchExactly);
 
-    for (int i = 0; i < rightModelCount; i++) {
-        auto rightModelIdx =  m_rightModel->index(i, 0);
-        auto rightJointRoleValue = m_rightModel->data(rightModelIdx,
-                                                      m_rightModelJoinRole);
+    if (match.empty())
+        return {};
 
-        if (joinRoleLeftValue == rightJointRoleValue) {
-            m_lastUsedRightModelIndex = rightModelIdx;
-
-            return m_rightModel->data(rightModelIdx,
-                                      role - m_rightModelRolesOffset);
-        }
-    }
-
-    return {};
+    m_lastUsedRightModelIndex = match.first();
+    return match.first().data(role - m_rightModelRolesOffset);
 }
 
 void LeftJoinModel::setLeftModel(QAbstractItemModel* model)

--- a/ui/StatusQ/tests/tst_LeftJoinModel.cpp
+++ b/ui/StatusQ/tests/tst_LeftJoinModel.cpp
@@ -1,3 +1,4 @@
+#include <QAbstractItemModelTester>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -28,7 +29,7 @@ public:
 
     QVariant data(const QModelIndex& index, int role) const override
     {
-        if (!index.isValid())
+        if (!index.isValid() || role < 0 || role >= m_data.size())
             return {};
 
         const auto row = index.row();
@@ -95,6 +96,7 @@ private slots:
 
     void emptyModelTest() {
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
 
         QCOMPARE(model.rowCount(), 0);
         QCOMPARE(model.roleNames(), {});
@@ -113,6 +115,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
 
         QCOMPARE(model.rowCount(), 0);
@@ -139,6 +143,7 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
 
         QTest::ignoreMessage(QtWarningMsg,
                              "Source model is not intended to be set directly "
@@ -163,6 +168,8 @@ private slots:
             });
 
             LeftJoinModel model;
+            QAbstractItemModelTester tester(&model);
+
             model.setLeftModel(&leftModel);
 
             QCOMPARE(model.rowCount(), 0);
@@ -194,6 +201,8 @@ private slots:
             });
 
             LeftJoinModel model;
+            QAbstractItemModelTester tester(&model);
+
             model.setLeftModel(&leftModel);
 
             QCOMPARE(model.rowCount(), 0);
@@ -225,6 +234,8 @@ private slots:
             });
 
             LeftJoinModel model;
+            QAbstractItemModelTester tester(&model);
+
             model.setLeftModel(&leftModel);
 
             QCOMPARE(model.rowCount(), 0);
@@ -259,6 +270,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
         model.setRightModel(&rightModel);
         model.setJoinRole("communityId");
@@ -286,6 +299,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
         model.setRightModel(&rightModel);
         model.setJoinRole("communityId");
@@ -341,6 +356,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
         model.setRightModel(&rightModel);
         model.setJoinRole("communityId");
@@ -376,6 +393,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
         model.setRightModel(&rightModel);
         model.setJoinRole("communityId");
@@ -411,6 +430,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
         model.setRightModel(&rightModel);
         model.setJoinRole("communityId");
@@ -449,6 +470,8 @@ private slots:
         });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(&leftModel);
         model.setRightModel(&rightModel);
         model.setJoinRole("communityId");
@@ -493,6 +516,8 @@ private slots:
                     });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(leftModel.get());
         model.setRightModel(rightModel.get());
 
@@ -540,6 +565,8 @@ private slots:
                     });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(leftModel.get());
         model.setRightModel(rightModel.get());
 
@@ -588,6 +615,8 @@ private slots:
                     });
 
         LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
         model.setLeftModel(leftModel.get());
         model.setRightModel(rightModel.get());
 


### PR DESCRIPTION
### What does the PR do

A small follow-up to https://github.com/status-im/status-desktop/pull/12530

- `QModelIndexList::match` used instead of plain loop over right model entries to allow lookup optimizations
- warning printing when join model contains duplicated roles
- tests amended, `QAbstractItemModelTester` used

Closes: https://github.com/status-im/status-desktop/issues/12574

### Affected areas
`LeftJoinModel` (`StatusQ`)
