### PR TITLE
Chore/nim build warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,13 @@ else
 endif
 
 ifeq ($(detected_OS),Darwin)
- CFLAGS := -mmacosx-version-min=10.14
+ CFLAGS := -mmacosx-version-min=11.0
  export CFLAGS
- CGO_CFLAGS := -mmacosx-version-min=10.14
+ CGO_CFLAGS := -mmacosx-version-min=11.0
  export CGO_CFLAGS
  LIBSTATUS_EXT := dylib
- MACOSX_DEPLOYMENT_TARGET := 10.14
+  # keep in sync with BOTTLE_MACOS_VERSION
+ MACOSX_DEPLOYMENT_TARGET := 11.0
  export MACOSX_DEPLOYMENT_TARGET
  PKG_TARGET := pkg-macos
  RUN_TARGET := run-macos
@@ -123,13 +124,14 @@ ifeq ($(detected_OS),Darwin)
 BOTTLES_DIR := $(shell pwd)/bottles
 BOTTLES := $(addprefix $(BOTTLES_DIR)/,openssl@1.1 pcre)
 ifeq ($(QT_ARCH),arm64)
-	EXCLUDE_BOTTLES := 'linux'
+# keep in sync with MACOSX_DEPLOYMENT_TARGET
+	BOTTLE_MACOS_VERSION := 'arm64_big_sur'
 else
-	EXCLUDE_BOTTLES := 'arm|linux'
+	BOTTLE_MACOS_VERSION := 'big_sur'
 endif
 $(BOTTLES): | $(BOTTLES_DIR)
-	echo -e "\033[92mFetching:\033[39m $(notdir $@) bottle arch $(QT_ARCH)"
-	./scripts/fetch-brew-bottle.sh $(notdir $@) $(EXCLUDE_BOTTLES)
+	echo -e "\033[92mFetching:\033[39m $(notdir $@) bottle arch $(QT_ARCH) $(BOTTLE_MACOS_VERSION)"
+	./scripts/fetch-brew-bottle.sh $(notdir $@) $(BOTTLE_MACOS_VERSION) $(HANDLE_OUTPUT)
 
 $(BOTTLES_DIR):
 	echo -e "\033[92mUpdating:\033[39m macOS Homebrew"

--- a/config.nims
+++ b/config.nims
@@ -23,8 +23,8 @@ if defined(macosx):
   switch("passL", "bottles/pcre/lib/libpcre.a")
   # https://code.videolan.org/videolan/VLCKit/-/issues/232
   switch("passL", "-Wl,-no_compact_unwind")
-  # set the minimum supported macOS version to 10.14
-  switch("passC", "-mmacosx-version-min=10.14")
+  # set the minimum supported macOS version to 11.0
+  switch("passC", "-mmacosx-version-min=11.0")
 elif defined(windows):
   --app:gui
   --tlsEmulation:off

--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -10,10 +10,7 @@ function get_gh_pkgs_token() {
 }
 
 function get_bottle_json() {
-    brew info --json=v1 "${1}" | jq "
-        .[0].bottle.stable.files | to_entries
-        | map(select(.key | test(\"${2}\") | not))
-        | first.value"
+    brew info --json=v1 "${1}" | jq ".[0].bottle.stable.files[\"${2}\"]"
 }
 
 function fetch_bottle() {
@@ -50,7 +47,7 @@ else
 fi
 
 echo "${BOTTLE_NAME} - Finding bottle URL"
-echo "Excluding: ${BOTTLE_FILTER}"
+echo "${BOTTLE_NAME} - Selecting: ${BOTTLE_FILTER}"
 
 BOTTLE_JSON=$(get_bottle_json "${BOTTLE_NAME}" "${BOTTLE_FILTER}")
 BOTTLE_URL=$(echo "${BOTTLE_JSON}" | jq -r .url)
@@ -61,7 +58,7 @@ if [[ -z "${BOTTLE_URL}" ]] || [[ -z "${BOTTLE_SHA}" ]]; then
     exit 1
 fi
 
-echo "${BOTTLE_NAME} - Fetching bottle for macOS"
+echo "${BOTTLE_NAME} - Fetching bottle for macOS, bottle sha256: ${BOTTLE_SHA}"
 fetch_bottle "${BOTTLE_PATH}" "${BOTTLE_URL}"
 trap "rm -fr ${BOTTLE_PATH}" EXIT ERR INT QUIT
 

--- a/src/app/core/tasks/qt.nim
+++ b/src/app/core/tasks/qt.nim
@@ -10,7 +10,7 @@ type
     slot*: string
 
 proc finish*[T](arg: QObjectTaskArg, payload: T) =
-  signal_handler(cast[pointer](arg.vptr), Json.encode(payload), arg.slot)
+  signal_handler(cast[pointer](arg.vptr), cstring(Json.encode(payload)), cstring(arg.slot))
 
 proc finish*(arg: QObjectTaskArg, payload: string) =
-  signal_handler(cast[pointer](arg.vptr), payload, arg.slot)
+  signal_handler(cast[pointer](arg.vptr), cstring(payload), cstring(arg.slot))

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, sequtils, strformat, std/tables
+import NimQml, json, strutils, sequtils, std/tables
 import ../../../../app_service/service/activity_center/service as activity_center_service
 
 import ./model

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -1,4 +1,4 @@
-import io_interface, tables, sequtils, strutils, sugar, sets
+import io_interface, tables, sets
 
 
 import ../../../../../../app_service/service/settings/service as settings_service

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, sets
+import NimQml, tables
 
 import ../../../../../../app_service/service/gif/dto
 import ../../../../../../app_service/service/message/dto/link_preview

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -99,7 +99,7 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method setText*(self: AccessInterface, text: string, unfurlUrls: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getPlainText*(self: AccessInterface): string =
+method getPlainText*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setLinkPreviewUrls*(self: AccessInterface, urls: seq[string]) {.base.} =
@@ -114,22 +114,22 @@ method clearLinkPreviewCache*(self: AccessInterface) {.base.} =
 method linkPreviewsFromCache*(self: AccessInterface, urls: seq[string]): Table[string, LinkPreview] {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method reloadUnfurlingPlan*(self: AccessInterface) =
+method reloadUnfurlingPlan*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method loadLinkPreviews*(self: AccessInterface, urls: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getLinkPreviewEnabled*(self: AccessInterface): bool =
+method getLinkPreviewEnabled*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setLinkPreviewEnabled*(self: AccessInterface, enabled: bool) =
+method setLinkPreviewEnabled*(self: AccessInterface, enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setAskToEnableLinkPreview*(self: AccessInterface, value: bool) =
+method setAskToEnableLinkPreview*(self: AccessInterface, value: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setLinkPreviewEnabledForThisMessage*(self: AccessInterface, enabled: bool) =
+method setLinkPreviewEnabledForThisMessage*(self: AccessInterface, enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setUrls*(self: AccessInterface, urls: seq[string]) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, sets
+import NimQml, tables
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -13,7 +13,6 @@ import ../../../../app_service/service/shared_urls/service as shared_urls_servic
 import model as chats_model
 import item as chat_item
 
-import ../../../core/eventemitter
 import ../../../core/unique_event_emitter
 
 type

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -63,14 +63,6 @@ method activeItemSet*(self: AccessInterface, itemId: string) {.base.} =
 method makeChatWithIdActive*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method addNewChat*(self: AccessInterface, chatDto: ChatDto, belongsToCommunity: bool, events: EventEmitter,
-    settingsService: settings_service.Service, contactService: contact_service.Service,
-    chatService: chat_service.Service, communityService: community_service.Service,
-    messageService: message_service.Service, gifService: gif_service.Service,
-    mailserversService: mailservers_service.Service, sharedUrlsService: shared_urls_service.Service,
-    setChatAsActive: bool = true, insertIntoModel: bool = true): Item {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method doesCatOrChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -516,7 +516,7 @@ method onActiveSectionChange*(self: Module, sectionId: string) =
 method chatsModel*(self: Module): chats_model.Model =
   return self.view.chatsModel()
 
-method addNewChat*(
+proc addNewChat*(
     self: Module,
     chatDto: ChatDto,
     channelGroup: ChannelGroupDto,

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -123,6 +123,9 @@ method communityInfoRequestFailed*(self: AccessInterface, communityId: string, e
 method onImportCommunityErrorOccured*(self: AccessInterface, communityId: string, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onImportCommunityCancelled*(self: AccessInterface, communityId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -421,7 +421,7 @@ method importCommunity*(self: Module, communityId: string) =
 method onImportCommunityErrorOccured*(self: Module, communityId: string, error: string) =
   self.view.emitImportingCommunityStateChangedSignal(communityId, ImportCommunityState.ImportingError.int, error)
 
-method onImportCommunityCanceled*(self: Module, communityId: string) =
+method onImportCommunityCancelled*(self: Module, communityId: string) =
   self.view.emitImportingCommunityStateChangedSignal(communityId, ImportCommunityState.ImportingCanceled.int, errorMsg = "")
 
 method requestExtractDiscordChannelsAndCategories*(self: Module, filesToImport: seq[string]) =
@@ -656,7 +656,7 @@ method shareCommunityChannelUrlWithChatKey*(self: Module, communityId: string, c
 method shareCommunityChannelUrlWithData*(self: Module, communityId: string, chatId: string): string =
   return self.controller.shareCommunityChannelUrlWithData(communityId, chatId)
 
-method signRevealedAddressesThatBelongToRegularKeypairs(self: Module): bool =
+proc signRevealedAddressesThatBelongToRegularKeypairs(self: Module): bool =
   var signingParams: seq[SignParamsDto]
   for address, details in self.joiningCommunityDetails.addressesToShare.pairs:
     if details.signature.len > 0:

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -118,6 +118,8 @@ type
     pendingSpectateRequest: SpectateRequest
     statusDeepLinkToActivate: string
 
+{.push warning[Deprecated]: off.}
+
 # Forward declaration
 method calculateProfileSectionHasNotification*[T](self: Module[T]): bool
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
@@ -1567,3 +1569,5 @@ method insertMockedKeycardAction*[T](self: Module[T], cardIndex: int) =
 
 method removeMockedKeycardAction*[T](self: Module[T]) =
   self.keycardService.removeMockedKeycardAction()
+
+{.pop.}

--- a/src/app/modules/main/profile_section/communities/controller.nim
+++ b/src/app/modules/main/profile_section/communities/controller.nim
@@ -23,6 +23,6 @@ proc shareCommunityToUsers*(self: Controller, communityID: string, pubKeys: stri
 proc leaveCommunity*(self: Controller, communityID: string) =
   self.communityService.leaveCommunity(communityID)
 
-method setCommunityMuted*(self: Controller, communityID: string, mutedType: int) =
+proc setCommunityMuted*(self: Controller, communityID: string, mutedType: int) =
   self.communityService.setCommunityMuted(communityID, mutedType)
 

--- a/src/app/modules/main/profile_section/communities/view.nim
+++ b/src/app/modules/main/profile_section/communities/view.nim
@@ -19,11 +19,11 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  method shareCommunityToUsers*(self: View, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
+  proc shareCommunityToUsers*(self: View, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
     result = self.delegate.shareCommunityToUsers(communityID, pubKeysJSON, inviteMessage)
 
-  method leaveCommunity*(self: View, communityID: string) {.slot.} =
+  proc leaveCommunity*(self: View, communityID: string) {.slot.} =
     self.delegate.leaveCommunity(communityID)
 
-  method setCommunityMuted*(self: View, communityID: string, mutedType: int) {.slot.} =
+  proc setCommunityMuted*(self: View, communityID: string, mutedType: int) {.slot.} =
     self.delegate.setCommunityMuted(communityID, mutedType)

--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -304,7 +304,7 @@ method onLoggedInUserImageChanged*(self: Module) =
     return
   self.view.keycardDetailsModel().setImage(singletonInstance.userProfile.getKeyUid(), singletonInstance.userProfile.getIcon())
 
-method resolveRelatedKeycardsForKeypair(self: Module, keypair: KeypairDto) =
+proc resolveRelatedKeycardsForKeypair(self: Module, keypair: KeypairDto) =
   if keypair.keyUid.len == 0:
     error "cannot rebuild keycards for a keypair with empty keyUid"
     return

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -95,10 +95,10 @@ proc getMessagesFromContactsOnly*(self: Controller): bool =
 proc setMessagesFromContactsOnly*(self: Controller, value: bool): bool =
   return self.settingsService.saveMessagesFromContactsOnly(value)
 
-method urlUnfurlingMode*(self: Controller): int {.base.} =
+proc urlUnfurlingMode*(self: Controller): int =
   return int(self.settingsService.urlUnfurlingMode())
 
-method setUrlUnfurlingMode*(self: Controller, value: int) {.base.} =
+proc setUrlUnfurlingMode*(self: Controller, value: int) =
   let mode = toUrlUnfurlingMode(value)
   if not self.settingsService.saveUrlUnfurlingMode(mode):
     error "failed to save url unfurling mode setting", value
@@ -106,7 +106,7 @@ method setUrlUnfurlingMode*(self: Controller, value: int) {.base.} =
 proc validatePassword*(self: Controller, password: string): bool =
   return self.privacyService.validatePassword(password)
 
-method getPasswordStrengthScore*(self: Controller, password, userName: string): int =
+proc getPasswordStrengthScore*(self: Controller, password, userName: string): int =
   return self.generalService.getPasswordStrengthScore(password, userName)
 
 proc storeToKeychain*(self: Controller, data: string) =

--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -63,7 +63,7 @@ method getModuleAsVariant*(self: Module): QVariant =
 method getCollectiblesModel*(self: Module): QVariant =
   return self.collectiblesController.getModelAsVariant()
 
-method convertWalletAccountDtoToKeyPairAccountItem(self: Module, account: WalletAccountDto): KeyPairAccountItem =
+proc convertWalletAccountDtoToKeyPairAccountItem(self: Module, account: WalletAccountDto): KeyPairAccountItem =
   result = newKeyPairAccountItem(
     name = account.name,
     path = account.path,
@@ -81,7 +81,7 @@ method convertWalletAccountDtoToKeyPairAccountItem(self: Module, account: Wallet
     testPreferredChainIds = account.testPreferredChainIds,
     hideFromTotalBalance = account.hideFromTotalBalance)
 
-method setBalance(self: Module, accountsTokens: OrderedTable[string, seq[WalletTokenDto]]) =
+proc setBalance(self: Module, accountsTokens: OrderedTable[string, seq[WalletTokenDto]]) =
   let enabledChainIds = self.controller.getEnabledChainIds()
   let currency = self.controller.getCurrentCurrency()
   let currencyFormat = self.controller.getCurrencyFormat(currency)
@@ -89,7 +89,7 @@ method setBalance(self: Module, accountsTokens: OrderedTable[string, seq[WalletT
     let balance = currencyAmountToItem(tokens.map(t => t.getCurrencyBalance(enabledChainIds, currency)).foldl(a + b, 0.0),currencyFormat)
     self.view.setBalanceForKeyPairs(address, balance)
 
-method createKeypairItems*(self: Module, walletAccounts: seq[WalletAccountDto]): seq[KeyPairItem] =
+proc createKeypairItems(self: Module, walletAccounts: seq[WalletAccountDto]): seq[KeyPairItem] =
   var keyPairItems = keypairs.buildKeyPairsList(self.controller.getKeypairs(), excludeAlreadyMigratedPairs = false,
   excludePrivateKeyKeypairs = false, self.controller.areTestNetworksEnabled())
 

--- a/src/app/modules/main/profile_section/wallet/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/io_interface.nim
@@ -15,6 +15,9 @@ method load*(self: AccessInterface) {.base.} =
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method viewDidLoad*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # View Delegate Interface
 # Delegate for the view must be declared here due to use of QtObject and multi
 # inheritance, which is not well supported in Nim.

--- a/src/app/modules/main/profile_section/wallet/networks/module.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/module.nim
@@ -93,7 +93,7 @@ proc checkIfModuleDidLoad(self: Module) =
 method viewDidLoad*(self: Module) =
   self.checkIfModuleDidLoad()
 
-method areTestNetworksEnabled*(self: Module): bool = 
+proc areTestNetworksEnabled*(self: Module): bool = 
   return self.controller.areTestNetworksEnabled()
 
 method toggleTestNetworksEnabled*(self: Module) = 

--- a/src/app/modules/main/shared_urls/io_interface.nim
+++ b/src/app/modules/main/shared_urls/io_interface.nim
@@ -9,6 +9,9 @@ method delete*(self: AccessInterface) {.base.} =
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method isLoaded*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/all_tokens/controller.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/controller.nim
@@ -35,13 +35,13 @@ proc init*(self: Controller) =
     let args = TokenBalanceHistoryDataArgs(e)
     self.delegate.tokenBalanceHistoryDataResolved(args.result)
 
-method findTokenSymbolByAddress*(self: Controller, address: string): string =
+proc findTokenSymbolByAddress*(self: Controller, address: string): string =
   return self.walletAccountService.findTokenSymbolByAddress(address)
 
-method getHistoricalDataForToken*(self: Controller, symbol: string, currency: string, range: int) =
+proc getHistoricalDataForToken*(self: Controller, symbol: string, currency: string, range: int) =
   self.tokenService.getHistoricalDataForToken(symbol, currency, range)
 
-method fetchHistoricalBalanceForTokenAsJson*(self: Controller, address: string, tokenSymbol: string, currencySymbol: string, timeIntervalEnum: int) =
+proc fetchHistoricalBalanceForTokenAsJson*(self: Controller, address: string, tokenSymbol: string, currencySymbol: string, timeIntervalEnum: int) =
   self.tokenService.fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, BalanceHistoryTimeInterval(timeIntervalEnum))
 
 proc getSourcesOfTokensList*(self: Controller): var seq[SupportedSourcesItem] =

--- a/src/app/modules/main/wallet_section/all_tokens/module.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/module.nim
@@ -74,13 +74,13 @@ method fetchHistoricalBalanceForTokenAsJson*(self: Module, address: string, toke
 method tokenBalanceHistoryDataResolved*(self: Module, balanceHistoryJson: string) =
   self.view.setTokenBalanceHistoryDataReady(balanceHistoryJson)
 
-method getFlatTokensList*(self: Module): var seq[TokenItem]  =
+proc getFlatTokensList*(self: Module): var seq[TokenItem]  =
   return self.controller.getFlatTokensList()
 
-method getTokenBySymbolList*(self: Module): var seq[TokenBySymbolItem] =
+proc getTokenBySymbolList*(self: Module): var seq[TokenBySymbolItem] =
   return self.controller.getTokenBySymbolList()
 
-method getSourcesOfTokensList*(self: Module): var seq[SupportedSourcesItem] =
+proc getSourcesOfTokensList*(self: Module): var seq[SupportedSourcesItem] =
   return self.controller.getSourcesOfTokensList()
 
 # Interfaces for getting lists from the service files into the abstract models

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -176,7 +176,7 @@ method setTotalCurrencyBalance*(self: Module) =
   var addresses = walletAccounts.filter(a => not a.hideFromTotalBalance).map(a => a.address)
   self.view.setTotalCurrencyBalance(self.controller.getCurrencyBalance(addresses))
 
-method notifyFilterChanged(self: Module) =
+proc notifyFilterChanged(self: Module) =
   self.overviewModule.filterChanged(self.filter.addresses, self.filter.chainIds, self.filter.allAddresses)
   self.assetsModule.filterChanged(self.filter.addresses, self.filter.chainIds)
   self.accountsModule.filterChanged(self.filter.addresses, self.filter.chainIds)

--- a/src/app/modules/main/wallet_section/networks/module.nim
+++ b/src/app/modules/main/wallet_section/networks/module.nim
@@ -50,7 +50,7 @@ method load*(self: Module) =
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 
-method areTestNetworksEnabled*(self: Module): bool =
+proc areTestNetworksEnabled*(self: Module): bool =
   return self.controller.areTestNetworksEnabled()
 
 proc checkIfModuleDidLoad(self: Module) =

--- a/src/app/modules/main/wallet_section/send/accounts_model.nim
+++ b/src/app/modules/main/wallet_section/send/accounts_model.nim
@@ -96,12 +96,12 @@ QtObject:
     of ModelRole.PreferredSharingChainIds:
       result = newQVariant(item.preferredSharingChainIds())
 
-  method getItemByIndex*(self: AccountsModel, index: int): AccountItem =
+  proc getItemByIndex*(self: AccountsModel, index: int): AccountItem =
     if index < 0 or index >= self.items.len:
       return
     return self.items[index]
 
-method getItemByAddress*(self: AccountsModel, address: string): tuple[account: AccountItem, index: int] =
+proc getItemByAddress*(self: AccountsModel, address: string): tuple[account: AccountItem, index: int] =
   for i in 0 ..< self.items.len:
     if self.items[i].address() == address:
       return (self.items[i], i)

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -50,19 +50,19 @@ method authenticateUser*(self: AccessInterface) {.base.} =
 method onUserAuthenticated*(self: AccessInterface, pin: string, password: string, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setSelectedSenderAccountIndex*(self: AccessInterface, index: int) =
+method setSelectedSenderAccountIndex*(self: AccessInterface, index: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setSelectedReceiveAccountIndex*(self: AccessInterface, index: int) =
+method setSelectedReceiveAccountIndex*(self: AccessInterface, index: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int]) =
+method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getCollectiblesModel*(self: AccessInterface): collectibles.Model =
+method getCollectiblesModel*(self: AccessInterface): collectibles.Model {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getNestedCollectiblesModel*(self: AccessInterface): nested_collectibles.Model =
+method getNestedCollectiblesModel*(self: AccessInterface): nested_collectibles.Model {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method splitAndFormatAddressPrefix*(self: AccessInterface, text : string, updateInStore: bool): string {.base.} =

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -90,7 +90,7 @@ method delete*(self: Module) =
   self.nestedCollectiblesModel.delete
   self.collectiblesController.delete
 
-method convertSendToNetworkToNetworkItem(self: Module, network: SendToNetwork): NetworkItem =
+proc convertSendToNetworkToNetworkItem(self: Module, network: SendToNetwork): NetworkItem =
   result = initNetworkItem(
       network.chainId,
       network.chainName,
@@ -110,7 +110,7 @@ method convertSendToNetworkToNetworkItem(self: Module, network: SendToNetwork): 
       amountIn = "",
       $network.amountOut)
 
-method convertNetworkDtoToNetworkItem(self: Module, network: NetworkDto): NetworkItem =
+proc convertNetworkDtoToNetworkItem(self: Module, network: NetworkDto): NetworkItem =
   result = initNetworkItem(
       network.chainId,
       network.chainName,
@@ -127,7 +127,7 @@ method convertNetworkDtoToNetworkItem(self: Module, network: NetworkDto): Networ
       self.getTokenBalanceOnChain(self.view.getSelectedSenderAccountAddress(), network.chainId, self.view.getSelectedAssetSymbol())
       )
 
-method convertSuggestedFeesDtoToGasFeesItem(self: Module, gasFees: SuggestedFeesDto): GasFeesItem =
+proc convertSuggestedFeesDtoToGasFeesItem(self: Module, gasFees: SuggestedFeesDto): GasFeesItem =
   result = newGasFeesItem(
     gasPrice = gasFees.gasPrice,
     baseFee = gasFees.baseFee,
@@ -138,14 +138,14 @@ method convertSuggestedFeesDtoToGasFeesItem(self: Module, gasFees: SuggestedFees
     eip1559Enabled = gasFees.eip1559Enabled
     )
 
-method convertFeesDtoToGasEstimateItem(self: Module, fees: FeesDto): GasEstimateItem =
+proc convertFeesDtoToGasEstimateItem(self: Module, fees: FeesDto): GasEstimateItem =
   result = newGasEstimateItem(
     totalFeesInEth = fees.totalFeesInEth,
     totalTokenFees = fees.totalTokenFees,
     totalTime = fees.totalTime
     )
 
-method convertTransactionPathDtoToSuggestedRouteItem(self: Module, path: TransactionPathDto): SuggestedRouteItem =
+proc convertTransactionPathDtoToSuggestedRouteItem(self: Module, path: TransactionPathDto): SuggestedRouteItem =
   result = newSuggestedRouteItem(
     bridgeName = path.bridgeName,
     fromNetwork = path.fromNetwork.chainId,
@@ -196,7 +196,7 @@ method refreshWalletAccounts*(self: Module) =
   self.view.switchSenderAccount(self.senderCurrentAccountIndex)
   self.view.switchReceiveAccount(self.receiveCurrentAccountIndex)
 
-method refreshNetworks*(self: Module) =
+proc refreshNetworks*(self: Module) =
   let networks = self.controller.getNetworks()
   let fromNetworks = networks.map(x => self.convertNetworkDtoToNetworkItem(x))
   let toNetworks = networks.map(x => self.convertNetworkDtoToNetworkItem(x))
@@ -289,7 +289,7 @@ method onUserAuthenticated*(self: Module, password: string, pin: string) =
       self.tmpSendTransactionDetails.paths, password, self.tmpSendTransactionDetails.sendType, usePassword, doHashing
     )
 
-method signOnKeycard*(self: Module) =
+proc signOnKeycard(self: Module) =
   self.tmpTxHashBeingProcessed = ""
   for h, (r, s, v) in self.tmpSendTransactionDetails.resolvedSignatures.pairs:
     if r.len != 0 and s.len != 0 and v.len != 0:

--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -131,7 +131,7 @@ proc authenticateOrigin*(self: Controller, keyUid = "") =
     keyUid: keyUid)
   self.events.emit(SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER, data)
 
-method fetchDerivedAddresses*(self: Controller, derivedFrom: string, paths: seq[string])=
+proc fetchDerivedAddresses*(self: Controller, derivedFrom: string, paths: seq[string])=
   var hashPassword = true
   if self.getPin().len > 0:
     hashPassword = false

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -70,6 +70,8 @@ proc newModule*[T](delegate: T,
   result.authenticationReason = AuthenticationReason.AddingAccount
   result.fetchingAddressesIsInProgress = false
 
+{.push warning[Deprecated]: off.}
+
 method delete*[T](self: Module[T]) =
   self.view.delete
   self.viewVariant.delete
@@ -741,3 +743,5 @@ method buildNewSeedPhraseKeypairAndAddItToOrigin*[T](self: Module[T]) =
     pairType = KeyPairType.SeedImport,
     derivedFrom = genAcc.address)
   self.setItemForSelectedOrigin(item)
+
+{.pop.}

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -56,6 +56,8 @@ proc newModule*[T](delegate: T,
   result.authenticationPopupIsAlreadyRunning = false
   result.runningFlow = FlowType.General
 
+{.push warning[Deprecated]: off.}
+
 method delete*[T](self: Module[T]) =
   self.view.delete
   self.viewVariant.delete
@@ -739,3 +741,5 @@ method keychainObtainedDataSuccess*[T](self: Module[T], data: string) =
       self.controller.enterKeycardPin(data)
     else:
       self.view.setCurrentState(newBiometricsPinInvalidState(self.runningFlow, nil))
+
+{.pop.}

--- a/src/app/modules/shared_modules/keypair_import/module.nim
+++ b/src/app/modules/shared_modules/keypair_import/module.nim
@@ -38,6 +38,8 @@ proc newModule*[T](delegate: T,
   result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, events, accountsService, walletAccountService, devicesService)
 
+{.push warning[Deprecated]: off.}
+
 method delete*[T](self: Module[T]) =
   self.view.delete
   self.viewVariant.delete
@@ -270,3 +272,5 @@ method onUserAuthenticated*[T](self: Module[T], pin: string, password: string, k
       error "ki_unable to make a keypair operable", errDesription=res
       return
   self.closeKeypairImportPopup()
+
+{.pop.}

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -81,6 +81,8 @@ proc newModule*[T](delegate: T,
   result.controller = controller.newController(result, events, generalService, accountsService, keychainService,
   profileService, keycardService, devicesService)
 
+{.push warning[Deprecated]: off.}
+
 method delete*[T](self: Module[T]) =
   singletonInstance.engine.setRootContextProperty("startupModule", newQVariant())
   self.view.delete
@@ -571,3 +573,5 @@ method insertMockedKeycardAction*[T](self: Module[T], cardIndex: int) =
 
 method removeMockedKeycardAction*[T](self: Module[T]) =
   self.keycardService.removeMockedKeycardAction()
+
+{.pop.}

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, strformat
+import json, strformat
 import stint, Tables, strutils
 import core
 import response_type, collectibles_types

--- a/vendor/DOtherSide/lib/CMakeLists.txt
+++ b/vendor/DOtherSide/lib/CMakeLists.txt
@@ -29,6 +29,11 @@ macro(add_target name type)
 
     if (WIN32)
         target_compile_definitions(${name} PRIVATE -DWIN32)
+        target_compile_options(${name} PRIVATE /wd4996)
+    endif()
+
+    if (UNIX)
+        target_compile_options(${name} PRIVATE -Wno-deprecated)
     endif()
 
     set_target_properties(${name} PROPERTIES CXX_STANDARD 17 AUTOMOC ON)


### PR DESCRIPTION
### What does the PR do

Fix more warnings in status-desktop build log.
1335 → 83 lines 😱

Review by commits:
- 5112d346257738f5e24b1e665868cd3911a90923: fix all baseless methods
- 8dd2538d5c409934fde0c39993db704adc0581ad: qt.nim - explicit cstring conversion to fix warning
- 2c8a8d6e498b4b1f827876113a264de932af1ab7: fix more nim unused import warnings
- 3f22cf71b9df00abdb23e15b40ba487afba547de: suppress dotherside deprecation warnings
- fa02873c9b4cc4c23086b89601015d95ce6c664d: fix homebrew bottles version and macos-min-version
- cb4c110189868df2909a6c73789e8e40c0e93d8d: turn off  'generic methods are deprecated' warnings
- Also thanks to Jakub for help with this status-go issue: https://github.com/status-im/status-go/pull/4344
