### PR TITLE
fix(@desktop/edit) : clicking up arrow opens edit view for a message …

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -122,9 +122,12 @@ QtObject:
   proc jumpToMessage*(self: View, messageId: string) {.slot.} =
     self.delegate.scrollToMessage(messageId)
 
+  proc isEditAllowed(messageImage: string, sticker: string): bool =
+    return messageImage == "" and sticker == ""
+
   proc setEditModeOnAndScrollToLastMessage*(self: View, pubkey: string) {.slot.} =
     let lastMessage = self.model.getLastItemFrom(pubKey)
-    if lastMessage != nil and lastMessage.id != "":
+    if lastMessage != nil and lastMessage.id != "" and isEditAllowed(lastMessage.messageImage, lastMessage.sticker):
       self.model.setEditModeOn(lastMessage.id)
       self.jumpToMessage(lastMessage.id)
 


### PR DESCRIPTION
### What does the PR do

This PR fixes #12019

This feature enables the user to edit the last message when clicking the Key_Up from the chat input. Based on the code base, this feature is triggered when the StatusChatInput receives events.
What we are trying to achieve is bring consistency between this Edit on Key_Up press in StatusChatInput and the Key_Right click from a mouse in order to trigger the Edit or the contextual menu that contains the Edit message.

### Affected areas

Chat screen when clicking Up Key on keyboard

### Screenshot of functionality (including design for comparison)

![output](https://github.com/status-im/status-desktop/assets/2589171/8c91db63-2049-4e83-9ec3-860c48823e53)
