### PR TITLE
fix: quit from community settings in UI if member privileged role changed

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -45,6 +45,8 @@ StackLayout {
     // Community transfer ownership related props/signals:
     property bool isPendingOwnershipRequest: sectionItemModel.isPendingOwnershipRequest
 
+    onIsPrivilegedUserChanged: if (root.currentIndex === 1) root.currentIndex = 0
+
     onCurrentIndexChanged: {
         Global.closeCreateChatView()
     }


### PR DESCRIPTION

### What does the PR do

If a privileged user lost his permission while being in the community settings - the community UI became blank

Closes: 
- https://github.com/status-im/status-desktop/issues/12805
- https://github.com/status-im/status-desktop/issues/12468


https://github.com/status-im/status-desktop/assets/117639195/981ef7e6-26ae-4a91-87c2-656c99c0a41f

