### PR TITLE
fix(mocked-keycard-lib): details for the default export public flow updated

### DIFF
--- a/ui/imports/shared/panels/MockedKeycardLibControllerWindow.qml
+++ b/ui/imports/shared/panels/MockedKeycardLibControllerWindow.qml
@@ -241,11 +241,13 @@ ApplicationWindow {
                         if (!mockedKeycard.input.valid || !mockedKeycardHelper.input.valid) {
                             return
                         }
+
+                        keycardSettingsTabRoot.registerKeycard(keycardState.selectedState,
+                                                               mockedKeycard.text,
+                                                               mockedKeycardHelper.text)
                     }
 
-                    keycardSettingsTabRoot.registerKeycard(keycardState.selectedState,
-                                                           mockedKeycard.text,
-                                                           mockedKeycardHelper.text)
+                    keycardSettingsTabRoot.registerKeycard(keycardState.selectedState, "", "")
                 }
             }
         }


### PR DESCRIPTION
Corresponding `status-keycard-go` PR:
- https://github.com/status-im/status-keycard-go/pull/7