### PR TITLE
fix(keycard): unable to pass pin entry screen in certain flows

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
@@ -25,14 +25,14 @@ proc ensureReaderAndCardPresence*(state: State, keycardFlowType: string, keycard
         keycardEvent.error == ErrorReaderList):
           controller.reRunCurrentFlowLater()
           if state.stateType == StateType.PluginReader:
-            return nil
+            return state
           return createState(StateType.PluginReader, state.flowType, nil)
       if keycardFlowType == ResponseTypeValueInsertCard and
         keycardEvent.error.len > 0 and
         keycardEvent.error == ErrorConnection:
           controller.reRunCurrentFlowLater()
           if state.stateType == StateType.InsertKeycard:
-            return nil
+            return state
           return createState(StateType.InsertKeycard, state.flowType, nil)
       if keycardFlowType == ResponseTypeValueCardInserted:
         controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WronglyInsertedCard, add = false))
@@ -645,6 +645,8 @@ proc readingKeycard*(state: State, keycardFlowType: string, keycardEvent: Keycar
           if keyUid != keycardEvent.keyUid:
             return createState(StateType.WrongKeycard, state.flowType, nil)
           controller.setKeycardUid(keycardEvent.instanceUID)
+        return nextState
+      return ensureKeycardPresenceState
 
   # this is used in case a keycard is inserted and we jump to the first meaningful screen
   return ensureReaderAndCardPresenceAndResolveNextState(state, keycardFlowType, keycardEvent, controller)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
@@ -22,6 +22,7 @@ method executePrePrimaryStateCommand*(self: WrongKeycardState, controller: Contr
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true, nextFlow = FlowType.MigrateFromAppToKeycard,
         forceFlow = controller.getForceFlow(), nextKeyUid = controller.getKeyPairForProcessing().getKeyUid())
       return
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
   if self.flowType == FlowType.MigrateFromAppToKeycard:
     controller.runLoginFlow()
     return

--- a/ui/app/AppLayouts/Profile/views/keycard/DetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/DetailsView.qml
@@ -35,13 +35,6 @@ ColumnLayout {
                 root.detailsModelIsEmpty()
             }
         }
-
-        function checkAndCheckTitleIfNeeded(newKeycardName) {
-            // We change title if there is only a single keycard for a keypair in keycard details view
-            if (root.keycardStore.keycardModule.keycardDetailsModel.count === 1) {
-                root.changeSectionTitle(newKeycardName)
-            }
-        }
     }
 
     StatusListView {
@@ -61,10 +54,6 @@ ColumnLayout {
             keyPairIcon: model.keycard.icon
             keyPairImage: model.keycard.image
             keyPairAccounts: model.keycard.accounts
-
-            onKeycardNameChanged: {
-                d.checkAndCheckTitleIfNeeded(keycardName)
-            }
         }
     }
 


### PR DESCRIPTION
Among this, two other things are fixed:
- a keycard details screen's title should follow the keypair's name, not the keycard's names
- copy keycard flow is blocked if the keycard user is copying to is locked and doesn't belong to any of the app's known keypairs

Fixes: #13289