### PR TITLE
feat: Emit notifications when an asset/collectible is hidden in the settings

### DIFF
--- a/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
+++ b/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
@@ -6,6 +6,7 @@ import AppLayouts.Wallet.panels 1.0
 
 import Storybook 1.0
 import Models 1.0
+import utils 1.0
 
 Item {
     id: root
@@ -23,6 +24,12 @@ Item {
             width: 500
             baseModel: collectiblesModel
         }
+    }
+
+    SignalSpy {
+        id: notificationSpy
+        target: Global
+        signalName: "displayToastMessage"
     }
 
     TestCase {
@@ -65,6 +72,8 @@ Item {
 
         function init() {
             controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            controlUnderTest.clearSettings()
+            notificationSpy.clear()
         }
 
         function test_showHideToken() {
@@ -82,9 +91,10 @@ Item {
             const delegate0 = findChild(lvRegular, "manageTokensDelegate-0")
             verify(!!delegate0)
             const title = delegate0.title
+            tryCompare(notificationSpy, "count", 0)
             triggerDelegateMenuAction(lvRegular, 0, "miHideToken")
-
-            verify(controlUnderTest.dirty)
+            // verify the signal to show the notification toast got fired
+            tryCompare(notificationSpy, "count", 1)
 
             // verify we now have +1 hidden and -1 regular tokens after the "hide" operation
             waitForItemPolished(lvHidden)
@@ -107,8 +117,6 @@ Item {
             verify(!!delegateN)
             const titleN = delegateN.title
             compare(title, titleN)
-
-            verify(controlUnderTest.dirty)
         }
 
         function test_showHideCommunityGroup() {
@@ -125,9 +133,10 @@ Item {
 
             // verify we have 2 community collectible groups
             tryCompare(lvCommunityTokenGroups, "count", 3)
+            tryCompare(notificationSpy, "count", 0)
             triggerDelegateMenuAction(lvCommunityTokenGroups, 0, "miHideTokenGroup", true)
-
-            verify(controlUnderTest.dirty)
+            // verify the signal to show the notification toast got fired
+            tryCompare(notificationSpy, "count", 1)
 
             // verify we have one less group
             waitForItemPolished(lvCommunityTokenGroups)
@@ -135,8 +144,6 @@ Item {
             const lvHidden = findChild(controlUnderTest, "lvHiddenTokens")
             verify(!!lvHidden)
             tryCompare(lvHidden, "count", 4) // we've just hidden 4 collectibles coming from this group
-
-            verify(controlUnderTest.dirty)
 
             // verify hidden items are not draggable
             const hiddenToken = findChild(lvHidden, "manageTokensDelegate-0")
@@ -152,21 +159,15 @@ Item {
             waitForItemPolished(lvHidden)
             triggerDelegateMenuAction(lvHidden, 0, "miShowToken")
 
-            verify(controlUnderTest.dirty)
-
             // verify we again have 3 community groups, and one less hidden token
             tryCompare(lvCommunityTokenGroups, "count", 3)
             tryCompare(lvHidden, "count", 3)
-
-            verify(controlUnderTest.dirty)
 
             // now mass show tokens from this group, verify we have 0 hidden tokens and 2 visible groups
             triggerDelegateMenuAction(lvHidden, 0, "miShowTokenGroup")
             waitForItemPolished(lvHidden)
             tryCompare(lvHidden, "count", 0)
             tryCompare(lvCommunityTokenGroups, "count", 3)
-
-            verify(controlUnderTest.dirty)
         }
 
         function test_dnd() {
@@ -258,8 +259,10 @@ Item {
             // find the 2385 delegate from the Bearz group and hide it
             const bear2385DelegateIdx = findDelegateIndexWithTitle(bearzChildLV, "KILLABEAR #2385")
             verify(bear2385DelegateIdx !== -1)
+            tryCompare(notificationSpy, "count", 0)
             triggerDelegateMenuAction(bearzChildLV, bear2385DelegateIdx, "miHideCommunityToken")
-            verify(controlUnderTest.dirty)
+            // verify the signal to show the notification toast got fired
+            tryCompare(notificationSpy, "count", 1)
 
             // verify the hidden section now has 1 item and it's the one we just hid
             const lvHidden = findChild(controlUnderTest, "lvHiddenTokens")
@@ -282,7 +285,8 @@ Item {
             verify(!!pandasChildLV)
             const panda909DelegateIdx = findDelegateIndexWithTitle(pandasChildLV, "Frenly Panda #909")
             triggerDelegateMenuAction(pandasChildLV, panda909DelegateIdx, "miHideCommunityToken")
-            verify(controlUnderTest.dirty)
+            // verify the signal to show the notification toast got fired
+            tryCompare(notificationSpy, "count", 2)
 
             // finally verify that the Bearz group is still at top
             waitForItemPolished(lvCommunityTokenGroups)

--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -16,7 +16,7 @@ class ManageTokensController : public QObject, public QQmlParserStatus
     // input properties
     Q_PROPERTY(QAbstractItemModel* sourceModel READ sourceModel WRITE setSourceModel NOTIFY sourceModelChanged FINAL)
     Q_PROPERTY(QString settingsKey READ settingsKey WRITE setSettingsKey NOTIFY settingsKeyChanged FINAL REQUIRED)
-    Q_PROPERTY(bool arrangeByCommunity READ arrangeByCommunity WRITE setArrangeByCommunity NOTIFY arrangeByCommunityChanged FINAL) // TODO persist in settings
+    Q_PROPERTY(bool arrangeByCommunity READ arrangeByCommunity WRITE setArrangeByCommunity NOTIFY arrangeByCommunityChanged FINAL) // TODO persist in settings?
     // TODO arrangeByCollection for collectibles
 
     // output properties
@@ -57,6 +57,12 @@ signals:
     void arrangeByCommunityChanged();
     void settingsKeyChanged();
     void settingsDirtyChanged(bool dirty);
+
+    void tokenHidden(const QString& symbol, const QString& name);
+    void tokenShown(const QString& symbol, const QString& name);
+    void communityTokenGroupHidden(const QString& communityName);
+    void communityTokenGroupShown(const QString& communityName);
+    // TODO collectionTokenGroupHidden(const QString& collectionName);
 
 private:
     QAbstractItemModel* m_sourceModel{nullptr};

--- a/ui/StatusQ/src/wallet/managetokensmodel.cpp
+++ b/ui/StatusQ/src/wallet/managetokensmodel.cpp
@@ -36,7 +36,6 @@ void ManageTokensModel::addItem(const TokenData& item, bool append)
     beginInsertRows({}, destRow, destRow);
     append ? m_data.append(item) : m_data.prepend(item);
     endInsertRows();
-    setDirty(true);
 }
 
 std::optional<TokenData> ManageTokensModel::takeItem(int row)
@@ -47,7 +46,6 @@ std::optional<TokenData> ManageTokensModel::takeItem(int row)
     beginRemoveRows({}, row, row);
     auto res = m_data.takeAt(row);
     endRemoveRows();
-    setDirty(true);
     return res;
 }
 
@@ -72,7 +70,6 @@ QList<TokenData> ManageTokensModel::takeAllItems(const QString& communityId)
         endRemoveRows();
     }
 
-    setDirty(true);
     return result;
 }
 

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
@@ -94,9 +94,17 @@ DropArea {
                 isCommunityAsset: !!model.communityId
                 isCollectible: root.isCollectible
                 onMoveRequested: (from, to) => root.ListView.view.model.moveItem(from, to)
-                onShowHideRequested: (index, flag) => isCommunityAsset ? root.controller.showHideCommunityToken(index, flag)
-                                                                       : root.controller.showHideRegularToken(index, flag)
-                onShowHideGroupRequested: (groupId, flag) => root.controller.showHideGroup(groupId, flag)
+                onShowHideRequested: function(index, flag) {
+                    if (isCommunityAsset)
+                        root.controller.showHideCommunityToken(index, flag)
+                    else
+                        root.controller.showHideRegularToken(index, flag)
+                    root.controller.saveSettings()
+                }
+                onShowHideGroupRequested: function(groupId, flag) {
+                    root.controller.showHideGroup(groupId, flag)
+                    root.controller.saveSettings()
+                }
             }
         ]
     }

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensGroupDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensGroupDelegate.qml
@@ -116,7 +116,10 @@ DropArea {
                     isCollectible: root.isCollectible
                     groupId: model.communityId
                     onMoveRequested: (from, to) => root.controller.communityTokenGroupsModel.moveItem(from, to) // TODO collection
-                    onShowHideGroupRequested: (groupId, flag) => root.controller.showHideGroup(groupId, flag)
+                    onShowHideGroupRequested: function(groupId, flag) {
+                        root.controller.showHideGroup(groupId, flag)
+                        root.controller.saveSettings()
+                    }
                 }
             }
 

--- a/ui/app/AppLayouts/Wallet/panels/ManageAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageAssetsPanel.qml
@@ -44,6 +44,12 @@ Control {
             sourceModel: root.baseModel
             arrangeByCommunity: switchArrangeByCommunity.checked
             settingsKey: "WalletAssets"
+            onTokenHidden: (symbol, name) => Global.displayToastMessage(
+                               qsTr("%1 (%2) was successfully hidden.").arg(name).arg(symbol), "", "checkmark-circle",
+                               false, Constants.ephemeralNotificationType.success, "")
+            onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(
+                                             qsTr("%1 community assets successfully hidden").arg(communityName), "", "checkmark-circle",
+                                             false, Constants.ephemeralNotificationType.success, "")
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/panels/ManageCollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageCollectiblesPanel.qml
@@ -58,6 +58,12 @@ Control {
             sourceModel: d.renamedModel
             arrangeByCommunity: switchArrangeByCommunity.checked
             settingsKey: "WalletCollectibles"
+            onTokenHidden: (symbol, name) => Global.displayToastMessage(
+                               qsTr("%1 was successfully hidden.").arg(name), "", "checkmark-circle",
+                               false, Constants.ephemeralNotificationType.success, "")
+            onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(
+                                             qsTr("%1 community collectibles successfully hidden").arg(communityName), "", "checkmark-circle",
+                                             false, Constants.ephemeralNotificationType.success, "")
         }
     }
 


### PR DESCRIPTION
- emit the signal from the backend
- trigger the toast notification in QML
- update the test(s)

Fixes #12704

### What does the PR do

Emit a toast notification when an asset/collectible is hidden in the Manage tokens settings

### Affected areas

Settings/Wallet/Manage tokens

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/e84259a2-3eb5-4800-93b2-7b6a6242479e)

