### PR TITLE
fix(@desktop/communities): Keep community tokens in cache.

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -163,11 +163,6 @@ proc init*(self: Controller) =
     let args = CommunitiesArgs(e)
     self.delegate.curatedCommunitiesLoaded(args.communities)
 
-  # We use once here because we only need it to generate the original list of tokens from communities
-  self.events.once(SIGNAL_ALL_COMMUNITY_TOKENS_LOADED) do(e: Args):
-    let args = CommunityTokensArgs(e)
-    self.delegate.onAllCommunityTokensLoaded(args.communityTokens)
-
   self.events.on(SIGNAL_COMMUNITY_TOKEN_METADATA_ADDED) do(e: Args):
     let args = CommunityTokenMetadataArgs(e)
     self.delegate.onCommunityTokenMetadataAdded(args.communityId, args.tokenMetadata)
@@ -368,8 +363,8 @@ proc requestCancelDiscordChannelImport*(self: Controller, discordChannelId: stri
 proc getCommunityTokens*(self: Controller, communityId: string): seq[CommunityTokenDto] =
   self.communityTokensService.getCommunityTokens(communityId)
 
-proc getAllCommunityTokensAsync*(self: Controller) =
-  self.communityTokensService.getAllCommunityTokensAsync()
+proc getAllCommunityTokens*(self: Controller): seq[CommunityTokenDto] =
+  self.communityTokensService.getAllCommunityTokens()
 
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -257,8 +257,5 @@ method onCommunityMemberRevealedAccountsLoaded*(self: AccessInterface, community
     revealedAccounts: seq[RevealedAccount]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onAllCommunityTokensLoaded*(self: AccessInterface, communityTokens: seq[CommunityTokenDto]) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method removeCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -95,6 +95,7 @@ type
 method setCommunityTags*(self: Module, communityTags: string)
 method setAllCommunities*(self: Module, communities: seq[CommunityDto])
 method setCuratedCommunities*(self: Module, curatedCommunities: seq[CommunityDto])
+proc buildTokensAndCollectiblesFromCommunities(self: Module)
 
 proc newModule*(
     delegate: delegate_interface.AccessInterface,
@@ -158,8 +159,7 @@ method viewDidLoad*(self: Module) =
 method communityDataLoaded*(self: Module) =
   self.setCommunityTags(self.controller.getCommunityTags())
   self.setAllCommunities(self.controller.getAllCommunities())
-  # Get all community tokens to construct the original list of collectibles and assets from communities
-  self.controller.getAllCommunityTokensAsync()
+  self.buildTokensAndCollectiblesFromCommunities()
 
 method onActivated*(self: Module) =
   self.controller.asyncLoadCuratedCommunities()
@@ -555,10 +555,11 @@ proc createCommunityTokenItem(self: Module, token: CommunityTokensMetadataDto, c
     infiniteSupply,
   )
 
-proc buildTokensAndCollectiblesFromCommunities(self: Module, communityTokens: seq[CommunityTokenDto]) =
+proc buildTokensAndCollectiblesFromCommunities(self: Module) =
   var tokenListItems: seq[TokenListItem]
   var collectiblesListItems: seq[TokenListItem]
 
+  let communityTokens = self.controller.getAllCommunityTokens()
   let communities = self.controller.getAllCommunities()
   for community in communities:
     if not community.isOwner and not community.isTokenMaster:
@@ -613,9 +614,6 @@ proc buildTokensAndCollectiblesFromWallet(self: Module) =
 
 method onWalletAccountTokensRebuilt*(self: Module) =
   self.buildTokensAndCollectiblesFromWallet()
-
-method onAllCommunityTokensLoaded*(self: Module, communityTokens: seq[CommunityTokenDto]) =
-  self.buildTokensAndCollectiblesFromCommunities(communityTokens)
 
 method onCommunityTokenMetadataAdded*(self: Module, communityId: string, tokenMetadata: CommunityTokensMetadataDto) =
   let communityTokens = self.controller.getCommunityTokens(communityId)

--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -101,6 +101,8 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_OWNER_TOKEN_SENT) do(e: Args):
     let args = OwnerTokenSentArgs(e)
     self.communityTokensModule.onSendOwnerTokenStateChanged(args.chainId, args.txHash, args.tokenName, args.status)
+  self.events.on(SIGNAL_COMMUNITY_TOKENS_CHANGED) do(e:Args):
+    self.communityTokensService.getAllCommunityTokensAsync()
 
 proc deployContract*(self: Controller, communityId: string, addressFrom: string, password: string, deploymentParams: DeploymentParameters, tokenMetadata: CommunityTokensMetadataDto, tokenImageCropInfoJson: string, chainId: int) =
   self.communityTokensService.deployContract(communityId, addressFrom, password, deploymentParams, tokenMetadata, tokenImageCropInfoJson, chainId)


### PR DESCRIPTION
Fix #12547

Keep community tokens in cache.
Community tokens are loaded from database only once at the beginning.
The cache should be updated anytime we update database:

- deploy new contracts,
- remove contracts from database,
- update supply (burn),
- update deploy state,
- update owner and master contracts addresses (deployment)