### PR TITLE
chore(StatusQ): Models-related testing utilities moved to a testing lib

### DIFF
--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(Qt5 COMPONENTS QuickTest Qml Quick WebEngine REQUIRED)
 add_library(StatusQTestLib
     src/TestHelpers/MonitorQtOutput.cpp
     src/TestHelpers/MonitorQtOutput.h
+    src/TestHelpers/listmodelwrapper.cpp
+    src/TestHelpers/listmodelwrapper.h
     src/TestHelpers/modelaccessobserverproxy.cpp
     src/TestHelpers/modelaccessobserverproxy.h
 )
@@ -55,7 +57,7 @@ target_link_libraries(LeftJoinModelTest PRIVATE Qt5::Test StatusQ)
 add_test(NAME LeftJoinModelTest COMMAND LeftJoinModelTest)
 
 add_executable(SubmodelProxyModelTest tst_SubmodelProxyModel.cpp)
-target_link_libraries(SubmodelProxyModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
+target_link_libraries(SubmodelProxyModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME SubmodelProxyModelTest COMMAND SubmodelProxyModelTest)
 
 add_executable(AggregatorTest tst_Aggregator.cpp)
@@ -71,5 +73,5 @@ target_link_libraries(SumAggregatorTest PRIVATE Qt5::Test StatusQ)
 add_test(NAME SumAggregatorTest COMMAND SumAggregatorTest)
 
 add_executable(ConcatModelTest tst_ConcatModel.cpp)
-target_link_libraries(ConcatModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
+target_link_libraries(ConcatModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME ConcatModelTest COMMAND ConcatModelTest)

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(StatusQTestLib
     src/TestHelpers/listmodelwrapper.h
     src/TestHelpers/modelaccessobserverproxy.cpp
     src/TestHelpers/modelaccessobserverproxy.h
+    src/TestHelpers/testmodel.cpp
+    src/TestHelpers/testmodel.h
 )
 
 target_link_libraries(StatusQTestLib PUBLIC Qt5::Core Qt5::Quick)
@@ -49,29 +51,29 @@ add_test(NAME QmlTests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 ###########
 
 add_executable(RolesRenamingModelTest tst_RolesRenamingModel.cpp)
-target_link_libraries(RolesRenamingModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ)
+target_link_libraries(RolesRenamingModelTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME RolesRenamingModelTest COMMAND RolesRenamingModelTest)
 
 add_executable(LeftJoinModelTest tst_LeftJoinModel.cpp)
-target_link_libraries(LeftJoinModelTest PRIVATE Qt5::Test StatusQ)
+target_link_libraries(LeftJoinModelTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME LeftJoinModelTest COMMAND LeftJoinModelTest)
 
 add_executable(SubmodelProxyModelTest tst_SubmodelProxyModel.cpp)
-target_link_libraries(SubmodelProxyModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ StatusQTestLib)
+target_link_libraries(SubmodelProxyModelTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME SubmodelProxyModelTest COMMAND SubmodelProxyModelTest)
 
 add_executable(AggregatorTest tst_Aggregator.cpp)
-target_link_libraries(AggregatorTest PRIVATE Qt5::Test StatusQ)
+target_link_libraries(AggregatorTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME AggregatorTest COMMAND AggregatorTest)
 
 add_executable(SingleRoleAggregatorTest tst_SingleRoleAggregator.cpp)
-target_link_libraries(SingleRoleAggregatorTest PRIVATE Qt5::Test StatusQ)
+target_link_libraries(SingleRoleAggregatorTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME SingleRoleAggregatorTest COMMAND SingleRoleAggregatorTest)
 
 add_executable(SumAggregatorTest tst_SumAggregator.cpp)
-target_link_libraries(SumAggregatorTest PRIVATE Qt5::Test StatusQ)
+target_link_libraries(SumAggregatorTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME SumAggregatorTest COMMAND SumAggregatorTest)
 
 add_executable(ConcatModelTest tst_ConcatModel.cpp)
-target_link_libraries(ConcatModelTest PRIVATE Qt5::Qml Qt5::Test StatusQ StatusQTestLib)
+target_link_libraries(ConcatModelTest PRIVATE Qt5::Test StatusQ StatusQTestLib)
 add_test(NAME ConcatModelTest COMMAND ConcatModelTest)

--- a/ui/StatusQ/tests/main.cpp
+++ b/ui/StatusQ/tests/main.cpp
@@ -3,8 +3,8 @@
 
 #include <QtWebEngine>
 
-#include "TestHelpers/MonitorQtOutput.h"
-#include "TestHelpers/modelaccessobserverproxy.h"
+#include <TestHelpers/MonitorQtOutput.h>
+#include <TestHelpers/modelaccessobserverproxy.h>
 
 class RunBeforeQApplicationIsInitialized {
 public:

--- a/ui/StatusQ/tests/src/TestHelpers/listmodelwrapper.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/listmodelwrapper.cpp
@@ -1,0 +1,118 @@
+#include "listmodelwrapper.h"
+
+#include <QAbstractItemModel>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQmlExpression>
+
+ListModelWrapper::ListModelWrapper(QQmlEngine& engine, const QString& content)
+{
+    QQmlComponent component(&engine);
+    auto componentBody = QStringLiteral(R"(
+        import QtQml 2.15
+        import QtQml.Models 2.15
+
+        ListModel {
+            Component.onCompleted: {
+                const content = %1
+
+                if (content.length)
+                    append(content)
+            }
+        }
+    )").arg(content);
+
+    component.setData(componentBody.toUtf8(), {});
+
+    m_model.reset(qobject_cast<QAbstractItemModel*>(
+                      component.create(engine.rootContext())));
+}
+
+ListModelWrapper::ListModelWrapper(QQmlEngine& engine, const QJsonArray& content)
+    : ListModelWrapper(engine, QJsonDocument(content).toJson())
+{
+}
+
+QAbstractItemModel* ListModelWrapper::model() const
+{
+    return m_model.get();
+}
+
+ListModelWrapper::operator QAbstractItemModel*() const
+{
+    return model();
+}
+
+int ListModelWrapper::count() const
+{
+    return m_model->rowCount();
+}
+
+int ListModelWrapper::role(const QString& roleName)
+{
+    QHash<int, QByteArray> roleNames = m_model->roleNames();
+    QList<int> roles = roleNames.keys(roleName.toUtf8());
+
+    return roles.length() != 1 ? -1 : roles.first();
+}
+
+void ListModelWrapper::set(int index, const QJsonObject& dict)
+{
+    QString jsonDict = QJsonDocument(dict).toJson();
+    runExpression(QString("set(%1, %2)").arg(index).arg(jsonDict));
+}
+
+void ListModelWrapper::setProperty(int index, const QString& property,
+                                   const QVariant& value)
+{
+    QString valueStr = value.type() == QVariant::String
+            ? QString("'%1'").arg(value.toString())
+            : value.toString();
+
+    runExpression(QString("setProperty(%1, '%2', %3)").arg(index)
+                  .arg(property, valueStr));
+}
+
+QVariant ListModelWrapper::get(int index, const QString& roleName)
+{
+    auto role = this->role(roleName);
+
+    if (role == -1)
+        return {};
+
+    return m_model->data(m_model->index(index, 0), role);
+}
+
+void ListModelWrapper::insert(int index, const QJsonObject& dict) {
+    QString jsonDict = QJsonDocument(dict).toJson();
+    runExpression(QString("insert(%1, %2)").arg(index).arg(jsonDict));
+}
+
+void ListModelWrapper::append(const QJsonArray& data) {
+    QString jsonData = QJsonDocument(data).toJson();
+    runExpression(QString("append(%1)").arg(jsonData));
+}
+
+void ListModelWrapper::clear() {
+    runExpression(QString("clear()"));
+}
+
+void ListModelWrapper::remove(int index, int count) {
+    runExpression(QString("remove(%1, %2)").arg(QString::number(index),
+                                                QString::number(count)));
+}
+
+void ListModelWrapper::move(int from, int to, int n) {
+    runExpression(QString("move(%1, %2, %3)").arg(QString::number(from),
+                                                  QString::number(to),
+                                                  QString::number(n)));
+}
+
+void ListModelWrapper::runExpression(const QString& expression)
+{
+    QQmlExpression(QQmlEngine::contextForObject(m_model.get()),
+                   m_model.get(), expression).evaluate();
+}

--- a/ui/StatusQ/tests/src/TestHelpers/listmodelwrapper.h
+++ b/ui/StatusQ/tests/src/TestHelpers/listmodelwrapper.h
@@ -1,0 +1,37 @@
+#include <QVariant>
+
+#include <memory>
+
+class QJsonArray;
+class QJsonObject;
+class QQmlEngine;
+class QAbstractItemModel;
+
+class ListModelWrapper {
+
+public:
+    explicit ListModelWrapper(QQmlEngine& engine, const QString& content = "[]");
+    explicit ListModelWrapper(QQmlEngine& engine, const QJsonArray& content);
+
+    QAbstractItemModel* model() const;
+    operator QAbstractItemModel*() const;
+
+    int count() const;
+    int role(const QString& roleName);
+
+    void set(int index, const QJsonObject& dict);
+    void setProperty(int index, const QString& property, const QVariant& value);
+
+    QVariant get(int index, const QString& roleName);
+
+    void insert(int index, const QJsonObject& dict);
+    void append(const QJsonArray& data);
+    void clear();
+    void remove(int index, int count = 1);
+    void move(int from, int to, int n = 1);
+
+private:
+    void runExpression(const QString& expression);
+
+    std::unique_ptr<QAbstractItemModel> m_model;
+};

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
@@ -1,0 +1,91 @@
+#include "testmodel.h"
+
+
+TestModel::TestModel(QList<QPair<QString, QVariantList>> data)
+    : m_data(std::move(data))
+{
+    initRoles();
+}
+
+TestModel::TestModel(QList<QString> roles)
+{
+    QList<QPair<QString, QVariantList>> data;
+    data.reserve(roles.size());
+
+    for (auto& role : roles)
+        data.append({std::move(role), {}});
+
+    m_data = std::move(data);
+    initRoles();
+}
+
+int TestModel::rowCount(const QModelIndex& parent) const
+{
+    if(parent.isValid())
+        return 0;
+
+    Q_ASSERT(m_data.size());
+    return m_data.first().second.size();
+}
+
+QHash<int, QByteArray> TestModel::roleNames() const
+{
+    return m_roles;
+}
+
+QVariant TestModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || role < 0 || role >= m_data.size())
+        return {};
+
+    const auto row = index.row();
+
+    if (role >= m_data.length() || row >= m_data.at(0).second.length())
+        return {};
+
+    return m_data.at(role).second.at(row);
+}
+
+void TestModel::insert(int index, QVariantList row)
+{
+    beginInsertRows(QModelIndex{}, index, index);
+
+    Q_ASSERT(row.size() == m_data.size());
+
+    for (int i = 0; i < m_data.size(); i++) {
+        auto& roleVariantList = m_data[i].second;
+        Q_ASSERT(index <= roleVariantList.size());
+        roleVariantList.insert(index, std::move(row[i]));
+    }
+
+    endInsertRows();
+}
+
+void TestModel::update(int index, int role, QVariant value)
+{
+    Q_ASSERT(role < m_data.size() && index < m_data[role].second.size());
+    m_data[role].second[index].setValue(std::move(value));
+
+    emit dataChanged(this->index(index, 0), this->index(index, 0), { role });
+}
+
+void TestModel::remove(int index)
+{
+    beginRemoveRows(QModelIndex{}, index, index);
+
+    for (int i = 0; i < m_data.size(); i++) {
+        auto& roleVariantList = m_data[i].second;
+        Q_ASSERT(index < roleVariantList.size());
+        roleVariantList.removeAt(index);
+    }
+
+    endRemoveRows();
+}
+
+void TestModel::initRoles()
+{
+    m_roles.reserve(m_data.size());
+
+    for (auto i = 0; i < m_data.size(); i++)
+        m_roles.insert(i, m_data.at(i).first.toUtf8());
+}

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.h
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.h
@@ -1,0 +1,22 @@
+#include <QAbstractListModel>
+
+class TestModel : public QAbstractListModel {
+
+public:
+    explicit TestModel(QList<QPair<QString, QVariantList>> data);
+    explicit TestModel(QList<QString> roles);
+
+    int rowCount(const QModelIndex& parent) const override;
+    QHash<int, QByteArray> roleNames() const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+
+    void insert(int index, QVariantList row);
+    void update(int index, int role, QVariant value);
+    void remove(int index);
+
+private:
+    void initRoles();
+
+    QList<QPair<QString, QVariantList>> m_data;
+    QHash<int, QByteArray> m_roles;
+};

--- a/ui/StatusQ/tests/tst_Aggregator.cpp
+++ b/ui/StatusQ/tests/tst_Aggregator.cpp
@@ -1,74 +1,9 @@
 #include <QtTest>
-#include <QAbstractListModel>
-#include <QCoreApplication>
 
-#include "StatusQ/aggregator.h"
+#include <StatusQ/aggregator.h>
+#include <TestHelpers/testmodel.h>
 
 namespace {
-
-// TODO: To be removed once issue #12843 is resolved and we have a testing utils
-class TestSourceModel : public QAbstractListModel {
-
-public:
-    explicit TestSourceModel(QList<QPair<QString, QVariantList>> data)
-        : m_data(std::move(data)) {
-        m_roles.reserve(m_data.size());
-
-        for (auto i = 0; i < m_data.size(); i++)
-            m_roles.insert(i, m_data.at(i).first.toUtf8());
-    }
-
-    int rowCount(const QModelIndex& parent) const override {
-        Q_ASSERT(m_data.size());
-        return m_data.first().second.size();
-    }
-
-    QVariant data(const QModelIndex& index, int role) const override {
-        if (!index.isValid() || role < 0 || role >= m_data.size())
-            return {};
-
-        const auto row = index.row();
-
-        if (role >= m_data.length() || row >= m_data.at(0).second.length())
-            return {};
-
-        return m_data.at(role).second.at(row);
-    }
-
-    bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override {
-        beginInsertRows(parent, row, row + count - 1);
-        m_data.insert(row, QPair<QString, QVariantList>());
-        endInsertRows();
-        return true;
-    }
-
-    void update(int index, int role, QVariant value) {
-        Q_ASSERT(role < m_data.size() && index < m_data[role].second.size());
-        m_data[role].second[index].setValue(std::move(value));
-
-        emit dataChanged(this->index(index, 0), this->index(index, 0), { role });
-    }
-
-    void remove(int index) {
-        beginRemoveRows(QModelIndex{}, index, index);
-
-        for (int i = 0; i < m_data.size(); i++) {
-            auto& roleVariantList = m_data[i].second;
-            Q_ASSERT(index < roleVariantList.size());
-            roleVariantList.removeAt(index);
-        }
-
-        endRemoveRows();
-    }
-
-    QHash<int, QByteArray> roleNames() const override {
-        return m_roles;
-    }
-
-private:
-    QList<QPair<QString, QVariantList>> m_data;
-    QHash<int, QByteArray> m_roles;
-};
 
 class ChildAggregator : public Aggregator {
  Q_OBJECT
@@ -98,10 +33,10 @@ private:
 private slots:
     void testModel() {
         ChildAggregator aggregator;
-        TestSourceModel sourceModel({
-                                        { "chainId", { "12", "13", "1", "321" }},
-                                        { "balance", { "0.123", "0.0000015", "1.45", "25.45221001" }}
-                                    });
+        TestModel sourceModel({
+            { "chainId", { "12", "13", "1", "321" }},
+            { "balance", { "0.123", "0.0000015", "1.45", "25.45221001" }}
+        });
         QSignalSpy modelChangedSpy(&aggregator, &Aggregator::modelChanged);
         QSignalSpy valueChangedSpy(&aggregator, &Aggregator::valueChanged);
 
@@ -120,10 +55,10 @@ private slots:
 
     void testCalculateAggregationTrigger() {
         ChildAggregator aggregator;
-        TestSourceModel sourceModel({
-                                        { "chainId", { "12", "13", "1", "321" }},
-                                        { "balance", { 0.123, 1.0, 1.45, 25.45 }}
-                                    });
+        TestModel sourceModel({
+            { "chainId", { "12", "13", "1", "321" }},
+            { "balance", { 0.123, 1.0, 1.45, 25.45 }}
+        });
         QSignalSpy valueChangedSpy(&aggregator, &Aggregator::valueChanged);
         int valueChangedSpyCount = 0;
 

--- a/ui/StatusQ/tests/tst_SingleRoleAggregator.cpp
+++ b/ui/StatusQ/tests/tst_SingleRoleAggregator.cpp
@@ -1,74 +1,9 @@
 #include <QtTest>
-#include <QAbstractListModel>
-#include <QCoreApplication>
 
-#include "StatusQ/singleroleaggregator.h"
+#include <StatusQ/singleroleaggregator.h>
+#include <TestHelpers/testmodel.h>
 
 namespace {
-
-// TODO: To be removed once issue #12843 is resolved and we have a testing utils
-class TestSourceModel : public QAbstractListModel {
-
-public:
-    explicit TestSourceModel(QList<QPair<QString, QVariantList>> data)
-        : m_data(std::move(data)) {
-        m_roles.reserve(m_data.size());
-
-        for (auto i = 0; i < m_data.size(); i++)
-            m_roles.insert(i, m_data.at(i).first.toUtf8());
-    }
-
-    int rowCount(const QModelIndex& parent) const override {
-        Q_ASSERT(m_data.size());
-        return m_data.first().second.size();
-    }
-
-    QVariant data(const QModelIndex& index, int role) const override {
-        if (!index.isValid() || role < 0 || role >= m_data.size())
-            return {};
-
-        const auto row = index.row();
-
-        if (role >= m_data.length() || row >= m_data.at(0).second.length())
-            return {};
-
-        return m_data.at(role).second.at(row);
-    }
-
-    bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override {
-        beginInsertRows(parent, row, row + count - 1);
-        m_data.insert(row, QPair<QString, QVariantList>());
-        endInsertRows();
-        return true;
-    }
-
-    void update(int index, int role, QVariant value) {
-        Q_ASSERT(role < m_data.size() && index < m_data[role].second.size());
-        m_data[role].second[index].setValue(std::move(value));
-
-        emit dataChanged(this->index(index, 0), this->index(index, 0), { role });
-    }
-
-    void remove(int index) {
-        beginRemoveRows(QModelIndex{}, index, index);
-
-        for (int i = 0; i < m_data.size(); i++) {
-            auto& roleVariantList = m_data[i].second;
-            Q_ASSERT(index < roleVariantList.size());
-            roleVariantList.removeAt(index);
-        }
-
-        endRemoveRows();
-    }
-
-    QHash<int, QByteArray> roleNames() const override {
-        return m_roles;
-    }
-
-private:
-    QList<QPair<QString, QVariantList>> m_data;
-    QHash<int, QByteArray> m_roles;
-};
 
 class ChildSingleRoleAggregator : public SingleRoleAggregator {
     Q_OBJECT
@@ -93,10 +28,10 @@ private slots:
 
     void testRoleName() {
         ChildSingleRoleAggregator aggregator;
-        TestSourceModel sourceModel({
-                                        { "chainId", { "12", "13", "1", "321" }},
-                                        { "balance", { "0.123", "0.0000015", "1.45", "25.45221001" }}
-                                    });
+        TestModel sourceModel({
+            { "chainId", { "12", "13", "1", "321" }},
+            { "balance", { "0.123", "0.0000015", "1.45", "25.45221001" }}
+        });
         QSignalSpy roleNameSpy(&aggregator, &SingleRoleAggregator::roleNameChanged);
 
         // Test 1 - Assign role name but model is nullptr


### PR DESCRIPTION
### What does the PR do

Before creating common testing library (https://github.com/status-im/status-desktop/pull/13032) some utilities were duplicated across multiple test files. Now they are moved to the library reducing duplication.

- `ListModelWrapper` (testing utility exposing qml's `ListModel` to cpp) excluded to a separate file
- Generic `TestModel` excluded to a separate file

Closes: https://github.com/status-im/status-desktop/issues/12843

### Affected areas
`StatusQ`'s tests related to proxy models
