### PR TITLE
fix(ConfirmPasswordView): only use privacyModule when in main app state

### DIFF
--- a/ui/app/AppLayouts/Onboarding/stores/StartupStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/StartupStore.qml
@@ -11,6 +11,8 @@ QtObject {
     property var fetchingDataModel: startupModuleInst ? startupModuleInst.fetchingDataModel
                                                          : null
 
+    readonly property int appState: startupModuleInst.appState
+
     readonly property int localPairingState: startupModuleInst ? startupModuleInst.localPairingState : -1
     readonly property string localPairingError: startupModuleInst ? startupModuleInst.localPairingError : ""
     readonly property string localPairingName: startupModuleInst ? startupModuleInst.localPairingName : ""

--- a/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.15
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.12
 
@@ -141,7 +141,9 @@ Item {
     }
 
     Connections {
-        target: RootStore.privacyModule
+        enabled: root.startupStore.appState == Constants.appState.main
+        // Only use the privacyModule if we are in the app, otherwise we try to use modules that don't exist yet
+        target: enabled ? RootStore.privacyModule : null
         function onPasswordChanged(success: bool, errorMsg: string) {
             if (success) {
                 submitBtn.loading = false


### PR DESCRIPTION
Fixes part of [#12605](https://github.com/status-im/status-desktop/issues/12605)

I put this on top of the release branch because the issue happened in the release mostly. 

It also only happens in release builds, so it was definitely a race condition.

In the end, the issue was that we were using the `privacyModule` during the account creation when the `privacyModule` doesn't exist and it ended up calling multiple modules that also weren't initialized and probably during all this, it created a race condition that crashed.