### PR TITLE
fix: quit from community settings in UI if member privileged role changed (cherry-pick)

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -46,6 +46,8 @@ StackLayout {
     // Community transfer ownership related props/signals:
     property bool isPendingOwnershipRequest: sectionItemModel.isPendingOwnershipRequest
 
+    onIsPrivilegedUserChanged: if (root.currentIndex === 1) root.currentIndex = 0
+
     onCurrentIndexChanged: {
         Global.closeCreateChatView()
     }


### PR DESCRIPTION
### What does the PR do

Cherry-pick of f011fcd5c311738e28ddf865675a7aa86ae1581a

if a privileged user lost his permission while being in the community settings - the community UI became blank

Closes:
- https://github.com/status-im/status-desktop/issues/12805
- https://github.com/status-im/status-desktop/issues/12468
