### PR TITLE
fix(stickers): fix crash in async task + clean up  + set bought status

### DIFF
--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -122,8 +122,11 @@ QtObject:
     self.packs.apply(proc(it: var StickerPackView) =
       if it.pack.id == packId:
         it.installed = installed
+        if installed:
+          it.bought = true
         it.pending = pending)
-    self.dataChanged(index, index, @[StickerPackRoles.Installed.int, StickerPackRoles.Pending.int])
+    self.dataChanged(index, index, @[StickerPackRoles.Installed.int, StickerPackRoles.Bought.int,
+      StickerPackRoles.Pending.int])
 
   proc getStickers*(self: StickerPackList): QVariant {.slot.} =
     let packInfo = self.packs[self.packIdToRetrieve]

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -120,7 +120,8 @@ method onUserAuthenticated*(self: Module, password: string) =
       self.tmpBuyStickersTransactionDetails.eip1559Enabled
     )
     if response.error.isEmptyOrWhitespace():
-      self.view.stickerPacks.updateStickerPackInList(self.tmpBuyStickersTransactionDetails.packId, false, true)
+      self.view.stickerPacks.updateStickerPackInList(self.tmpBuyStickersTransactionDetails.packId, installed = false,
+        pending = true)
     self.view.transactionWasSent(chainId = response.chainId, txHash = response.txHash, error = response.error)
 
 method obtainMarketStickerPacks*(self: Module) =
@@ -250,10 +251,10 @@ method getChainIdForStickers*(self: Module): int =
   return self.controller.getChainIdForStickers()
 
 method stickerTransactionConfirmed*(self: Module, trxType: string, packID: string, transactionHash: string) =
-  self.view.stickerPacks.updateStickerPackInList(packID, true, false)
+  self.view.stickerPacks.updateStickerPackInList(packID, installed = true, pending = false)
   self.controller.installStickerPack(packID)
   self.view.emitTransactionCompletedSignal(true, transactionHash, packID, trxType)
 
 method stickerTransactionReverted*(self: Module, trxType: string, packID: string, transactionHash: string) =
-  self.view.stickerPacks.updateStickerPackInList(packID, false, false)
+  self.view.stickerPacks.updateStickerPackInList(packID, installed = false, pending = false)
   self.view.emitTransactionCompletedSignal(false, transactionHash, packID, trxType)

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -7,12 +7,13 @@ type
     packId*: string
     fromAddress*: string
     uuid*: string
+  
   ObtainMarketStickerPacksTaskArg = ref object of QObjectTaskArg
     chainId*: int
   InstallStickerPackTaskArg = ref object of QObjectTaskArg
     packId*: string
     chainId*: int
-    hasKey*: bool
+  
   AsyncGetRecentStickersTaskArg* = ref object of QObjectTaskArg
   AsyncGetInstalledStickerPacksTaskArg* = ref object of QObjectTaskArg
 
@@ -68,9 +69,7 @@ const obtainMarketStickerPacksTask: Task = proc(argEncoded: string) {.gcsafe, ni
 
 const installStickerPackTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[InstallStickerPackTaskArg](argEncoded)
-  if not arg.hasKey:
-    arg.finish(false)
-    return
+
   var installed = false
   try:
     let installResponse = status_stickers.install(arg.chainId, arg.packId)


### PR DESCRIPTION
Fixes #12664

1. The issue was that the async task was badly made. It could return `false` instead of a tuple, so it made the app crashed.
I fixed it by removing that condition, since I we don't actually care if the pack we are installing is in the cache. Worst case, status-go will return an error and we can handle it. In the better case, it was just a weird problem with the cache and since it exists in the model, it probably exists in the backend, so it would go through anyway. That issue was very random for me and I could trigger it only once.

2. Another issue I found was that when buying a pack, we set the `installed` property in the model, but not `bought`, so if you uninstall the pack, it looks like you didn't buy it. That's fixed.

3. Finally, I found that we called `obtainMarketStickerPacks` twice on app start. I fixed it by only using the one from the front-end, since it's the one that reacts to the online status changing.
In an ideal world, that should all be handled by the backend, but it works from the frontend and the whole sticker service is messy, so it's not worth it refactoring it all just for that.

The rest of the changes are just clean ups