### PR TITLE
fix(delete): fix closing the app before login would make it crash

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -477,7 +477,7 @@ proc finishAppLoading*(self: AppController) =
     self.privacyService.removeMnemonic()
 
   if not self.startupModule.isNil:
-    self.startupModule.delete
+    self.startupModule.onAppLoaded()
     self.startupModule = nil
 
   self.mainModule.checkAndPerformProfileMigrationIfNeeded()

--- a/src/app/modules/main/wallet_section/send/account_item.nim
+++ b/src/app/modules/main/wallet_section/send/account_item.nim
@@ -44,7 +44,7 @@ QtObject:
     self.canSend = canSend
 
   proc delete*(self: AccountItem) =
-      self.QObject.delete
+    self.QObject.delete
 
   proc newAccountItem*(
     name: string = "",

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -35,11 +35,13 @@ QtObject:
   proc delete*(self: View) =
     self.accounts.delete
     self.senderAccounts.delete
-    self.selectedSenderAccount.delete
+    if self.selectedSenderAccount != nil:
+      self.selectedSenderAccount.delete
     self.fromNetworksModel.delete
     self.toNetworksModel.delete
     self.transactionRoutes.delete
-    self.selectedReceiveAccount.delete
+    if self.selectedReceiveAccount != nil:
+      self.selectedReceiveAccount.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/startup/io_interface.nim
+++ b/src/app/modules/startup/io_interface.nim
@@ -19,6 +19,9 @@ type
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onAppLoaded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -84,6 +84,13 @@ proc newModule*[T](delegate: T,
 {.push warning[Deprecated]: off.}
 
 method delete*[T](self: Module[T]) =
+  self.view.delete
+  self.viewVariant.delete
+  self.controller.delete
+  if not self.keycardSharedModule.isNil:
+    self.keycardSharedModule.delete
+
+method onAppLoaded*[T](self: Module[T]) =
   singletonInstance.engine.setRootContextProperty("startupModule", newQVariant())
   self.view.delete
   self.view = nil


### PR DESCRIPTION
Fixes #12880

There were two problems:
1. We manually delete the startup module on login to free memory. Part of that clean up includes remove the QVariant (` singletonInstance.engine.setRootContextProperty("startupModule", newQVariant())`), but since that code was put in the `delete` function of the module, it meant it was also executed on quit, and you can't call `setRootContextProperty` on quit
2. The wallet module is created on app start. That's fine, it doesn't do anything. However, it has a sub module that later in its cycle creates account items, but most of the time, those account items are not initiated, so on `delete`, there was a crash.