### PR TITLE
Fix incorrect suggestion input when entering seed phrase

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -164,9 +164,11 @@ Item {
             }
             if (input.edit.keyEvent === Qt.Key_Down) {
                 seedSuggestionsList.incrementCurrentIndex()
+                input.edit.keyEvent = null
             }
             if (input.edit.keyEvent === Qt.Key_Up) {
                 seedSuggestionsList.decrementCurrentIndex()
+                input.edit.keyEvent = null
             }
             root.keyPressed(event);
         }


### PR DESCRIPTION
### What does the PR do

This PR fixes #10708

During the entering of Seed phrase, when pressing `Qt.Key_Up`, Qt would handle the event and keep the event cached. Similarly, when pressing `Qt.Key_Down`, that event will also be cached. When the user then pressed `Qt.Key_Return` the previous event would be replayed then changing the actual expected result. Here are some example from the bug :

In input we enter `z` to have the following : 

<img width="187" alt="Screenshot 2023-11-08 at 4 37 56 PM" src="https://github.com/status-im/status-desktop/assets/2589171/77336e80-71db-424d-946d-c80ab423df5d">

On this state, the first word is selected automatically and the cache of event is empty.
- If I press Key_Return, the expected result is `zebra` which is correct

Now if I do a Key_Down
- The event cache contains Key_Down, and the currently selected word is `zero`
- If I press Key_Return, the expected result should be `zero` but is `zone`

Now if I do a Key_Down, Key_Down again and then Key_Up
- The event cached contains Key_Up, the currently selected word is `zero` 
- If I press Key_Return, the expected result should be `zero` but is `zebra`

There are 2 more hidden edge cases that can be grouped into 1

If I go to the latest element in the list after moving `Key_Down`, the expected is `zoo` and that's expected because we handle the boundaries of the list correctly.
Similarly, if I move to the first element of the list after multiple Key_Up, the expected is `zebra` because the cached event will also point to the first element as we handle the boundaries correctly here too.

### Affected areas

- Restauration of account with seed phrase

### Screenshot of functionality (including design for comparison)

![output](https://github.com/status-im/status-desktop/assets/2589171/889bf8a5-bf35-4149-ae32-dfa688865d8f)

### Note / Discussion

As of now, I haven't found anything suspicious in event handle of the flow : 

```
StatusBaseInput -> StatusInput -> StatusSeedPhraseInput -> SeedPhraseInputView

```

I have tried to used `event.accepted = true` to avoid an event having to be processed further, but this doesn't change anything. So this point to a lower level mechanism of handling the event that I might not be aware of as of now.
Action item should be to understand why previous event are replayed when the Key_Return is pressed.
I have also checked that the event doesn't come from an AutoRepeating key.

Here are some log, where 90 is letter 'z'

```
Debug: DEBUG : StatusInput onKeyPressed  QQuickKeyEvent(0x6000004a32d8)   1699516206934 (qrc:/StatusQ/Controls/StatusInput.qml:451, onKeyPressed)
Debug: DEBUG : isAutoRepeat  false   1699516206934 (qrc:/StatusQ/Controls/StatusInput.qml:452, onKeyPressed)
Debug: DEBUG : StatusSeedPhraseInput onKeyPressed  90   1699516206934 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:158, onKeyPressed)
Debug: DEBUG : SeedPhraseInputView onKeyPressed  90   1699516206934 (qrc:/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml:232, onKeyPressed)
Debug: DEBUG : StatusInput onKeyPressed  QQuickKeyEvent(0x6000004a32d8)   1699516209033 (qrc:/StatusQ/Controls/StatusInput.qml:451, onKeyPressed)
Debug: DEBUG : isAutoRepeat  false   1699516209033 (qrc:/StatusQ/Controls/StatusInput.qml:452, onKeyPressed)
Debug: DEBUG : StatusSeedPhraseInput onKeyPressed  16777237   1699516209033 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:158, onKeyPressed)
Debug: DEBUG : Qt.Key_Down  1699516209033 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:169, onKeyPressed)
Debug: DEBUG : SeedPhraseInputView onKeyPressed  16777237   1699516209033 (qrc:/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml:232, onKeyPressed)


Debug: DEBUG : StatusInput onKeyPressed  QQuickKeyEvent(0x6000004a32d8)   1699516219931 (qrc:/StatusQ/Controls/StatusInput.qml:451, onKeyPressed)
Debug: DEBUG : isAutoRepeat  false   1699516219931 (qrc:/StatusQ/Controls/StatusInput.qml:452, onKeyPressed)
Debug: DEBUG : StatusSeedPhraseInput onKeyPressed  16777237   1699516219931 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:158, onKeyPressed)
Debug: DEBUG : Qt.Key_Down  1699516219931 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:169, onKeyPressed)
Debug: DEBUG : SeedPhraseInputView onKeyPressed  16777220   1699516219931 (qrc:/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml:232, onKeyPressed)
Debug: DEBUG : StatusInput onKeyPressed  QQuickKeyEvent(0x6000004a32d8)   1699516219932 (qrc:/StatusQ/Controls/StatusInput.qml:451, onKeyPressed)
Debug: DEBUG : isAutoRepeat  false   1699516219932 (qrc:/StatusQ/Controls/StatusInput.qml:452, onKeyPressed)
Debug: DEBUG : StatusSeedPhraseInput onKeyPressed  16777220   1699516219932 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:158, onKeyPressed)
Debug: DEBUG : Qt.Key_Return  1699516219940 (qrc:/StatusQ/Controls/StatusSeedPhraseInput.qml:163, onKeyPressed)
```