### PR TITLE
fix(UserListPanel): use `FastExpressionRole`

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
@@ -60,11 +61,12 @@ Item {
             model: SortFilterProxyModel {
                 sourceModel: root.usersModel
 
-                proxyRoles: ExpressionRole {
+                proxyRoles: FastExpressionRole {
                     function displayNameProxy(nickname, ensName, displayName, aliasName) {
                         return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
                     }
                     name: "preferredDisplayName"
+                    expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
                     expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
                 }
 


### PR DESCRIPTION
Related to https://github.com/status-im/status-desktop/issues/13354

### What does the PR do

As @caybro proposed here: https://github.com/status-im/status-desktop/issues/12363#issuecomment-1873850368, I replaced `ExpressionRole` with `FastExpressionRole`, it helped.

As noted in comments, this doesn't fix the issue. But should be there anyway.
https://github.com/status-im/status-desktop/pull/13299#discussion_r1467794778