### PR TITLE
fix(ci): run old e2e on dediated hosts

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -6,7 +6,8 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
   agent {
-    label 'linux && x86_64 && qt-5.15.2'
+    /* Temporary desktop-e2e-old label to debug delays. */
+    label 'linux && x86_64 && qt-5.15.2 && desktop-e2e-old'
   }
 
   parameters {


### PR DESCRIPTION
For debugging possible delays caused by old and new e2e jobs running on the same CI host.

Related to:
* https://github.com/status-im/desktop-qa-automation/pull/298