### PR TITLE
Fix recent stickers displayed after sticker packs are deleted

### DIFF
--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -56,6 +56,7 @@ proc delete*(self: Controller) =
 proc init*(self: Controller) =
 
   self.events.on(SIGNAL_LOAD_RECENT_STICKERS_DONE) do(e: Args):
+    self.delegate.clearStickers()
     let args = StickersArgs(e)
     for sticker in args.stickers:
       self.delegate.addRecentStickerToList(sticker)

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -42,6 +42,9 @@ method obtainMarketStickerPacks*(self: AccessInterface) {.base.} =
 method addRecentStickerToList*(self: AccessInterface, sticker: StickerDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method clearStickers*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method clearStickerPacks*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/stickers/models/sticker_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_list.nim
@@ -45,6 +45,11 @@ QtObject:
       StickerRoles.PackId.int:"packId"
     }.toTable
 
+  proc clear*(self: StickerList) =
+    self.beginResetModel()
+    self.stickers = @[]
+    self.endResetModel()
+
   proc addStickerToList*(self: StickerList, sticker: Item) =
     if(self.stickers.any(proc(existingSticker: Item): bool = return existingSticker.getHash == sticker.getHash)):
       return

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -232,6 +232,9 @@ method getInstalledStickerPacks*(self: Module) =
 method clearStickerPacks*(self: Module) =
   self.view.clearStickerPacks()
 
+method clearStickers*(self: Module) =
+  self.view.clearStickers()
+
 method allPacksLoaded*(self: Module) =
   self.view.allPacksLoaded()
 

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -74,6 +74,9 @@ QtObject:
 
   proc installedStickerPacksUpdated*(self: View) {.signal.}
 
+  proc clearStickers*(self: View) =
+    self.recentStickers.clear()
+
   proc clearStickerPacks*(self: View) =
     self.stickerPacks.clear()
 


### PR DESCRIPTION
### What does the PR do

linked to https://github.com/status-im/status-go/pull/4474

Fix recent stickers displayed after sticker packs are deleted

### Affected areas

- Sticker functionality

### Screenshot of functionality (including design for comparison)

[Screencast from 2023-12-20 06:03:27 PM.webm](https://github.com/status-im/status-desktop/assets/2589171/fadda375-b400-426d-ab11-0e2d0c2f0bd6)
