### PR TITLE
chore: Generation of timestamp in Tests

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -61,13 +61,11 @@ pipeline {
           linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e-old')
         } } }
         stage('Linux/E2E/new') { steps { script {
-          def Date date = new Date()
-          def String datePart = date.format("dd.MM.yyyy")
           linux_e2e = build(
             job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
             parameters: jenkins.mapToParams([
               BUILD_SOURCE:       linux_x86_64.fullProjectName, 
-              TESTRAIL_RUN_NAME: "Nightly regression ${datePart}"  
+              TESTRAIL_RUN_NAME: "Nightly regression"  
             ]),
           )
         } } }


### PR DESCRIPTION
#320
Generating a name with a timestamp for TestRail Run is not working.
In PR I added a template for the run. The timestamp will be added on the test scripts side. 

Test run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/1064/parameters/
Test results: https://ethstatus.testrail.net/index.php?/runs/view/13721&group_by=cases:title&group_order=asc

