### PR TITLE
fix(keycard): unable to re-run keycard flow on windows

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
@@ -21,7 +21,8 @@ proc ensureReaderAndCardPresence*(state: State, keycardFlowType: string, keycard
     state.flowType == FlowType.MigrateFromAppToKeycard:
       if keycardFlowType == ResponseTypeValueKeycardFlowResult and
         keycardEvent.error.len > 0 and
-        keycardEvent.error == ErrorNoReader:
+        (keycardEvent.error == ErrorNoReader or
+        keycardEvent.error == ErrorReaderList):
           controller.reRunCurrentFlowLater()
           if state.stateType == StateType.PluginReader:
             return nil
@@ -41,8 +42,9 @@ proc ensureReaderAndCardPresence*(state: State, keycardFlowType: string, keycard
   if state.flowType == FlowType.SetupNewKeycard:
     if keycardFlowType == ResponseTypeValueKeycardFlowResult and
       keycardEvent.error.len > 0 and
-      keycardEvent.error == ErrorConnection or
-      keycardEvent.error == ErrorNoReader:
+      (keycardEvent.error == ErrorConnection or
+      keycardEvent.error == ErrorNoReader or
+      keycardEvent.error == ErrorReaderList):
         controller.reRunCurrentFlowLater()
         if state.stateType == StateType.PluginReader:
           return nil

--- a/src/app/modules/startup/internal/state_factory_login_implementation.nim
+++ b/src/app/modules/startup/internal/state_factory_login_implementation.nim
@@ -3,11 +3,12 @@ proc ensureReaderAndCardPresenceLogin*(state: State, keycardFlowType: string, ke
     keycardEvent.error.len > 0:
       if keycardEvent.error == ErrorPCSC:
         return createState(StateType.LoginNoPCSCService, state.flowType, nil)
-      if keycardEvent.error == ErrorNoReader:
-        controller.reRunCurrentFlowLater()
-        if state.stateType == StateType.LoginPlugin:
-          return nil
-        return createState(StateType.LoginPlugin, state.flowType, nil)
+      if keycardEvent.error == ErrorNoReader or
+        keycardEvent.error == ErrorReaderList:
+          controller.reRunCurrentFlowLater()
+          if state.stateType == StateType.LoginPlugin:
+            return nil
+          return createState(StateType.LoginPlugin, state.flowType, nil)
   if keycardFlowType == ResponseTypeValueInsertCard and
     keycardEvent.error.len > 0 and
     keycardEvent.error == ErrorConnection:

--- a/src/app/modules/startup/internal/state_factory_onboarding_implementation.nim
+++ b/src/app/modules/startup/internal/state_factory_onboarding_implementation.nim
@@ -4,11 +4,12 @@ proc ensureReaderAndCardPresenceOnboarding*(state: State, keycardFlowType: strin
     keycardEvent.error.len > 0:
       if keycardEvent.error == ErrorPCSC:
         return createState(StateType.KeycardNoPCSCService, state.flowType, backState)
-      if keycardEvent.error == ErrorNoReader:
-        controller.reRunCurrentFlowLater()
-        if state.stateType == StateType.KeycardPluginReader:
-          return nil
-        return createState(StateType.KeycardPluginReader, state.flowType, backState)
+      if keycardEvent.error == ErrorNoReader or
+        keycardEvent.error == ErrorReaderList:
+          controller.reRunCurrentFlowLater()
+          if state.stateType == StateType.KeycardPluginReader:
+            return nil
+          return createState(StateType.KeycardPluginReader, state.flowType, backState)
   if keycardFlowType == ResponseTypeValueInsertCard and
     keycardEvent.error.len > 0 and
     keycardEvent.error == ErrorConnection:

--- a/ui/imports/shared/popups/keycard/KeycardPopupContent.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupContent.qml
@@ -235,7 +235,7 @@ Item {
             sharedKeycardModule: root.sharedKeycardModule
 
             Component.onCompleted: {
-                seedPhraseRevealed = false
+                d.primaryButtonEnabled = seedPhraseRevealed
             }
 
             onSeedPhraseRevealedChanged: {


### PR DESCRIPTION
The issue re-running keycard flows on Windows is fixed in this commit, cause a different signal was emitted on Windows in case of missing Keycard.