### PR TITLE
fix(wallet) remove unused API GetTokensBalances old api

### DIFF
--- a/src/app/modules/main/browser_section/current_account/controller.nim
+++ b/src/app/modules/main/browser_section/current_account/controller.nim
@@ -1,9 +1,11 @@
 import sugar, sequtils
 import io_interface
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../../app_service/service/network/service as network_service
-import ../../../../../app_service/service/token/service as token_service
-import ../../../../../app_service/service/currency/service as currency_service
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/network/service as network_service
+import app_service/service/token/service as token_service
+import app_service/service/currency/service as currency_service
+
+import backend/helpers/token
 
 type
   Controller* = ref object of RootObj

--- a/src/app/modules/main/browser_section/current_account/module.nim
+++ b/src/app/modules/main/browser_section/current_account/module.nim
@@ -1,16 +1,18 @@
 import NimQml, Tables, sequtils, strutils, sugar
 
-import ../../../../global/global_singleton
-import ../../../../core/eventemitter
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../../app_service/service/network/service as network_service
-import ../../../../../app_service/service/token/service as token_service
-import ../../../../../app_service/service/currency/service as currency_service
-import ../../../shared/wallet_utils
-import ../../../shared_models/token_model as token_model
+import app/global/global_singleton
+import app/core/eventemitter
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/network/service as network_service
+import app_service/service/token/service as token_service
+import app_service/service/currency/service as currency_service
+import app/modules/shared/wallet_utils
+import app/modules/shared_models/token_model as token_model
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
+
+import backend/helpers/token
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -10,6 +10,8 @@ import app_service/common/types
 
 import app_service/service/profile/dto/profile_showcase_preferences
 
+import backend/helpers/token
+
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
@@ -5,10 +5,12 @@ import profile_preferences_base_item
 import app_service/service/wallet_account/dto/account_dto
 import app_service/service/profile/dto/profile_showcase_preferences
 
-import ../../../../shared_models/currency_amount
+import app/modules/shared_models/currency_amount
 
 include app_service/common/json_utils
 include app_service/common/utils
+
+import backend/helpers/token
 
 type
   ProfileShowcaseAssetItem* = ref object of ProfileShowcaseBaseItem

--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -15,6 +15,8 @@ import app_service/service/settings/service
 
 import backend/collectibles as backend_collectibles
 
+import backend/helpers/token
+
 export io_interface
 
 type

--- a/src/app/modules/main/wallet_section/assets/controller.nim
+++ b/src/app/modules/main/wallet_section/assets/controller.nim
@@ -1,9 +1,11 @@
 import sugar, sequtils
 import io_interface
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../../app_service/service/network/service as network_service
-import ../../../../../app_service/service/token/service as token_service
-import ../../../../../app_service/service/currency/service as currency_service
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/network/service as network_service
+import app_service/service/token/service as token_service
+import app_service/service/currency/service as currency_service
+
+import backend/helpers/token
 
 type
   Controller* = ref object of RootObj
@@ -36,7 +38,7 @@ proc init*(self: Controller) =
 proc getWalletAccountsByAddresses*(self: Controller, addresses: seq[string]): seq[wallet_account_service.WalletAccountDto] =
   return self.walletAccountService.getAccountsByAddresses(addresses)
 
-proc getWalletTokensByAddresses*(self: Controller, addresses: seq[string]): seq[wallet_account_service.WalletTokenDto] =
+proc getWalletTokensByAddresses*(self: Controller, addresses: seq[string]): seq[WalletTokenDto] =
   return self.walletAccountService.getTokensByAddresses(addresses)
 
 proc getChainIds*(self: Controller): seq[int] =

--- a/src/app/modules/main/wallet_section/assets/module.nim
+++ b/src/app/modules/main/wallet_section/assets/module.nim
@@ -1,19 +1,21 @@
 import NimQml, sequtils, sugar
 
-import ../../../../global/global_singleton
-import ../../../../core/eventemitter
-import ../../../../../app_service/service/token/service as token_service
-import ../../../../../app_service/service/currency/service as currency_service
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../../app_service/service/network/service as network_service
-import ../../../../../app_service/service/network_connection/service as network_connection
-import ../../../../../app_service/service/node/service as node_service
-import ../../../shared/wallet_utils
-import ../../../shared_models/token_model as token_model
-import ../../../shared_models/token_item as token_item
+import app/global/global_singleton
+import app/core/eventemitter
+import app_service/service/token/service as token_service
+import app_service/service/currency/service as currency_service
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/network/service as network_service
+import app_service/service/network_connection/service as network_connection
+import app_service/service/node/service as node_service
+import app/modules/shared/wallet_utils
+import app/modules/shared_models/token_model as token_model
+import app/modules/shared_models/token_item as token_item
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
+
+import backend/helpers/token
 
 export io_interface
 

--- a/src/app/modules/main/wallet_section/overview/controller.nim
+++ b/src/app/modules/main/wallet_section/overview/controller.nim
@@ -1,13 +1,15 @@
 import io_interface
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../../app_service/service/currency/service as currency_service
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/currency/service as currency_service
+
+import backend/helpers/token
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     walletAccountService: wallet_account_service.Service
     currencyService: currency_service.Service
- 
+
 proc newController*(
   delegate: io_interface.AccessInterface,
   walletAccountService: wallet_account_service.Service,
@@ -27,7 +29,7 @@ proc init*(self: Controller) =
 proc getWalletAccountsByAddresses*(self: Controller, addresses: seq[string]): seq[wallet_account_service.WalletAccountDto] =
   return self.walletAccountService.getAccountsByAddresses(addresses)
 
-proc getWalletTokensByAddresses*(self: Controller, addresses: seq[string]): seq[wallet_account_service.WalletTokenDto] =
+proc getWalletTokensByAddresses*(self: Controller, addresses: seq[string]): seq[WalletTokenDto] =
   return self.walletAccountService.getTokensByAddresses(addresses)
 
 proc getCurrentCurrency*(self: Controller): string =

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -1,15 +1,17 @@
 import NimQml, sequtils, sugar
 
-import ../../../../global/global_singleton
-import ../../../../core/eventemitter
-import ../../../../../app_service/service/currency/service as currency_service
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../shared/wallet_utils
-import ../../../shared_models/currency_amount
+import app/global/global_singleton
+import app/core/eventemitter
+import app_service/service/currency/service as currency_service
+import app_service/service/wallet_account/service as wallet_account_service
+import app/modules/shared/wallet_utils
+import app/modules/shared_models/currency_amount
 import ./item
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
+
+import backend/helpers/token
 
 export io_interface
 

--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -15,6 +15,8 @@ import app/modules/shared_models/currency_amount
 import app/core/signals/types
 import app/core/eventemitter
 
+import backend/helpers/token
+
 logScope:
   topics = "wallet-send-controller"
 

--- a/src/app/modules/shared/wallet_utils.nim
+++ b/src/app/modules/shared/wallet_utils.nim
@@ -2,12 +2,15 @@ import tables, sequtils, stint, sugar
 
 import ../shared_models/[balance_item, currency_amount, token_item, token_model, wallet_account_item]
 
-import ../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../app_service/service/currency/dto as currency_dto
+import backend/helpers/token
+
+import app_service/service/currency/dto as currency_dto
 
 import ../main/wallet_section/accounts/item as wallet_accounts_item
 import ../main/wallet_section/assets/item as wallet_assets_item
 import ../main/wallet_section/send/account_item as wallet_send_account_item
+
+import backend/helpers/balance
 
 proc currencyAmountToItem*(amount: float64, format: CurrencyFormatDto) : CurrencyAmount =
   return newCurrencyAmount(

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -1,7 +1,9 @@
 import NimQml, tables
 import app/core/eventemitter
 from app_service/service/keycard/service import KeycardEvent, CardMetadata, KeyDetails
-from app_service/service/wallet_account/service as wallet_account_service import WalletTokenDto
+
+from backend/helpers/token import WalletTokenDto
+
 import app/modules/shared_models/keypair_item
 
 type FlowType* {.pure.} = enum

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -3,21 +3,23 @@ import NimQml, tables, strutils, sequtils, sugar, chronicles
 import io_interface
 import view, controller
 import internal/[state, state_factory]
-import ../../shared/[keypairs, wallet_utils]
-import ../../shared_models/[keypair_model, keypair_item, currency_amount]
-import ../../../global/app_translatable_constants as atc
-import ../../../global/global_singleton
-import ../../../core/eventemitter
+import app/modules/shared/[keypairs, wallet_utils]
+import app/modules/shared_models/[keypair_model, keypair_item, currency_amount]
+import app/global/app_translatable_constants as atc
+import app/global/global_singleton
+import app/core/eventemitter
 
-import ../../../../app_service/common/utils
-import ../../../../app_service/service/keycard/constants
-import ../../../../app_service/service/keycard/service as keycard_service
-import ../../../../app_service/service/settings/service as settings_service
-import ../../../../app_service/service/network/service as network_service
-import ../../../../app_service/service/privacy/service as privacy_service
-import ../../../../app_service/service/accounts/service as accounts_service
-import ../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../app_service/service/keychain/service as keychain_service
+import app_service/common/utils
+import app_service/service/keycard/constants
+import app_service/service/keycard/service as keycard_service
+import app_service/service/settings/service as settings_service
+import app_service/service/network/service as network_service
+import app_service/service/privacy/service as privacy_service
+import app_service/service/accounts/service as accounts_service
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/keychain/service as keychain_service
+
+import backend/helpers/token
 
 export io_interface
 

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -8,8 +8,10 @@ import app/global/global_singleton
 import backend/ens as status_ens
 import backend/backend as status_go_backend
 import backend/wallet as status_wallet
+import backend/helpers/helpers
 
 import app_service/common/conversion as common_conversion
+
 import utils as ens_utils
 import app_service/service/settings/service as settings_service
 import app_service/service/wallet_account/service as wallet_account_service
@@ -311,8 +313,11 @@ QtObject:
   proc getSNTBalance*(self: Service): string =
     let token = self.getStatusToken()
     let account = self.walletAccountService.getWalletAccount(0).address
-    let balances = status_go_backend.getTokensBalancesForChainIDs(@[self.getChainId()], @[account], @[token.address]).result
-    return ens_utils.hex2Token(balances{account}{token.address}.getStr, token.decimals)
+
+    let info = getTokenBalanceForAccount(self.getChainId(), account, token.symbol)
+    if info.isNone:
+      return "0"
+    return ens_utils.hex2Token(info.get().rawBalance.toString(16), token.decimals)
 
   proc resourceUrl*(self: Service, username: string): (string, string, string) =
     try:

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -6,14 +6,14 @@ import backend/backend as backend
 
 import app_service/service/network/service as network_service
 import app_service/service/settings/service as settings_service
-import app_service/service/wallet_account/dto/account_dto
 
 import app/core/eventemitter
 import app/core/tasks/[qt, threadpool]
 import app/core/signals/types
 import app_service/common/cache
-import ../../../constants as main_constants
+import constants as main_constants
 import ./dto, ./service_items
+import backend/helpers/token
 
 export dto, service_items
 

--- a/src/app_service/service/token/service_items.nim
+++ b/src/app_service/service/token/service_items.nim
@@ -1,8 +1,8 @@
 import strformat
 
 import app_service/common/types as common_types
-#TODO: remove dependency
-import ../wallet_account/dto/token_dto
+
+import backend/helpers/token
 
 # This file holds the data types used by models internally
 

--- a/src/app_service/service/wallet_account/dto/account_dto.nim
+++ b/src/app_service/service/wallet_account/dto/account_dto.nim
@@ -1,10 +1,6 @@
 import tables, json, strformat, strutils
 
-import token_dto
-
 include  app_service/common/json_utils
-
-export token_dto
 
 const WalletTypeGenerated* = "generated" # refers to accounts generated from the profile keypair
 const WalletTypeSeed* = "seed"

--- a/src/app_service/service/wallet_account/signals_and_payloads.nim
+++ b/src/app_service/service/wallet_account/signals_and_payloads.nim
@@ -1,3 +1,5 @@
+import backend/helpers/token
+
 #################################################
 # Special signal emitted by main module and handled in wallet account service
 #################################################

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -98,11 +98,6 @@ rpc(getTokens, "wallet"):
 rpc(getTokenList, "wallet"):
   discard
 
-rpc(getTokensBalancesForChainIDs, "wallet"):
-  chainIds: seq[int]
-  accounts: seq[string]
-  tokens: seq[string]
-
 rpc(getPendingTransactions, "wallet"):
   discard
 

--- a/src/backend/helpers/balance.nim
+++ b/src/backend/helpers/balance.nim
@@ -1,13 +1,16 @@
-import json, strformat, stint, strutils
+import json, tables, stint, strutils, net, options, chronicles, strformat
 
-include  app_service/common/json_utils
+import backend/backend
 
-type BalanceDto* = object
-  rawBalance*: Uint256
-  balance*: float64
-  address*: string
-  chainId*: int
-  hasError*: bool
+include app_service/common/json_utils
+
+type
+  BalanceDto* = object
+    rawBalance*: Uint256
+    balance*: float64
+    address*: string
+    chainId*: int
+    hasError*: bool
 
 proc `$`*(self: BalanceDto): string =
   result = fmt"""BalanceDto[

--- a/src/backend/helpers/helpers.nim
+++ b/src/backend/helpers/helpers.nim
@@ -1,0 +1,23 @@
+import json, tables, stint, strutils, net, sequtils, options, chronicles, strformat
+
+import token
+import balance
+import backend/backend
+
+proc getTokenBalanceForAccount*(chainId: int, accAddress: string, symbol: string): Option[BalanceDto] =
+  try:
+    let response = backend.getWalletToken(@[accAddress])
+    if not response.result.contains(accAddress):
+      error "Missing balance for account ", accAddress
+      return none[BalanceDto]()
+
+    let tokens = parseWalletTokenDtoJson(response.result[accAddress])
+    for token in tokens:
+      if token.symbol == symbol:
+        if chainId in token.balancesPerChain:
+          return some(token.balancesPerChain[chainId])
+
+  except Exception as e:
+    error "Error getting balance ", message=e.msg
+
+  return none[BalanceDto]()

--- a/src/backend/helpers/token.nim
+++ b/src/backend/helpers/token.nim
@@ -1,10 +1,8 @@
-import tables, json, strformat, stint, strutils
+import tables, json, strformat, stint, strutils, sequtils
 
-import balance_dto
+import backend/helpers/balance
 
-include  app_service/common/json_utils
-
-export balance_dto
+include app_service/common/json_utils
 
 type
   TokenMarketValuesDto* = object
@@ -179,4 +177,11 @@ proc getCurrencyBalance*(self: WalletTokenDto, chainIds: seq[int], currency: str
       sum += self.balancesPerChain[chainId].getCurrencyBalance(price)
   return sum
 
+proc parseWalletTokenDtoJson*(jsonData: JsonNode): seq[WalletTokenDto] =
+    if jsonData.kind != JArray:
+        raise newException(Exception, "Invalid tokens details json")
 
+    var tokens: seq[WalletTokenDto]
+    tokens = map(jsonData.getElems(), proc(x: JsonNode): WalletTokenDto = x.toWalletTokenDto())
+
+    return tokens


### PR DESCRIPTION
### Closes: #12914

Replace it with the new API `GetWalletToken`

Move the backend-related JSON parsing to the `backend/helpers` folder close to the source so as not to create reverse dependencies.
Update some imports to absolute paths.
Remove related indirect imports.