### PR TITLE
fix: Misaligned profile image in chat header

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
@@ -18,18 +18,16 @@ ToolBar {
     signal notificationButtonClicked()
 
     objectName: "statusToolBar"
-    implicitWidth: visible ? 518 : 0
-    implicitHeight: visible ? 56 : 0
-    leftPadding: 24
+    leftPadding: 4
     rightPadding: 10
     topPadding: 8
     bottomPadding: 4
     background: null
 
-    RowLayout {
-        anchors.fill: parent
+    contentItem: RowLayout {
         spacing: 0
         StatusFlatButton {
+            Layout.leftMargin: 20
             objectName: "toolBarBackButton"
             icon.name: "arrow-left"
             visible: !!root.backButtonName


### PR DESCRIPTION
align the left padding with the chat contents; reapply the needed extra margin for the back button

Fixes #12859

### What does the PR do

Fixes too big left margin in chat header

### Affected areas

Chat, StatusToolbar

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-11-23 23-53-24](https://github.com/status-im/status-desktop/assets/5377645/606cfcd5-cca2-4422-b93a-ce7287917da2)
![Snímek obrazovky z 2023-11-23 23-53-37](https://github.com/status-im/status-desktop/assets/5377645/e8fcead7-31e7-4a05-829b-5e1a0f0688c2)

