### PR TITLE
chore: object names for new settings items in wallet settings

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -143,6 +143,7 @@ Column {
     Separator {}
 
     StatusListItem {
+        objectName: "manageTokensItem"
         title: qsTr("Manage Tokens")
         height: 64
         width: parent.width
@@ -158,6 +159,7 @@ Column {
     Separator {}
 
     StatusListItem {
+        objectName: "savedAddressesItem"
         title: qsTr("Saved Addresses")
         height: 64
         width: parent.width


### PR DESCRIPTION
### What does the PR do

Added object names for new settings items in `ui/app/AppLayouts/Profile/views/wallet/MainView.qml`

### Affected areas

`ui/app/AppLayouts/Profile/views/wallet/MainView.qml`