### PR TITLE
fix(keycard): app crashes when trying to generate new keys with an already used keycard

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -851,4 +851,6 @@ proc tryToStoreDataToKeychain*(self: Controller, password: string) =
   self.keychainService.storeData(singletonInstance.userProfile.getKeyUid(), password)
 
 proc getCurrencyFormat*(self: Controller, symbol: string): CurrencyFormatDto =
+  if not serviceApplicable(self.walletAccountService):
+    return
   return self.walletAccountService.getCurrencyFormat(symbol)


### PR DESCRIPTION
A crash was happening cause the wallet account service was not available before the user logged in.

Fixes: #13286