### PR TITLE
fix(chat_section): remove duplicated event handling

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -374,12 +374,6 @@ proc init*(self: Controller) =
     var args = ChatUpdateDetailsArgs(e)
     self.delegate.onGroupChatDetailsUpdated(args.id, args.newName, args.newColor, args.newImage)
 
-  self.events.on(SIGNAL_MAKE_SECTION_CHAT_ACTIVE) do(e: Args):
-    var args = ActiveSectionChatArgs(e)
-    if (self.sectionId != args.sectionId):
-      return
-    self.delegate.makeChatWithIdActive(args.chatId)
-
   if (not self.isCommunitySection):
     self.events.on(SIGNAL_CHAT_SWITCH_TO_OR_CREATE_1_1_CHAT) do(e:Args):
       let args = ChatExtArgs(e)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -60,9 +60,6 @@ method chatContentDidLoad*(self: AccessInterface) {.base.} =
 method activeItemSet*(self: AccessInterface, itemId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method makeChatWithIdActive*(self: AccessInterface, chatId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method doesCatOrChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -382,10 +382,6 @@ method chatContentDidLoad*(self: Module) =
 method setActiveItem*(self: Module, itemId: string) =
   self.controller.setActiveItem(itemId)
 
-method makeChatWithIdActive*(self: Module, chatId: string) =
-  self.setActiveItem(chatId)
-  singletonInstance.localAccountSensitiveSettings.setSectionLastOpenChat(self.controller.getMySectionId(), chatId)
-
 proc updateActiveChatMembership*(self: Module) =
   let activeChatId = self.controller.getActiveChatId()
   let chat = self.controller.getChatDetails(activeChatId)


### PR DESCRIPTION
Fixes #12719

The problem was that we had two event handlers that did the same thing and if the main module's event processed first, the second event would basically reset the active item, causing the UI to try to fetch an empty chat content.

If you comment out the main module event handler, it doesn't work correctly, because it's the one doing the actual section switching.

Removing the chat section event handling is ok, because the main module already calls its child's (chat section) same functions.

@igor-sirotin I'm guessing you couldn't reproduce because somehow for you, the chat section event processed first.