### PR TITLE
chore(general): a simplification of fetching active app chain

### DIFF
--- a/src/app/modules/main/browser_section/provider/controller.nim
+++ b/src/app/modules/main/browser_section/provider/controller.nim
@@ -34,8 +34,8 @@ proc newController*(
 proc delete*(self: Controller) =
   discard
 
-proc getNetwork*(self: Controller): NetworkDto =
-  return self.networkService.getNetworkForBrowser()
+proc getAppNetwork*(self: Controller): NetworkDto =
+  return self.networkService.getAppNetwork()
 
 proc init*(self: Controller) =
   self.events.on(PROVIDER_SIGNAL_ON_POST_MESSAGE) do(e:Args):
@@ -43,7 +43,7 @@ proc init*(self: Controller) =
     self.delegate.onPostMessage(args.payloadMethod, args.result, args.chainId)
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e: Args):
-    self.delegate.updateNetwork(self.getNetwork())
+    self.delegate.updateNetwork(self.getAppNetwork())
 
   self.events.on(SIGNAL_SHARED_KEYCARD_MODULE_USER_AUTHENTICATED) do(e: Args):
     let args = SharedKeycarModuleArgs(e)

--- a/src/app/modules/main/browser_section/provider/module.nim
+++ b/src/app/modules/main/browser_section/provider/module.nim
@@ -49,7 +49,7 @@ method delete*(self: Module) =
 method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("providerModule", self.viewVariant)
   self.view.dappsAddress = self.controller.getDappsAddress()
-  let network = self.controller.getNetwork()
+  let network = self.controller.getAppNetwork()
   self.view.chainId = network.chainId
   self.view.chainName = network.chainName
   self.view.load()

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -480,6 +480,9 @@ proc init*(self: Controller) =
     let args = CommunityTokensDetailsArgs(e)
     self.delegate.onCommunityTokensDetailsLoaded(args.communityId, args.communityTokens, args.communityTokenJsonItems)
 
+  self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e: Args):
+    self.delegate.onAppNetworkChanged()
+
 proc isConnected*(self: Controller): bool =
   return self.nodeService.isConnected()
 
@@ -566,6 +569,9 @@ proc getRemoteDestructedAmount*(self: Controller, chainId: int, contractAddress:
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)
 
+proc getAppNetwork*(self:Controller): NetworkDto =
+  self.networksService.getAppNetwork()
+
 proc slowdownArchivesImport*(self:Controller) =
   communityService.slowdownArchivesImport()
 
@@ -583,4 +589,4 @@ proc asyncGetRevealedAccountsForAllMembers*(self: Controller, communityId: strin
 
 proc asyncReevaluateCommunityMembersPermissions*(self: Controller, communityId: string) =
   self.communityService.asyncReevaluateCommunityMembersPermissions(communityId)
-  
+

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -14,6 +14,7 @@ import app_service/service/token/service as token_service
 import app_service/service/community_tokens/service as community_tokens_service
 import app_service/service/community_tokens/community_collectible_owner
 import app_service/service/shared_urls/service as urls_service
+import app_service/service/network/dto as network_dto
 from app_service/common/types import StatusType, ContractTransactionStatus, MembershipRequestState, Shard
 
 import app/global/app_signals
@@ -40,6 +41,12 @@ method load*(
   gifService: gif_service.Service,
   mailserversService: mailservers_service.Service)
   {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getAppNetwork*(self: AccessInterface): NetworkDto =
+  raise newException(ValueError, "No implementation available")
+
+method onAppNetworkChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method calculateProfileSectionHasNotification*(self: AccessInterface): bool {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -256,6 +256,12 @@ method delete*[T](self: Module[T]) =
   self.view.delete
   self.viewVariant.delete
 
+method getAppNetwork*[T](self: Module[T]): NetworkDto =
+  return self.controller.getAppNetwork()
+
+method onAppNetworkChanged*[T](self: Module[T]) =
+  self.view.emitAppNetworkChangedSignal()
+
 proc createTokenItem[T](self: Module[T], tokenDto: CommunityTokenDto) : token_item.TokenItem =
   let network = self.controller.getNetwork(tokenDto.chainId)
   let tokenOwners = self.controller.getCommunityTokenOwners(tokenDto.communityId, tokenDto.chainId, tokenDto.address)

--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -72,11 +72,8 @@ proc init*(self: Controller) =
       return
     self.delegate.onKeypairAuthenticated(args.password,  args.pin)
 
-proc getChainId*(self: Controller): int =
-  return self.networkService.getChainIdForEns()
-
-proc getNetwork*(self: Controller): NetworkDto =
-  return self.networkService.getNetworkForEns()
+proc getAppNetwork*(self: Controller): NetworkDto =
+  return self.networkService.getAppNetwork()
 
 proc checkEnsUsernameAvailability*(self: Controller, desiredEnsUsername: string, statusDomain: bool) =
   self.ensService.checkEnsUsernameAvailability(desiredEnsUsername, statusDomain)
@@ -121,7 +118,7 @@ proc fixPreferredName*(self: Controller, ignoreCurrentValue: bool = false) =
   if (not ignoreCurrentValue and singletonInstance.userProfile.getPreferredName().len > 0):
     return
   let ensUsernames = self.getAllMyEnsUsernames(false)
-  let currentChainId = self.getNetwork().chainId
+  let currentChainId = self.getAppNetwork().chainId
   var firstEnsName = ""
   for ensUsername in ensUsernames:
     if ensUsername.chainId == currentChainId:

--- a/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
@@ -95,9 +95,6 @@ method getGasEthValue*(self: AccessInterface, gweiValue: string, gasLimit: strin
 method getStatusToken*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getChainIdForEns*(self: AccessInterface): int {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method setPrefferedEnsUsername*(self: AccessInterface, ensUsername: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -39,16 +39,6 @@ QtObject:
     read = getModel
     notify = modelChanged
 
-  proc chainIdChanged*(self: View) {.signal.}
-  proc chainId(self: View): int {.slot.} =
-    return self.delegate.getChainIdForEns()
-  QtProperty[int] chainId:
-    read = chainId
-    notify = chainIdChanged
-
-  proc emitChainIdChanged*(self: View) =
-    self.chainIdChanged()
-
   proc getEnsRegistry(self: View): string {.slot.} =
     return ENS_REGISTRY
 
@@ -142,9 +132,6 @@ QtObject:
 
   proc getStatusToken*(self: View): string {.slot.} =
     return self.delegate.getStatusToken()
-
-  proc getChainIdForEns*(self: View): int {.slot.} =
-    return self.delegate.getChainIdForEns()
 
   proc setPrefferedEnsUsername*(self: View, ensUsername: string) {.slot.} =
     self.delegate.setPrefferedEnsUsername(ensUsername)

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -177,8 +177,8 @@ proc getCurrentCurrency*(self: Controller): string =
 proc getPrice*(self: Controller, crypto: string, fiat: string): float64 =
   return self.tokenService.getTokenPrice(crypto, fiat)
 
-proc getChainIdForStickers*(self: Controller): int =
-  return self.networkService.getNetworkForStickers().chainId
+proc getAppNetwork*(self: Controller): NetworkDto =
+  return self.networkService.getAppNetwork()
 
 proc getStatusToken*(self: Controller): string =
   let token = self.stickerService.getStatusToken()

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -106,9 +106,6 @@ method getGasEthValue*(self: AccessInterface, gweiValue: string, gasLimit: strin
 method getStatusToken*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getChainIdForStickers*(self: AccessInterface): int {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method stickerTransactionConfirmed*(self: AccessInterface, trxType: string, packID: string, transactionHash: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -111,7 +111,7 @@ proc sendBuyingStickersTxWithSignatureAndWatch(self: Module, signature: string) 
     return
 
   let response = self.controller.sendBuyingStickersTxWithSignatureAndWatch(
-    self.getChainIdForStickers(),
+    self.controller.getAppNetwork().chainId,
     self.tmpBuyStickersTransactionDetails.txData,
     self.tmpBuyStickersTransactionDetails.packId,
     signature
@@ -130,9 +130,8 @@ method onKeypairAuthenticated*(self: Module, password: string, pin: string) =
     self.finish(chainId = 0, txHash =  "", error = cancelledRequest)
     return
 
-  let chainId = self.getChainIdForStickers()
   let txDataJson = self.controller.prepareTxForBuyingStickers(
-    chainId,
+    self.controller.getAppNetwork().chainId,
     self.tmpBuyStickersTransactionDetails.packId,
     self.tmpBuyStickersTransactionDetails.address,
     self.tmpBuyStickersTransactionDetails.gas,
@@ -310,9 +309,6 @@ method getGasEthValue*(self: Module, gweiValue: string, gasLimit: string): strin
 
 method getStatusToken*(self: Module): string =
   return self.controller.getStatusToken()
-
-method getChainIdForStickers*(self: Module): int =
-  return self.controller.getChainIdForStickers()
 
 method stickerTransactionConfirmed*(self: Module, trxType: string, packID: string, transactionHash: string) =
   self.view.stickerPacks.updateStickerPackInList(packID, installed = true, pending = false)

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -176,9 +176,6 @@ QtObject:
   proc getSNTBalance*(self: View): string {.slot.} =
     return self.delegate.getSNTBalance()
 
-  proc getChainIdForStickers*(self: View): int {.slot.} =
-    return self.delegate.getChainIdForStickers()
-  
   proc getWalletDefaultAddress*(self: View): string {.slot.} =
     return self.delegate.getWalletDefaultAddress()
 

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -8,6 +8,7 @@ import chat_search_model
 import ephemeral_notification_model
 from app_service/common/conversion import intToEnum
 from app_service/common/types import StatusType
+import app_service/service/network/dto as network_dto
 
 QtObject:
   type
@@ -59,6 +60,16 @@ QtObject:
   proc load*(self: View) =
     # In some point, here, we will setup some exposed main module related things.
     self.delegate.viewDidLoad()
+
+  proc appNetworkChanged*(self: View) {.signal.}
+  proc getAppNetworkId*(self: View): int {.slot.} =
+    return self.delegate.getAppNetwork().chainId
+  QtProperty[int] appNetworkId:
+    read = getAppNetworkId
+    notify = appNetworkChanged
+
+  proc emitAppNetworkChangedSignal*(self: View) =
+    self.appNetworkChanged()
 
   proc editItem*(self: View, item: SectionItem) =
     self.model.editItem(item)

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -88,9 +88,6 @@ method destroyAddAccountPopup*(self: AccessInterface) {.base.} =
 method getNetworkLayer*(self: AccessInterface, chainId: int): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getChainIdForChat*(self: AccessInterface): int {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method getLatestBlockNumber*(self: AccessInterface, chainId: int): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -386,9 +386,6 @@ method onAddAccountModuleLoaded*(self: Module) =
 method getNetworkLayer*(self: Module, chainId: int): string =
   return self.networksModule.getNetworkLayer(chainId)
 
-method getChainIdForChat*(self: Module): int =
-  return self.networksService.getNetworkForChat().chainId
-
 method getLatestBlockNumber*(self: Module, chainId: int): string =
   return self.transactionService.getLatestBlockNumber(chainId)
 

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -160,9 +160,6 @@ QtObject:
   QtProperty[QVariant] tmpActivityController:
     read = getTmpActivityController
 
-  proc getChainIdForChat*(self: View): int {.slot.} =
-    return self.delegate.getChainIdForChat()
-
   proc getLatestBlockNumber*(self: View, chainId: int): string {.slot.} =
     return self.delegate.getLatestBlockNumber(chainId)
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -260,31 +260,31 @@ QtObject:
     var contacts: seq[ContactsDto] = @[]
     for cd in self.contacts.values:
       let dto = cd.dto
-      if dto.id == myPubKey: 
+      if dto.id == myPubKey:
         continue
       case group
       of ContactsGroup.AllKnownContacts:
         contacts.add(dto)
       of ContactsGroup.IncomingPendingContactRequests:
-        if dto.isContactRequestReceived() and 
+        if dto.isContactRequestReceived() and
            not dto.isContactRequestSent() and
            not dto.isContactRemoved() and
            not dto.isReceivedContactRequestRejected() and
            not dto.isBlocked():
           contacts.add(dto)
       of ContactsGroup.OutgoingPendingContactRequests:
-        if dto.isContactRequestSent() and 
-           not dto.isContactRequestReceived() and 
+        if dto.isContactRequestSent() and
+           not dto.isContactRequestReceived() and
            not dto.isContactRemoved() and
            not dto.isBlocked():
           contacts.add(dto)
       of ContactsGroup.IncomingRejectedContactRequests:
-        if dto.isContactRequestReceived() and 
+        if dto.isContactRequestReceived() and
            dto.isReceivedContactRequestRejected() and
            not dto.isBlocked():
           contacts.add(dto)
       of ContactsGroup.OutgoingRejectedContactRequests:
-        # if dto.isContactRequestSent() and 
+        # if dto.isContactRequestSent() and
         #    dto.isSentContactRequestRejected() and
         #    not dto.isBlocked():
         #   contacts.add(dto)
@@ -505,7 +505,7 @@ QtObject:
         else:
           status_contacts.dismissLatestContactRequestForContact(publicKey)
 
-      if not response.error.isNil: 
+      if not response.error.isNil:
         error "error dismissing contact ", msg = response.error.message
         return
 
@@ -577,7 +577,7 @@ QtObject:
       vptr: cast[ByteAddress](self.vptr),
       slot: "ensResolved",
       value: value,
-      chainId: self.networkService.getNetworkForEns().chainId,
+      chainId: self.networkService.getAppNetwork().chainId,
       uuid: uuid,
       reason: reason
     )
@@ -818,7 +818,7 @@ QtObject:
       self.threadpool.start(arg)
     except Exception as e:
       error "Error requesting contact info", msg = e.msg, pubkey
-  
+
   proc shareUserUrlWithData*(self: Service, pubkey: string): string =
     try:
       let response = status_contacts.shareUserUrlWithData(pubkey)

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -105,7 +105,7 @@ QtObject:
     result.tokenService = tokenService
 
   proc getChainId(self: Service): int =
-    return self.networkService.getNetworkForEns().chainId
+    return self.networkService.getAppNetwork().chainId
 
   proc confirmTransaction(self: Service, trxType: string, ensUsername: string, transactionHash: string) =
     let dto = EnsUsernameDto(chainId: self.getChainId(), username: ensUsername)
@@ -307,7 +307,7 @@ QtObject:
       error "error occurred", procName="registerENSGasEstimate", msg = e.msg
 
   proc getStatusToken*(self: Service): TokenDto =
-    let networkDto = self.networkService.getNetworkForEns()
+    let networkDto = self.networkService.getAppNetwork()
     return self.tokenService.findTokenBySymbol(networkDto.chainId, networkDto.sntSymbol())
 
   proc getSNTBalance*(self: Service): string =

--- a/src/app_service/service/network/dto.nim
+++ b/src/app_service/service/network/dto.nim
@@ -3,6 +3,8 @@ import hashes, strformat, json_serialization
 
 import ./types
 
+export types
+
 type NetworkDto* = ref object
   chainId* {.serializedFieldName("chainId").}: int
   nativeCurrencyDecimals* {.serializedFieldName("nativeCurrencyDecimals").}: int

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -56,7 +56,7 @@ QtObject:
         response.result.getElems(),
         proc(x: JsonNode): SavedAddressDto = toSavedAddressDto(x)
       )
-      let chainId = self.networkService.getNetworkForEns().chainId
+      let chainId = self.networkService.getAppNetwork().chainId
       for savedAddress in self.savedAddresses:
         if savedAddress.ens != "":
           try:

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -127,7 +127,7 @@ QtObject:
 
   proc getStickerMarketAddress*(self: Service): string =
     try:
-      let chainId = self.networkService.getNetworkForStickers().chainId
+      let chainId = self.networkService.getAppNetwork().chainId
       let response = status_stickers.stickerMarketAddress(chainId)
       return response.result.getStr()
     except RpcException:
@@ -185,7 +185,7 @@ QtObject:
         self.revertTransaction($PendingTransactionTypeDto.BuyStickerPack, receivedData.data, receivedData.transactionHash)
 
   proc getStatusToken*(self: Service): TokenDto =
-    let networkDto = self.networkService.getNetworkForStickers()
+    let networkDto = self.networkService.getAppNetwork()
     return self.tokenService.findTokenBySymbol(networkDto.chainId, networkDto.sntSymbol())
 
   proc setMarketStickerPacks*(self: Service, strickersJSON: string) {.slot.} =
@@ -221,7 +221,7 @@ QtObject:
     self.events.emit(SIGNAL_ALL_STICKER_PACKS_LOADED, Args())
 
   proc obtainMarketStickerPacks*(self: Service) =
-    let chainId = self.networkService.getNetworkForStickers().chainId
+    let chainId = self.networkService.getAppNetwork().chainId
 
     let arg = ObtainMarketStickerPacksTaskArg(
       tptr: cast[ByteAddress](obtainMarketStickerPacksTask),
@@ -239,7 +239,7 @@ QtObject:
   # definition so we'll need to setup the type, task, and helper outside of body
   # passed to `QtObject:`
   proc estimate*(self: Service, packId: string, address: string, price: string, uuid: string) =
-    let chainId = self.networkService.getNetworkForStickers().chainId
+    let chainId = self.networkService.getAppNetwork().chainId
 
     let arg = EstimateTaskArg(
       tptr: cast[ByteAddress](estimateTask),
@@ -340,7 +340,7 @@ QtObject:
       tptr: cast[ByteAddress](installStickerPackTask),
       vptr: cast[ByteAddress](self.vptr),
       slot: "onStickerPackInstalled",
-      chainId: self.networkService.getNetworkForStickers().chainId,
+      chainId: self.networkService.getAppNetwork().chainId,
       packId: packId,
     )
     self.threadpool.start(arg)
@@ -393,7 +393,7 @@ QtObject:
   proc getSNTBalance*(self: Service): string =
     let token = self.getStatusToken()
     let account = self.walletAccountService.getWalletAccount(0).address
-    let network = self.networkService.getNetworkForStickers()
+    let network = self.networkService.getAppNetwork()
 
     let info = getTokenBalanceForAccount(network.chainId, account, token.address)
     if info.isNone:

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -135,7 +135,7 @@ proc startWallet(self: Service) =
 
 proc init*(self: Service) =
   try:
-    let chainId = self.networkService.getNetworkForEns().chainId
+    let chainId = self.networkService.getAppNetwork().chainId
     let woAccounts = getWatchOnlyAccountsFromDb()
     for acc in woAccounts:
       acc.ens = getEnsName(acc.address, chainId)
@@ -183,7 +183,7 @@ proc init*(self: Service) =
     self.importPartiallyOperableAccounts(args.keyUid, args.password)
 
 proc addNewKeypairsAccountsToLocalStoreAndNotify(self: Service, notify: bool = true) =
-  let chainId = self.networkService.getNetworkForEns().chainId
+  let chainId = self.networkService.getAppNetwork().chainId
   let allLocalAaccounts = self.getWalletAccounts()
   # check if there is new watch only account
   let woAccountsDb = getWatchOnlyAccountsFromDb()
@@ -684,7 +684,7 @@ proc onDerivedAddressesForMnemonicFetched*(self: Service, jsonString: string) {.
   ))
 
 proc fetchDetailsForAddresses*(self: Service, uniqueId: string, addresses: seq[string]) =
-  let network = self.networkService.getNetworkForActivityCheck()
+  let network = self.networkService.getAppNetwork()
   let arg = FetchDetailsForAddressesTaskArg(
     uniqueId: uniqueId,
     chainId: network.chainId,

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -406,10 +406,6 @@ QtObject {
         communitiesModuleInst.joinCommunityOrEditSharedAddresses()
     }
 
-    function getChainIdForChat() {
-        return walletSection.getChainIdForChat()
-    }
-
     function getLatestBlockNumber(chainId) {
         return walletSection.getChainIdForSend(chainId)
     }

--- a/ui/app/AppLayouts/Chat/stores/StickersStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/StickersStore.qml
@@ -65,9 +65,5 @@ QtObject {
             return ""
         return stickersModule.authenticateAndBuy(packId, address, price, gasLimit, gasPrice, tipLimit, overallLimit, eip1559Enabled)
     }
-
-    function getChainIdForStickers() {
-        return stickersModule.getChainIdForStickers()
-    }
 }
 

--- a/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
@@ -20,7 +20,7 @@ QtObject {
     property string pubkey: !!Global.userProfile? Global.userProfile.pubKey : ""
     property string icon: !!Global.userProfile? Global.userProfile.icon : ""
     property string preferredUsername: !!Global.userProfile? Global.userProfile.preferredName : ""
-    readonly property string chainId: ensUsernamesModule.chainId
+    readonly property string chainId: mainModule.appNetworkId
 
     property string username: !!Global.userProfile? Global.userProfile.username : ""
 

--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -50,10 +50,10 @@ QtObject {
 
     readonly property bool noTokenBalanceAvailable: notOnlineWithNoCache || noBlockchainConnectionAndNoCache
 
-    readonly property bool ensNetworkAvailable: !blockchainNetworksDown.includes(profileSectionModule.ensUsernamesModule.chainId.toString())
-    readonly property string ensNetworkUnavailableText: qsTr("Requires POKT/Infura for %1, which is currently unavailable").arg(networksModule.all.getNetworkFullName(profileSectionModule.ensUsernamesModule.chainId))
-    readonly property bool stickersNetworkAvailable: !blockchainNetworksDown.includes(stickersModule.getChainIdForStickers().toString())
-    readonly property string stickersNetworkUnavailableText: qsTr("Requires POKT/Infura for %1, which is currently unavailable").arg(networksModule.all.getNetworkFullName(stickersModule.getChainIdForStickers()))
+    readonly property bool ensNetworkAvailable: !blockchainNetworksDown.includes(mainModule.appNetworkId.toString())
+    readonly property string ensNetworkUnavailableText: qsTr("Requires POKT/Infura for %1, which is currently unavailable").arg(networksModule.all.getNetworkFullName(mainModule.appNetworkId))
+    readonly property bool stickersNetworkAvailable: !blockchainNetworksDown.includes(mainModule.appNetworkId.toString())
+    readonly property string stickersNetworkUnavailableText: qsTr("Requires POKT/Infura for %1, which is currently unavailable").arg(networksModule.all.getNetworkFullName(mainModule.appNetworkId))
 
     function getBlockchainNetworkDownTextForToken(balances) {
         if(!!balances && !networkConnectionModule.blockchainNetworkConnection.completelyDown && !notOnlineWithNoCache) {


### PR DESCRIPTION
The chain we're using for stickers, collectibles, ens names and other similar activities is simply determined by the mode the Status app is operating in and it could be either mainnet or testnet mode. Having that fact in mind we don't need all the calls we were using in the past for fetching explicitly chain id for each of the sections mentioned above and that's simplified with these changes.