### PR TITLE
fix: supported image formats are case sensitive

### DIFF
--- a/ui/StatusQ/src/QClipboardProxy.cpp
+++ b/ui/StatusQ/src/QClipboardProxy.cpp
@@ -76,7 +76,7 @@ bool QClipboardProxy::isValidImageUrl(const QUrl& url, const QStringList& accept
 {
     const auto strippedUrl = url.url(QUrl::RemoveAuthority | QUrl::RemoveFragment | QUrl::RemoveQuery);
     return std::any_of(acceptedExtensions.constBegin(), acceptedExtensions.constEnd(), [strippedUrl](const auto & ext) {
-        return strippedUrl.endsWith(ext);
+        return strippedUrl.endsWith(ext, Qt::CaseInsensitive);
     });
 }
 


### PR DESCRIPTION
check for the (supported) extension in case insensitive manner. Fixes uploading/sending/DND files like "foo.JPG"

Fixes #12835

### What does the PR do

Fixes uploading supported images with uppercase extension

### Affected areas

Chat

![image](https://github.com/status-im/status-desktop/assets/5377645/5b6a74d6-6c4d-4e12-98bb-99b017b7dda5)
