### PR TITLE
fix(Onboarding): Apply 2 line constraint for create password description text

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
@@ -39,12 +39,11 @@ Item {
     ColumnLayout {
         spacing: Style.current.bigPadding
         anchors.centerIn: parent
-        width: 416
         height: 460
         z: view.zFront
         PasswordView {
             id: view
-            Layout.fillWidth: true
+            Layout.preferredWidth: root.width - 2 * Style.current.bigPadding
             Layout.fillHeight: true
             passwordStrengthScoreFunction: root.startupStore.getPasswordStrengthScore
             highSizeIntro: true

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -74,12 +74,13 @@ StatusModal {
             fill: parent
             topMargin: Style.current.padding
             bottomMargin: Style.current.padding
-            leftMargin: Style.current.xlPadding
-            rightMargin: Style.current.xlPadding
+            leftMargin: Style.current.padding
+            rightMargin: Style.current.padding
         }
         passwordStrengthScoreFunction: RootStore.getPasswordStrengthScore
         titleVisible: false
         introText: qsTr("Change password used to unlock Status on this device & sign transactions.")
+        fixIntroTextWidth: true
         createNewPsw: false
         onReturnPressed: if(submitBtn.enabled) d.submit()
     }

--- a/ui/imports/shared/popups/keycard/states/CreatePassword.qml
+++ b/ui/imports/shared/popups/keycard/states/CreatePassword.qml
@@ -26,6 +26,7 @@ Item {
             Layout.fillHeight: true
             passwordStrengthScoreFunction: RootStore.getPasswordStrengthScore
             highSizeIntro: true
+            fixIntroTextWidth: true
 
             newPswText: root.sharedKeycardModule.getNewPassword()
             confirmationPswText: root.sharedKeycardModule.getNewPassword()

--- a/ui/imports/shared/views/PasswordView.qml
+++ b/ui/imports/shared/views/PasswordView.qml
@@ -23,6 +23,7 @@ ColumnLayout {
     property string recoverText: qsTr("You will not be able to recover this password if it is lost.")
     property string strengthenText: qsTr("Minimum %n character(s). To strengthen your password consider including:", "", Constants.minPasswordLength)
     property bool highSizeIntro: false
+    property bool fixIntroTextWidth: false
 
     property var passwordStrengthScoreFunction: function () {}
 
@@ -78,6 +79,8 @@ ColumnLayout {
 
         readonly property var validatorRegexp: /^[!-~]{0,64}$/
         readonly property string validatorErrMessage: qsTr("Only letters, numbers, underscores and hyphens allowed")
+
+        readonly property int defaultInputWidth: 416
 
         // Password strength categorization / validation
         function lowerCaseValidator(text) { return (/[a-z]/.test(text)) }
@@ -153,14 +156,34 @@ ColumnLayout {
         color: Theme.palette.directColor1
     }
 
-    StatusBaseText {
-        id: introTxtField
-        Layout.fillWidth: true
-        text: "%1 <font color=\"%2\">%3</font>".arg(root.introText).arg(Theme.palette.dangerColor1).arg(root.recoverText)
-        font.pixelSize: root.highSizeIntro ? 15 : 12
-        color: Theme.palette.baseColor1
-        wrapMode: Text.WordWrap
-        horizontalAlignment: TextEdit.AlignHCenter
+    ColumnLayout {
+        id: introColumn
+
+        Layout.preferredWidth: root.fixIntroTextWidth ? d.defaultInputWidth : parent.width
+        Layout.alignment: Qt.AlignHCenter
+        spacing: 4
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
+
+            text: root.introText
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: root.highSizeIntro ? Style.current.primaryTextFontSize : Style.current.tertiaryTextFontSize
+            wrapMode: Text.WordWrap
+            color: Theme.palette.baseColor1
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
+
+            text: root.recoverText
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: root.highSizeIntro ? Style.current.primaryTextFontSize : Style.current.tertiaryTextFontSize
+            wrapMode: Text.WordWrap
+            color: Theme.palette.dangerColor1
+        }
     }
 
     StatusPasswordInput {
@@ -171,7 +194,8 @@ ColumnLayout {
 
         z: root.zFront
         visible: !root.createNewPsw
-        Layout.fillWidth: true
+        Layout.preferredWidth: d.defaultInputWidth
+        Layout.alignment: Qt.AlignHCenter
         placeholderText: qsTr("Current password")
         echoMode: showPassword ? TextInput.Normal : TextInput.Password
         rightPadding: showHideCurrentIcon.width + showHideCurrentIcon.anchors.rightMargin + Style.current.padding / 2
@@ -193,9 +217,9 @@ ColumnLayout {
     }
 
     ColumnLayout {
-        spacing: Style.current.padding / 2
+        spacing: 4
         z: root.zFront
-        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignHCenter
 
         StatusPasswordInput {
             id: newPswInput
@@ -203,7 +227,8 @@ ColumnLayout {
 
             property bool showPassword
 
-            Layout.fillWidth: true
+            Layout.preferredWidth: d.defaultInputWidth
+            Layout.alignment: Qt.AlignHCenter
             placeholderText: qsTr("New password")
             echoMode: showPassword ? TextInput.Normal : TextInput.Password
             rightPadding: showHideNewIcon.width + showHideNewIcon.anchors.rightMargin + Style.current.padding / 2
@@ -244,7 +269,6 @@ ColumnLayout {
 
         StatusPasswordStrengthIndicator {
             id: strengthInditactor
-            Layout.fillWidth: true
             value: Math.min(Constants.minPasswordLength, newPswInput.text.length)
             from: 0
             to: Constants.minPasswordLength
@@ -258,7 +282,6 @@ ColumnLayout {
 
     StatusBaseText {
         id: strengthenTxt
-        Layout.fillWidth: true
         Layout.alignment: Qt.AlignHCenter
         wrapMode: Text.WordWrap
         text: root.strengthenText
@@ -307,7 +330,8 @@ ColumnLayout {
         property bool showPassword
 
         z: root.zFront
-        Layout.fillWidth: true
+        Layout.preferredWidth: d.defaultInputWidth
+        Layout.alignment: Qt.AlignHCenter
         placeholderText: qsTr("Confirm password")
         echoMode: showPassword ? TextInput.Normal : TextInput.Password
         rightPadding: showHideConfirmIcon.width + showHideConfirmIcon.anchors.rightMargin + Style.current.padding / 2


### PR DESCRIPTION
### What does the PR do

This PR fixes #11965

During the password creation flow, the description underneath the Create password label didn't have any constraints on the number of lines to display the text. This caused the overall components below the description to move down, which is not expected. This pull request adds a 2 lines constraint on the mentioned description.

### Affected areas

- Onboarding Create and Confirm screens.
- Also can affect Change Password view since they share qml component.

### Screenshot of functionality (including design for comparison)

Here is the original text in English : 

![Image](https://github.com/status-im/status-desktop/assets/2589171/516468ae-640f-4756-9f1e-9439b9c1dcc7)

The longest translation for the first sentence is in German, with 76 characters: `Erstellen Sie ein Passwort, um Status auf diesem Gerät zu entsperren und Transaktionen zu signieren.`

The longest translation for the second sentence is in French, with 61 characters: `Vous ne pourrez pas récupérer le mot de passe si vous le perdez.`

NOTE : The image below is just for showing the final rending for both strings. In reality both languages will not appear at the same time.

![Image](https://github.com/status-im/status-desktop/assets/2589171/89737846-4481-44e6-8b97-a324d3b1d214)

### Result

<img width="1312" alt="Screenshot 2023-11-08 at 8 17 29 AM" src="https://github.com/status-im/status-desktop/assets/2589171/4e1e903c-985a-4637-86f0-3370ed120ba8">

<img width="1312" alt="Screenshot 2023-11-08 at 10 48 38 AM" src="https://github.com/status-im/status-desktop/assets/2589171/bef34038-abe8-4b84-8b8e-70576a76e62d">

