### PR TITLE
fix(discord): Process `delete channel & restart import` button

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -142,7 +142,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_DISCORD_CHANNEL_IMPORT_FINISHED) do(e:Args):
     let args = CommunityChatIdArgs(e)
-    self.delegate.discordImportChannelFinished(args.chatId)
+    self.delegate.discordImportChannelFinished(args.communityId, args.chatId)
 
   self.events.on(SIGNAL_DISCORD_CHANNEL_IMPORT_CANCELED) do(e:Args):
     let args = ChannelIdArgs(e)
@@ -481,3 +481,6 @@ proc runSigningOnKeycard*(self: Controller, keyUid: string, path: string, dataTo
   self.silentSigningPath = path
   self.silentSigningPin = pin
   self.runSignFlow(pin, path, finalDataToSign)
+
+proc removeCommunityChat*(self: Controller, communityId: string, channelId: string) =
+  self.communityService.deleteCommunityChat(communityId, channelId)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -160,7 +160,7 @@ method discordImportChannelProgressUpdated*(
   ) {.base.} =
     raise newException(ValueError, "No implementation available")
 
-method discordImportChannelFinished*(self: AccessInterface, channelId: string) {.base.} =
+method discordImportChannelFinished*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method discordImportChannelCanceled*(self: AccessInterface, channelId: string) {.base.} =
@@ -254,4 +254,7 @@ method onCommunityMemberRevealedAccountsLoaded*(self: AccessInterface, community
   raise newException(ValueError, "No implementation available")
 
 method onAllCommunityTokensLoaded*(self: AccessInterface, communityTokens: seq[CommunityTokenDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method removeCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -475,8 +475,12 @@ method discordImportProgressUpdated*(
   if stopped or progress.int >= 1:
     self.view.setDiscordImportInProgress(false)
 
-method discordImportChannelFinished*(self: Module, channelId: string) =
-  if self.view.getDiscordImportChannelId() == channelId:
+method removeCommunityChat*(self: Module, communityId: string, channelId: string) =
+  self.controller.removeCommunityChat(communityId, channelId)
+
+method discordImportChannelFinished*(self: Module, communityId: string, channelId: string) =
+    self.view.setDiscordImportedChannelCommunityId(communityId)
+    self.view.setDiscordImportedChannelId(channelId)
     self.view.setDiscordImportProgress(100)
     self.view.setDiscordImportProgressStopped(true)
     self.view.setDiscordImportInProgress(false)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -50,6 +50,8 @@ QtObject:
       discordImportChannelId: string
       discordImportChannelName: string
       discordImportCommunityImage: string
+      discordImportedChannelId: string
+      discordImportedChannelCommunityId: string
       discordImportHasCommunityImage: bool
       downloadingCommunityHistoryArchives: bool
       checkingPermissionsInProgress: bool
@@ -191,6 +193,20 @@ QtObject:
   QtProperty[int] discordImportWarningsCount:
     read = getDiscordImportWarningsCount
     notify = discordImportWarningsCountChanged
+
+  proc discordImportedChannelIdChanged*(self: View) {.signal.}
+
+  proc setDiscordImportedChannelId*(self: View, id: string) =
+    if (self.discordImportedChannelId == id): return
+    self.discordImportedChannelId = id
+    self.discordImportedChannelIdChanged()
+
+  proc getDiscordImportedChannelId*(self: View): string {.slot.} =
+    return self.discordImportedChannelId
+
+  QtProperty[int] discordImportedChannelId:
+    read = getDiscordImportedChannelIdCount
+    notify = discordImportedChannelIdChanged
 
   proc setDiscordImportErrorsCount*(self: View, count: int) =
     if (self.discordImportErrorsCount == count): return
@@ -499,6 +515,8 @@ QtObject:
     self.setDiscordImportCommunityName("")
     self.discordImportChannelId = ""
     self.discordImportChannelName = ""
+    self.discordImportedChannelId = ""
+    self.discordImportedChannelCommunityId = ""
     self.setDiscordImportCommunityImage("")
     self.setDiscordImportHasCommunityImage(false)
     self.setDiscordImportInProgress(false)
@@ -634,6 +652,10 @@ QtObject:
     self.delegate.requestCancelDiscordChannelImport(discordChannelId)
     self.resetDiscordImport(true)
 
+  proc removeImportedDiscordChannel*(self: View) {.slot.} =
+    self.delegate.removeCommunityChat(self.discordImportedChannelCommunityId, self.discordImportedChannelId)
+    self.resetDiscordImport(true)
+
   proc toggleDiscordCategory*(self: View, id: string, selected: bool) {.slot.} =
     if selected:
       self.discordCategoriesModel.selectItem(id)
@@ -662,6 +684,10 @@ QtObject:
     self.discordImportChannelId = id
     self.discordImportChannelName = item.getName()
     self.discordImportChannelChanged()
+
+  proc setDiscordImportedChannelCommunityId*(self: View, id: string) =
+    if (self.discordImportedChannelCommunityId == id): return
+    self.discordImportedChannelCommunityId = id
   
   proc setDiscordImportChannelId*(self: View, id: string) {.slot.} =
     if (self.discordImportChannelId == id): return

--- a/ui/app/AppLayouts/Communities/popups/DiscordImportProgressContents.qml
+++ b/ui/app/AppLayouts/Communities/popups/DiscordImportProgressContents.qml
@@ -40,8 +40,12 @@ StatusScrollView {
             type: StatusButton.Danger
             text: root.importingSingleChannel ? qsTr("Delete channel & restart import") : qsTr("Delete community & restart import")
             onClicked: {
-                // TODO display a confirmation and restart the whole flow
-                root.close()
+                if (root.importingSingleChannel) {
+                    Global.openPopup(deleteAndRestartConfirmationPopupCmp)
+                } else {
+                    // TODO do similar for community import
+                    root.close()
+                }
             }
         },
         StatusButton {
@@ -358,6 +362,30 @@ StatusScrollView {
             }
             onCancelButtonClicked: {
                 cancelConfirmationPopup.close()
+            }
+            onClosed: {
+                destroy()
+            }
+        }
+    }
+
+    Component {
+        id: deleteAndRestartConfirmationPopupCmp
+        ConfirmationDialog {
+            id: deleteAndRestartConfirmationPopup
+            headerSettings.title: qsTr("Are you sure you want to delete the channel?")
+            confirmationText: qsTr("Your new Status channel will be deleted and all information entered will be lost.")
+            showCancelButton: true
+            cancelBtnType: "default"
+            confirmButtonLabel: qsTr("Delete channel & cancel import")
+            cancelButtonLabel: qsTr("Cancel")
+            onConfirmButtonClicked: {
+                root.store.removeImportedDiscordChannel()
+                deleteAndRestartConfirmationPopup.close()
+                root.close()
+            }
+            onCancelButtonClicked: {
+                deleteAndRestartConfirmationPopup.close()
             }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -195,6 +195,10 @@ QtObject {
         root.communitiesModuleInst.requestCancelDiscordChannelImport(id)
     }
 
+    function removeImportedDiscordChannel() {
+        root.communitiesModuleInst.removeImportedDiscordChannel()
+    }
+
     function resetDiscordImport() {
         root.communitiesModuleInst.resetDiscordImport(false)
     }


### PR DESCRIPTION
Fixes: #12684

### What does the PR do

Process `delete channel & restart import` button

### Affected areas

Discord import single channel

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

