### PR TITLE
feat(@desktop/tokens): Handle community ID and community token image

### DIFF
--- a/src/app/modules/shared/wallet_utils.nim
+++ b/src/app/modules/shared/wallet_utils.nim
@@ -103,6 +103,10 @@ proc walletTokenToItem*(
     marketValues.change24hour,
     currencyAmountToItem(marketValues.price, currencyFormat),
     t.decimals,
+    t.image,
+    t.communityId,
+    t.communityName,
+    t.communityImage,
     loading = false
     )
 

--- a/src/app/modules/shared_models/token_item.nim
+++ b/src/app/modules/shared_models/token_item.nim
@@ -27,6 +27,10 @@ type
     change24hour: float64
     currencyPrice: CurrencyAmount
     decimals: int
+    image: string
+    communityId: string
+    communityName: string
+    communityImage: string
     loading: bool
 
 proc initItem*(
@@ -49,6 +53,10 @@ proc initItem*(
   change24hour: float64,
   currencyPrice: CurrencyAmount,
   decimals: int,
+  image: string,
+  communityId: string,
+  communityName: string,
+  communityImage: string,
   loading: bool = false
 ): Item =
   result.name = name
@@ -73,6 +81,10 @@ proc initItem*(
   result.change24hour = change24hour
   result.currencyPrice = currencyPrice
   result.decimals = decimals
+  result.image = image
+  result.communityId = communityId
+  result.communityName = communityName
+  result.communityImage = communityImage
   result.loading = loading
 
 proc `$`*(self: Item): string =
@@ -97,6 +109,10 @@ proc `$`*(self: Item): string =
     change24hour: {self.change24hour},
     currencyPrice: {self.currencyPrice},
     decimals: {self.decimals},
+    image: {self.image},
+    communityId: {self.communityId},
+    communityName: {self.communityName},
+    communityImage: {self.communityImage},
     loading: {self.loading},
     ]"""
 
@@ -123,6 +139,10 @@ proc initLoadingItem*(): Item =
     change24hour = 0,
     currencyPrice = newCurrencyAmount(),
     decimals = 0,
+    image = "",
+    communityId = "",
+    communityName = "",
+    communityImage = "",
     loading = true
   )
 
@@ -188,6 +208,18 @@ proc getCurrencyPrice*(self: Item): CurrencyAmount =
 
 proc getDecimals*(self: Item): int =
   return self.decimals
+
+proc getImage*(self: Item): string =
+  return self.image
+
+proc getCommunityId*(self: Item): string =
+  return self.communityId
+
+proc getCommunityName*(self: Item): string =
+  return self.communityName
+
+proc getCommunityImage*(self: Item): string =
+  return self.communityImage
 
 proc getLoading*(self: Item): bool =
   return self.loading

--- a/src/app/modules/shared_models/token_model.nim
+++ b/src/app/modules/shared_models/token_model.nim
@@ -26,6 +26,10 @@ type
     Change24hour
     CurrencyPrice
     Decimals
+    CommunityId
+    CommunityName
+    CommunityImage
+    ImageUrl
     Loading
 
 QtObject:
@@ -83,6 +87,10 @@ QtObject:
       ModelRole.Change24hour.int:"change24hour",
       ModelRole.CurrencyPrice.int:"currencyPrice",
       ModelRole.Decimals.int:"decimals",
+      ModelRole.CommunityId.int:"communityId",
+      ModelRole.CommunityName.int:"communityName",
+      ModelRole.CommunityImage.int:"communityImage",
+      ModelRole.ImageUrl.int:"imageUrl",
       ModelRole.Loading.int:"loading",
     }.toTable
 
@@ -139,6 +147,14 @@ QtObject:
       result = newQVariant(item.getCurrencyPrice())
     of ModelRole.Decimals:
       result = newQVariant(item.getDecimals())
+    of ModelRole.CommunityId:
+      result = newQVariant(item.getCommunityId())
+    of ModelRole.CommunityName:
+      result = newQVariant(item.getCommunityName())
+    of ModelRole.CommunityImage:
+      result = newQVariant(item.getCommunityImage())
+    of ModelRole.ImageUrl:
+      result = newQVariant(item.getImage())
     of ModelRole.Loading:
       result = newQVariant(item.getLoading())
 
@@ -167,6 +183,10 @@ QtObject:
       of "change24hour": result = $item.getChange24hour()
       of "currencyPrice": result = $item.getCurrencyPrice()
       of "decimals": result = $item.getDecimals()
+      of "communityId": result = $item.getCommunityId()
+      of "communityName": result = $item.getCommunityName()
+      of "communityImage": result = $item.getCommunityImage()
+      of "ImageUrl": result = $item.getImage()
       of "loading": result = $item.getLoading()
 
   proc setItems*(self: Model, items: seq[Item]) =

--- a/src/app_service/service/token/dto.nim
+++ b/src/app_service/service/token/dto.nim
@@ -21,6 +21,7 @@ type
     decimals* {.serializedFieldName("decimals").}: int
     chainID* {.serializedFieldName("chainId").}: int
     communityID* {.serializedFieldName("communityId").}: string
+    image* {.serializedFieldName("image").}: string
 
 proc `$`*(self: TokenDto): string =
   result = fmt"""TokenDto[
@@ -29,7 +30,8 @@ proc `$`*(self: TokenDto): string =
     symbol: {self.symbol},
     decimals: {self.decimals},
     chainID: {self.chainID},
-    communityID: {self.communityID}
+    communityID: {self.communityID},
+    image: {self.image}
     ]"""
 
 # TODO: Remove after https://github.com/status-im/status-desktop/issues/12513
@@ -39,7 +41,8 @@ proc newTokenDto*(
   symbol: string,
   decimals: int,
   chainId: int,
-  communityId: string = ""
+  communityId: string = "",
+  image: string = ""
 ): TokenDto =
   return TokenDto(
     address: address,
@@ -47,7 +50,8 @@ proc newTokenDto*(
     symbol: symbol,
     decimals: decimals,
     chainId: chainId,
-    communityId: communityId
+    communityId: communityId,
+    image: image
   )
 
 type TokenSourceDto* = ref object of RootObj

--- a/src/backend/helpers/token.nim
+++ b/src/backend/helpers/token.nim
@@ -27,6 +27,10 @@ type
     assetWebsiteUrl*: string
     builtOn*: string
     marketValuesPerCurrency*: Table[string, TokenMarketValuesDto]
+    image*: string
+    communityId*: string
+    communityName*: string
+    communityImage*: string
 
 proc newTokenMarketValuesDto*(
   marketCap: float64,
@@ -72,6 +76,13 @@ proc toWalletTokenDto*(jsonObj: JsonNode): WalletTokenDto =
   discard jsonObj.getProp("description", result.description)
   discard jsonObj.getProp("assetWebsiteUrl", result.assetWebsiteUrl)
   discard jsonObj.getProp("builtOn", result.builtOn)
+  discard jsonObj.getProp("image", result.image)
+
+  var communityDataObj: JsonNode
+  if(jsonObj.getProp("community_data", communityDataObj)):
+    discard communityDataObj.getProp("id", result.communityId)
+    discard communityDataObj.getProp("name", result.communityName)
+    discard communityDataObj.getProp("image", result.communityImage)
 
   var marketValuesPerCurrencyObj: JsonNode
   if(jsonObj.getProp("marketValuesPerCurrency", marketValuesPerCurrencyObj)):
@@ -105,6 +116,10 @@ proc `$`*(self: WalletTokenDto): string =
     description: {self.description},
     assetWebsiteUrl: {self.assetWebsiteUrl},
     builtOn: {self.builtOn},
+    image: {self.image},
+    communityId: {self.communityId},
+    communityName: {self.communityName},
+    communityImage: {self.communityImage},
     balancesPerChain:
     """
   for chain, balance in self.balancesPerChain:
@@ -131,6 +146,10 @@ proc copyToken*(self: WalletTokenDto): WalletTokenDto =
   result.description = self.description
   result.assetWebsiteUrl = self.assetWebsiteUrl
   result.builtOn = self.builtOn
+  result.image = self.image
+  result.communityId = self.communityId
+  result.communityName = self.communityName
+  result.communityImage = self.communityImage
 
   result.balancesPerChain = initTable[int, BalanceDto]()
   for chainId, balanceDto in self.balancesPerChain:

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -37,7 +37,15 @@ StatusListItem {
     property string errorTooltipText_2
 
     readonly property bool isCommunityToken: !!modelData && !!modelData.communityId
-    readonly property string symbolUrl: !!modelData && modelData.symbol ? Constants.tokenIcon(modelData.symbol, false) : ""
+    readonly property string symbolUrl: {
+        if (!modelData)
+            return ""
+        if (modelData.imageUrl)
+            return modelData.imageUrl
+        if (modelData.symbol)
+            return Constants.tokenIcon(modelData.symbol, false)
+        return ""
+    }
     readonly property string upDownTriangle: {
         if (!modelData)
             return ""


### PR DESCRIPTION
Task #12945

corresponding status-go change https://github.com/status-im/status-go/pull/4440

### What does the PR do

Pass community ID and image url for community tokens to the UI

### Affected areas

* wallet token view 
* setting manage token

### Screenshot of functionality (including design for comparison)

Community assets: 
![image](https://github.com/status-im/status-desktop/assets/11396062/f830d77e-00c9-48c9-a559-6055a73ea478)

Wallet view:
![image](https://github.com/status-im/status-desktop/assets/11396062/d085b0a8-8eb3-4f5c-9bda-20ea8b3ad758)
