### PR TITLE
fix(Wallet/AddAccountPopup): Removed emoji random selection

### DIFF
--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -35,12 +35,18 @@ Item {
         }
 
         accountName.text = root.store.addAccountModule.accountName
+        if (d.isEdit) {
+            accountName.input.asset.emoji = root.store.addAccountModule.selectedEmoji;
+        } else {
+            accountName.input.asset.isLetterIdenticon = true;
+        }
         accountName.input.edit.forceActiveFocus()
         accountName.validate(true)
     }
 
     QtObject {
         id: d
+        readonly property bool isEdit: root.store.editMode
 
         function evaluateColorIndex(color) {
             for (let i = 0; i < Theme.palette.customisationColorsArray.length; i++) {
@@ -72,6 +78,8 @@ Item {
         function onEmojiSelected (emojiText, atCursor) {
             let emoji = StatusQUtils.Emoji.deparse(emojiText)
             root.store.addAccountModule.selectedEmoji = emoji
+            accountName.input.asset.isLetterIdenticon = false
+            accountName.input.asset.emoji = emojiText
         }
     }
 
@@ -110,7 +118,6 @@ Item {
                 input.isIconSelectable: true
                 input.leftPadding: Style.current.padding
                 input.asset.color: Utils.getColorForId(root.store.addAccountModule.selectedColorId)
-                input.asset.emoji: root.store.addAccountModule.selectedEmoji
                 onIconClicked: {
                     d.openEmojiPopup(true)
                 }
@@ -139,6 +146,9 @@ Item {
 
                 onTextChanged: {
                     root.store.addAccountModule.accountName = text
+                    if (input.asset.emoji === "") {
+                        input.letterIconName = text;
+                    }
                 }
 
                 onKeyPressed: {


### PR DESCRIPTION
Closes #12907

### What does the PR do
Wallet/AddAccountPopup: Removed emoji random selection

### Affected areas
Wallet/AddAccountPopup

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/31625338/f09e220b-41ab-4fb3-9d85-83d6d718df75


