### PR TITLE
fix: Show wrong password error on V4 migration as well

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -138,7 +138,7 @@ Item {
             if (error) {
                 if (!root.startupStore.selectedLoginAccount.keycardCreatedAccount) {
                     // SQLITE_NOTADB: "file is not a database"
-                    if (error === "file is not a database" || error.startsWith("failed to set ")) {
+                    if (error.includes("file is not a database")) {
                         txtPassword.validationError = qsTr("Password incorrect")
                     } else {
                         txtPassword.validationError = qsTr("Login failed: %1").arg(error.toUpperCase())


### PR DESCRIPTION
### What does the PR do

Closing #11274 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

The wrong password error message coming from status-go can be different depending on the app flow. The only constant is the sqlite error message used for wrong key: `SQLITE_NOTADB: "file is not a database"`.

The LoginView now checks if the sqlite `file is not a database` error is included in the message.

### Affected areas

LoginView
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/fc5c6003-d5fe-4253-8b79-70b3f1337a98


