### PR TITLE
chore: Generate test run name for Test Rail

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -61,12 +61,13 @@ pipeline {
           linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e-old')
         } } }
         stage('Linux/E2E/new') { steps { script {
-          def timeStamp = Calendar.getInstance().getTime().format('dd.MM.YYY',TimeZone.getTimeZone('CST'))
+          def Date date = new Date()
+          def String datePart = date.format("dd.MM.yyyy")
           linux_e2e = build(
             job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
             parameters: jenkins.mapToParams([
               BUILD_SOURCE:       linux_x86_64.fullProjectName, 
-              TESTRAIL_RUN_NAME: "Nightly regression ${timeStamp}"  
+              TESTRAIL_RUN_NAME: "Nightly regression ${datePart}"  
             ]),
           )
         } } }


### PR DESCRIPTION
The current solution needs to be fixed.

We have nightly build #59: https://ci.status.im/job/status-desktop/job/nightly/
And e2e tests:
https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/66/parameters/
Looks like we didn't receive TESTRAIL_RUN_NAME parameter

In the PR I updated the creation of data time variable.

Tested here with echo:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/934/console
![image](https://github.com/status-im/status-desktop/assets/128374224/998aa1c7-268c-4d1c-a607-1a3e00b54881)
