### PR TITLE
fix(ci): archive artifacts in pkg folder

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -18,6 +18,8 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '10',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-desktop/*')
   }
 
   parameters {
@@ -74,14 +76,16 @@ pipeline {
     }
   }
   post {
-    always { script { dir('pkg') {
-      /* Generate sha256 checksums for all artifacts. */
-      sha = "./${utils.pkgFilename(ext: 'sha256')}"
-      sh "sha256sum * | tee ../${sha}"
-      archiveArtifacts('*')
-      urls['SHA'] = s3.uploadArtifact(sha)
-      jenkins.setBuildDesc(urls)
-    } } }
+    always { script {
+      dir('pkg') {
+        /* Generate sha256 checksums for all artifacts. */
+        sha = "./${utils.pkgFilename(ext: 'sha256')}"
+        sh "sha256sum * | tee ./${sha}"
+        urls['SHA'] = s3.uploadArtifact(sha)
+        jenkins.setBuildDesc(urls)
+      }
+      archiveArtifacts('pkg/*')
+    } }
     failure { script {
       withCredentials([
         string(


### PR DESCRIPTION
This allows `jenkins.copyArts()` - which assumes existence of `pkg` folder - to work with meta-jobs.

Required for:
* https://github.com/status-im/desktop-qa-automation/pull/270