### PR TITLE
chore: update to new squish version

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -139,7 +139,7 @@ pipeline {
               '--config', 'addAUT', 'nim_status_client',
               "${WORKSPACE}/bin",
             ]).join('\n'),
-            squishPackageName: 'squish-7.1-20230222-1555-qt515x-linux64',
+            squishPackageName: 'squish-7.2.1-qt515x-linux64',
             testSuite: "${WORKSPACE}/test/ui-test/testSuites/${params.SQUISH_SUITE}",
           ])
           print("Squish run result: ${result}")


### PR DESCRIPTION
### What does the PR do

Update config to `squish-7.2.1-qt515x-linux64`


```
21:08:00  ---------------------------------------------
21:08:00  Squish plug-in version is: 8.6
21:08:00  ---------------------------------------------
21:08:00  Squish tests executed on "linux-03" agent
21:08:00  ---------------------------------------------
21:08:00  Squish tests executed with squishrunner:
21:08:00  /opt/squish-runner-7.2.1/buildinfo.txt
21:08:00  Package Name:  squish-7.2.1-qt515x-linux64
21:08:00  Internal Name: /home/autotest/public_html/binpackages/2023/11/04-1700/bin_package/7.2.1/qt/Dock10-Qt5.15.0binary-TkNone-iOSNone-def-08dc30a
21:08:00  Git Branch:    7.2.1
21:08:00  Git Revision:  966be14528b68781a196490efd4b6f21e7340b66
21:08:00  
21:08:00  Python Version: default
21:08:00  Patched:        False
21:08:00  Debug Build:    False
21:08:00  Debug Symbols:  False
21:08:00  Pure Qt4 Build: False
21:08:00  Include IDE:    True
21:08:00  
21:08:00  Python 2:       /home/autotest/binPackage/x64/Python/2.7.10ucs4_ssl
21:08:00  Python 3:       /home/autotest/binPackage/x64/Python/3.10.6
21:08:00  Tcl:            /home/autotest/binPackage/x64/Tcl/8.6.4
21:08:00  Perl:           /home/autotest/binPackage/x64/Perl/5.34.0
21:08:00  Ruby:           /home/autotest/binPackage/x64/Ruby/2.5.3
```


<img width="1840" alt="Screenshot 2023-12-01 at 21 33 05" src="https://github.com/status-im/status-desktop/assets/82375995/09e2ec94-5a0a-4a3f-9007-5ed55ee3106b">

