### PR TITLE
chore: object name for adding saved address in settings

### DIFF
--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -323,6 +323,7 @@ SettingsContentBase {
             id: addNewSavedAddressButtonComponent
 
             StatusButton {
+                objectName: "addNewSavedAddressButton"
                 text: qsTr("Add new address")
                 onClicked: {
                     Global.openAddEditSavedAddressesPopup({})


### PR DESCRIPTION
### What does the PR do

Object name for new button to add saved address from wallet settings

### Affected areas

`ui/app/AppLayouts/Profile/views/WalletView.qml`