### PR TITLE
feat: update chat unseen counters from the Activity Center

### DIFF
--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -6,6 +6,20 @@ import ../../../backend/chat as status_go_chat
 
 import ../../../app/core/custom_urls/urls_manager
 
+import dto/seen_unseen_messages
+
+proc getCountAndCountWithMentionsFromResponse(chatId: string, seenAndUnseenMessagesBatch: JsonNode): (int, int) =
+  var count: int
+  var countWithMentions: int
+
+  if seenAndUnseenMessagesBatch.len > 0:
+    for seenAndUnseenMessagesRaw in seenAndUnseenMessagesBatch:
+      let seenAndUnseenMessages = seenAndUnseenMessagesRaw.toSeenUnseenMessagesDto()
+      if seenAndUnseenMessages.chatId == chatId:
+        count = seenAndUnseenMessages.count
+        countWithMentions = seenAndUnseenMessages.countWithMentions
+        break
+  return (count, countWithMentions)
 
 #################################################
 # Async load messages
@@ -149,11 +163,9 @@ const asyncMarkCertainMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe
 
   let response = status_go.markCertainMessagesFromChatWithIdAsRead(arg.chatId, arg.messagesIds)
 
-  var count: int
-  discard response.result.getProp("count", count)
-
-  var countWithMentions: int
-  discard response.result.getProp("countWithMentions", countWithMentions)
+  var seenAndUnseenMessagesBatch: JsonNode = newJObject()
+  discard response.result.getProp("seenAndUnseenMessages", seenAndUnseenMessagesBatch)
+  let (count, countWithMentions) = getCountAndCountWithMentionsFromResponse(arg.chatId, seenAndUnseenMessagesBatch)
 
   var activityCenterNotifications: JsonNode = newJObject()
   discard response.result.getProp("activityCenterNotifications", activityCenterNotifications)
@@ -319,10 +331,13 @@ const asyncMarkMessageAsUnreadTask: Task = proc(argEncoded: string) {.gcsafe, ni
 
     var activityCenterNotifications: JsonNode = newJObject()
     discard response.result.getProp("activityCenterNotifications", activityCenterNotifications)
-
-    responseJson["messagesCount"] = %response.result["count"]
     responseJson["activityCenterNotifications"] = activityCenterNotifications
-    responseJson["messagesWithMentionsCount"] = %response.result["countWithMentions"]
+
+    var seenAndUnseenMessagesBatch: JsonNode = newJObject()
+    discard response.result.getProp("seenAndUnseenMessages", seenAndUnseenMessagesBatch)
+    let (count, countWithMentions) = getCountAndCountWithMentionsFromResponse(arg.chatId, seenAndUnseenMessagesBatch)
+    responseJson["messagesCount"] = %count
+    responseJson["messagesWithMentionsCount"] = %countWithMentions
 
     if response.error != nil:
       responseJson["error"] = %response.error

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -9,17 +9,12 @@ import ../../../app/core/custom_urls/urls_manager
 import dto/seen_unseen_messages
 
 proc getCountAndCountWithMentionsFromResponse(chatId: string, seenAndUnseenMessagesBatch: JsonNode): (int, int) =
-  var count: int
-  var countWithMentions: int
-
   if seenAndUnseenMessagesBatch.len > 0:
     for seenAndUnseenMessagesRaw in seenAndUnseenMessagesBatch:
       let seenAndUnseenMessages = seenAndUnseenMessagesRaw.toSeenUnseenMessagesDto()
       if seenAndUnseenMessages.chatId == chatId:
-        count = seenAndUnseenMessages.count
-        countWithMentions = seenAndUnseenMessages.countWithMentions
-        break
-  return (count, countWithMentions)
+        return (seenAndUnseenMessages.count, seenAndUnseenMessages.countWithMentions)
+  return (0, 0)
 
 #################################################
 # Async load messages

--- a/src/app_service/service/message/dto/seen_unseen_messages.nim
+++ b/src/app_service/service/message/dto/seen_unseen_messages.nim
@@ -1,0 +1,16 @@
+import json
+
+include ../../../common/json_utils
+
+type SeenUnseenMessagesDto* = object
+  chatId*: string
+  count*: int
+  countWithMentions*: int
+  seen*: bool
+
+proc toSeenUnseenMessagesDto*(jsonObj: JsonNode): SeenUnseenMessagesDto =
+  result = SeenUnseenMessagesDto()
+  discard jsonObj.getProp("chatId", result.chatId)
+  discard jsonObj.getProp("count", result.count)
+  discard jsonObj.getProp("countWithMentions", result.countWithMentions)
+  discard jsonObj.getProp("seen", result.seen)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -828,7 +828,7 @@ QtObject:
     discard responseObj.getProp("countWithMentions", countWithMentions)
 
     let data = MessagesMarkedAsReadArgs(
-      chatId: chatId, 
+      chatId: chatId,
       allMessagesMarked: false,
       messagesIds: messagesIds,
       messagesCount: count,

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -61,7 +61,7 @@ proc markAllMessagesFromChatWithIdAsRead*(chatId: string): RpcResponse[JsonNode]
 proc markCertainMessagesFromChatWithIdAsRead*(chatId: string, messageIds: seq[string]):
   RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chatId, messageIds]
-  result = callPrivateRPC("markMessagesSeen".prefix, payload)
+  result = callPrivateRPC("markMessagesRead".prefix, payload)
 
 proc deleteMessageAndSend*(messageID: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("deleteMessageAndSend".prefix, %* [messageID])


### PR DESCRIPTION
Close #12857
Waits https://github.com/status-im/status-go/pull/4461

### What does the PR do

When a user marks an activation center notification as read, the corresponding message in the chat is considered read and the chat and community counters are updated.

### Affected areas

Chat, Communities, Activity Center

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/2522130/9e158e8d-646c-439f-8114-228a11372d81

