### PR TITLE
fix(savedaddresses): preferred chains maintained in two places

### DIFF
--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -78,6 +78,7 @@ type
     keycardService: keycard_service.Service
     accountsService: accounts_service.Service
     walletAccountService: wallet_account_service.Service
+    savedAddressService: saved_address_service.Service
     devicesService: devices_service.Service
 
     activityController: activityc.Controller
@@ -114,6 +115,7 @@ proc newModule*(
   result.keycardService = keycardService
   result.accountsService = accountsService
   result.walletAccountService = walletAccountService
+  result.savedAddressService = savedAddressService
   result.devicesService = devicesService
   result.moduleLoaded = false
   result.controller = newController(result, settingsService, walletAccountService, currencyService, networkService)
@@ -375,13 +377,13 @@ method destroyAddAccountPopup*(self: Module) =
 method runAddAccountPopup*(self: Module, addingWatchOnlyAccount: bool) =
   self.destroyAddAccountPopup()
   self.addAccountModule = add_account_module.newModule(self, self.events, self.keycardService, self.accountsService,
-    self.walletAccountService)
+    self.walletAccountService, self.savedAddressService)
   self.addAccountModule.loadForAddingAccount(addingWatchOnlyAccount)
 
 method runEditAccountPopup*(self: Module, address: string) =
   self.destroyAddAccountPopup()
   self.addAccountModule = add_account_module.newModule(self, self.events, self.keycardService, self.accountsService,
-    self.walletAccountService)
+    self.walletAccountService, self.savedAddressService)
   self.addAccountModule.loadForEditingAccount(address)
 
 method getAddAccountModule*(self: Module): QVariant =

--- a/src/app/modules/shared_modules/add_account/io_interface.nim
+++ b/src/app/modules/shared_modules/add_account/io_interface.nim
@@ -101,6 +101,11 @@ method buildNewPrivateKeyKeypairAndAddItToOrigin*(self: AccessInterface) {.base.
 method buildNewSeedPhraseKeypairAndAddItToOrigin*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method removingSavedAddressConfirmed*(self: AccessInterface, address: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method savedAddressDeleted*(self: AccessInterface, address: string, errorMsg: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
 
 type
   DelegateInterface* = concept c

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -354,3 +354,12 @@ QtObject:
   proc startScanningForActivity*(self: View) {.slot.} =
     self.delegate.startScanningForActivity()
 
+  proc confirmSavedAddressRemoval*(self: View, name: string, address: string) {.signal.}
+  proc sendConfirmSavedAddressRemovalSignal*(self: View, name: string, address: string) =
+    self.confirmSavedAddressRemoval(name, address)
+
+  proc removingSavedAddressConfirmed*(self: View, address: string) {.slot.} =
+    self.delegate.removingSavedAddressConfirmed(address)
+
+  proc removingSavedAddressRejected*(self: View) {.slot.} =
+    self.setDisablePopup(false)

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, json
+import NimQml, chronicles, strutils, sequtils, json
 
 import dto
 
@@ -72,6 +72,11 @@ QtObject:
 
   proc getSavedAddresses*(self: Service): seq[SavedAddressDto] =
     return self.savedAddresses
+
+  proc getSavedAddress*(self: Service, address: string): SavedAddressDto =
+    for sa in self.savedAddresses:
+      if cmpIgnoreCase(sa.address, address) == 0:
+        return sa
 
   proc updateAddresses(self: Service, signal: string, arg: Args) =
     self.savedAddresses = self.getAddresses()

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -99,11 +99,16 @@ StatusModal {
         readonly property var chainPrefixRegexPattern: /[^:]+\:?|:/g
         readonly property bool addressInputIsENS: !!d.ens
 
-        property bool addressAlreadyAdded: false
-        function checkIfAddressIsAlreadyAddded(address) {
+        property bool addressAlreadyAddedToWallet: false
+        function checkIfAddressIsAlreadyAdddedToWallet(address) {
+            let name = RootStore.getNameForWalletAddress(address)
+            d.addressAlreadyAddedToWallet = !!name
+        }
+
+        property bool addressAlreadyAddedToSavedAddresses: false
+        function checkIfAddressIsAlreadyAdddedToSavedAddresses(address) {
             let details = RootStore.getSavedAddress(address)
-            d.addressAlreadyAdded = !!details.address
-            return !d.addressAlreadyAdded
+            d.addressAlreadyAddedToSavedAddresses = !!details.address
         }
 
         /// Ensures that the \c root.address and \c root.chainShortNames are not reset when the initial text is set
@@ -211,7 +216,8 @@ StatusModal {
                         errorMessage: qsTr("Please enter an ethereum address")
                     },
                     StatusValidator {
-                        errorMessage: d.addressAlreadyAdded? qsTr("This address is already saved") : qsTr("Ethereum address invalid")
+                        errorMessage: d.addressAlreadyAddedToWallet? qsTr("This address is already added to Wallet") :
+                                                                     d.addressAlreadyAddedToSavedAddresses? qsTr("This address is already saved") : qsTr("Ethereum address invalid")
                         validate: function (value) {
                             if (value !== Constants.zeroAddress) {
                                 if (Utils.isValidEns(value)) {
@@ -222,7 +228,12 @@ StatusModal {
                                         return true
                                     }
                                     const prefixAndAddress = Utils.splitToChainPrefixAndAddress(value)
-                                    return d.checkIfAddressIsAlreadyAddded(prefixAndAddress.address)
+                                    d.checkIfAddressIsAlreadyAdddedToWallet(prefixAndAddress.address)
+                                    if (d.addressAlreadyAddedToWallet) {
+                                        return false
+                                    }
+                                    d.checkIfAddressIsAlreadyAdddedToSavedAddresses(prefixAndAddress.address)
+                                    return !d.addressAlreadyAddedToSavedAddresses
                                 }
                             }
 
@@ -234,7 +245,8 @@ StatusModal {
                     StatusAsyncValidator {
                         id: resolvingEnsName
                         name: "resolving-ens-name"
-                        errorMessage: d.addressAlreadyAdded? qsTr("This address is already saved") : qsTr("Ethereum address invalid")
+                        errorMessage: d.addressAlreadyAddedToWallet? qsTr("This address is already added to Wallet") :
+                                                                     d.addressAlreadyAddedToSavedAddresses? qsTr("This address is already saved") : qsTr("Ethereum address invalid")
                         asyncOperation: (value) => {
                                             if (!Utils.isValidEns(value)) {
                                                 resolvingEnsName.asyncComplete("not-ens")
@@ -248,7 +260,12 @@ StatusModal {
                                           return true
                                       }
                                       if (!!value) {
-                                          return d.checkIfAddressIsAlreadyAddded(value)
+                                          d.checkIfAddressIsAlreadyAdddedToWallet(prefixAndAddress.address)
+                                          if (d.addressAlreadyAddedToWallet) {
+                                              return false
+                                          }
+                                          d.checkIfAddressIsAlreadyAdddedToSavedAddresses(value)
+                                          return !d.addressAlreadyAddedToSavedAddresses
                                       }
                                       return false
                                   }
@@ -281,7 +298,7 @@ StatusModal {
                     if (skipTextUpdate || !d.initialized)
                         return
 
-                    d.addressAlreadyAdded = false
+                    d.addressAlreadyAddedToSavedAddresses = false
                     plainText = input.edit.getText(0, text.length)
 
                     if (input.edit.previousText != plainText) {

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -6,6 +6,7 @@ import StatusQ.Popups 0.1
 import StatusQ.Controls 0.1
 
 import utils 1.0
+import shared.popups 1.0
 
 import "./stores"
 import "./states"
@@ -29,6 +30,13 @@ StatusModal {
 
     onClosed: {
         root.store.currentState.doCancelAction()
+    }
+
+    Connections {
+        target: root.store.addAccountModule
+        function onConfirmSavedAddressRemoval(name, address) {
+            Global.openPopup(confirmSavedAddressRemoval, {address: address, name: name})
+        }
     }
 
     StatusScrollView {
@@ -151,6 +159,37 @@ StatusModal {
                     onContinueOnKeycard: {
                         root.close()
                     }
+                }
+            }
+        }
+
+        Component {
+            id: confirmSavedAddressRemoval
+
+            ConfirmationDialog {
+
+                property string name
+                property string address
+
+                closePolicy: Popup.NoAutoClose
+                hasCloseButton: false
+                headerSettings.title: qsTr("Removing saved address")
+                confirmationText: qsTr("The account you're trying to add <b>%1</b> is already saved under the name <b>%2</b>.<br/><br/>Do you want to remove it from saved addresses in favour of adding it to the Wallet?")
+                .arg(address)
+                .arg(name)
+                showCancelButton: true
+                cancelBtnType: ""
+                confirmButtonLabel: qsTr("Yes")
+                cancelButtonLabel: qsTr("No")
+
+                onConfirmButtonClicked: {
+                    root.store.addAccountModule.removingSavedAddressConfirmed(address)
+                    close()
+                }
+
+                onCancelButtonClicked: {
+                    root.store.addAccountModule.removingSavedAddressRejected()
+                    close()
                 }
             }
         }


### PR DESCRIPTION
This commit prevents the user from adding an address to the saved addresses list, if it was already added to the Wallet section. Also when the user is about to add an address to the Wallet section, which is already added to the saved addresses list, the app will ask whether to proceed with that action by removing the related saved address or cancel the action.

Closes: #13109


https://github.com/status-im/status-desktop/assets/86303051/d39d83ae-7775-4896-9c5c-ccef7b3247d4

