### PR TITLE
Add fetch messages 

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,42 @@
+{ pkgs ? import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/e7603eba51f2c7820c0a182c6bbb351181caa8e7.zip";
+    sha256 = "sha256:0mwck8jyr74wh1b7g6nac1mxy6a0rkppz8n12andsffybsipz5jw";
+  }) { } }:
+
+let
+  qtCustom = with pkgs.qt515;
+    env "qt-custom-${qtbase.version}" ([
+      qtquickcontrols2
+      qtgraphicaleffects
+      qtbase qttools qtdeclarative
+      qtlottie qtmultimedia
+      qtquickcontrols qtquickcontrols2
+      qtsvg qtwebengine qtwebview
+    ]);
+in pkgs.mkShell {
+  name = "status-desktop-build-shell";
+
+  buildInputs = with pkgs; [
+    qt5Full
+    bash curl wget git file unzip jq lsb-release
+    cmake gnumake pkg-config gnugrep qtCustom
+    go_1_19
+    pcre nss pcsclite extra-cmake-modules
+    xorg.libxcb xorg.libX11 libxkbcommon
+  ] ++ (with gst_all_1; [
+    gst-libav gstreamer
+    gst-plugins-bad  gst-plugins-base
+    gst-plugins-good gst-plugins-ugly
+  ]);
+
+  # Avoid terminal issues.
+  TERM = "xterm";
+  LANG = "en_US.UTF-8";
+  LANGUAGE = "en_US.UTF-8";
+
+  QTDIR = qtCustom;
+
+  shellHook = ''
+    export MAKEFLAGS="-j$NIX_BUILD_CORES"
+  '';
+}

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -8,6 +8,7 @@ import ../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../app_service/service/chat/service as chat_service
 import ../../../../../app_service/service/community/service as community_service
 import ../../../../../app_service/service/message/service as message_service
+import ../../../../../app_service/service/mailservers/service as mailservers_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 
 import ../../../../core/signals/types
@@ -26,6 +27,7 @@ type
     isUsersListAvailable: bool #users list is not available for 1:1 chat
     nodeConfigurationService: node_configuration_service.Service
     settingsService: settings_service.Service
+    mailserversService: mailservers_service.Service
     contactService: contact_service.Service
     chatService: chat_service.Service
     communityService: community_service.Service
@@ -220,6 +222,9 @@ proc unblockChat*(self: Controller) =
 
 proc markAllMessagesRead*(self: Controller) =
   self.messageService.markAllMessagesRead(self.chatId)
+
+proc requestMoreMessages*(self: Controller) =
+  self.mailserversService.requestMoreMessages(self.chatId)
 
 proc markMessageRead*(self: Controller, msgID: string) =
   self.messageService.markCertainMessagesRead(self.chatId, @[msgID])

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -101,6 +101,9 @@ method unblockChat*(self: AccessInterface) {.base.} =
 method markAllMessagesRead*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method requestMoreMessages*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method markMessageRead*(self: AccessInterface, msgID: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -126,9 +126,6 @@ method editMessage*(self: AccessInterface, messageId: string, contentType: int, 
 method onHistoryCleared*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestMoreMessages*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method fillGaps*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -157,6 +154,9 @@ method resetAndScrollToNewMessagesMarker*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method markAllMessagesRead*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method requestMoreMessages*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method markMessagesAsRead*(self: AccessInterface, messages: seq[string]) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -281,6 +281,9 @@ method unblockChat*(self: Module) =
 method markAllMessagesRead*(self: Module) =
   self.controller.markAllMessagesRead()
 
+method requestMoreMessages*(self: Module) =
+  self.controller.requestMoreMessages()
+
 method markMessageRead*(self: Module, msgID: string) =
   self.controller.markMessageRead(msgID)
 

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -91,6 +91,9 @@ QtObject:
   proc markAllMessagesRead*(self: View) {.slot.} =
     self.delegate.markAllMessagesRead()
 
+  proc requestMoreMessages*(self: View) {.slot.} =
+    self.delegate.requestMoreMessages()
+
   proc markMessageRead*(self: View, msgID: string) {.slot.} =
     self.delegate.markMessageRead(msgID)
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -479,6 +479,9 @@ proc unmuteChat*(self: Controller, chatId: string) =
 proc markAllMessagesRead*(self: Controller, chatId: string) =
   self.messageService.markAllMessagesRead(chatId)
 
+proc requestMoreMessages*(self: Controller, chatId: string) =
+  self.mailserversService.requestMoreMessages(chatId)
+
 proc clearChatHistory*(self: Controller, chatId: string) =
   self.chatService.clearChatHistory(chatId)
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -202,6 +202,9 @@ method markAllMessagesRead*(self: AccessInterface, chatId: string) {.base.} =
 method clearChatHistory*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method requestMoreMessages*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getCurrentFleet*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -902,6 +902,9 @@ method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
 method markAllMessagesRead*(self: Module, chatId: string) =
   self.controller.markAllMessagesRead(chatId)
 
+method requestMoreMessages*(self: Module, chatId: string) =
+  self.controller.requestMoreMessages(chatId)
+
 method clearChatHistory*(self: Module, chatId: string) =
   self.controller.clearChatHistory(chatId)
 

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -201,6 +201,9 @@ QtObject:
   proc markAllMessagesRead*(self: View, chatId: string) {.slot.} =
     self.delegate.markAllMessagesRead(chatId)
 
+  proc requestMoreMessages*(self: View, chatId: string) {.slot.} =
+    self.delegate.requestMoreMessages(chatId)
+
   proc clearChatHistory*(self: View, chatId: string) {.slot.} =
     self.delegate.clearChatHistory(chatId)
 

--- a/src/backend/mailservers.nim
+++ b/src/backend/mailservers.nim
@@ -33,3 +33,10 @@ proc fillGaps*(chatId: string, messageIds: seq[string]): RpcResponse[JsonNode] {
 proc requestAllHistoricMessagesWithRetries*(forceFetchingBackup: bool): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[forceFetchingBackup]
   result = core.callPrivateRPC("requestAllHistoricMessagesWithRetries".prefix, payload)
+
+proc requestMoreMessages*(chatId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[{
+    "id": chatId
+  }]
+  result = core.callPrivateRPC("fetchMessages".prefix, payload)
+  info "requestMoreMessages", topics="mailserver-interaction", rpc_method="wakuext_fetchMessages", chatId, result

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -232,7 +232,7 @@ Item {
                 onAddRemoveGroupMember: {
                     root.addRemoveGroupMember()
                 }
-                onFetchMoreMessages: {
+                onRequestMoreMessages: {
                     messageStore.requestMoreMessages();
                 }
                 onLeaveGroup: {

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -179,6 +179,10 @@ Item {
                         root.chatSectionModule.markAllMessagesRead(chatId)
                     }
 
+                    onRequestMoreMessages: {
+                        root.chatSectionModule.requestMoreMessages(chatId)
+                    }
+
                     onClearChatHistory: {
                         root.chatSectionModule.clearChatHistory(chatId)
                     }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -339,6 +339,10 @@ Item {
                     root.communitySectionModule.markAllMessagesRead(chatId)
                 }
 
+                onRequestMoreMessages: {
+                    root.communitySectionModule.requestMoreMessages(chatId)
+                }
+
                 onClearChatHistory: {
                     root.communitySectionModule.clearChatHistory(chatId)
                 }

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -42,7 +42,7 @@ StatusMenu {
 
     signal createCommunityChannel(string chatId, string newName, string newDescription, string newEmoji, string newColor)
     signal editCommunityChannel(string chatId, string newName, string newDescription, string newEmoji, string newColor, string newCategory)
-    signal fetchMoreMessages(int timeFrame)
+    signal requestMoreMessages(string chatId)
     signal addRemoveGroupMember()
 
     width: root.amIChatAdmin && (root.chatType === Constants.chatType.privateGroupChat) ? 207 : implicitWidth
@@ -124,39 +124,15 @@ StatusMenu {
         }
     }
 
-    //TODO uncomment when implemented
-//    StatusMenu {
-//        title: qsTr("Fetch messages")
-//        enabled: (root.chatType === Constants.chatType.oneToOne ||
-//                  root.chatType === Constants.chatType.privateGroupChat)
-//        StatusAction {
-//            text: "Last 24 hours"
-//            onTriggered: {
-//                root.fetchMoreMessages();
-//            }
-//        }
-
-//        StatusAction {
-//            text: "Last 2 days"
-//            onTriggered: {
-
-//            }
-//        }
-
-//        StatusAction {
-//            text: "Last 3 days"
-//            onTriggered: {
-
-//            }
-//        }
-
-//        StatusAction {
-//            text: "Last 7 days"
-//            onTriggered: {
-
-//            }
-//        }
-//    }
+    StatusAction {
+        objectName: "chatFetchMessagesMenuItem"
+        text: qsTr("Fetch messages")
+        icon.name: "download"
+        enabled: !production
+        onTriggered: {
+            root.requestMoreMessages(root.chatId)
+        }
+    }
 
     StatusAction {
         objectName: "editChannelMenuItem"


### PR DESCRIPTION
This PR adds support for fetching messages for a given channel.

It will perform a request fetching the last 30 days.
This is useful for dogfooding and debugging, and it will be enabled only on developer mode (have yet to do that). 
We discussed with John/Design and they are not going to want the feature on production builds.
I have added a working nix shell to build the project, taken from @jakubgs and slightly modified, it pulls too many dependencies, but it works.

I have literally no clue what I am doing, but it seems to be working (I can see the request is made correctly in status-go).

