### PR TITLE
feat: implement generalized collectibles filter

### DIFF
--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -128,7 +128,7 @@ method refreshWalletAccounts*(self: Module) =
   let ownedWalletAccounts = walletAccounts.filter(a => a.walletType != WalletTypeWatch)
   let ownedWalletAccountAddresses = ownedWalletAccounts.map(a => a.address)
   let enabledNetworks = self.controller.getEnabledChainIds()
-  self.collectiblesController.globalFilterChanged(ownedWalletAccountAddresses, enabledNetworks)
+  self.collectiblesController.setFilterAddressesAndChains(ownedWalletAccountAddresses, enabledNetworks)
 
 method load*(self: Module) =
   self.events.on(SIGNAL_KEYPAIR_SYNCED) do(e: Args):

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -175,7 +175,7 @@ method notifyFilterChanged(self: Module) =
   self.accountsModule.filterChanged(self.filter.addresses, self.filter.chainIds)
   self.sendModule.filterChanged(self.filter.addresses, self.filter.chainIds)
   self.activityController.globalFilterChanged(self.filter.addresses, self.filter.allAddresses, self.filter.chainIds, self.filter.allChainsEnabled)
-  self.collectiblesController.globalFilterChanged(self.filter.addresses, self.filter.chainIds)
+  self.collectiblesController.setFilterAddressesAndChains(self.filter.addresses, self.filter.chainIds)
   if self.filter.addresses.len > 0:
     self.view.filterChanged(self.filter.addresses[0], self.filter.allAddresses)
 

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -356,7 +356,7 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) 
 proc updateCollectiblesFilter*(self: Module) =
   let addresses = @[self.view.getSenderAddressByIndex(self.senderCurrentAccountIndex)]
   let chainIds = self.controller.getChainIds()
-  self.collectiblesController.globalFilterChanged(addresses, chainIds)
+  self.collectiblesController.setFilterAddressesAndChains(addresses, chainIds)
 
 method setSelectedSenderAccountIndex*(self: Module, index: int) =
   self.senderCurrentAccountIndex = index


### PR DESCRIPTION
Closes #12520
status-go part: https://github.com/status-im/status-go/pull/4245

### What does the PR do

Implement additional Collectibles filtering, using some communities-related criteria.

This allows us to, for example, get a list of all Owner Tokens owned by the user.