### PR TITLE
fix(chat): Emoji is html-encoded in message reply

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -97,7 +97,7 @@ Item {
         color: d.isQuote ? Theme.palette.baseColor1 : Theme.palette.directColor1
         font.family: Theme.palette.baseFont.name
         font.pixelSize: Theme.primaryTextFontSize
-        textFormat: root.stripHtmlTags ? Text.PlainText : Text.RichText
+        textFormat: Text.RichText
         wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
         readOnly: true
         selectByMouse: true


### PR DESCRIPTION
### What does the PR do

Fixes emojis being shown as plain HTML markup in replies

- revert to previous behavior, we want RichText even though we really don't :)

Fixes #12786

### Affected areas

StatusTextMessage

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-11-24 11-49-34](https://github.com/status-im/status-desktop/assets/5377645/1839942c-1484-482c-852b-6b6d8ccc0920)
