### PR TITLE
chore(@desktop/wallet): Unifying the various "TokensTypes" across the  app

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -34,8 +34,6 @@ import ../../../../app_service/service/community_tokens/service as community_tok
 import ../../../../app_service/service/shared_urls/service as shared_urls_service
 import ../../../../app_service/service/visual_identity/service as visual_identity
 import ../../../../app_service/service/contacts/dto/contacts as contacts_dto
-import ../../../../app_service/service/community/dto/community as community_dto
-import ../../../../app_service/common/types
 
 export io_interface
 
@@ -1307,11 +1305,11 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
 
     let viewAmount = tokenCriteria{"amount"}.getFloat
     var tokenCriteriaDto = tokenCriteria.toTokenCriteriaDto
-    if tokenCriteriaDto.`type` == community_dto.TokenType.ERC20:
+    if tokenCriteriaDto.`type` == TokenType.ERC20:
       tokenCriteriaDto.decimals = self.controller.getTokenDecimals(tokenCriteriaDto.symbol)
 
     let contractAddresses = self.controller.getContractAddressesForToken(tokenCriteriaDto.symbol)
-    if contractAddresses.len == 0 and tokenCriteriaDto.`type` != community_dto.TokenType.ENS:
+    if contractAddresses.len == 0 and tokenCriteriaDto.`type` != TokenType.ENS:
       if permissionId == "":
         self.onCommunityTokenPermissionCreationFailed(communityId)
         return

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -582,7 +582,7 @@ proc buildTokensAndCollectiblesFromCommunities(self: Module, communityTokens: se
         infiniteSupply,
       )
 
-      if tokenMetadata.tokenType == community_dto.TokenType.ERC20:
+      if tokenMetadata.tokenType == TokenType.ERC20:
       # Community ERC20 tokens
         tokenListItems.add(communityTokenItem)
       else:
@@ -635,12 +635,12 @@ method onCommunityTokenMetadataAdded*(self: Module, communityId: string, tokenMe
     infiniteSupply,
   )
 
-  if tokenMetadata.tokenType == community_dto.TokenType.ERC721 and
+  if tokenMetadata.tokenType == TokenType.ERC721 and
       not self.view.collectiblesListModel().hasItem(tokenMetadata.symbol):
     self.view.collectiblesListModel.addItems(@[tokenListItem])
     return
 
-  if tokenMetadata.tokenType == community_dto.TokenType.ERC20 and
+  if tokenMetadata.tokenType == TokenType.ERC20 and
       not self.view.tokenListModel().hasItem(tokenMetadata.symbol):
     self.view.tokenListModel.addItems(@[tokenListItem])
 

--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -1,13 +1,13 @@
 import stint
 import ./io_interface as community_tokens_module_interface
 
-import ../../../../../app_service/service/community_tokens/service as community_tokens_service
-import ../../../../../app_service/service/transaction/service as transaction_service
-import ../../../../../app_service/service/network/service as networks_service
-import ../../../../../app_service/service/community/service as community_service
-import ../../../../../app_service/service/community/dto/community
-import ../../../../core/signals/types
-import ../../../../core/eventemitter
+import app_service/service/community_tokens/service as community_tokens_service
+import app_service/service/transaction/service as transaction_service
+import app_service/service/network/service as networks_service
+import app_service/service/community/service as community_service
+import app_service/common/types
+import app/core/signals/types
+import app/core/eventemitter
 import ../../../shared_modules/keycard_popup/io_interface as keycard_shared_module
 
 

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -4,7 +4,6 @@ import ../../../../../app_service/service/community_tokens/service as community_
 import ../../../../../app_service/service/transaction/service as transaction_service
 import ../../../../../app_service/service/network/service as networks_service
 import ../../../../../app_service/service/community/service as community_service
-import ../../../../../app_service/service/community/dto/community
 import ../../../../../app_service/service/accounts/utils as utl
 import ../../../../../app_service/common/types
 import ../../../../core/eventemitter

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -1,9 +1,9 @@
 import NimQml, json, strutils, sequtils
 
 import ./io_interface as community_tokens_module_interface
-import ../../../shared_models/currency_amount
-import ../../../../../app_service/common/conversion
-import ../../../../../app_service/service/community/dto/community
+import app/modules/shared_models/currency_amount
+import app_service/common/conversion
+import app_service/common/types
 
 QtObject:
   type

--- a/src/app/modules/main/wallet_section/activity/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_model.nim
@@ -4,6 +4,7 @@ import logging
 import ./collectibles_item
 import web3/ethtypes as eth
 import backend/activity as backend_activity
+import app_service/common/types
 
 type
   CollectibleRole* {.pure.} = enum
@@ -187,7 +188,7 @@ QtObject:
   proc getActivityToken*(self: CollectiblesModel, id: string): backend_activity.Token =
     for item in self.items:
       if(cmpIgnoreCase(item.getId(), id) == 0):
-        result.tokenType = backend_activity.TokenType.Erc721
+        result.tokenType = TokenType.ERC721
         result.chainId = backend_activity.ChainId(item.getChainId())
         var contract = item.getContractAddress()
         if len(contract) > 0:

--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -16,9 +16,9 @@ import app/core/eventemitter
 import app/core/signals/types
 
 import backend/activity as backend_activity
-import backend/backend as backend
 
 import app_service/common/conversion
+import app_service/common/types
 import app_service/service/currency/service as currency_service
 import app_service/service/transaction/service as transaction_service
 import app_service/service/token/service as token_service
@@ -358,7 +358,7 @@ QtObject:
       for chainId in self.chainIds:
         let token = self.tokenService.findTokenBySymbol(chainId, tokenCode)
         if token != nil:
-          let tokenType = if token.symbol == "ETH": backend_activity.TokenType.Native else: backend_activity.TokenType.Erc20
+          let tokenType = if token.symbol == "ETH": TokenType.Native else: TokenType.ERC20
           assets.add(backend_activity.Token(
             tokenType: tokenType,
             chainId: backend_activity.ChainId(token.chainId),

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -4,6 +4,8 @@ import logging
 import ./collectibles_item
 import web3/ethtypes as eth
 import backend/activity as backend_activity
+import app_service/common/utils as common_utils
+import app_service/common/types
 
 type
   CollectibleRole* {.pure.} = enum
@@ -350,7 +352,7 @@ QtObject:
   proc getActivityToken*(self: Model, id: string): backend_activity.Token =
     for item in self.items:
       if(cmpIgnoreCase(item.getId(), id) == 0):
-        result.tokenType = backend_activity.TokenType.Erc721
+        result.tokenType = TokenType.ERC721
         result.chainId = backend_activity.ChainId(item.getChainId())
         var contract = item.getContractAddress()
         if len(contract) > 0:
@@ -380,4 +382,3 @@ QtObject:
     if chainId > 0 and len(tokenAddress) > 0 and len(tokenId) > 0:
       return $chainId & "+" & tokenAddress & "+" & tokenId
     return ""
-

--- a/src/app/modules/shared_models/token_criteria_model.nim
+++ b/src/app/modules/shared_models/token_criteria_model.nim
@@ -1,6 +1,8 @@
 import NimQml, Tables
+
+import app_service/common/types
+
 import token_criteria_item
-import ../../../app_service/service/community/dto/community
 
 type
   ModelRole {.pure.} = enum

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -80,9 +80,10 @@ type Shard* = ref object
   cluster*: int
   index*: int
 
-# ToDo: Will be streamlined to single TokenType under https://github.com/status-im/status-desktop/pull/12654/files
-type NewTokenType* {.pure.} = enum
+type TokenType* {.pure.} = enum
   Native = 0
   ERC20 = 1,
   ERC721 = 2,
-  ERC1155
+  ERC1155 = 3,
+  Unknown = 4,
+  ENS = 5

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -73,12 +73,6 @@ type TokenPermissionState* {.pure.}= enum
   UpdatePending = 2,
   RemovalPending = 3,
 
-type TokenType* {.pure.}= enum
-  Unknown = 0,
-  ERC20 = 1,
-  ERC721 = 2,
-  ENS = 3 # ENS is also ERC721 but we want to distinguish without heuristics
-
 type TokenCriteriaDto* = object
   contractAddresses* {.serializedFieldName("contract_addresses").}: Table[int, string]
   `type`* {.serializedFieldName("type").}: TokenType

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -127,8 +127,8 @@ QtObject:
           if flatTokensList.hasKey(unique_key):
             flatTokensList[unique_key].sources.add(s.name)
           else:
-            let tokenType = if s.name == "native" : NewTokenType.Native
-                            else: NewTokenType.ERC20
+            let tokenType = if s.name == "native" : TokenType.Native
+                            else: TokenType.ERC20
             flatTokensList[unique_key] = TokenItem(
               key: unique_key,
               name: token.name,
@@ -159,8 +159,8 @@ QtObject:
             if not addedChains.contains(token.chainID):
               tokenBySymbolList[token_by_symbol_key].addressPerChainId.add(AddressPerChain(chainId: token.chainID, address: token.address))
           else:
-            let tokenType = if s.name == "native": NewTokenType.Native
-                            else: NewTokenType.ERC20
+            let tokenType = if s.name == "native": TokenType.Native
+                            else: TokenType.ERC20
             tokenBySymbolList[token_by_symbol_key] = TokenBySymbolItem(
               key: token_by_symbol_key,
               name: token.name,

--- a/src/app_service/service/token/service_items.nim
+++ b/src/app_service/service/token/service_items.nim
@@ -36,7 +36,7 @@ type
     decimals*: int
     # will remain empty until backend provides us this data
     image*: string
-    `type`*: common_types.NewTokenType
+    `type`*: common_types.TokenType
     communityId*: string
 
 proc `$`*(self: TokenItem): string =

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -6,6 +6,7 @@ import stint
 import web3/ethtypes as eth
 import web3/conversions
 
+import app_service/common/types
 from gen import rpc
 import backend
 
@@ -34,10 +35,6 @@ type
   # see status-go/services/wallet/activity/filter.go Status
   ActivityStatus* {.pure.} = enum
     Failed, Pending, Complete, Finalized
-
-  # see status-go/services/wallet/activity/filter.go TokenType
-  TokenType* {.pure.} = enum
-    Native, Erc20, Erc721, Erc1155
 
   # see status-go/services/wallet/activity/filter.go TokenID
   TokenId* = distinct string
@@ -94,14 +91,18 @@ proc `%`*(tt: TokenType): JsonNode {.inline.} =
 
 proc `$`*(tt: TokenType): string {.inline.} =
   case tt:
-    of Native:
+    of TokenType.Native:
       return "ETH"
-    of Erc20:
+    of TokenType.ERC20:
       return "ERC-20"
-    of Erc721:
+    of TokenType.ERC721:
       return "ERC-721"
-    of Erc1155:
+    of TokenType.ERC1155:
       return "ERC-1155"
+    of TokenType.Unknown:
+      return "Unknown"
+    of TokenType.ENS:
+      return "ENS"
 
 proc fromJson*(jn: JsonNode, T: typedesc[TokenType]): TokenType {.inline.} =
   return cast[TokenType](jn.getInt())

--- a/storybook/pages/CommunityPermissionsHoldingItemEditor.qml
+++ b/storybook/pages/CommunityPermissionsHoldingItemEditor.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import AppLayouts.Communities.controls 1.0
+import utils 1.0
 
 ColumnLayout {
     id: root
@@ -17,12 +18,12 @@ ColumnLayout {
     QtObject {
         id: d
 
-        readonly property bool ensLayout: root.type === HoldingTypes.Type.Ens
+        readonly property bool ensLayout: root.type === Constants.TokenType.ENS
 
         readonly property var holdingTypesModel: [
-            { value: HoldingTypes.Type.Asset, text: "Asset" },
-            { value: HoldingTypes.Type.Collectible, text: "Collectible" },
-            { value: HoldingTypes.Type.Ens, text: "ENS" }
+            { value: Constants.TokenType.ERC20, text: "Asset" },
+            { value: Constants.TokenType.ERC721, text: "Collectible" },
+            { value: Constants.TokenType.ENS, text: "ENS" }
         ]
     }
 
@@ -72,7 +73,7 @@ ColumnLayout {
                 Layout.fillWidth: true
 
                 visible: !d.ensLayout
-                model: root.type === HoldingTypes.Type.Asset
+                model: root.type === Constants.TokenType.ERC20
                        ? root.assetKeys : root.collectibleKeys
 
                 onActivated: root.key = currentText

--- a/storybook/pages/CommunityPermissionsSettingsPanelEditor.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelEditor.qml
@@ -8,6 +8,8 @@ import AppLayouts.Communities.controls 1.0
 
 import Models 1.0
 
+import utils 1.0
+
 Flickable {
     id: root
 
@@ -132,7 +134,7 @@ Flickable {
                             }
 
                             Button {
-                                enabled: d.newKey && (d.newAmount || d.newType === HoldingTypes.Type.Ens)
+                                enabled: d.newKey && (d.newAmount || d.newType === Constants.TokenType.ENS)
                                 Layout.fillWidth: true
                                 text: "Add new holding"
 

--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -40,7 +40,7 @@ SplitView {
                 text: "Update"
                 onClicked: {
                     holdingsDropdown.close()
-                    holdingsDropdown.setActiveTab(HoldingTypes.Type.Ens)
+                    holdingsDropdown.setActiveTab(Constants.TokenType.ENS)
                     holdingsDropdown.openUpdateFlow()
                 }
             }

--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -106,7 +106,7 @@ SplitView {
 
             property var preSelectedAccount: txStore.selectedSenderAccount
             property string preSelectedHoldingID
-            property int preSelectedHoldingType
+            property int preSelectedHoldingType: Constants.TokenType.Unknown
             property int preSelectedSendType: Constants.SendType.Unknown
             property bool onlyAssets: false
             property string preDefinedAmountToSend
@@ -204,13 +204,16 @@ SplitView {
                 }
                 ComboBox {
                     id: tokenType
-                    model: ["Unknown", "Asset", "Collectible"]
-                    onCurrentIndexChanged: loader.preSelectedHoldingType = currentIndex
+                    model: ["Native", "Asset", "Collectible", "Fungible Token", "Unknown", "ENS"]
+                    currentIndex: 4
+                    onCurrentIndexChanged: {
+                        loader.preSelectedHoldingType = currentIndex
+                    }
                 }
             }
 
             StatusInput {
-                enabled: tokenType.currentIndex !== 0
+                enabled: tokenType.currentIndex > 0 && tokenType.currentIndex < 3
                 label: "preSelectedHoldingID (case sensitive)"
                 onTextChanged: loader.preSelectedHoldingID = text
             }

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -6,6 +6,8 @@ import Models 1.0
 import StatusQ.Core.Utils 0.1
 import AppLayouts.Communities.controls 1.0
 
+import utils 1.0
+
 QtObject {
     id: root
 
@@ -584,7 +586,7 @@ QtObject {
     function createHoldingsModel1() {
         return [
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "zrx",
                         amount: 15,
                         available: false
@@ -595,7 +597,7 @@ QtObject {
     function createHoldingsModel1b() {
         return [
                     {
-                        type: HoldingTypes.Type.Ens,
+                        type: Constants.TokenType.ENS,
                         key: "*.eth",
                         amount: 1,
                         available: true
@@ -606,13 +608,13 @@ QtObject {
     function createHoldingsModel2() {
         return [
                     {
-                        type: HoldingTypes.Type.Collectible,
+                        type: Constants.TokenType.ERC721,
                         key: "Kitty6",
                         amount: 50.25,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "Dai",
                         amount: 11,
                         available: true
@@ -623,13 +625,13 @@ QtObject {
     function createHoldingsModel2b() {
         return [
                     {
-                        type: HoldingTypes.Type.Collectible,
+                        type: Constants.TokenType.ERC721,
                         key: "Anniversary2",
                         amount: 1,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "snt",
                         amount: 666,
                         available: true
@@ -640,19 +642,19 @@ QtObject {
     function createHoldingsModel3() {
         return [
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "socks",
                         amount: 15,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Collectible,
+                        type: Constants.TokenType.ERC721,
                         key: "Kitty4",
                         amount: 50.25,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Collectible,
+                        type: Constants.TokenType.ERC721,
                         key: "SuperRare",
                         amount: 11,
                         available: false
@@ -663,25 +665,25 @@ QtObject {
     function createHoldingsModel4() {
         return [
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "socks",
                         amount: 15,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "snt",
                         amount: 25000,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Ens,
+                        type: Constants.TokenType.ENS,
                         key: "foo.bar.eth",
                         amount: 1,
                         available: false
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "Amp",
                         amount: 2,
                         available: true
@@ -692,31 +694,31 @@ QtObject {
     function createHoldingsModel5() {
         return [
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "socks",
                         amount: 15,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "zrx",
                         amount: 10,
                         available: false
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "1inch",
                         amount: 25000,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "Aave",
                         amount: 100,
                         available: true
                     },
                     {
-                        type: HoldingTypes.Type.Asset,
+                        type: Constants.TokenType.ERC20,
                         key: "Amp",
                         amount: 2,
                         available: true

--- a/storybook/stubs/shared/stores/send/TransactionStore.qml
+++ b/storybook/stubs/shared/stores/send/TransactionStore.qml
@@ -82,9 +82,9 @@ QtObject {
     }
 
     function getHolding(holdingId, holdingType) {
-        if (holdingType === Constants.HoldingType.Asset) {
+        if (holdingType === Constants.TokenType.ERC20) {
             return getAsset(selectedSenderAccount.assets, holdingId)
-        } else if (holdingType === Constants.HoldingType.Collectible) {
+        } else if (holdingType === Constants.TokenType.ERC721) {
             return getCollectible(holdingId)
         } else {
             return {}
@@ -92,9 +92,9 @@ QtObject {
     }
 
     function getSelectorHolding(holdingId, holdingType) {
-        if (holdingType === Constants.HoldingType.Asset) {
+        if (holdingType === Constants.TokenType.ERC20) {
             return getAsset(selectedSenderAccount.assets, holdingId)
-        } else if (holdingType === Constants.HoldingType.Collectible) {
+        } else if (holdingType === Constants.TokenType.ERC721) {
             return getSelectorCollectible(holdingId)
         } else {
             return {}
@@ -118,9 +118,9 @@ QtObject {
     }
 
     function holdingToSelectorHolding(holding, holdingType) {
-        if (holdingType === Constants.HoldingType.Asset) {
+        if (holdingType === Constants.TokenType.Asset) {
             return assetToSelectorAsset(holding)
-        } else if (holdingType === Constants.HoldingType.Collectible) {
+        } else if (holdingType === Constants.TokenType.Collectible) {
             return collectibleToSelectorCollectible(holding)
         } else {
             return {}

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -64,7 +64,7 @@ StatusSectionLayout {
         property Component sendTransactionModalComponent: SendModal {
             anchors.centerIn: parent
             preSelectedHoldingID: "ETH"
-            preSelectedHoldingType: Constants.HoldingType.Asset
+            preSelectedHoldingType: Constants.TokenType.ERC20
         }
 
         property Component signMessageModalComponent: SignMessageModal {}

--- a/ui/app/AppLayouts/Communities/controls/HoldingTypes.qml
+++ b/ui/app/AppLayouts/Communities/controls/HoldingTypes.qml
@@ -1,10 +1,6 @@
 import QtQml 2.14
 
 QtObject {
-    enum Type {
-        Unknown, Asset, Collectible, Ens
-    }
-
     enum Mode {
         Add, Update, UpdateOrRemove
     }

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -8,6 +8,8 @@ import StatusQ.Internal 0.1 as Internal
 
 import AppLayouts.Communities.controls 1.0
 
+import utils 1.0
+
 QtObject {
     function getTokenByKey(model, key) {
         if (!model)
@@ -81,13 +83,13 @@ QtObject {
             amount = AmountsArithmetic.toNumber(AmountsArithmetic.fromString(amount))
 
         switch (type) {
-            case HoldingTypes.Type.Asset:
+            case Constants.TokenType.ERC20:
                 return `${LocaleUtils.numberToLocaleString(amount)} ${name}`
-            case HoldingTypes.Type.Collectible:
+            case Constants.TokenType.ERC721:
                 if (amount === 1)
                     return name
                 return `${LocaleUtils.numberToLocaleString(amount)} ${name}`
-            case HoldingTypes.Type.Ens:
+            case Constants.TokenType.ENS:
                 if (name === "*.eth")
                     return qsTr("Any ENS username")
                 if (name.startsWith("*."))

--- a/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
@@ -51,7 +51,7 @@ Control {
         readonly property string memberchipRequestRejectedText: qsTr("Membership Request Rejected")
 
         function holdingsTextFormat(name, amount) {
-            return PermissionsHelpers.setHoldingsTextFormat(HoldingTypes.Type.Asset, name, amount)
+            return PermissionsHelpers.setHoldingsTextFormat(Constants.TokenType.ERC20, name, amount)
         }
 
         function getInvitationPendingText() {

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -20,9 +20,9 @@ StatusDropdown {
     property var collectiblesModel
     property bool isENSTab: true
     property string noDataText: {
-        if(d.currentHoldingType  ===  HoldingTypes.Type.Asset)
+        if(d.currentHoldingType  ===  Constants.TokenType.ERC20)
             return noDataTextForAssets
-        if(d.currentHoldingType === HoldingTypes.Type.Collectible)
+        if(d.currentHoldingType === Constants.TokenType.ERC721)
             return noDataTextForCollectibles
         return qsTr("No data found")
     }
@@ -61,7 +61,7 @@ StatusDropdown {
 
     function openUpdateFlow() {
         d.initialHoldingMode = HoldingTypes.Mode.UpdateOrRemove
-        if(d.currentHoldingType !== HoldingTypes.Type.Ens) {
+        if(d.currentHoldingType !== Constants.TokenType.ENS) {
             if(statesStack.size === 0)
                 statesStack.push(HoldingsDropdown.FlowType.List_Deep1)
 
@@ -75,7 +75,7 @@ StatusDropdown {
     }
 
     function reset() {
-        d.currentHoldingType = HoldingTypes.Type.Asset
+        d.currentHoldingType = Constants.TokenType.ERC20
         d.initialHoldingMode = HoldingTypes.Mode.Add
 
         root.assetKey = ""
@@ -91,7 +91,7 @@ StatusDropdown {
 
         // Internal management properties and signals:
         readonly property var holdingTypes: [
-            HoldingTypes.Type.Asset, HoldingTypes.Type.Collectible, HoldingTypes.Type.Ens
+            Constants.TokenType.ERC20, Constants.TokenType.ERC721, Constants.TokenType.ENS
         ]
         readonly property var tabsModel: [qsTr("Assets"), qsTr("Collectibles"), qsTr("ENS")]
         readonly property var tabsModelNoEns: [qsTr("Assets"), qsTr("Collectibles")]
@@ -102,7 +102,7 @@ StatusDropdown {
         readonly property bool ensReady: d.ensDomainNameValid
 
         property int extendedDropdownType: ExtendedDropdownContent.Type.Assets
-        property int currentHoldingType: HoldingTypes.Type.Asset
+        property int currentHoldingType: Constants.TokenType.ERC20
 
         property bool updateSelected: false
 
@@ -133,7 +133,7 @@ StatusDropdown {
 
         function setInitialFlow() {
             statesStack.clear()
-            if(d.currentHoldingType !== HoldingTypes.Type.Ens)
+            if(d.currentHoldingType !== Constants.TokenType.ENS)
                 statesStack.push(HoldingsDropdown.FlowType.List_Deep1)
             else
                 statesStack.push(HoldingsDropdown.FlowType.Selected)
@@ -197,17 +197,17 @@ StatusDropdown {
             state: d.currentHoldingType
             states: [
                 State {
-                    name: HoldingTypes.Type.Asset
+                    name: Constants.TokenType.ERC20
                     PropertyChanges {target: loader; sourceComponent: listLayout}
                     PropertyChanges {target: d; extendedDropdownType: ExtendedDropdownContent.Type.Assets}
                 },
                 State {
-                    name: HoldingTypes.Type.Collectible
+                    name: Constants.TokenType.ERC721
                     PropertyChanges {target: loader; sourceComponent: listLayout}
                     PropertyChanges {target: d; extendedDropdownType: ExtendedDropdownContent.Type.Collectibles}
                 },
                 State {
-                    name: HoldingTypes.Type.Ens
+                    name: Constants.TokenType.ENS
                     PropertyChanges {target: loader; sourceComponent: ensLayout}
                 }
             ]
@@ -245,9 +245,9 @@ StatusDropdown {
                 PropertyChanges {
                     target: loader
                     sourceComponent: {
-                        if (d.currentHoldingType === HoldingTypes.Type.Asset)
+                        if (d.currentHoldingType === Constants.TokenType.ERC20)
                             return assetLayout
-                        if (d.currentHoldingType === HoldingTypes.Type.Collectible)
+                        if (d.currentHoldingType === Constants.TokenType.ERC721)
                             return collectibleLayout
                         return ensLayout
                     }

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
@@ -112,7 +112,7 @@ StatusDialog {
                     root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
                     root.sendModalPopup.preSelectedAccount = ModelUtils.getByKey(root.accounts, "address", token.accountAddress)
                     root.sendModalPopup.preSelectedHoldingID = token.key
-                    root.sendModalPopup.preSelectedHoldingType = Constants.HoldingType.Collectible
+                    root.sendModalPopup.preSelectedHoldingType = Constants.TokenType.ERC721
                     root.sendModalPopup.open()
                     close()
                 }

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -358,16 +358,16 @@ StatusScrollView {
                 const modelItem = selectedHoldingsModel.get(index)
 
                 switch(modelItem.type) {
-                    case HoldingTypes.Type.Asset:
+                    case Constants.TokenType.ERC20:
                         dropdown.assetKey = modelItem.key
                         dropdown.assetAmount = modelItem.amount
                         dropdown.assetMultiplierIndex = modelItem.multiplierIndex
-                        dropdown.setActiveTab(HoldingTypes.Type.Asset)
+                        dropdown.setActiveTab(Constants.TokenType.ERC20)
                         break
-                    case HoldingTypes.Type.Collectible:
+                    case Constants.TokenType.ERC721:
                         dropdown.collectibleKey = modelItem.key
                         dropdown.collectibleAmount = modelItem.amount
-                        dropdown.setActiveTab(HoldingTypes.Type.Collectible)
+                        dropdown.setActiveTab(Constants.TokenType.ERC721)
                         break
                     default:
                         console.warn("Unsupported token type.")

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -125,13 +125,13 @@ StatusScrollView {
 
             function getTokenKeysAndAmounts() {
                 return ModelUtils.modelToArray(selectedHoldingsModel, ["type", "key", "amount"])
-                    .filter(item => item.type !== HoldingTypes.Type.Ens)
+                    .filter(item => item.type !== Constants.TokenType.ENS)
                     .map(item => ({ key: item.key, amount: item.amount }))
             }
 
             function getEnsNames() {
                 return ModelUtils.modelToArray(selectedHoldingsModel, ["type", "name"])
-                    .filter(item => item.type === HoldingTypes.Type.Ens)
+                    .filter(item => item.type === Constants.TokenType.ENS)
                     .map(item => item.name)
             }
         }
@@ -271,7 +271,7 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.assetsModel, key)
 
-                    addItem(HoldingTypes.Type.Asset, modelItem, amount)
+                    addItem(Constants.TokenType.ERC20, modelItem, amount)
                     dropdown.close()
                 }
 
@@ -279,13 +279,13 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.collectiblesModel, key)
 
-                    addItem(HoldingTypes.Type.Collectible, modelItem, amount)
+                    addItem(Constants.TokenType.ERC721, modelItem, amount)
                     dropdown.close()
                 }
 
                 onAddEns: {
                     d.dirtyValues.selectedHoldingsModel.append(
-                                { type: HoldingTypes.Type.Ens, key: domain, amount: 1 })
+                                { type: Constants.TokenType.ENS, key: domain, amount: 1 })
                     dropdown.close()
                 }
 
@@ -294,7 +294,7 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(root.assetsModel, key)
 
                     d.dirtyValues.selectedHoldingsModel.set(
-                                itemIndex, { type: HoldingTypes.Type.Asset, key, amount: parseFloat(amount) })
+                                itemIndex, { type: Constants.TokenType.ERC20, key, amount: parseFloat(amount) })
                     dropdown.close()
                 }
 
@@ -305,14 +305,14 @@ StatusScrollView {
 
                     d.dirtyValues.selectedHoldingsModel.set(
                                 itemIndex,
-                                { type: HoldingTypes.Type.Collectible, key, amount: parseFloat(amount) })
+                                { type: Constants.TokenType.ERC721, key, amount: parseFloat(amount) })
                     dropdown.close()
                 }
 
                 onUpdateEns: {
                     d.dirtyValues.selectedHoldingsModel.set(
                                 tokensSelector.editedIndex,
-                                { type: HoldingTypes.Type.Ens, key: domain, amount: 1 })
+                                { type: Constants.TokenType.ENS, key: domain, amount: 1 })
                     dropdown.close()
                 }
 
@@ -347,15 +347,15 @@ StatusScrollView {
                 const modelItem = tokensSelector.model.get(index)
 
                 switch(modelItem.type) {
-                    case HoldingTypes.Type.Asset:
+                    case Constants.TokenType.ERC20:
                         dropdown.assetKey = modelItem.key
                         dropdown.assetAmount = modelItem.amount
                         break
-                    case HoldingTypes.Type.Collectible:
+                    case Constants.TokenType.ERC721:
                         dropdown.collectibleKey = modelItem.key
                         dropdown.collectibleAmount = modelItem.amount
                         break
-                    case HoldingTypes.Type.Ens:
+                    case Constants.TokenType.ENS:
                         dropdown.ensDomainName = modelItem.key
                         break
                     default:

--- a/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
+++ b/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
@@ -25,10 +25,10 @@ SortFilterProxyModel {
             name: "text"
 
             function getName(type, key) {
-                if (type === HoldingTypes.Type.Ens)
+                if (type === Constants.TokenType.ENS)
                     return key
 
-                const model = type === HoldingTypes.Type.Asset
+                const model = type === Constants.TokenType.ERC20
                             ? assetsModel
                             : collectiblesModel
                 const item = PermissionsHelpers.getTokenByKey(model, key)
@@ -55,10 +55,10 @@ SortFilterProxyModel {
             name: "imageSource"
 
             function getIcon(type, key) {
-                if (type === HoldingTypes.Type.Ens)
+                if (type === Constants.TokenType.ENS)
                     return Style.png("tokens/ENS")
 
-                const model = type === HoldingTypes.Type.Asset
+                const model = type === Constants.TokenType.ERC20
                             ? assetsModel : collectiblesModel
 
                 return PermissionsHelpers.getTokenIconByKey(model, key)

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -122,7 +122,7 @@ Item {
             preSelectedRecipient: root.ensUsernamesStore.getEnsRegisteredAddress()
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0)
             preSelectedHoldingID: Constants.ethToken
-            preSelectedHoldingType: Constants.HoldingType.Asset
+            preSelectedHoldingType: Constants.TokenType.ERC20
             sendTransaction: function() {
                 if(bestRoutes.count === 1) {
                     let path = bestRoutes.firstItem()

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -67,7 +67,7 @@ Item {
             preSelectedRecipient: root.ensUsernamesStore.getEnsRegisteredAddress()
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0)
             preSelectedHoldingID: Constants.ethToken
-            preSelectedHoldingType: Constants.HoldingType.Asset
+            preSelectedHoldingType: Constants.TokenType.ERC20
             sendTransaction: function() {
                 if(bestRoutes.count === 1) {
                     let path = bestRoutes.firstItem()

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -52,7 +52,7 @@ Item {
             preSelectedRecipient: root.ensUsernamesStore.getEnsRegisteredAddress()
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(10)
             preSelectedHoldingID: JSON.parse(root.stickersStore.getStatusToken()).symbol
-            preSelectedHoldingType: Constants.HoldingType.Asset
+            preSelectedHoldingType: Constants.TokenType.ERC20
             sendTransaction: function() {
                 if(bestRoutes.count === 1) {
                     let path = bestRoutes.firstItem()

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -124,9 +124,9 @@ QtObject {
 
     property var cryptoRampServicesModel: walletSectionBuySellCrypto.model
 
-    function resetCurrentViewedHolding() {
+    function resetCurrentViewedHolding(type) {
         currentViewedHoldingID = ""
-        currentViewedHoldingType = Constants.HoldingType.Unknown
+        currentViewedHoldingType = type
     }
 
     function setCurrentViewedHoldingType(type) {

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -113,7 +113,7 @@ Item {
                     text: qsTr("Activity")
                 }
                 onCurrentIndexChanged: {
-                    RootStore.setCurrentViewedHoldingType(walletTabBar.currentIndex === 1 ? Constants.HoldingType.Collectible : Constants.HoldingType.Asset)
+                    RootStore.setCurrentViewedHoldingType(walletTabBar.currentIndex === 1 ? Constants.TokenType.ERC721 : Constants.TokenType.ERC20)
                 }
             }
             StackLayout {
@@ -129,7 +129,7 @@ Item {
                     assetDetailsLaunched: stack.currentIndex === 2
                     onAssetClicked: {
                         assetDetailView.token = token
-                        RootStore.setCurrentViewedHolding(token.symbol, Constants.HoldingType.Asset)
+                        RootStore.setCurrentViewedHolding(token.symbol, Constants.TokenType.ERC20)
                         stack.currentIndex = 2
                     }
                 }
@@ -137,7 +137,7 @@ Item {
                     collectiblesModel: RootStore.collectiblesStore.ownedCollectibles
                     onCollectibleClicked: {
                         RootStore.collectiblesStore.getDetailedCollectible(chainId, contractAddress, tokenId)
-                        RootStore.setCurrentViewedHolding(uid, Constants.HoldingType.Collectible)
+                        RootStore.setCurrentViewedHolding(uid, Constants.TokenType.ERC721)
                         stack.currentIndex = 1
                     }
                 }
@@ -163,7 +163,7 @@ Item {
 
             onVisibleChanged: {
                 if (!visible)
-                    RootStore.resetCurrentViewedHolding()
+                    RootStore.resetCurrentViewedHolding(Constants.TokenType.ERC721)
             }
         }
         AssetsDetailView {
@@ -180,7 +180,7 @@ Item {
 
             onVisibleChanged: {
                 if (!visible)
-                    RootStore.resetCurrentViewedHolding()
+                    RootStore.resetCurrentViewedHolding(Constants.TokenType.ERC20)
             }
         }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1420,7 +1420,7 @@ Item {
             property var preSelectedRecipient
             property int preSelectedRecipientType
             property string preSelectedHoldingID
-            property int preSelectedHoldingType
+            property int preSelectedHoldingType: Constants.TokenType.Unknown
             property int preSelectedSendType: Constants.SendType.Unknown
             property string preDefinedAmountToSend
             property bool onlyAssets: false
@@ -1431,7 +1431,7 @@ Item {
                     sendModal.closed()
                     sendModal.preSelectedSendType = Constants.SendType.Unknown
                     sendModal.preSelectedHoldingID = ""
-                    sendModal.preSelectedHoldingType = Constants.HoldingType.Unknown
+                    sendModal.preSelectedHoldingType = Constants.TokenType.Unknown
                     sendModal.preSelectedAccount = undefined
                     sendModal.preSelectedRecipient = undefined
                     sendModal.preDefinedAmountToSend = ""
@@ -1448,7 +1448,7 @@ Item {
                 if(sendModal.preSelectedSendType !== Constants.SendType.Unknown) {
                     item.preSelectedSendType = sendModal.preSelectedSendType
                 }
-                if(preSelectedHoldingType !== Constants.HoldingType.Unknown) {
+                if(preSelectedHoldingType !== Constants.TokenType.Unknown) {
                     item.preSelectedHoldingID = sendModal.preSelectedHoldingID
                     item.preSelectedHoldingType = sendModal.preSelectedHoldingType
                 }

--- a/ui/imports/shared/popups/send/Helpers.qml
+++ b/ui/imports/shared/popups/send/Helpers.qml
@@ -22,7 +22,7 @@ QtObject {
             preSelectedAccount: null,
             preSelectedRecipientType: TabAddressSelectorView.Type.Address,
             preSelectedRecipient: null,
-            preSelectedHoldingType: 0,
+            preSelectedHoldingType: Constants.TokenType.Unknown,
             preSelectedHolding: null,
             preSelectedHoldingID: "",
             preDefinedAmountToSend: "",
@@ -56,10 +56,10 @@ QtObject {
         }
 
         if (isCollectible) {
-            req.preSelectedHoldingType = Constants.HoldingType.Collectible
+            req.preSelectedHoldingType = Constants.TokenType.ERC721
             req.preSelectedHolding = token
         } else {
-            req.preSelectedHoldingType = Constants.HoldingType.Asset
+            req.preSelectedHoldingType = Constants.TokenType.ERC20
             req.preSelectedHoldingID = token
         }
 

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -31,7 +31,7 @@ StatusDialog {
     property string preDefinedAmountToSend
     // token symbol
     property string preSelectedHoldingID
-    property int preSelectedHoldingType
+    property int preSelectedHoldingType: Constants.TokenType.Unknown
     property int preSelectedSendType
     property bool interactive: true
     property alias onlyAssets: holdingSelector.onlyAssets
@@ -89,11 +89,11 @@ StatusDialog {
         readonly property bool isBridgeTx: store.sendType === Constants.SendType.Bridge
         readonly property bool isERC721Transfer: store.sendType === Constants.SendType.ERC721Transfer
         property var selectedHolding: null
-        property var selectedHoldingType: Constants.HoldingType.Unknown
-        readonly property bool isSelectedHoldingValidAsset: !!selectedHolding && selectedHoldingType === Constants.HoldingType.Asset
+        property var selectedHoldingType: Constants.TokenType.Unknown
+        readonly property bool isSelectedHoldingValidAsset: !!selectedHolding && selectedHoldingType === Constants.TokenType.ERC20
         property var hoveredHolding: null
-        property var hoveredHoldingType: Constants.HoldingType.Unknown
-        readonly property bool isHoveredHoldingValidAsset: !!hoveredHolding && hoveredHoldingType === Constants.HoldingType.Asset
+        property var hoveredHoldingType: Constants.TokenType.Unknown
+        readonly property bool isHoveredHoldingValidAsset: !!hoveredHolding && hoveredHoldingType === Constants.TokenType.ERC20
 
         function setSelectedHoldingId(holdingId, holdingType) {
             let holding = store.getHolding(holdingId, holdingType)
@@ -120,11 +120,11 @@ StatusDialog {
         }
 
         onSelectedHoldingChanged: {
-            if (d.selectedHoldingType === Constants.HoldingType.Asset) {
+            if (d.selectedHoldingType === Constants.TokenType.ERC20) {
                 if(!d.ensOrStickersPurpose && store.sendType !== Constants.SendType.Bridge)
                     store.setSendType(Constants.SendType.Transfer)
                 store.setSelectedAssetSymbol(selectedHolding.symbol)
-            } else if (d.selectedHoldingType === Constants.HoldingType.Collectible) {
+            } else if (d.selectedHoldingType === Constants.TokenType.ERC721) {
                 store.setSendType(Constants.SendType.ERC721Transfer)
                 amountToSendInput.input.text = 1
                 store.setSelectedAssetSymbol(selectedHolding.contractAddress+":"+selectedHolding.tokenId)
@@ -157,7 +157,8 @@ StatusDialog {
             store.setSendType(popup.preSelectedSendType)
         }
 
-        if (popup.preSelectedHoldingType !== Constants.HoldingType.Unknown) {
+        if ((popup.preSelectedHoldingType > Constants.TokenType.Native) &&
+                (popup.preSelectedHoldingType < Constants.TokenType.ERC1155)) {
             tokenListRect.browsingHoldingType = popup.preSelectedHoldingType
             if (!!popup.preSelectedHoldingID) {
                 d.setSelectedHoldingId(popup.preSelectedHoldingID, popup.preSelectedHoldingType)
@@ -262,8 +263,8 @@ StatusDialog {
                             collectiblesModel: popup.preSelectedAccount ? popup.nestedCollectiblesModel : null
                             networksModel: popup.store.allNetworksModel
                             currentCurrencySymbol: d.currencyStore.currentCurrencySymbol
-                            visible: (!!d.selectedHolding && d.selectedHoldingType !== Constants.HoldingType.Unknown) ||
-                                     (!!d.hoveredHolding && d.hoveredHoldingType !== Constants.HoldingType.Unknown)
+                            visible: (!!d.selectedHolding && d.selectedHoldingType !== Constants.TokenType.Unknown) ||
+                                     (!!d.hoveredHolding && d.hoveredHoldingType !== Constants.TokenType.Unknown)
                             onItemSelected: {
                                 d.setSelectedHoldingId(holdingId, holdingType)
                             }
@@ -408,7 +409,7 @@ StatusDialog {
                             if(hovered) {
                                 d.setHoveredHoldingId(symbol, holdingType)
                             } else {
-                                d.setHoveredHoldingId("", Constants.HoldingType.Unknown)
+                                d.setHoveredHoldingId("", Constants.TokenType.Unknown)
                             }
                         }
                     }

--- a/ui/imports/shared/popups/send/panels/HoldingSelector.qml
+++ b/ui/imports/shared/popups/send/panels/HoldingSelector.qml
@@ -54,8 +54,8 @@ Item {
         id: d
         // Internal management properties and signals:
         readonly property var holdingTypes: onlyAssets ?
-         [Constants.HoldingType.Asset] :
-         [Constants.HoldingType.Asset, Constants.HoldingType.Collectible]
+         [Constants.TokenType.ERC20] :
+         [Constants.TokenType.ERC20, Constants.TokenType.ERC721]
 
         readonly property var tabsModel: onlyAssets ?
          [qsTr("Assets")] :
@@ -66,15 +66,15 @@ Item {
         })
     
         function isAsset(type) {
-            return type === Constants.HoldingType.Asset
+            return type === Constants.TokenType.ERC20
         }
 
-        property int browsingHoldingType: Constants.HoldingType.Asset
+        property int browsingHoldingType: Constants.TokenType.ERC20
         readonly property bool isCurrentBrowsingTypeAsset: isAsset(browsingHoldingType)
         readonly property bool isBrowsingCollection: !isCurrentBrowsingTypeAsset && !!collectiblesModel && collectiblesModel.currentCollectionUid !== ""
         property string currentBrowsingCollectionName
 
-        property var currentHoldingType: Constants.HoldingType.Unknown
+        property var currentHoldingType: Constants.TokenType.Unknown
 
         property string searchText
         readonly property string assetSymbolByAddress: isCurrentBrowsingTypeAsset ? "": root.searchAssetSymbolByAddressFn(searchText)
@@ -298,8 +298,8 @@ Item {
             }
             onTokenSelected: {
                 holdingItemSelector.selectedItem = selectedToken
-                d.currentHoldingType = Constants.HoldingType.Asset
-                root.itemSelected(selectedToken.symbol, Constants.HoldingType.Asset)
+                d.currentHoldingType = Constants.TokenType.ERC20
+                root.itemSelected(selectedToken.symbol, Constants.TokenType.ERC20)
                 holdingItemSelector.comboBoxControl.popup.close()
             }
         }
@@ -316,8 +316,8 @@ Item {
                     root.collectiblesModel.currentCollectionUid = collectionUid
                 } else {
                     holdingItemSelector.selectedItem = selectedItem
-                    d.currentHoldingType = Constants.HoldingType.Collectible
-                    root.itemSelected(selectedItem.uid, Constants.HoldingType.Collectible)
+                    d.currentHoldingType = Constants.TokenType.ERC721
+                    root.itemSelected(selectedItem.uid, Constants.TokenType.ERC721)
                     holdingItemSelector.comboBoxControl.popup.close()
                 }
             }

--- a/ui/imports/shared/popups/send/views/TokenListView.qml
+++ b/ui/imports/shared/popups/send/views/TokenListView.qml
@@ -25,10 +25,10 @@ Item {
         return ""
     }
     property bool onlyAssets: false
-    property int browsingHoldingType: Constants.HoldingType.Asset
+    property int browsingHoldingType: Constants.TokenType.ERC20
 
     onVisibleChanged: {
-        if(!visible)
+        if(!visible && root.collectibles)
             root.collectibles.currentCollectionUid = ""
     }
 
@@ -46,8 +46,8 @@ Item {
 
         // Internal management properties and signals:
         readonly property var holdingTypes: onlyAssets ?
-                                                [Constants.HoldingType.Asset] :
-                                                [Constants.HoldingType.Asset, Constants.HoldingType.Collectible]
+                                                [Constants.TokenType.ERC20] :
+                                                [Constants.TokenType.ERC20, Constants.TokenType.ERC721]
 
         readonly property var tabsModel: onlyAssets ?
                                              [qsTr("Assets")] :
@@ -128,9 +128,9 @@ Item {
                     width: parent.width
                     height: tokenList.contentHeight
 
-                    header: root.browsingHoldingType === Constants.HoldingType.Asset ? tokenHeader : collectibleHeader
-                    model: root.browsingHoldingType === Constants.HoldingType.Asset ? tokensModel : collectiblesModel
-                    delegate: root.browsingHoldingType === Constants.HoldingType.Asset ? tokenDelegate : collectiblesDelegate
+                    header: root.browsingHoldingType === Constants.TokenType.ERC20 ? tokenHeader : collectibleHeader
+                    model: root.browsingHoldingType === Constants.TokenType.ERC20 ? tokensModel : collectiblesModel
+                    delegate: root.browsingHoldingType === Constants.TokenType.ERC20 ? tokenDelegate : collectiblesDelegate
                 }
             }
         }
@@ -171,19 +171,19 @@ Item {
         TokenBalancePerChainDelegate {
             width: ListView.view.width
             balancesModel: LeftJoinModel {
-                leftModel: balances
+                leftModel: model.balances
                 rightModel: root.networksModel
                 joinRole: "chainId"
             }
-            onTokenSelected: root.tokenSelected(symbol, Constants.HoldingType.Asset)
-            onTokenHovered: root.tokenHovered(symbol, Constants.HoldingType.Asset, hovered)
+            onTokenSelected: root.tokenSelected(symbol, Constants.TokenType.ERC20)
+            onTokenHovered: root.tokenHovered(symbol, Constants.TokenType.ERC20, hovered)
         }
     }
     Component {
         id: tokenHeader
         SearchBoxWithRightIcon {
             showTopBorder: !root.onlyAssets
-            width: parent.width
+            width: ListView.view.width
             placeholderText: qsTr("Search for token or enter token address")
             onTextChanged: Qt.callLater(d.updateAssetSearchText, text)
         }
@@ -192,13 +192,13 @@ Item {
         id: collectiblesDelegate
         CollectibleNestedDelegate {
             width: ListView.view.width
-            onItemHovered: root.tokenHovered(selectedItem.uid, Constants.HoldingType.Collectible, hovered)
+            onItemHovered: root.tokenHovered(selectedItem.uid, Constants.TokenType.ERC721, hovered)
             onItemSelected: {
                 if (isCollection) {
                     d.currentBrowsingCollectionName = collectionName
                     root.collectibles.currentCollectionUid = collectionUid
                 } else {
-                    root.tokenSelected(selectedItem.uid, Constants.HoldingType.Collectible)
+                    root.tokenSelected(selectedItem.uid, Constants.TokenType.ERC721)
                 }
             }
         }

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -204,7 +204,7 @@ Item {
             preSelectedRecipient: root.store.stickersStore.getStickersMarketAddress()
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(parseFloat(price))
             preSelectedHoldingID: JSON.parse(root.store.stickersStore.getStatusToken()).symbol
-            preSelectedHoldingType: Constants.HoldingType.Asset
+            preSelectedHoldingType: Constants.TokenType.ERC20
             sendTransaction: function() {
                 if(bestRoutes.count === 1) {
                     let path = bestRoutes.firstItem()

--- a/ui/imports/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/imports/shared/status/StatusStickerPackClickPopup.qml
@@ -73,7 +73,7 @@ ModalPopup {
                 preSelectedRecipient: stickerPackDetailsPopup.store.stickersStore.getStickersMarketAddress()
                 preDefinedAmountToSend: LocaleUtils.numberToLocaleString(parseFloat(price))
                 preSelectedHoldingID: JSON.parse(stickerPackDetailsPopup.store.stickersStore.getStatusToken()).symbol
-                preSelectedHoldingType: Constants.HoldingType.Asset
+                preSelectedHoldingType: Constants.TokenType.ERC20
                 sendTransaction: function() {
                     if(bestRoutes.count === 1) {
                         let path = bestRoutes.firstItem()

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -140,9 +140,9 @@ QtObject {
     }
 
     function getHolding(holdingId, holdingType) {
-        if (holdingType === Constants.HoldingType.Asset) {
+        if (holdingType === Constants.TokenType.ERC20) {
             return getAsset(selectedSenderAccount.assets, holdingId)
-        } else if (holdingType === Constants.HoldingType.Collectible) {
+        } else if (holdingType === Constants.TokenType.ERC721) {
             return getCollectible(holdingId)
         } else {
             return {}
@@ -150,9 +150,9 @@ QtObject {
     }
 
     function getSelectorHolding(holdingId, holdingType) {
-        if (holdingType === Constants.HoldingType.Asset) {
+        if (holdingType === Constants.TokenType.ERC20) {
             return getAsset(selectedSenderAccount.assets, holdingId)
-        } else if (holdingType === Constants.HoldingType.Collectible) {
+        } else if (holdingType === Constants.TokenType.ERC721) {
             return getSelectorCollectible(holdingId)
         } else {
             return {}
@@ -176,9 +176,9 @@ QtObject {
     }
 
     function holdingToSelectorHolding(holding, holdingType) {
-        if (holdingType === Constants.HoldingType.Asset) {
+        if (holdingType === Constants.TokenType.ERC20) {
             return assetToSelectorAsset(holding)
-        } else if (holdingType === Constants.HoldingType.Collectible) {
+        } else if (holdingType === Constants.TokenType.ERC721) {
             return collectibleToSelectorCollectible(holding)
         } else {
             return {}

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1057,11 +1057,14 @@ QtObject {
         Dismissed = 4
     }
 
+    // these are in sync with app_service/common/types.nim
     enum TokenType {
-        Unknown = 0,
+        Native = 0,
         ERC20 = 1, // Asset
         ERC721 = 2, // Collectible
-        ENS = 3
+        ERC1155 = 3,
+        Unknown = 4,
+        ENS = 5
     }
 
     enum TokenPrivilegesLevel {
@@ -1254,10 +1257,6 @@ QtObject {
     enum StandardLinkPreviewType {
         Link = 0,
         Image = 1
-    }
-
-    enum HoldingType {
-        Unknown, Asset, Collectible
     }
 
     enum UrlUnfurlingMode {


### PR DESCRIPTION
fixes #12501

### What does the PR do

We found that TokenTypes was declared at multiple places in the app and this is an attempt to unify it into one

different versions found on nim side:

src/backend/activity.nim --> Used for activity as this was the only one that depended on backend for the values we kept those untouched
src/app_service/service/community/dto/community.nim --> used for community permission

New place:
src/app_service/common/types.nim
```
type TokenType* {.pure.} = enum
  Native = 0
  ERC20 = 1,
  ERC721 = 2,
  ERC1155 = 3,
  Unknown = 4,
  ENS = 5
```

### Affected areas

Community permissions, transaction activity , SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
