### PR TITLE
feat: Adding virtual horizontal anchors to be used by listviews nested in Flickabe

### DIFF
--- a/storybook/pages/ManageTokensPanelPage.qml
+++ b/storybook/pages/ManageTokensPanelPage.qml
@@ -28,6 +28,8 @@ SplitView {
         ManageTokensPanel {
             id: showcasePanel
             width: 500
+            //Removing the height property will break the initial height due to Layout internal handling
+            height: root.height
             baseModel: ctrlEmptyModel.checked ? null : assetsModel
         }
     }

--- a/storybook/pages/StatusLazyScrollViewPage.qml
+++ b/storybook/pages/StatusLazyScrollViewPage.qml
@@ -1,0 +1,234 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+import Models 1.0
+import Storybook 1.0
+
+import SortFilterProxyModel 0.2
+
+import utils 1.0
+
+SplitView {
+    id: root
+
+    component Separator: Rectangle {
+        height: 30
+        width: 300
+        color: "green"
+        Label {
+            anchors.centerIn: parent
+            color: "white"
+            text: "separator"
+        }
+    }
+
+    StatusLazyScrollView {
+        id: scrollView
+        // TODO: fix this
+        //Layout.fillHeight: true //doesn't work well. The initial height of the listviews is max
+        height: root.height
+        Layout.fillWidth: true
+
+        Rectangle {
+            color: "transparent"
+            border.color: "red"
+            border.width: 5
+            anchors.fill: parent
+        }
+
+        contentWidth: layout.width
+        contentHeight: layout.height
+
+        ColumnLayout {
+            id: layout
+
+            Separator {
+                id: separator0
+            }
+
+            ListView {
+                id: listview1
+                objectName: "listview1"
+
+                property int delegatesCount: 0
+                onDelegatesCountChanged: listView1MaxDelegatesCount.number = Math.max(listView1MaxDelegatesCount.number, delegatesCount)
+
+                NestedListViewAnchor {
+                    target: listview1
+                    anchorIn: scrollView.flickable
+                }
+
+                Label {
+                    text: "Listview 1 top"
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                }
+
+                model: 50
+                clip: true
+
+                delegate: Rectangle {
+                    height: Math.random() * 200
+                    width: 50
+                    color: Qt.rgba(Math.random(),Math.random(),Math.random(),1)
+                    Label {
+                        anchors.centerIn: parent
+                        color: "white"
+                        text: index
+                    }
+
+                    Component.onCompleted: listview1.delegatesCount++
+                    Component.onDestruction: listview1.delegatesCount--
+                }
+            }
+
+            Separator {
+                id: separator1
+            }
+
+            ListView {
+                id: listview2
+                property int delegatesCount: 0
+                onDelegatesCountChanged: listView2MaxDelegatesCount.number = Math.max(listView2MaxDelegatesCount.number, delegatesCount)
+
+
+                NestedListViewAnchor {
+                    target: listview2
+                    anchorIn: scrollView.flickable
+                }
+
+                Label {
+                    text: "Listview 2 top"
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                }
+
+                objectName: "listview2"
+                model: 50
+                clip: true
+                delegate: Rectangle {
+                    height: Math.random() * 200
+                    width: 50
+                    color: Qt.rgba(Math.random(),Math.random(),Math.random(),1)
+                    Label {
+                        anchors.centerIn: parent
+                        color: "white"
+                        text: index
+                    }
+
+                    Component.onCompleted: listview2.delegatesCount++
+                    Component.onDestruction: listview2.delegatesCount--
+                }
+            }
+
+            Separator {
+                id: separator2
+            }
+
+            ListView {
+                id: listview3
+
+                property int delegatesCount: 0
+                onDelegatesCountChanged: listView3MaxDelegatesCount.number = Math.max(listView3MaxDelegatesCount.number, delegatesCount)
+
+                NestedListViewAnchor {
+                    target: listview3
+                    anchorIn: scrollView.flickable
+                }
+
+                Label {
+                    text: "Listview 3 top"
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                }
+
+                model: 50
+                clip: true
+
+                objectName: "listview3"
+                delegate: Rectangle {
+                    height: Math.random() * 200
+                    width: 50
+                    color: Qt.rgba(Math.random(),Math.random(),Math.random(),1)
+                    Label {
+                        anchors.centerIn: parent
+                        color: "white"
+                        text: index
+                    }
+
+                    Component.onCompleted: {
+                        listview3.delegatesCount++
+                    }
+                    Component.onDestruction: listview3.delegatesCount--
+                }
+            }
+
+            Separator {
+                id: separator3
+            }
+        }
+    }
+
+    Pane {
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 400
+        ColumnLayout {
+            Label {
+                text: "Listview 1 delegates count: " + listview1.delegatesCount + " model count: " + listview1.count
+            }
+            Label {
+                id: listView1MaxDelegatesCount
+                property int number: 0
+                text: "Listview 1 Max delegates count: " + number + " model count: " + listview1.count
+            }
+            Slider {
+                from: 0
+                to: 1000
+                value: listview1.model
+                onValueChanged: listview1.model = value
+            }
+            Label {
+                text: "Listview 2 delegates count: " + listview2.delegatesCount + " model count: " + listview2.count
+            }
+
+            Label {
+                id: listView2MaxDelegatesCount
+                property int number: 0
+                text: "Listview 1 Max delegates count: " + number + " model count: " + listview2.count
+            }
+
+            Slider {
+                from: 0
+                to: 1000
+                value: listview2.model
+                onValueChanged: listview2.model = value
+            }
+
+            Label {
+                text: "Listview 3 delegates count: " + listview3.delegatesCount + " model count: " + listview3.count
+            }
+            Label {
+                id: listView3MaxDelegatesCount
+                property int number: 0
+                text: "Listview 3 Max delegates count: " + number + " model count: " + listview3.count
+            }
+
+            Slider {
+                from: 0
+                to: 1000
+                value: listview3.model
+                onValueChanged: listview3.model = value
+            }
+        }
+    }
+}
+
+// category: POC

--- a/storybook/src/Models/ManageTokensModel.qml
+++ b/storybook/src/Models/ManageTokensModel.qml
@@ -8,9 +8,8 @@ ListModel {
         var data = []
         for (let i = 0; i < 100; i++) {
             const communityId = i % 2 == 0 ? "" : "communityId%1".arg(Math.round(i))
-            const enabledNetworkBalance = !!communityId ? Math.round(i)
-                                                        : {
-                                                              amount: 1,
+            const enabledNetworkBalance =  {
+                                                              amount: Math.round(i),
                                                               symbol: "ZRX"
                                                           }
             var obj = {

--- a/ui/StatusQ/src/StatusQ/Core/FlickableAnchoringListviews.qml
+++ b/ui/StatusQ/src/StatusQ/Core/FlickableAnchoringListviews.qml
@@ -1,0 +1,296 @@
+import QtQuick 2.15
+import QtQml 2.15
+import QtQuick.Controls 2.15
+
+
+
+// FlickableAnchoringListviews is a flickable that can anchor nested listviews
+// Anchoring listviews refers to the ability to scroll the flickable by scrolling the nested listviews and vice versa. A child listview will be anchored in the flickable
+// when it is scrolled
+// The main goal is to have a single scrollable area that contains all the nested listviews withoud unrolling the nested listviews
+// This is achieved by using scrolling breakpoints and switching the scrolling between the flickable and the nested listviews, depending on the content position.
+// The scrolling can switch between the flickable and the nested listviews.
+//
+// Input: 
+//     NestedListViewAnchor
+// Output:
+//     property virtualContentHeight - The global content height. It can be different than the flickable content height if the flickable contains nested listviews
+//     property virtualContentYPosition - The global content y. It can be different than the flickable content y if the flickable contains nested listviews
+//
+// Usage:
+//     FlickableAnchoringListviews {
+//         id: root
+//         anchors.fill: parent              // Give it a size
+//         contentWidth: childLayout.width   // Set the content width
+//         contentHeight: childLayout.height // Set the content height. This height is the implicit height of the childLayout
+//         ColumnLayout {
+//             id: childLayout
+//             ListView {
+//                 id: listview1
+//                  NestedListViewAnchor {
+//                      target: listview1
+//                      anchorIn: root
+//                  }
+//             }
+//             ListView {
+//                 id: listview2
+//                  NestedListViewAnchor {
+//                      target: listview2
+//                      anchorIn: root
+//                  }
+//             }
+//         }
+//    }
+
+
+Flickable {
+    id: root
+
+    //Output property for the global content height
+    //It's the sum of the flickable content height and the nested listviews content heightd
+    readonly property alias virtualContentHeight: d.virtualContentHeight
+
+    //Input and Output property for the global content y. The global content y is the calculated contentY if the listviews would be unrolled.
+    //It depends on the flickable contentY and the nested listviews contentY and originY
+    //
+    //Input:
+    //Setting this property will scroll the flickable and/or the nested listviews depending on the destination. When the scrolling is done, this property will be updatedd with the new value
+    //The new position can be different than the set destination if it is out of range
+    //This can often happen when the nested listviews use delegates with dynamic height
+    //
+    //Output:
+    //Reading this property will return the global content y. It can be used for scrollbars
+    property real virtualContentYPosition: d.virtualContentYPosition
+
+    Binding on virtualContentYPosition {
+        value: d.virtualContentYPosition
+        delayed: true
+        restoreMode: Binding.RestoreNone
+    }
+
+    //The active scroll area is the Flickable that handles the scrolling events
+    property Flickable activeScrollArea: root
+
+    //Function that receives the NestedListViewAnchor and configures the nested listview
+    function addAnchor(item) {
+        d.addAnchor(item)
+    }
+
+    //Function that receives the NestedListViewAnchor and removes the nested listview
+    function removeAnchor(item) {
+        d.removeAnchor(item)
+    }
+
+    //Function that receives the NestedListViewAnchor and locks the nested listview for scrolling
+    //Calling this will lock the nested listview for scrolling and will scroll the flickable
+    //`activeScrollArea` will be updated and the Flickable will lock the contentY to the top of the `activeScrollArea`
+    function anchor(item) {
+        d.anchor(item)
+    }
+
+    //Function that receives the NestedListViewAnchor and releases the nested listview
+    //Calling this will release the nested listview for scrolling and the `activeScrollArea` will be set to the flickable
+    function releaseAnchor(item) {
+        d.releaseAnchor(item)
+    }
+
+
+    //External scrolling handler
+    //This handler is used to scroll into the new position when the virtualContentYPosition is changed
+    //When the scrolling is done, `virtualContentYPosition` is updated
+    onVirtualContentYPositionChanged: {
+
+        if(Math.floor(root.virtualContentYPosition) === Math.floor(d.virtualContentYPosition) ||
+            root.virtualContentYPosition < 0 ||
+            root.virtualContentYPosition > d.virtualContentHeight - root.height ||
+            d.internalScrolling === true) {
+            return
+        }
+
+        //Just in case - guard against re-entry
+        d.internalScrolling = true
+
+        //There are two levels of scrolling:
+        //1. The underlying flickable
+        //2. Each of the nested listviews
+        //
+        //if the destination is is the range of any nested listview, lock the anchor and scroll the nested listview
+        //otherwise scroll the flickable by substracting the extra content height from the destination
+        let destination = root.virtualContentYPosition
+        let hiddenContentBeforeDestination = 0
+        let destinationOverlappingAnchor = null
+
+        //iterate to find the anchor at the destination
+        //if there is no anchor at the destination, the destination is in the flickable
+        //if there is an anchor at the destination, the destination is in the nested listview
+        for (var i = 0; i < d.anchors.length; i++) {
+            var anchor = d.anchors[i]
+
+            if(destination < anchor.virtualY) {
+                break
+            }
+
+            let anchorBegin = anchor.virtualY
+            let anchorEnd = hiddenContentBeforeDestination + anchor.virtualY + anchor.target.contentHeight
+
+            destinationOverlappingAnchor = destination >= anchorBegin && destination <= anchorEnd
+
+            if(destinationOverlappingAnchor) {
+                //There are 2 cases when the destination is overlapping the anchor:
+                //1. The destination is in the anchor and the anchor needs to be locked for scrolling
+                //   In this case the destination is greated the max contentY of the nested listview
+                //2. The destination is in the anchor and the flickable needs to be scrolled
+                //   In this case the destination is smaller than the max contentY of the nested listview
+
+                let destinationFlickable = destination < anchorEnd - anchor.target.height ? anchor.target : root
+                //Case 1: The destination is in the anchor and the anchor is needs to be locked for scroll
+                if(destinationFlickable === anchor.target) {
+                    root.contentY = anchor.virtualY
+                    //Try to position the nested listview at the destination
+                    anchor.target.contentY = destination - hiddenContentBeforeDestination - anchor.virtualY + anchor.target.originY
+                    root.activeScrollArea = anchor.target
+                }
+
+                //Case 2: The destination is in the anchor and the flickable needs to be scrolled
+                //Try to position the nested listview at the end of the anchor
+                else {
+                    //anchor.target.positionViewAtEnd()
+                    anchor.lockAt = NestedListViewAnchor.ContentLock.Bottom
+                    root.contentY = destination - hiddenContentBeforeDestination - anchor.target.contentY - anchor.target.originY + root.originY
+                    root.activeScrollArea = root
+                }
+
+                break
+            }
+            anchor.target.positionViewAtEnd()
+            hiddenContentBeforeDestination += anchor.target.contentHeight - anchor.target.height
+        }
+
+        //if there is no anchor at the destination, the destination is in the flickable
+        if(!destinationOverlappingAnchor) {
+            root.contentY = destination - hiddenContentBeforeDestination + root.originY
+        }
+
+        d.internalScrolling = false
+    }
+
+    onContentYChanged: d.onContentYChanged()
+
+    boundsBehavior: Flickable.StopAtBounds
+    boundsMovement: Flickable.StopAtBounds
+
+    clip: true
+    
+    Binding on interactive {
+        //Disable the default scroll when there are nested listviews anchored in the flickable
+        value: d.virtualContentHeight <= root.contentHeight
+    }
+
+    QtObject {
+        id: d
+        //The global content height calculated for the flickable and all the nested listviews
+        property real virtualContentHeight: root.contentHeight + d.hiddenContentHeight
+        //The hidden content height is the sum of the content height of the nested listviews that is not visible at any time
+        //It needs to be accounted for when calculating the global content height
+        property real hiddenContentHeight: 0
+        //The virtual content y position is the global content y position
+        property real virtualContentYPosition: 0
+
+        //Internal scrolling flag. It's used to guard against re-entry
+        property bool internalScrolling: false
+
+        //The anchors holding the nested listviews anchored in the flickable
+        property var anchors: []
+
+        //The NestedListViewAnchor is a helper object that contains the nested listview and the virtual position of the nested listview
+        //The anchor will signal when it needs to be locked for scrolling
+        function addAnchor(item) {
+            console.assert(item instanceof NestedListViewAnchor, "item must be a NestedListViewAnchor")
+            //TODO: Use Instantiator instead of the code below and create proper Bindings
+            configureNestedListView(item.target)
+            d.anchors.push(item)
+            d.anchors.sort((lhs, rhs) => lhs.virtualY - rhs.virtualY)
+            updateHiddenContentHeight()
+            item.target.contentHeightChanged.connect(d.updateHiddenContentHeight)
+            item.target.contentYChanged.connect(d.onContentYChanged)
+            item.target.originYChanged.connect(d.onContentYChanged)
+        }
+
+        //Removing the anchor - probably the nested listview is getting destroyed
+        function removeAnchor(item) {
+            console.assert(item instanceof NestedListViewAnchor, "item must be a NestedListViewAnchor")
+            
+            //TODO: Use Instantiator instead of the code below and create proper Bindings
+            d.anchors = d.anchors.filter((element, idex, array) => {
+                return element !== item
+            })
+
+            updateHiddenContentHeight()
+            item.target.contentHeightChanged.disconnect(d.updateHiddenContentHeight)
+            item.target.contentYChanged.disconnect(d.onContentYChanged)
+            item.target.originYChanged.disconnect(d.onContentYChanged)
+        }
+
+        //Locking the anchor for scrolling
+        function anchor(item) {
+            console.assert(item instanceof NestedListViewAnchor, "item must be a NestedListViewAnchor")
+            item.lockAt = NestedListViewAnchor.ContentLock.None
+            root.cancelFlick()
+            root.contentY = item.virtualY
+            root.activeScrollArea = item.target
+        }
+        
+        //Releasing the anchor for scrolling
+        function releaseAnchor(item) {
+            console.assert(item instanceof NestedListViewAnchor, "item must be a NestedListViewAnchor")
+            item.target.cancelFlick()
+            root.activeScrollArea = root
+        }
+
+        //Configuring the nested listview
+        function configureNestedListView(item) {
+            if(!item)
+                return
+            
+            item.interactive = false
+            item.boundsBehavior = Flickable.StopAtBounds
+            item.boundsMovement = Flickable.StopAtBounds
+
+            if(!!item.ScrollBar.vertical) {
+                item.ScrollBar.vertical.visible = false
+            }
+        }
+
+        //Compute the global virtual content y position by aggregating the total content y of the nested listviews
+        function onContentYChanged() {
+                let virtualContentY = 0
+                for(var i = d.anchors.length - 1; i >= 0; i--) {
+                    var anchor = d.anchors[i]
+                    virtualContentY += (anchor.target.contentY - anchor.target.originY)
+                }
+                virtualContentY += root.contentY - root.originY
+                d.virtualContentYPosition = virtualContentY
+        }
+
+        //Compute the hidden content height by aggregating the total content height of the nested listviews
+        function updateHiddenContentHeight() {
+            d.hiddenContentHeight = anchors.reduce((accumulator, anchor) => accumulator + anchor.target.contentHeight - anchor.target.height, 0)
+        }
+    }
+
+
+    //Main scrolling handler
+    WheelHandler {
+        enabled: !root.interactive
+        target: root.activeScrollArea
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+        invertible: true
+        onWheel: event => {
+            if (!!event.angleDelta.y || !!event.angleDelta.x) {
+                root.activeScrollArea.contentY += event.inverted ? -event.angleDelta.y : event.angleDelta.y
+            } else {
+                root.activeScrollArea.cancelFlick()
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/NestedListViewAnchor.qml
+++ b/ui/StatusQ/src/StatusQ/Core/NestedListViewAnchor.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.15
+import QtQml 2.15
+import QtQuick.Window 2.15
+
+//Component used to update the nested listview size and determine the active scrolling area
+//The scrolling area can be either the nested listview, or the parent Flickable
+
+QtObject {
+    id: root
+    required property ListView target
+    required property FlickableAnchoringListviews anchorIn
+
+    readonly property alias virtualY: d.breakpoint.virtualY
+    readonly property alias enable: d.breakpoint.enabled
+
+    property int lockAt: d.lockAt
+
+    enum ContentLock {
+        None,
+        Top,
+        Bottom
+    }
+
+    onTargetChanged: {
+        if(!target)
+            root.anchorIn.removeAnchor(root)
+    }
+
+    onLockAtChanged: {
+        if(d.lockAt === lockAt)
+            return
+
+        d.lockAt = lockAt
+    }
+
+    Component.onCompleted: {
+        if(!!target)
+            root.anchorIn.addAnchor(root)
+    }
+    Component.onDestruction: root.anchorIn.removeAnchor(root)
+
+    readonly property QtObject d: QtObject {
+        id: d
+
+        property int lockAt: NestedListViewAnchor.Top
+
+        readonly property NestedListViewScrollBreakpoint breakpoint: NestedListViewScrollBreakpoint {
+            id: breakpoint
+            target: root.target
+            parentFlickable: root.anchorIn
+            enabled: root.target.contentHeight > root.anchorIn.height && root.target.visible
+
+            onHit: root.anchorIn.anchor(root)
+            onMiss: root.anchorIn.releaseAnchor(root)
+        }
+
+        //This is just for model reset while the target is in the upper part of the screen
+        readonly property ScrollBreakpoint modelResetBrekpoint: ScrollBreakpoint {
+            target: root.target
+            enabled: breakpoint.enabled && root.anchorIn.contentY - root.anchorIn.originY > root.virtualY + 2 && root.target.count > 0
+            checkOnEnabled: true
+            condition: () => root.target.contentY === 0
+            onHit: d.lockAt = NestedListViewAnchor.Bottom
+        }
+
+        //This is just for model reset while the target is in the upper part of the screen
+        readonly property ScrollBreakpoint layoutResetBreakpoint: ScrollBreakpoint {
+            target: root.target
+            enabled: breakpoint.enabled && root.anchorIn.contentY - root.anchorIn.originY < root.virtualY - 2 && root.target.count > 0
+            checkOnEnabled: true
+            condition: () => root.target.contentY - root.target.originY !== 0
+            onHit: d.lockAt = NestedListViewAnchor.Top
+        }
+
+        readonly property ScrollBreakpoint lockAtTop: ScrollBreakpoint {
+            target: root.target
+            enabled: breakpoint.enabled && d.lockAt === NestedListViewAnchor.Top
+            condition: () => root.target.contentY - root.target.originY + root.target.height !== root.target.contentHeight
+            onHit: Qt.callLater(() => root.target.contentY = 0)
+        }
+
+        readonly property ScrollBreakpoint lockAtBottom: ScrollBreakpoint {
+            target: root.target
+            enabled: breakpoint.enabled && d.lockAt === NestedListViewAnchor.Bottom
+            condition: () => root.target.contentY - root.target.originY + root.target.height !== root.target.contentHeight
+            onHit: Qt.callLater(() => root.target.contentY = root.target.contentHeight * root.target.contentHeight)
+        }
+
+        readonly property Binding targetHeightBinding: Binding {
+            target: root.target
+            property: "implicitHeight"
+            value: Math.max(0, Math.min(root.anchorIn.height, root.target.contentHeight))
+            restoreMode: Binding.RestoreNone
+        }
+
+        readonly property Binding targetWidthBinding: Binding {
+            target: root.target
+            property: "implicitWidth"
+            value: root.anchorIn.width
+            restoreMode: Binding.RestoreNone
+        }
+
+        //Biding on internal events
+        readonly property Binding lockAtBinding: Binding {
+            target: root
+            property: "lockAt"
+            value: d.lockAt
+            delayed: true
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/NestedListViewScrollBreakpoint.qml
+++ b/ui/StatusQ/src/StatusQ/Core/NestedListViewScrollBreakpoint.qml
@@ -1,0 +1,164 @@
+import QtQuick 2.14
+import QtQuick.Window 2.15
+
+QtObject {
+    id: root
+    
+    /*
+    This component is tracking the position and scrolling of a target flickable inside a parent flickable and 
+    is signalling when the target Flickable is perfectly aligned in the parent viewport and the scrolling position is synced as well so that the target can take over the scrolling.
+    */
+
+    //The target is the item that is being tracked. It is assumed that the target is a child of the parentFlickable
+    required property Flickable target
+
+    //The parentFlickable is the item that is being tracked. It is assumed that the target is a child of the parentFlickable
+    required property Flickable parentFlickable
+
+    //The enabled property is used to enable/disable the tracking
+    property bool enabled: false
+
+    //The target can take over the active scrolling
+    signal hit()
+
+    //The target needs to release the active scrolling
+    signal miss()
+
+    readonly property alias virtualY: d.virtualY
+
+
+    onTargetChanged: {
+        //3 levels of nesting are allowed.
+        //The nesting level is limited because the child item virtual y position is calculated using bindings. This binding needs to statically declare it's dependencies.
+        //The dependency in this case is also item.parent.parent.y. If the nesting level is increased, the binding needs to be updated.
+        console.assert(root.target.parent === root.parentFlickable.contentItem ||
+                        root.target.parent.parent === root.parentFlickable.contentItem ||
+                        root.target.parent.parent.parent === root.parentFlickable.contentItem, "Anchored item must be a close child of the Flickable")
+    }
+    
+    readonly property QtObject d: QtObject {
+        id: d
+        property bool hit: false
+
+        readonly property real virtualY: {
+            ///The target y position in the parentFlickable content coordinates
+            //3 nesting levels are supported
+            root.target.y
+            root.target.parent ? root.target.parent.y : 0
+            root.target.parent.parent ? root.target.parent.parent.y : 0
+            root.target.parent.parent.parent ? root.target.parent.parent.parent.y : 0
+
+
+            return Math.floor(root.target.mapToItem(root.parentFlickable.contentItem, 0, 0).y)
+        }
+        readonly property bool breakpointsReady: root.enabled && root.target.contentHeight > root.parentFlickable.height
+        readonly property bool breakpointsActive: breakpointsReady && root.target.height === root.parentFlickable.height
+        readonly property bool externalBreakpointsEnabled: d.breakpointsActive && !d.hit
+
+        //Tracking the parent flickable scroll down. It's used to detect a hit
+        //Will hit whe the target is perfectly aligned in the top viewport
+        readonly property ScrollBreakpoint externalScrollDownBreakpoint : ScrollBreakpoint {
+            id: externalScrollDownBreakpoint
+            target: root.parentFlickable
+            enabled: d.breakpointsActive
+            condition: () => root.parentFlickable.contentY - root.parentFlickable.originY >= d.virtualY
+            onHit: {
+                externalScrollDownBreakpoint.enabled = false
+                externalScrollDownBreakpoint.enabled = false
+                d.hit = true
+                internalBottomBreakpoint.enabled = d.breakpointsActive
+                internalTopBreakpoint.enabled = d.breakpointsActive
+            }
+        }
+
+        //Tracking the parent flickable scroll up. It's used to detect a hit
+        //Will hit whe the target is perfectly aligned in the bottom viewport
+        readonly property ScrollBreakpoint externalScrollUpBreakpoint: ScrollBreakpoint {
+            id: externalScrollUpBreakpoint
+            target: root.parentFlickable
+            enabled: false
+            condition: () => root.parentFlickable.contentY - root.parentFlickable.originY <= d.virtualY
+            onHit: {
+                externalScrollUpBreakpoint.enabled = false
+                externalScrollDownBreakpoint.enabled = false
+                d.hit = true
+                internalBottomBreakpoint.enabled = d.breakpointsActive
+                internalTopBreakpoint.enabled = d.breakpointsActive
+            }
+        }
+
+        //Tracking the target scroll down. It's used to detect a miss
+        //Will hit whe the target is scrolled to the bottom
+        readonly property ScrollBreakpoint internalBottomBreakpoint: ScrollBreakpoint {
+            id: internalBottomBreakpoint
+            target: root.target
+            enabled: false
+            waitFor: ScrollBreakpoint {
+                target: root.target
+                enabled: internalBottomBreakpoint.enabled
+                condition: () => Math.ceil((root.target.contentY - root.target.originY) + root.target.height) < root.target.contentHeight
+            }
+            condition: () => Math.ceil((root.target.contentY - root.target.originY) + root.target.height) >= root.target.contentHeight
+           
+            onHit: {
+                d.hit = false
+                internalBottomBreakpoint.enabled = false
+                internalTopBreakpoint.enabled = false
+                externalScrollUpBreakpoint.enabled = d.breakpointsActive
+            }
+        }
+
+        //Tracking the target scroll up. It's used to detect a miss
+        //Will hit whe the target is scrolled to the top
+        readonly property ScrollBreakpoint internalTopBreakpoint: ScrollBreakpoint {
+            id: internalTopBreakpoint
+            target: root.target
+            enabled: false
+            condition: () => Math.floor(root.target.contentY - root.target.originY) <= 0
+
+            onHit: {
+                d.hit = false
+                internalTopBreakpoint.enabled = false
+                internalBottomBreakpoint.enabled = false
+                externalScrollDownBreakpoint.enabled = d.breakpointsActive
+            }
+        }
+
+        ///This breakpoint is used to detect if the target is about to enter the viewport from the top
+        ///It is used to ensure that the target is scrolled to the bottom when it is about to enter the viewport from the bottom
+        ///Needed when a listview in the middle of the page is reset to the top by a model reset
+        readonly property ScrollBreakpoint aboutToEnterViewportBreakpoint: ScrollBreakpoint {
+            id: aboutToEnterViewportBreakpoint
+            target: root.target
+            enabled: d.breakpointsActive && root.parentFlickable.contentY - root.target.originY + root.target.height === 0
+            condition: () => root.parentFlickable.contentY - root.parentFlickable.originY > d.virtualY
+            onHit: Qt.callLater(() => root.target.positionViewAtEnd())
+        }
+
+        onHitChanged: hit ? root.hit() : root.miss()
+
+        onBreakpointsReadyChanged: {
+            root.target.implicitHeight = breakpointsReady ? root.parentFlickable.height : root.target.contentHeight
+            if(!breakpointsReady && d.hit) {
+                d.hit = false
+            }
+        }
+
+        onBreakpointsActiveChanged: {
+            if(!d.breakpointsActive && d.hit) {
+                d.hit = false
+            }
+
+            if(d.breakpointsActive) {
+                externalScrollDownBreakpoint.enabled = root.parentFlickable.contentY - root.parentFlickable.originY <= d.virtualY
+                externalScrollUpBreakpoint.enabled = root.parentFlickable.contentY - root.parentFlickable.originY >= d.virtualY
+            }
+            else {
+                externalScrollDownBreakpoint.enabled = false
+                externalScrollUpBreakpoint.enabled = false
+                internalBottomBreakpoint.enabled = false
+                internalTopBreakpoint.enabled = false
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/ScrollBreakpoint.qml
+++ b/ui/StatusQ/src/StatusQ/Core/ScrollBreakpoint.qml
@@ -1,0 +1,70 @@
+import QtQuick 2.15
+
+QtObject {
+    id: root
+
+    // The target object to watch for scrolling breakpoints
+    required property Flickable target
+
+    // The condition for the breakpoint to be hit
+    property var condition: () => false
+
+    // enabled property will toggle the breakpoint on and off
+    property bool enabled: true
+
+    // checkOnEnabled will check the condition when enabled is set to true
+    property bool checkOnEnabled: false
+
+    // The waitFor property allows you to wait for another event before checking the condition
+    property ScrollBreakpoint waitFor: null
+
+    // This signal is emitted when the condition is met
+    signal hit()
+
+    property Connections flickableConnections: Connections {
+        target: root.target
+        enabled: _d.enabled && _d.active
+        function onContentYChanged() {
+            Qt.callLater(() => _d.check())
+        }
+
+        function onOriginYChanged() {
+            Qt.callLater(() => _d.check())
+        }
+
+        function onContentHeightChanged() {
+            Qt.callLater(() => _d.check())
+        }
+    }
+
+    // Wait for another event before checking the condition
+    property Connections waitForConnections: Connections {
+        id: _waitForConnections
+        target: root.waitFor
+        enabled: _d.enabled && !!root.waitFor && !_d.active
+        function onHit() {
+            _d.active = true
+        }
+    }
+
+    property QtObject d: QtObject {
+        id: _d
+
+        property bool enabled: root.enabled && !!root.target
+        property bool active: !root.waitFor
+
+       onEnabledChanged: {
+           if(enabled && root.checkOnEnabled)
+               Qt.callLater(() => _d.check())
+       }
+
+        function check() {
+            if(!root.enabled || !root.condition())
+                return
+
+            root.hit()
+            if(root.waitFor)
+                _d.active = false
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/StatusLazyScrollView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusLazyScrollView.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Controls 0.1
+
+//StatusLazyScrollView is the decorator for the FlickableAnchoringListviews
+//It adds the scrollbar
+
+StatusScrollView {
+    id: root
+
+    implicitWidth: contentWidth
+    implicitHeight: contentHeight
+
+    contentItem: FlickableAnchoringListviews {
+        id: flickableAnchor
+        //anchors.fill: parent
+    }
+
+     ScrollBar.vertical.visible: false //hide the default scrollbar
+     StatusScrollBar {
+        property bool externalUpdate: false
+        parent: root
+        x: root.mirrored ? 1 : root.width - width - 1
+        y: root.topPadding
+        height: root.availableHeight
+        size: root.availableHeight / flickableAnchor.virtualContentHeight
+
+        //TODO: fix the virtualContentYPosition. It's jumpy and sometimes unreliable
+        position: {
+            externalUpdate = true
+            return flickableAnchor.virtualContentYPosition / flickableAnchor.virtualContentHeight
+        }
+
+        onPositionChanged: {
+            if(externalUpdate) {
+                externalUpdate = false
+                return
+            }
+
+            flickableAnchor.virtualContentYPosition = position * flickableAnchor.virtualContentHeight
+        }
+        //TODO: fix the inteactive scrolling!!
+        interactive: true
+        policy: root.availableHeight < flickableAnchor.virtualContentHeight ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
+        visible: true
+        opacity: 1
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/qmldir
@@ -1,5 +1,5 @@
 module StatusQ.Core
-
+NestedListViewAnchor 0.1 NestedListViewAnchor.qml
 StatusAnimatedStack 0.1 StatusAnimatedStack.qml
 StatusAssetSettings 0.1 StatusAssetSettings.qml
 StatusBaseText 0.1 StatusBaseText.qml
@@ -8,6 +8,7 @@ StatusFontSettings 0.1 StatusFontSettings.qml
 StatusGridView 0.1 StatusGridView.qml
 StatusIcon 0.1 StatusIcon.qml
 StatusIdenticonRingSettings 0.1 StatusIdenticonRingSettings.qml
+StatusLazyScrollView 0.1 StatusLazyScrollView.qml
 StatusListView 0.1 StatusListView.qml
 StatusModalHeaderSettings 0.1 StatusModalHeaderSettings.qml
 StatusProfileImageSettings 0.1 StatusProfileImageSettings.qml

--- a/ui/app/AppLayouts/Wallet/panels/ManageTokensPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageTokensPanel.qml
@@ -13,7 +13,7 @@ import utils 1.0
 
 import AppLayouts.Wallet.controls 1.0
 
-Control {
+StatusLazyScrollView {
     id: root
 
     required property var baseModel
@@ -34,6 +34,9 @@ Control {
         d.controller.clearSettings();
     }
 
+    contentWidth: layout.width
+    contentHeight: layout.height
+
     QtObject {
         id: d
 
@@ -46,14 +49,21 @@ Control {
         }
     }
 
-    contentItem: ColumnLayout {
+
+    ColumnLayout {
+        id: layout
         spacing: Style.current.padding
 
         StatusListView {
-            Layout.fillWidth: true
+            id: regularTokens
+            objectName: "regularTokens"
+
+            NestedListViewAnchor {
+                target: regularTokens
+                anchorIn: root.flickable
+            }
+
             model: d.controller.regularTokensModel
-            implicitHeight: contentHeight
-            interactive: false
 
             displaced: Transition {
                 NumberAnimation { properties: "x,y"; easing.type: Easing.OutQuad }
@@ -140,9 +150,14 @@ Control {
     Component {
         id: cmpCommunityTokens
         StatusListView {
+            id: communityTokens
+
+            NestedListViewAnchor {
+                target: communityTokens
+                anchorIn: root.flickable
+            }
+
             model: d.controller.communityTokensModel
-            implicitHeight: contentHeight
-            interactive: false
 
             displaced: Transition {
                 NumberAnimation { properties: "x,y"; easing.type: Easing.OutQuad }
@@ -161,9 +176,15 @@ Control {
     Component {
         id: cmpCommunityTokenGroups
         StatusListView {
+            id: communityTokensGroups
+
+            NestedListViewAnchor {
+                target: communityTokensGroups
+                anchorIn: root.flickable
+            }
+
             model: d.controller.communityTokenGroupsModel
-            implicitHeight: contentHeight
-            interactive: false
+
             spacing: Style.current.halfPadding
 
             displaced: Transition {


### PR DESCRIPTION
### What does the PR do

Adding the possibility to position multiple listviews in a single scrollable area without unrolling them

This commit adds the basic infrastructure for a lazy scroll area that will not unroll nested listviews.

#### Public API

There are two public components to be used. 
- `StatusLazyScrollView`
- `NestedListViewAnchor`. 

The  `StatusLazyScrollView` component is the main scrollable area. It implements a custom Flickable as `contentItem` and a custom vertical ScrollBar. The `NestedListViewAnchor` needs to be defined for each nested ListView created as a child of `StatusLazyScrollView`. It defines the target ListView to be managed and the Flickable where the ListView is anchored. The ListView implicitHeight, interactive and boundsBehaviour properties are managed by the anchors so that it can properly set the size and scroll the ListView when needed.

The main idea is to have a scrollable area that can switch the scroll event handler from the main Flickable to each child ListView when needed.

#### Example
 The main Flickable has two ListViews. One at the top, one at the bottom. When scrolling from beginning and the first listview is in viewport, the scrolling handling will be switched to the Listview. When continuing to scroll, the ListView is scrolled until the end. At this point, the scrolling handling is moved back to the main Flickable until the next Listview is reached.

```
    StatusLazyScrollView {
        id: scrollView
            ListView {
                id: listview1
                NestedListViewAnchor {
                    target: listview1
                    anchorIn: scrollView.flickable
                }
            }
            ListView {
                id: listview2
                NestedListViewAnchor {
                    target: listview1
                    anchorIn: scrollView.flickable
                }
            }
     }
```


#### Implementation details

To achieve this, other helper components are used:
`ScrollBreakpoint` - This component can watch a target flickable for scrolling related events (`onContentYChanged`, `onOriginYChanged`, `onContentHeightchanged`) and emit a hit signal when the breakpoint conditions is met. This is the base component used to detect when the scrolling handling needs to be switched from one Flickable to another
`NestedListViewScrollBreakpoint` - This component is configuring a few `ScrollBreakpoints` on both main Flickable the the nested ListView. There are two main types of scroll breakpoints. The first one is the external breakpoint. It's meant to detect when the nested Listview is in viewport and send an event. The internal breakpoints will detect when the ListView is scrolled at beginning or at the end.

Limitations:
1. The main Flickable needs to be in the nested ListView parent hierarchy. Only 3 levels are currently supported. The number of levels can be extended or totally eliminated
2. The `StatusLazyScrollView` height cannot be managed by a Layout. Not sure it's an implementation bug or a Qt bug, but if the `StatusLazyScrollView` is managed by a Layout the initial height is set to maximum and all the nested listviews are unrolled until all the heights are properly calculated. Then the ListViews are properly updated.
3. The interactive scrolling using the ScrollBar is not fully supported yet. It needs extra work to overcome the limitations introduced by the unreliable `contentHeight` property of the ListView

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/7e7a1310-0bc8-47b7-be25-d1100c3349fe
