### PR TITLE
bug(@desktop/wallet): Fix new transaction button visuals

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -113,6 +113,7 @@ Item {
                 root.resetView()
                 RootStore.setFillterAllAddresses()
             }
+            onCurrentAddressChanged: root.resetView()
             onShowSavedAddressesChanged: {
                 if(showSavedAddresses)
                     rightPanelStackView.replace(cmpSavedAddresses)

--- a/ui/app/AppLayouts/Wallet/panels/ActivityFilterPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ActivityFilterPanel.qml
@@ -18,6 +18,7 @@ Column {
     property var activityFilterStore
     property var store
     property bool isLoading: false
+    property bool hideNoResults: false
 
     spacing: 12
 
@@ -212,14 +213,15 @@ Column {
     }
 
     Separator {
-        visible: noResultsAfterFilter.visible
+        visible: noResultsAfterFilter.noResults
     }
 
     StatusBaseText {
         id: noResultsAfterFilter
+        readonly property bool noResults: !root.isLoading && activityFilterStore.transactionsList.count === 0 && activityFilterStore.filtersSet
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 16
-        visible: !root.isLoading && activityFilterStore.transactionsList.count === 0 && activityFilterStore.filtersSet
+        visible: !root.hideNoResults && noResults
         text: qsTr("No activity items for the current filter")
         font.pixelSize: Style.current.primaryTextFontSize
         color: Theme.palette.baseColor1

--- a/ui/app/AppLayouts/Wallet/stores/ActivityFiltersStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/ActivityFiltersStore.qml
@@ -12,7 +12,7 @@ QtObject {
 
     property bool autoUpdateFilter: true
     property var activityController: walletSection.activityController
-    property bool filtersSet: selectedTime !== Constants.TransactionTimePeriod.All ||
+    readonly property bool filtersSet: selectedTime !== Constants.TransactionTimePeriod.All ||
                                 typeFilters.length !== 0 ||
                                 statusFilters.length !== 0 ||
                                 tokensFilter.length !== 0 ||
@@ -146,7 +146,7 @@ QtObject {
         applyTimeRange()
     }
 
-    function applyTimeRange() {
+    function applyTimeRange(callUpdate = true) {
         const startTimestamp = d.fromTimestampNoLimit
                             ? activityController.noLimitTimestamp
                             : fromTimestamp/1000
@@ -154,7 +154,7 @@ QtObject {
                             ? activityController.noLimitTimestamp
                             : toTimestamp/1000
         activityController.setFilterTime(startTimestamp, endTimestamp)
-        if (autoUpdateFilter)
+        if (autoUpdateFilter && callUpdate)
             activityController.updateFilter()
     }
 
@@ -259,7 +259,7 @@ QtObject {
     }
 
     function applyAllFilters() {
-        applyTimeRange()
+        applyTimeRange(false)
         activityController.setFilterType(JSON.stringify(typeFilters))
         activityController.setFilterStatus(JSON.stringify(statusFilters))
         activityController.setFilterAssets(JSON.stringify(tokensFilter), false)

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -112,6 +112,7 @@ ColumnLayout {
             visible: d.isInitialLoading || transactionListRoot.count > 0 || WalletStores.RootStore.currentActivityFiltersStore.filtersSet
             activityFilterStore: WalletStores.RootStore.currentActivityFiltersStore
             store: WalletStores.RootStore
+            hideNoResults: newTransactions.visible
             isLoading: d.isInitialLoading
         }
     }
@@ -277,6 +278,12 @@ ColumnLayout {
 
             function onNewDataAvailableChanged() {
                 if (!d.lastRefreshTime || ((Date.now() - d.lastRefreshTime) > (1000 * d.maxSecondsBetweenRefresh))) {
+                    // Show `New transactions` button only when filter is applied
+                    if (!WalletStores.RootStore.currentActivityFiltersStore.filtersSet) {
+                        d.refreshData()
+                        return
+                    }
+
                     newTransactions.visible = RootStore.newDataAvailable
                     return
                 }


### PR DESCRIPTION
fixes #12567

### What does the PR do

* Fixed new transactions button display
Activity is refreshed automatically in case list is empty and filter is not applied.
When filter is applied the "clear button" is hidden and new transactions button is showed.

Other fixes:
* Fixed duplicated wallet activity fetch request
* Fixed wallet view tab was not resetting to `assets` after account is added

### Affected areas

Wallet activity 

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/db383a34-d65a-4dd2-af8f-92ea53908e67

