### PR TITLE
(fix/desktop) removing custom picture is not reflected on contact's side

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -1,6 +1,7 @@
 import NimQml, strutils, uri, strformat, strutils, stint, re
 import stew/byteutils
 import ./utils/qrcodegen
+import ./utils/time_utils
 
 # Services as instances shouldn't be used in this class, just some general/global procs
 import ../../app_service/common/conversion
@@ -175,3 +176,6 @@ QtObject:
     if value.startsWith("0x"):
       return value[2..^1]
     return value
+
+  proc addTimestampToURL*(self: Utils, url: string): string {.slot.} =
+    return time_utils.addTimestampToURL(url)

--- a/src/app/global/utils/time_utils.nim
+++ b/src/app/global/utils/time_utils.nim
@@ -1,0 +1,12 @@
+import times
+
+proc addTimestampToURL*(url: string): string =
+  if url.len == 0:
+    return ""
+
+  let timestamp = epochTime()
+
+  if '?' in url:
+    return url & "&timestamp=" & $timestamp
+  else:
+    return url & "?timestamp=" & $timestamp

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, uuids, sets, times, tables
+import NimQml, chronicles, sequtils, uuids, sets, times, tables, strutils, system
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller
@@ -17,6 +17,8 @@ import ../../../../../../app_service/service/message/service as message_service
 import ../../../../../../app_service/service/mailservers/service as mailservers_service
 import ../../../../../../app_service/service/shared_urls/service as shared_urls_service
 import ../../../../../../app_service/common/types
+import ../../../../../global/utils as utils
+import ../../../../../global/global_singleton
 
 export io_interface
 
@@ -533,11 +535,13 @@ method getNumberOfPinnedMessages*(self: Module): int =
 
 method updateContactDetails*(self: Module, contactId: string) =
   let updatedContact = self.controller.getContactDetails(contactId)
+
+  let updatedSenderIcon = singletonInstance.utils().addTimestampToURL(updatedContact.icon)
   for item in self.view.model().modelContactUpdateIterator(contactId):
     if item.senderId == contactId:
       item.senderDisplayName = updatedContact.defaultDisplayName
       item.senderOptionalName = updatedContact.optionalName
-      item.senderIcon = updatedContact.icon
+      item.senderIcon = updatedSenderIcon
       item.senderColorHash = updatedContact.colorHash
       item.senderIsAdded = updatedContact.dto.added
       item.senderTrustStatus = updatedContact.dto.trustStatus
@@ -546,7 +550,7 @@ method updateContactDetails*(self: Module, contactId: string) =
     if item.quotedMessageAuthorDetails.dto.id == contactId:
       item.quotedMessageAuthorDetails = updatedContact
       item.quotedMessageAuthorDisplayName = updatedContact.defaultDisplayName
-      item.quotedMessageAuthorAvatar = updatedContact.icon
+      item.quotedMessageAuthorAvatar = updatedSenderIcon
 
     if item.messageContainsMentions and item.mentionedUsersPks.anyIt(it == contactId):
       let communityChats = self.controller.getCommunityDetails().chats

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -1,8 +1,10 @@
-import NimQml, Tables, strutils, strformat, json, sequtils
+import NimQml, Tables, strutils, strformat, json, sequtils, times, system
 import ../../../../app_service/common/types
 import ../../../../app_service/service/chat/dto/chat
 from ../../../../app_service/service/contacts/dto/contacts import TrustStatus
 import item
+import ../../../global/utils as utils
+import ../../../global/global_singleton
 
 type
   ModelRole {.pure.} = enum
@@ -345,7 +347,10 @@ QtObject:
     if index == -1:
       return
     self.items[index].name = name
-    self.items[index].icon = icon
+
+    var updatedIcon = singletonInstance.utils().addTimestampToURL(icon)
+
+    self.items[index].icon = updatedIcon
     self.items[index].trustStatus = trustStatus
     let modelIndex = self.createIndex(index, 0, nil)
     defer: modelIndex.delete

--- a/test/nim/utils_test.nim
+++ b/test/nim/utils_test.nim
@@ -1,0 +1,28 @@
+import unittest, strutils
+
+import app/global/utils/time_utils
+
+suite "adding timestamp to url":
+  test "adding timestamp to an image url with query containing ?":
+    let url = "https://Localhost:35651/contactImages?imageName=thumbnail?publicKey=0x04d76f84ec"
+    let result = time_utils.addTimestampToURL(url)
+
+    check(result.startsWith(url & "&timestamp="))
+
+  test "adding timestamp to an image url with query containing &":
+    let url = "https://Localhost:35651/contactImages&imageName=thumbnail&publicKey=0x04d76f84e8dc"
+    let result = time_utils.addTimestampToURL(url)
+
+    check(result.startsWith(url & "?timestamp="))
+
+  test "image contains a mix of & and ? queries, & is added":
+    let url = "https://Localhost:35651/contactImages?imageName=thumbnail&publicKey=0x04d76f84e8dc"
+    let result = time_utils.addTimestampToURL(url)
+
+    check(result.startsWith(url & "&timestamp="))
+
+  test "adding timestamp to an empty image url":
+    let result = time_utils.addTimestampToURL("")
+
+    let expectedResult = ""
+    check(result == expectedResult)

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -264,6 +264,7 @@ Item {
 
         StatusChatInfoButton {
             readonly property string emojiIcon: chatContentModule? chatContentModule.chatDetails.emoji : "" // Needed for test
+            readonly property string assetName: chatContentModule && Utils.addTimestampToURL(chatContentModule.chatDetails.icon)
 
             objectName: "chatInfoBtnInHeader"
             title: chatContentModule? chatContentModule.chatDetails.name : ""
@@ -283,7 +284,7 @@ Item {
                     return ""
                 }
             }
-            asset.name: chatContentModule? chatContentModule.chatDetails.icon : ""
+            asset.name: assetName
             asset.isImage: chatContentModule && chatContentModule.chatDetails.icon !== ""
             asset.isLetterIdenticon: chatContentModule && chatContentModule.chatDetails.icon === ""
             ringSettings.ringSpecModel: chatContentModule && chatContentModule.chatDetails.type === Constants.chatType.oneToOne ?

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -278,7 +278,7 @@ Pane {
                                  : d.mainDisplayName
                 pubkey: root.publicKey
                 image: root.dirty ? root.dirtyValues.profileLargeImage
-                                  : d.contactDetails.largeImage
+                                  : Utils.addTimestampToURL(d.contactDetails.largeImage)
                 interactive: false
                 imageWidth: 80
                 imageHeight: imageWidth

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -938,4 +938,8 @@ QtObject {
     function isPunct(c) {
         return /(!|\@|#|\$|%|\^|&|\*|\(|\)|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)
     }
+
+    function addTimestampToURL(url) {
+        return globalUtilsInst.addTimestampToURL(url)
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes [9947](https://github.com/status-im/status-desktop/issues/9947) and contains : 

- Commit to fix the changing of custom picture and having the change reflected on contact's side
- Commit to fix the deleting of picture and having the change reflected on contact's side

-------

### Design decisions :

Previously, the inconsistency in reflecting profile picture changes occurred due to a bug tied to the design choice for generating and serving images through URLs. Upon uploading an image, status-go generates an image and saves a URL link. The observed issue was that even after changing the profile image, the URL remained the same. Although the backend correctly associated the URL with the newly uploaded image, Qt/QML failed to update the value accordingly.

### Possible solutions :

- **[Preferred - Implemented]** Using the same link but with subtle parameter to help Qt/Qml update the underlying values
   - This approach adds a silent parameter (Timestamp)
   - It helps version the image in a way
   - It's not breaking the current design and is invisible to the view
  
- Generating different image URL links for each images
   - While this approach looks ideal, it's resource intensive
   - It represents a breaking change for the Status App
   - It requires some dive deep to understand the impact

-------

### Affected areas

- Chat, Image URL generation, Contact Profile updating

### Screenshot of functionality (including design for comparison)

[profile updates.webm](https://github.com/status-im/status-go/assets/2589171/60a24da8-3ff2-4efa-8d6f-b52f845c4e05)
