### PR TITLE
Fix: Crash when handling response without AC notifications

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1669,7 +1669,7 @@ QtObject:
 
       let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: rpcresponse.result["activityCenterNotifications"]))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: rpcResponse.result["activityCenterNotifications"]))
 
       if not self.processRequestsToJoinCommunity(rpcResponse.result):
         raise newException(CatchableError, "no 'requestsToJoinCommunity' key in response")

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -559,7 +559,7 @@ QtObject:
         self.events.emit(SIGNAL_COMMUNITY_LOST_OWNERSHIP, CommunityIdArgs(communityId: community.id))
         let response = tokens_backend.registerLostOwnershipNotification(community.id)
         self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-          RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+          RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
       # If there's settings without `id` it means the original
       # signal didn't include actual communitySettings, hence we
@@ -1038,7 +1038,7 @@ QtObject:
     try:
       let response = status_go.leaveCommunity(communityId)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)
@@ -1669,7 +1669,7 @@ QtObject:
 
       let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: rpcResponse.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: rpcresponse.result["activityCenterNotifications"]))
 
       if not self.processRequestsToJoinCommunity(rpcResponse.result):
         raise newException(CatchableError, "no 'requestsToJoinCommunity' key in response")
@@ -2008,7 +2008,7 @@ QtObject:
             return
           self.myCommunityRequests.delete(i)
           self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-            RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+            RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
           self.events.emit(SIGNAL_REQUEST_TO_JOIN_COMMUNITY_CANCELED, Args())
           return
 
@@ -2021,7 +2021,7 @@ QtObject:
     try:
       let response = status_go.declineRequestToJoinCommunity(requestId)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
       let requestToJoin = response.result["requestsToJoinCommunity"][0].toCommunityMembershipRequestDto
 

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -299,7 +299,7 @@ QtObject:
           self.events.emit(SIGNAL_FINALISE_OWNERSHIP_STATUS, finaliseStatusArgs)
           let response = tokens_backend.registerOwnerTokenReceivedNotification(communityId)
           self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-            RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+            RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
     except Exception as e:
       error "Error registering owner token received notification", msg=e.msg
@@ -322,7 +322,7 @@ QtObject:
       self.events.emit(SIGNAL_SET_SIGNER_STATUS, data)
       let response = if transactionArgs.success: tokens_backend.registerReceivedOwnershipNotification(contractDetails.communityId) else: tokens_backend.registerSetSignerFailedNotification(contractDetails.communityId)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
       let notificationToSetRead = self.acService.getNotificationForTypeAndCommunityId(notification.ActivityCenterNotificationType.OwnerTokenReceived, contractDetails.communityId)
       if notificationToSetRead != nil:
         self.acService.markActivityCenterNotificationRead(notificationToSetRead.id)
@@ -1283,7 +1283,7 @@ QtObject:
     try:
       let response = tokens_backend.registerSetSignerDeclinedNotification(communityId)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
     except Exception as e:
       error "Error registering decline set signer notification", msg=e.msg
     let finaliseStatusArgs = FinaliseOwnershipStatusArgs(isPending: false, communityId: communityId)

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -471,7 +471,7 @@ QtObject:
 
       self.parseContactsResponse(response)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
       self.events.emit(SIGNAL_RELOAD_ONE_TO_ONE_CHAT, ReloadOneToOneArgs(sectionId: publicKey))
 
     except Exception as e:
@@ -492,7 +492,7 @@ QtObject:
 
       self.parseContactsResponse(response)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
       self.events.emit(SIGNAL_RELOAD_ONE_TO_ONE_CHAT, ReloadOneToOneArgs(sectionId: publicKey))
 
     except Exception as e:
@@ -513,7 +513,7 @@ QtObject:
 
       self.parseContactsResponse(response)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
     except Exception as e:
       error "an error occurred while dismissing contact request", msg=e.msg
@@ -562,7 +562,7 @@ QtObject:
     self.events.emit(SIGNAL_RELOAD_ONE_TO_ONE_CHAT, ReloadOneToOneArgs(sectionId: publicKey))
     self.parseContactsResponse(response)
     self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-      RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+      RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
   proc ensResolved*(self: Service, jsonObj: string) {.slot.} =
     let jsonObj = jsonObj.parseJson()
@@ -621,7 +621,7 @@ QtObject:
         let msg = response.error.message
         raise newException(RpcException, msg)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
       if self.contacts.hasKey(publicKey):
         self.contacts[publicKey].dto.trustStatus = TrustStatus.Trusted
@@ -647,7 +647,7 @@ QtObject:
         let msg = response.error.message
         raise newException(RpcException, msg)
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
 
       if self.contacts.hasKey(publicKey):
         self.contacts[publicKey].dto.trustStatus = TrustStatus.Untrustworthy
@@ -721,7 +721,7 @@ QtObject:
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_SENT, ContactArgs(contactId: publicKey))
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
     except Exception as e:
       error "Error sending verification request", msg = e.msg
 
@@ -745,7 +745,7 @@ QtObject:
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_CANCELLED, ContactArgs(contactId: publicKey))
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
     except Exception as e:
       error "Error canceling verification request", msg = e.msg
 
@@ -768,7 +768,7 @@ QtObject:
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_ACCEPTED,
         VerificationRequestArgs(verificationRequest: request))
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
     except Exception as e:
       error "error accepting contact verification request", msg=e.msg
 
@@ -788,7 +788,7 @@ QtObject:
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_DECLINED, ContactArgs(contactId: publicKey))
       self.events.emit(SIGNAL_PARSE_RAW_ACTIVITY_CENTER_NOTIFICATIONS,
-        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result{"activityCenterNotifications"}))
+        RawActivityCenterNotificationsArgs(activityCenterNotifications: response.result["activityCenterNotifications"]))
     except Exception as e:
       error "error declining contact verification request", msg=e.msg
 

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -126,7 +126,7 @@ const asyncMarkAllMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe, ni
   let response =  status_go.markAllMessagesFromChatWithIdAsRead(arg.chatId)
 
   var activityCenterNotifications: JsonNode
-  if response.result{"activityCenterNotifications"} != nil:
+  if response.result["activityCenterNotifications"] != nil:
     activityCenterNotifications = response.result["activityCenterNotifications"]
 
   let responseJson = %*{
@@ -157,7 +157,7 @@ const asyncMarkCertainMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe
   discard response.result.getProp("countWithMentions", countWithMentions)
 
   var activityCenterNotifications: JsonNode
-  if response.result{"activityCenterNotifications"} != nil:
+  if response.result["activityCenterNotifications"] != nil:
     activityCenterNotifications = response.result["activityCenterNotifications"]
 
   var error = ""


### PR DESCRIPTION
Close #12889

### What does the PR do

Fixes the crash when accepting a CR and a few more random crashes

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)

<img width="1020" alt="Screenshot 2023-11-28 at 18 14 25" src="https://github.com/status-im/status-desktop/assets/2522130/f9a03448-aede-4a09-a047-253144eef88b">
