### PR TITLE
fix(ConcatModel): Changed behavior on submodel destruction to not emit signals

### DIFF
--- a/ui/StatusQ/include/StatusQ/concatmodel.h
+++ b/ui/StatusQ/include/StatusQ/concatmodel.h
@@ -3,6 +3,7 @@
 #include <QAbstractListModel>
 #include <QQmlListProperty>
 #include <QQmlParserStatus>
+#include <QPointer>
 
 #include <unordered_map>
 
@@ -27,13 +28,11 @@ public:
 
 signals:
     void modelAboutToBeChanged();
-    void modelChanged(bool deleted);
+    void modelChanged();
     void markerRoleValueChanged();
 
 private:
-    void onModelDestroyed();
-
-    QAbstractItemModel* m_model = nullptr;
+    QPointer<QAbstractItemModel> m_model;
     QString m_markerRoleValue;
 };
 

--- a/ui/StatusQ/src/concatmodel.cpp
+++ b/ui/StatusQ/src/concatmodel.cpp
@@ -90,17 +90,10 @@ void SourceModel::setModel(QAbstractItemModel* model)
     if (m_model == model)
         return;
 
-    if (model)
-        connect(model, &QObject::destroyed, this, &SourceModel::onModelDestroyed);
-
-    if (m_model)
-        disconnect(m_model, &QObject::destroyed, this, &SourceModel::onModelDestroyed);
-
     emit modelAboutToBeChanged();
     m_model = model;
-    emit modelChanged(false);
+    emit modelChanged();
 }
-
 
 /*!
     \qmlproperty any StatusQ::SourceModel::model
@@ -131,12 +124,6 @@ void SourceModel::setMarkerRoleValue(const QString& markerRoleValue)
 const QString& SourceModel::markerRoleValue() const
 {
     return m_markerRoleValue;
-}
-
-void SourceModel::onModelDestroyed()
-{
-    m_model = nullptr;
-    emit modelChanged(true);
 }
 
 
@@ -350,14 +337,9 @@ void ConcatModel::componentComplete()
         });
 
         connect(source, &SourceModel::modelChanged, this,
-                [this, source, i](bool deleted)
+                [this, source, i]()
         {
             auto previousRowCount = m_rowCounts[i];
-
-            if (deleted) {
-                auto prefix = countPrefix(i);
-                beginRemoveRows({}, prefix, prefix + previousRowCount - 1);
-            }
 
             if (previousRowCount) {
                 m_rowCounts[i] = 0;

--- a/ui/StatusQ/tests/tst_ConcatModel.cpp
+++ b/ui/StatusQ/tests/tst_ConcatModel.cpp
@@ -1379,43 +1379,26 @@ private slots:
         QSignalSpy rowsAboutToBeRemovedSpy(&model, &ConcatModel::rowsAboutToBeRemoved);
         QSignalSpy rowsRemovedSpy(&model, &ConcatModel::rowsRemoved);
 
-        // checking validity inside rowsAboutToBeRemoved signal
-        {
-            QObject context;
-            connect(&model, &ConcatModel::rowsAboutToBeRemoved, &context,
-                    [this, &model, &roles] {
-                QCOMPARE(model.rowCount(), 6);
+        sourceModel2.reset();
 
-                QCOMPARE(model.data(model.index(0, 0), roleForName(roles, "key")), 1);
-                QCOMPARE(model.data(model.index(1, 0), roleForName(roles, "key")), 2);
-                QCOMPARE(model.data(model.index(2, 0), roleForName(roles, "key")), {});
-                QCOMPARE(model.data(model.index(3, 0), roleForName(roles, "key")), {});
-                QCOMPARE(model.data(model.index(4, 0), roleForName(roles, "key")), 5);
-                QCOMPARE(model.data(model.index(5, 0), roleForName(roles, "key")), 6);
+        QCOMPARE(model.rowCount(), 6);
 
-                QCOMPARE(model.data(model.index(0, 0), roleForName(roles, "whichModel")), "");
-                QCOMPARE(model.data(model.index(1, 0), roleForName(roles, "whichModel")), "");
-                QCOMPARE(model.data(model.index(2, 0), roleForName(roles, "whichModel")), "");
-                QCOMPARE(model.data(model.index(3, 0), roleForName(roles, "whichModel")), "");
-                QCOMPARE(model.data(model.index(4, 0), roleForName(roles, "whichModel")), "");
-                QCOMPARE(model.data(model.index(5, 0), roleForName(roles, "whichModel")), "");
-            });
+        QCOMPARE(rowsAboutToBeRemovedSpy.count(), 0);
+        QCOMPARE(rowsRemovedSpy.count(), 0);
 
-            sourceModel2.reset();
-        }
+        QCOMPARE(model.data(model.index(0, 0), roleForName(roles, "key")), 1);
+        QCOMPARE(model.data(model.index(1, 0), roleForName(roles, "key")), 2);
+        QCOMPARE(model.data(model.index(2, 0), roleForName(roles, "key")), {});
+        QCOMPARE(model.data(model.index(3, 0), roleForName(roles, "key")), {});
+        QCOMPARE(model.data(model.index(4, 0), roleForName(roles, "key")), 5);
+        QCOMPARE(model.data(model.index(5, 0), roleForName(roles, "key")), 6);
 
-        QCOMPARE(model.rowCount(), 4);
-
-        QCOMPARE(rowsAboutToBeRemovedSpy.count(), 1);
-        QCOMPARE(rowsRemovedSpy.count(), 1);
-
-        QCOMPARE(rowsAboutToBeRemovedSpy.at(0).at(0), QModelIndex{});
-        QCOMPARE(rowsAboutToBeRemovedSpy.at(0).at(1), 2);
-        QCOMPARE(rowsAboutToBeRemovedSpy.at(0).at(2), 3);
-
-        QCOMPARE(rowsRemovedSpy.at(0).at(0), QModelIndex{});
-        QCOMPARE(rowsRemovedSpy.at(0).at(1), 2);
-        QCOMPARE(rowsRemovedSpy.at(0).at(2), 3);
+        QCOMPARE(model.data(model.index(0, 0), roleForName(roles, "whichModel")), "");
+        QCOMPARE(model.data(model.index(1, 0), roleForName(roles, "whichModel")), "");
+        QCOMPARE(model.data(model.index(2, 0), roleForName(roles, "whichModel")), "");
+        QCOMPARE(model.data(model.index(3, 0), roleForName(roles, "whichModel")), "");
+        QCOMPARE(model.data(model.index(4, 0), roleForName(roles, "whichModel")), "");
+        QCOMPARE(model.data(model.index(5, 0), roleForName(roles, "whichModel")), "");
     }
 
     void removalTest()


### PR DESCRIPTION
### What does the PR do

The general rule should be to avoid any actions on destruction different than setting relevant pointers to null. Other actions like emiting signals are potentially dangerous when the whole objects hierarchy is under destruction.

Closes: #13065

### Affected areas
`StatusQ`/`ConcatModel`