### PR TITLE
Fix missing pending animation when switching channels

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -1,4 +1,4 @@
-import Tables, sugar, sequtils, strutils
+import Tables, sugar, sequtils, strutils, times
 
 import io_interface
 
@@ -450,7 +450,9 @@ proc setActiveItem*(self: Controller, itemId: string) =
     self.messageService.asyncLoadInitialMessagesForChat(self.activeItemId)
 
   # We need to take other actions here like notify status go that unviewed mentions count is updated and so...
+  var time = cpuTime()
   self.delegate.activeItemSet(self.activeItemId)
+  echo "Time taken: ", cpuTime() - time
 
 proc removeCommunityChat*(self: Controller, itemId: string) =
   self.communityService.deleteCommunityChat(self.getMySectionId(), itemId)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, sequtils, strutils, strformat, sugar, marshal
+import NimQml, Tables, chronicles, json, sequtils, strutils, strformat, sugar, marshal, times
 
 import io_interface
 import ../io_interface as delegate_interface
@@ -14,9 +14,7 @@ import ../../shared_models/token_criteria_model
 import ../../shared_models/token_permission_chat_list_model
 
 import chat_content/module as chat_content_module
-import chat_content/users/module as users_module
 
-import ../../../global/app_sections_config as conf
 import ../../../global/global_singleton
 import ../../../core/eventemitter
 import ../../../core/unique_event_emitter
@@ -406,13 +404,15 @@ method activeItemSet*(self: Module, itemId: string) =
 
   # update view maintained by this module
   self.view.chatsModel().setActiveItem(itemId)
+  var time = cpuTime()
   self.view.activeItemSet(chat_item)
+  echo "view update duration: ", cpuTime() - time
 
   self.updateActiveChatMembership()
 
   let activeChatId = self.controller.getActiveChatId()
 
-  # # update child modules
+  # update child modules
   for chatId, chatContentModule in self.chatContentModules:
     if chatId == activeChatId:
       chatContentModule.onMadeActive()

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, strutils
+import NimQml, json, sequtils, strutils, times
 import model as chats_model
 import item, active_item
 import ../../shared_models/user_model as user_model
@@ -148,7 +148,9 @@ QtObject:
 
   proc activeItemSet*(self: View, item: Item) =
     self.activeItem.setActiveItemData(item)
-    self.activeItemChanged()
+    var time = cpuTime()
+    self.activeItemChanged() # UI block happens after emitting this signal
+    echo "activeItemSet duration: ", cpuTime() - time
 
   proc setActiveItem*(self: View, itemId: string) {.slot.} =
     self.delegate.setActiveItem(itemId)

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -1,4 +1,4 @@
-import std/uri, uuids
+import std/uri, uuids, os
 include ../../common/json_utils
 include ../../../app/core/tasks/common
 
@@ -28,6 +28,7 @@ const asyncFetchChatMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimc
     var messagesArr: JsonNode
     var messagesCursor: JsonNode
     let msgsResponse = status_go.fetchMessages(arg.chatId, arg.msgCursor, arg.limit)
+    # sleep(3000)
     discard msgsResponse.result.getProp("cursor", messagesCursor)
     discard msgsResponse.result.getProp("messages", messagesArr)
     responseJson["messages"] = messagesArr

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -99,7 +99,8 @@ StatusSectionLayout {
         ignoreUnknownSignals: true
 
         function onActiveItemChanged() {
-            Global.closeCreateChatView()
+            // Connection from activeItemChanged signal of ChatSectionModule
+            Global.closeCreateChatView() // Commenting this one out doesn't have any effect
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Attempt to fix the missing whole page animation that should occur when switching channels (and chats?), before the first initial message is loaded, excluding the **chat identifier** and **fetch more** _faux messages_. 

### To clarify

Since the **chat identifier** and **fetch more** _faux messages_ are always supposed to be present in a chat view, I'm assuming we should only display the loading animation as long as there is at least one single unseen message that hasn't been loaded for display.

Fixes #12363