### PR TITLE
chore(e2e): Generate name of Nightly run for TesRail

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -61,9 +61,13 @@ pipeline {
           linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e-old')
         } } }
         stage('Linux/E2E/new') { steps { script {
+          def timeStamp = Calendar.getInstance().getTime().format('dd.MM.YYY',TimeZone.getTimeZone('CST'))
           linux_e2e = build(
             job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
-            parameters: jenkins.mapToParams([BUILD_SOURCE: linux_x86_64.fullProjectName]),
+            parameters: jenkins.mapToParams([
+              BUILD_SOURCE:       linux_x86_64.fullProjectName, 
+              TESTRAIL_RUN_NAME: "Nightly regression ${timeStamp}"  
+            ]),
           )
         } } }
       }


### PR DESCRIPTION
#276
Each night, we run e2e tests. To have a report in TestRail, we need to fill in the TESTRAIL_RUN_NAME field.
In PR, I added generating the name of test runs in TestRail.

Tested here:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/856/console
In the console output, you can find that the name was generated in the format: Nightly regression 10.11.2023