### PR TITLE
fix(LinkPreviews): Left align the message link preview tight corner

### DIFF
--- a/storybook/pages/LinksMessageViewPage.qml
+++ b/storybook/pages/LinksMessageViewPage.qml
@@ -27,7 +27,6 @@ SplitView {
             playAnimations: true
             linkPreviewModel: mockedLinkPreviewModel
             gifLinks: [ "https://media.tenor.com/qN_ytiwLh24AAAAC/cold.gif" ]
-            isCurrentUser: true
 
             gifUnfurlingEnabled: false
             canAskToUnfurlGifs: true
@@ -44,14 +43,6 @@ SplitView {
         ColumnLayout {
             spacing: 25
             ColumnLayout {
-                Label {
-                    text: qsTr("Sender")
-                }
-                CheckBox {
-                    text: qsTr("Current user")
-                    checked: linksMessageView.isCurrentUser
-                    onToggled: linksMessageView.isCurrentUser = !linksMessageView.isCurrentUser
-                }
                 Label {
                     text: qsTr("GIF unfuring settings")
                 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -315,7 +315,7 @@ Control {
                                     album: root.messageDetails.albumCount > 0 ? root.messageDetails.album : [root.messageDetails.messageContent]
                                     albumCount: root.messageDetails.albumCount > 0 ? root.messageDetails.albumCount : 1
                                     imageWidth: Math.min(messageLayout.width / root.messageDetails.albumCount - 9 * (root.messageDetails.albumCount - 1), 144)
-                                    shapeType: root.messageDetails.amISender ? StatusImageMessage.ShapeType.RIGHT_ROUNDED : StatusImageMessage.ShapeType.LEFT_ROUNDED
+                                    shapeType: StatusImageMessage.ShapeType.LEFT_ROUNDED
                                     onImageClicked: root.imageClicked(image, mouse, imageSource)
                                 }
                             }
@@ -333,7 +333,7 @@ Control {
                                 delegate: StatusImageMessage {
                                     source: model.source
                                     onClicked: root.imageClicked(image, mouse, imageSource)
-                                    shapeType: root.messageDetails.amISender ? StatusImageMessage.ShapeType.RIGHT_ROUNDED : StatusImageMessage.ShapeType.LEFT_ROUNDED
+                                    shapeType: StatusImageMessage.ShapeType.LEFT_ROUNDED
                                 }
                             }
                         }

--- a/ui/imports/shared/controls/delegates/LinkPreviewCardDelegate.qml
+++ b/ui/imports/shared/controls/delegates/LinkPreviewCardDelegate.qml
@@ -48,9 +48,6 @@ LinkPreviewCard {
     required property var statusCommunityChannelCommunityPreviewBanner
 
     //View properties
-    property bool isCurrentUser: false
-
-    leftTail: !isCurrentUser
     type: root.previewType
     linkData {
         title: standardPreview ? standardPreview.title : ""

--- a/ui/imports/shared/controls/delegates/LinkPreviewGifDelegate.qml
+++ b/ui/imports/shared/controls/delegates/LinkPreviewGifDelegate.qml
@@ -13,7 +13,6 @@ CalloutCard {
     required property string link
     required property bool playAnimation
     required property bool isOnline
-    required property bool isCurrentUser
 
     readonly property bool isPlaying: linkImage.playing
     readonly property alias imageAlias: linkImage.imageAlias
@@ -23,7 +22,6 @@ CalloutCard {
     
     implicitWidth: linkImage.width
     implicitHeight: linkImage.height
-    leftTail: !isCurrentUser
     
     StatusChatImageLoader {
         id: linkImage
@@ -34,7 +32,6 @@ CalloutCard {
         anchors.centerIn: parent
         source: root.link
         imageWidth: 300
-        isCurrentUser: root.isCurrentUser
         playing: root.playAnimation && localAnimationEnabled
         isOnline: root.isOnline
         asynchronous: true

--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -10,7 +10,6 @@ Item {
 
     property int verticalPadding: 0
     property int imageWidth: 350
-    property bool isCurrentUser: false
     property url source
     property bool isActiveChannel: false
     property bool playing: Global.applicationWindow.active
@@ -20,6 +19,7 @@ Item {
     property bool isOnline: true // TODO: mark as required when migrating to 5.15 or above
     property bool imageLoaded: (imageMessage.status === Image.Ready)
     property alias asynchronous: imageMessage.asynchronous
+    property bool leftTail: true
 
     signal clicked(var image, var mouse)
 
@@ -90,7 +90,7 @@ Item {
                     width: 32
                     height: 32
                     radius: 4
-                    visible: !root.isCurrentUser && !allCornersRounded
+                    visible: root.leftTail && !allCornersRounded
                 }
                 Rectangle {
                     anchors.bottom: parent.bottom
@@ -98,7 +98,7 @@ Item {
                     width: 32
                     height: 32
                     radius: 4
-                    visible: root.isCurrentUser && !allCornersRounded
+                    visible: !root.leftTail && !allCornersRounded
                 }
             }
         }

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -22,8 +22,6 @@ Flow {
     required property var linkPreviewModel
     required property var gifLinks
 
-    required property bool isCurrentUser
-
     required property bool gifUnfurlingEnabled
     required property bool canAskToUnfurlGifs
 
@@ -65,7 +63,6 @@ Flow {
 
             link: modelData
             isOnline: root.isOnline
-            isCurrentUser: root.isCurrentUser
             playAnimation: root.playAnimations
             onClicked: root.imageClicked(imageAlias, mouse, link, link)
         }
@@ -79,7 +76,6 @@ Flow {
         model: root.linkPreviewModel
         delegate: LinkPreviewCardDelegate {
             id: delegate
-            isCurrentUser: root.isCurrentUser
             highlight: url === root.highlightLink
             onHoveredChanged: {
                 linksRepeater.hoveredUrl = hovered ? url : ""

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -758,7 +758,6 @@ Loader {
                         gifLinks: root.gifLinks
                         playAnimations: root.messageStore.playAnimation
                         isOnline: root.rootStore.mainModuleInst.isOnline
-                        isCurrentUser: root.amISender
                         highlightLink: delegate.hoveredLink
                         onImageClicked: (image, mouse, imageSource, url) => {
                             d.onImageClicked(image, mouse, imageSource, url)


### PR DESCRIPTION
### What does the PR do
Closing: #12599 

Set the link preview tight corner on the left side.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Link previews
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/1cb5aeda-a27c-4017-bfa5-43197f38e6f2

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
