### PR TITLE
fix(StatusQ): Run all unittests via make and on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,13 +321,11 @@ statusq-tests:
 	echo -e "\033[92mBuilding:\033[39m StatusQ Unit Tests"
 	cmake \
 		--build $(STATUSQ_BUILD_PATH) \
-                --target TestStatusQ \
 		$(HANDLE_OUTPUT)
 
 run-statusq-tests: statusq-tests
 	echo -e "\033[92mRunning:\033[39m StatusQ Unit Tests"
-	$(STATUSQ_BUILD_PATH)/bin/TestStatusQ
-
+	ctest -V --test-dir $(STATUSQ_BUILD_PATH) ${ARGS}
 
 ##
 ##	Storybook

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -183,5 +183,6 @@ if (${STATUSQ_BUILD_SANITY_CHECKER})
 endif ()
 
 if (${STATUSQ_BUILD_TESTS})
+    enable_testing()
     add_subdirectory(tests)
 endif ()

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -15,13 +15,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_executable(${PROJECT_NAME} main.cpp)
-add_dependencies(${PROJECT_NAME} StatusQ)
 
 add_test(NAME ${PROJECT_NAME} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME} -input "${CMAKE_CURRENT_SOURCE_DIR}")
-
-add_custom_target("Run_${PROJECT_NAME}" COMMAND ${CMAKE_CTEST_COMMAND} --test-dir "${CMAKE_CURRENT_BINARY_DIR}")
-add_dependencies("Run_${PROJECT_NAME}" ${PROJECT_NAME})
+    COMMAND ${PROJECT_NAME} -input "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # TODO: move this to a test helpers library
 target_include_directories(${PROJECT_NAME}
@@ -35,6 +31,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::QuickTest
     Qt${QT_VERSION_MAJOR}::Qml
     Qt${QT_VERSION_MAJOR}::Quick
+    StatusQ
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
@@ -44,12 +41,12 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 
 add_executable(RolesRenamingModelTest tst_RolesRenamingModel.cpp)
 target_link_libraries(RolesRenamingModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
-add_test(RolesRenamingModelTest COMMAND RolesRenamingModelTest)
+add_test(NAME RolesRenamingModelTest COMMAND RolesRenamingModelTest)
 
 add_executable(LeftJoinModelTest tst_LeftJoinModel.cpp)
 target_link_libraries(LeftJoinModelTest PRIVATE Qt5::Test StatusQ)
-add_test(LeftJoinModelTest COMMAND LeftJoinModelTest)
+add_test(NAME LeftJoinModelTest COMMAND LeftJoinModelTest)
 
 add_executable(SubmodelProxyModelTest tst_SubmodelProxyModel.cpp)
 target_link_libraries(SubmodelProxyModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
-add_test(SubmodelProxyModelTest COMMAND SubmodelProxyModelTest)
+add_test(NAME SubmodelProxyModelTest COMMAND SubmodelProxyModelTest)


### PR DESCRIPTION
### What does the PR do

It fixes `make run-statusq-tests` to run all `StatusQ`'s test targets via `ctest`. Also applies required ctest-related fixes in `StatusQ`'s cmake files.

Closes: #12841

![Screenshot from 2023-11-23 12-58-39](https://github.com/status-im/status-desktop/assets/20650004/2db7ed9d-8223-45eb-9497-1e1b07f0c71f)

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusQ` cmake configs, `Makefile`
