### PR TITLE
fix(@desktop/general): runtime log level control doesn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,7 @@ ifeq ($(shell test $(KDF_ITERATIONS) -gt 0; echo $$?),0)
   NIM_PARAMS += -d:KDF_ITERATIONS:"$(KDF_ITERATIONS)"
 endif
 
-NIM_PARAMS += -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors] -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=dynamic
+NIM_PARAMS += -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors] -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=dynamic -d:chronicles_log_level=trace
 
 RESOURCES_LAYOUT ?= -d:development
 


### PR DESCRIPTION
The issue was in setting the minimum log level on the `nim-chronicles` during the app build time.

We're able now to set the desired log level for the Status app using any of the following ways:
- `export STATUS_RUNTIME_LOG_LEVEL=TRACE` then run `make run` or `./nim_status_client`
- `./nim_status_client --LOG_LEVEL=TRACE`

Fixes: #12919