### PR TITLE
fix: prevent recursive logging

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -51,7 +51,7 @@ proc prepareLogging() =
       proc (logLevel: LogLevel, msg: LogOutputStr) {.gcsafe, raises: [Defect].} =
         try:
           if signalsManagerQObjPointer != nil:
-            signal_handler(signalsManagerQObjPointer, ($(%* {"type": "chronicles-log", "event": msg})).cstring, "receiveSignal")
+            signal_handler(signalsManagerQObjPointer, ($(%* {"type": "chronicles-log", "event": msg})).cstring, "receiveChroniclesLogEvent")
         except:
           logLoggingFailure(cstring(msg), getCurrentException())
 


### PR DESCRIPTION
### What does the PR do

This code was creating a recursive call to chronicles logs:
https://github.com/status-im/status-desktop/blob/8e0db2e666e566f207b8dcaf02dbf2917b188397/src/nim_status_client.nim#L54

... because the log event would produce new logs, which would produce new log event and so on.

This wasn't usually a problem until you switch to `TRACE` log level. Then this line was called recursively and the program won't work:
https://github.com/status-im/status-desktop/blob/8e0db2e666e566f207b8dcaf02dbf2917b188397/src/app/core/signals/signals_manager.nim#L37

I've made several attempts to fix this and couldn't find a better workaround.
The best solution IMO would be this: instead of dispatching a `ChroniclesLogs` signal, make a direct call to `EventsEmitter.emit`. The problem is that his type is `ref object` and can't be used in `{.gcsafe.}` procedure. And that's smth I couldn't win.

By the way, `TRACE` logs currently can't be used because we try to pass it to status-go, which doesn't know of such log level. I'll fix it in a separate PR.