### PR TITLE
fix(@desktop/wallet): Use LeftJoinModel to link networks with chainId in various models such collectibles model, assets models and transactions as well.

### DIFF
--- a/storybook/pages/TokenListViewPage.qml
+++ b/storybook/pages/TokenListViewPage.qml
@@ -23,12 +23,9 @@ SplitView {
 
             width: 400
 
-            getNetworkIcon: function(chainId) {
-                return "network/Network=Optimism"
-            }
-
             assets: WalletAssetsModel {}
             collectibles: WalletNestedCollectiblesModel {}
+            networksModel: NetworksModel.allNetworks
         }
     }
 

--- a/storybook/stubs/shared/stores/send/TransactionStore.qml
+++ b/storybook/stubs/shared/stores/send/TransactionStore.qml
@@ -17,6 +17,7 @@ QtObject {
         property ListModel model: ListModel{}
     }
 
+    property var allNetworksModel: NetworksModel.allNetworks
     property var fromNetworksModel: NetworksModel.sendFromNetworks
     property var toNetworksModel: NetworksModel.sendToNetworks
     property var selectedSenderAccount: senderAccounts.get(0)
@@ -235,10 +236,6 @@ QtObject {
         default:
             return qsTr("> 5 minutes")
         }
-    }
-
-    function getNetworkIcon(chainId) {
-        return ModelUtils.getByKey(NetworksModel.allNetworks, "chainId", Number(chainId), "iconUrl")
     }
 
     function resetStoredProperties() {

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -57,14 +57,9 @@ Item {
         secondaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkBalance) : Constants.dummyText
         tertiaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkCurrencyBalance) : Constants.dummyText
         balances: token && token.balances ? token.balances : null
+        networksModel: RootStore.allNetworks
         isLoading: root.assetsLoading
         errorTooltipText: token && token.balances ? networkConnectionStore.getBlockchainNetworkDownTextForToken(token.balances): ""
-        getNetworkColor: function(chainId){
-            return RootStore.getNetworkColor(chainId)
-        }
-        getNetworkIcon: function(chainId){
-            return RootStore.getNetworkIcon(chainId)
-        }
         formatBalance: function(balance){
             return LocaleUtils.currencyAmountToLocaleString(balance)
         }

--- a/ui/imports/shared/controls/AssetsDetailsHeader.qml
+++ b/ui/imports/shared/controls/AssetsDetailsHeader.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.14
 import utils 1.0
 import shared.controls 1.0
 
+import StatusQ 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core 0.1
@@ -16,14 +17,13 @@ Control {
     property alias secondaryText: cryptoBalance.text
     property alias tertiaryText: fiatBalance.text
     property var balances
+    property var networksModel
     property bool isLoading: false
     property string errorTooltipText
     property StatusAssetSettings asset: StatusAssetSettings {
         width: 40
         height: 40
     }
-    property var getNetworkColor: function(chainId){}
-    property var getNetworkIcon: function(chainId){}
     property var formatBalance: function(balance){}
 
     topPadding: Style.current.padding
@@ -82,11 +82,15 @@ Control {
             anchors.leftMargin: identiconLoader.width
             Repeater {
                 id: chainRepeater
-                model: balances ? balances : null
+                model: LeftJoinModel {
+                    leftModel: root.balances
+                    rightModel: root.networksModel
+                    joinRole: "chainId"
+                }
                 delegate: InformationTag {
                     tagPrimaryLabel.text: root.formatBalance(model.balance)
-                    tagPrimaryLabel.color: root.getNetworkColor(model.chainId)
-                    image.source: Style.svg("tiny/%1".arg(root.getNetworkIcon(model.chainId)))
+                    tagPrimaryLabel.color: model.chainColor
+                    image.source: Style.svg("tiny/%1".arg(model.iconUrl))
                     loading: root.isLoading
                     rightComponent: StatusFlatRoundButton {
                         width: 14

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -39,7 +39,6 @@ StatusDialog {
     property alias modalHeader: modalHeader.text
 
     property TransactionStore store: TransactionStore {}
-    property var collectiblesModel: store.collectiblesModel
     property var nestedCollectiblesModel: store.nestedCollectiblesModel
     property var bestRoutes
     property bool isLoading: false
@@ -247,12 +246,10 @@ StatusDialog {
                             Layout.fillHeight: true
                             assetsModel: popup.preSelectedAccount && popup.preSelectedAccount.assets ? popup.preSelectedAccount.assets : null
                             collectiblesModel: popup.preSelectedAccount ? popup.nestedCollectiblesModel : null
+                            networksModel: popup.store.allNetworksModel
                             currentCurrencySymbol: d.currencyStore.currentCurrencySymbol
                             visible: (!!d.selectedHolding && d.selectedHoldingType !== Constants.HoldingType.Unknown) ||
                                      (!!d.hoveredHolding && d.hoveredHoldingType !== Constants.HoldingType.Unknown)
-                            getNetworkIcon: function(chainId){
-                                return popup.store.getNetworkIcon(chainId)
-                            }
                             onItemSelected: {
                                 d.setSelectedHoldingId(holdingId, holdingType)
                             }
@@ -376,12 +373,11 @@ StatusDialog {
                         visible: !d.selectedHolding
                         assets: popup.preSelectedAccount && popup.preSelectedAccount.assets ? popup.preSelectedAccount.assets : null
                         collectibles: popup.preSelectedAccount ? popup.nestedCollectiblesModel : null
+                        networksModel: popup.store.allNetworksModel
                         onlyAssets: holdingSelector.onlyAssets
+                        // TODO remove this as address should be found directly in model itself
                         searchTokenSymbolByAddressFn: function (address) {
                             return store.findTokenSymbolByAddress(address)
-                        }
-                        getNetworkIcon: function(chainId){
-                            return popup.store.getNetworkIcon(chainId)
                         }
                         onTokenSelected: {
                             d.setSelectedHoldingId(symbol, holdingType)

--- a/ui/imports/shared/popups/send/controls/CollectibleNestedDelegate.qml
+++ b/ui/imports/shared/popups/send/controls/CollectibleNestedDelegate.qml
@@ -9,9 +9,6 @@ import utils 1.0
 StatusListItem {
     id: root
 
-    property var getNetworkIcon: function(chainId) {
-        return ""
-    }
     signal itemSelected(var selectedItem)
     signal itemHovered(var selectedItem, bool hovered)
 
@@ -48,7 +45,7 @@ StatusListItem {
         StatusRoundedImage {
             width: 20
             height: 20
-            image.source: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
+            image.source: Style.svg("tiny/%1".arg(networkIconUrl))
             visible: !isCollection && root.sensor.containsMouse
         },
         StatusIcon {

--- a/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
@@ -9,9 +9,7 @@ import utils 1.0
 StatusListItem {
     id: root
 
-    property var getNetworkIcon: function(chainId){
-        return ""
-    }
+    property var balancesModel
     signal tokenSelected(var selectedToken)
     signal tokenHovered(var selectedToken, bool hovered)
 
@@ -50,13 +48,13 @@ StatusListItem {
     statusListItemLabel.anchors.verticalCenterOffset: -12
     statusListItemLabel.color: Theme.palette.directColor1
     statusListItemInlineTagsSlot.spacing: 0
-    tagsModel: balances.count > 0 ? balances : []
+    tagsModel: root.balancesModel
     tagsDelegate: expandedItem
     statusListItemInlineTagsSlot.children: Row {
         id: compactRow
         spacing: -6
         Repeater {
-            model: balances.count > 0 ? balances : []
+            model: root.balancesModel
             delegate: compactItem
         }
     }
@@ -72,7 +70,7 @@ StatusListItem {
             z: index + 1
             width: 16
             height: 16
-            image.source: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
+            image.source: Style.svg("tiny/%1".arg(iconUrl))
             visible: !root.sensor.containsMouse || index > d.indexesThatCanBeShown
         }
     }
@@ -88,7 +86,7 @@ StatusListItem {
             asset.width: 16
             asset.height: 16
             asset.isImage: true
-            asset.name: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
+            asset.name: Style.svg("tiny/%1".arg(iconUrl))
             visible: root.sensor.containsMouse && index <= d.indexesThatCanBeShown
         }
     }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -30,11 +30,14 @@ QtObject {
     property bool isNonArchivalNode: Global.appIsReady && walletSectionInst.isNonArchivalNode
 
     property var marketValueStore: TokenMarketValuesStore{}
+    property var allNetworks: networksModule.all
 
     function resetFilter() {
         walletSectionInst.activityController.updateFilter()
     }
 
+    // TODO remove all these by linking chainId for networks and activity using LeftJoinModel
+    // not possible currently due to the current structure of the activity model
     function getNetworkColor(chainId) {
         return networksModule.all.getChainColor(chainId)
     }

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -19,6 +19,7 @@ QtObject {
     property var assets: walletSectionAssets.assets
     property var fromNetworksModel: walletSectionSendInst.fromNetworksModel
     property var toNetworksModel: walletSectionSendInst.toNetworksModel
+    property var allNetworksModel: networksModule.all
     property var senderAccounts: walletSectionSendInst.senderAccounts
     property var selectedSenderAccount: walletSectionSendInst.selectedSenderAccount
     property var accounts: walletSectionSendInst.accounts
@@ -246,9 +247,5 @@ QtObject {
 
     function getShortChainIds(chainShortNames) {
         return walletSectionSendInst.getShortChainIds(chainShortNames)
-    }
-
-    function getNetworkIcon(chainId) {
-        return walletSectionSendInst.getIconUrl(chainId)
     }
 }


### PR DESCRIPTION
Use LeftJoinModel to link networks with chainId in various models such collectibles model, assets models and transactions as well.

fixes #8923

### What does the PR do

Uses the LeftJoinModel in order to link chainIds for assets and collectibles with networks model using chainId

### Affected areas

Asset Details View, Send Modal -> Tokens list and holding dropdown selector

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/76430f25-4ef3-42ab-a8b0-2e5e204f3364

