### PR TITLE
fix(communities): make users module always use channels members

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -46,19 +46,6 @@ proc newController*(
 proc delete*(self: Controller) =
   self.events.disconnect()
 
-proc handleCommunityOnlyConnections(self: Controller) =
-  self.events.on(SIGNAL_COMMUNITY_MEMBER_APPROVED) do(e: Args):
-    let args = CommunityMemberArgs(e)
-    if (args.communityId == self.sectionId):
-      self.delegate.onChatMembersAdded(@[args.pubKey])
-
-  self.events.on(SIGNAL_COMMUNITY_MEMBERS_CHANGED) do(e:Args):
-    let args = CommunityMembersArgs(e)
-    if args.communityId != self.sectionId:
-      return
-
-    self.delegate.onMembersChanged(args.members)
-
 proc init*(self: Controller) =
   # Events that are needed for all chats because of mentions
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
@@ -124,10 +111,6 @@ proc init*(self: Controller) =
       let args = ChatMemberUpdatedArgs(e)
       if (args.chatId == self.chatId):
         self.delegate.onChatMemberUpdated(args.id, args.role, args.joined)
-
-    # Events only for community channel
-    if (self.belongsToCommunity):
-      self.handleCommunityOnlyConnections()
 
 proc belongsToCommunity*(self: Controller): bool =
   self.belongsToCommunity

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -629,7 +629,7 @@ QtObject:
             self.chatService.updateChannelMembers(chat)
 
       # members list was changed
-      if (community.isMember or community.tokenPermissions.len == 0) and community.members != prev_community.members:
+      if community.members != prev_community.members:
         self.events.emit(SIGNAL_COMMUNITY_MEMBERS_CHANGED,
         CommunityMembersArgs(communityId: community.id, members: community.members))
 


### PR DESCRIPTION
This fixes members list of the channels. The conficting signal, `SIGNAL_COMMUNITY_MEMBERS_CHANGED`, was causing it to always show all members.

As a consequence, it enables mentioning only members of a given channel.

closes: #12384


https://github.com/status-im/status-desktop/assets/33099791/c543e938-a373-4ce6-8ec5-5cf0541de7f3

