### PR TITLE
feat(StatusQ): 2-sections `Flickable` component

### DIFF
--- a/storybook/pages/DoubleFlickablePage.qml
+++ b/storybook/pages/DoubleFlickablePage.qml
@@ -1,0 +1,238 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    readonly property int headerSize: 40
+
+    function fillModel(model, count) {
+        const content = []
+
+        for (let i = 0; i < count; i++)
+            content.push({})
+
+        model.clear()
+        model.append(content)
+    }
+
+    function adjustModel(model, newCount) {
+        const countDiff = newCount - model.count
+        const randPos = () => Math.floor(Math.random() * model.count)
+
+        if (countDiff > 0) {
+            for (let i = 0; i < countDiff; i++)
+                model.insert(randPos(), {})
+        } else {
+            for (let i = 0; i < -countDiff; i++)
+                model.remove(randPos())
+        }
+    }
+
+    ListModel {
+        id: firstModel
+
+        Component.onCompleted: fillModel(this, firstSlider.value)
+    }
+
+    ListModel {
+        id: secondModel
+
+        Component.onCompleted: fillModel(this, secondSlider.value)
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Rectangle {
+            id: frame
+
+            anchors.centerIn: parent
+
+            width: Math.round(parent.width / 2)
+            height: Math.round(parent.height / 2)
+            border.width: 1
+            color: "transparent"
+
+            DoubleFlickable {
+                id: doubleFlickable
+
+                anchors.fill: parent
+                clip: clipCheckBox.checked
+                z: -1
+
+                ScrollBar.vertical: ScrollBar { policy: ScrollBar.AlwaysOn }
+
+                flickable1: GridView {
+                    width: frame.width
+                    interactive: false
+                    model: firstModel
+
+                    cellWidth: 120
+                    cellHeight: 30
+
+                    header: Rectangle {
+                        height: root.headerSize
+                        width: GridView.view.width
+
+                        color: "orange"
+
+                        Label {
+                            anchors.centerIn: parent
+                            font.bold: true
+                            text: "Community"
+                        }
+                    }
+
+                    delegate: Rectangle {
+                        width: GridView.view.cellWidth
+                        height: GridView.view.cellHeight
+
+                        border.color: "black"
+                        color: "lightblue"
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: index
+                        }
+                    }
+
+                    Rectangle {
+                        border.color: "green"
+                        border.width: 5
+                        anchors.fill: parent
+                        color: "transparent"
+                    }
+                }
+
+                flickable2: GridView {
+                    width: frame.width
+                    interactive: false
+                    model: secondModel
+
+                    cellWidth: 100
+                    cellHeight: 100
+
+                    header: Rectangle {
+                        height: root.headerSize
+                        width: GridView.view.width
+
+                        color: "red"
+
+                        Label {
+                            anchors.centerIn: parent
+                            font.bold: true
+                            text: "Others"
+                        }
+                    }
+
+                    delegate: Rectangle {
+                        width: GridView.view.cellWidth
+                        height: GridView.view.cellHeight
+
+                        border.color: "black"
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: index
+                        }
+                    }
+
+                    Rectangle {
+                        border.color: "blue"
+                        border.width: 5
+                        anchors.fill: parent
+                        color: "transparent"
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+        SplitView.fillWidth: true
+
+        Column {
+            CheckBox {
+                id: clipCheckBox
+                text: "clip"
+                checked: true
+            }
+
+            RowLayout {
+                Label {
+                    text: "first model:"
+                }
+
+                Slider {
+                    id: firstSlider
+                    from: 0
+                    to: 200
+                    stepSize: 1
+
+                    value: 160
+
+                    onValueChanged: adjustModel(firstModel, value)
+                }
+
+                RoundButton {
+                    text: "-"
+                    onClicked: firstSlider.decrease()
+                }
+
+                RoundButton {
+                    text: "+"
+                    onClicked: firstSlider.increase()
+                }
+
+                Label {
+                    text: firstSlider.value
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "second model:"
+                }
+
+                Slider {
+                    id: secondSlider
+                    from: 0
+                    to: 100
+                    stepSize: 1
+
+                    value: 90
+
+                    onValueChanged: adjustModel(secondModel, value)
+                }
+
+                RoundButton {
+                    text: "-"
+                    onClicked: secondSlider.decrease()
+                }
+
+                RoundButton {
+                    text: "+"
+                    onClicked: secondSlider.increase()
+                }
+
+                Label {
+                    text: secondSlider.value
+                }
+            }
+        }
+    }
+}
+
+// category: Components

--- a/storybook/pages/DoubleFlickableWithFoldingPage.qml
+++ b/storybook/pages/DoubleFlickableWithFoldingPage.qml
@@ -1,0 +1,277 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    readonly property int header1Size: 40
+    readonly property int header2Size: 40
+
+    function fillModel(model, count) {
+        const content = []
+
+        for (let i = 0; i < count; i++)
+            content.push({})
+
+        model.clear()
+        model.append(content)
+    }
+
+    function adjustModel(model, newCount) {
+        const countDiff = newCount - model.count
+        const randPos = () => Math.floor(Math.random() * model.count)
+
+        if (countDiff > 0) {
+            for (let i = 0; i < countDiff; i++)
+                model.insert(randPos(), {})
+        } else {
+            for (let i = 0; i < -countDiff; i++)
+                model.remove(randPos())
+        }
+    }
+
+    ListModel {
+        id: firstModel
+
+        Component.onCompleted: fillModel(this, firstSlider.value)
+    }
+
+    ListModel {
+        id: secondModel
+
+        Component.onCompleted: fillModel(this, secondSlider.value)
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Rectangle {
+            id: frame
+
+            anchors.centerIn: parent
+
+            width: Math.round(parent.width / 2)
+            height: Math.round(parent.height / 2)
+            border.width: 1
+            color: "transparent"
+
+            DoubleFlickableWithFolding {
+                id: doubleFlickable
+
+                anchors.fill: parent
+                clip: clipCheckBox.checked
+                z: -1
+
+                ScrollBar.vertical: ScrollBar { policy: ScrollBar.AlwaysOn }
+
+                flickable1: GridView {
+                    id: grid1
+
+                    width: frame.width
+                    model: firstModel
+
+                    cellWidth: 120
+                    cellHeight: 30
+
+                    header: Item {
+                        id: header1
+
+                        height: root.header1Size
+                        width: GridView.view.width
+
+                        Rectangle {
+                            parent: doubleFlickable.contentItem
+                            y: doubleFlickable.gridHeader1YInContentItem
+                            z: 1
+
+                            width: header1.width
+                            height: header1.height
+
+                            color: "orange"
+
+                            Label {
+                                anchors.centerIn: parent
+                                font.bold: true
+                                text: (doubleFlickable.flickable1Folded ? "⬇" : "➡️")
+                                      + " Community"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+
+                                onClicked: doubleFlickable.flip1Folding()
+                            }
+                        }
+                    }
+
+                    delegate: Rectangle {
+                        width: grid1.cellWidth
+                        height: grid1.cellHeight
+
+                        border.color: "black"
+                        color: "lightblue"
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: index
+                        }
+                    }
+
+                    Rectangle {
+                        border.color: "green"
+                        border.width: 5
+                        anchors.fill: parent
+                        color: "transparent"
+                    }
+                }
+
+                flickable2: GridView {
+                    id: grid2
+
+                    width: frame.width
+                    model: secondModel
+
+                    cellWidth: 100
+                    cellHeight: 100
+
+                    header: Item {
+                        id: header2
+
+                        height: root.header2Size
+                        width: GridView.view.width
+
+                        Rectangle {
+                            parent: doubleFlickable.contentItem
+                            y: doubleFlickable.gridHeader2YInContentItem
+                            z: 1
+
+                            width: header2.width
+                            height: header2.height
+
+                            color: "red"
+
+                            Label {
+                                anchors.centerIn: parent
+                                font.bold: true
+                                text: (doubleFlickable.flickable2Folded ? "➡️" : "⬇")
+                                      + " Others"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+
+                                onClicked: doubleFlickable.flip2Folding()
+                            }
+                        }
+                    }
+
+                    delegate: Rectangle {
+                        width: grid2.cellWidth
+                        height: grid2.cellHeight
+
+                        border.color: "black"
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: index
+                        }
+                    }
+
+                    Rectangle {
+                        border.color: "blue"
+                        border.width: 5
+                        anchors.fill: parent
+                        color: "transparent"
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+        SplitView.fillWidth: true
+
+        Column {
+            CheckBox {
+                id: clipCheckBox
+                text: "clip"
+                checked: true
+            }
+
+            RowLayout {
+                Label {
+                    text: "first model:"
+                }
+
+                Slider {
+                    id: firstSlider
+                    from: 0
+                    to: 200
+                    stepSize: 1
+
+                    value: 160
+
+                    onValueChanged: adjustModel(firstModel, value)
+                }
+
+                RoundButton {
+                    text: "-"
+                    onClicked: firstSlider.decrease()
+                }
+
+                RoundButton {
+                    text: "+"
+                    onClicked: firstSlider.increase()
+                }
+
+                Label {
+                    text: firstSlider.value
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "second model:"
+                }
+
+                Slider {
+                    id: secondSlider
+                    from: 0
+                    to: 100
+                    stepSize: 1
+
+                    value: 90
+
+                    onValueChanged: adjustModel(secondModel, value)
+                }
+
+                RoundButton {
+                    text: "-"
+                    onClicked: secondSlider.decrease()
+                }
+
+                RoundButton {
+                    text: "+"
+                    onClicked: secondSlider.increase()
+                }
+
+                Label {
+                    text: secondSlider.value
+                }
+            }
+        }
+    }
+}
+
+// category: Components

--- a/ui/StatusQ/src/StatusQ/Core/Utils/DoubleFlickable.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/DoubleFlickable.qml
@@ -1,0 +1,114 @@
+import QtQuick 2.15
+import QtQml 2.15
+
+Flickable {
+    id: root
+
+    boundsBehavior: Flickable.StopAtBounds
+    maximumFlickVelocity: 2000
+    synchronousDrag: true
+
+    property Flickable flickable1: Flickable {}
+    property Flickable flickable2: Flickable {}
+
+    readonly property real flickable1ContentHeight: flickable1.contentHeight
+    readonly property real flickable2ContentHeight: flickable2.contentHeight
+
+    onWidthChanged: returnToBounds()
+    onHeightChanged: returnToBounds()
+
+    contentWidth: root.width
+    contentHeight: flickable1ContentHeight + flickable2ContentHeight
+
+    QtObject {
+        id: d
+
+        property real offsetY1
+        property real offsetY2
+
+        Binding on offsetY1 {
+            value: flickable1.originY
+            delayed: true
+        }
+
+        Binding on offsetY2 {
+            value: flickable2.originY
+            delayed: true
+        }
+    }
+
+    // First flickable
+
+    Binding {
+        target: flickable1
+        property: "parent"
+        value: contentItem
+    }
+
+    Binding {
+        target: flickable1
+        property: "interactive"
+        value: false
+    }
+
+    Binding {
+        target: flickable1
+        property: "height"
+        value: Math.min(root.height, flickable1ContentHeight)
+        delayed: true
+    }
+
+    Binding {
+        target: flickable1
+        property: "y"
+        value: Math.min(Math.max(0, root.contentY),
+                        flickable1ContentHeight - flickable1.height)
+    }
+
+    Binding {
+        target: flickable1
+        property: "contentY"
+        value: Math.min(Math.max(root.contentY, 0),
+                        flickable1ContentHeight - flickable1.height) + d.offsetY1
+
+        delayed: true
+    }
+
+    // Second flickable
+
+    Binding {
+        target: flickable2
+        property: "parent"
+        value: contentItem
+    }
+
+    Binding {
+        target: flickable2
+        property: "interactive"
+        value: false
+    }
+
+    Binding {
+        target: flickable2
+        property: "height"
+        value: Math.min(root.height, flickable2ContentHeight)
+
+        delayed: true
+    }
+
+    Binding {
+        target: flickable2
+        property: "y"
+        value: Math.min(Math.max(flickable1ContentHeight, root.contentY),
+                        root.contentHeight - flickable2.height)
+    }
+
+    Binding {
+        target: flickable2
+        property: "contentY"
+        value: Math.min(Math.max(0, root.contentY - flickable1ContentHeight),
+                        flickable2ContentHeight - flickable2.height) + d.offsetY2
+
+        delayed: true
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/DoubleFlickableWithFolding.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/DoubleFlickableWithFolding.qml
@@ -1,0 +1,112 @@
+import QtQuick 2.15
+import QtQml 2.15
+
+DoubleFlickable {
+    readonly property real gridHeader1YInContentItem: contentY
+    readonly property real gridHeader2YInContentItem: contentY + d.grid2HeaderOffset
+
+    readonly property bool flickable1Folded: d.grid1ConentInViewport
+    readonly property bool flickable2Folded: d.grid2HeaderAtEnd || d.model2Blocked
+
+    function flip1Folding() {
+        if (d.grid1ConentInViewport) {
+            if (d.grid2FullyFilling)
+                contentY = flickable1ContentHeight - d.header1Size
+            else
+                d.model1Blocked = true
+        } else {
+            d.model1Blocked = false
+            contentY = 0
+        }
+    }
+
+    function flip2Folding() {
+        // header at the end (always folded)
+        if (d.grid2HeaderAtEnd) {
+            contentY = flickable1ContentHeight - d.header1Size -
+                    Math.max(0, height - flickable2ContentHeight - d.header1Size)
+            return
+        }
+
+        // header on top, unfolded
+        // explicitly folding both sections
+        if (d.grid2HeaderAtTop && !d.model2Blocked) {
+            d.model1Blocked = true
+            d.model2Blocked = true
+
+            return
+        }
+
+        // header on top, folded
+        if (d.grid2HeaderAtTop && d.model2Blocked) {
+            d.model2Blocked = false
+
+            return
+        }
+
+        // header in the middle
+        if (d.grid1FullyFilling) { // top section long enough to fill the whole view
+            contentY = flickable1ContentHeight + d.header2Size - height
+        } else {
+            d.model2Blocked = !d.model2Blocked
+        }
+    }
+
+    QtObject {
+        id: d
+
+        readonly property real header1Size: flickable1.headerItem.height
+        readonly property real header2Size: flickable2.headerItem.height
+
+        readonly property bool grid1ConentInViewport:
+            flickable1.y > contentY - Math.min(height, flickable1ContentHeight) + header1Size
+        readonly property real grid2HeaderOffset:
+            Math.min(Math.max(flickable2.y - contentY, header1Size), height - header2Size)
+
+        readonly property bool grid2HeaderAtTop:
+            grid2HeaderOffset === header1Size
+        readonly property bool grid2HeaderAtEnd:
+            grid2HeaderOffset === height - header2Size
+
+        property bool model1Blocked: false
+        property bool model2Blocked: false
+
+        readonly property bool grid1FullyFilling:
+            flickable1ContentHeight >= height - header2Size
+        readonly property bool grid2FullyFilling:
+            flickable2ContentHeight >= height - header1Size
+
+        onGrid1FullyFillingChanged: {
+            if (grid1FullyFilling) {
+                model2Blocked = false
+                contentY = 0
+            }
+        }
+
+        onGrid2FullyFillingChanged: {
+            if (grid2FullyFilling && model1Blocked) {
+                model1Blocked = false
+                contentY = flickable1ContentHeight - header1Size
+            }
+        }
+    }
+
+    Binding {
+        when: d.model1Blocked
+        target: flickable1
+        property: "model"
+        value: null
+
+        restoreMode: Binding.RestoreBinding
+    }
+
+    Binding {
+        when: d.model2Blocked
+        target: flickable2
+        property: "model"
+        value: null
+
+        restoreMode: Binding.RestoreBinding
+    }
+}
+

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -2,6 +2,7 @@ module StatusQ.Core.Utils
 
 ClippingWrapper 0.1 ClippingWrapper.qml
 DoubleFlickable 0.1 DoubleFlickable.qml
+DoubleFlickableWithFolding 0.1 DoubleFlickableWithFolding.qml
 EmojiJSON 1.0 emojiList.js
 JSONListModel 0.1 JSONListModel.qml
 ModelChangeGuard 0.1 ModelChangeGuard.qml

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -1,6 +1,7 @@
 module StatusQ.Core.Utils
 
 ClippingWrapper 0.1 ClippingWrapper.qml
+DoubleFlickable 0.1 DoubleFlickable.qml
 EmojiJSON 1.0 emojiList.js
 JSONListModel 0.1 JSONListModel.qml
 ModelChangeGuard 0.1 ModelChangeGuard.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -1,82 +1,94 @@
 <RCC>
     <qresource prefix="/">
-        <file>StatusQ/Components/private/statusMessage/StatusAudioMessage.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusEditMessage.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusImageMessage.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusMessageImageAlbum.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusMessageReply.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusPinMessageDetails.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusSticker.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusTextMessage.qml</file>
-        <file>StatusQ/Components/StatusTimeStampLabel.qml</file>
-        <file>StatusQ/Components/qmldir</file>
-        <file>StatusQ/Components/private/qmldir</file>
+        <file>StatusQ/Components/LoadingComponent.qml</file>
         <file>StatusQ/Components/StatusAddress.qml</file>
         <file>StatusQ/Components/StatusAddressPanel.qml</file>
         <file>StatusQ/Components/StatusAnimatedImage.qml</file>
         <file>StatusQ/Components/StatusBadge.qml</file>
         <file>StatusQ/Components/StatusCard.qml</file>
+        <file>StatusQ/Components/StatusChartPanel.qml</file>
         <file>StatusQ/Components/StatusChatInfoToolBar.qml</file>
         <file>StatusQ/Components/StatusChatList.qml</file>
         <file>StatusQ/Components/StatusChatListAndCategories.qml</file>
         <file>StatusQ/Components/StatusChatListCategoryItem.qml</file>
         <file>StatusQ/Components/StatusChatListItem.qml</file>
-        <file>StatusQ/Components/StatusImage.qml</file>
-        <file>StatusQ/Components/StatusToolBar.qml</file>
         <file>StatusQ/Components/StatusColorSpace.qml</file>
         <file>StatusQ/Components/StatusCommunityCard.qml</file>
         <file>StatusQ/Components/StatusCommunityTags.qml</file>
         <file>StatusQ/Components/StatusContactRequestsIndicatorListItem.qml</file>
         <file>StatusQ/Components/StatusContactVerificationIcons.qml</file>
         <file>StatusQ/Components/StatusCursorDelegate.qml</file>
+        <file>StatusQ/Components/StatusDateGroupLabel.qml</file>
         <file>StatusQ/Components/StatusDatePicker.qml</file>
         <file>StatusQ/Components/StatusDescriptionListItem.qml</file>
+        <file>StatusQ/Components/StatusDotsLoadingIndicator.qml</file>
+        <file>StatusQ/Components/StatusDraggableListItem.qml</file>
         <file>StatusQ/Components/StatusEmoji.qml</file>
+        <file>StatusQ/Components/StatusEmojiAndColorComboBox.qml</file>
         <file>StatusQ/Components/StatusExpandableItem.qml</file>
-        <file>StatusQ/Components/StatusImageCropPanel.qml</file>
         <file>StatusQ/Components/StatusFlowSelector.qml</file>
+        <file>StatusQ/Components/StatusGroupBox.qml</file>
+        <file>StatusQ/Components/StatusImage.qml</file>
+        <file>StatusQ/Components/StatusImageCropPanel.qml</file>
+        <file>StatusQ/Components/StatusInfoBoxPanel.qml</file>
         <file>StatusQ/Components/StatusItemSelector.qml</file>
         <file>StatusQ/Components/StatusLetterIdenticon.qml</file>
         <file>StatusQ/Components/StatusListItem.qml</file>
         <file>StatusQ/Components/StatusListItemBadge.qml</file>
         <file>StatusQ/Components/StatusListItemTag.qml</file>
         <file>StatusQ/Components/StatusListPicker.qml</file>
+        <file>StatusQ/Components/StatusListPickerProxies.qml</file>
         <file>StatusQ/Components/StatusListSectionHeadline.qml</file>
         <file>StatusQ/Components/StatusLoadingIndicator.qml</file>
         <file>StatusQ/Components/StatusMemberListItem.qml</file>
         <file>StatusQ/Components/StatusMessage.qml</file>
         <file>StatusQ/Components/StatusMessageDetails.qml</file>
         <file>StatusQ/Components/StatusMessageHeader.qml</file>
+        <file>StatusQ/Components/StatusMessageSenderDetails.qml</file>
         <file>StatusQ/Components/StatusNavigationListItem.qml</file>
         <file>StatusQ/Components/StatusNavigationPanelHeadline.qml</file>
+        <file>StatusQ/Components/StatusOnlineBadge.qml</file>
+        <file>StatusQ/Components/StatusPageIndicator.qml</file>
+        <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
+        <file>StatusQ/Components/StatusRoundIcon.qml</file>
         <file>StatusQ/Components/StatusRoundedComponent.qml</file>
         <file>StatusQ/Components/StatusRoundedImage.qml</file>
         <file>StatusQ/Components/StatusRoundedMedia.qml</file>
-        <file>StatusQ/Components/StatusRoundIcon.qml</file>
         <file>StatusQ/Components/StatusSmartIdenticon.qml</file>
+        <file>StatusQ/Components/StatusSortableColumnHeader.qml</file>
+        <file>StatusQ/Components/StatusStepper.qml</file>
+        <file>StatusQ/Components/StatusSyncDeviceDelegate.qml</file>
         <file>StatusQ/Components/StatusTagSelector.qml</file>
+        <file>StatusQ/Components/StatusTimeStampLabel.qml</file>
         <file>StatusQ/Components/StatusToastMessage.qml</file>
+        <file>StatusQ/Components/StatusToolBar.qml</file>
         <file>StatusQ/Components/StatusVideo.qml</file>
         <file>StatusQ/Components/StatusWizardStepper.qml</file>
-        <file>StatusQ/Components/StatusSortableColumnHeader.qml</file>
-        <file>StatusQ/Controls/Validators/qmldir</file>
-        <file>StatusQ/Controls/Validators/StatusAddressOrEnsValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusAddressValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusAsyncEnsValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusAsyncValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusFloatValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusIntValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusMinLengthValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusUrlValidator.qml</file>
-        <file>StatusQ/Controls/Validators/StatusValidator.qml</file>
-        <file>StatusQ/Controls/qmldir</file>
+        <file>StatusQ/Components/WebEngineLoader.qml</file>
+        <file>StatusQ/Components/private/chart/Chart.js</file>
+        <file>StatusQ/Components/private/chart/Chart.qml</file>
+        <file>StatusQ/Components/private/chart/LICENSE</file>
+        <file>StatusQ/Components/private/qmldir</file>
+        <file>StatusQ/Components/private/qwebchannel/helpers.js</file>
+        <file>StatusQ/Components/private/qwebchannel/qwebchannel.js</file>
+        <file>StatusQ/Components/private/statusMessage/StatusAudioMessage.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusEditMessage.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusImageMessage.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusMessageImageAlbum.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusMessageReply.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusPinMessageDetails.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusSticker.qml</file>
+        <file>StatusQ/Components/private/statusMessage/StatusTextMessage.qml</file>
+        <file>StatusQ/Components/qmldir</file>
         <file>StatusQ/Controls/StatusAccountSelector.qml</file>
         <file>StatusQ/Controls/StatusActivityCenterButton.qml</file>
+        <file>StatusQ/Controls/StatusBackButton.qml</file>
         <file>StatusQ/Controls/StatusBanner.qml</file>
         <file>StatusQ/Controls/StatusBaseButton.qml</file>
         <file>StatusQ/Controls/StatusBaseInput.qml</file>
+        <file>StatusQ/Controls/StatusBlockProgressBar.qml</file>
         <file>StatusQ/Controls/StatusButton.qml</file>
         <file>StatusQ/Controls/StatusChatCommandButton.qml</file>
         <file>StatusQ/Controls/StatusChatInfoButton.qml</file>
@@ -85,6 +97,7 @@
         <file>StatusQ/Controls/StatusColorRadioButton.qml</file>
         <file>StatusQ/Controls/StatusColorSelector.qml</file>
         <file>StatusQ/Controls/StatusColorSelectorGrid.qml</file>
+        <file>StatusQ/Controls/StatusComboBox.qml</file>
         <file>StatusQ/Controls/StatusCommunityTag.qml</file>
         <file>StatusQ/Controls/StatusDropdown.qml</file>
         <file>StatusQ/Controls/StatusFlatButton.qml</file>
@@ -93,12 +106,16 @@
         <file>StatusQ/Controls/StatusIconTextButton.qml</file>
         <file>StatusQ/Controls/StatusIdenticonRing.qml</file>
         <file>StatusQ/Controls/StatusImageCrop.qml</file>
+        <file>StatusQ/Controls/StatusImageSelector.qml</file>
         <file>StatusQ/Controls/StatusInput.qml</file>
+        <file>StatusQ/Controls/StatusItemDelegate.qml</file>
         <file>StatusQ/Controls/StatusItemPicker.qml</file>
         <file>StatusQ/Controls/StatusLabeledSlider.qml</file>
+        <file>StatusQ/Controls/StatusLinkText.qml</file>
         <file>StatusQ/Controls/StatusNavBarTabButton.qml</file>
-        <file>StatusQ/Controls/StatusPasswordStrengthIndicator.qml</file>
+        <file>StatusQ/Controls/StatusNavigationButton.qml</file>
         <file>StatusQ/Controls/StatusPasswordInput.qml</file>
+        <file>StatusQ/Controls/StatusPasswordStrengthIndicator.qml</file>
         <file>StatusQ/Controls/StatusPickerButton.qml</file>
         <file>StatusQ/Controls/StatusPinInput.qml</file>
         <file>StatusQ/Controls/StatusProgressBar.qml</file>
@@ -116,122 +133,105 @@
         <file>StatusQ/Controls/StatusTabBarIconButton.qml</file>
         <file>StatusQ/Controls/StatusTabButton.qml</file>
         <file>StatusQ/Controls/StatusTagItem.qml</file>
+        <file>StatusQ/Controls/StatusTextArea.qml</file>
+        <file>StatusQ/Controls/StatusTextWithLoadingState.qml</file>
         <file>StatusQ/Controls/StatusTokenInlineSelector.qml</file>
         <file>StatusQ/Controls/StatusToolTip.qml</file>
         <file>StatusQ/Controls/StatusWalletColorButton.qml</file>
         <file>StatusQ/Controls/StatusWalletColorSelect.qml</file>
-        <file>StatusQ/Controls/StatusTextArea.qml</file>
+        <file>StatusQ/Controls/StatusWarningBox.qml</file>
+        <file>StatusQ/Controls/Validators/StatusAddressOrEnsValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusAddressValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusAsyncEnsValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusAsyncValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusFloatValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusIntValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusMinLengthValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusUrlValidator.qml</file>
+        <file>StatusQ/Controls/Validators/StatusValidator.qml</file>
+        <file>StatusQ/Controls/Validators/qmldir</file>
+        <file>StatusQ/Controls/qmldir</file>
         <file>StatusQ/Core/Backpressure/Backpressure.qml</file>
         <file>StatusQ/Core/Backpressure/LICENSE</file>
-        <file>StatusQ/Core/Backpressure/qmldir</file>
         <file>StatusQ/Core/Backpressure/README.md</file>
-        <file>StatusQ/Core/Theme/qmldir</file>
+        <file>StatusQ/Core/Backpressure/qmldir</file>
+        <file>StatusQ/Core/LocaleUtils.qml</file>
+        <file>StatusQ/Core/StatusAnimatedStack.qml</file>
+        <file>StatusQ/Core/StatusAssetSettings.qml</file>
+        <file>StatusQ/Core/StatusBaseText.qml</file>
+        <file>StatusQ/Core/StatusCenteredFlow.qml</file>
+        <file>StatusQ/Core/StatusFontSettings.qml</file>
+        <file>StatusQ/Core/StatusGridView.qml</file>
+        <file>StatusQ/Core/StatusIcon.qml</file>
+        <file>StatusQ/Core/StatusIdenticonRingSettings.qml</file>
+        <file>StatusQ/Core/StatusListView.qml</file>
+        <file>StatusQ/Core/StatusModalHeaderSettings.qml</file>
+        <file>StatusQ/Core/StatusProfileImageSettings.qml</file>
+        <file>StatusQ/Core/StatusRollArea.qml</file>
+        <file>StatusQ/Core/StatusScrollView.qml</file>
+        <file>StatusQ/Core/StatusTooltipSettings.qml</file>
         <file>StatusQ/Core/Theme/StatusColors.qml</file>
         <file>StatusQ/Core/Theme/StatusDarkTheme.qml</file>
         <file>StatusQ/Core/Theme/StatusLightTheme.qml</file>
         <file>StatusQ/Core/Theme/Theme.qml</file>
         <file>StatusQ/Core/Theme/ThemePalette.qml</file>
+        <file>StatusQ/Core/Theme/qmldir</file>
+        <file>StatusQ/Core/Utils/AmountsArithmetic.qml</file>
         <file>StatusQ/Core/Utils/ClippingWrapper.qml</file>
+        <file>StatusQ/Core/Utils/DoubleFlickable.qml</file>
+        <file>StatusQ/Core/Utils/DoubleFlickableWithFolding.qml</file>
         <file>StatusQ/Core/Utils/Emoji.qml</file>
+        <file>StatusQ/Core/Utils/JSONListModel.qml</file>
+        <file>StatusQ/Core/Utils/ModelChangeGuard.qml</file>
+        <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
+        <file>StatusQ/Core/Utils/ModelUtils.qml</file>
+        <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
+        <file>StatusQ/Core/Utils/OperatorsUtils.qml</file>
+        <file>StatusQ/Core/Utils/StackViewStates.qml</file>
+        <file>StatusQ/Core/Utils/StatesStack.qml</file>
+        <file>StatusQ/Core/Utils/StringUtils.qml</file>
+        <file>StatusQ/Core/Utils/Subscription.qml</file>
+        <file>StatusQ/Core/Utils/SubscriptionBroker.qml</file>
+        <file>StatusQ/Core/Utils/Utils.qml</file>
+        <file>StatusQ/Core/Utils/big.min.mjs</file>
         <file>StatusQ/Core/Utils/emojiList.js</file>
         <file>StatusQ/Core/Utils/qmldir</file>
-        <file>StatusQ/Core/Utils/Utils.qml</file>
-        <file>StatusQ/Core/Utils/StatesStack.qml</file>
+        <file>StatusQ/Core/Utils/xss.js</file>
         <file>StatusQ/Core/qmldir</file>
-        <file>StatusQ/Core/LocaleUtils.qml</file>
-        <file>StatusQ/Core/StatusAnimatedStack.qml</file>
-        <file>StatusQ/Core/StatusBaseText.qml</file>
-        <file>StatusQ/Core/StatusFontSettings.qml</file>
-        <file>StatusQ/Core/StatusIcon.qml</file>
-        <file>StatusQ/Core/StatusIdenticonRingSettings.qml</file>
-        <file>StatusQ/Core/StatusModalHeaderSettings.qml</file>
-        <file>StatusQ/Core/StatusScrollView.qml</file>
-        <file>StatusQ/Core/StatusTooltipSettings.qml</file>
-        <file>StatusQ/Layout/qmldir</file>
         <file>StatusQ/Layout/StatusAppNavBar.qml</file>
-        <file>StatusQ/Platform/qmldir</file>
+        <file>StatusQ/Layout/StatusMainLayout.qml</file>
+        <file>StatusQ/Layout/StatusSectionLayout.qml</file>
+        <file>StatusQ/Layout/qmldir</file>
         <file>StatusQ/Platform/StatusMacNotification.qml</file>
         <file>StatusQ/Platform/StatusMacTrafficLights.qml</file>
         <file>StatusQ/Platform/StatusWindowsTitleBar.qml</file>
-        <file>StatusQ/Popups/Dialog/qmldir</file>
+        <file>StatusQ/Platform/qmldir</file>
         <file>StatusQ/Popups/Dialog/StatusDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusDialogBackground.qml</file>
         <file>StatusQ/Popups/Dialog/StatusDialogDivider.qml</file>
         <file>StatusQ/Popups/Dialog/StatusDialogFooter.qml</file>
         <file>StatusQ/Popups/Dialog/StatusDialogHeader.qml</file>
         <file>StatusQ/Popups/Dialog/StatusHeaderActions.qml</file>
         <file>StatusQ/Popups/Dialog/StatusTitleSubtitle.qml</file>
-        <file>StatusQ/Popups/statusModal/StatusImageWithTitle.qml</file>
-        <file>StatusQ/Popups/statusModal/StatusModalFooter.qml</file>
-        <file>StatusQ/Popups/statusModal/StatusModalHeader.qml</file>
-        <file>StatusQ/Popups/qmldir</file>
-        <file>StatusQ/Popups/StatusColorDialog.qml</file>
-        <file>StatusQ/Popups/StatusMenuHeadline.qml</file>
+        <file>StatusQ/Popups/Dialog/qmldir</file>
         <file>StatusQ/Popups/StatusAction.qml</file>
-        <file>StatusQ/Popups/StatusSuccessAction.qml</file>
+        <file>StatusQ/Popups/StatusColorDialog.qml</file>
+        <file>StatusQ/Popups/StatusMenu.qml</file>
+        <file>StatusQ/Popups/StatusMenuHeadline.qml</file>
+        <file>StatusQ/Popups/StatusMenuInstantiator.qml</file>
         <file>StatusQ/Popups/StatusMenuItem.qml</file>
         <file>StatusQ/Popups/StatusMenuSeparator.qml</file>
         <file>StatusQ/Popups/StatusModal.qml</file>
         <file>StatusQ/Popups/StatusModalDivider.qml</file>
-        <file>StatusQ/Popups/StatusMenu.qml</file>
         <file>StatusQ/Popups/StatusSearchLocationMenu.qml</file>
         <file>StatusQ/Popups/StatusSearchPopup.qml</file>
         <file>StatusQ/Popups/StatusSearchPopupMenuItem.qml</file>
         <file>StatusQ/Popups/StatusStackModal.qml</file>
-        <file>StatusQ/Components/StatusListPickerProxies.qml</file>
-        <file>StatusQ/Layout/StatusSectionLayout.qml</file>
-        <file>StatusQ/Layout/StatusMainLayout.qml</file>
-        <file>StatusQ/Components/private/chart/Chart.js</file>
-        <file>StatusQ/Components/private/chart/Chart.qml</file>
-        <file>StatusQ/Components/private/chart/LICENSE</file>
-        <file>StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml</file>
-        <file>StatusQ/Components/StatusChartPanel.qml</file>
-        <file>StatusQ/Components/StatusDateGroupLabel.qml</file>
-        <file>StatusQ/Components/StatusMessageSenderDetails.qml</file>
-        <file>StatusQ/Controls/StatusBackButton.qml</file>
-        <file>StatusQ/Controls/StatusComboBox.qml</file>
-        <file>StatusQ/Controls/StatusItemDelegate.qml</file>
-        <file>StatusQ/Controls/StatusNavigationButton.qml</file>
-        <file>StatusQ/Core/Utils/JSONListModel.qml</file>
-        <file>StatusQ/Core/Utils/xss.js</file>
-        <file>StatusQ/Core/StatusAssetSettings.qml</file>
-        <file>StatusQ/Core/StatusCenteredFlow.qml</file>
-        <file>StatusQ/Core/StatusGridView.qml</file>
-        <file>StatusQ/Core/StatusListView.qml</file>
-        <file>StatusQ/Core/StatusProfileImageSettings.qml</file>
-        <file>StatusQ/Core/StatusRollArea.qml</file>
-        <file>StatusQ/Popups/Dialog/StatusDialogBackground.qml</file>
-        <file>StatusQ/Popups/StatusMenuInstantiator.qml</file>
-        <file>StatusQ/Core/Utils/OperatorsUtils.qml</file>
-        <file>StatusQ/Controls/StatusTextWithLoadingState.qml</file>
-        <file>StatusQ/Components/LoadingComponent.qml</file>
-        <file>StatusQ/Core/Utils/ModelUtils.qml</file>
-        <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
-        <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
-        <file>StatusQ/Core/Utils/StringUtils.qml</file>
-        <file>StatusQ/Core/Utils/DoubleFlickable.qml</file>
-        <file>StatusQ/Core/Utils/DoubleFlickableWithFolding.qml</file>
-        <file>StatusQ/Components/StatusPageIndicator.qml</file>
-        <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
-        <file>StatusQ/Components/StatusOnlineBadge.qml</file>
-        <file>StatusQ/Components/StatusGroupBox.qml</file>
-        <file>StatusQ/Components/StatusDotsLoadingIndicator.qml</file>
-        <file>StatusQ/Components/StatusDraggableListItem.qml</file>
-        <file>StatusQ/Components/StatusEmojiAndColorComboBox.qml</file>
-        <file>StatusQ/Components/StatusStepper.qml</file>
-        <file>StatusQ/Components/StatusSyncDeviceDelegate.qml</file>
-        <file>StatusQ/Controls/StatusImageSelector.qml</file>
-        <file>StatusQ/Controls/StatusLinkText.qml</file>
-        <file>StatusQ/Core/Utils/ModelChangeGuard.qml</file>
-        <file>StatusQ/Core/Utils/StackViewStates.qml</file>
-        <file>StatusQ/Core/Utils/AmountsArithmetic.qml</file>
-        <file>StatusQ/Core/Utils/big.min.mjs</file>
-        <file>StatusQ/Controls/StatusBlockProgressBar.qml</file>
-        <file>StatusQ/Components/StatusInfoBoxPanel.qml</file>
-        <file>StatusQ/Controls/StatusWarningBox.qml</file>
-        <file>StatusQ/Core/Utils/Subscription.qml</file>
-        <file>StatusQ/Core/Utils/SubscriptionBroker.qml</file>
-        <file>StatusQ/Components/WebEngineLoader.qml</file>
-        <file>StatusQ/Components/private/qwebchannel/qwebchannel.js</file>
-        <file>StatusQ/Components/private/qwebchannel/helpers.js</file>
+        <file>StatusQ/Popups/StatusSuccessAction.qml</file>
+        <file>StatusQ/Popups/qmldir</file>
+        <file>StatusQ/Popups/statusModal/StatusImageWithTitle.qml</file>
+        <file>StatusQ/Popups/statusModal/StatusModalFooter.qml</file>
+        <file>StatusQ/Popups/statusModal/StatusModalHeader.qml</file>
     </qresource>
 </RCC>

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -208,6 +208,7 @@
         <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
         <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
         <file>StatusQ/Core/Utils/StringUtils.qml</file>
+        <file>StatusQ/Core/Utils/DoubleFlickable.qml</file>
         <file>StatusQ/Components/StatusPageIndicator.qml</file>
         <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
         <file>StatusQ/Components/StatusOnlineBadge.qml</file>

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -209,6 +209,7 @@
         <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
         <file>StatusQ/Core/Utils/StringUtils.qml</file>
         <file>StatusQ/Core/Utils/DoubleFlickable.qml</file>
+        <file>StatusQ/Core/Utils/DoubleFlickableWithFolding.qml</file>
         <file>StatusQ/Components/StatusPageIndicator.qml</file>
         <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
         <file>StatusQ/Components/StatusOnlineBadge.qml</file>


### PR DESCRIPTION
### What does the PR do

It adds two components:
- `DoubleFlickable` - Utility making two `Flickable`s operating as a single one. They are not "unrolled" and only needed delegates from both underlying `ListView`s/`GridView`s are instantiated.
- `DoubleFlickableWithFolding` - Built on top of `DoubleFlickable`, provides custom behavior of sticky headers and folding.

Closes: #13193

### Affected areas
`StatusQ`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00082.webm](https://github.com/status-im/status-desktop/assets/20650004/b21f9eac-48ba-4add-9e81-2da71e535ccb)

[Kazam_screencast_00083.webm](https://github.com/status-im/status-desktop/assets/20650004/777258fd-0754-44b1-b38e-d67d91a4773c)

