### PR TITLE
fix: activate community channel link

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -195,6 +195,7 @@ proc init*(self: Controller) =
       setActive = args.fromUserAction
     )
     self.delegate.onFinaliseOwnershipStatusChanged(args.isPendingOwnershipRequest, args.community.id)
+    self.delegate.communitySpectated(args.community.id)
 
   self.events.on(TOGGLE_SECTION) do(e:Args):
     let args = ToggleSectionArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -141,6 +141,9 @@ method activeSectionSet*(self: AccessInterface, sectionId: string) {.base.} =
 method toggleSection*(self: AccessInterface, sectionType: SectionType) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communitySpectated*(self: AccessInterface, communityId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method communityJoined*(self: AccessInterface, community: CommunityDto, events: EventEmitter,
   settingsService: settings_service.Service,
   nodeConfigurationService: node_configuration_service.Service,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1834,7 +1834,6 @@ QtObject:
     if self.communityInfoRequests.hasKey(communityId):
       let lastRequestTime = self.communityInfoRequests[communityId]
       let actualTimeSincLastRequest = now - lastRequestTime
-      debug "requestCommunityInfo: TIME", communityId, now, lastRequestTime, requiredTimeSinceLastRequest, actualTimeSincLastRequest
       if actualTimeSincLastRequest < requiredTimeSinceLastRequest:
         debug "requestCommunityInfo: skipping as required time has not passed yet since last request", communityId, actualTimeSincLastRequest, requiredTimeSinceLastRequest
         return

--- a/src/app_service/service/shared_urls/dto/url_data.nim
+++ b/src/app_service/service/shared_urls/dto/url_data.nim
@@ -48,7 +48,7 @@ proc toCommunityChannelUrlDataDto*(jsonObj: JsonNode): CommunityChannelUrlDataDt
   discard jsonObj.getProp("description", result.description)
   discard jsonObj.getProp("emoji", result.emoji)
   discard jsonObj.getProp("color", result.color)
-  discard jsonObj.getProp("uuid", result.uuid)
+  discard jsonObj.getProp("channelUuid", result.uuid)
 
 proc toContactUrlDataDto*(jsonObj: JsonNode): ContactUrlDataDto =
   result = ContactUrlDataDto()


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12539

### What does the PR do

1. Improve the algorithm of switching to channel by using the known community id
2. Fix the used `chatID` for chat lookup, as it should be a concatenation of community id and channel id
3. Fix the order of processing channel/community in `activateStatusDeepLink`. Channel should be processed earlier, because communityId is also set
4. Fix json parsing of `channelUuid` field 
5. Refactor switching to community/channel to use `switchTo` function
6. Works for non-spectated/joined community too!

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/7d5d887c-2664-4ae5-ad95-d042f8f457b8