### PR TITLE
fix(CommunityIntroDialog): Unable to join token gated community

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -228,7 +228,7 @@ StackLayout {
             collectiblesModel: root.rootStore.collectiblesModel
 
             onPrepareForSigning: {
-                root.rootStore.prepareKeypairsForSigning(sharedAddresses)
+                root.rootStore.prepareKeypairsForSigning(communityIntroDialog.communityId, communityIntroDialog.name, sharedAddresses, airdropAddress)
 
                 communityIntroDialog.keypairSigningModel = root.rootStore.communitiesModuleInst.keypairsSigningModel
             }


### PR DESCRIPTION
Closes #12678

### What does the PR do

Fixed unable to join token gated community

### Affected areas

CommunityIntroDialog

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/31625338/9c73db03-175f-4e06-a8f0-874023f6fa7f


