### PR TITLE
fix(ActivityCenter): Fix crash when marking all messages as read

### DIFF
--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -126,8 +126,7 @@ const asyncMarkAllMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe, ni
   let response =  status_go.markAllMessagesFromChatWithIdAsRead(arg.chatId)
 
   var activityCenterNotifications: JsonNode
-  if response.result{"activityCenterNotifications"} != nil:
-    activityCenterNotifications = response.result["activityCenterNotifications"]
+  discard response.result.getProp("notifications", activityCenterNotifications)
 
   let responseJson = %*{
     "chatId": arg.chatId,
@@ -157,8 +156,7 @@ const asyncMarkCertainMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe
   discard response.result.getProp("countWithMentions", countWithMentions)
 
   var activityCenterNotifications: JsonNode
-  if response.result{"activityCenterNotifications"} != nil:
-    activityCenterNotifications = response.result["activityCenterNotifications"]
+  discard response.result.getProp("notifications", activityCenterNotifications)
 
   var error = ""
   if(count == 0):


### PR DESCRIPTION
### What does the PR do

Fix crash when setting all messages as read in the async flow

### Affected areas

- Chat is affected as a crash happens after reading all missed messages

### Parent PR

https://github.com/status-im/status-desktop/pull/12815