### PR TITLE
feat(ProfileShowcase): Implement profile showcase collectibles

### DIFF
--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -94,7 +94,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.controller = controller.newController(result)
   result.moduleLoaded = false
 
-  result.profileModule = profile_module.newModule(result, events, profileService, settingsService, communityService, walletAccountService)
+  result.profileModule = profile_module.newModule(result, events, profileService, settingsService, communityService, walletAccountService, networkService)
   result.contactsModule = contacts_module.newModule(result, events, contactsService, chatService)
   result.languageModule = language_module.newModule(result, events, languageService)
   result.privacyModule = privacy_module.newModule(result, events, settingsService, keychainService, privacyService, generalService)

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -92,9 +92,6 @@ proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAcco
 proc getTokensByAddresses*(self: Controller, addresses: seq[string]): seq[WalletTokenDto] =
   return self.walletAccountService.getTokensByAddresses(addresses)
 
-proc getBalancesByChain*(self: Controller, accountAddresses: seq[string], tokenAddresses: seq[string]): seq[WalletTokenDto] =
-  return self.walletAccountService.getBalancesByChain(accountAddresses, tokenAddresses)
-
 proc getChainIds*(self: Controller): seq[int] =
   return self.networkService.getNetworks().map(n => n.chainId)
 

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -86,6 +86,12 @@ proc getCommunityById*(self: Controller, id: string): CommunityDto =
 proc getAccountByAddress*(self: Controller, address: string): WalletAccountDto =
   return self.walletAccountService.getAccountByAddress(address)
 
+proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAccountDto] =
+  return self.walletAccountService.getWalletAccounts(true)
+
+proc getTokensByAddresses*(self: Controller, addresses: seq[string]): seq[WalletTokenDto] =
+  return self.walletAccountService.getTokensByAddresses(addresses)
+
 proc getBalancesByChain*(self: Controller, accountAddresses: seq[string], tokenAddresses: seq[string]): seq[WalletTokenDto] =
   return self.walletAccountService.getBalancesByChain(accountAddresses, tokenAddresses)
 

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -81,8 +81,8 @@ proc getCommunityById*(self: Controller, id: string): CommunityDto =
 proc getAccountByAddress*(self: Controller, address: string): WalletAccountDto =
   return self.walletAccountService.getAccountByAddress(address)
 
-proc getTokensByAddresses*(self: Controller, addresses: seq[string]): seq[WalletTokenDto] =
-  return self.walletAccountService.getTokensByAddresses(addresses)
+proc getBalancesByChain*(self: Controller, accountAddresses: seq[string], tokenAddresses: seq[string]): seq[WalletTokenDto] =
+  return self.walletAccountService.getBalancesByChain(accountAddresses, tokenAddresses)
 
 proc setSocialLinks*(self: Controller, links: SocialLinks) =
   self.settingsService.setSocialLinks(links)

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -1,3 +1,4 @@
+import sugar, sequtils
 import io_interface
 
 import app/global/app_signals
@@ -6,6 +7,7 @@ import app_service/service/profile/service as profile_service
 import app_service/service/settings/service as settings_service
 import app_service/service/community/service as community_service
 import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/network/service as network_service
 import app_service/common/social_links
 import app_service/common/types
 
@@ -21,6 +23,7 @@ type
     settingsService: settings_service.Service
     communityService: community_service.Service
     walletAccountService: wallet_account_service.Service
+    networkService: network_service.Service
 
 proc newController*(
     delegate: io_interface.AccessInterface,
@@ -28,7 +31,8 @@ proc newController*(
     profileService: profile_service.Service,
     settingsService: settings_service.Service,
     communityService: community_service.Service,
-    walletAccountService: wallet_account_service.Service): Controller =
+    walletAccountService: wallet_account_service.Service,
+    networkService: network_service.Service): Controller =
   result = Controller()
   result.delegate = delegate
   result.events = events
@@ -36,6 +40,7 @@ proc newController*(
   result.settingsService = settingsService
   result.communityService = communityService
   result.walletAccountService = walletAccountService
+  result.networkService = networkService
 
 proc delete*(self: Controller) =
   discard
@@ -83,6 +88,12 @@ proc getAccountByAddress*(self: Controller, address: string): WalletAccountDto =
 
 proc getBalancesByChain*(self: Controller, accountAddresses: seq[string], tokenAddresses: seq[string]): seq[WalletTokenDto] =
   return self.walletAccountService.getBalancesByChain(accountAddresses, tokenAddresses)
+
+proc getChainIds*(self: Controller): seq[int] =
+  return self.networkService.getNetworks().map(n => n.chainId)
+
+proc getEnabledChainIds*(self: Controller): seq[int] =
+  return self.networkService.getNetworks().filter(n => n.enabled).map(n => n.chainId)
 
 proc setSocialLinks*(self: Controller, links: SocialLinks) =
   self.settingsService.setSocialLinks(links)

--- a/src/app/modules/main/profile_section/profile/io_interface.nim
+++ b/src/app/modules/main/profile_section/profile/io_interface.nim
@@ -26,6 +26,9 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getCollectiblesModel*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method storeIdentityImage*(self: AccessInterface, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
@@ -53,6 +53,7 @@ proc toShowcasePreferenceItem*(self: ProfileShowcaseAssetItem): ProfileShowcaseA
   result = ProfileShowcaseAssetPreference()
 
   result.symbol = self.symbol
+  # TODO: result.contractAddress = self.contractAddress
   result.showcaseVisibility = self.showcaseVisibility
   result.order = self.order
 

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
@@ -14,18 +14,24 @@ import backend/helpers/token
 
 type
   ProfileShowcaseAssetItem* = ref object of ProfileShowcaseBaseItem
+    contractAddress*: string
+    communityId*: string
+    chainId*: string
     symbol*: string
     name*: string
     enabledNetworkBalance*: CurrencyAmount
     color*: string
     decimals*: int
 
-proc initProfileShowcaseAssetItem*(token: WalletTokenDto, visibility: ProfileShowcaseVisibility, order: int): ProfileShowcaseAssetItem =
+proc initProfileShowcaseAssetItem*(token: WalletTokenDto, contractAddress: string, visibility: ProfileShowcaseVisibility, order: int): ProfileShowcaseAssetItem =
   result = ProfileShowcaseAssetItem()
 
   result.showcaseVisibility = visibility
   result.order = order
 
+  result.contractAddress = contractAddress
+  # TODO: result.chainId = token.chainId
+  result.communityId = token.communityId
   result.symbol = token.symbol
   result.name = token.name
   result.enabledNetworkBalance = newCurrencyAmount(token.getTotalBalanceOfSupportedChains(), token.symbol, token.decimals, false)
@@ -42,6 +48,8 @@ proc toProfileShowcaseAssetItem*(jsonObj: JsonNode): ProfileShowcaseAssetItem =
     visibilityInt <= ord(high(ProfileShowcaseVisibility)))):
       result.showcaseVisibility = ProfileShowcaseVisibility(visibilityInt)
 
+  discard jsonObj.getProp("address", result.contractAddress)
+  discard jsonObj.getProp("communityId", result.communityId)
   discard jsonObj.getProp("symbol", result.symbol)
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("color", result.color)
@@ -49,22 +57,17 @@ proc toProfileShowcaseAssetItem*(jsonObj: JsonNode): ProfileShowcaseAssetItem =
 
   result.enabledNetworkBalance = newCurrencyAmount(jsonObj{"enabledNetworkBalance"}.getFloat, result.symbol, result.decimals, false)
 
-proc toShowcasePreferenceItem*(self: ProfileShowcaseAssetItem): ProfileShowcaseAssetPreference =
-  result = ProfileShowcaseAssetPreference()
+proc toShowcaseVerifiedTokenPreference*(self: ProfileShowcaseAssetItem): ProfileShowcaseVerifiedTokenPreference =
+  result = ProfileShowcaseVerifiedTokenPreference()
 
   result.symbol = self.symbol
-  # TODO: result.contractAddress = self.contractAddress
   result.showcaseVisibility = self.showcaseVisibility
   result.order = self.order
 
-proc symbol*(self: ProfileShowcaseAssetItem): string {.inline.} =
-  self.symbol
+proc toShowcaseUnverifiedTokenPreference*(self: ProfileShowcaseAssetItem): ProfileShowcaseUnverifiedTokenPreference =
+  result = ProfileShowcaseUnverifiedTokenPreference()
 
-proc name*(self: ProfileShowcaseAssetItem): string {.inline.} =
-  self.name
-
-proc enabledNetworkBalance*(self: ProfileShowcaseAssetItem): CurrencyAmount {.inline.} =
-  self.enabledNetworkBalance
-
-proc color*(self: ProfileShowcaseAssetItem): string {.inline.} =
-  self.color
+  result.contractAddress = self.contractAddress
+  result.chainId = self.chainId
+  result.showcaseVisibility = self.showcaseVisibility
+  result.order = self.order

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
@@ -22,20 +22,20 @@ type
     color*: string
     decimals*: int
 
-proc initProfileShowcaseAssetItem*(token: WalletTokenDto, contractAddress: string, visibility: ProfileShowcaseVisibility, order: int): ProfileShowcaseAssetItem =
+
+proc initProfileShowcaseVerifiedToken*(token: WalletTokenDto, visibility: ProfileShowcaseVisibility, order: int): ProfileShowcaseAssetItem =
   result = ProfileShowcaseAssetItem()
 
   result.showcaseVisibility = visibility
   result.order = order
 
-  result.contractAddress = contractAddress
-  # TODO: result.chainId = token.chainId
-  result.communityId = token.communityId
   result.symbol = token.symbol
   result.name = token.name
   result.enabledNetworkBalance = newCurrencyAmount(token.getTotalBalanceOfSupportedChains(), token.symbol, token.decimals, false)
   result.color = token.color
   result.decimals = token.decimals
+
+  # TODO: initProfileShowcaseUnverifiedToken
 
 proc toProfileShowcaseAssetItem*(jsonObj: JsonNode): ProfileShowcaseAssetItem =
   result = ProfileShowcaseAssetItem()

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
@@ -2,7 +2,6 @@ import json, strutils, stint, json_serialization, tables
 
 import profile_preferences_base_item
 
-import app_service/service/wallet_account/dto/account_dto
 import app_service/service/profile/dto/profile_showcase_preferences
 
 import app/modules/shared_models/currency_amount
@@ -16,7 +15,7 @@ type
   ProfileShowcaseAssetItem* = ref object of ProfileShowcaseBaseItem
     contractAddress*: string
     communityId*: string
-    chainId*: string
+    chainId*: int
     symbol*: string
     name*: string
     enabledNetworkBalance*: CurrencyAmount

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
@@ -8,6 +8,8 @@ type
     ShowcaseVisibility = UserRole + 1
     Order
 
+    Address
+    CommunityId
     Symbol
     Name
     EnabledNetworkBalance
@@ -52,6 +54,8 @@ QtObject:
       ModelRole.ShowcaseVisibility.int: "showcaseVisibility",
       ModelRole.Order.int: "order",
 
+      ModelRole.Address.int: "address",
+      ModelRole.CommunityId.int: "communityId",
       ModelRole.Symbol.int: "symbol",
       ModelRole.Name.int: "name",
       ModelRole.EnabledNetworkBalance.int: "enabledNetworkBalance",
@@ -74,6 +78,10 @@ QtObject:
       result = newQVariant(item.showcaseVisibility.int)
     of ModelRole.Order:
       result = newQVariant(item.order)
+    of ModelRole.Address:
+      result = newQVariant(item.contractAddress)
+    of ModelRole.CommunityId:
+      result = newQVariant(item.communityId)
     of ModelRole.Symbol:
       result = newQVariant(item.symbol)
     of ModelRole.Name:
@@ -120,6 +128,8 @@ QtObject:
       self.dataChanged(index, index, @[
         ModelRole.ShowcaseVisibility.int,
         ModelRole.Order.int,
+        ModelRole.Address.int,
+        ModelRole.CommunityId.int,
         ModelRole.Symbol.int,
         ModelRole.Name.int,
         ModelRole.EnabledNetworkBalance.int,

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
@@ -1,4 +1,4 @@
-import json, strutils, stint, json_serialization, tables
+import json, strutils, strformat, stint, json_serialization, tables
 
 import profile_preferences_base_item
 
@@ -9,7 +9,10 @@ include app_service/common/utils
 
 type
   ProfileShowcaseCollectibleItem* = ref object of ProfileShowcaseBaseItem
-    uid*: string
+    chainId*: string
+    tokenId*: string
+    contractAddress*: string
+    communityId*: string
     name*: string
     collectionName*: string
     imageUrl*: string
@@ -25,7 +28,10 @@ proc toProfileShowcaseCollectibleItem*(jsonObj: JsonNode): ProfileShowcaseCollec
     visibilityInt <= ord(high(ProfileShowcaseVisibility)))):
       result.showcaseVisibility = ProfileShowcaseVisibility(visibilityInt)
 
-  discard jsonObj.getProp("uid", result.uid)
+  discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("tokenId", result.tokenId)
+  discard jsonObj.getProp("contractAddress", result.contractAddress)
+  discard jsonObj.getProp("communityId", result.communityId)
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("collectionName", result.collectionName)
   discard jsonObj.getProp("imageUrl", result.imageUrl)
@@ -34,18 +40,13 @@ proc toProfileShowcaseCollectibleItem*(jsonObj: JsonNode): ProfileShowcaseCollec
 proc toShowcasePreferenceItem*(self: ProfileShowcaseCollectibleItem): ProfileShowcaseCollectiblePreference =
   result = ProfileShowcaseCollectiblePreference()
 
-  result.uid = self.uid
+  result.chainId = self.chainId
+  result.tokenId = self.tokenId
+  result.contractAddress = self.contractAddress
+  result.communityId = self.communityId
   result.showcaseVisibility = self.showcaseVisibility
   result.order = self.order
 
-proc name*(self: ProfileShowcaseCollectibleItem): string {.inline.} =
-  self.name
-
-proc collectionName*(self: ProfileShowcaseCollectibleItem): string {.inline.} =
-  self.collectionName
-
-proc imageUrl*(self: ProfileShowcaseCollectibleItem): string {.inline.} =
-  self.imageUrl
-
-proc backgroundColor*(self: ProfileShowcaseCollectibleItem): string {.inline.} =
-  self.backgroundColor
+# NOTE: should be same as CollectiblesEntry::getID
+proc getID*(self: ProfileShowcaseCollectibleItem): string =
+  return fmt"{self.chainId}+{self.contractAddress}+{self.tokenId}"

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
@@ -9,7 +9,7 @@ include app_service/common/utils
 
 type
   ProfileShowcaseCollectibleItem* = ref object of ProfileShowcaseBaseItem
-    chainId*: string
+    chainId*: int
     tokenId*: string
     contractAddress*: string
     communityId*: string

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
@@ -3,6 +3,7 @@ import json, strutils, strformat, stint, json_serialization, tables
 import profile_preferences_base_item
 
 import app_service/service/profile/dto/profile_showcase_preferences
+import app/modules/shared_models/collectibles_entry
 
 include app_service/common/json_utils
 include app_service/common/utils
@@ -17,6 +18,23 @@ type
     collectionName*: string
     imageUrl*: string
     backgroundColor*: string
+    loading*: bool
+
+proc initProfileShowcaseCollectibleItem*(collectible: CollectiblesEntry, visibility: ProfileShowcaseVisibility, order: int): ProfileShowcaseCollectibleItem =
+  result = ProfileShowcaseCollectibleItem()
+  result.contractAddress = collectible.getContractAddress()
+  result.chainId = collectible.getChainID()
+  result.tokenId = collectible.getTokenIDAsString()
+  result.communityId = collectible.getCommunityId()
+  result.name = collectible.getName()
+  result.collectionName = collectible.getCollectionName()
+  result.imageUrl = collectible.getImageURL()
+  result.backgroundColor = collectible.getBackgroundColor()
+  result.showcaseVisibility = visibility
+  result.order = order
+  result.showcaseVisibility = visibility
+  result.order = order
+  result.loading = false
 
 proc toProfileShowcaseCollectibleItem*(jsonObj: JsonNode): ProfileShowcaseCollectibleItem =
   result = ProfileShowcaseCollectibleItem()

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
@@ -32,8 +32,6 @@ proc initProfileShowcaseCollectibleItem*(collectible: CollectiblesEntry, visibil
   result.backgroundColor = collectible.getBackgroundColor()
   result.showcaseVisibility = visibility
   result.order = order
-  result.showcaseVisibility = visibility
-  result.order = order
   result.loading = false
 
 proc toProfileShowcaseCollectibleItem*(jsonObj: JsonNode): ProfileShowcaseCollectibleItem =

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
@@ -5,17 +5,19 @@ import app_service/service/profile/dto/profile_showcase_preferences
 
 type
   ModelRole {.pure.} = enum
-    ShowcaseVisibility = UserRole + 1
-    Order
-
+    Uid = UserRole + 1,
     ChainId
-    TokenId
     ContractAddress
-    CommunityId
+    TokenId
     Name
-    CollectionName
     ImageUrl
     BackgroundColor
+    CollectionName
+    IsLoading
+    CommunityId
+
+    ShowcaseVisibility
+    Order
 
 QtObject:
   type
@@ -52,17 +54,19 @@ QtObject:
 
   method roleNames(self: ProfileShowcaseCollectiblesModel): Table[int, string] =
     {
-      ModelRole.ShowcaseVisibility.int: "showcaseVisibility",
-      ModelRole.Order.int: "order",
-
-      ChainId.int: "chainId",
-      TokenId.int: "tokenId",
-      ContractAddress.int: "contractAddress",
-      CommunityId.int: "communityId",
+      ModelRole.Uid.int:"uid",
+      ModelRole.ChainId.int: "chainId",
+      ModelRole.ContractAddress.int: "contractAddress",
+      ModelRole.TokenId.int: "tokenId",
       ModelRole.Name.int: "name",
-      ModelRole.CollectionName.int: "collectionName",
       ModelRole.ImageUrl.int: "imageUrl",
       ModelRole.BackgroundColor.int: "backgroundColor",
+      ModelRole.CollectionName.int: "collectionName",
+      ModelRole.IsLoading.int:"isLoading",
+      ModelRole.CommunityId.int: "communityId",
+
+      ModelRole.ShowcaseVisibility.int: "showcaseVisibility",
+      ModelRole.Order.int: "order",
     }.toTable
 
   method data(self: ProfileShowcaseCollectiblesModel, index: QModelIndex, role: int): QVariant =
@@ -76,26 +80,31 @@ QtObject:
     let enumRole = role.ModelRole
 
     case enumRole:
-    of ModelRole.ShowcaseVisibility:
-      result = newQVariant(item.showcaseVisibility.int)
-    of ModelRole.Order:
-      result = newQVariant(item.order)
+    of ModelRole.Uid:
+      result = newQVariant(item.getID())
     of ModelRole.ChainId:
       result = newQVariant(item.chainId)
-    of ModelRole.TokenId:
-      result = newQVariant(item.tokenId)
     of ModelRole.ContractAddress:
       result = newQVariant(item.contractAddress)
-    of ModelRole.CommunityId:
-      result = newQVariant(item.communityId)
+    of ModelRole.TokenId:
+      result = newQVariant(item.tokenId)
     of ModelRole.Name:
       result = newQVariant(item.name)
-    of ModelRole.CollectionName:
-      result = newQVariant(item.collectionName)
     of ModelRole.ImageUrl:
       result = newQVariant(item.imageUrl)
     of ModelRole.BackgroundColor:
       result = newQVariant(item.backgroundColor)
+    of ModelRole.CollectionName:
+      result = newQVariant(item.collectionName)
+    of ModelRole.IsLoading:
+      result = newQVariant(false)
+    of ModelRole.CommunityId:
+      result = newQVariant(item.communityId)
+
+    of ModelRole.ShowcaseVisibility:
+      result = newQVariant(item.showcaseVisibility.int)
+    of ModelRole.Order:
+      result = newQVariant(item.order)
 
   proc findIndexForCollectible(self: ProfileShowcaseCollectiblesModel, uid: string): int =
     for i in 0 ..< self.items.len:

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
@@ -8,7 +8,10 @@ type
     ShowcaseVisibility = UserRole + 1
     Order
 
-    Uid
+    ChainId
+    TokenId
+    ContractAddress
+    CommunityId
     Name
     CollectionName
     ImageUrl
@@ -52,7 +55,10 @@ QtObject:
       ModelRole.ShowcaseVisibility.int: "showcaseVisibility",
       ModelRole.Order.int: "order",
 
-      ModelRole.Uid.int: "uid",
+      ChainId.int: "chainId",
+      TokenId.int: "tokenId",
+      ContractAddress.int: "contractAddress",
+      CommunityId.int: "communityId",
       ModelRole.Name.int: "name",
       ModelRole.CollectionName.int: "collectionName",
       ModelRole.ImageUrl.int: "imageUrl",
@@ -74,8 +80,14 @@ QtObject:
       result = newQVariant(item.showcaseVisibility.int)
     of ModelRole.Order:
       result = newQVariant(item.order)
-    of ModelRole.Uid:
-      result = newQVariant(item.uid)
+    of ModelRole.ChainId:
+      result = newQVariant(item.chainId)
+    of ModelRole.TokenId:
+      result = newQVariant(item.tokenId)
+    of ModelRole.ContractAddress:
+      result = newQVariant(item.contractAddress)
+    of ModelRole.CommunityId:
+      result = newQVariant(item.communityId)
     of ModelRole.Name:
       result = newQVariant(item.name)
     of ModelRole.CollectionName:
@@ -87,7 +99,7 @@ QtObject:
 
   proc findIndexForCollectible(self: ProfileShowcaseCollectiblesModel, uid: string): int =
     for i in 0 ..< self.items.len:
-      if (self.items[i].uid == uid):
+      if (self.items[i].getID() == uid):
         return i
     return -1
 
@@ -109,7 +121,7 @@ QtObject:
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc upsertItemImpl(self: ProfileShowcaseCollectiblesModel, item: ProfileShowcaseCollectibleItem) =
-    let ind = self.findIndexForCollectible(item.uid)
+    let ind = self.findIndexForCollectible(item.getID())
     if ind == -1:
       self.appendItem(item)
     else:
@@ -120,7 +132,10 @@ QtObject:
       self.dataChanged(index, index, @[
         ModelRole.ShowcaseVisibility.int,
         ModelRole.Order.int,
-        ModelRole.Uid.int,
+        ModelRole.ChainId.int,
+        ModelRole.TokenId.int,
+        ModelRole.ContractAddress.int,
+        ModelRole.CommunityId.int,
         ModelRole.Name.int,
         ModelRole.CollectionName.int,
         ModelRole.ImageUrl.int,

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
@@ -97,7 +97,7 @@ QtObject:
     of ModelRole.CollectionName:
       result = newQVariant(item.collectionName)
     of ModelRole.IsLoading:
-      result = newQVariant(false)
+      result = newQVariant(item.loading)
     of ModelRole.CommunityId:
       result = newQVariant(item.communityId)
 
@@ -149,6 +149,7 @@ QtObject:
         ModelRole.CollectionName.int,
         ModelRole.ImageUrl.int,
         ModelRole.BackgroundColor.int,
+        ModelRole.IsLoading.int
       ])
 
   proc upsertItemJson(self: ProfileShowcaseCollectiblesModel, itemJson: string) {.slot.} =

--- a/src/app/modules/main/profile_section/profile/module.nim
+++ b/src/app/modules/main/profile_section/profile/module.nim
@@ -166,7 +166,7 @@ method updateProfileShowcase(self: Module, profileShowcase: ProfileShowcaseDto) 
         community, ProfileShowcaseVisibility.ToEveryone, communityEntry.order))
   self.view.updateProfileShowcaseCommunities(profileCommunityItems)
 
-  var addresses: seq[string] = @[]
+  var accountAddresses: seq[string] = @[]
   for account in profileShowcase.accounts:
     profileAccountItems.add(initProfileShowcaseAccountItem(
       account.address,
@@ -176,12 +176,12 @@ method updateProfileShowcase(self: Module, profileShowcase: ProfileShowcaseDto) 
       ProfileShowcaseVisibility.ToEveryone,
       account.order
     ))
-    addresses.add(account.address)
+    accountAddresses.add(account.address)
 
   for assetEntry in profileShowcase.assets:
-    for token in self.controller.getTokensByAddresses(addresses):
-      if assetEntry.symbol == token.symbol:
-        profileAssetItems.add(initProfileShowcaseAssetItem(token, ProfileShowcaseVisibility.ToEveryone, assetEntry.order))
+    let tokens = self.controller.getBalancesByChain(accountAddresses, @[assetEntry.contractAddress])
+    if len(tokens) == 1:
+      profileAssetItems.add(initProfileShowcaseAssetItem(tokens[0], ProfileShowcaseVisibility.ToEveryone, assetEntry.order))
 
   self.view.updateProfileShowcaseAccounts(profileAccountItems)
   self.view.updateProfileShowcaseAssets(profileAssetItems)
@@ -204,7 +204,7 @@ method updateProfileShowcasePreferences(self: Module, preferences: ProfileShowca
         community, communityEntry.showcaseVisibility, communityEntry.order))
   self.view.updateProfileShowcaseCommunities(profileCommunityItems)
 
-  var addresses: seq[string] = @[]
+  var accountAddresses: seq[string] = @[]
   for account in preferences.accounts:
     profileAccountItems.add(initProfileShowcaseAccountItem(
       account.address,
@@ -214,12 +214,12 @@ method updateProfileShowcasePreferences(self: Module, preferences: ProfileShowca
       account.showcaseVisibility,
       account.order
     ))
-    addresses.add(account.address)
+    accountAddresses.add(account.address)
 
-  for assetEntry in preferences.assets:
-    for token in self.controller.getTokensByAddresses(addresses):
-      if assetEntry.symbol == token.symbol:
-        profileAssetItems.add(initProfileShowcaseAssetItem(token, assetEntry.showcaseVisibility, assetEntry.order))
+  for asset in preferences.assets:
+    let tokens = self.controller.getBalancesByChain(accountAddresses, @[asset.contractAddress])
+    if len(tokens) == 1:
+      profileAssetItems.add(initProfileShowcaseAssetItem(tokens[0], asset.showcaseVisibility, asset.order))
 
   self.view.updateProfileShowcaseAccounts(profileAccountItems)
   self.view.updateProfileShowcaseAssets(profileAssetItems)

--- a/src/app/modules/main/profile_section/profile/module.nim
+++ b/src/app/modules/main/profile_section/profile/module.nim
@@ -118,11 +118,17 @@ method storeProfileShowcasePreferences(self: Module,
     if acc.showcaseVisibility != ProfileShowcaseVisibility.ToNoOne:
       revealedAddresses.add(acc.address)
 
+  var verifiedTokens: seq[ProfileShowcaseVerifiedTokenPreference] = @[]
+  var unverifiedTokens: seq[ProfileShowcaseUnverifiedTokenPreference] = @[]
+
+  # TODO: run through assets and collect verified/unverified tokens
+
   self.controller.storeProfileShowcasePreferences(ProfileShowcasePreferencesDto(
     communities: communities.map(item => item.toShowcasePreferenceItem()),
     accounts: accounts.map(item => item.toShowcasePreferenceItem()),
     collectibles: collectibles.map(item => item.toShowcasePreferenceItem()),
-    assets: assets.map(item => item.toShowcasePreferenceItem()),
+    verifiedTokens: verifiedTokens,
+    unverifiedTokens: unverifiedTokens
     ),
     revealedAddresses
   )
@@ -153,6 +159,7 @@ method updateProfileShowcase(self: Module, profileShowcase: ProfileShowcaseDto) 
   var profileCommunityItems: seq[ProfileShowcaseCommunityItem] = @[]
   var profileAccountItems: seq[ProfileShowcaseAccountItem] = @[]
   var profileAssetItems: seq[ProfileShowcaseAssetItem] = @[]
+  var profileCollectibleItems: seq[ProfileShowcaseCollectibleItem] = @[]
 
   for communityEntry in profileShowcase.communities:
     let community = self.controller.getCommunityById(communityEntry.communityId)
@@ -177,15 +184,10 @@ method updateProfileShowcase(self: Module, profileShowcase: ProfileShowcaseDto) 
       account.order
     ))
     accountAddresses.add(account.address)
-
-  for assetEntry in profileShowcase.assets:
-    let tokens = self.controller.getBalancesByChain(accountAddresses, @[assetEntry.contractAddress])
-    if len(tokens) == 1:
-      profileAssetItems.add(initProfileShowcaseAssetItem(tokens[0], ProfileShowcaseVisibility.ToEveryone, assetEntry.order))
-
   self.view.updateProfileShowcaseAccounts(profileAccountItems)
-  self.view.updateProfileShowcaseAssets(profileAssetItems)
-  # TODO: collectibles, need wallet api to fetch collectible by uid
+
+  # TODO: verified and unverified tokens
+  # TODO: collectibles
 
 method updateProfileShowcasePreferences(self: Module, preferences: ProfileShowcasePreferencesDto) =
   if self.presentedPublicKey != singletonInstance.userProfile.getPubKey():
@@ -194,6 +196,7 @@ method updateProfileShowcasePreferences(self: Module, preferences: ProfileShowca
   var profileCommunityItems: seq[ProfileShowcaseCommunityItem] = @[]
   var profileAccountItems: seq[ProfileShowcaseAccountItem] = @[]
   var profileAssetItems: seq[ProfileShowcaseAssetItem] = @[]
+  var profileCollectibleItems: seq[ProfileShowcaseCollectibleItem] = @[]
 
   for communityEntry in preferences.communities:
     let community = self.controller.getCommunityById(communityEntry.communityId)
@@ -215,15 +218,10 @@ method updateProfileShowcasePreferences(self: Module, preferences: ProfileShowca
       account.order
     ))
     accountAddresses.add(account.address)
-
-  for asset in preferences.assets:
-    let tokens = self.controller.getBalancesByChain(accountAddresses, @[asset.contractAddress])
-    if len(tokens) == 1:
-      profileAssetItems.add(initProfileShowcaseAssetItem(tokens[0], asset.showcaseVisibility, asset.order))
-
   self.view.updateProfileShowcaseAccounts(profileAccountItems)
-  self.view.updateProfileShowcaseAssets(profileAssetItems)
-  # TODO: collectibles, need wallet api to fetch collectible by uid
+
+  # TODO: verified and unverified tokens
+  # TODO: collectibles
 
 method onCommunitiesUpdated*(self: Module, communities: seq[CommunityDto]) =
   var profileCommunityItems = self.view.getProfileShowcaseCommunities()

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -174,6 +174,12 @@ QtObject:
   proc emitBioChangedSignal*(self: View) =
     self.bioChanged()
 
+  proc getCollectiblesModel(self: View): QVariant {.slot.} =
+    return self.delegate.getCollectiblesModel()
+
+  QtProperty[QVariant] collectiblesModel:
+    read = getCollectiblesModel
+
   proc getProfileShowcaseCommunitiesModel(self: View): QVariant {.slot.} =
     return self.profileShowcaseCommunitiesModelVariant
 
@@ -227,7 +233,7 @@ QtObject:
   proc updateProfileShowcaseAccounts*(self: View, accounts: seq[ProfileShowcaseAccountItem]) =
     self.profileShowcaseAccountsModel.reset(accounts.sorted((a, b) => cmp(a.order, b.order), SortOrder.Ascending))
 
-  proc updateProfileShowcaseCollectibless*(self: View, collectibles: seq[ProfileShowcaseCollectibleItem]) =
+  proc updateProfileShowcaseCollectibles*(self: View, collectibles: seq[ProfileShowcaseCollectibleItem]) =
     self.profileShowcaseCollectiblesModel.reset(collectibles.sorted((a, b) => cmp(a.order, b.order), SortOrder.Ascending))
 
   proc updateProfileShowcaseAssets*(self: View, assets: seq[ProfileShowcaseAssetItem]) =

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -332,6 +332,12 @@ QtObject:
   proc getItems*(self: Model): seq[CollectiblesEntry] =
     return self.items
 
+  proc getItemById*(self: Model, id: string): CollectiblesEntry =
+    for item in self.items:
+      if(cmpIgnoreCase(item.getID(), id) == 0):
+        return item
+    return nil
+
   proc setItems*(self: Model, newItems: seq[CollectiblesEntry], offset: int, hasMore: bool) =
     if offset == 0:
       self.removeCollectibleItems()

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -301,3 +301,10 @@ QtObject:
     self.filter = filter
 
     self.resetModel()
+
+  proc getActivityToken*(self: Controller, id: string): backend_activity.Token =
+    return self.model.getActivityToken(id)
+
+  proc getItemForData*(self: Controller, tokenId: string, tokenAddress: string, chainId: int): CollectiblesEntry =
+    let uid = self.model.getUidForData(tokenId, tokenAddress, chainId)
+    return self.model.getItemById(uid)

--- a/src/app_service/service/profile/dto/profile_showcase.nim
+++ b/src/app_service/service/profile/dto/profile_showcase.nim
@@ -14,9 +14,9 @@ type ProfileShowcaseAccount* = ref object of RootObj
   order*: int
 
 type ProfileShowcaseCollectible* = ref object of RootObj
-  chainId*: string
-  tokenId*: string
   contractAddress*: string
+  chainId*: int
+  tokenId*: string
   communityId*: string
   accountAddress*: string
   order*: int
@@ -27,7 +27,7 @@ type ProfileShowcaseVerifiedToken* = ref object of RootObj
 
 type ProfileShowcaseUnverifiedToken* = ref object of RootObj
   contractAddress*: string
-  chainId*: string
+  chainId*: int
   order*: int
 
 type ProfileShowcaseDto* = ref object of RootObj

--- a/src/app_service/service/profile/dto/profile_showcase.nim
+++ b/src/app_service/service/profile/dto/profile_showcase.nim
@@ -19,6 +19,7 @@ type ProfileShowcaseCollectible* = ref object of RootObj
 
 type ProfileShowcaseAsset* = ref object of RootObj
   symbol*: string
+  contractAddress*: string
   order*: int
 
 type ProfileShowcaseDto* = ref object of RootObj
@@ -49,6 +50,7 @@ proc toProfileShowcaseCollectible*(jsonObj: JsonNode): ProfileShowcaseCollectibl
 proc toProfileShowcaseAsset*(jsonObj: JsonNode): ProfileShowcaseAsset =
   result = ProfileShowcaseAsset()
   discard jsonObj.getProp("symbol", result.symbol)
+  discard jsonObj.getProp("contractAddress", result.contractAddress)
   discard jsonObj.getProp("order", result.order)
 
 proc toProfileShowcaseDto*(jsonObj: JsonNode): ProfileShowcaseDto =

--- a/src/app_service/service/profile/dto/profile_showcase.nim
+++ b/src/app_service/service/profile/dto/profile_showcase.nim
@@ -14,12 +14,20 @@ type ProfileShowcaseAccount* = ref object of RootObj
   order*: int
 
 type ProfileShowcaseCollectible* = ref object of RootObj
-  uid*: string
+  chainId*: string
+  tokenId*: string
+  contractAddress*: string
+  communityId*: string
+  accountAddress*: string
   order*: int
 
-type ProfileShowcaseAsset* = ref object of RootObj
+type ProfileShowcaseVerifiedToken* = ref object of RootObj
   symbol*: string
+  order*: int
+
+type ProfileShowcaseUnverifiedToken* = ref object of RootObj
   contractAddress*: string
+  chainId*: string
   order*: int
 
 type ProfileShowcaseDto* = ref object of RootObj
@@ -27,7 +35,8 @@ type ProfileShowcaseDto* = ref object of RootObj
   communities*: seq[ProfileShowcaseCommunity]
   accounts*: seq[ProfileShowcaseAccount]
   collectibles*: seq[ProfileShowcaseCollectible]
-  assets*: seq[ProfileShowcaseAsset]
+  verifiedTokens*: seq[ProfileShowcaseVerifiedToken]
+  unverifiedTokens*: seq[ProfileShowcaseUnverifiedToken]
 
 proc toProfileShowcaseCommunity*(jsonObj: JsonNode): ProfileShowcaseCommunity =
   result = ProfileShowcaseCommunity()
@@ -44,13 +53,22 @@ proc toProfileShowcaseAccount*(jsonObj: JsonNode): ProfileShowcaseAccount =
 
 proc toProfileShowcaseCollectible*(jsonObj: JsonNode): ProfileShowcaseCollectible =
   result = ProfileShowcaseCollectible()
-  discard jsonObj.getProp("uid", result.uid)
+  discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("tokenId", result.tokenId)
+  discard jsonObj.getProp("contractAddress", result.contractAddress)
+  discard jsonObj.getProp("communityId", result.communityId)
+  discard jsonObj.getProp("accountAddress", result.accountAddress)
   discard jsonObj.getProp("order", result.order)
 
-proc toProfileShowcaseAsset*(jsonObj: JsonNode): ProfileShowcaseAsset =
-  result = ProfileShowcaseAsset()
+proc toProfileShowcaseVerifiedToken*(jsonObj: JsonNode): ProfileShowcaseVerifiedToken =
+  result = ProfileShowcaseVerifiedToken()
   discard jsonObj.getProp("symbol", result.symbol)
+  discard jsonObj.getProp("order", result.order)
+
+proc toProfileShowcaseUnverifiedToken*(jsonObj: JsonNode): ProfileShowcaseUnverifiedToken =
+  result = ProfileShowcaseUnverifiedToken()
   discard jsonObj.getProp("contractAddress", result.contractAddress)
+  discard jsonObj.getProp("chainId", result.chainId)
   discard jsonObj.getProp("order", result.order)
 
 proc toProfileShowcaseDto*(jsonObj: JsonNode): ProfileShowcaseDto =
@@ -64,5 +82,7 @@ proc toProfileShowcaseDto*(jsonObj: JsonNode): ProfileShowcaseDto =
     result.accounts.add(jsonMsg.toProfileShowcaseAccount())
   for jsonMsg in jsonObj["collectibles"]:
     result.collectibles.add(jsonMsg.toProfileShowcaseCollectible())
-  for jsonMsg in jsonObj["assets"]:
-    result.assets.add(jsonMsg.toProfileShowcaseAsset())
+  for jsonMsg in jsonObj["verifiedTokens"]:
+    result.verifiedTokens.add(jsonMsg.toProfileShowcaseVerifiedToken())
+  for jsonMsg in jsonObj["unverifiedTokens"]:
+    result.unverifiedTokens.add(jsonMsg.toProfileShowcaseUnverifiedToken())

--- a/src/app_service/service/profile/dto/profile_showcase_preferences.nim
+++ b/src/app_service/service/profile/dto/profile_showcase_preferences.nim
@@ -29,6 +29,7 @@ type ProfileShowcaseCollectiblePreference* = ref object of RootObj
 
 type ProfileShowcaseAssetPreference* = ref object of RootObj
   symbol*: string
+  contractAddress*: string
   showcaseVisibility*: ProfileShowcaseVisibility
   order*: int
 
@@ -94,12 +95,14 @@ proc toJsonNode*(self: ProfileShowcaseCollectiblePreference): JsonNode =
 proc toProfileShowcaseAssetPreference*(jsonObj: JsonNode): ProfileShowcaseAssetPreference =
   result = ProfileShowcaseAssetPreference()
   discard jsonObj.getProp("symbol", result.symbol)
+  discard jsonObj.getProp("contractAddress", result.contractAddress)
   discard jsonObj.getProp("order", result.order)
   result.showcaseVisibility = jsonObj.toProfileShowcaseVisibility()
 
 proc toJsonNode*(self: ProfileShowcaseAssetPreference): JsonNode =
   %* {
     "symbol": self.symbol,
+    "contractAddress": self.contractAddress,
     "showcaseVisibility": self.showcaseVisibility.int,
     "order": self.order,
   }

--- a/src/app_service/service/profile/dto/profile_showcase_preferences.nim
+++ b/src/app_service/service/profile/dto/profile_showcase_preferences.nim
@@ -23,13 +23,22 @@ type ProfileShowcaseAccountPreference* = ref object of RootObj
   order*: int
 
 type ProfileShowcaseCollectiblePreference* = ref object of RootObj
-  uid*: string
+  chainId*: string
+  tokenId*: string
+  contractAddress*: string
+  communityId*: string
+  accountAddress*: string
   showcaseVisibility*: ProfileShowcaseVisibility
   order*: int
 
-type ProfileShowcaseAssetPreference* = ref object of RootObj
+type ProfileShowcaseVerifiedTokenPreference* = ref object of RootObj
   symbol*: string
+  showcaseVisibility*: ProfileShowcaseVisibility
+  order*: int
+
+type ProfileShowcaseUnverifiedTokenPreference* = ref object of RootObj
   contractAddress*: string
+  chainId*: string
   showcaseVisibility*: ProfileShowcaseVisibility
   order*: int
 
@@ -37,7 +46,8 @@ type ProfileShowcasePreferencesDto* = ref object of RootObj
   communities*: seq[ProfileShowcaseCommunityPreference]
   accounts*: seq[ProfileShowcaseAccountPreference]
   collectibles*: seq[ProfileShowcaseCollectiblePreference]
-  assets*: seq[ProfileShowcaseAssetPreference]
+  verifiedTokens*: seq[ProfileShowcaseVerifiedTokenPreference]
+  unverifiedTokens*: seq[ProfileShowcaseUnverifiedTokenPreference]
 
 proc toProfileShowcaseVisibility*(jsonObj: JsonNode): ProfileShowcaseVisibility =
   var visibilityInt: int
@@ -81,28 +91,49 @@ proc toJsonNode*(self: ProfileShowcaseAccountPreference): JsonNode =
 
 proc toProfileShowcaseCollectiblePreference*(jsonObj: JsonNode): ProfileShowcaseCollectiblePreference =
   result = ProfileShowcaseCollectiblePreference()
-  discard jsonObj.getProp("uid", result.uid)
+  discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("tokenId", result.tokenId)
+  discard jsonObj.getProp("contractAddress", result.contractAddress)
+  discard jsonObj.getProp("communityId", result.communityId)
+  discard jsonObj.getProp("accountAddress", result.accountAddress)
   discard jsonObj.getProp("order", result.order)
   result.showcaseVisibility = jsonObj.toProfileShowcaseVisibility()
 
 proc toJsonNode*(self: ProfileShowcaseCollectiblePreference): JsonNode =
   %* {
-    "uid": self.uid,
+    "chainId": self.chainId,
+    "tokenId": self.tokenId,
+    "contractAddress": self.contractAddress,
+    "communityId": self.communityId,
+    "accountAddress": self.accountAddress,
     "showcaseVisibility": self.showcaseVisibility.int,
     "order": self.order,
   }
 
-proc toProfileShowcaseAssetPreference*(jsonObj: JsonNode): ProfileShowcaseAssetPreference =
-  result = ProfileShowcaseAssetPreference()
+proc toProfileShowcaseVerifiedTokenPreference*(jsonObj: JsonNode): ProfileShowcaseVerifiedTokenPreference =
+  result = ProfileShowcaseVerifiedTokenPreference()
   discard jsonObj.getProp("symbol", result.symbol)
-  discard jsonObj.getProp("contractAddress", result.contractAddress)
   discard jsonObj.getProp("order", result.order)
   result.showcaseVisibility = jsonObj.toProfileShowcaseVisibility()
 
-proc toJsonNode*(self: ProfileShowcaseAssetPreference): JsonNode =
+proc toJsonNode*(self: ProfileShowcaseVerifiedTokenPreference): JsonNode =
   %* {
     "symbol": self.symbol,
+    "showcaseVisibility": self.showcaseVisibility.int,
+    "order": self.order,
+  }
+
+proc toProfileShowcaseUnverifiedTokenPreference*(jsonObj: JsonNode): ProfileShowcaseUnverifiedTokenPreference =
+  result = ProfileShowcaseUnverifiedTokenPreference()
+  discard jsonObj.getProp("contractAddress", result.contractAddress)
+  discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("order", result.order)
+  result.showcaseVisibility = jsonObj.toProfileShowcaseVisibility()
+
+proc toJsonNode*(self: ProfileShowcaseUnverifiedTokenPreference): JsonNode =
+  %* {
     "contractAddress": self.contractAddress,
+    "chainId": self.chainId,
     "showcaseVisibility": self.showcaseVisibility.int,
     "order": self.order,
   }
@@ -116,18 +147,22 @@ proc toProfileShowcasePreferencesDto*(jsonObj: JsonNode): ProfileShowcasePrefere
     result.accounts.add(jsonMsg.toProfileShowcaseAccountPreference())
   for jsonMsg in jsonObj["collectibles"]:
     result.collectibles.add(jsonMsg.toProfileShowcaseCollectiblePreference())
-  for jsonMsg in jsonObj["assets"]:
-    result.assets.add(jsonMsg.toProfileShowcaseAssetPreference())
+  for jsonMsg in jsonObj["verifiedTokens"]:
+    result.verifiedTokens.add(jsonMsg.toProfileShowcaseVerifiedTokenPreference())
+  for jsonMsg in jsonObj["unverifiedTokens"]:
+    result.unverifiedTokens.add(jsonMsg.toProfileShowcaseUnverifiedTokenPreference())
 
 proc toJsonNode*(self: ProfileShowcasePreferencesDto): JsonNode =
   let communities = self.communities.map(entry => entry.toJsonNode())
   let accounts = self.accounts.map(entry => entry.toJsonNode())
   let collectibles = self.collectibles.map(entry => entry.toJsonNode())
-  let assets = self.assets.map(entry => entry.toJsonNode())
+  let verifiedTokens = self.verifiedTokens.map(entry => entry.toJsonNode())
+  let unverifiedTokens = self.unverifiedTokens.map(entry => entry.toJsonNode())
 
   return %*[{
     "communities": communities,
     "accounts": accounts,
     "collectibles": collectibles,
-    "assets": assets,
+    "verifiedTokens": verifiedTokens,
+    "unverifiedTokens": unverifiedTokens
   }]

--- a/src/app_service/service/profile/dto/profile_showcase_preferences.nim
+++ b/src/app_service/service/profile/dto/profile_showcase_preferences.nim
@@ -23,9 +23,9 @@ type ProfileShowcaseAccountPreference* = ref object of RootObj
   order*: int
 
 type ProfileShowcaseCollectiblePreference* = ref object of RootObj
-  chainId*: string
-  tokenId*: string
   contractAddress*: string
+  chainId*: int
+  tokenId*: string
   communityId*: string
   accountAddress*: string
   showcaseVisibility*: ProfileShowcaseVisibility
@@ -38,7 +38,7 @@ type ProfileShowcaseVerifiedTokenPreference* = ref object of RootObj
 
 type ProfileShowcaseUnverifiedTokenPreference* = ref object of RootObj
   contractAddress*: string
-  chainId*: string
+  chainId*: int
   showcaseVisibility*: ProfileShowcaseVisibility
   order*: int
 

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -87,7 +87,7 @@ proc getAccountsByAddresses*(self: Service, addresses: seq[string]): seq[WalletA
       continue
     result.add(acc)
 
-proc getWalletAccounts*(self: Service): seq[WalletAccountDto] =
+proc getWalletAccounts*(self: Service, excludeWatchOnly: bool = false): seq[WalletAccountDto] =
   for _, kp in self.keypairs:
     if kp.keypairType == KeypairTypeProfile:
       for acc in kp.accounts:
@@ -96,7 +96,8 @@ proc getWalletAccounts*(self: Service): seq[WalletAccountDto] =
         result.add(acc)
       continue
     result.add(kp.accounts)
-  result.add(toSeq(self.watchOnlyAccounts.values))
+  if not excludeWatchOnly:
+    result.add(toSeq(self.watchOnlyAccounts.values))
   result.sort(walletAccountsCmp)
 
 proc getWalletAddresses*(self: Service): seq[string] =

--- a/src/app_service/service/wallet_account/service_token.nim
+++ b/src/app_service/service/wallet_account/service_token.nim
@@ -45,6 +45,21 @@ proc getTokensByAddresses*(self: Service, addresses: seq[string]): seq[WalletTok
   result = toSeq(tokens.values)
   result.sort(priorityTokenCmp)
 
+proc getBalancesByChain*(self: Service, accountAddresses: seq[string], tokenAddresses: seq[string]): seq[WalletTokenDto] =
+  try:
+    # NOTE: profile showcase networks should be always all networks
+    let chainIds = self.networkService.getNetworks().map(n => n.chainId)
+
+    let balancesResponse = backend.getBalancesByChain(chainIds, accountAddresses, tokenAddresses)
+    let walletBalanceTable = balanceInfoToTable(balancesResponse.result)
+
+    var result: seq[WalletTokenDto] = @[]
+    # TODO: replace balanceInfoToTable with wallet tokens parsing
+    return result
+
+  except Exception as e:
+    error "error: ", procName="getBalancesByChain", errName = e.name, errDesription = e.msg
+
 proc onAllTokensBuilt*(self: Service, response: string) {.slot.} =
   try:
     let chainIds = self.networkService.getNetworks().map(n => n.chainId)

--- a/src/app_service/service/wallet_account/service_token.nim
+++ b/src/app_service/service/wallet_account/service_token.nim
@@ -45,21 +45,6 @@ proc getTokensByAddresses*(self: Service, addresses: seq[string]): seq[WalletTok
   result = toSeq(tokens.values)
   result.sort(priorityTokenCmp)
 
-proc getBalancesByChain*(self: Service, accountAddresses: seq[string], tokenAddresses: seq[string]): seq[WalletTokenDto] =
-  try:
-    # NOTE: profile showcase networks should be always all networks
-    let chainIds = self.networkService.getNetworks().map(n => n.chainId)
-
-    let balancesResponse = backend.getBalancesByChain(chainIds, accountAddresses, tokenAddresses)
-    let walletBalanceTable = balanceInfoToTable(balancesResponse.result)
-
-    var result: seq[WalletTokenDto] = @[]
-    # TODO: replace balanceInfoToTable with wallet tokens parsing
-    return result
-
-  except Exception as e:
-    error "error: ", procName="getBalancesByChain", errName = e.name, errDesription = e.msg
-
 proc onAllTokensBuilt*(self: Service, response: string) {.slot.} =
   try:
     let chainIds = self.networkService.getNetworks().map(n => n.chainId)

--- a/src/app_service/service/wallet_account/utils.nim
+++ b/src/app_service/service/wallet_account/utils.nim
@@ -102,12 +102,3 @@ proc hasPairedDevices(): bool =
     return response.result.getBool
   except Exception as e:
     error "error: ", errDesription=e.msg
-
-proc balanceInfoToTable(jsonNode: JsonNode): Table[string, UInt256] =
-  for pair in jsonNode.pairs():
-    for pair2 in pair.val.pairs():
-      for pair3 in pair2.val.pairs():
-        let amount = fromHex(UInt256, pair3.val.getStr)
-        if amount != stint.u256(0):
-          result[pair2.key.toUpper] = amount
-        break

--- a/src/app_service/service/wallet_account/utils.nim
+++ b/src/app_service/service/wallet_account/utils.nim
@@ -102,3 +102,12 @@ proc hasPairedDevices(): bool =
     return response.result.getBool
   except Exception as e:
     error "error: ", errDesription=e.msg
+
+proc balanceInfoToTable(jsonNode: JsonNode): Table[string, UInt256] =
+  for pair in jsonNode.pairs():
+    for pair2 in pair.val.pairs():
+      for pair3 in pair2.val.pairs():
+        let amount = fromHex(UInt256, pair3.val.getStr)
+        if amount != stint.u256(0):
+          result[pair2.key.toUpper] = amount
+        break

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAssetsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAssetsPanel.qml
@@ -10,7 +10,7 @@ ProfileShowcasePanel {
     property var formatCurrencyAmount: function(amount, symbol){}
 
     keyRole: "symbol"
-    roleNames: ["symbol", "name", "enabledNetworkBalance", "decimals"].concat(showcaseRoles)
+    roleNames: ["symbol", "name", "address", "communityId", "enabledNetworkBalance", "decimals"].concat(showcaseRoles)
     filterFunc: (modelData) => modelData.symbol !== "" && !showcaseModel.hasItemInShowcase(modelData.symbol)
     hiddenPlaceholderBanner: qsTr("Assets here will show on your profile")
     showcasePlaceholderBanner: qsTr("Assets here will be hidden from your profile")

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCollectiblesPanel.qml
@@ -8,7 +8,7 @@ ProfileShowcasePanel {
     id: root
 
     keyRole: "uid"
-    roleNames: ["uid", "name", "collectionName", "backgroundColor", "imageUrl"].concat(showcaseRoles)
+    roleNames: ["uid", "chainId", "tokenId", "contractAddress", "communityId", "name", "collectionName", "backgroundColor", "imageUrl"].concat(showcaseRoles)
     filterFunc: (modelData) => !showcaseModel.hasItemInShowcase(modelData.uid)
     hiddenPlaceholderBanner: qsTr("Collectibles here will show on your profile")
     showcasePlaceholderBanner: qsTr("Collectibles here will be hidden from your profile")

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -29,6 +29,8 @@ QtObject {
 
     readonly property bool isWalletEnabled: Global.appIsReady? mainModule.sectionsModel.getItemEnabledBySectionType(Constants.appSection.wallet) : true
 
+    readonly property var collectiblesModel: profileModule.collectiblesModel
+
     readonly property var profileShowcaseCommunitiesModel: profileModule.profileShowcaseCommunitiesModel
     readonly property var profileShowcaseAccountsModel: profileModule.profileShowcaseAccountsModel
     readonly property var profileShowcaseCollectiblesModel: profileModule.profileShowcaseCollectiblesModel

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -203,7 +203,6 @@ ColumnLayout {
         StatusTabButton {
             width: implicitWidth
             text: qsTr("Collectibles")
-            enabled: false // TODO: implement collectibles nim part
         }
 
         StatusTabButton {
@@ -240,7 +239,7 @@ ColumnLayout {
             id: profileShowcaseCollectiblesPanel
             Layout.minimumHeight: implicitHeight
             Layout.maximumHeight: implicitHeight
-            baseModel: root.walletStore.collectibles
+            baseModel: root.profileStore.collectiblesModel
             showcaseModel: root.profileStore.profileShowcaseCollectiblesModel
             onShowcaseEntryChanged: hasAnyProfileShowcaseChanges = true
         }
@@ -249,7 +248,7 @@ ColumnLayout {
             id: profileShowcaseAssetsPanel
             Layout.minimumHeight: implicitHeight
             Layout.maximumHeight: implicitHeight
-            baseModel: root.walletAssetsStore.groupedAccountAssetsModel
+            baseModel: root.walletAssetsStore.groupedAccountAssetsModel // TODO: separated model instance from profile section
             showcaseModel: root.profileStore.profileShowcaseAssetsModel
             onShowcaseEntryChanged: hasAnyProfileShowcaseChanges = true
             formatCurrencyAmount: function(amount, symbol) {

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -248,7 +248,7 @@ ColumnLayout {
             id: profileShowcaseAssetsPanel
             Layout.minimumHeight: implicitHeight
             Layout.maximumHeight: implicitHeight
-            baseModel: root.walletAssetsStore.groupedAccountAssetsModel // TODO: separated model instance from profile section
+            baseModel: root.walletAssetsStore.groupedAccountAssetsModel // TODO: instantiate an assets model in profile module
             showcaseModel: root.profileStore.profileShowcaseAssetsModel
             onShowcaseEntryChanged: hasAnyProfileShowcaseChanges = true
             formatCurrencyAmount: function(amount, symbol) {


### PR DESCRIPTION
Close #13073
Waits https://github.com/status-im/status-go/pull/4511

### What does the PR do

- [x] Separate profile showcase assets on verified and unverified tokens
- [x] Implement profile showcase collectibles
- [x] Support status-go changes from https://github.com/status-im/status-go/pull/4511
### Affected areas

ProfileShowcase

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/2522130/018fab85-bebf-4c62-b416-56bce02f0063

