### PR TITLE
fix: show info about the control node offline, during rejoining the community after the ownership change

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -213,6 +213,25 @@ StackLayout {
     }
 
     Component {
+        id: controlNodeOfflineComponent
+        ControlNodeOfflineCommunityView {
+            id: controlNodeOfflineView
+            readonly property var communityData: sectionItemModel
+            readonly property string communityId: communityData.id
+            name: communityData.name
+            communityDesc: communityData.description
+            color: communityData.color
+            image: communityData.image
+            membersCount: communityData.members.count
+            communityItemsModel: root.rootStore.communityItemsModel
+            notificationCount: activityCenterStore.unreadNotificationsCount
+            hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
+            onNotificationButtonClicked: Global.openActivityCenterPopup()
+            onAdHocChatButtonClicked: rootStore.openCloseCreateChatView()
+        }
+    }
+
+    Component {
         id: communityIntroDialogPopup
         CommunityIntroDialog {
             id: communityIntroDialog


### PR DESCRIPTION
### What does the PR do

Show info about the control node offline, during rejoining the community after the ownership change

This code was accidentally removed during the rebase

Closes: https://github.com/status-im/status-desktop/issues/12868