### PR TITLE
chore(@dekstop/keycard): os sleep used in the past is not needed any more

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -1,4 +1,4 @@
-import stint, std/strutils, uuids, os
+import stint, std/strutils, uuids
 import ./io_interface
 
 import app/core/signals/types
@@ -457,9 +457,6 @@ proc connectKeycardReponseSignal(self: Controller) =
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc runSignFlow(self: Controller, pin, path, dataToSign: string) =
   self.cancelCurrentFlow()

--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -1,4 +1,4 @@
-import Tables, os, uuids, chronicles, json
+import Tables, uuids, chronicles, json
 import io_interface
 
 import app/global/global_singleton
@@ -196,9 +196,6 @@ proc connectKeycardReponseSignal(self: Controller) =
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc runSignFlow*(self: Controller, pin, bip44Path, txHash: string) =
   self.cancelCurrentFlow()

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -1,4 +1,4 @@
-import Tables, os, uuids, stint, json
+import Tables, uuids, stint, json
 
 import ./io_interface
 
@@ -212,9 +212,6 @@ proc connectKeycardReponseSignal(self: Controller) =
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc runSignFlow*(self: Controller, pin, bip44Path, txHash: string) =
   self.cancelCurrentFlow()

--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -1,5 +1,5 @@
 import sugar, sequtils, stint, json, json_serialization
-import uuids, os, chronicles
+import uuids, chronicles
 import io_interface
 import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/network/service as network_service
@@ -151,9 +151,6 @@ proc connectKeycardReponseSignal(self: Controller) =
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc runSignFlow*(self: Controller, pin, bip44Path, txHash: string) =
   self.cancelCurrentFlow()

--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -1,4 +1,4 @@
-import times, os, chronicles
+import times, chronicles
 import uuids
 import io_interface
 
@@ -224,9 +224,6 @@ proc connectKeycardReponseSignal(self: Controller) =
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc fetchAddressesFromKeycard*(self: Controller, bip44Paths: seq[string]) =
   self.cancelCurrentFlow()

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -1,4 +1,4 @@
-import chronicles, tables, strutils, os, sequtils, sugar
+import chronicles, tables, strutils, sequtils, sugar
 import uuids
 import io_interface
 
@@ -483,9 +483,6 @@ proc cancelCurrentFlow*(self: Controller) =
   if not serviceApplicable(self.keycardService):
     return
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc runGetAppInfoFlow*(self: Controller, factoryReset = false) =
   if not serviceApplicable(self.keycardService):

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -1,4 +1,4 @@
-import Tables, chronicles, strutils, os
+import Tables, chronicles, strutils
 import uuids
 import io_interface
 
@@ -534,9 +534,6 @@ proc getLastReceivedKeycardData*(self: Controller): tuple[flowType: string, flow
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()
-  # in most cases we're running another flow after canceling the current one,
-  # this way we're giving to the keycard some time to cancel the current flow
-  sleep(200)
 
 proc runLoadAccountFlow*(self: Controller, seedPhraseLength = 0, seedPhrase = "", pin = "", puk = "", factoryReset = false) =
   self.cancelCurrentFlow() # before running into any flow we're making sure that the previous flow is canceled


### PR DESCRIPTION
I've checked some complex and critical flows after I removed os `sleep`, looks like the keycard flows work just fine.
Since that was introduced a long time ago, after that the code was copied wherever we wanted to cancel the current and run a new flow successively, we ended up with that code in several places across the app.

But during that period many things on the keycard lib side were improved as well as on the desktop app side, many things that were called directly initially are not async calls, seems that we got rid of the need for that line of code, that's why I'm removing it here.

Though I cannot recall exactly what was the case where we needed it at the beginning with keycard features implementation, I cannot find the reason now why should we keep it, I've checked and tested the code and all works correctly.