### PR TITLE
Makefile changes for macOS Sonoma

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ $(BOTTLES): | $(BOTTLES_DIR)
 
 $(BOTTLES_DIR):
 	echo -e "\033[92mUpdating:\033[39m macOS Homebrew"
-	if [[ $$(stat -f %u /usr/local/var/homebrew) -ne "$${UID}" ]]; then \
+	if [[ $$(stat -f %u /usr/local/var/homebrew) -ne "$${UID}" ]] && [[ $$(stat -f %u /opt/homebrew/bin/brew) -ne "$${UID}" ]]; then \
 		echo "Missing permissions to update Homebrew formulae!" >&2; \
 	else \
 		brew update >/dev/null; \
@@ -609,7 +609,7 @@ ifeq ($(detected_OS),Darwin)
 		bin/nim_status_client
 ifeq ("$(wildcard ./node_modules/.bin/fileicon)","")
 	echo -e "\033[92mInstalling:\033[39m fileicon"
-	npm i
+	yarn install
 endif
 endif
 
@@ -705,7 +705,7 @@ DMG_TOOL := node_modules/.bin/create-dmg
 
 $(DMG_TOOL):
 	echo -e "\033[92mInstalling:\033[39m create-dmg"
-	npm i
+	yarn install
 
 MACOS_OUTER_BUNDLE := tmp/macos/dist/Status.app
 MACOS_INNER_BUNDLE := $(MACOS_OUTER_BUNDLE)/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app


### PR DESCRIPTION
Changes:
1. `brew` was installed at a different dir, so I condition is changed a bit
2. `yarn install` instead of `npm i` solves error during `nan` installation
```
npm ERR! In file included from ../src/volume.cc:2:
npm ERR! In file included from ../../nan/nan.h:178:
npm ERR! ../../nan/nan_callbacks.h:55:23: error: no member named 'AccessorSignature' in namespace 'v8'
npm ERR! typedef v8::Local<v8::AccessorSignature> Sig;
npm ERR!                   ~~~~^
```

status: ready