### PR TITLE
fix(wallet): unbreak scrolling of the wallet views

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
@@ -19,15 +19,10 @@ FocusScope {
     property alias headerButton: header.headerButton
     property alias networkFilter: header.networkFilter
 
-    default property Item content
-
-    Component.onCompleted: {
-        content.parent = contentWrapper
-    }
+    default property alias content: contentWrapper.children
 
     ColumnLayout {
-        anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.fill: parent
         spacing: 0
 
         WalletHeader {
@@ -42,6 +37,7 @@ FocusScope {
         Column {
             id: contentWrapper
             Layout.fillWidth: true
+            Layout.fillHeight: true
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -39,7 +39,7 @@ RightTabBaseView {
 
     StackLayout {
         id: stack
-        width: parent.width
+        anchors.fill: parent
 
         Connections {
             target: walletSection


### PR DESCRIPTION
Fixes #13157

### What does the PR do

Set and propagate the correct height for the scrolling to work again

### Affected areas

Wallet/RightTabView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-01-10 10-31-22.webm](https://github.com/status-im/status-desktop/assets/5377645/6f341f86-65fe-4cc1-9da9-c9f5daf1144c)

