### PR TITLE
chore: several object names for permissions tags

### DIFF
--- a/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
+++ b/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
@@ -113,4 +113,4 @@ communityItem_CommunityListItem = {"container": statusDesktop_mainWindow_overlay
 editPermissionView_switchItem_StatusSwitch = {"checkable": True, "container": mainWindow_editPermissionView_EditPermissionView, "id": "switchItem", "type": "StatusSwitch", "unnamed": 1, "visible": True}
 editPermissionView_Create_permission_StatusButton = {"checkable": False, "container": mainWindow_editPermissionView_EditPermissionView, "text": "Create permission", "type": "StatusButton", "unnamed": 1, "visible": True}
 mainWindow_PermissionsView = {"container": mainWindow_StatusWindow, "type": "PermissionsView", "unnamed": 1, "visible": True}
-o_StatusListItemTag = {"container": mainWindow_PermissionsView, "type": "StatusListItemTag", "unnamed": 1, "visible": True}
+o_StatusListItemTag = {"container": mainWindow_PermissionsView, "type": "StatusListItemTag", "visible": True}

--- a/ui/app/AppLayouts/Communities/controls/PermissionItem.qml
+++ b/ui/app/AppLayouts/Communities/controls/PermissionItem.qml
@@ -129,6 +129,7 @@ Control{
                 model: root.holdingsListModel
 
                 StatusListItemTag {
+                    objectName: "whoHoldsStatusListItem"
                     height: d.flowRowHeight
                     width: (implicitWidth > content.width) ? content.width : implicitWidth
                     leftPadding: 2
@@ -188,6 +189,7 @@ Control{
                     spacing: 6
 
                     StatusListItemTag {
+                        objectName: "isAllowedStatusListItem"
                         height: d.flowRowHeight
                         title: PermissionTypes.getName(model.permissionType === PermissionTypes.Type.None
                                                        ? root.permissionType : model.permissionType)
@@ -221,6 +223,7 @@ Control{
                 model: root.channelsListModel
 
                 StatusListItemTag {
+                    objectName: "inCommunityStatusListItem"
                     readonly property bool isLetterIdenticon: !model.imageSource
 
                     asset.isLetterIdenticon: isLetterIdenticon


### PR DESCRIPTION
### What does the PR do

Object names for permission tags

### Affected areas

`ui/app/AppLayouts/Communities/controls/PermissionItem.qml`