### PR TITLE
fix(keycard): fetching balances for unknown accounts (those read from keycard) is fixed

### DIFF
--- a/src/app/modules/shared_models/keypair_account_item.nim
+++ b/src/app/modules/shared_models/keypair_account_item.nim
@@ -165,12 +165,11 @@ QtObject:
     write = setBalance
     notify = balanceChanged
 
-  proc balanceFetchedChanged*(self: KeyPairAccountItem) {.signal.}
   proc getBalanceFetched*(self: KeyPairAccountItem): bool {.slot.} =
     return self.balanceFetched
   QtProperty[bool] balanceFetched:
     read = getBalanceFetched
-    notify = balanceFetchedChanged
+    notify = balanceChanged
 
   proc isDefaultAccountChanged*(self: KeyPairAccountItem) {.signal.}
   proc getIsDefaultAccount*(self: KeyPairAccountItem): bool {.slot.} =

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -670,14 +670,17 @@ method setSelectedKeyPair*[T](self: Module[T], item: KeyPairItem) =
   self.setKeyPairForProcessing(item)
 
 method onTokensRebuilt*[T](self: Module[T], accountsTokens: OrderedTable[string, seq[WalletTokenDto]]) =
-  if self.getKeyPairForProcessing().isNil:
+  if self.getKeyPairForProcessing().isNil and self.getKeyPairHelper().isNil:
     return
   let chainIds = self.controller.getChainIdsOfAllKnownNetworks()
   let currency = self.controller.getCurrency()
   let currencyFormat = self.controller.getCurrencyFormat(currency)
   for address, tokens in accountsTokens.pairs:
     let balance = currencyAmountToItem(tokens.map(t => t.getCurrencyBalance(chainIds, currency)).foldl(a + b, 0.0), currencyFormat)
-    self.getKeyPairForProcessing().setBalanceForAddress(address, balance)
+    if not self.getKeyPairForProcessing().isNil:
+      self.getKeyPairForProcessing().setBalanceForAddress(address, balance)
+    if not self.getKeyPairHelper().isNil:
+      self.getKeyPairHelper().setBalanceForAddress(address, balance)
 
 proc buildKeyPairItemBasedOnCardMetadata[T](self: Module[T], cardMetadata: CardMetadata):
   tuple[item: KeyPairItem, knownKeyPair: bool] =

--- a/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
+++ b/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
@@ -9,8 +9,9 @@ import StatusQ.Core.Utils 0.1 as StatusQUtils
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
+import AppLayouts.Wallet.stores 1.0 as WalletStore
+
 import utils 1.0
-import shared.stores 1.0 as SharedStore
 
 Rectangle {
     id: root
@@ -98,13 +99,7 @@ Rectangle {
                         Component {
                             id: balance
                             StatusBaseText {
-
-                                text: {
-                                    return LocaleUtils.currencyAmountToLocaleString({
-                                                                                        amount: parseFloat(model.account.balance),
-                                                                                        symbol: SharedStore.RootStore.currencyStore.currentCurrencySymbol,
-                                                                                        displayDecimals: 2})
-                                }
+                                text: LocaleUtils.currencyAmountToLocaleString(model.account.balance)
                                 wrapMode: Text.WordWrap
                                 font.pixelSize: Constants.keycard.general.fontSize2
                                 color: Theme.palette.baseColor1
@@ -147,7 +142,11 @@ Rectangle {
                                 icon.width: 16
                                 icon.height: 16
                                 onClicked: {
-                                    Qt.openUrlExternally("https://etherscan.io/address/%1".arg(model.account.address))
+                                    let link = Utils.getUrlForAddressOnNetwork(Constants.networkShortChainNames.mainnet,
+                                                                               WalletStore.RootStore.areTestNetworksEnabled,
+                                                                               WalletStore.RootStore.isSepoliaEnabled,
+                                                                               model.account.address)
+                                    Global.openLink(link)
                                 }
                             }
                         }

--- a/ui/imports/shared/popups/keycard/states/ManageAccounts.qml
+++ b/ui/imports/shared/popups/keycard/states/ManageAccounts.qml
@@ -8,9 +8,10 @@ import StatusQ.Core.Utils 0.1 as StatusQUtils
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
+import AppLayouts.Wallet.stores 1.0 as WalletStore
+
 import utils 1.0
 import shared.popups 1.0
-import shared.stores 1.0 as SharedStore
 
 import "../helpers"
 
@@ -163,16 +164,7 @@ Item {
 
                 ColumnLayout {
                     StatusBaseText {
-                        text: {
-                            return qsTr("Balance: %1").arg(LocaleUtils.currencyAmountToLocaleString(
-                                                               {
-                                                                   amount: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard?
-                                                                               parseFloat(root.sharedKeycardModule.keyPairHelper.observedAccount.balance) :
-                                                                               0,
-                                                                   symbol: SharedStore.RootStore.currencyStore.currentCurrencySymbol,
-                                                                   displayDecimals: 2
-                                                               }))
-                        }
+                        text: qsTr("Balance: %1").arg(LocaleUtils.currencyAmountToLocaleString(root.sharedKeycardModule.keyPairHelper.observedAccount.balance))
                         wrapMode: Text.WordWrap
                         font.pixelSize: Constants.keycard.general.fontSize2
                         color: Theme.palette.baseColor1
@@ -195,7 +187,11 @@ Item {
                             icon.width: 16
                             icon.height: 16
                             onClicked: {
-                                Qt.openUrlExternally("https://etherscan.io/address/%1".arg(root.sharedKeycardModule.keyPairHelper.observedAccount.address))
+                                let link = Utils.getUrlForAddressOnNetwork(Constants.networkShortChainNames.mainnet,
+                                                                           WalletStore.RootStore.areTestNetworksEnabled,
+                                                                           WalletStore.RootStore.isSepoliaEnabled,
+                                                                           root.sharedKeycardModule.keyPairHelper.observedAccount.address)
+                                Global.openLink(link)
                             }
                         }
                     }


### PR DESCRIPTION
The same issue was present in two places:
- check what's on a Keycard
- importing an account from a Keycard to the Status app

Fixes #11841