### PR TITLE
fix(@desktop/wallet): Create new go API to get token balances without market details so that we are making wasteful api calls to coingecko/cryptocompare

### DIFF
--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -84,6 +84,7 @@ type
     accounts: seq[string]
     storeResult: bool
 
+# TODO:: Clean up once all dependencies are removed
 const prepareTokensTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[BuildTokensTaskArg](argEncoded)
   var output = %*{
@@ -92,6 +93,20 @@ const prepareTokensTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   }
   try:
     let response = backend.getWalletToken(arg.accounts)
+    output["result"] = response.result
+    output["storeResult"] = %* arg.storeResult
+  except Exception as e:
+    let err = fmt"Error getting wallet tokens"
+  arg.finish(output) 
+
+const newPrepareTokensTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[BuildTokensTaskArg](argEncoded)
+  var output = %*{
+    "result": "",
+    "storeResult": false
+  }
+  try:
+    let response = backend.getWalletTokenBalances(arg.accounts)
     output["result"] = response.result
     output["storeResult"] = %* arg.storeResult
   except Exception as e:

--- a/src/app_service/service/wallet_account/service_token_new.nim
+++ b/src/app_service/service/wallet_account/service_token_new.nim
@@ -79,7 +79,7 @@ proc newBuildAllTokens*(self: Service, accounts: seq[string], store: bool) =
   self.events.emit(SIGNAL_WALLET_ACCOUNT_TOKENS_BEING_FETCHED, Args())
 
   let arg = BuildTokensTaskArg(
-    tptr: cast[ByteAddress](prepareTokensTask),
+    tptr: cast[ByteAddress](newPrepareTokensTask),
     vptr: cast[ByteAddress](self.vptr),
     slot: "onNewAllTokensBuilt",
     accounts: accounts,

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -141,6 +141,9 @@ rpc(getTransfersForIdentities, "wallet"):
 rpc(getWalletToken, "wallet"):
   accounts: seq[string]
 
+rpc(getWalletTokenBalances, "wallet"):
+  accounts: seq[string]
+
 rpc(fetchMarketValues, "wallet"):
   symbols: seq[string]
   currency: string


### PR DESCRIPTION
status-go PR: https://github.com/status-im/status-go/pull/4517

fixes #13084

### What does the PR do

Use the new getWalletBalances api to get balanced without making calls to crypto compare/coingecko

### Affected areas

AssetsView.qml 
### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
