### PR TITLE
fix(ActivityCenter): Notification title is cut when long

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -38,8 +38,11 @@ Item {
     RowLayout {
         id: layout
         spacing: 4
+        width: parent.width
         StatusBaseText {
+
             id: primaryDisplayName
+            Layout.fillWidth: true
             objectName: "StatusMessageHeader_DisplayName"
             verticalAlignment: Text.AlignVCenter
             Layout.bottomMargin: 2 // offset for the underline to stay vertically centered

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationTransferOwnership.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationTransferOwnership.qml
@@ -96,6 +96,7 @@ ActivityNotificationBase {
             Layout.fillWidth: true
 
             StatusMessageHeader {
+                Layout.fillWidth: true
                 displayNameLabel.text: d.title
                 timestamp: root.notification.timestamp
             }


### PR DESCRIPTION
* Added wrapMode in Text

Closes #12870

### What does the PR do

ActivityCenter: fixed title text not cut when long

### Affected areas

ActivityCenter notification view

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/31625338/a8086a7b-6fd4-42bf-87f5-5e93a8f07b69

