### PR TITLE
fix: fake collections shouldn't be visible in a filtering combo

### DIFF
--- a/ui/StatusQ/src/wallet/managetokensmodel.cpp
+++ b/ui/StatusQ/src/wallet/managetokensmodel.cpp
@@ -120,6 +120,7 @@ QHash<int, QByteArray> ManageTokensModel::roleNames() const
         {CustomSortOrderNoRole, kCustomSortOrderNoRoleName},
         {TokenImageRole, kTokenImageRoleName},
         {TokenBackgroundColorRole, kBackgroundColorRoleName},
+        {IsSelfCollectionRole, kIsSelfCollectionRoleName},
     };
 
     return roles;
@@ -146,6 +147,7 @@ QVariant ManageTokensModel::data(const QModelIndex& index, int role) const
     case CustomSortOrderNoRole: return token.customSortOrderNo;
     case TokenImageRole: return token.image;
     case TokenBackgroundColorRole: return token.backgroundColor;
+    case IsSelfCollectionRole: return token.isSelfCollection;
     }
 
     return {};

--- a/ui/StatusQ/src/wallet/managetokensmodel.h
+++ b/ui/StatusQ/src/wallet/managetokensmodel.h
@@ -23,6 +23,8 @@ const auto kEnabledNetworkCurrencyBalanceRoleName = QByteArrayLiteral("enabledNe
 const auto kCustomSortOrderNoRoleName = QByteArrayLiteral("customSortOrderNo");
 const auto kTokenImageRoleName = QByteArrayLiteral("imageUrl");
 const auto kBackgroundColorRoleName = QByteArrayLiteral("backgroundColor");
+
+const auto kIsSelfCollectionRoleName = QByteArrayLiteral("isSelfCollection");
 // TODO add communityPrivilegesLevel for collectibles
 } // namespace
 
@@ -31,6 +33,7 @@ struct TokenData {
     QColor backgroundColor{Qt::transparent};
     QVariant balance, currencyBalance;
     int customSortOrderNo{INT_MAX};
+    bool isSelfCollection{false};
 };
 
 // symbol -> {sortOrder, visible, groupId}
@@ -56,6 +59,7 @@ public:
         CustomSortOrderNoRole,
         TokenImageRole,
         TokenBackgroundColorRole,
+        IsSelfCollectionRole,
     };
     Q_ENUM(TokenDataRoles)
 

--- a/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
@@ -88,6 +88,14 @@ ComboBox {
                         return model.groupName.toLowerCase().includes(d.searchTextLowerCase) || model.groupId.toLowerCase().includes(d.searchTextLowerCase)
                     }
                     expectedRoles: ["groupName", "groupId"]
+                },
+                FastExpressionFilter {
+                    expression: {
+                        if (model.sourceGroup === "collection")
+                            return !model.isSelfCollection
+                        return true
+                    }
+                    expectedRoles: ["sourceGroup", "isSelfCollection"]
                 }
             ]
         }
@@ -95,8 +103,8 @@ ComboBox {
         readonly property var uncategorizedModel: SortFilterProxyModel { // regular collectibles with no collection
             sourceModel: root.regularTokensModel
             filters: ValueFilter {
-                roleName: "collectionUid"
-                value: ""
+                roleName: "isSelfCollection"
+                value: true
             }
             onCountChanged: if (!count) d.removeFilter("") // different underlying model -> uncheck
         }

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokenMenuButton.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokenMenuButton.qml
@@ -79,7 +79,7 @@ StatusFlatButton {
             // any token
             StatusAction {
                 objectName: "miHideToken"
-                enabled: !root.inHidden && root.hideEnabled && !root.isGroup && !root.isCommunityToken && !root.isCollectible
+                enabled: !root.inHidden && root.hideEnabled && !root.isGroup && !root.isCommunityToken && !root.groupId
                 type: StatusAction.Type.Danger
                 icon.name: "hide"
                 text: root.isCollectible ? qsTr("Hide collectible") : qsTr("Hide asset")
@@ -122,7 +122,7 @@ StatusFlatButton {
             // (hide) collection tokens
             StatusMenu {
                 id: collectionSubmenu
-                enabled: !root.inHidden && root.isCollectible && !root.isCommunityToken && !root.isGroup
+                enabled: !root.inHidden && root.isCollectible && !root.isCommunityToken && !root.isGroup && root.groupId
                 title: qsTr("Hide")
                 assetSettings.name: "hide"
                 type: StatusAction.Type.Danger

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
@@ -90,9 +90,10 @@ DropArea {
                 currentIndex: root.visualIndex
                 count: root.count
                 inHidden: root.isHidden
-                groupId: model.communityId || model.collectionUid
+                groupId: isCollection ? model.collectionUid : model.communityId
                 isCommunityToken: root.isCommunityToken
                 isCollectible: root.isCollectible
+                isCollection: isCollectible && !model.isSelfCollection
                 onMoveRequested: (from, to) => root.ListView.view.model.moveItem(from, to)
                 onShowHideRequested: function(symbol, flag) {
                     if (isCommunityToken)


### PR DESCRIPTION
teach the model about the special cased self-collections containing just one single collectible item; we need that for the "Arrange by collection" token mgmt feature but in all other cases it shouldn't be treated as a collection/group

Fixes #13281

### Affected areas

CollectiblesView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/258ebd3b-72ee-41a0-b01c-141eb55e07ab)

![image](https://github.com/status-im/status-desktop/assets/5377645/64e1da76-7442-4f39-9428-2a3764d9ffd5)

