### PR TITLE
chore: keycard mocked lib is set to false by default

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -34,7 +34,7 @@ pipeline {
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
       description: 'Decides whether the mocked status-keycard-go library is built.',
-      defaultValue: getMockedKeycardLibDefault()
+      defaultValue: false
     )
   }
 
@@ -129,8 +129,4 @@ def getArch() {
   for (def arch in ['x86_64', 'aarch64']) {
     if (tokens.contains(arch)) { return arch }
   }
-}
-
-def getMockedKeycardLibDefault() {
-  return utils.isReleaseBuild() ? 'false' : 'true'
 }


### PR DESCRIPTION
### What does the PR do

Set keycard mock lib to False. I made some investigation over here https://github.com/status-im/desktop-qa-automation/issues/328#issuecomment-1820981445 and as a conclusion I can say that KEYCARD_MOCK_LIB affects the application behaviour in unpredictable way. It also impacts the tests we try to implement. 

I need to have it disabled so I can monitor the progress, but i also need the possibility to enable it when i need it (manually)

https://ci.status.im/job/status-desktop/job/e2e/job/manual/1057/allure/


<img width="1988" alt="Screenshot 2023-11-21 at 19 44 53" src="https://github.com/status-im/status-desktop/assets/82375995/bf8454a7-169e-4679-ae0c-71429f625f66">
