### PR TITLE
fix(ActivityCenter): Fix Community and Chat badges in the Activity Center

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -174,6 +174,8 @@ method convertToItems*(
         if (notification.notificationType == ActivityCenterNotificationType.ContactVerification):
           repliedMessageItem = self.createMessageItemFromDto(notification.replyMessage, communityId, @[])
 
+      let chatDetails = self.controller.getChatDetails(notification.chatId)
+
       return notification_item.initItem(
         notification.id,
         notification.chatId,
@@ -190,7 +192,7 @@ method convertToItems*(
         notification.accepted,
         messageItem,
         repliedMessageItem,
-        ChatType.Unknown # TODO: should use correct chat type
+        chatDetails.chatType
       )
     )
 


### PR DESCRIPTION
Close #10311

### What does the PR do

Display Community and Chat badges in the Activity Center

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

<img width="559" alt="Screenshot 2023-11-24 at 14 41 53" src="https://github.com/status-im/status-desktop/assets/2522130/9537d425-88cf-4851-b43f-9067074240f7">
