### PR TITLE
chore: receive all non-approved requests to join through the API allNonApprovedCommunitiesRequestsToJoin

### DIFF
--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -10,11 +10,13 @@ const asyncLoadCommunitiesDataTask: Task = proc(argEncoded: string) {.gcsafe, ni
     let responseTags = status_go.getCommunityTags()
     let responseCommunities = status_go.getAllCommunities()
     let responseSettings = status_go.getCommunitiesSettings()
+    let responseNonApprovedRequestsToJoin = status_go.allNonApprovedCommunitiesRequestsToJoin()
 
     arg.finish(%* {
       "tags": responseTags,
       "communities": responseCommunities,
       "settings": responseSettings,
+      "nonAprrovedRequestsToJoin": responseNonApprovedRequestsToJoin,
       "error": "",
     })
   except Exception as e:

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -467,22 +467,6 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
 
   result.shard = jsonObj.getShard()
 
-  var requestsToJoinCommunityObj: JsonNode
-  if(jsonObj.getProp("requestsToJoinCommunity", requestsToJoinCommunityObj) and requestsToJoinCommunityObj.kind == JArray):
-    for requestObj in requestsToJoinCommunityObj:
-      let request = requestObj.toCommunityMembershipRequestDto()
-      case RequestToJoinType(request.state):
-        of RequestToJoinType.Pending, RequestToJoinType.AcceptedPending, RequestToJoinType.DeclinedPending:
-          result.pendingRequestsToJoin.add(request)
-        of RequestToJoinType.Declined:
-          result.declinedRequestsToJoin.add(request)
-        of RequestToJoinType.Canceled:
-          result.canceledRequestsToJoin.add(request)
-        of RequestToJoinType.AwaitingAddress:
-          result.waitingForSharedAddressesRequestsToJoin.add(request)
-        of RequestToJoinType.Accepted:
-          continue
-
 proc toMembershipRequestState*(state: CommunityMemberPendingBanOrKick): MembershipRequestState =
   case state:
     of CommunityMemberPendingBanOrKick.Banned:

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -118,6 +118,9 @@ proc checkAllCommunityChannelsPermissions*(communityId: string, addresses: seq[s
     "addresses": addresses,
   }])
 
+proc allNonApprovedCommunitiesRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("allNonApprovedCommunitiesRequestsToJoin".prefix)
+
 proc cancelRequestToJoinCommunity*(requestId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("cancelRequestToJoinCommunity".prefix, %*[{
     "id": requestId


### PR DESCRIPTION
### What does the PR do

Receive all non-approved requests to join through the API `allNonApprovedCommunitiesRequestsToJoin`

Closes: https://github.com/status-im/status-go/issues/4419

Status-go PR: https://github.com/status-im/status-go/pull/4422
### Affected areas

Requests to join

