### PR TITLE
Activity dynamic updates integration

### DIFF
--- a/src/app/modules/main/wallet_section/activity/events_handler.nim
+++ b/src/app/modules/main/wallet_section/activity/events_handler.nim
@@ -20,13 +20,7 @@ QtObject:
       eventHandlers: Table[string, EventCallbackProc]
       walletEventHandlers: Table[string, WalletEventCallbackProc]
 
-      # Ignore events older than this relevantTimestamp
-      relevantTimestamp: int
-      subscribedAddresses: HashSet[string]
-      subscribedChainIDs: HashSet[int]
-      newDataAvailableFn: proc()
-
-      requestId: int
+      sessionId: Option[int32]
 
   proc setup(self: EventsHandler) =
     self.QObject.setup
@@ -40,6 +34,9 @@ QtObject:
   proc onFilteringUpdateDone*(self: EventsHandler, handler: EventCallbackProc) =
     self.eventHandlers[backend_activity.eventActivityFilteringUpdate] = handler
 
+  proc onFilteringSessionUpdated*(self: EventsHandler, handler: EventCallbackProc) =
+    self.eventHandlers[backend_activity.eventActivitySessionUpdated] = handler
+
   proc onGetRecipientsDone*(self: EventsHandler, handler: EventCallbackProc) =
     self.eventHandlers[backend_activity.eventActivityGetRecipientsDone] = handler
 
@@ -49,13 +46,10 @@ QtObject:
   proc onGetCollectiblesDone*(self: EventsHandler, handler: EventCallbackProc) =
     self.eventHandlers[backend_activity.eventActivityGetCollectiblesDone] = handler
 
-  proc onNewDataAvailable*(self: EventsHandler, handler: proc()) =
-    self.newDataAvailableFn = handler
-
   proc handleApiEvents(self: EventsHandler, e: Args) =
     var data = WalletSignal(e)
 
-    if data.requestId.isSome and data.requestId.get() != self.requestId:
+    if not data.requestId.isSome() or not self.sessionId.isSome() or data.requestId.get() != self.sessionId.get():
       return
 
     if self.walletEventHandlers.hasKey(data.eventType):
@@ -66,55 +60,13 @@ QtObject:
       let responseJson = parseJson(data.message)
       callback(responseJson)
 
-  proc setupWalletEventHandlers(self: EventsHandler) =
-    let newDataAvailableCallback = proc (data: WalletSignal) =
-      if self.newDataAvailableFn == nil:
-        return
-
-      if data.at > 0 and self.relevantTimestamp > 0 and data.at < self.relevantTimestamp:
-        return
-
-      # Check chain, if any was reported
-      if len(self.subscribedChainIDs) > 0 and data.chainID > 0:
-        var contains = false
-        for chainID in self.subscribedChainIDs:
-          if data.chainID == chainID:
-            contains = true
-            break
-        if not contains:
-          return
-
-      var contains = data.accounts.len == 0
-      # Check addresses if any was reported
-      for address in data.accounts:
-        if address in self.subscribedAddresses:
-          contains = true
-          break
-
-      if not contains:
-        return
-
-      self.newDataAvailableFn()
-
-    # TODO #12120: Replace these specific events with incremental updates events
-    self.walletEventHandlers[EventNewTransfers] = newDataAvailableCallback
-    self.walletEventHandlers[EventPendingTransactionUpdate] = newDataAvailableCallback
-    self.walletEventHandlers[EventMTTransactionUpdate] = newDataAvailableCallback
-
-  proc newEventsHandler*(requestId: int, events: EventEmitter): EventsHandler =
+  proc newEventsHandler*(events: EventEmitter): EventsHandler =
     new(result, delete)
 
     result.events = events
     result.eventHandlers = initTable[string, EventCallbackProc]()
 
-    result.subscribedAddresses = initHashSet[string]()
-    result.subscribedChainIDs = initHashSet[int]()
-
-    result.requestId = requestId
-
     result.setup()
-
-    result.setupWalletEventHandlers()
 
     # Register for wallet events
     let eventsHandler = result
@@ -122,15 +74,15 @@ QtObject:
         eventsHandler.handleApiEvents(e)
     )
 
-  proc updateRelevantTimestamp*(self: EventsHandler, timestamp: int) =
-    self.relevantTimestamp = timestamp
+  proc getSessionId*(self: EventsHandler): int32 =
+    self.sessionId.get(-1)
 
-  proc updateSubscribedAddresses*(self: EventsHandler, addresses: seq[string]) =
-    self.subscribedAddresses.clear()
-    for address in addresses:
-      self.subscribedAddresses.incl(address)
+  proc setSessionId*(self: EventsHandler, sessionId: int32) =
+    self.sessionId = some(sessionId)
 
-  proc updateSubscribedChainIDs*(self: EventsHandler, chainIDs: seq[int]) =
-    self.subscribedChainIDs.clear()
-    for chainID in chainIDs:
-      self.subscribedChainIDs.incl(chainID)
+  proc hasSessionId*(self: EventsHandler): bool =
+    self.sessionId.isSome()
+
+  proc clearSessionId*(self: EventsHandler) =
+    self.sessionId = none(int32)
+

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -111,6 +111,19 @@ QtObject:
 
     return m.getTransactionIdentity().isSome() and d.transaction.isSome() and m.getTransactionIdentity().get() == d.transaction.get()
 
+  proc addNewEntries*(self: Model, newEntries: seq[entry.ActivityEntry], insertPositions: seq[int]) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    for j in countdown(newEntries.high, 0):
+      let ae = newEntries[j]
+      let pos = insertPositions[j]
+      self.beginInsertRows(parentModelIndex, pos, pos)
+      self.entries.insert(ae, pos)
+      self.endInsertRows()
+
+    self.countChanged()
+
   proc updateEntries*(self: Model, updates: seq[backend.Data]) =
     for i in countdown(self.entries.high, 0):
       for j in countdown(updates.high, 0):

--- a/src/app/modules/main/wallet_section/activity/status.nim
+++ b/src/app/modules/main/wallet_section/activity/status.nim
@@ -9,7 +9,7 @@ import backend/activity as backend_activity
 QtObject:
   type
     Status* = ref object of QObject
-      loadingData: Atomic[int]
+      loadingData: bool
       errorCode: backend_activity.ErrorCode
 
       loadingRecipients: Atomic[int]
@@ -36,7 +36,7 @@ QtObject:
   proc loadingDataChanged*(self: Status) {.signal.}
 
   proc setLoadingData*(self: Status, loadingData: bool) =
-    discard fetchAdd(self.loadingData, if loadingData: 1 else: -1)
+    self.loadingData = loadingData
     self.loadingDataChanged()
 
   proc loadingRecipientsChanged*(self: Status) {.signal.}
@@ -72,7 +72,7 @@ QtObject:
     result.setup()
 
   proc getLoadingData*(self: Status): bool {.slot.} =
-    return load(self.loadingData) > 0
+    return self.loadingData
 
   QtProperty[bool] loadingData:
     read = getLoadingData

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -50,11 +50,6 @@ logScope:
 export io_interface
 
 type
-  ActivityID = enum
-    History
-    Temporary0
-    Temporary1
-
   Module* = ref object of io_interface.AccessInterface
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
@@ -145,28 +140,26 @@ proc newModule*(
   result.transactionService = transactionService
   result.activityDetailsController = activity_detailsc.newController(currencyService)
   result.activityController = activityc.newController(
-    int32(ActivityID.History), 
-    result.activityDetailsController, 
+    result.activityDetailsController,
     currencyService,
     tokenService,
-    savedAddressService, 
+    savedAddressService,
     events)
   result.tmpActivityControllers = [
     activityc.newController(
-      int32(ActivityID.Temporary0),
       result.activityDetailsController,
       currencyService,
       tokenService,
       savedAddressService,
       events),
     activityc.newController(
-      int32(ActivityID.Temporary1),
       result.activityDetailsController,
       currencyService,
       tokenService,
       savedAddressService,
       events)
   ]
+
   result.collectibleDetailsController = collectible_detailsc.newController(int32(backend_collectibles.CollectiblesRequestID.WalletAccount), networkService, events)
   result.filter = initFilter(result.controller)
 

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -111,6 +111,13 @@ type
     hash*: string
     address*: string
 
+proc fromJson*(t: JsonNode, T: typedesc[TransactionIdentity]): T {.inline.} =
+  result = TransactionIdentity(
+    chainId: if t.hasKey("chainId"): t["chainId"].getInt() else: 0,
+    hash: if t.hasKey("hash"): t["hash"].getStr() else: "",
+    address: if t.hasKey("address"): t["address"].getStr() else: "",
+  )
+
 proc hash*(ti: TransactionIdentity): Hash =
   var h: Hash = 0
   h = h !& hash(ti.chainId)

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -33,7 +33,6 @@ type
     multiTxType* {.serializedFieldName("type").}: MultiTransactionType
 
 # Mirrors the transfer events from status-go, services/wallet/transfer/commands.go
-const EventNewTransfers*: string = "new-transfers"
 const EventFetchingRecentHistory*: string = "recent-history-fetching"
 const EventRecentHistoryReady*: string = "recent-history-ready"
 const EventFetchingHistoryError*: string = "fetching-history-error"
@@ -41,7 +40,6 @@ const EventNonArchivalNodeDetected*: string = "non-archival-node-detected"
 
 # Mirrors the pending transfer event from status-go, status-go/services/wallet/transfer/transaction.go
 const EventPendingTransactionUpdate*: string = "pending-transaction-update"
-const EventMTTransactionUpdate*: string = "multi-transaction-update"
 
 proc `$`*(self: MultiTransactionDto): string =
   return fmt"""MultiTransactionDto(

--- a/storybook/pages/TransactionDelegatePage.qml
+++ b/storybook/pages/TransactionDelegatePage.qml
@@ -11,6 +11,7 @@ import shared.controls 1.0
 SplitView {
     id: root
 
+    // mirrors ActivityEntry defined in src/app/modules/main/wallet_section/activity/entry.nim
     readonly property QtObject mockupModelData: QtObject {
         readonly property int timestamp: Date.now() / 1000
         readonly property int status: ctrlStatus.currentValue
@@ -38,6 +39,12 @@ SplitView {
         readonly property string chainId: "NETWORKID"
         readonly property string chainIdIn: "NETWORKID-IN"
         readonly property string chainIdOut: "NETWORKID-OUT"
+
+        readonly property bool highlight: _highlight
+        function doneHighlighting() {
+            _highlight = false
+        }
+        property bool _highlight: false
     }
 
     SplitView {
@@ -174,6 +181,13 @@ SplitView {
             Switch {
                 id: ctrlMultiTrans
                 text: "Multi transaction"
+            }
+
+            Button {
+                text: "New transaction"
+                onClicked: {
+                    mockupModelData._highlight = true
+                }
             }
         }
     }

--- a/test/nim/activity_tests.nim
+++ b/test/nim/activity_tests.nim
@@ -1,0 +1,54 @@
+import unittest, json, options
+
+import backend/activity
+
+const testOneNewJsonData = "{\"new\": [{\"pos\": 3, \"entry\": {\"payloadType\": 1, \"id\": 12, \"activityType\": 1, \"activityStatus\": 2, \"timestamp\": 1234567890, \"isNew\": true}}]}"
+const testOneNewJsonDataMissingIsNew = "{\"new\": [{\"pos\": 3, \"entry\": {\"payloadType\": 1, \"id\": 12, \"activityType\": 1, \"activityStatus\": 2, \"timestamp\": 1234567890}}]}"
+const oneRemovedJsonTestData = "{\"removed\":[{\"chainId\": 7, \"hash\": \"0x5\", \"address\": \"0x6\"}]}"
+const testAllSetJsonData = "{\"hasNewOnTop\": true, \"new\": [{\"pos\": 3, \"entry\": {\"payloadType\": 1, \"id\": 12, \"activityType\": 1, \"activityStatus\": 2, \"timestamp\": 1234567890, \"isNew\": true}}], \"removed\":[{\"chainId\": 7, \"hash\": \"0x5\", \"address\": \"0x6\"}]}"
+
+suite "activity filter API json parsing":
+
+  test "just hasNewOnTop":
+    const jsonData = "{\"hasNewOnTop\": true}"
+    let jsonNode = json.parseJson(jsonData)
+
+    let parsed = fromJson(jsonNode, activity.SessionUpdate)
+    check(parsed.hasNewOnTop == true)
+    check(len(parsed.new) == 0)
+
+  test "just new":
+    let jsonNode = json.parseJson(testOneNewJsonData)
+
+    let parsed = fromJson(jsonNode, activity.SessionUpdate)
+    check(len(parsed.new) == 1)
+    let update = parsed.new[0]
+    check(update.pos == 3)
+    check(update.entry.isNew == true)
+    check(update.entry.getMultiTransactionId().get(-1) == 12)
+    check(update.entry.timestamp == 1234567890)
+
+  test "just isNew optional":
+    let jsonNode = json.parseJson(testOneNewJsonDataMissingIsNew)
+
+    let parsed = fromJson(jsonNode, activity.SessionUpdate)
+    check(len(parsed.new) == 1)
+    check(parsed.new[0].entry.isNew == false)
+
+  test "just removed":
+    let jsonNode = json.parseJson(oneRemovedJsonTestData)
+
+    let parsed = fromJson(jsonNode, activity.SessionUpdate)
+    check(len(parsed.removed) == 1)
+    let removed = parsed.removed[0]
+    check(removed.chainId == 7)
+    check(removed.hash == "0x5")
+    check(removed.address == "0x6")
+
+  test "all set":
+    let jsonNode = json.parseJson(testAllSetJsonData)
+
+    let parsed = fromJson(jsonNode, activity.SessionUpdate)
+    check(parsed.hasNewOnTop == true)
+    check(len(parsed.new) == 1)
+    check(len(parsed.removed) == 1)

--- a/test/status-go/integration/helpers/helpers.go
+++ b/test/status-go/integration/helpers/helpers.go
@@ -114,6 +114,7 @@ func WaitForWalletEvents(eventQueue chan GoEvent, eventNames []walletevent.Event
 
 // WaitForWalletEvents waits for the given events to be received on the eventQueue.
 // It returns the wallet events in the order they are received.
+// If a condition is provided, only returning true on the respective call will discard that event.
 func WaitForWalletEventsWithOptionals(eventQueue chan GoEvent, eventNames []walletevent.EventType, timeout time.Duration, condition func(walletEvent *walletevent.Event) bool, optionalEventNames []walletevent.EventType) (walletEvents []*walletevent.Event, err error) {
 	if len(eventNames) == 0 {
 		return nil, errors.New("no event names provided")

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -158,7 +158,7 @@ StatusListItem {
         bgWidth: width + 2
         bgHeight: height + 2
         bgRadius: bgWidth / 2
-        bgColor: Style.current.name === Constants.lightThemeName && Constants.isDefaultTokenIcon(root.tokenImage) ?
+        bgColor: d.lightTheme && Constants.isDefaultTokenIcon(root.tokenImage) ?
                      Theme.palette.white : "transparent"
         color: "transparent"
         isImage: !loading
@@ -174,6 +174,9 @@ StatusListItem {
         property int titlePixelSize: 15
         property int subtitlePixelSize: 13
         property bool showRetryButton: false
+
+        readonly property bool isLightTheme: Style.current.name === Constants.lightThemeName
+        property color animatedBgColor
     }
 
     function getDetailsString(detailsObj) {
@@ -530,6 +533,12 @@ StatusListItem {
     rightPadding: 16
     enabled: !loading
     loading: !isModelDataValid
+    color: {
+        if (bgColorAnimation.running) {
+            return d.animatedBgColor
+        }
+        return sensor.containsMouse ? Theme.palette.baseColor5 : Style.current.transparent
+    }
 
     statusListItemIcon.active: (loading || root.asset.name)
     asset {
@@ -863,4 +872,29 @@ StatusListItem {
             }
         }
     ]
+
+    ColorAnimation {
+        id: bgColorAnimation
+
+        target: d
+        property: "animatedBgColor"
+        from: d.isLightTheme ? "#33869eff" : "#1a4360df"
+        to: "transparent"
+        duration: 1000
+        alwaysRunToEnd: true
+
+        onStopped: {
+            modelData.doneHighlighting()
+        }
+    }
+    // Add a delay before the animation to make it easier to notice when scrolling
+    Timer {
+        id: delayAnimation
+        interval: 250
+        running: root.visible && isModelDataValid && modelData.highlight
+        repeat: false
+        onTriggered: {
+            bgColorAnimation.start()
+        }
+    }
 }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -32,8 +32,8 @@ QtObject {
     property var marketValueStore: TokenMarketValuesStore{}
     property var allNetworks: networksModule.all
 
-    function resetFilter() {
-        walletSectionInst.activityController.updateFilter()
+    function resetActivityData() {
+        walletSectionInst.activityController.resetActivityData()
     }
 
     // TODO remove all these by linking chainId for networks and activity using LeftJoinModel
@@ -160,7 +160,7 @@ QtObject {
         walletSectionInst.activityController.loadMoreItems()
     }
 
-    function updateTransactionFilter() {
+    function updateTransactionFilterIfDirty() {
         if (transactionActivityStatus.isFilterDirty)
             walletSectionInst.activityController.updateFilter()
     }


### PR DESCRIPTION
### Closes #12120

- [x] Depends on status-go change [#4893](https://github.com/status-im/status-go/pull/4893)

Switch the activity filter to use the new session-based API, which provides incremental updates to the current filter. 
Replace the previous method of listening for individual change events with this unified API that delivers all the updates at filter entry level.

The new transactions now activate the "new transactions" button, causing a reset of the current filter and highlighting the top new transactions.

New entries (pulled by downloader) older than the latest visible entries are inserted in the view and highlithed

On all filter clear the updates made while the filter was active are highlighted

#### New transactions (on top)

https://github.com/status-im/status-desktop/assets/47554641/1c997635-2500-4754-846b-dde93162e766

#### New transactions (mixed with existing)

https://github.com/status-im/status-desktop/assets/47554641/f0f0c86e-0078-4817-aad2-ecdd5258bc8a

#### Clean filter updates

https://github.com/status-im/status-desktop/assets/47554641/3a94c006-6906-4600-9d42-94a41b7428d1
