### PR TITLE
chore: add object name for online identify header

### DIFF
--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -22,6 +22,7 @@ StatusMenu {
         pubkey: root.store.userProfileInst.pubKey
         icon: root.store.userProfileInst.icon
         userIsEnsVerified: !!root.store.userProfileInst.preferredName
+        objectName: 'onlineIdentifierProfileHeader'
     }
 
     StatusMenuSeparator {


### PR DESCRIPTION
### What does the PR do

Added an object name for this header so i can better init this whole object of context menu better (improves test stability)

