### PR TITLE
fix(@desktop/wallet): Adds STT for default tokens visible

### DIFF
--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -43,14 +43,15 @@ StatusScrollView {
 
         readonly property bool isCustomView: d.controller.hasSettings // TODO add respect other predefined orders (#12517)
 
-        function symbolIsVisible(symbol, balance) {
+        function symbolIsVisible(symbol) {
             if (symbol === "ETH") // always visible
                 return true
             if (!d.controller.filterAcceptsSymbol(symbol)) // explicitely hidden
                 return false
-            if (symbol === "SNT" || symbol === "DAI") // visible by default
+            if (symbol === "SNT" || symbol === "STT" || symbol === "DAI") // visible by default
                 return true
-            return !!balance && !!balance.amount // visible with non-zero balance
+            // We'll receive the tokens only with non zero balance except for Eth, Dai or SNT/STT
+            return true
         }
 
         readonly property var regularAssetsModel: SortFilterProxyModel {
@@ -60,7 +61,7 @@ StatusScrollView {
                 ExpressionFilter {
                     expression: {
                         d.controller.settingsDirty
-                        return d.symbolIsVisible(model.symbol, model.enabledNetworkBalance) && !model.communityId
+                        return d.symbolIsVisible(model.symbol) && !model.communityId
                     }
                 }
                 // TODO add other sort/filter using ManageTokensController (#12517)
@@ -80,7 +81,7 @@ StatusScrollView {
                 ExpressionFilter {
                     expression: {
                         d.controller.settingsDirty
-                        return d.symbolIsVisible(model.symbol, model.enabledNetworkBalance) && !!model.communityId
+                        return d.symbolIsVisible(model.symbol) && !!model.communityId
                     }
                 }
                 // TODO add other sort/filter using ManageTokensController (#12517)


### PR DESCRIPTION
fix(@desktop/wallet): Adds STT for default tokens visible

removes condition for showing only tokens with non zero balance as that part is already done on status_go side

### What does the PR do

Read description

### Affected areas

Wallet Assets View

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/0ac353e2-74bf-4491-a8fa-3f9f3582ce8d



