### PR TITLE
chore: update for StoreNodeRequestManager

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -79,9 +79,6 @@ proc init*(self: Controller) =
     let args = CommunityArgs(e)
     self.delegate.communityInfoRequestFailed(args.communityId, args.error)
 
-  self.events.on(SIGNAL_COMMUNITY_INFO_ALREADY_REQUESTED) do(e: Args):
-    self.delegate.communityInfoAlreadyRequested()
-
   self.events.on(SIGNAL_CURATED_COMMUNITY_FOUND) do(e:Args):
     let args = CommunityArgs(e)
     self.delegate.curatedCommunityAdded(args.community)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -194,9 +194,6 @@ method curatedCommunitiesLoadingFailed*(self: AccessInterface) {.base.} =
 method curatedCommunitiesLoaded*(self: AccessInterface, curatedCommunities: seq[CommunityDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method communityInfoAlreadyRequested*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onCommunityTokenMetadataAdded*(self: AccessInterface, communityId: string, tokenMetadata: CommunityTokensMetadataDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -538,9 +538,6 @@ method requestCancelDiscordCommunityImport*(self: Module, id: string) =
 method requestCancelDiscordChannelImport*(self: Module, discordChannelId: string) =
   self.controller.requestCancelDiscordChannelImport(discordChannelId)
 
-method communityInfoAlreadyRequested*(self: Module) =
-  self.view.communityInfoAlreadyRequested()
-
 proc createCommunityTokenItem(self: Module, token: CommunityTokensMetadataDto, communityId: string, supply: string,
     infiniteSupply: bool): TokenListItem =
   result = initTokenListItem(

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -132,7 +132,6 @@ QtObject:
   proc communityAccessFailed*(self: View, communityId: string, error: string) {.signal.}
   proc communityEditSharedAddressesSucceeded*(self: View, communityId: string) {.signal.}
   proc communityEditSharedAddressesFailed*(self: View, communityId: string, error: string) {.signal.}
-  proc communityInfoAlreadyRequested*(self: View) {.signal.}
 
   proc communityTagsChanged*(self: View) {.signal.}
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -98,8 +98,6 @@ QtObject {
 
     signal communityAdded(string communityId)
 
-    signal communityInfoAlreadyRequested()
-
     signal communityAccessRequested(string communityId)
 
     signal goToMembershipRequestsPage()
@@ -573,10 +571,6 @@ QtObject {
       target: communitiesModuleInst
       function onImportingCommunityStateChanged(communityId, state, errorMsg) {
           root.importingCommunityStateChanged(communityId, state, errorMsg)
-      }
-
-      function onCommunityInfoAlreadyRequested() {
-          root.communityInfoAlreadyRequested()
       }
 
       function onCommunityAccessRequested(communityId) {

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -60,8 +60,6 @@ QtObject {
 
     signal importingCommunityStateChanged(string communityId, int state, string errorMsg)
 
-    signal communityInfoAlreadyRequested()
-
     signal communityInfoRequestCompleted(string communityId, string errorMsg)
 
     function createCommunity(args = {
@@ -249,10 +247,6 @@ QtObject {
         target: communitiesModuleInst
         function onImportingCommunityStateChanged(communityId, state, errorMsg) {
             root.importingCommunityStateChanged(communityId, state, errorMsg)
-        }
-
-        function onCommunityInfoAlreadyRequested() {
-          root.communityInfoAlreadyRequested()
         }
 
         function onCommunityInfoRequestCompleted(communityId, erorrMsg) {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12537
status-go PR: https://github.com/status-im/status-go/pull/4446

This status-go update contains refactoring of fetching communities.
I made quick tests of where we fetch communities in status-desltop:
- Import community (with public key)
- Link previews

Would be nice to test other places if we have any. E.g. community directory, but I couldn't get any curated communities.