### PR TITLE
Fix `TRACE` log level support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,7 @@ ifeq ($(shell test $(KDF_ITERATIONS) -gt 0; echo $$?),0)
   NIM_PARAMS += -d:KDF_ITERATIONS:"$(KDF_ITERATIONS)"
 endif
 
-NIM_PARAMS += -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors] -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=dynamic
+NIM_PARAMS += -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors] -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=dynamic -d:chronicles_log_level=trace
 
 RESOURCES_LAYOUT ?= -d:development
 

--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar, chronicles, os, uuids
+import NimQml, sequtils, sugar, chronicles, uuids
 
 import ../../app_service/service/general/service as general_service
 import ../../app_service/service/keychain/service as keychain_service
@@ -133,7 +133,7 @@ proc connect(self: AppController) =
     discard
 
   # Handle runtime log level settings changes
-  if not existsEnv("LOG_LEVEL"):
+  if not main_constants.runtimeLogLevelSet():
     self.statusFoundation.events.on(node_configuration_service.SIGNAL_NODE_LOG_LEVEL_UPDATE) do(a: Args):
       let args = NodeLogLevelUpdatedArgs(a)
       if args.logLevel == chronicles.LogLevel.DEBUG:
@@ -439,7 +439,7 @@ proc load(self: AppController) =
   self.walletAccountService.init()
 
   # Apply runtime log level settings
-  if not existsEnv("LOG_LEVEL"):
+  if not main_constants.runtimeLogLevelSet():
     if self.nodeConfigurationService.isDebugEnabled():
       setLogLevel(chronicles.LogLevel.DEBUG)
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -263,6 +263,11 @@ QtObject:
       if(self.importedAccount.id == accountId):
         return self.prepareSubaccountJsonObject(self.importedAccount, displayName)
 
+  proc toStatusGoSupportedLogLevel*(logLevel: string): string =
+    if logLevel == "TRACE":
+      return "DEBUG"
+    return logLevel
+
   proc prepareAccountSettingsJsonObject(self: Service, account: GeneratedAccountDto,
     installationId: string, displayName: string): JsonNode =
     result = %* {
@@ -343,7 +348,7 @@ QtObject:
       result["ClusterConfig"]["DiscV5BootstrapNodes"] = %* (@[])
       result["Rendezvous"] = newJBool(false)
 
-    result["LogLevel"] = newJString(main_constants.LOG_LEVEL)
+    result["LogLevel"] = newJString(toStatusGoSupportedLogLevel(main_constants.LOG_LEVEL))
 
     if STATUS_PORT != 0:
       result["ListenAddr"] = newJString("0.0.0.0:" & $main_constants.STATUS_PORT)
@@ -407,7 +412,7 @@ QtObject:
       "TorrentDir": DEFAULT_TORRENT_CONFIG_TORRENTDIR
     }
 
-    result["LogLevel"] = newJString(main_constants.LOG_LEVEL)
+    result["LogLevel"] = newJString(toStatusGoSupportedLogLevel(main_constants.LOG_LEVEL))
 
     if STATUS_PORT != 0:
       result["ListenAddr"] = newJString("0.0.0.0:" & $main_constants.STATUS_PORT)

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -273,7 +273,6 @@ proc isDebugEnabled*(self: Service): bool =
   return self.getLogLevel() == $LogLevel.DEBUG
 
 proc setLogLevel*(self: Service, logLevel: LogLevel): bool =
-  echo "<<< node_configuration.service.setLogLevel " & $logLevel
   var newConfiguration = self.configuration
   newConfiguration.LogLevel = $logLevel
   if self.saveConfiguration(newConfiguration):

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -273,6 +273,7 @@ proc isDebugEnabled*(self: Service): bool =
   return self.getLogLevel() == $LogLevel.DEBUG
 
 proc setLogLevel*(self: Service, logLevel: LogLevel): bool =
+  echo "<<< node_configuration.service.setLogLevel " & $logLevel
   var newConfiguration = self.configuration
   newConfiguration.LogLevel = $logLevel
   if self.saveConfiguration(newConfiguration):

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -60,3 +60,12 @@ let
   RARIBLE_TESTNET_API_KEY_RESOLVED* = desktopConfig.raribleTestnetApiKey
   TENOR_API_KEY_RESOLVED* = desktopConfig.tenorApiKey
   WALLET_CONNECT_PROJECT_ID* = BUILD_WALLET_CONNECT_PROJECT_ID
+
+proc hasLogLevelOption*(): bool =
+  for p in cliParams:
+    if p.startswith("--log-level") or p.startsWith("--LOG_LEVEL"):
+      return true
+  return false
+
+proc runtimeLogLevelSet*(): bool =
+  return existsEnv(RUN_TIME_PREFIX & "_LOG_LEVEL") or hasLogLevelOption()


### PR DESCRIPTION
Requires https://github.com/status-im/status-desktop/pull/12916
Requires https://github.com/status-im/status-desktop/pull/12934

### What does the PR do

1. Pass correct value to status-go log level when `TRACE` logs are used.
`TRACE` is not supported by status-go, so we replace it with `DEBUG`.

2. Fix places that were checking for `LOG_LEVEL` env variable.
- Use `STATUS_RUNTIME_LOG_LEVEL` instead
- Aldo check if `--log-level` CLI option is set