### PR TITLE
fix: apply Custom order to main wallet view 

### DIFF
--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -20,7 +20,7 @@ FocusScope {
     property alias titleRowComponentLoader: loader
     property list<Item> headerComponents
     property alias bottomHeaderComponents: secondHeaderRow.contentItem
-    default property Item content
+    default property alias content: contentWrapper.children
     property alias titleLayout: titleLayout
 
     property bool dirty: false
@@ -49,8 +49,6 @@ FocusScope {
     }
 
     Component.onCompleted: {
-        content.parent = contentWrapper
-
         if (headerComponents.length) {
             for (let i in headerComponents) {
                 headerComponents[i].parent = titleRow

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
+import Qt.labs.settings 1.1
 import QtQml 2.15
 
 import StatusQ.Controls 0.1
@@ -22,6 +23,8 @@ import "../panels"
 
 import AppLayouts.Profile.views.wallet 1.0
 import AppLayouts.Wallet.stores 1.0
+import AppLayouts.Wallet.controls 1.0
+import AppLayouts.Wallet 1.0
 
 SettingsContentBase {
     id: root
@@ -65,9 +68,22 @@ SettingsContentBase {
     }
     onSaveChangesClicked: {
         manageTokensView.saveChanges()
+
+        let sectionLink = "%1/%2/".arg(Constants.appSection.wallet).arg(WalletLayout.LeftPanelSelection.AllAddresses)
+
+        if (Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets) {
+            sectionLink += WalletLayout.RightPanelSelection.Assets
+            priv.assetSettings.setValue("currentSortValue", SortOrderComboBox.TokenOrderCustom)
+            priv.assetSettings.sync()
+        } else if (Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles) {
+            sectionLink += WalletLayout.RightPanelSelection.Collectibles
+            priv.collectiblesSettings.setValue("currentSortValue", SortOrderComboBox.TokenOrderCustom)
+            priv.collectiblesSettings.sync()
+        }
+
         Global.displayToastMessage(
             qsTr("Your new custom token order has been applied to your %1", "Go to Wallet")
-                    .arg(`<a style="text-decoration:none" href="#${Constants.appSection.wallet}">` + qsTr("Wallet", "Go to Wallet") + "</a>"),
+                    .arg(`<a style="text-decoration:none" href="#${sectionLink}">` + qsTr("Wallet", "Go to Wallet") + "</a>"),
             "",
             "checkmark-circle",
             false,
@@ -77,6 +93,24 @@ SettingsContentBase {
     }
     onResetChangesClicked: {
         manageTokensView.resetChanges()
+    }
+
+    readonly property var priv: QtObject {
+        id: priv
+        readonly property bool isManageTokensSubsection: Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets ||
+                                                         Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles ||
+                                                         Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageHidden ||
+                                                         Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAdvanced
+
+        readonly property var assetSettings: Settings {
+            category: "AssetsViewSortSettings"
+            //property int currentSortValue
+        }
+
+        readonly property var collectiblesSettings: Settings {
+            category: "CollectiblesViewSortSettings"
+            //property int currentSortValue
+        }
     }
 
     StackLayout {
@@ -94,9 +128,7 @@ SettingsContentBase {
 
         Binding on currentIndex {
             value: root.manageTokensViewIndex
-            when: Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets ||
-                  Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles ||
-                  Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageTokenLists
+            when: priv.isManageTokensSubsection
             restoreMode: Binding.RestoreNone
         }
 
@@ -285,13 +317,13 @@ SettingsContentBase {
                         return 0
                     case Constants.walletSettingsSubsection.manageCollectibles:
                         return 1
-                    case Constants.walletSettingsSubsection.manageTokenLists:
-                        return 2
+                    case Constants.walletSettingsSubsection.manageHidden:
+                        return 3
+                    case Constants.walletSettingsSubsection.manageAdvanced:
+                        return 4
                     }
                 }
-                when: Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets ||
-                      Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles ||
-                      Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageTokenLists
+                when: priv.isManageTokensSubsection
                 restoreMode: Binding.RestoreNone
             }
         }

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -46,12 +46,6 @@ ColumnLayout {
         loader.item.saveSettings()
     }
 
-    function resetChanges() {
-        if (tabBar.currentIndex > d.hiddenTabIndex)
-            return
-        loader.item.revert()
-    }
-
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -57,8 +57,8 @@ Item {
     }
 
     enum RightPanelSelection {
-        Collectibles,
         Assets,
+        Collectibles,
         Activity
     }
 

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -142,10 +142,20 @@ ColumnLayout {
     }
 
     Settings {
+        id: settings
         category: "CollectiblesViewSortSettings"
-        property alias currentSortField: cmbTokenOrder.currentIndex
+        property int currentSortValue: SortOrderComboBox.TokenOrderDateAdded
         property alias currentSortOrder: cmbTokenOrder.currentSortOrder
         property alias selectedFilterGroupIds: cmbFilter.selectedFilterGroupIds
+    }
+
+    Component.onCompleted: {
+        settings.sync()
+        cmbTokenOrder.currentIndex = cmbTokenOrder.indexOfValue(settings.currentSortValue)
+    }
+
+    Component.onDestruction: {
+        settings.currentSortValue = cmbTokenOrder.currentValue
     }
 
     ColumnLayout {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -335,18 +335,12 @@ Item {
                 return
 
             appMain.rootStore.mainModuleInst.setActiveSectionBySectionType(sectionType)
+
             if (sectionType === Constants.appSection.profile) {
                 Global.settingsSubsection = subsection;
-                Global.settingsSubSubsection = settingsSubsection;
-                return
-            }
-
-            if (sectionType === Constants.appSection.wallet) {
-                appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(
-                            WalletLayout.LeftPanelSelection.AllAddresses,
-                            WalletLayout.RightPanelSelection.Activity,
-                            data
-                            )
+                Global.settingsSubSubsection = subSubsection;
+            } else if (sectionType === Constants.appSection.wallet) {
+                appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
             }
         }
 

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -156,9 +156,19 @@ ColumnLayout {
     }
 
     Settings {
+        id: settings
         category: "AssetsViewSortSettings"
-        property alias currentSortField: cmbTokenOrder.currentIndex
+        property int currentSortValue: SortOrderComboBox.TokenOrderCurrencyBalance
         property alias currentSortOrder: cmbTokenOrder.currentSortOrder
+    }
+
+    Component.onCompleted: {
+        settings.sync()
+        cmbTokenOrder.currentIndex = cmbTokenOrder.indexOfValue(settings.currentSortValue)
+    }
+
+    Component.onDestruction: {
+        settings.currentSortValue = cmbTokenOrder.currentValue
     }
 
     ColumnLayout {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -357,7 +357,8 @@ QtObject {
         readonly property int manageAccounts: 1
         readonly property int manageAssets: 2
         readonly property int manageCollectibles: 3
-        readonly property int manageTokenLists: 4
+        readonly property int manageHidden: 4
+        readonly property int manageAdvanced: 5
     }
 
     readonly property QtObject currentUserStatus: QtObject{


### PR DESCRIPTION
### What does the PR do

Fixes applying the Custom order settings in the main wallet view

Updates the Constants with the correct subsections and fix navigating into section/subsection

Fixes https://github.com/status-im/status-desktop/issues/13275

### Affected areas

Settings/Wallet/Manage tokens

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2024-01-24 21-29-49](https://github.com/status-im/status-desktop/assets/5377645/0f188f0b-5eeb-4b6e-8b96-03c098fbdb38)


