### PR TITLE
fix(StatusImage) blurry rendering due to wrong sourceSize

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusImage.qml
@@ -46,5 +46,5 @@ Image {
     readonly property bool isError: status === Image.Error
 
     fillMode: Image.PreserveAspectFit
-    sourceSize: source.toString().endsWith(".svg") ? Qt.size(width, 0) : Qt.size(width * Screen.devicePixelRatio, 0)
+    sourceSize: source.toString().endsWith(".svg") ? Qt.size(width, 0) : Qt.size(width * Screen.devicePixelRatio, height * Screen.devicePixelRatio)
 }


### PR DESCRIPTION
Fixes #12991

### What does the PR do

Fixes blurry rendering for non SVG images

### Affected areas

StatusImage

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-12-12 11-05-19](https://github.com/status-im/status-desktop/assets/5377645/adb4dd96-45bd-425c-ae7d-2636e7756270)


