### PR TITLE
fix(OwnerToken): TOwner item footer button must be visible only for TOwner owner

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -729,7 +729,7 @@ StackView {
 
             communityName: root.communityName
             visible: {
-                if(tokenViewPage.isTMasterTokenItem)
+                if(tokenViewPage.isOwnerTokenItem || tokenViewPage.isTMasterTokenItem)
                     // Only footer if owner profile
                     return root.isOwner
                 // Always present
@@ -746,7 +746,7 @@ StackView {
             burnEnabled: deployStateCompleted            
             sendOwnershipEnabled: deployStateCompleted
 
-            sendOwnershipVisible: tokenViewPage.isOwnerTokenItem
+            sendOwnershipVisible: root.isOwner && tokenViewPage.isOwnerTokenItem
             airdropVisible: !tokenViewPage.isOwnerTokenItem
             remotelyDestructVisible: !tokenViewPage.isOwnerTokenItem && token.remotelyDestruct
             burnVisible: !tokenViewPage.isOwnerTokenItem && !token.infiniteSupply


### PR DESCRIPTION
Fixes #12911

### What does the PR do

- It changes footer visibility condition for `TOwner` item depending on the user profile.

### Affected areas

Community Settings / Mint token / Token Owner item

### Screenshot of functionality 

https://github.com/status-im/status-desktop/assets/97019400/afcd08f3-b50b-4bda-86fa-750173aa9cf2
