### PR TITLE
fix(message): fix deleting a quoted message loses the user info

### DIFF
--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -461,20 +461,11 @@ QtObject:
         var item = self.items[i]
         item.quotedMessageText = ""
         item.quotedMessageParsedText = ""
-        item.quotedMessageFrom = ""
         item.quotedMessageDeleted = true
-        item.quotedMessageAuthorDetails = ContactDetails()
         self.dataChanged(ind, ind, @[
-          ModelRole.QuotedMessageFrom.int,
+          ModelRole.QuotedMessageText.int,
           ModelRole.QuotedMessageParsedText.int,
-          ModelRole.QuotedMessageContentType.int,
           ModelRole.QuotedMessageDeleted.int,
-          ModelRole.QuotedMessageAuthorName.int,
-          ModelRole.QuotedMessageAuthorDisplayName.int,
-          ModelRole.QuotedMessageAuthorThumbnailImage.int,
-          ModelRole.QuotedMessageAuthorEnsVerified.int,
-          ModelRole.QuotedMessageAuthorIsContact.int,
-          ModelRole.QuotedMessageAuthorColorHash.int
         ])
 
   proc removeItem*(self: Model, messageId: string) =


### PR DESCRIPTION
Fixes #12785

Based on top of https://github.com/status-im/status-desktop/pull/12804 to make sure I didn't create conflicts

Status-go PR https://github.com/status-im/status-go/pull/4354

[delte-reply.webm](https://github.com/status-im/status-desktop/assets/11926403/344fceb8-38c9-4c2c-ba6c-a9140558247f)
