### PR TITLE
fix(CommunitiesView): display proper member count

### DIFF
--- a/storybook/pages/CommunitiesViewPage.qml
+++ b/storybook/pages/CommunitiesViewPage.qml
@@ -155,7 +155,7 @@ SplitView {
             property var communitiesList: ctrlEmptyView.checked ? emptyModel : communitiesModel
         }
         rootStore: QtObject {
-            function isCommunityRequestPending(communityId) {
+            function isMyCommunityRequestPending(communityId) {
                 return communityId === "0x0006"
             }
             function cancelPendingRequest(communityId) {

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -13,6 +13,7 @@ SplitView {
 
     property bool globalUtilsReady: false
     property bool mainModuleReady: false
+    property bool communitiesModuleReady: false
 
     Item {
 
@@ -44,6 +45,9 @@ SplitView {
                                        {colorId: 19, segmentLength: 2}])
             }
 
+            function copyToClipboard(text) {
+            }
+
             Component.onCompleted: {
                 Utils.globalUtilsInst = this
                 globalUtilsReady = true
@@ -70,9 +74,24 @@ SplitView {
             }
         }
 
+        QtObject {
+            function shareCommunityUrlWithData(communityId) {
+                return "status-app:/"+communityId
+            }
+
+            Component.onCompleted: {
+                communitiesModuleReady = true
+                Utils.communitiesModuleInst = this
+            }
+            Component.onDestruction: {
+                communitiesModuleReady = false
+                Utils.communitiesModuleInst = {}
+            }
+        }
+
         Loader {
             id: loader
-            active: globalUtilsReady && mainModuleReady
+            active: globalUtilsReady && mainModuleReady && communitiesModuleReady
             anchors.fill: parent
 
             sourceComponent: InviteFriendsToCommunityPopup {

--- a/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
@@ -54,8 +54,8 @@ StatusStackModal {
 
     stackTitle: qsTr("Invite Contacts to %1").arg(community.name)
     width: 640
+    height: d.popupContentHeight
 
-    padding: 0
     leftPadding: 0
     rightPadding: 0
 
@@ -90,30 +90,17 @@ StatusStackModal {
     }
 
     stackItems: [
-        Item {
-            implicitHeight: d.popupContentHeight
-
-            ProfilePopupInviteFriendsPanel {
-                anchors.fill: parent
-                anchors.topMargin: 16
-                anchors.bottomMargin: 16
-
-                rootStore: root.rootStore
-                contactsStore: root.contactsStore
-                community: root.community
-                onPubKeysChanged: root.pubKeys = pubKeys
-            }
+        ProfilePopupInviteFriendsPanel {
+            rootStore: root.rootStore
+            contactsStore: root.contactsStore
+            community: root.community
+            onPubKeysChanged: root.pubKeys = pubKeys
         },
 
-        Item {
-            ProfilePopupInviteMessagePanel {
-                anchors.fill: parent
-                anchors.topMargin: 16
-
-                contactsStore: root.contactsStore
-                pubKeys: root.pubKeys
-                onInviteMessageChanged: root.inviteMessage = inviteMessage
-            }
+        ProfilePopupInviteMessagePanel {
+            contactsStore: root.contactsStore
+            pubKeys: root.pubKeys
+            onInviteMessageChanged: root.inviteMessage = inviteMessage
         }
     ]
 }

--- a/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
@@ -3,6 +3,8 @@ import utils 1.0
 
 import AppLayouts.Chat.stores 1.0
 
+import SortFilterProxyModel 0.2
+
 QtObject {
     id: root
 
@@ -73,7 +75,13 @@ QtObject {
     property bool walletMenuItemEnabled: profileStore.isWalletEnabled
 
     property var communitiesModuleInst: Global.appIsReady? communitiesModule : null
-    property var communitiesList: !!communitiesModuleInst? communitiesModuleInst.model : null
+    property var communitiesList: SortFilterProxyModel {
+        sourceModel: root.mainModuleInst.sectionsModel
+        filters: ValueFilter {
+            roleName: "sectionType"
+            value: Constants.appSection.community
+        }
+    }
     property var communitiesProfileModule: profileSectionModuleInst.communitiesModule
 
     property ListModel mainMenuItems: ListModel {


### PR DESCRIPTION
turns out the model from the communitiesModule doesn't contain the members; use the sectionModel (as in all other places) instead which already has the correct info

additionally, fix the InviteFriendsToCommunityPopup display, it appeared empty all the time

(plus some relevant storybook fixes)

Fixes #12967

### What does the PR do

Fixes the member count and invite popup in Communities settings

### Affected areas

CommunitiesView, InviteFriendsToCommunityPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Correct member count:
![Snímek obrazovky z 2023-12-11 10-40-55](https://github.com/status-im/status-desktop/assets/5377645/51687936-46cd-431a-96d6-fa7d818b099c)

... in SB too:
![Snímek obrazovky z 2023-12-11 10-42-17](https://github.com/status-im/status-desktop/assets/5377645/623504be-94b9-47e0-b3ec-346e79df06d7)

Invite popup working again:
![Snímek obrazovky z 2023-12-11 10-42-45](https://github.com/status-im/status-desktop/assets/5377645/1192fee4-dfa3-454a-9f00-1d587acac891)

![Snímek obrazovky z 2023-12-11 10-43-04](https://github.com/status-im/status-desktop/assets/5377645/a6db15f7-e64f-41a4-9a20-ca6f8669b2e9)
