### PR TITLE
performance(ChannelsSelectionModel): Use LeftJoinModel for ChannelsSelectionModel.qml

### DIFF
--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -513,9 +513,8 @@ StatusScrollView {
             ChannelsSelectionModel {
                 id: channelsSelectionModel
 
-                sourceModel: d.dirtyValues.selectedChannelsModel
-
-                channelsModel: root.channelsModel
+                selectedChannels: d.dirtyValues.selectedChannelsModel
+                allChannels: root.channelsModel
             }
 
             InDropdown {

--- a/ui/app/AppLayouts/Communities/views/PermissionsView.qml
+++ b/ui/app/AppLayouts/Communities/views/PermissionsView.qml
@@ -90,8 +90,8 @@ StatusScrollView {
                 ChannelsSelectionModel {
                     id: channelsSelectionModel
 
-                    sourceModel: model.channelsListModel ?? null
-                    channelsModel: root.channelsModel
+                    selectedChannels: model.channelsListModel ?? null
+                    allChannels: root.channelsModel
                 }
 
                 channelsListModel: channelsSelectionModel.count


### PR DESCRIPTION
### What does the PR do

#### Needed for: https://github.com/status-im/status-desktop/pull/12160

Motivation:
ChannelsSelectionModel.qml is freezing the app when used with a live channel that's being edited because on each channel change the selection model is re-created.

The fix for this is to use the LeftJoinModel to unify the channels selection (a light model containing only keys) and the full channels model containing the channels data. On top of this, the SortFilterProxyModel is added to decorate the model with the roles expected in the UI. Another improvement is by replacing the ExpressionRole with the FastExpressionRole.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

PermissionsView
EditPermissionsView
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/3e4bd8df-c23f-47a1-812f-e036d712579b

https://github.com/status-im/status-desktop/assets/47811206/fdf62f3e-6794-43c6-9135-fa590a7d8d33

