### PR TITLE
Fix/13162 send modal collectibles fixes

### DIFF
--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -70,7 +70,7 @@ QtObject:
       traits:{self.traits}
     )"""
 
-  proc getCollectiblUniqueID*(self: CollectiblesEntry): backend.CollectibleUniqueID =
+  proc getCollectibleUniqueID*(self: CollectiblesEntry): backend.CollectibleUniqueID =
     return self.id
 
   proc hasCollectibleData(self: CollectiblesEntry): bool =
@@ -122,9 +122,10 @@ QtObject:
 
   proc nameChanged*(self: CollectiblesEntry) {.signal.}
   proc getName*(self: CollectiblesEntry): string {.slot.} =
-    if not self.hasCollectibleData():
-      return ""
-    return self.data.collectibleData.get().name
+    if self.hasCollectibleData():
+      result = self.data.collectibleData.get().name
+    if result == "":
+      result = "#" & self.getTokenIDAsString() 
 
   QtProperty[string] name:
     read = getName
@@ -205,9 +206,10 @@ QtObject:
 
   proc collectionNameChanged*(self: CollectiblesEntry) {.signal.}
   proc getCollectionName*(self: CollectiblesEntry): string {.slot.} =
-    if not self.hasCollectionData():
-      return ""
-    return self.getCollectionData().name
+    if self.hasCollectionData():
+      result = self.getCollectionData().name
+    if result == "":
+      result = self.getContractAddress()
 
   QtProperty[string] collectionName:
     read = getCollectionName
@@ -244,9 +246,10 @@ QtObject:
 
   proc communityNameChanged*(self: CollectiblesEntry) {.signal.}
   proc getCommunityName*(self: CollectiblesEntry): string {.slot.} =
-    if not self.hasCommunityData():
-      return ""
-    return self.getCommunityData().name
+    if self.hasCommunityData():
+      result = self.getCommunityData().name
+    if result == "":
+      result = self.getCommunityID()
 
   QtProperty[string] communityName:
     read = getCommunityName

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -340,7 +340,7 @@ QtObject:
       let entry = self.items[i]
       for j in countdown(updates.high, 0):
         let update = updates[j]
-        if entry.getCollectiblUniqueID() == update.id:
+        if entry.getCollectibleUniqueID() == update.id:
           entry.updateData(update)
           let index = self.createIndex(i, 0, nil)
           defer: index.delete

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -131,7 +131,7 @@ QtObject:
     return getExtraData(network)
 
   proc processGetOwnedCollectiblesResponse(self: Controller, response: JsonNode) =
-    defer: self.model.setIsFetching(false)
+    self.model.setIsFetching(false)
 
     let res = fromJson(response, backend_collectibles.GetOwnedCollectiblesResponse)
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/13162

The collectibles controller is supposed to load all pages in Autofetch mode. However, "IsFetching" was not properly set to false before attempting to load more items, so the second and later pages were never loaded. This PR fixes that.

Moreover, we now show some non-blank kind of identifying name for Collectibles (TokenID) , Collections (Contract Address) and Communities (CommunityID) when metadata is missing. Ben's working on a design for this scenario, so this should only be a temporary fix.

![image](https://github.com/status-im/status-desktop/assets/11161531/24faa092-5ec9-4531-9fe2-c1ecfd0d3608)

![image](https://github.com/status-im/status-desktop/assets/11161531/a3adfdcd-06d0-4217-aa6d-1b1abc8762de)

