### PR TITLE
feature(@desktop/chat) Enhance message context menu with mark as unread

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -111,6 +111,12 @@ proc init*(self: Controller) =
       return
     self.delegate.onUnpinMessage(args.messageId)
 
+  self.events.on(SIGNAL_MESSAGE_MARKED_AS_UNREAD) do(e:Args):
+    let args = MessageMarkMessageAsUnreadArgs(e)
+    if (self.chatId != args.chatId):
+      return
+    self.delegate.onMarkMessageAsUnread(args.messageId)
+
   self.events.on(SIGNAL_MESSAGE_REACTION_ADDED) do(e:Args):
     let args = MessageAddRemoveReactionArgs(e)
     if(self.chatId != args.chatId):
@@ -266,6 +272,9 @@ proc removeReaction*(self: Controller, messageId: string, emojiId: int, reaction
 
 proc pinUnpinMessage*(self: Controller, messageId: string, pin: bool) =
   self.messageService.pinUnpinMessage(self.chatId, messageId, pin)
+
+proc markMessageAsUnread*(self: Controller, messageId: string) =
+  self.messageService.asyncMarkMessageAsUnread(self.chatId, messageId)
 
 proc getContactById*(self: Controller, contactId: string): ContactsDto =
   return self.contactService.getContactById(contactId)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -48,6 +48,12 @@ method onPinMessage*(self: AccessInterface, messageId: string, actionInitiatedBy
 method onUnpinMessage*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method markMessageAsUnread*(self: AccessInterface, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onMarkMessageAsUnread*(self: AccessInterface, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method messagesAdded*(self: AccessInterface, messages: seq[MessageDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -510,11 +510,17 @@ method toggleReactionFromOthers*(self: Module, messageId: string, emojiId: int, 
 method pinUnpinMessage*(self: Module, messageId: string, pin: bool) =
   self.controller.pinUnpinMessage(messageId, pin)
 
+method markMessageAsUnread*(self: Module, messageId: string) =
+  self.controller.markMessageAsUnread(messageId)
+
 method onPinMessage*(self: Module, messageId: string, actionInitiatedBy: string) =
   self.view.model().pinUnpinMessage(messageId, true, actionInitiatedBy)
 
 method onUnpinMessage*(self: Module, messageId: string) =
   self.view.model().pinUnpinMessage(messageId, false, "")
+
+method onMarkMessageAsUnread*(self: Module, messageId: string) =
+  self.view.model().markMessageAsUnread(messageId)
 
 method getSectionId*(self: Module): string =
   return self.controller.getMySectionId()

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -17,6 +17,7 @@ QtObject:
       chatIcon: string
       chatType: int
       loading: bool
+      keepUnread: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -36,6 +37,7 @@ QtObject:
     result.chatIcon = ""
     result.chatType = ChatType.Unknown.int
     result.loading = false
+    result.keepUnread = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -56,6 +58,25 @@ QtObject:
 
   proc unpinMessage*(self: View, messageId: string) {.slot.} =
     self.delegate.pinUnpinMessage(messageId, false)
+
+  proc keepUnreadChanged*(self: View) {.signal.}
+  proc getKeepUnread*(self: View): bool {.slot.} =
+    return self.keepUnread
+
+  QtProperty[bool] keepUnread:
+    read = getKeepUnread
+    notify = keepUnreadChanged
+
+  proc setKeepUnread*(self: View, value: bool) =
+    self.keepUnread = value
+    self.keepUnreadChanged()
+
+  proc markMessageAsUnread*(self: View, messageId: string) {.slot.} =
+    self.delegate.markMessageAsUnread(messageId)
+    self.setKeepUnread(true)
+
+  proc updateKeepUnread*(self: View, flag: bool) {.slot.} =
+    self.setKeepUnread(flag)
 
   proc getMessageByIdAsJson*(self: View, messageId: string): string {.slot.} =
     let jsonObj = self.model.getMessageByIdAsJson(messageId)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -135,6 +135,12 @@ proc init*(self: Controller) =
     self.chatService.updateUnreadMessagesAndMentions(args.chatId, args.allMessagesMarked, args.messagesCount, args.messagesWithMentionsCount)
     self.delegate.onMarkAllMessagesRead(chat)
 
+  self.events.on(message_service.SIGNAL_MESSAGE_MARKED_AS_UNREAD) do(e:Args):
+    let args = message_service.MessageMarkMessageAsUnreadArgs(e)
+    let chat = self.chatService.getChatById(args.chatId)
+    self.delegate.onMarkMessageAsUnread(chat)
+
+
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)
     self.delegate.onCommunityChannelDeletedOrChatLeft(args.chatId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -94,6 +94,9 @@ method changeMutedOnChat*(self: AccessInterface, chatId: string, muted: bool) {.
 method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onMarkMessageAsUnread*(self: AccessInterface, chat: ChatDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onCommunityMuted*(self: AccessInterface, chatId: string, muted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -899,6 +899,9 @@ method onJoinedCommunity*(self: Module) =
 method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
   self.updateBadgeNotifications(chat, hasUnreadMessages=false, unviewedMentionsCount=0)
 
+method onMarkMessageAsUnread*(self: Module, chat: ChatDto) =
+  self.updateBadgeNotifications(chat, hasUnreadMessages=true, chat.unviewedMentionsCount)
+
 method markAllMessagesRead*(self: Module, chatId: string) =
   self.controller.markAllMessagesRead(chatId)
 

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -784,6 +784,24 @@ QtObject:
         defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Seen.int])
 
+  proc setMessageMarker*(self: Model, messageId: string) =
+    self.firstUnseenMessageId = messageId
+    self.resetNewMessagesMarker()
+
+  proc markMessageAsUnread*(self: Model, messageId: string) =
+    self.setMessageMarker(messageId)
+
+    for i in 0 ..< self.items.len:
+      let item = self.items[i]
+
+      if item.id == messageId and item.seen:
+        item.seen = false
+        let index = self.createIndex(i, 0, nil)
+        defer: index.delete
+        self.dataChanged(index, index, @[ModelRole.Seen.int])
+        break
+
+
   proc markAsSeen*(self: Model, messages: seq[string]) =
     var messagesSet = toHashSet(messages)
 

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -763,6 +763,15 @@ QtObject:
     except Exception as e:
       error "error while getting members", msg = e.msg, communityID, chatId
 
+  proc updateUnreadMessage*(self: Service, chatID: string, messagesCount:int, messagesWithMentionsCount:int) =
+    var chat = self.getChatById(chatID)
+    if chat.id == "":
+      return
+
+    chat.unviewedMessagesCount = messagesCount
+    chat.unviewedMentionsCount = messagesWithMentionsCount
+    self.updateOrAddChat(chat)
+
   proc updateUnreadMessagesAndMentions*(self: Service, chatID: string, markAllAsRead: bool, markAsReadCount: int, markAsReadMentionsCount: int) =
     var chat = self.getChatById(chatID)
     if chat.id == "":

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -32,6 +32,10 @@ proc pinUnpinMessage*(chatId: string, messageId: string, pin: bool): RpcResponse
   }]
   result = callPrivateRPC("sendPinMessage".prefix, payload)
 
+proc markMessageAsUnread*(chatId: string, messageId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[chatId, messageId]
+  result = callPrivateRPC("markMessageAsUnread".prefix, payload)
+
 proc getMessageByMessageId*(messageId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [messageId]
   result = callPrivateRPC("messageByMessageID".prefix, payload)

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -352,3 +352,66 @@ suite "mark as seen":
     check(model.items[0].seen == true)
     check(model.items[1].seen == true)
     check(model.items[2].seen == true)
+
+suite "mark message as unread":
+  setup:
+    let model = newModel()
+
+    var msg1 = createTestMessageItem("0xa", 1)
+    msg1.seen = true
+    var msg2 = createTestMessageItem("0xb", 2)
+    msg2.seen = true
+    var msg3 = createTestMessageItem("0xc", 3)
+    msg3.seen = true
+
+    model.insertItemsBasedOnClock(@[msg1, msg2, msg3])
+    require(model.items.len == 3)
+    check(model.items[0].seen == true)
+    check(model.items[1].seen == true)
+    check(model.items[2].seen == true)
+
+  test "mark message as unread":
+    model.markMessageAsUnread("0xa")
+    check(model.items[2].seen == false)
+
+    model.markMessageAsUnread("0xb")
+    check(model.items[1].seen == false)
+
+    model.markMessageAsUnread("0xc")
+    check(model.items[0].seen == false)
+
+  test "mark an already unread message as unread":
+    model.markMessageAsUnread("0xa")
+    check(model.items[2].seen == false)
+    model.markMessageAsUnread("0xa")
+    check(model.items[2].seen == false)
+
+    model.markMessageAsUnread("0xb")
+    check(model.items[1].seen == false)
+    model.markMessageAsUnread("0xb")
+    check(model.items[1].seen == false)
+
+    model.markMessageAsUnread("0xc")
+    check(model.items[0].seen == false)
+    model.markMessageAsUnread("0xc")
+    check(model.items[0].seen == false)
+
+  test "mark all messages as unread":
+    require(model.items.len == 3)
+
+    model.markMessageAsUnread("0xa")
+    model.markMessageAsUnread("0xc")
+    model.markMessageAsUnread("0xb")
+
+
+    # Because new row is inserted for message marker
+    require(model.items.len == 4)
+
+    check(model.items[0].seen == false)
+    check(model.items[1].seen == false)
+
+    # message marker is inserted on top of the last inserted element
+    # last inserted element is `0xc` which is at position 0
+    # and marker is insert last at position : position('0xb') - 1 equals to position 2 here
+    check(model.items[2].seen == true)
+    check(model.items[3].seen == false)

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -19,6 +19,7 @@ QtObject {
     readonly property int chatType: messageModule ? messageModule.chatType : Constants.chatType.unknown
     readonly property string chatColor: messageModule ? messageModule.chatColor : Style.current.blue
     readonly property string chatIcon: messageModule ? messageModule.chatIcon : ""
+    readonly property bool keepUnread: messageModule ? messageModule.keepUnread : false
 
     onMessageModuleChanged: {
         if(!messageModule)
@@ -34,6 +35,14 @@ QtObject {
             return
 
         messageModule.loadMoreMessages()
+    }
+
+    function setKeepUnread(flag: bool) {
+        if (!messageModule) {
+            return
+        }
+
+        messageModule.updateKeepUnread(flag)
     }
 
     function getMessageByIdAsJson (id) {
@@ -122,6 +131,13 @@ QtObject {
         if(!messageModule)
             return
         messageModule.deleteMessage(messageId)
+    }
+
+    function markMessageAsUnread(messageId) {
+        if (!messageModule) {
+            return
+        }
+        messageModule.markMessageAsUnread(messageId)
     }
 
     function warnAndDeleteMessage(messageId) {

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -52,13 +52,18 @@ Item {
         readonly property real scrollY: chatLogView.visibleArea.yPosition * chatLogView.contentHeight
         readonly property bool isMostRecentMessageInViewport: chatLogView.visibleArea.yPosition >= 0.999 - chatLogView.visibleArea.heightRatio
         readonly property var chatDetails: chatContentModule && chatContentModule.chatDetails || null
+        readonly property bool keepUnread: messageStore.keepUnread
 
         readonly property var loadMoreMessagesIfScrollBelowThreshold: Backpressure.oneInTimeQueued(root, 100, function() {
             if(scrollY < 1000) messageStore.loadMoreMessages()
         })
 
+        function setKeepUnread(flag: bool) {
+            root.messageStore.setKeepUnread(flag)
+        }
+
         function markAllMessagesReadIfMostRecentMessageIsInViewport() {
-            if (!isMostRecentMessageInViewport || !chatLogView.visible) {
+            if (!isMostRecentMessageInViewport || !chatLogView.visible || keepUnread) {
                 return
             }
 
@@ -107,6 +112,7 @@ Item {
         target: !!d.chatDetails ? d.chatDetails : null
 
         function onActiveChanged() {
+            d.setKeepUnread(false)
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
             d.loadMoreMessagesIfScrollBelowThreshold()
         }

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -47,6 +47,7 @@ StatusMenu {
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
     signal editClicked(string messageId)
+    signal markMessageAsUnread(string messageId)
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 230)
 
@@ -150,6 +151,17 @@ StatusMenu {
             default:
                 return false
             }
+        }
+    }
+
+    StatusAction {
+        id: markMessageAsUnreadAction
+        text: qsTr("Mark as unread")
+        icon.name: "hide"
+        enabled: !root.disabledForChat
+        onTriggered: {
+            root.markMessageAsUnread(root.messageId)
+            root.close()
         }
     }
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -981,6 +981,21 @@ Loader {
                         }
                     },
                     Loader {
+                        active: !root.editModeOn && delegate.hovered && !delegate.hideQuickActions
+                        visible: active
+                        sourceComponent: StatusFlatRoundButton {
+                            objectName: "markAsUnreadButton"
+                            width: d.chatButtonSize
+                            height: d.chatButtonSize
+                            icon.name: "hide"
+                            type: StatusFlatRoundButton.Type.Tertiary
+                            tooltip.text: qsTr("Mark as unread")
+                            onClicked: {
+                                root.messageStore.markMessageAsUnread(root.messageId)
+                            }
+                        }
+                    },
+                    Loader {
                         active: {
                             if(!delegate.hovered)
                                 return false;
@@ -1100,6 +1115,10 @@ Loader {
                                                         root.chatContentModule.pinnedMessagesModel,
                                                         messageId,
                                                         root.chatId)
+            }
+
+            onMarkMessageAsUnread: (messageId) => {
+                root.messageStore.markMessageAsUnread(messageId)
             }
 
             onToggleReaction: (messageId, emojiId) => {


### PR DESCRIPTION
[Link to status-go changes](https://github.com/status-im/status-go/pull/4382)

### Description

Feature to enhance message context menu with mark as unread.

[Figma design](https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/%F0%9F%92%AC-Chat%E2%8E%9CDesktop?type=design&node-id=14632-460085&mode=design&t=9iVc38RXY5QVm5uz-0)

fixes #10329

### What does the PR do

The PR does the following : 

- Adds capacity to mark a message as unread
- Adds capacity to mark a message with mention as unread
- Adds persistence to the marking of the message (change can be seen at after reboot)
- Adds marking in right click contextual menu

### Affected areas

- Chat screen
- Contextual menu (Right click 

### Screenshot of functionality (including design for comparison)

[Screencast from 2023-11-30 09:08:03 AM.webm](https://github.com/status-im/status-desktop/assets/2589171/9da6b145-603d-4999-9052-228195f34cce)

