### PR TITLE
fix(@desktop/permissions): Hide permissions list in sharing addresses…

### DIFF
--- a/src/app/modules/shared_models/token_permission_item.nim
+++ b/src/app/modules/shared_models/token_permission_item.nim
@@ -20,7 +20,10 @@ proc `$`*(self: TokenPermissionItem): string =
   result = fmt"""TokenPermissionItem(
     id: {self.id},
     type: {self.type},
-    ]"""
+    isPrivate: {self.isPrivate},
+    tokenCriteriaMet: {self.tokenCriteriaMet},
+    state: {self.state}
+    )"""
 
 proc initTokenPermissionItem*(
   id: string,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1550,7 +1550,6 @@ QtObject:
         raise newException(RpcException, error.message)
 
       let checkPermissionsToJoinResponse = rpcResponseObj["response"]["result"].toCheckPermissionsToJoinResponseDto
-
       self.events.emit(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_RESPONSE, CheckPermissionsToJoinResponseArgs(
         communityId: communityId,
         checkPermissionsToJoinResponse: checkPermissionsToJoinResponse

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -215,7 +215,7 @@ Control {
             radius: Style.current.padding
             border.width: 1
             border.color: Theme.palette.baseColor3
-            visible: d.hasPermissions
+            visible: permissionsView.hasAnyVisiblePermission
 
             layer.enabled: true
             layer.effect: DropShadow {
@@ -240,7 +240,7 @@ Control {
             Layout.fillHeight: true
             Layout.fillWidth: true
             Layout.topMargin: -Style.current.padding // compensate for the half-rounded divider above
-            visible: d.hasPermissions
+            visible: permissionsView.hasAnyVisiblePermission
         }
     }
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -436,6 +436,8 @@ QtObject {
         readonly property int member: 2
         readonly property int read: 3
         readonly property int viewAndPost: 4
+        readonly property int becomeTokenMaster: 5
+        readonly property int becomeTokenOwner: 6
     }
 
     readonly property QtObject messageContentType: QtObject {


### PR DESCRIPTION
Hide permissions list in sharing addresses dialog if only base permissions (become token owner and become token master) are set.

Fix #12884

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/61889657/99114152-5402-433f-8970-94dea3f45b57)

![image](https://github.com/status-im/status-desktop/assets/61889657/6b530d9a-22d8-4e97-99a9-fff15ea9bd6f)

![image](https://github.com/status-im/status-desktop/assets/61889657/01f3f85c-4831-4a47-bca6-f0b86b9e95df)
