### PR TITLE
fix(@deaktop/wallet): Slowness when switching accounts

### DIFF
--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
 
 import utils 1.0
 
@@ -59,7 +60,7 @@ QtObject {
         if(!!balances && !networkConnectionModule.blockchainNetworkConnection.completelyDown && !notOnlineWithNoCache) {
             let chainIdsDown = []
             for (var i =0; i<balances.count; i++) {
-                let chainId = balances.get(i, "chainId")
+                let chainId = ModelUtils.get(i, "chainId")
                 if(blockchainNetworksDown.includes(chainId))
                     chainIdsDown.push(chainId)
             }


### PR DESCRIPTION
fixes #13136

### What does the PR do

This PR is trying to achieving better performance when switching tabs in AssetsView. 
This lag is seen specifically on windows OS.

This change improves the peformance but we still a seconds delay which will be discussed further in the Token Management offsite.

### Affected areas

AssetsView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Behvaior after changes as seen on Anthonys machine

https://github.com/status-im/status-desktop/assets/60327365/1421a729-eb4e-4b84-9d9e-5f176993c5c4
