### PR TITLE
feature: live status link previews

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -1,4 +1,4 @@
-import chronicles, uuids
+import chronicles, uuids, times
 import io_interface
 import json
 
@@ -213,8 +213,7 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_COMMUNITIES_UPDATE) do(e: Args):
     let args = CommunitiesArgs(e)
     for community in args.communities:
-      if (community.id == self.sectionId):
-        self.delegate.updateCommunityDetails(community)
+      self.delegate.updateCommunityDetails(community)
 
   self.events.on(SIGNAL_FIRST_UNSEEN_MESSAGE_LOADED) do(e: Args):
     let args = FirstUnseenMessageLoadedArgs(e)
@@ -237,6 +236,12 @@ proc getChatDetails*(self: Controller): ChatDto =
 
 proc getCommunityDetails*(self: Controller): CommunityDto =
   return self.communityService.getCommunityById(self.sectionId)
+
+proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+  return self.communityService.getCommunityById(communityId)
+
+proc requestCommunityInfo*(self: Controller, communityId: string, useDataabse: bool, requiredTimeSinceLastRequest: Duration) =
+  self.communityService.requestCommunityInfo(communityId, false, useDataabse, requiredTimeSinceLastRequest)
 
 proc getOneToOneChatNameAndImage*(self: Controller):
     tuple[name: string, image: string, largeImage: string] =
@@ -263,6 +268,9 @@ proc getContactById*(self: Controller, contactId: string): ContactsDto =
 
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
   return self.contactService.getContactDetails(contactId)
+
+proc requestContactInfo*(self: Controller, contactId: string) =
+  self.contactService.requestContactInfo(contactId)
 
 proc getNumOfPinnedMessages*(self: Controller): int =
   return self.messageService.getNumOfPinnedMessages(self.chatId)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -176,3 +176,6 @@ method reevaluateViewLoadingState*(self: AccessInterface) {.base.} =
 
 method onGetMessageById*(self: AccessInterface, requestId: UUID, messageId: string, message: MessageDto, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method forceLinkPreviewsLocalData*(self: AccessInterface, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -787,8 +787,6 @@ method forceLinkPreviewsLocalData*(self: Module, messageId: string) =
   debug "forceLinkPreviewsLocalData", messageId, itemFound = $(item != nil)
   if item == nil:
     return
-  if not item.linkPreviewModel.updateForcedLocalDataTimestamp():
-    return
   self.updateLinkPreviewsContacts(item, requestFromMailserver = true)
   self.updateLinkPreviewsCommunities(item, requestFromMailserver = true)
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, uuids
+import NimQml, chronicles, sequtils, uuids, sets, times
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller
@@ -6,6 +6,7 @@ import ../../../../shared_models/message_model
 import ../../../../shared_models/message_item
 import ../../../../shared_models/message_reaction_item
 import ../../../../shared_models/message_transaction_parameters_item
+import ../../../../shared_models/link_preview_model
 import ../../../../../global/global_singleton
 import ../../../../../core/eventemitter
 import ../../../../../../app_service/service/contacts/dto/contacts
@@ -62,6 +63,8 @@ proc createChatIdentifierItem(self: Module): Item
 proc createFetchMoreMessagesItem(self: Module): Item
 proc setChatDetails(self: Module, chatDetails: ChatDto)
 proc updateItemsByAlbum(self: Module, items: var seq[Item], message: MessageDto): bool
+proc updateLinkPreviewsContacts(self: Module, item: Item, requestFromMailserver: bool)
+proc updateLinkPreviewsCommunities(self: Module, item: Item, requestFromMailserver: bool)
 
 method delete*(self: Module) =
   self.controller.delete
@@ -319,6 +322,9 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         message.albumImagesCount,
         )
 
+      self.updateLinkPreviewsContacts(item, item.seen)
+      self.updateLinkPreviewsCommunities(item, item.seen)
+
       for r in reactions:
         if(r.messageId == message.id):
           var emojiIdAsEnum: EmojiId
@@ -453,6 +459,9 @@ method messagesAdded*(self: Module, messages: seq[MessageDto]) =
       message.albumImagesCount,
     )
     items.add(item)
+
+    self.updateLinkPreviewsContacts(item, item.seen)
+    self.updateLinkPreviewsCommunities(item, item.seen)
 
   self.view.model().insertItemsBasedOnClock(items)
 
@@ -596,6 +605,8 @@ method updateContactDetails*(self: Module, contactId: string) =
       let communityChats = self.controller.getCommunityDetails().chats
       item.messageText = self.controller.getRenderedText(item.parsedText, communityChats)
 
+    item.linkPreviewModel.setContactInfo(updatedContact)
+
 method deleteMessage*(self: Module, messageId: string) =
   self.controller.deleteMessage(messageId)
 
@@ -728,8 +739,12 @@ method markMessagesAsRead*(self: Module, messages: seq[string]) =
   self.view.model().markAsSeen(messages)
 
 method updateCommunityDetails*(self: Module, community: CommunityDto) =
-  self.view.setAmIChatAdmin(community.isPrivilegedUser)
-  self.view.setIsPinMessageAllowedForMembers(community.adminSettings.pinMessageAllMembersEnabled)
+  if community.id == self.getSectionId():
+    self.view.setAmIChatAdmin(community.isPrivilegedUser)
+    self.view.setIsPinMessageAllowedForMembers(community.adminSettings.pinMessageAllMembersEnabled)
+
+  for item in self.view.model().items:
+    item.linkPreviewModel.setCommunityInfo(community)
 
 proc setChatDetails(self: Module, chatDetails: ChatDto) =
   self.view.setChatColor(chatDetails.color)
@@ -766,3 +781,38 @@ method onFirstUnseenMessageLoaded*(self: Module, messageId: string) =
   self.firstUnseenMessageState.initialized = true
   self.firstUnseenMessageState.fetching = false
   self.reevaluateViewLoadingState()
+
+method forceLinkPreviewsLocalData*(self: Module, messageId: string) =
+  let item = self.view.model().getItemWithMessageId(messageId)
+  debug "forceLinkPreviewsLocalData", messageId, itemFound = $(item != nil)
+  if item == nil:
+    return
+  if not item.linkPreviewModel.updateForcedLocalDataTimestamp():
+    return
+  self.updateLinkPreviewsContacts(item, true)
+  self.updateLinkPreviewsCommunities(item, true)
+
+proc updateLinkPreviewsContacts(self: Module, item: Item, requestFromMailserver: bool) =
+  for contactId in item.linkPreviewModel.getContactIds().items:
+    let contact = self.controller.getContactDetails(contactId)
+    if contact.dto.displayName != "":
+      item.linkPreviewModel.setContactInfo(contact)
+      continue
+    if requestFromMailserver:
+      debug "updateLinkPreviewsContacts: contact not found, requesting from mailserver", contactId
+      item.linkPreviewModel.onContactDataRequested(contactId)
+      self.controller.requestContactInfo(contactId)
+  
+proc updateLinkPreviewsCommunities(self: Module, item: Item, requestFromMailserver: bool) =
+  for communityId in item.linkPreviewModel.getCommunityIds().items:
+    
+    if (let community = self.controller.getCommunityById(communityId); community).id != "":
+      item.linkPreviewModel.setCommunityInfo(community)
+    
+    if not requestFromMailserver:
+      return
+    
+    debug "updateLinkPreviewsCommunites: requesting from mailserver", communityId
+    item.linkPreviewModel.onCommunityInfoRequested(communityId)
+    self.controller.requestCommunityInfo(communityId, false, initDuration(minutes = 10))
+

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -224,3 +224,6 @@ QtObject:
 
   proc firstUnseenMentionMessageId(self: View): string {.slot.} =
     return self.model.getFirstUnseenMentionMessageId()
+
+  proc forceLinkPreviewsLocalData*(self: View, messageId: string) {.slot.} =
+    self.delegate.forceLinkPreviewsLocalData(messageId)

--- a/src/app/modules/shared_models/link_preview_item.nim
+++ b/src/app/modules/shared_models/link_preview_item.nim
@@ -7,6 +7,8 @@ type
   Item* = ref object
     unfurled*: bool
     immutable*: bool
+    isLocalData*: bool
+    loadingLocalData*: bool
     linkPreview*: LinkPreview
 
 proc delete*(self: Item) =

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -346,7 +346,7 @@ QtObject:
 
   # Checks the time since local data was previously forced.
   # If more than 10 minutes passed, updates the timestamp to current timestamp.
-  # Returns true if timestamp was upates, i.e. a request from mailserver is expected to happen after.
+  # Returns true if timestamp was updated, i.e. a request from mailserver is expected to happen after.
   proc updateForcedLocalDataTimestamp*(self: Model): bool =
     let now = now().toTime()
     if now - self.forcedLocalDataTimestamp < initDuration(minutes = 10):

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat, tables, sequtils, sets, times
+import NimQml, strformat, tables, sequtils, sets
 import ./link_preview_item
 import ../../../app_service/service/message/dto/link_preview
 import ../../../app_service/service/message/dto/standard_link_preview
@@ -41,7 +41,6 @@ QtObject:
   type
     Model* = ref object of QAbstractListModel
       items: seq[Item]
-      forcedLocalDataTimestamp: Time
 
   proc delete*(self: Model) = 
     for i in 0 ..< self.items.len:
@@ -55,7 +54,6 @@ QtObject:
   proc newLinkPreviewModel*(linkPreviews: seq[LinkPreview] = @[]): Model =
     new(result, delete)
     result.setup
-    result.forcedLocalDataTimestamp = initTime(0, 0)
     for linkPreview in linkPreviews:
       var item = Item()
       item.unfurled = true
@@ -343,14 +341,3 @@ QtObject:
     for row, item in self.items:
       if item.linkPreview.getCommunityId() == communityId:
         self.setItemLoadingLocalData(row, item, true)
-
-  # Checks the time since local data was previously forced.
-  # If more than 10 minutes passed, updates the timestamp to current timestamp.
-  # Returns true if timestamp was updated, i.e. a request from mailserver is expected to happen after.
-  proc updateForcedLocalDataTimestamp*(self: Model): bool =
-    let now = now().toTime()
-    if now - self.forcedLocalDataTimestamp < initDuration(minutes = 10):
-      return false
-    self.forcedLocalDataTimestamp = now
-    return true
-

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -396,6 +396,8 @@ proc seen*(self: Item): bool {.inline.} =
 
 proc `seen=`*(self: Item, value: bool) {.inline.} =
   self.seen = value
+  # if self.seen:
+  #   self.linkPreviewModel.forceLocalData()
 
 proc timestamp*(self: Item): int64 {.inline.} =
   self.timestamp

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -396,8 +396,6 @@ proc seen*(self: Item): bool {.inline.} =
 
 proc `seen=`*(self: Item, value: bool) {.inline.} =
   self.seen = value
-  # if self.seen:
-  #   self.linkPreviewModel.forceLocalData()
 
 proc timestamp*(self: Item): int64 {.inline.} =
   self.timestamp

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -552,6 +552,10 @@ QtObject:
       return
     self.items[index].toJsonNode()
 
+  iterator items*(self: Model): Item =
+    for i in 0 ..< self.items.len:
+      yield self.items[i]
+
   iterator modelContactUpdateIterator*(self: Model, contactId: string): Item =
     for i in 0 ..< self.items.len:
       yield self.items[i]

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -5,7 +5,6 @@ import ../../community/dto/community
 
 include ../../../common/json_utils
 import ../../../../app_service/common/types
-import ../../../../app/global/global_singleton
 
 type ChatType* {.pure.}= enum
   Unknown = 0,

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -5,6 +5,7 @@ import ../../community/dto/community
 
 include ../../../common/json_utils
 import ../../../../app_service/common/types
+import ../../../../app/global/global_singleton
 
 type ChatType* {.pure.}= enum
   Unknown = 0,
@@ -415,3 +416,8 @@ proc hasMoreMessagesToRequest*(chatDto: ChatDto, syncedFrom: int64): bool =
 
 proc hasMoreMessagesToRequest*(chatDto: ChatDto): bool =
   chatDto.hasMoreMessagesToRequest(chatDto.syncedFrom)
+
+proc communityChannelUuid*(self: ChatDto): string =
+  if self.communityId == "":
+    return ""
+  return self.id[self.communityId.len .. ^1]

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -53,11 +53,12 @@ type
   AsyncRequestCommunityInfoTaskArg = ref object of QObjectTaskArg
     communityId: string
     importing: bool
+    useDatabase: bool
 
 const asyncRequestCommunityInfoTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestCommunityInfoTaskArg](argEncoded)
   try:
-    let response = status_go.requestCommunityInfo(arg.communityId)
+    let response = status_go.requestCommunityInfo(arg.communityId, arg.useDatabase)
     arg.finish(%* {
       "communityId": arg.communityId,
       "importing": arg.importing,

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -53,12 +53,12 @@ type
   AsyncRequestCommunityInfoTaskArg = ref object of QObjectTaskArg
     communityId: string
     importing: bool
-    useDatabase: bool
+    tryDatabase: bool
 
 const asyncRequestCommunityInfoTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestCommunityInfoTaskArg](argEncoded)
   try:
-    let response = status_go.requestCommunityInfo(arg.communityId, arg.useDatabase)
+    let response = status_go.requestCommunityInfo(arg.communityId, arg.tryDatabase)
     arg.finish(%* {
       "communityId": arg.communityId,
       "importing": arg.importing,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1739,7 +1739,7 @@ QtObject:
     )
     self.threadpool.start(arg)
 
-  proc requestCommunityInfo*(self: Service, communityId: string, importing = false, useDatabase = true, requiredTimeSinceLastRequest = initDuration(0, 0)) =
+  proc requestCommunityInfo*(self: Service, communityId: string, importing = false, tryDatabase = true, requiredTimeSinceLastRequest = initDuration(0, 0)) =
 
     if communityId in self.requestedCommunityIds:
       info "requestCommunityInfo: skipping as already requested", communityId
@@ -1764,7 +1764,7 @@ QtObject:
       slot: "asyncCommunityInfoLoaded",
       communityId: communityId,
       importing: importing,
-      useDatabase: useDatabase
+      tryDatabase: tryDatabase
     )
     self.threadpool.start(arg)
 

--- a/src/app_service/service/message/dto/link_preview.nim
+++ b/src/app_service/service/message/dto/link_preview.nim
@@ -1,11 +1,13 @@
 import json, strformat, tables
 import ./link_preview_thumbnail, ./status_link_preview, ./standard_link_preview
 import ./status_contact_link_preview, ./status_community_link_preview, ./status_community_channel_link_preview
+import ../../contacts/dto/contact_details
+import ../../community/dto/community
 include ../../../common/json_utils
 
 
 type
-  PreviewType {.pure.} = enum
+  PreviewType* {.pure.} = enum
     NoPreview = 0
     StandardPreview
     StatusContactPreview
@@ -126,3 +128,27 @@ proc getChannelCommunity*(self: LinkPreview): StatusCommunityLinkPreview =
   if self.statusCommunityChannelPreview == nil:
     return nil
   return self.statusCommunityChannelPreview.getCommunity()
+
+proc getContactId*(self: LinkPreview): string =
+  if self.previewType == PreviewType.StatusContactPreview:
+    return self.statusContactPreview.getPublicKey()
+  return ""
+
+proc getCommunityId*(self: LinkPreview): string =
+  if self.previewType == PreviewType.StatusCommunityPreview:
+    return self.statusCommunityPreview.getCommunityId()
+  if self.previewType == PreviewType.StatusCommunityChannelPreview:
+    return self.statusCommunityChannelPreview.getCommunity().getCommunityId()
+  return ""
+
+proc setContactInfo*(self: LinkPreview, contactDetails: ContactDetails): bool =
+  if self.previewType == PreviewType.StatusContactPreview:
+    return self.statusContactPreview.setContactInfo(contactDetails)
+  return false
+
+proc setCommunityInfo*(self: LinkPreview, community: CommunityDto): bool =
+  if self.previewType == PreviewType.StatusCommunityPreview:
+    return self.statusCommunityPreview.setCommunityInfo(community)
+  if self.previewType == PreviewType.StatusCommunityChannelPreview:
+    return self.statusCommunityChannelPreview.setCommunityInfo(community)
+  return false

--- a/src/app_service/service/message/dto/link_preview_thumbnail.nim
+++ b/src/app_service/service/message/dto/link_preview_thumbnail.nim
@@ -14,11 +14,7 @@ QtObject:
   proc delete*(self: LinkPreviewThumbnail) =
     self.QObject.delete()
 
-  proc update*(self: LinkPreviewThumbnail, width: int, height: int, url: string, dataUri: string) =
-    self.width = width
-    self.height = height
-    self.url = url
-    self.dataUri = dataUri
+  proc update*(self: LinkPreviewThumbnail, width: int, height: int, url: string, dataUri: string)
 
   proc copy*(self: LinkPreviewThumbnail, other: LinkPreviewThumbnail) =
     if other != nil:
@@ -82,3 +78,17 @@ QtObject:
       "url": self.url,
       "dataUri": self.dataUri
     }
+
+  proc update*(self: LinkPreviewThumbnail, width: int, height: int, url: string, dataUri: string) =
+    if self.width != width:
+      self.width = width
+      self.widthChanged()
+    if self.height != height:
+      self.height = height
+      self.heightChanged()
+    if self.url != url:
+      self.url = url
+      self.urlChanged()
+    if self.dataUri != dataUri:
+      self.dataUri = dataUri
+      self.dataUriChanged()

--- a/src/app_service/service/message/dto/status_community_channel_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_channel_link_preview.nim
@@ -1,6 +1,8 @@
 import json, strformat, NimQml, chronicles
 import link_preview_thumbnail
 import status_community_link_preview
+import ../../community/dto/community
+import ../../chat/dto/chat
 include ../../../common/json_utils
 
 QtObject:
@@ -93,3 +95,31 @@ QtObject:
 
   proc empty*(self: StatusCommunityChannelLinkPreview): bool =
     return self.channelUUID.len == 0
+
+  proc setCommunityInfo*(self: StatusCommunityChannelLinkPreview, community: CommunityDto): bool =
+    if not self.community.setCommunityInfo(community):
+      return false
+
+    for chat in community.chats:
+      if chat.communityChannelUuid() != self.channelUuid:
+        continue
+
+      debug "setChannelInfo", communityId = $self.community.getCommunityId(), channelUuid = $self.channelUuid
+
+      if self.displayName != chat.name:
+        self.displayName = chat.name
+        self.displayNameChanged()
+
+      if self.description != chat.description:
+        self.description = chat.description
+        self.descriptionChanged()
+
+      if self.emoji != chat.emoji:
+        self.emoji = chat.emoji
+        self.emojiChanged()
+
+      if self.color != community.color:
+        self.color = community.color
+        self.colorChanged()
+
+      return true

--- a/src/app_service/service/message/dto/status_community_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_link_preview.nim
@@ -130,7 +130,7 @@ QtObject:
     if self.communityId != community.id:
       return false
 
-    debug "setCommunityInfo", communityId = $self.communityId, communityName = community.name
+    debug "setCommunityInfo", communityId = self.communityId, communityName = community.name
 
     if self.displayName != community.name:
       self.displayName = community.name

--- a/src/app_service/service/message/dto/status_contact_link_preview.nim
+++ b/src/app_service/service/message/dto/status_contact_link_preview.nim
@@ -96,7 +96,7 @@ QtObject:
     if self.publicKey != contactDetails.dto.id:
       return false
     
-    debug "setContactInfo", publicKey = $self.publicKey, displayName = $contactDetails.dto.displayname
+    debug "setContactInfo", publicKey = self.publicKey, displayName = $contactDetails.dto.displayname
 
     if self.displayName != contactDetails.defaultDisplayName:
       self.displayName = contactDetails.defaultDisplayName

--- a/src/app_service/service/message/dto/status_contact_link_preview.nim
+++ b/src/app_service/service/message/dto/status_contact_link_preview.nim
@@ -2,9 +2,6 @@ import json, strformat, NimQml, chronicles
 import link_preview_thumbnail
 import ../../contacts/dto/contact_details
 
-import ../../../../app/global/global_singleton
-import ../../../../app/global/utils as utils
-
 include ../../../common/json_utils
 
 QtObject:
@@ -25,8 +22,6 @@ QtObject:
   proc newStatusContactLinkPreview*(publicKey: var string, displayName: string, description: string, icon: LinkPreviewThumbnail): StatusContactLinkPreview =
     new(result, delete)
     result.setup()
-    if singletonInstance.utils().isCompressedPubKey(publicKey):
-      publicKey = singletonInstance.utils().getDecompressedPk(publicKey)
     result.publicKey = publicKey
     result.displayName = displayName
     result.description = description

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -409,7 +409,7 @@ proc collectCommunityMetrics*(communityId: string, metricsType: int, intervals: 
     }])
 
 proc requestCommunityInfo*(communityId: string, useDatabase: bool): RpcResponse[JsonNode] {.raises: [Exception].} =
-  result = callPrivateRPC("requestCommunityInfoFromMailserverV2".prefix, %*[{
+  result = callPrivateRPC("fetchCommunity".prefix, %*[{
     "communityId": communityId,
     "useDatabase": useDatabase,
     "waitForResponse": true

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -408,10 +408,10 @@ proc collectCommunityMetrics*(communityId: string, metricsType: int, intervals: 
       "intervals": intervals
     }])
 
-proc requestCommunityInfo*(communityId: string, useDatabase: bool): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc requestCommunityInfo*(communityId: string, tryDatabase: bool): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("fetchCommunity".prefix, %*[{
     "communityId": communityId,
-    "useDatabase": useDatabase,
+    "tryDatabase": tryDatabase,
     "waitForResponse": true
   }])
 

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -408,8 +408,12 @@ proc collectCommunityMetrics*(communityId: string, metricsType: int, intervals: 
       "intervals": intervals
     }])
 
-proc requestCommunityInfo*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  result = callPrivateRPC("requestCommunityInfoFromMailserver".prefix, %*[communityId])
+proc requestCommunityInfo*(communityId: string, useDatabase: bool): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("requestCommunityInfoFromMailserverV2".prefix, %*[{
+    "communityId": communityId,
+    "useDatabase": useDatabase,
+    "waitForResponse": true
+  }])
 
 proc importCommunity*(communityKey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("importCommunity".prefix, %*[communityKey])

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -410,7 +410,7 @@ proc collectCommunityMetrics*(communityId: string, metricsType: int, intervals: 
 
 proc requestCommunityInfo*(communityId: string, tryDatabase: bool): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("fetchCommunity".prefix, %*[{
-    "communityId": communityId,
+    "communityKey": communityId,
     "tryDatabase": tryDatabase,
     "waitForResponse": true
   }])

--- a/ui/StatusQ/src/assets.qrc
+++ b/ui/StatusQ/src/assets.qrc
@@ -202,6 +202,7 @@
         <file>assets/img/icons/github.svg</file>
         <file>assets/img/icons/group-chat.svg</file>
         <file>assets/img/icons/group.svg</file>
+        <file>assets/img/icons/active-members.svg</file>
         <file>assets/img/icons/help.svg</file>
         <file>assets/img/icons/hide.svg</file>
         <file>assets/img/icons/history.svg</file>

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -366,15 +366,6 @@ Item {
                                        notificationType,
                                        "")
         }
-
-        function onCommunityInfoAlreadyRequested() {
-            Global.displayToastMessage(qsTr("Community data not loaded yet."),
-                                       qsTr("Please wait for the unfurl to show"),
-                                       "",
-                                       true,
-                                       Constants.ephemeralNotificationType.normal,
-                                       "")
-        }
     }
 
     Connections {

--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -191,7 +191,7 @@ CalloutCard {
             }
             FooterText {
                 Layout.fillHeight: true
-                Layout.fillWidth: communityData.activeMembersCount === -1 //TODO: remove magic number once we have activeMembersCount
+                Layout.fillWidth: !communityData.activeMembersCountAvailable
                 color: Theme.palette.directColor1
                 text: LocaleUtils.numberToLocaleStringInCompactForm(communityData.membersCount)
                 verticalAlignment: Text.AlignVCenter
@@ -202,7 +202,7 @@ CalloutCard {
                 color: Theme.palette.directColor1
                 width: 16
                 height: width
-                visible: communityData.activeMembersCount > -1
+                visible: communityData.activeMembersCountAvailable
             }
             FooterText {
                 Layout.fillWidth: true
@@ -210,7 +210,7 @@ CalloutCard {
                 color: Theme.palette.directColor1
                 text: LocaleUtils.numberToLocaleStringInCompactForm(communityData.activeMembersCount)
                 verticalAlignment: Text.AlignVCenter
-                visible: communityData.activeMembersCount > -1
+                visible: communityData.activeMembersCountAvailable
             }
         }
     }

--- a/ui/imports/shared/controls/chat/private/CommunityData.qml
+++ b/ui/imports/shared/controls/chat/private/CommunityData.qml
@@ -7,5 +7,6 @@ QtObject {
     property string image
     property string color
     property int    membersCount
-    property int    activeMembersCount: -1 // TODO: implement this and remove the magic number
+    property int    activeMembersCount // -1 when not available. >= 0 otherwise.
+    readonly property bool activeMembersCountAvailable: activeMembersCount >= 0
 }

--- a/ui/imports/shared/controls/delegates/LinkPreviewCardDelegate.qml
+++ b/ui/imports/shared/controls/delegates/LinkPreviewCardDelegate.qml
@@ -34,6 +34,8 @@ LinkPreviewCard {
     required property bool empty
     required property string url
     required property bool immutable
+    required property bool isLocalData
+    required property bool loadingLocalData
     required property int previewType
     required property var standardPreview
     required property var standardPreviewThumbnail
@@ -69,6 +71,7 @@ LinkPreviewCard {
         banner: statusCommunityPreviewBanner ? (statusCommunityPreviewBanner.url || statusCommunityPreviewBanner.dataUri) || "" : ""
         image: statusCommunityPreviewIcon ? (statusCommunityPreviewIcon.url || statusCommunityPreviewIcon.dataUri) || "" : ""
         membersCount: statusCommunityPreview ? statusCommunityPreview.membersCount : 0
+        activeMembersCount: statusCommunityPreview && isLocalData ? statusCommunityPreview.activeMembersCount : -1
         color: statusCommunityPreview ? statusCommunityPreview.color : ""
     }
     channelData {
@@ -82,6 +85,7 @@ LinkPreviewCard {
             banner: statusCommunityChannelCommunityPreviewBanner ? (statusCommunityChannelCommunityPreviewBanner.url || statusCommunityChannelCommunityPreviewBanner.dataUri) || "" : ""
             image:  statusCommunityChannelCommunityPreviewIcon ? (statusCommunityChannelCommunityPreviewIcon.url || statusCommunityChannelCommunityPreviewIcon.dataUri) || "" : ""
             membersCount: statusCommunityChannelCommunityPreview ? statusCommunityChannelCommunityPreview.membersCount : 0
+            activeMembersCount: statusCommunityChannelCommunityPreview && isLocalData ? statusCommunityChannelCommunityPreview.activeMembersCount : -1
             color: statusCommunityChannelCommunityPreview ? statusCommunityChannelCommunityPreview.color : ""
         }
     }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -769,6 +769,10 @@ Loader {
                         gifUnfurlingEnabled: RootStore.gifUnfurlingEnabled
                         canAskToUnfurlGifs: !RootStore.neverAskAboutUnfurlingAgain
                         onSetNeverAskAboutUnfurlingAgain: RootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+
+                        Component.onCompleted: {
+                            root.messageStore.messageModule.forceLinkPreviewsLocalData(root.messageId)
+                        }
                     }
                 }
 


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/12459
Requires https://github.com/status-im/status-go/pull/4238
Requires https://github.com/status-im/status-go/pull/4246
Requires https://github.com/status-im/status-go/pull/4260

## What does the PR do

This introduces a feature about updating status link previews with trusted data from waku.

### Implementation details:

1. I decided to do it fully on client (desktop) side, because we want to keep original LinkPreviews untouched and not modify `user_messages` table.

2. The real data is pushed to `LinkPreviewModel` (it's transparent for UI)

3. When a new message is loaded, we check if there's real data locally available already.

4. When a message comes into user viewport (i.e. `LinksMessageView.onCompleted:  ...`), we "force" the real data to be loaded into the link preview. At this point we allow the data to be requested from waku. 
I added a limit, so that data of same contact/community is requested not more often than once in 10 minutes.

5. Now `activeMembersCount` is live

6. `requestCommunityInfo` now uses new `RequestCommunityInfoFromMailserverV2` endpoint. 
It's does the same thing, but has different parameters and gives more control over the operation, e.g. `useDatabase = false`, which was needed for this PR.

### Screenshot of functionality (including design for comparison)

<img width="1500" alt="Screenshot 2023-11-01 at 14 37 59" src="https://github.com/status-im/status-desktop/assets/25482501/116c34d1-9a64-4a42-9cbe-7e68cb6ee581"> 

https://github.com/status-im/status-desktop/assets/25482501/6d3ed47d-5dbf-4f43-8a7a-833793c536e6


