### PR TITLE
chore: add object name for InsertDetailsView

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -21,7 +21,7 @@ import "../shared"
 
 Item {
     id: root
-
+    objectName: "onboardingInsertDetailsView"
     property StartupStore startupStore
 
     property string pubKey


### PR DESCRIPTION
### What does the PR do

Add an object name for `ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml` in onboarding so my tests can access the view easer and hopefully got stuck less often

