### PR TITLE
fix: Fixing broken binding on text input enabled property

### DIFF
--- a/test/ui-test/testSuites/suite_communities/tst_communityMessageFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityMessageFlows/test.feature
@@ -59,8 +59,7 @@ Feature: Status Desktop community messages
 
         When the user unpins the message at index 0
         Then the amount of pinned messages is 1
-	@mayfail
-	# https://github.com/status-im/status-desktop/issues/12440
+
     Scenario Outline: The user can reply to own message
         Given the user sends a chat message "<message>"
         When the user replies to community chat message at index 0 with "<reply>"

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -121,14 +121,9 @@ Rectangle {
     }
 
     function setText(text) {
-        const textInputEnabled = textInput.enabled
-        if(textInputEnabled) {
-            textInput.enabled = false
-        }
-
         textInput.clear()
+        hyperlinksFormatter.undoStackManager.clear()
         textInput.append(text)
-        textInput.enabled = textInputEnabled
     }
 
     implicitWidth: layout.implicitWidth + layout.anchors.leftMargin + layout.anchors.rightMargin
@@ -1250,6 +1245,10 @@ Rectangle {
                             bottomPadding: 9
                             leftPadding: 0
                             padding: 0
+                            // This is needed to make sure the text area is disabled when the input is disabled
+                            Binding on enabled {
+                                value: root.enabled
+                            }
                             Keys.onUpPressed: {
                                 if (isEdit && !activeFocus) {
                                     forceActiveFocus();


### PR DESCRIPTION
### What does the PR do

Closing #12440 

The enabled property of the text input needs to have a binding to the StatusChatInput enabled property

+ re-enable the squish test

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

StatusChatInput
<!-- List the affected areas (e.g wallet, browser, etc..) -->
### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/ccf8ded7-1a5d-40c8-95e9-3e5051c6f09e
