### PR TITLE
fix: workaround to crash on startup with Qt 5.15.11

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
@@ -287,6 +287,13 @@ Rectangle {
             bottomPadding: 0
             leftPadding: 8
             rightPadding: 5
+            input.edit.color: { // crash workaround, https://bugreports.qt.io/browse/QTBUG-107795
+                if (root.state === "error")
+                    return Theme.palette.dangerColor1
+                if (root.locked)
+                    return Theme.palette.directColor5
+                return Theme.palette.directColor1
+            }
             input.edit.font.pixelSize: 13
             input.edit.readOnly: disabled
             input.background.radius: 4
@@ -319,7 +326,7 @@ Rectangle {
                 }
             ]
             text: root.preCalculatedAdvancedText
-            onTextChanged: waitTimer.restart()           
+            onTextChanged: waitTimer.restart()
             Timer {
                 id: waitTimer
                 interval: lockTimeout
@@ -393,7 +400,7 @@ Rectangle {
             PropertyChanges {
                 target: secondaryLabel
                 text: disabled ? sensor.containsMouse ? root.enableText : disabledText : secondaryText
-            } 
+            }
             PropertyChanges {
                 target: secondaryLabel
                 font.weight: disabled && sensor.containsMouse ? Font.Medium : Font.Normal
@@ -421,11 +428,6 @@ Rectangle {
             PropertyChanges {
                 target: advancedInput
                 visible: advancedMode
-            }
-            PropertyChanges {
-                target: advancedInput
-                input.edit.color: input.edit.activeFocus || !root.locked ?
-                                      Theme.palette.directColor1 : Theme.palette.directColor5
             }
             PropertyChanges {
                 target: basicInput
@@ -497,10 +499,6 @@ Rectangle {
                 visible: advancedMode
             }
             PropertyChanges {
-                target: advancedInput
-                input.edit.color: Theme.palette.dangerColor1
-            }
-            PropertyChanges {
                 target: basicInput
                 visible: !advancedMode && !(root.loading && !disabled)
             }
@@ -570,10 +568,6 @@ Rectangle {
                 visible: advancedMode
             }
             PropertyChanges {
-                target: advancedInput
-                input.edit.color: root.locked ? Theme.palette.directColor5 : Theme.palette.directColor1
-            }
-            PropertyChanges {
                 target: basicInput
                 visible: !advancedMode && !(root.loading && !disabled)
             }
@@ -641,10 +635,6 @@ Rectangle {
                 visible: false
             }
             PropertyChanges {
-                target: advancedInput
-                input.edit.color: Theme.palette.directColor1
-            }
-            PropertyChanges {
                 target: basicInput
                 visible: true
             }
@@ -653,4 +643,5 @@ Rectangle {
                 active: false
             }
         }
-    ]}
+    ]
+}

--- a/ui/imports/shared/popups/send/views/NetworkSelector.qml
+++ b/ui/imports/shared/popups/send/views/NetworkSelector.qml
@@ -22,7 +22,7 @@ Item {
     property var selectedAccount
     property string ensAddressOrEmpty: ""
     property var selectedAsset
-    property var amountToSend
+    property double amountToSend
     property int minSendCryptoDecimals: 0
     property int minReceiveCryptoDecimals: 0
     property bool isLoading: false
@@ -39,7 +39,7 @@ Item {
     QtObject {
         id: d
         readonly property int backgroundRectRadius: 13
-        readonly property string backgroundRectColor: Theme.palette.indirectColor1
+        readonly property color backgroundRectColor: Theme.palette.indirectColor1
     }
 
     StatusSwitchTabBar {


### PR DESCRIPTION
the most recent Qt upstream version introduced a regression that causes our app to crash right on startup when a grouped property is assigned to inside a `PropertyChanges` handler

upstream issue: https://bugreports.qt.io/browse/QTBUG-107795

Upstream fix will be released with Qt 5.15.12, code being at https://codereview.qt-project.org/c/qt/qtdeclarative/+/424702

Culprit found thanks to `PagesValidator` from `storybook`

### What does the PR do

Fixes a nasty crash with Qt 5.15.11

### Affected areas

ALL (indirectly via SendModal)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Back in business ;)
![image](https://github.com/status-im/status-desktop/assets/5377645/50874ed4-6949-4d1e-9071-790fd79e2465)


