### PR TITLE
fix(StatusChatInput): Request link previews only when the StatusChatInput text string changes

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -292,7 +292,7 @@ Item {
                     chatType: root.activeChatType
 
                     textInput.onTextChanged: {
-                        if (!!d.activeChatContentModule) {
+                        if (!!d.activeChatContentModule && textInput.text !== d.activeChatContentModule.inputAreaModule.preservedProperties.text) {
                             d.activeChatContentModule.inputAreaModule.preservedProperties.text = textInput.text
                             d.updateLinkPreviews()
                         }


### PR DESCRIPTION
### What does the PR do

Closing #12779 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

The `onTextChanged` event is triggered by the StatusSynthaxHighlighter whenever the text style changes even if the text string doesn't. This event needs to be filtered before notifying the backend about the text change.

### Affected areas

ChatColumnView
<!-- List the affected areas (e.g wallet, browser, etc..) -->

