### PR TITLE
fix(LinkPreviewMiniCard): dark theme background color

### DIFF
--- a/storybook/pages/LinkPreviewMiniCardPage.qml
+++ b/storybook/pages/LinkPreviewMiniCardPage.qml
@@ -22,11 +22,11 @@ SplitView {
             color: Theme.palette.statusChatInput.secondaryBackgroundColor
         }
 
-         LinkPreviewMiniCard {
-             id: previewMiniCard
-             anchors.centerIn: parent
-             type: previewTypeInput.currentIndex
-             previewState: stateInput.currentIndex
+        LinkPreviewMiniCard {
+            id: previewMiniCard
+            anchors.centerIn: parent
+            type: previewTypeInput.currentIndex
+            previewState: stateInput.currentIndex
             linkData {
                 title: titleInput.text
                 description: ""

--- a/ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
@@ -7,7 +7,6 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
 import shared 1.0
-
 import utils 1.0
 
 import "./private" 1.0
@@ -42,7 +41,7 @@ CalloutCard {
     verticalPadding: 15
     horizontalPadding: 12
     borderColor: Theme.palette.directColor7
-    backgroundColor: root.containsMouse ? Theme.palette.directColor7 : Theme.palette.baseColor4
+    backgroundColor: root.containsMouse ? Theme.palette.directColor7 : Style.current.background
 
     // behavior
     states: [
@@ -79,7 +78,6 @@ CalloutCard {
                   root.linkData.type === Constants.StandardLinkPreviewType.Link
             PropertyChanges { 
                 target: root; visible: true; dashedBorder: false; borderWidth: 0;
-                backgroundColor: root.containsMouse ? Theme.palette.directColor8 : Theme.palette.indirectColor1; 
                 borderColor: backgroundColor;
             }
             PropertyChanges { target: loadingAnimation; visible: false; }


### PR DESCRIPTION
### What does the PR do

- Fix the color of `LinkPreviewMiniCard` in dark theme.

### Screenshot of functionality (including design for comparison)

<img width="947" alt="Screenshot 2023-11-14 at 22 12 15" src="https://github.com/status-im/status-desktop/assets/25482501/7b2cafe5-0650-4371-b898-4feaaa1fd08a">
<img width="947" alt="Screenshot 2023-11-14 at 22 12 18" src="https://github.com/status-im/status-desktop/assets/25482501/d0c6ed18-402a-4a0c-bf00-b1827e3155cd">
