### PR TITLE
feat(StatusQ): Ability to change sources in `LeftJoinModel`

### DIFF
--- a/ui/StatusQ/include/StatusQ/leftjoinmodel.h
+++ b/ui/StatusQ/include/StatusQ/leftjoinmodel.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <QIdentityProxyModel>
+#include <QAbstractListModel>
+#include <QPointer>
 
-class LeftJoinModel : public QIdentityProxyModel
+class LeftJoinModel : public QAbstractListModel
 {
     Q_OBJECT
 
@@ -27,9 +28,9 @@ public:
     void setJoinRole(const QString& joinRole);
     const QString& joinRole() const;
 
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
-    void setSourceModel(QAbstractItemModel* newSourceModel) override;
 
 signals:
     void leftModelChanged();
@@ -37,10 +38,15 @@ signals:
     void joinRoleChanged();
 
 private:
-    void initializeIfReady();
-    void initialize();
+    void initializeIfReady(bool reset);
+    void initialize(bool reset);
+
+    void connectLeftModelSignals();
+    void connectRightModelSignals();
 
     int m_rightModelRolesOffset = 0;
+    QHash<int, QByteArray> m_leftRoleNames;
+    QHash<int, QByteArray> m_rightRoleNames;
     QHash<int, QByteArray> m_roleNames;
     QVector<int> m_joinedRoles;
 
@@ -48,11 +54,10 @@ private:
     int m_leftModelJoinRole = 0;
     int m_rightModelJoinRole = 0;
 
-    QAbstractItemModel* m_leftModel = nullptr;
-    QAbstractItemModel* m_rightModel = nullptr;
+    QPointer<QAbstractItemModel> m_leftModel;
+    QPointer<QAbstractItemModel> m_rightModel;
 
-    bool m_leftModelDestroyed = false;
-    bool m_rightModelDestroyed = false;
+    bool m_initialized = false;
 
     mutable QPersistentModelIndex m_lastUsedRightModelIndex;
 };

--- a/ui/StatusQ/tests/tst_ConcatModel.cpp
+++ b/ui/StatusQ/tests/tst_ConcatModel.cpp
@@ -17,8 +17,9 @@
 #include <StatusQ/concatmodel.h>
 
 namespace {
-
-// Workaround for a bug in QIdentityProxyModel (returning roleNames improperly)
+// Workaround for https://bugreports.qt.io/browse/QTBUG-57971 (ListModel doesn't
+// emit modelReset when role names are initially set, therefore QIdentityProxyModel
+// doesn't update role names appropriately)
 class IdentityModel : public QIdentityProxyModel {
 public:
     QHash<int,QByteArray>  roleNames() const override {


### PR DESCRIPTION
### What does the PR do

- ability to change left/right models
- improved handling of model deletion
- base class changed to QAbstractListModel, dataChanged signal emision improved

Closes: #12912

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusQ`, `Qt Proxy Models Lib`

<!-- optional but cool ->
