### PR TITLE
Feat/issue hidden confirmation popup

### DIFF
--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -84,6 +84,9 @@ SplitView {
         popupParent: root
         rootStore: QtObject {}
         communityTokensStore: QtObject {}
+        walletAssetsStore: WalletAssetsStore {
+            manageAssetsController: assetsView.controller
+        }
     }
 
     StackLayout {

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -10,6 +10,7 @@ import mainui 1.0
 import utils 1.0
 
 import AppLayouts.Wallet.views 1.0
+import AppLayouts.Wallet.stores 1.0
 
 import shared.views 1.0
 
@@ -45,6 +46,9 @@ SplitView {
         popupParent: root
         rootStore: QtObject {}
         communityTokensStore: QtObject {}
+        walletCollectiblesStore: CollectiblesStore {
+            manageCollectiblesController: collectiblesView.controller
+        }
     }
 
     QtObject {
@@ -69,7 +73,7 @@ SplitView {
     }
 
     CollectiblesView {
-        id: assetsView
+        id: collectiblesView
 
         SplitView.fillWidth: true
         SplitView.fillHeight: true

--- a/storybook/stubs/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/storybook/stubs/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.15
+
+QtObject {
+    property var manageCollectiblesController
+}

--- a/storybook/stubs/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/storybook/stubs/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -41,4 +41,6 @@ QtObject {
         rightModel: communityModel
         joinRole: "communityId"
     }
+
+    property var manageAssetsController
 }

--- a/storybook/stubs/AppLayouts/Wallet/stores/qmldir
+++ b/storybook/stubs/AppLayouts/Wallet/stores/qmldir
@@ -1,3 +1,4 @@
+CollectiblesStore 1.0 CollectiblesStore.qml
 WalletAssetsStore 1.0 WalletAssetsStore.qml
 TokensStore 1.0 TokensStore.qml
 ActivityFiltersStore 1.0 ActivityFiltersStore.qml

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -35,6 +35,8 @@ ColumnLayout {
     property bool sendEnabled: true
     property bool filterVisible
 
+    readonly property var controller: d.controller
+
     signal collectibleClicked(int chainId, string contractAddress, string tokenId, string uid)
     signal sendRequested(string symbol)
     signal receiveRequested(string symbol)
@@ -463,7 +465,7 @@ ColumnLayout {
                 type: StatusAction.Type.Danger
                 icon.name: "hide"
                 text: qsTr("Hide collectible")
-                onTriggered: Global.openPopup(confirmHideCollectiblePopup, {symbol, tokenName, tokenImage, communityId})
+                onTriggered: Global.openConfirmHideCollectiblePopup(symbol, tokenName, tokenImage)
             }
             StatusAction {
                 enabled: !!communityId
@@ -490,41 +492,6 @@ ColumnLayout {
     }
 
     Component {
-        id: confirmHideCollectiblePopup
-        ConfirmationDialog {
-            property string symbol
-            property string tokenName
-            property string tokenImage
-            property string communityId
-
-            readonly property string formattedName: tokenName + (communityId ? " (" + qsTr("community collectible") + ")" : "")
-
-            width: 520
-            destroyOnClose: true
-            confirmButtonLabel: qsTr("Hide %1").arg(tokenName)
-            cancelBtnType: ""
-            showCancelButton: true
-            headerSettings.title: qsTr("Hide %1").arg(formattedName)
-            headerSettings.asset.name: tokenImage
-            confirmationText: qsTr("Are you sure you want to hide %1? You will no longer see or be able to interact with this collectible anywhere inside Status.").arg(formattedName)
-            onCancelButtonClicked: close()
-            onConfirmButtonClicked: {
-                d.controller.settingsHideToken(symbol)
-                close()
-                Global.displayToastMessage(
-                    qsTr("%1 was successfully hidden. You can toggle collectible visibility via %2.").arg(formattedName)
-                            .arg(`<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.wallet}/${Constants.walletSettingsSubsection.manageCollectibles}">` + qsTr("Settings", "Go to Settings") + "</a>"),
-                    "",
-                    "checkmark-circle",
-                    false,
-                    Constants.ephemeralNotificationType.success,
-                    ""
-                )
-            }
-        }
-    }
-
-    Component {
         id: confirmHideCommunityCollectiblesPopup
         ConfirmationDialog {
             property string communityId
@@ -533,7 +500,7 @@ ColumnLayout {
 
             width: 520
             destroyOnClose: true
-            confirmButtonLabel: qsTr("Hide all collectibles minted by this community")
+            confirmButtonLabel: qsTr("Hide '%1' collectibles").arg(communityName)
             cancelBtnType: ""
             showCancelButton: true
             headerSettings.title: qsTr("Hide %1 community collectibles").arg(communityName)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -257,6 +257,7 @@ Item {
         devicesStore: appMain.rootStore.profileSectionStore.devicesStore
         currencyStore: appMain.currencyStore
         walletAssetsStore: appMain.walletAssetsStore
+        walletCollectiblesStore: appMain.walletCollectiblesStore
         isDevBuild: !production
 
         onOpenExternalLink: globalConns.onOpenLink(link)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -35,6 +35,7 @@ QtObject {
     property var devicesStore
     property CurrenciesStore currencyStore
     property WalletStore.WalletAssetsStore walletAssetsStore
+    property WalletStore.CollectiblesStore walletCollectiblesStore
     property bool isDevBuild
 
     signal openExternalLink(string link)
@@ -79,6 +80,8 @@ QtObject {
         Global.openFinaliseOwnershipPopup.connect(openFinaliseOwnershipPopup)
         Global.openDeclineOwnershipPopup.connect(openDeclineOwnershipPopup)
         Global.openFirstTokenReceivedPopup.connect(openFirstTokenReceivedPopup)
+        Global.openConfirmHideAssetPopup.connect(openConfirmHideAssetPopup)
+        Global.openConfirmHideCollectiblePopup.connect(openConfirmHideCollectiblePopup)
     }
 
     property var currentPopup
@@ -331,6 +334,14 @@ QtObject {
                       tokenType: tokenType,
                       tokenImage: tokenImage
                   })
+    }
+    
+    function openConfirmHideAssetPopup(assetSymbol, assetName, assetImage) {
+        openPopup(confirmHideAssetPopup, { assetSymbol, assetName, assetImage })
+    }
+
+    function openConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage) {
+        openPopup(confirmHideCollectiblePopup, { collectibleSymbol, collectibleName, collectibleImage })
     }
 
     readonly property list<Component> _components: [
@@ -958,6 +969,66 @@ QtObject {
                 communitiesStore: root.communitiesStore
 
                 onHideClicked: console.warn("TODO: OPEN HIDE POPUP")
+            }
+        },
+        Component {
+            id: confirmHideAssetPopup
+            ConfirmationDialog {
+
+                property string assetSymbol
+                property string assetName
+                property string assetImage
+
+                width: 520
+                destroyOnClose: true
+                confirmButtonLabel: qsTr("Hide asset")
+                cancelBtnType: ""
+                showCancelButton: true
+                headerSettings.title: qsTr("Hide %1 (%2)").arg(assetName).arg(assetSymbol)
+                headerSettings.asset.name: assetImage
+                confirmationText: qsTr("Are you sure you want to hide %1 (%2)? You will no longer see or be able to interact with this asset anywhere inside Status.").arg(assetName).arg(assetSymbol)
+                onCancelButtonClicked: close()
+                onConfirmButtonClicked: {
+                    root.walletAssetsStore.manageAssetsController.settingsHideToken(assetSymbol)
+                    close()
+                    Global.displayToastMessage(qsTr("%1 (%2) successfully hidden. You can toggle asset visibility via %3.").arg(assetName).arg(assetSymbol)
+                                               .arg(`<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.wallet}/${Constants.walletSettingsSubsection.manageAssets}">` + qsTr("Settings", "Go to Settings") + "</a>"),
+                                               "",
+                                               "checkmark-circle",
+                                               false,
+                                               Constants.ephemeralNotificationType.success,
+                                               "")
+                }
+            }
+        },
+        Component {
+            id: confirmHideCollectiblePopup
+            ConfirmationDialog {
+
+                property string collectibleSymbol
+                property string collectibleName
+                property string collectibleImage
+
+                width: 520
+                destroyOnClose: true
+                confirmButtonLabel: qsTr("Hide collectible")
+                cancelBtnType: ""
+                showCancelButton: true
+                headerSettings.title: qsTr("Hide %1").arg(collectibleName)
+                headerSettings.asset.name: collectibleImage
+                confirmationText: qsTr("Are you sure you want to hide %1? You will no longer see or be able to interact with this collectible anywhere inside Status.").arg(collectibleName)
+                onCancelButtonClicked: close()
+                onConfirmButtonClicked: {
+                    root.walletCollectiblesStore.manageCollectiblesController.settingsHideToken(collectibleSymbol)
+                    close()
+                    Global.displayToastMessage(qsTr("%1 successfully hidden. You can toggle collectible visibility via %2.").arg(collectibleName)
+                                               .arg(`<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.wallet}/${Constants.walletSettingsSubsection.manageCollectibles}">` + qsTr("Settings", "Go to Settings") + "</a>"),
+                                               "",
+                                               "checkmark-circle",
+                                               false,
+                                               Constants.ephemeralNotificationType.success,
+                                               "")
+                }
             }
         }
     ]

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -39,6 +39,8 @@ ColumnLayout {
     property string addressFilters
     property string networkFilters
 
+    readonly property var controller: d.controller
+
     signal assetClicked(var token)
     signal sendRequested(string symbol)
     signal receiveRequested(string symbol)
@@ -366,7 +368,7 @@ ColumnLayout {
                 type: StatusAction.Type.Danger
                 icon.name: "hide"
                 text: qsTr("Hide asset")
-                onTriggered: Global.openPopup(confirmHideAssetPopup, {symbol, assetName, assetImage, communityId})
+                onTriggered: Global.openConfirmHideAssetPopup(symbol, assetName, assetImage)
             }
             StatusAction {
                 enabled: !!communityId
@@ -393,41 +395,6 @@ ColumnLayout {
     }
 
     Component {
-        id: confirmHideAssetPopup
-        ConfirmationDialog {
-            property string symbol
-            property string assetName
-            property string assetImage
-            property string communityId
-
-            readonly property string formattedName: assetName + (communityId ? " (" + qsTr("community asset") + ")" : "")
-
-            width: 520
-            destroyOnClose: true
-            confirmButtonLabel: qsTr("Hide %1").arg(assetName)
-            cancelBtnType: ""
-            showCancelButton: true
-            headerSettings.title: qsTr("Hide %1").arg(formattedName)
-            headerSettings.asset.name: assetImage
-            confirmationText: qsTr("Are you sure you want to hide %1? You will no longer see or be able to interact with this asset anywhere inside Status.").arg(formattedName)
-            onCancelButtonClicked: close()
-            onConfirmButtonClicked: {
-                d.controller.settingsHideToken(symbol)
-                close()
-                Global.displayToastMessage(
-                            qsTr("%1 was successfully hidden. You can toggle asset visibility via %2.").arg(formattedName)
-                            .arg(`<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.wallet}/${Constants.walletSettingsSubsection.manageAssets}">` + qsTr("Settings", "Go to Settings") + "</a>"),
-                            "",
-                            "checkmark-circle",
-                            false,
-                            Constants.ephemeralNotificationType.success,
-                            ""
-                            )
-            }
-        }
-    }
-
-    Component {
         id: confirmHideCommunityAssetsPopup
         ConfirmationDialog {
             property string communityId
@@ -436,7 +403,7 @@ ColumnLayout {
 
             width: 520
             destroyOnClose: true
-            confirmButtonLabel: qsTr("Hide all assets minted by this community")
+            confirmButtonLabel: qsTr("Hide '%1' assets").arg(communityName)
             cancelBtnType: ""
             showCancelButton: true
             headerSettings.title: qsTr("Hide %1 community assets").arg(communityName)

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -66,6 +66,8 @@ QtObject {
                                        string tokenAmount,
                                        int tokenType,
                                        string tokenImage)
+    signal openConfirmHideAssetPopup(string assetSymbol, string assetName, string assetImage)
+    signal openConfirmHideCollectiblePopup(string collectibleSymbol, string collectibleName, string collectibleImage)
 
     signal openLink(string link)
     signal openLinkWithConfirmation(string link, string domain)


### PR DESCRIPTION
Part of #13293

### What does the PR do

Moved `ConfirmationDialog` popups related to hide individual assets or collectibles to `Popups`. Needed since this popup will be also open from a toast message (next task to do). 

### Affected areas

Hide confirmation popup for assets and collectibles from main wallet page.

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/533ba4c4-5184-4594-aeac-1bad2c50af6a