### PR TITLE
Fix thumbnail images for quoted message

### DIFF
--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -187,6 +187,15 @@ proc toQuotedMessage*(jsonObj: JsonNode): QuotedMessage =
   var discordMessageObj: JsonNode
   if(jsonObj.getProp("discordMessage", discordMessageObj)):
     result.discordMessage = toDiscordMessage(discordMessageObj)
+  
+  var quotedImagesArr: JsonNode
+  if jsonObj.getProp("albumImages", quotedImagesArr):
+    for element in quotedImagesArr.getElems():
+      if element.getStr() == "":
+        continue
+      result.albumImages.add(element.getStr())
+
+  discard jsonObj.getProp("albumImagesCount", result.albumImagesCount)
 
 proc toSticker*(jsonObj: JsonNode): Sticker =
   result = Sticker()


### PR DESCRIPTION
linked to https://github.com/status-im/status-go/pull/4516

This PR fixes [#12821](https://github.com/status-im/status-desktop/issues/12821)

### What does the PR do

This Pull Request is a continuation on [10986](https://github.com/status-im/status-desktop/issues/10986)

In the earlier version of the Status App, we employed a map associating albums with images to establish a connection between the received images and the corresponding message album. While this approach represented an improvement over the initial state of the application, where no mechanism facilitated the retrieval of quoted images, it faced limitations due to the finite number of messages received. Consequently, a quoted image might not be displayed if the associated message is too old.

The resolution presented in this Pull Request involves adding a field on the download side of the message. This field would part of fields for the quoted message, enabling their direct display in the view. It is essential to note that we intentionally avoid transmitting the images in the upload link to prevent imposing a significant processing and performance overhead on the application. Instead, within status-go, the quoted images are set at a specific stage and subsequently included in the message for the download step, facilitating their presentation in the view.

### Affected areas

- Chat message replies

### Screenshot of functionality (including design for comparison)

[Screencast from 2024-01-03 01:34:09 AM.webm](https://github.com/status-im/status-go/assets/2589171/a0063ed8-1288-4444-b1d3-e3bf33858d46)
