### PR TITLE
feat(Wallet): Collectibles view adjusted to design using `DoubleFlickableWithFolding`

### DIFF
--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -58,8 +58,10 @@ SplitView {
 
     CollectiblesView {
         id: assetsView
-        SplitView.preferredWidth: 600
+
+        SplitView.fillWidth: true
         SplitView.fillHeight: true
+
         collectiblesModel: collectiblesModel
         networkFilters: d.networksChainsCurrentlySelected
         addressFilters: d.addressesSelected
@@ -71,9 +73,13 @@ SplitView {
         onManageTokensRequested: logs.logEvent("onManageTokensRequested")
     }
 
-    Pane {
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
         SplitView.minimumWidth: 300
         SplitView.preferredWidth: 300
+
+        logsView.logText: logs.logText
 
         ColumnLayout {
             spacing: 12
@@ -139,16 +145,11 @@ SplitView {
                     }
                 }
             }
+
+            Item {
+                Layout.fillHeight: true
+            }
         }
-    }
-
-    LogsAndControlsPanel {
-        id: logsAndControlsPanel
-
-        SplitView.minimumWidth: 150
-        SplitView.preferredWidth: 250
-
-        logsView.logText: logs.logText
     }
 }
 

--- a/storybook/pages/DoubleFlickableWithFoldingPage.qml
+++ b/storybook/pages/DoubleFlickableWithFoldingPage.qml
@@ -101,7 +101,7 @@ SplitView {
                             Label {
                                 anchors.centerIn: parent
                                 font.bold: true
-                                text: (doubleFlickable.flickable1Folded ? "⬇" : "➡️")
+                                text: (doubleFlickable.flickable1Folded ? "➡️" : "⬇")
                                       + " Community"
                             }
 

--- a/storybook/src/Models/ManageCollectiblesModel.qml
+++ b/storybook/src/Models/ManageCollectiblesModel.qml
@@ -121,6 +121,7 @@ ListModel {
     readonly property var communityData: [
         {
             uid: "fp#9140",
+            chainId: 5,
             name: "Frenly Panda #9140",
             collectionUid: "",
             collectionName: "",
@@ -129,10 +130,12 @@ ListModel {
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/gae/qPfQjj4P1w0xVQXAmQJLmQ4ZtLFAJU6oiH69Lsny82LFbipLAgXhHKrcLBx2U09SmRnzeHY0ygz-3NIb-JegE_hWrZquFeL-qUPXPdw",
             isLoading: false,
-            backgroundColor: "pink"
+            backgroundColor: "pink",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
         {
             uid: "691",
+            chainId: 421613,
             name: "KILLABEAR #691",
             collectionUid: "",
             collectionName: "",
@@ -141,10 +144,12 @@ ListModel {
             communityImage: "https://i.seadn.io/gcs/files/4a875f997063f4f3772190852c1c44f0.png?w=128&auto=format",
             imageUrl: "https://assets.killabears.com/content/killabears/gif/691-e81f892696a8ae700e0dbc62eb072060679a2046d1ef5eb2671bdb1fad1f68e3.gif",
             isLoading: true,
-            backgroundColor: "navy"
+            backgroundColor: "navy",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
         {
             uid: "8876",
+            chainId: 421613,
             name: "KILLABEAR #2385",
             collectionUid: "",
             collectionName: "",
@@ -153,10 +158,12 @@ ListModel {
             communityImage: "https://i.seadn.io/gcs/files/4a875f997063f4f3772190852c1c44f0.png?w=128&auto=format",
             imageUrl: "https://assets.killabears.com/content/killabears/transparent-512/2385-86ba13cc6945ed0aea7c32a363a96be2f218898358745ae07b947452cb7e4e79.png",
             isLoading: false,
-            backgroundColor: "pink"
+            backgroundColor: "pink",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
         {
             uid: "fp#3195",
+            chainId: 5,
             name: "Frenly Panda #3195324354654756756756784234523",
             collectionUid: "",
             collectionName: "",
@@ -165,10 +172,12 @@ ListModel {
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/s/raw/files/59ad1f2e3c5eb5d4b62c06e200076514.png",
             isLoading: false,
-            backgroundColor: ""
+            backgroundColor: "",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
         {
             uid: "fp#4297",
+            chainId: 5,
             name: "Frenly Panda #4297",
             collectionUid: "",
             collectionName: "",
@@ -177,10 +186,12 @@ ListModel {
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/gae/K4_vmYtXAqU6LTnGDliLtJZc4UPmf9jUlk09_FDbXvSKKyUARyyV9RQEgXdb5bjje5OE9j9ZryC5pzcwBwH7TDOIl8oq7D2tSJ7p",
             isLoading: false,
-            backgroundColor: ""
+            backgroundColor: "",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
         {
             uid: "fp#909",
+            chainId: 5,
             name: "Frenly Panda #909",
             collectionUid: "",
             collectionName: "",
@@ -189,10 +200,12 @@ ListModel {
             communityImage: "https://pbs.twimg.com/profile_images/1599347398769143808/C6qG3RQv_400x400.jpg",
             imageUrl: "https://i.seadn.io/gae/cR-Bjmb6DsrywCJMOqEBPkkrMHjbTzeRSAKIvLpd7i8ss6raYZ3-doh8oF2z8bJsnmfC1oR3kllz6UxMfFaYAKdXYzXlhfVsDHo6bg",
             isLoading: false,
-            backgroundColor: ""
+            backgroundColor: "",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
         {
             uid: "lb#666",
+            chainId: 420,
             name: "Lonely Bear #666",
             collectionUid: "",
             collectionName: "",
@@ -201,7 +214,8 @@ ListModel {
             communityImage: "",
             imageUrl: "",
             isLoading: false,
-            backgroundColor: "pink"
+            backgroundColor: "pink",
+            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         },
     ]
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/DoubleFlickableWithFolding.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/DoubleFlickableWithFolding.qml
@@ -5,11 +5,11 @@ DoubleFlickable {
     readonly property real gridHeader1YInContentItem: contentY
     readonly property real gridHeader2YInContentItem: contentY + d.grid2HeaderOffset
 
-    readonly property bool flickable1Folded: d.grid1ConentInViewport
+    readonly property bool flickable1Folded: !d.grid1ContentInViewport
     readonly property bool flickable2Folded: d.grid2HeaderAtEnd || d.model2Blocked
 
     function flip1Folding() {
-        if (d.grid1ConentInViewport) {
+        if (d.grid1ContentInViewport) {
             if (d.grid2FullyFilling)
                 contentY = flickable1ContentHeight - d.header1Size
             else
@@ -55,10 +55,10 @@ DoubleFlickable {
     QtObject {
         id: d
 
-        readonly property real header1Size: flickable1.headerItem.height
-        readonly property real header2Size: flickable2.headerItem.height
+        readonly property real header1Size: flickable1.headerItem ? flickable1.headerItem.height : 0
+        readonly property real header2Size: flickable2.headerItem ? flickable2.headerItem.height : 0
 
-        readonly property bool grid1ConentInViewport:
+        readonly property bool grid1ContentInViewport:
             flickable1.y > contentY - Math.min(height, flickable1ContentHeight) + header1Size
         readonly property real grid2HeaderOffset:
             Math.min(Math.max(flickable2.y - contentY, header1Size), height - header2Size)
@@ -97,7 +97,7 @@ DoubleFlickable {
         property: "model"
         value: null
 
-        restoreMode: Binding.RestoreBinding
+        restoreMode: Binding.RestoreBindingOrValue
     }
 
     Binding {
@@ -106,7 +106,7 @@ DoubleFlickable {
         property: "model"
         value: null
 
-        restoreMode: Binding.RestoreBinding
+        restoreMode: Binding.RestoreBindingOrValue
     }
 }
 


### PR DESCRIPTION
### What does the PR do

- Wallet's main view, collectibles section is adjusted to the recent design
`DoubleFlickableWithFolding` provides foldable sections and controls
underlying grid views for both categories preventing from instantiating
too many delegates.
- `CollectiblesView`'s Storybook page fixed
- `DoubleFlickableWithFolding` - some minor fixes regarding bindings, flags for foldings
- `ManageCollectiblesModel` updated

### Affected areas
`CollectiblesView`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00084.webm](https://github.com/status-im/status-desktop/assets/20650004/7aedd4e1-aad9-47ea-97b0-a4916069b38a)

![image](https://github.com/status-im/status-desktop/assets/20650004/8be10c91-6d21-43d7-b5ba-c87c9f300864)

