### PR TITLE
Update new assets in profile

### DIFF
--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_asset_item.nim
@@ -18,6 +18,7 @@ type
     name*: string
     enabledNetworkBalance*: CurrencyAmount
     color*: string
+    decimals*: int
 
 proc initProfileShowcaseAssetItem*(token: WalletTokenDto, visibility: ProfileShowcaseVisibility, order: int): ProfileShowcaseAssetItem =
   result = ProfileShowcaseAssetItem()
@@ -29,6 +30,7 @@ proc initProfileShowcaseAssetItem*(token: WalletTokenDto, visibility: ProfileSho
   result.name = token.name
   result.enabledNetworkBalance = newCurrencyAmount(token.getTotalBalanceOfSupportedChains(), token.symbol, token.decimals, false)
   result.color = token.color
+  result.decimals = token.decimals
 
 proc toProfileShowcaseAssetItem*(jsonObj: JsonNode): ProfileShowcaseAssetItem =
   result = ProfileShowcaseAssetItem()
@@ -43,8 +45,9 @@ proc toProfileShowcaseAssetItem*(jsonObj: JsonNode): ProfileShowcaseAssetItem =
   discard jsonObj.getProp("symbol", result.symbol)
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("color", result.color)
+  discard jsonObj.getProp("decimals", result.decimals)
 
-  result.enabledNetworkBalance = jsonObj{"enabledNetworkBalance"}.toCurrencyAmount()
+  result.enabledNetworkBalance = newCurrencyAmount(jsonObj{"enabledNetworkBalance"}.getFloat, result.symbol, result.decimals, false)
 
 proc toShowcasePreferenceItem*(self: ProfileShowcaseAssetItem): ProfileShowcaseAssetPreference =
   result = ProfileShowcaseAssetPreference()

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
@@ -12,6 +12,7 @@ type
     Name
     EnabledNetworkBalance
     Color
+    Decimals
 
 QtObject:
   type
@@ -55,6 +56,7 @@ QtObject:
       ModelRole.Name.int: "name",
       ModelRole.EnabledNetworkBalance.int: "enabledNetworkBalance",
       ModelRole.Color.int: "color",
+      ModelRole.Decimals.int: "decimals",
     }.toTable
 
   method data(self: ProfileShowcaseAssetsModel, index: QModelIndex, role: int): QVariant =
@@ -80,6 +82,8 @@ QtObject:
       result = newQVariant(item.enabledNetworkBalance)
     of ModelRole.Color:
       result = newQVariant(item.color)
+    of ModelRole.Decimals:
+      result = newQVariant(item.decimals)
 
   proc findIndexForAsset(self: ProfileShowcaseAssetsModel, symbol: string): int =
     for i in 0 ..< self.items.len:
@@ -120,6 +124,7 @@ QtObject:
         ModelRole.Name.int,
         ModelRole.EnabledNetworkBalance.int,
         ModelRole.Color.int,
+        ModelRole.Decimals.int,
       ])
 
   proc upsertItemJson(self: ProfileShowcaseAssetsModel, itemJson: string) {.slot.} =

--- a/storybook/pages/ProfileShowcaseAssetsPanelPage.qml
+++ b/storybook/pages/ProfileShowcaseAssetsPanelPage.qml
@@ -13,6 +13,8 @@ import utils 1.0
 import Storybook 1.0
 import Models 1.0
 
+import AppLayouts.Wallet.stores 1.0
+
 SplitView {
     id: root
 
@@ -26,63 +28,8 @@ SplitView {
         communityTokensStore: CommunityTokensStore {}
     }
 
-    ListModel {
-        id: assetsModel
-
-        readonly property var data: [
-            {
-                name: "Decentraland",
-                symbol: "MANA",
-                enabledNetworkBalance: {
-                    amount: 301,
-                    symbol: "MANA"
-                },
-                changePct24hour: -2.1,
-            },
-            {
-                name: "Ave Maria",
-                symbol: "AAVE",
-                enabledNetworkBalance: {
-                    amount: 23.3,
-                    symbol: "AAVE"
-                },
-                changePct24hour: 4.56,
-            },
-            {
-                name: "Polymorphism",
-                symbol: "POLY",
-                enabledNetworkBalance: {
-                    amount: 3590,
-                    symbol: "POLY"
-                },
-                changePct24hour: -11.6789,
-            },
-            {
-                name: "Common DDT",
-                symbol: "CDT",
-                enabledNetworkBalance: {
-                    amount: 1000,
-                    symbol: "CDT"
-                },
-                changePct24hour: 0,
-            },
-            {
-                name: "Makers' choice",
-                symbol: "MKR",
-                enabledNetworkBalance: {
-                    amount: 1.3,
-                    symbol: "MKR"
-                },
-                changePct24hour: -1,
-            },
-            {
-                name: "GetOuttaHere",
-                symbol: "InvisibleHere",
-                enabledNetworkBalance: {},
-                changePct24hour: 0,
-            }
-        ]
-        Component.onCompleted: append(data)
+    readonly property WalletAssetsStore walletAssetStore: WalletAssetsStore {
+        assetsWithFilteredBalances: walletAssetStore.groupedAccountsAssetsModel
     }
 
     ListModel {
@@ -126,8 +73,14 @@ SplitView {
         ProfileShowcaseAssetsPanel {
             id: showcasePanel
             width: 500
-            baseModel: assetsModel
+            baseModel: walletAssetStore.groupedAccountAssetsModel
             showcaseModel: inShowcaseAssetsModel
+            formatCurrencyAmount: function (amount, symbol) {
+                return ({amount: amount,
+                                     symbol: symbol.toUpperCase(),
+                                     displayDecimals: 4,
+                                     stripTrailingZeroes: false})
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -34,6 +34,8 @@ StatusSectionLayout {
     property var networkConnectionStore
     required property TokensStore tokensStore
     required property TransactionStore transactionStore
+    required property WalletAssetsStore walletAssetsStore
+    required property SharedStores.CurrenciesStore currencyStore
 
     backButtonName: root.store.backButtonName
     notificationCount: activityCenterStore.unreadNotificationsCount
@@ -124,6 +126,8 @@ StatusSectionLayout {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
 
+                walletAssetsStore: root.walletAssetsStore
+                currencyStore: root.currencyStore
                 walletStore: root.store.walletStore
                 profileStore: root.store.profileStore
                 privacyStore: root.store.privacyStore

--- a/ui/app/AppLayouts/Profile/controls/AssetShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/AssetShowcaseDelegate.qml
@@ -1,12 +1,26 @@
 import QtQuick 2.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 
 import utils 1.0
 
 ShowcaseDelegate {
+    id: root
+
+    property var formatCurrencyAmount: function(amount, symbol){}
+    property double totalValue: !!showcaseObj && !!showcaseObj.decimals ? balancesAggregator.value/(10 ** showcaseObj.decimals): 0
+
     title: !!showcaseObj && !!showcaseObj.name ? showcaseObj.name : ""
-    secondaryTitle: !!showcaseObj ? LocaleUtils.currencyAmountToLocaleString(showcaseObj.enabledNetworkBalance) : Qt.locale().zeroDigit
+    secondaryTitle: !!showcaseObj && !!showcaseObj.enabledNetworkBalance ?
+                       LocaleUtils.currencyAmountToLocaleString(showcaseObj.enabledNetworkBalance) :
+                       !!showcaseObj && !!showcaseObj.symbol ? formatCurrencyAmount(totalValue, showcaseObj.symbol): Qt.locale().zeroDigit
     hasImage: true
     icon.source: !!showcaseObj ? Constants.tokenIcon(showcaseObj.symbol) : ""
+
+    SumAggregator {
+        id: balancesAggregator
+        model: !!showcaseObj && !!showcaseObj.balances ? showcaseObj.balances: null
+        roleName: "balance"
+    }
 }

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAssetsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAssetsPanel.qml
@@ -7,8 +7,10 @@ import AppLayouts.Profile.controls 1.0
 ProfileShowcasePanel {
     id: root
 
+    property var formatCurrencyAmount: function(amount, symbol){}
+
     keyRole: "symbol"
-    roleNames: ["symbol", "name", "enabledNetworkBalance"].concat(showcaseRoles)
+    roleNames: ["symbol", "name", "enabledNetworkBalance", "decimals"].concat(showcaseRoles)
     filterFunc: (modelData) => modelData.symbol !== "" && !showcaseModel.hasItemInShowcase(modelData.symbol)
     hiddenPlaceholderBanner: qsTr("Assets here will show on your profile")
     showcasePlaceholderBanner: qsTr("Assets here will be hidden from your profile")
@@ -18,6 +20,9 @@ ProfileShowcasePanel {
         showcaseObj: modelData
         dragParent: dragParentData
         visualIndex: visualIndexData
+        formatCurrencyAmount: function(amount, symbol) {
+            return root.formatCurrencyAmount(amount, symbol)
+        }
         onShowcaseVisibilityRequested: {
             var tmpObj = Object()
             root.roleNames.forEach(role => tmpObj[role] = showcaseObj[role])

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -80,6 +80,11 @@ Control {
                 onDropped: function(drop) {
                     var showcaseObj = drop.source.showcaseObj
 
+                    // need to set total balance for an asset
+                    if (drop.source.totalValue !== undefined) {
+                        showcaseObj.enabledNetworkBalance = drop.source.totalValue
+                    }
+
                     var tmpObj = Object()
                     root.roleNames.forEach(role => tmpObj[role] = showcaseObj[role])
                     tmpObj.showcaseVisibility = visibilityDropAreaLocal.showcaseVisibility

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -25,7 +25,6 @@ QtObject {
     }
     // TODO(alaibe): there should be no access to wallet section, create collectible in profile
     property var overview: walletSectionOverview
-    property var assets: walletSectionAssets.assets
     property var accounts: Global.appIsReady? accountsModule.accounts : null
     property var originModel: accountsModule.keyPairModel
 

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -6,6 +6,7 @@ import utils 1.0
 import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
+import shared.stores 1.0
 import shared.controls.chat 1.0
 
 import "../popups"
@@ -18,6 +19,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
+import AppLayouts.Wallet.stores 1.0
+
 SettingsContentBase {
     id: root
 
@@ -25,6 +28,9 @@ SettingsContentBase {
     property ProfileStore profileStore
     property PrivacyStore privacyStore
     property ContactsStore contactsStore
+    required property WalletAssetsStore walletAssetsStore
+    required property CurrenciesStore currencyStore
+
     property var communitiesModel
 
     titleRowComponentLoader.sourceComponent: StatusButton {
@@ -75,6 +81,8 @@ SettingsContentBase {
                 privacyStore: root.privacyStore
                 walletStore: root.walletStore
                 communitiesModel: root.communitiesModel
+                walletAssetsStore: root.walletAssetsStore
+                currencyStore: root.currencyStore
 
                 onVisibleChanged: if (visible) stackLayout.Layout.preferredHeight = settingsView.implicitHeight
                 Component.onCompleted: stackLayout.Layout.preferredHeight = Qt.binding(() => settingsView.implicitHeight)

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.13
 
 import utils 1.0
 import shared 1.0
+import shared.stores 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 import shared.controls.chat 1.0
@@ -18,6 +19,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
+import AppLayouts.Wallet.stores 1.0
+
 ColumnLayout {
     id: root
 
@@ -26,6 +29,8 @@ ColumnLayout {
     property PrivacyStore privacyStore
     property ProfileStore profileStore
     property WalletStore walletStore
+    required property WalletAssetsStore walletAssetsStore
+    required property CurrenciesStore currencyStore
     property var communitiesModel
 
     property bool hasAnyProfileShowcaseChanges: false
@@ -244,9 +249,12 @@ ColumnLayout {
             id: profileShowcaseAssetsPanel
             Layout.minimumHeight: implicitHeight
             Layout.maximumHeight: implicitHeight
-            baseModel: root.walletStore.assets
+            baseModel: root.walletAssetsStore.groupedAccountAssetsModel
             showcaseModel: root.profileStore.profileShowcaseAssetsModel
             onShowcaseEntryChanged: hasAnyProfileShowcaseChanges = true
+            formatCurrencyAmount: function(amount, symbol) {
+                return root.currencyStore.formatCurrencyAmount(amount, symbol)
+            }
         }
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1301,6 +1301,8 @@ Item {
                             networkConnectionStore: appMain.networkConnectionStore
                             tokensStore: appMain.tokensStore
                             transactionStore: appMain.transactionStore
+                            walletAssetsStore: appMain.walletAssetsStore
+                            currencyStore: appMain.currencyStore
                         }
                     }
 


### PR DESCRIPTION
### What does the PR do

Uses the New assets model in the Profile showcase view.

There are issues with saving the data currently but thats an already exisiting issue

### Affected areas

Profile Showcase view
### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/4ea0604d-739a-4b14-afa6-7caa6c896a3e



