### PR TITLE
fix(@wallet): wrong decimal place for market value in assets list

### DIFF
--- a/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
@@ -18,11 +18,14 @@ QtObject:
     self.QObject.delete
 
   proc newMarketDetailsItem*(
-    delegate: io_interface.TokenMarketValuesDataSource, symbol: string): MarketDetailsItem =
+    delegate: io_interface.TokenMarketValuesDataSource, symbol: string
+  ): MarketDetailsItem =
     new(result)
     result.setup()
     result.delegate = delegate
     result.symbol = symbol
+    result.currencyFormat = delegate.getCurrentCurrencyFormat()
+
 
   proc updateCurrencyFormat*(self: MarketDetailsItem) =
     self.currencyFormat = self.delegate.getCurrentCurrencyFormat()


### PR DESCRIPTION
fixes #13152

The response for market data may come before we have the token list