### PR TITLE
fix: share community instead of import during inviting community member in the community with minted owner token (CHERRY_PICK))

### DIFF
--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -472,7 +472,7 @@ QtObject:
     if (self.discordImportCommunityName == name): return
     self.discordImportCommunityName = name
     self.discordImportCommunityNameChanged()
-  
+
   QtProperty[string] discordImportCommunityName:
     read = getDiscordImportCommunityName
     notify = discordImportCommunityNameChanged
@@ -567,9 +567,8 @@ QtObject:
   proc cancelRequestToJoinCommunity*(self: View, communityId: string) {.slot.} =
     self.delegate.cancelRequestToJoinCommunity(communityId)
 
-  proc requestCommunityInfo*(self: View, communityId: string, importing: bool) {.slot.} =
-    # TODO update the slot to accept the shard arguments when it's available from the QML
-    self.delegate.requestCommunityInfo(communityId, shardCluster = -1, shardIndex = -1, importing)
+  proc requestCommunityInfo*(self: View, communityId: string, shardCluster: int, shardIndex: int, importing: bool) {.slot.} =
+    self.delegate.requestCommunityInfo(communityId, shardCluster, shardIndex, importing)
 
   proc getCommunityDetails*(self: View, communityId: string): string {.slot.} =
     let communityItem = self.model.getItemById(communityId)
@@ -689,7 +688,7 @@ QtObject:
   proc setDiscordImportedChannelCommunityId*(self: View, id: string) =
     if (self.discordImportedChannelCommunityId == id): return
     self.discordImportedChannelCommunityId = id
-  
+
   proc setDiscordImportChannelId*(self: View, id: string) {.slot.} =
     if (self.discordImportChannelId == id): return
     self.discordImportChannelId = id
@@ -701,7 +700,7 @@ QtObject:
   QtProperty[string] discordImportChannelId:
     read = getDiscordImportChannelId
     notify = discordImportChannelChanged
-  
+
   proc setDiscordImportChannelName*(self: View, name: string) {.slot.} =
     if (self.discordImportChannelName == name): return
     self.discordImportChannelName = name
@@ -814,4 +813,4 @@ QtObject:
   proc sharedAddressesForAllNonKeycardKeypairsSigned(self: View) {.signal.}
   proc sendSharedAddressesForAllNonKeycardKeypairsSignedSignal*(self: View) =
     self.sharedAddressesForAllNonKeycardKeypairsSigned()
-  
+


### PR DESCRIPTION
Cherry-pick

### What does the PR do

requestCommunityInfo signature was invalid, from QML side we sent 4 params, while here we accept only 2
It was working somehow, but importing was always true, which led to importing community instead of sharing it, when the community owner sent an invitation to the community with the minted owner

Closes: https://github.com/status-im/status-desktop/issues/12883