### PR TITLE
fix(images-formats): Remove .heif and .tif(f) from supported formats

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
@@ -55,7 +55,7 @@ Control {
        \qmlproperty var StatusImageSelector::acceptedImageExtensions.
        This property holds the list of possible image file extensions.
     */
-    property var acceptedImageExtensions: [".png", ".jpg", ".jpeg", ".heif", ".tif", ".tiff"]
+    property var acceptedImageExtensions: [".png", ".jpg", ".jpeg"]
 
     /*!
        \qmlproperty bool StatusImageSelector::preview.

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -39,7 +39,7 @@ Item {
 
         title: root.imageFileDialogTitle
         folder: root.userSelectedImage ? imageCropper.source.substr(0, imageCropper.source.lastIndexOf("/")) : shortcuts.pictures
-        nameFilters: [qsTr("Supported image formats (%1)").arg("*.jpg *.jpeg *.jfif *.webp *.png *.heif")]
+        nameFilters: [qsTr("Supported image formats (%1)").arg(Constants.acceptedDragNDropImageExtensions.map(img => "*" + img).join(" "))]
         onAccepted: {
             if (fileDialog.fileUrls.length > 0) {
                 cropImage(fileDialog.fileUrls[0])

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -961,7 +961,7 @@ QtObject {
     readonly property int maxNumberOfPins: 3
 
     readonly property string dataImagePrefix: "data:image"
-    readonly property var acceptedDragNDropImageExtensions: [".png", ".jpg", ".jpeg", ".heif", ".tif", ".tiff"]
+    readonly property var acceptedDragNDropImageExtensions: [".png", ".jpg", ".jpeg"]
 
     readonly property string mentionSpanTag: `<span style="background-color: ${Style.current.mentionBgColor};"><a style="color:${Style.current.mentionColor};text-decoration:none" href='http://'>`
 


### PR DESCRIPTION
Fixes: #13077

### What does the PR do

Removes `.heif, .tif(f)` supporting from file dialogs

### Affected areas

Edit profile

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

