### PR TITLE
Fix/issue 12651 unfurl status links

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -127,7 +127,7 @@ proc setLinkPreviewEnabledForThisMessage*(self: Controller, enabled: bool) =
 
 proc resetLinkPreviews(self: Controller) =
   debug "<<< controller.resetLinkPreviews"
-  self.delegate.setLinkPreviewUrls(@[], initHashSet[string]())
+  self.delegate.setLinkPreviewUrls(@[])
   self.linkPreviewCache.clear()
   self.linkPreviewCurrentMessageSetting = self.linkPreviewPersistentSetting
   self.delegate.setAskToEnableLinkPreview(false)
@@ -233,7 +233,6 @@ proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
   var allUrls = newSeq[string]() # Used for URLs syntax highlighting only
   var statusAllowedUrls = newSeq[string]()
   var otherAllowedUrls = newSeq[string]()
-  var pendingApproveUrls = initHashSet[string]()
   var askToEnableLinkPreview = false
 
   for url, metadata in self.unfurlingPlan.urls:
@@ -245,7 +244,6 @@ proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
 
     if metadata.permit == UrlUnfurlingAskUser:
       if self.linkPreviewCurrentMessageSetting == UrlUnfurlingMode.AlwaysAsk:
-        # pendingApproveUrls.incl(url)
         askToEnableLinkPreview = true
       else:
         otherAllowedUrls.add(url)
@@ -263,7 +261,7 @@ proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
   # Update UI
   let allAllowedUrls = statusAllowedUrls & otherAllowedUrls
   self.delegate.setUrls(allUrls)
-  self.delegate.setLinkPreviewUrls(allAllowedUrls, pendingApproveUrls)
+  self.delegate.setLinkPreviewUrls(allAllowedUrls)
 
   # let askToEnableLinkPreview = len(urlsToAsk) > 0 and 
   #                              self.linkPreviewCurrentMessageSetting == UrlUnfurlingMode.AlwaysAsk

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -228,7 +228,7 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
   self.handleUnfurlingPlan(unfurlNewUrls)
 
 proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
-  debug "<<< controller.handleUnfurlingPlan", unfurlNewUrls
+  debug "<<< controller.handleUnfurlingPlan", unfurlNewUrls = $unfurlNewUrls, linkPreviewCurrentMessageSetting = $self.linkPreviewCurrentMessageSetting
 
   var allUrls = newSeq[string]() # Used for URLs syntax highlighting only
   var statusAllowedUrls = newSeq[string]()
@@ -257,6 +257,8 @@ proc handleUnfurlingPlan*(self: Controller, unfurlNewUrls: bool) =
       statusAllowedUrls.add(url)
     else:
       otherAllowedUrls.add(url)
+
+  debug "<<< controller.handleUnfurlingPlan "
 
   # Update UI
   let allAllowedUrls = statusAllowedUrls & otherAllowedUrls
@@ -306,4 +308,5 @@ proc setLinkPreviewEnabled*(self: Controller, enabled: bool) =
 
 proc onUnfurlingModeChanged(self: Controller, value: UrlUnfurlingMode) =
   self.linkPreviewPersistentSetting = value
+  debug "<<< controller.onUnfurlingModeChanged", persistent = $self.linkPreviewPersistentSetting, current = $self.linkPreviewCurrentMessageSetting
   self.reloadUnfurlingPlan()

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -199,8 +199,6 @@ proc canAskToEnableLinkPreview(self: Controller): bool =
   return self.linkPreviewPersistentSetting == UrlUnfurlingMode.AlwaysAsk and self.linkPreviewCurrentMessageSetting == UrlUnfurlingMode.AlwaysAsk
 
 proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
-  debug "<<< setText"
-
   if text == "":
     self.resetLinkPreviews()
     self.delegate.setUrls(@[])
@@ -212,8 +210,6 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
   let supportedUrls = urls.filter(x => not x.endsWith(".gif")) # GIFs are currently unfurled by receiver
   self.delegate.setLinkPreviewUrls(supportedUrls)
   let newUrls = self.linkPreviewCache.unknownUrls(supportedUrls)
-
-  debug "<<< newUrls", newUrls
 
   let askToEnableLinkPreview = len(newUrls) > 0 and self.canAskToEnableLinkPreview()
   self.delegate.setAskToEnableLinkPreview(askToEnableLinkPreview)

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -199,6 +199,8 @@ proc canAskToEnableLinkPreview(self: Controller): bool =
   return self.linkPreviewPersistentSetting == UrlUnfurlingMode.AlwaysAsk and self.linkPreviewCurrentMessageSetting == UrlUnfurlingMode.AlwaysAsk
 
 proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
+  debug "<<< setText"
+
   if text == "":
     self.resetLinkPreviews()
     self.delegate.setUrls(@[])
@@ -210,6 +212,8 @@ proc setText*(self: Controller, text: string, unfurlNewUrls: bool) =
   let supportedUrls = urls.filter(x => not x.endsWith(".gif")) # GIFs are currently unfurled by receiver
   self.delegate.setLinkPreviewUrls(supportedUrls)
   let newUrls = self.linkPreviewCache.unknownUrls(supportedUrls)
+
+  debug "<<< newUrls", newUrls
 
   let askToEnableLinkPreview = len(newUrls) > 0 and self.canAskToEnableLinkPreview()
   self.delegate.setAskToEnableLinkPreview(askToEnableLinkPreview)

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -102,7 +102,7 @@ method setText*(self: AccessInterface, text: string, unfurlUrls: bool) {.base.} 
 method getPlainText*(self: AccessInterface): string =
   raise newException(ValueError, "No implementation available")
 
-method setLinkPreviewUrls*(self: AccessInterface, urls: seq[string], pendingUnfurlPermissionUrls: HashSet[string]) {.base.} =
+method setLinkPreviewUrls*(self: AccessInterface, urls: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateLinkPreviewsFromCache*(self: AccessInterface, urls: seq[string]) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import NimQml, tables, sets
 
 import ../../../../../../app_service/service/gif/dto
 import ../../../../../../app_service/service/message/dto/link_preview
@@ -102,7 +102,7 @@ method setText*(self: AccessInterface, text: string, unfurlUrls: bool) {.base.} 
 method getPlainText*(self: AccessInterface): string =
   raise newException(ValueError, "No implementation available")
 
-method setLinkPreviewUrls*(self: AccessInterface, urls: seq[string]) {.base.} =
+method setLinkPreviewUrls*(self: AccessInterface, urls: seq[string], pendingUnfurlPermissionUrls: HashSet[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateLinkPreviewsFromCache*(self: AccessInterface, urls: seq[string]) {.base.} =
@@ -112,6 +112,9 @@ method clearLinkPreviewCache*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method linkPreviewsFromCache*(self: AccessInterface, urls: seq[string]): Table[string, LinkPreview] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method reloadUnfurlingPlan*(self: AccessInterface) =
   raise newException(ValueError, "No implementation available")
 
 method loadLinkPreviews*(self: AccessInterface, urls: seq[string]) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/input_area/link_preview_cache.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/link_preview_cache.nim
@@ -1,4 +1,4 @@
-import tables, sets, chronicles
+import tables, sets
 import ../../../../../../app_service/service/message/dto/link_preview
 
 type
@@ -30,13 +30,10 @@ proc linkPreviewsSeq*(self: LinkPreviewCache, urls: seq[string]): seq[LinkPrevie
 # Returns list of urls, for which link preview was updated.
 # If a url is already found in cache, correcponding link preview is updated.
 proc add*(self: LinkPreviewCache, linkPreviews: Table[string, LinkPreview]): seq[string] =
-  debug "<<< cache.add start"
   for key, value in pairs(linkPreviews):
-    debug "<<< cache.add", key, value
     result.add(key)
     self.cache[key] = value
     self.requests.excl(key)
-  debug "<<< cache.add end"
 
 # Marks the URL as requested.
 # This should be used to avoid duplicating unfurl requests.

--- a/src/app/modules/main/chat_section/chat_content/input_area/link_preview_cache.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/link_preview_cache.nim
@@ -1,4 +1,4 @@
-import tables, sets
+import tables, sets, chronicles
 import ../../../../../../app_service/service/message/dto/link_preview
 
 type
@@ -30,10 +30,13 @@ proc linkPreviewsSeq*(self: LinkPreviewCache, urls: seq[string]): seq[LinkPrevie
 # Returns list of urls, for which link preview was updated.
 # If a url is already found in cache, correcponding link preview is updated.
 proc add*(self: LinkPreviewCache, linkPreviews: Table[string, LinkPreview]): seq[string] =
+  debug "<<< cache.add start"
   for key, value in pairs(linkPreviews):
+    debug "<<< cache.add", key, value
     result.add(key)
     self.cache[key] = value
     self.requests.excl(key)
+  debug "<<< cache.add end"
 
 # Marks the URL as requested.
 # This should be used to avoid duplicating unfurl requests.

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -166,8 +166,8 @@ method clearLinkPreviewCache*(self: Module) {.slot.} =
 method updateLinkPreviewsFromCache*(self: Module, urls: seq[string]) =
   self.view.updateLinkPreviewsFromCache(urls)
 
-method setLinkPreviewUrls*(self: Module, urls: seq[string], pendingUnfurlPermissionUrls: HashSet[string]) =
-  self.view.setLinkPreviewUrls(urls, pendingUnfurlPermissionUrls)
+method setLinkPreviewUrls*(self: Module, urls: seq[string]) =
+  self.view.setLinkPreviewUrls(urls)
 
 method linkPreviewsFromCache*(self: Module, urls: seq[string]): Table[string, LinkPreview] =
   return self.controller.linkPreviewsFromCache(urls)

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -154,8 +154,8 @@ method addToRecentsGif*(self: Module, item: GifDto) =
 method isFavorite*(self: Module, item: GifDto): bool =
   return self.controller.isFavorite(item)
 
-method setText*(self: Module, text: string, unfurlUrls: bool) =
-  self.controller.setText(text, unfurlUrls)
+method setText*(self: Module, text: string, unfurlNewUrls: bool) =
+  self.controller.setText(text, unfurlNewUrls)
 
 method getPlainText*(self: Module): string =
   return self.view.getPlainText()

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import NimQml, tables, sets
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller
@@ -166,11 +166,14 @@ method clearLinkPreviewCache*(self: Module) {.slot.} =
 method updateLinkPreviewsFromCache*(self: Module, urls: seq[string]) =
   self.view.updateLinkPreviewsFromCache(urls)
 
-method setLinkPreviewUrls*(self: Module, urls: seq[string]) =
-  self.view.setLinkPreviewUrls(urls)
+method setLinkPreviewUrls*(self: Module, urls: seq[string], pendingUnfurlPermissionUrls: HashSet[string]) =
+  self.view.setLinkPreviewUrls(urls, pendingUnfurlPermissionUrls)
 
 method linkPreviewsFromCache*(self: Module, urls: seq[string]): Table[string, LinkPreview] =
   return self.controller.linkPreviewsFromCache(urls)
+
+method reloadUnfurlingPlan*(self: Module) =
+  self.controller.reloadUnfurlingPlan()
 
 method loadLinkPreviews*(self: Module, urls: seq[string]) =
   self.controller.loadLinkPreviews(urls)

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sets
+import NimQml
 import ./io_interface
 import ./gif_column_model
 import ./preserved_properties
@@ -233,12 +233,8 @@ QtObject:
     self.linkPreviewModel.updateLinkPreviews(linkPreviews)
 
   proc setLinkPreviewUrls*(self: View, urls: seq[string]) =
-    debug "<<< view.setLinkPreviewUrls", urls, enabled = $self.delegate.getLinkPreviewEnabled()
     self.linkPreviewModel.setUrls(urls)
-    # if self.delegate.getLinkPreviewEnabled():
     self.updateLinkPreviewsFromCache(urls)
-    # else:
-      # self.linkPreviewModel.removeAllPreviewData()
 
   proc clearLinkPreviewCache*(self: View) {.slot.} =
     self.delegate.clearLinkPreviewCache()
@@ -256,31 +252,8 @@ QtObject:
     self.delegate.setLinkPreviewEnabled(false)
   
   proc setLinkPreviewEnabledForCurrentMessage(self: View, enabled: bool) {.slot.} =
-    debug "<<< view.setLinkPreviewEnabledForCurrentMessage", enabled
     self.delegate.setLinkPreviewEnabledForThisMessage(enabled)
-    
-    # NOTE: Here we need to start unfurling of the URLs
-    # that were probably not unfurled because of `AlwaysAsk` property.
-
-    ### Attempt 3
     self.delegate.reloadUnfurlingPlan()
-
-    ### Attempt 2
-    # if enabled:
-    #   let urls = self.linkPreviewModel.getPendingUfnurlPermissionUrls()
-    #   let allUrls = self.linkPreviewModel.getLinks()
-    #   self.loadLinkPreviews(urls)
-    #   self.setLinkPreviewUrls(allUrls, initHashSet[string]())
-    
-    ### Attempt 1
-    # Re-request unfulring plan for current text
-    # self.delegate.reloadUnfurlingPlan()
-    
-    ### OLD
-    # let links = self.linkPreviewModel.getLinks()
-    # self.linkPreviewModel.clearItems()
-    # self.loadLinkPreviews(links)
-    # self.setLinkPreviewUrls(links)
 
   proc removeLinkPreviewData*(self: View, index: int) {.slot.} =
     self.linkPreviewModel.removePreviewData(index)

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -232,9 +232,9 @@ QtObject:
     let linkPreviews = self.delegate.linkPreviewsFromCache(urls)
     self.linkPreviewModel.updateLinkPreviews(linkPreviews)
 
-  proc setLinkPreviewUrls*(self: View, urls: seq[string], pendingUnfurlPermissionUrls: HashSet[string]) =
-    debug "<<< view.setLinkPreviewUrls", urls, pendingUnfurlPermissionUrls, enabled = $self.delegate.getLinkPreviewEnabled()
-    self.linkPreviewModel.setUrls(urls, pendingUnfurlPermissionUrls)
+  proc setLinkPreviewUrls*(self: View, urls: seq[string]) =
+    debug "<<< view.setLinkPreviewUrls", urls, enabled = $self.delegate.getLinkPreviewEnabled()
+    self.linkPreviewModel.setUrls(urls)
     # if self.delegate.getLinkPreviewEnabled():
     self.updateLinkPreviewsFromCache(urls)
     # else:

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -58,10 +58,12 @@ QtObject:
       msg: string,
       replyTo: string,
       contentType: int) {.slot.} =
+    # FIXME: Update this when `setText` is async.
     self.delegate.setText(msg, false)
     self.delegate.sendChatMessage(msg, replyTo, contentType, self.linkPreviewModel.getUnfuledLinkPreviews())
 
   proc sendImages*(self: View, imagePathsAndDataJson: string, msg: string, replyTo: string): string {.slot.} =
+    # FIXME: Update this when `setText` is async.
     self.delegate.setText(msg, false)
     self.delegate.sendImages(imagePathsAndDataJson, msg, replyTo, self.linkPreviewModel.getUnfuledLinkPreviews())
 
@@ -260,15 +262,21 @@ QtObject:
     # NOTE: Here we need to start unfurling of the URLs
     # that were probably not unfurled because of `AlwaysAsk` property.
 
-    if enabled:
-      let urls = self.linkPreviewModel.getPendingUfnurlPermissionUrls()
-      let allUrls = self.linkPreviewModel.getLinks()
-      self.loadLinkPreviews(urls)
-      self.setLinkPreviewUrls(allUrls, initHashSet[string]())
+    ### Attempt 3
+    self.delegate.reloadUnfurlingPlan()
+
+    ### Attempt 2
+    # if enabled:
+    #   let urls = self.linkPreviewModel.getPendingUfnurlPermissionUrls()
+    #   let allUrls = self.linkPreviewModel.getLinks()
+    #   self.loadLinkPreviews(urls)
+    #   self.setLinkPreviewUrls(allUrls, initHashSet[string]())
     
+    ### Attempt 1
     # Re-request unfulring plan for current text
     # self.delegate.reloadUnfurlingPlan()
     
+    ### OLD
     # let links = self.linkPreviewModel.getLinks()
     # self.linkPreviewModel.clearItems()
     # self.loadLinkPreviews(links)

--- a/src/app/modules/shared_models/link_preview_item.nim
+++ b/src/app/modules/shared_models/link_preview_item.nim
@@ -9,7 +9,6 @@ type
     immutable*: bool
     isLocalData*: bool
     loadingLocalData*: bool
-    pendingUnfurlPermission*: bool
     linkPreview*: LinkPreview
 
 proc delete*(self: Item) =
@@ -26,7 +25,6 @@ proc `$`*(self: Item): string =
     unfurled: {self.unfurled},
     immutable: {self.immutable},
     linkPreview: {self.linkPreview},
-    pendingUnfurlPermission: {self.pendingUnfurlPermission},
   )"""
 
 proc markAsImmutable*(self: Item) =

--- a/src/app/modules/shared_models/link_preview_item.nim
+++ b/src/app/modules/shared_models/link_preview_item.nim
@@ -9,6 +9,7 @@ type
     immutable*: bool
     isLocalData*: bool
     loadingLocalData*: bool
+    pendingUnfurlPermission*: bool
     linkPreview*: LinkPreview
 
 proc delete*(self: Item) =
@@ -25,4 +26,10 @@ proc `$`*(self: Item): string =
     unfurled: {self.unfurled},
     immutable: {self.immutable},
     linkPreview: {self.linkPreview},
+    pendingUnfurlPermission: {self.pendingUnfurlPermission},
   )"""
+
+proc markAsImmutable*(self: Item) =
+  self.linkPreview = initLinkPreview(self.linkPreview.url)
+  self.unfurled = false
+  self.immutable = true

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -247,12 +247,12 @@ QtObject:
       let url = urls[i]
       let index = self.findUrlIndex(urls[i])
       if index >= 0:
-        let isPending = pendingApproveUrls.contains(url)
-        if self.items[index].pendingUnfurlPermission != isPending:
-          self.items[index].pendingUnfurlPermission = isPending
-          let modelIndex = self.createIndex(index, 0, nil)
-          defer: modelIndex.delete
-          self.dataChanged(modelIndex, modelIndex, @[ModelRole.PendingUnfurlPermission.int])
+        # let isPending = pendingApproveUrls.contains(url)
+        # if self.items[index].pendingUnfurlPermission != isPending:
+        #   self.items[index].pendingUnfurlPermission = isPending
+        #   let modelIndex = self.createIndex(index, 0, nil)
+        #   defer: modelIndex.delete
+        #   self.dataChanged(modelIndex, modelIndex, @[ModelRole.PendingUnfurlPermission.int])
         self.moveRow(index, i)
         continue
 
@@ -262,7 +262,7 @@ QtObject:
       item.immutable = false
       item.isLocalData = false
       item.loadingLocalData = false
-      item.pendingUnfurlPermission = pendingApproveUrls.contains(url)
+      # item.pendingUnfurlPermission = pendingApproveUrls.contains(url)
       item.linkPreview = linkPreview
 
       debug "<<< model.setUrls: inserting item", url = linkPreview.url, pendingUnfurlPermission = $item.pendingUnfurlPermission

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat, tables, sequtils, sets, chronicles
+import NimQml, strformat, tables, sequtils, sets
 import ./link_preview_item
 import ../../../app_service/service/message/dto/link_preview
 import ../../../app_service/service/message/dto/standard_link_preview
@@ -211,9 +211,7 @@ QtObject:
     self.endMoveRows()
 
   proc updateLinkPreviews*(self: Model, linkPreviews: Table[string, LinkPreview]) =
-    debug "<<< model.updateLinkPreviews start"
     for row, item in self.items:
-      debug "<<< model.updateLinkPreviews", row, url = item.linkPreview.url, immutable = $item.immutable
       if not linkPreviews.hasKey(item.linkPreview.url) or item.immutable:
         continue
       item.unfurled = true
@@ -221,11 +219,8 @@ QtObject:
       let modelIndex = self.createIndex(row, 0, nil)
       defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex)
-    debug "<<< model.updateLinkPreviews end"
 
   proc setUrls*(self: Model, urls: seq[string]) =
-    debug "<<< model.setUrls", urls
-
     var itemsToInsert: seq[Item]
     var indexesToRemove: seq[int]
 
@@ -254,8 +249,6 @@ QtObject:
       item.loadingLocalData = false
       item.linkPreview = linkPreview
 
-      debug "<<< model.setUrls: inserting item", url = linkPreview.url
-
       let parentModelIndex = newQModelIndex()
       defer: parentModelIndex.delete
       self.beginInsertRows(parentModelIndex, i, i)
@@ -271,7 +264,6 @@ QtObject:
     self.countChanged()
 
   proc removePreviewData*(self: Model, index: int) {.slot.} =
-    debug "<<< model.removePreviewData", index
     if index < 0 or index >= self.items.len:
       return
 
@@ -282,7 +274,6 @@ QtObject:
     self.dataChanged(modelIndex, modelIndex)
 
   proc removeAllPreviewData*(self: Model) {.slot.} =
-    debug "<<< model.removeAllPreviewData"
     for i in 0 ..< self.items.len:
       self.items[i].markAsImmutable()
   

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -236,7 +236,7 @@ QtObject:
     # Move or insert
     for i in 0 ..< urls.len:
       let url = urls[i]
-      let index = self.findUrlIndex(urls[i])
+      let index = self.findUrlIndex(url)
       if index >= 0:
         self.moveRow(index, i)
         continue

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -204,6 +204,7 @@ const asyncGetFirstUnseenMessageIdForTaskArg: Task = proc(argEncoded: string) {.
 type
   AsyncUnfurlUrlsTaskArg = ref object of QObjectTaskArg
     urls*: seq[string]
+    requestUuid*: string
 
 const asyncUnfurlUrlsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncUnfurlUrlsTaskArg](argEncoded)
@@ -212,7 +213,8 @@ const asyncUnfurlUrlsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
     let output = %*{
       "error": (if response.error != nil: response.error.message else: ""),
       "response": response.result,
-      "requestedUrls": %*arg.urls
+      "requestedUrls": %*arg.urls,
+      "requestUuid": arg.requestUuid
     }
     arg.finish(output)
   except Exception as e:
@@ -220,7 +222,8 @@ const asyncUnfurlUrlsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
     let output = %*{
       "error": e.msg,
       "response": "",
-      "requestedUrls": %*arg.urls
+      "requestedUrls": %*arg.urls,
+      "requestUuid": arg.requestUuid
     }
     arg.finish(output)
 

--- a/src/app_service/service/message/dto/urls_unfurling_plan.nim
+++ b/src/app_service/service/message/dto/urls_unfurling_plan.nim
@@ -1,0 +1,61 @@
+import json, strformat, chronicles, Tables
+include ../../../common/json_utils
+
+type 
+  UrlUnfurlingPermit* {.pure.} = enum
+    UrlUnfurlingAllowed = 0
+    UrlUnfurlingAskUser
+    UrlUnfurlingForbiddenBySettings
+    UrlUnfurlingNotSupported
+
+  UrlUnfurlingMetadata* = ref object
+    permit*: UrlUnfurlingPermit
+    isStatusSharedUrl*: bool
+
+  UrlsUnfurlingPlan* = ref object
+    urls*: Table[string, UrlUnfurlingMetadata]
+
+proc toUrlUnfurlingPermit*(value: int): UrlUnfurlingPermit =
+  try:
+    return UrlUnfurlingPermit(value)
+  except RangeDefect:
+    return UrlUnfurlingPermit.UrlUnfurlingForbiddenBySettings
+
+proc toUrlUnfurlingMetadata*(jsonObj: JsonNode): UrlUnfurlingMetadata =
+  result = UrlUnfurlingMetadata()
+
+  if jsonObj.kind != JObject:
+    warn "node is not an object", source = "toUrlUnfurlingMetadata"
+    return
+
+  result.permit = toUrlUnfurlingPermit(jsonObj["permission"].getInt)
+  result.isStatusSharedUrl = jsonObj["isStatusSharedURL"].getBool()
+
+proc toUrlUnfurlingPlan*(jsonObj: JsonNode): UrlsUnfurlingPlan =
+  result = UrlsUnfurlingPlan()
+  
+  if jsonObj.kind != JObject:
+    warn "node is not an object", source = "toUrlUnfurlingPlan"
+    return
+
+  let urlsMap = jsonObj["urls"]
+
+  if urlsMap.kind != JObject:
+    warn "urls is not an object", source = "toUrlUnfurlingPlan"
+    return
+
+  for url, metadata in urlsMap.pairs:
+    result.urls[url] = toUrlUnfurlingMetadata(metadata)
+
+proc `$`*(self: UrlUnfurlingMetadata): string =
+  result = fmt"""UrlUnfurlingMetadata( permit: {self.permit}, isStatusSharedUrl: {self.isStatusSharedUrl} )"""
+
+proc `$`*(self: UrlsUnfurlingPlan): string =
+  var rows = ""
+
+  for url, metadata in self.urls:
+    rows = fmt"""{rows}
+    url: {url}, metadata: {metadata}"""
+
+  result = fmt"""UrlsUnfurlingPlan({rows}
+  )""" 

--- a/src/app_service/service/message/dto/urls_unfurling_plan.nim
+++ b/src/app_service/service/message/dto/urls_unfurling_plan.nim
@@ -15,6 +15,10 @@ type
   UrlsUnfurlingPlan* = ref object
     urls*: Table[string, UrlUnfurlingMetadata]
 
+proc initUrlsUnfurlingPlan*(): UrlsUnfurlingPlan =
+  result = UrlsUnfurlingPlan()
+  result.urls = initTable[string, UrlUnfurlingMetadata]()
+
 proc toUrlUnfurlingPermit*(value: int): UrlUnfurlingPermit =
   try:
     return UrlUnfurlingPermit(value)
@@ -48,7 +52,9 @@ proc toUrlUnfurlingPlan*(jsonObj: JsonNode): UrlsUnfurlingPlan =
     result.urls[url] = toUrlUnfurlingMetadata(metadata)
 
 proc `$`*(self: UrlUnfurlingMetadata): string =
-  result = fmt"""UrlUnfurlingMetadata( permit: {self.permit}, isStatusSharedUrl: {self.isStatusSharedUrl} )"""
+  if self == nil:
+    return "nil"
+  return fmt"""UrlUnfurlingMetadata( permit: {self.permit}, isStatusSharedUrl: {self.isStatusSharedUrl} )"""
 
 proc `$`*(self: UrlsUnfurlingPlan): string =
   var rows = ""

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -831,8 +831,6 @@ QtObject:
       error "getTextURLsToUnfurl failed", errName = e.name, errDesription = e.msg
 
   proc onAsyncUnfurlUrlsFinished*(self: Service, response: string) {.slot.}=
-    debug "<<< service.onAsyncUnfurlUrlsFinished start"
-
     let responseObj = response.parseJson
     if responseObj.kind != JObject:
       warn "expected response is not a json object", methodName = "onAsyncUnfurlUrlsFinished"
@@ -872,7 +870,6 @@ QtObject:
       linkPreviews: linkPreviews,
       requestUuid: responseObj["requestUuid"].getStr
     )
-    debug "<<< service.onAsyncUnfurlUrlsFinished end"
     self.events.emit(SIGNAL_URLS_UNFURLED, args)
 
   proc asyncUnfurlUrls*(self: Service, urls: seq[string]): string =

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -19,6 +19,7 @@ import ./dto/pinned_message_update as pinned_msg_update_dto
 import ./dto/removed_message as removed_msg_dto
 import ./dto/link_preview
 import ./dto/status_link_preview
+import ./dto/urls_unfurling_plan
 import ./message_cursor
 
 import ../../common/message as message_common
@@ -120,8 +121,9 @@ type
     chatId*: string
     message*: MessageDto
 
-  LinkPreviewV2DataArgs* = ref object of Args
+  LinkPreviewDataArgs* = ref object of Args
     linkPreviews*: Table[string, LinkPreview]
+    requestUuid*: string
 
   ReloadMessagesArgs* = ref object of Args
     communityId*: string
@@ -821,7 +823,15 @@ QtObject:
     except Exception as e:
       error "getTextUrls failed", errName = e.name, errDesription = e.msg
 
+  proc getTextURLsToUnfurl*(self: Service, text: string): UrlsUnfurlingPlan =
+    try:
+      let response = status_go.getTextURLsToUnfurl(text)
+      return toUrlUnfurlingPlan(response.result)
+    except Exception as e:
+      error "getTextURLsToUnfurl failed", errName = e.name, errDesription = e.msg
+
   proc onAsyncUnfurlUrlsFinished*(self: Service, response: string) {.slot.}=
+    debug "<<< service.onAsyncUnfurlUrlsFinished start"
 
     let responseObj = response.parseJson
     if responseObj.kind != JObject:
@@ -858,22 +868,26 @@ QtObject:
       if not linkPreviews.hasKey(url):
         linkPreviews[url] = initLinkPreview(url)
 
-    let args = LinkPreviewV2DataArgs(
-      linkPreviews: linkPreviews
+    let args = LinkPreviewDataArgs(
+      linkPreviews: linkPreviews,
+      requestUuid: responseObj["requestUuid"].getStr
     )
+    debug "<<< service.onAsyncUnfurlUrlsFinished end"
     self.events.emit(SIGNAL_URLS_UNFURLED, args)
 
-
-  proc asyncUnfurlUrls*(self: Service, urls: seq[string]) =
+  proc asyncUnfurlUrls*(self: Service, urls: seq[string]): string =
     if len(urls) == 0:
-      return
+      return ""
+    let uuid = $genUUID()
     let arg = AsyncUnfurlUrlsTaskArg(
       tptr: cast[ByteAddress](asyncUnfurlUrlsTask),
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncUnfurlUrlsFinished",
-      urls: urls
+      urls: urls,
+      requestUuid: uuid,
     )
     self.threadpool.start(arg)
+    return uuid
 
 # See render-inline in status-mobile/src/status_im/ui/screens/chat/message/message.cljs
 proc renderInline(self: Service, parsedText: ParsedText, communityChats: seq[ChatDto]): string =

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -76,6 +76,10 @@ proc getTextUrls*(text: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[text]
   result = callPrivateRPC("getTextURLs".prefix, payload)
 
+proc getTextURLsToUnfurl*(text: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[text]
+  result = callPrivateRPC("getTextURLsToUnfurl".prefix, payload)
+
 proc unfurlUrls*(urls: seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[urls]
   result = callPrivateRPC("unfurlURLs".prefix, payload)

--- a/ui/imports/shared/controls/chat/ChatInputLinksPreviewArea.qml
+++ b/ui/imports/shared/controls/chat/ChatInputLinksPreviewArea.qml
@@ -159,12 +159,7 @@ Control {
             sourceModel: root.linkPreviewModel
             filters: [
                 ExpressionFilter {
-                    expression: { 
-                        if (model.pendingUnfurlPermission)
-                            return false
-                        // Filter out immutable links that haven't been unfurled yet
-                        return !model.immutable || model.unfurled 
-                    }
+                    expression: !model.immutable || model.unfurled // Filter out immutable links that haven't been unfurled yet
                 }
             ]
         }

--- a/ui/imports/shared/controls/chat/ChatInputLinksPreviewArea.qml
+++ b/ui/imports/shared/controls/chat/ChatInputLinksPreviewArea.qml
@@ -159,7 +159,12 @@ Control {
             sourceModel: root.linkPreviewModel
             filters: [
                 ExpressionFilter {
-                    expression: { return !model.immutable || model.unfurled } // Filter out immutable links that haven't been unfurled yet
+                    expression: { 
+                        if (model.pendingUnfurlPermission)
+                            return false
+                        // Filter out immutable links that haven't been unfurled yet
+                        return !model.immutable || model.unfurled 
+                    }
                 }
             ]
         }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12651
Requires https://github.com/status-im/status-go/pull/4294

I'm currently basing on `fix/avoid-duplicating-unfurling` branch, but will change it when https://github.com/status-im/status-desktop/pull/12687 is merged.

### What does the PR do

1. Switch to new `GetTextURLsToUnfurl` status-go endpoint
It gives us information for each URL in the text, which should be unfurled, which are not supported and if it's a status link.
2. Always unfurl Status shared URLs
3. Make separate RPCs for Status shared URLs and others.
This gives a better UX, because Status links are in most cases unfurled immediately.
4. Added UUID to `AsyncUnfurlUrls`.
So that we only process the signal in the chat that request it. Previously all chat sections were processing the signal.

Minor impeovements:
1. Rename `LinkPreviewV2DataArgs` to `LinkPreviewDataArgs` (the old one was removed already)
2. Improve signalling from `removeAllPreviewData`.
Though now this function is also not used, maybe we should drop it.

With the new endpoint `GetTextURLsToUnfurl` RPC is making request to the database (to get settings). So we should make it async. But the PR is too big already, I will make this in a separate PR later.

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/0bbf935d-1701-4da2-9aef-dc571294745c


