### PR TITLE
chore(@AccountContexMenu.qml): make the context menu dynamic

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
+++ b/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
@@ -18,7 +18,6 @@ StatusMenu {
     signal addWatchOnlyAccountClicked()
     signal hideFromTotalBalanceClicked(string address, bool hideFromTotalBalance)
 
-    width: 204
 
     StatusSuccessAction {
         id: copyAddressAction


### PR DESCRIPTION
Removed the predefined width in the context menu to allow the new option of including/excluding from total balance be fully visible

### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/12579

<img width="1512" alt="Screenshot 2023-11-01 at 16 28 18" src="https://github.com/status-im/status-desktop/assets/82375995/43f8fce3-7979-4bbb-80c4-b824619bc7b4">
