### PR TITLE
fix: avoid duplicating UnfurlURLs requests

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -199,6 +199,8 @@ proc canAskToEnableLinkPreview(self: Controller): bool =
   return self.linkPreviewPersistentSetting == UrlUnfurlingMode.AlwaysAsk and self.linkPreviewCurrentMessageSetting == UrlUnfurlingMode.AlwaysAsk
 
 proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
+  debug "<<< setText"
+
   if text == "":
     self.resetLinkPreviews()
     self.delegate.setUrls(@[])
@@ -211,6 +213,8 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
   self.delegate.setLinkPreviewUrls(supportedUrls)
   let newUrls = self.linkPreviewCache.unknownUrls(supportedUrls)
 
+  debug "<<< newUrls", newUrls
+
   let askToEnableLinkPreview = len(newUrls) > 0 and self.canAskToEnableLinkPreview()
   self.delegate.setAskToEnableLinkPreview(askToEnableLinkPreview)
 
@@ -219,6 +223,7 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
 
   if self.getLinkPreviewEnabled() and len(newUrls) > 0:
     self.messageService.asyncUnfurlUrls(newUrls)
+    self.linkPreviewCache.markAsRequested(newUrls)
     
 proc linkPreviewsFromCache*(self: Controller, urls: seq[string]): Table[string, LinkPreview] =
   return self.linkPreviewCache.linkPreviews(urls)

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -199,8 +199,6 @@ proc canAskToEnableLinkPreview(self: Controller): bool =
   return self.linkPreviewPersistentSetting == UrlUnfurlingMode.AlwaysAsk and self.linkPreviewCurrentMessageSetting == UrlUnfurlingMode.AlwaysAsk
 
 proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
-  debug "<<< setText"
-
   if text == "":
     self.resetLinkPreviews()
     self.delegate.setUrls(@[])
@@ -212,8 +210,6 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
   let supportedUrls = urls.filter(x => not x.endsWith(".gif")) # GIFs are currently unfurled by receiver
   self.delegate.setLinkPreviewUrls(supportedUrls)
   let newUrls = self.linkPreviewCache.unknownUrls(supportedUrls)
-
-  debug "<<< newUrls", newUrls
 
   let askToEnableLinkPreview = len(newUrls) > 0 and self.canAskToEnableLinkPreview()
   self.delegate.setAskToEnableLinkPreview(askToEnableLinkPreview)


### PR DESCRIPTION
### What does the PR do

There was a bug, we were checking `linkPreviewsCache` for unknown URLs.  But it's possible that we start editing the message before the unfurling response is received.

Now we also save the list of requested URLs and check it before making a new request.

It's possible to see from the logs that after the second `setText` there're no new URLs found.

```go
DBG 2023-11-10 11:02:30.104+00:00 <<< setText                                tid=28511231 file=controller.nim:202
DBG 2023-11-10 11:02:30.105+00:00 NewBE_callPrivateRPC                       topics="rpc" tid=28511231 file=core.nim:27 rpc_method=wakuext_getTextURLs
DBG 2023-11-10 11:02:30.146+00:00 <<< newUrls                                tid=28511231 file=controller.nim:216 newUrls="@[\"https://github.com/status-im/status-go/pull/4280\", \"https://github.com/status-im/status-go/pull/4283\", \"https://github.com/status-im/status-desktop/pull/12675\", \"https://github.com/status-im/status-go/issues/4273\", \"https://github.com\"]"
DBG 2023-11-10 11:02:30.146+00:00 [threadpool task thread] initiating task   topics="task-threadpool" tid=28511416 file=threadpool.nim:54 messageType=AsyncUnfurlUrlsTaskArg:ObjectType threadid=28511416 task="{\"$type\":\"AsyncUnfurlUrlsTaskArg:ObjectType\",\"urls\":[\"https://github.com/status-im/status-go/pull/4280\",\"https://github.com/status-im/status-go/pull/4283\",\"https://github.com/status-im/status-desktop/pull/12675\",\"https://github.com/status-im/status-go/issues/4273\",\"https://github.com\"],\"vptr\":5006224608,\"slot\":\"onAsyncUnfurlUrlsFinished\",\"tptr\":4340491496}"
DBG 2023-11-10 11:02:30.151+00:00 NewBE_callPrivateRPC                       topics="rpc" tid=28511416 file=core.nim:27 rpc_method=wakuext_unfurlURLs
DBG 2023-11-10 11:02:30.421+00:00 <<< setText                                tid=28511231 file=controller.nim:202
DBG 2023-11-10 11:02:30.421+00:00 NewBE_callPrivateRPC                       topics="rpc" tid=28511231 file=core.nim:27 rpc_method=wakuext_getTextURLs
DBG 2023-11-10 11:02:30.422+00:00 <<< newUrls                                tid=28511231 file=controller.nim:216 newUrls=@[]
2023-11-10T11:02:32+0000 unset [github.com/anacrolix/torrent.(*Client).NewAnacrolixDhtServer.func2:406]: dht server on 0.0.0.0:52546 (node id d9ae7297adbf918cb7df465daaa98d2045c592c1) completed boots
```
