### PR TITLE
fix(@desktop/wallet):  Prepare send modal to display community assets

### DIFF
--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -31,8 +31,9 @@ SplitView {
         submodelRoleName: "balances"
         delegateModel: SortFilterProxyModel {
             sourceModel: submodel
-            filters: ExpressionFilter {
-                expression: txStore.selectedSenderAccount.address === account
+            filters: FastExpressionFilter {
+                expression: txStore.selectedSenderAccount.address === model.account
+                expectedRoles: ["account"]
             }
         }
     }
@@ -40,6 +41,9 @@ SplitView {
     TransactionStore {
         id: txStore
         walletAssetStore: root.walletAssetStore
+        showCommunityAssetsInSend: showCommunityAssetsCheckBox.checked
+        balanceThresholdEnabled: balanceThresholdCheckbox.checked
+        balanceThresholdAmount: Number(balanceThresholdValue.text)
     }
 
     QtObject {
@@ -272,6 +276,32 @@ SplitView {
                 onClicked: {
                     loader.item.close()
                     loader.item.open()
+                }
+            }
+
+            CheckBox {
+                id: showCommunityAssetsCheckBox
+                text: "Show community assets when sending tokens"
+                checked: true
+            }
+
+            CheckBox {
+                id: balanceThresholdCheckbox
+                text: "Turn on balance threshold"
+                checked: false
+            }
+
+            Rectangle {
+                border.width: 1
+                Layout.preferredWidth: 100
+                Layout.preferredHeight: 50
+                color: "lightgrey"
+                TextInput {
+                    id: balanceThresholdValue
+                    anchors.fill: parent
+                    enabled: balanceThresholdCheckbox.checked
+                    text: "0.10"
+                    inputMethodHints: Qt.ImhFormattedNumbersOnly
                 }
             }
         }

--- a/storybook/pages/TokenListViewPage.qml
+++ b/storybook/pages/TokenListViewPage.qml
@@ -10,12 +10,24 @@ import AppLayouts.Wallet.stores 1.0
 
 import StatusQ.Core.Utils 0.1
 
+import shared.stores 1.0
+import shared.stores.send 1.0
+
 SplitView {
+    id: root
+
     orientation: Qt.Vertical
 
     readonly property WalletAssetsStore walletAssetStore: WalletAssetsStore {
         assetsWithFilteredBalances: groupedAccountsAssetsModel
     }
+
+    TransactionStore {
+        id: txStore
+        walletAssetStore: root.walletAssetStore
+    }
+
+    readonly property CurrenciesStore currencyStore: CurrenciesStore {}
 
     Item {
         SplitView.fillWidth: true
@@ -31,26 +43,16 @@ SplitView {
 
             width: 400
 
-            assets: walletAssetStore.groupedAccountAssetsModel
+            assets: txStore.processedAssetsModel
             collectibles: WalletNestedCollectiblesModel {}
             networksModel: NetworksModel.allNetworks
-            getCurrencyAmountFromBigInt: function(balance, symbol, decimals){
-                let bigIntBalance = AmountsArithmetic.fromString(balance)
-                let balance123 = AmountsArithmetic.toNumber(bigIntBalance, decimals)
-                return ({
-                            amount: balance123,
-                            symbol: symbol,
-                            displayDecimals: 2,
-                            stripTrailingZeroes: false
-                        })
+            formatCurrentCurrencyAmount: function(balance){
+                return currencyStore.formatCurrencyAmount(balance, "USD")
             }
-            getCurrentCurrencyAmount: function(balance){
-                return ({
-                            amount: balance,
-                            symbol: "USD",
-                            displayDecimals: 2,
-                            stripTrailingZeroes: false
-                        })
+            formatCurrencyAmountFromBigInt: function(balance, symbol, decimals){
+                let bigIntBalance = AmountsArithmetic.fromString(balance)
+                let decimalBalance = AmountsArithmetic.toNumber(bigIntBalance, decimals)
+                return currencyStore.formatCurrencyAmount(decimalBalance, symbol)
             }
         }
     }

--- a/storybook/src/Models/TokensBySymbolModel.qml
+++ b/storybook/src/Models/TokensBySymbolModel.qml
@@ -104,7 +104,7 @@ ListModel {
             addressPerChain: [
                 { chainId: 420, address: "0x6b175474e89094c44da98b954eedeac495271e0f"}
             ],
-            decimals: 18,
+            decimals: 0,
             type: 1,
             communityId: "ddls",
             description: "",
@@ -130,7 +130,7 @@ ListModel {
             addressPerChain: [
                 { chainId: 420, address: "0x6b175474e89094c44da98b954eedeac495271p0f"}
             ],
-            decimals: 18,
+            decimals: 0,
             type: 1,
             communityId: "sox",
             description: "",
@@ -156,7 +156,7 @@ ListModel {
             addressPerChain: [
                 { chainId: 420, address: "0x6b175474e89094c44da98b954eedeac495271d0f"}
             ],
-            decimals: 18,
+            decimals: 0,
             type: 1,
             communityId: "ddls",
             description: "",
@@ -182,7 +182,7 @@ ListModel {
             addressPerChain: [
                 { chainId: 420, address: "0x6b175474e89094c44da98b954eedeac495271a0f"}
             ],
-            decimals: 18,
+            decimals: 0,
             type: 1,
             communityId: "ast",
             description: "",

--- a/storybook/stubs/shared/stores/CurrenciesStore.qml
+++ b/storybook/stubs/shared/stores/CurrenciesStore.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.15
 
+import StatusQ.Core 0.1
+
 QtObject {
     id: root
 
@@ -7,7 +9,11 @@ QtObject {
     property string currentCurrencySymbol: "$"
 
     function formatCurrencyAmount(amount, symbol, options = null, locale = null) {
-        return amount
+        if (isNaN(amount)) {
+            return "N/A"
+        }
+        var currencyAmount = getCurrencyAmount(amount, symbol)
+        return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options, locale)
     }
 
     function getFiatValue(balance, cryptoSymbol, fiatSymbol) {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -15,6 +15,7 @@ Item {
     property alias count: comboBox.count
     property alias delegate: comboBox.delegate
     property alias contentItem: comboBox.contentItem
+    property alias comboBoxListViewSection: listView.section
 
     property alias currentIndex: comboBox.currentIndex
     property alias currentValue: comboBox.currentValue

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -98,4 +98,9 @@ QtObject {
             }
         ]
     }
+
+    // Property and methods below are used to apply advanced token management settings to the SendModal
+    readonly property bool showCommunityAssetsInSend: root._allTokensModule.showCommunityAssetWhenSendingTokens
+    readonly property bool balanceThresholdEnabled: root._allTokensModule.displayAssetsBelowBalance
+    readonly property real balanceThresholdAmount: root._allTokensModule.displayAssetsBelowBalanceThreshold
 }

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -72,8 +72,8 @@ Item {
         primaryText: token && token.name ? token.name : Constants.dummyText
         secondaryText: token ? LocaleUtils.currencyAmountToLocaleString(root.currencyStore.getCurrencyAmount(token.currentBalance, token.symbol)) : Constants.dummyText
         tertiaryText: {
-            let totalCurrencyBalance = token && token.currentCurrencyBalance ? token.currentCurrencyBalance : 0
-            return LocaleUtils.currencyAmountToLocaleString(root.currencyStore.getCurrentCurrencyAmount(totalCurrencyBalance))
+            let totalCurrencyBalance = token && token.currentCurrencyBalance && token.symbol ? token.currentCurrencyBalance : 0
+            return currencyStore.formatCurrencyAmount(totalCurrencyBalance, token.symbol)
         }
         decimals: token && token.decimals ? token.decimals : 4
         balances: token && token.balances ? token.balances: null

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -73,8 +73,9 @@ Item {
     readonly property WalletStore.TokensStore tokensStore: WalletStore.RootStore.tokensStore
     readonly property WalletStore.WalletAssetsStore walletAssetsStore: WalletStore.RootStore.walletAssetsStore
     readonly property CurrenciesStore currencyStore: CurrenciesStore{}
-    readonly property TransactionStore transactionStore: TransactionStore{
+    readonly property TransactionStore transactionStore: TransactionStore {
         walletAssetStore: appMain.walletAssetsStore
+        tokensStore: appMain.tokensStore
     }
 
     // set from main.qml

--- a/ui/imports/shared/controls/AssetsSectionDelegate.qml
+++ b/ui/imports/shared/controls/AssetsSectionDelegate.qml
@@ -1,0 +1,42 @@
+import QtQuick 2.13
+import QtQuick.Layouts 1.13
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import utils 1.0
+
+ColumnLayout {
+    signal openInfoPopup()
+
+    spacing: 0
+
+    StatusDialogDivider {
+        Layout.fillWidth: true
+        Layout.topMargin: Style.current.padding
+        Layout.bottomMargin: Style.current.halfPadding
+    }
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.leftMargin: Style.current.padding
+        Layout.rightMargin: Style.current.smallPadding
+        Layout.bottomMargin: 4
+        StatusBaseText {
+            text: qsTr("Community assets")
+            color: Theme.palette.baseColor1
+        }
+        Item { Layout.fillWidth: true }
+        StatusFlatButton {
+            Layout.preferredWidth: 32
+            Layout.preferredHeight: 32
+            icon.name: "info"
+            textColor: Theme.palette.baseColor1
+            horizontalPadding: 0
+            verticalPadding: 0
+            onClicked: openInfoPopup()
+        }
+    }
+}
+

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -45,3 +45,4 @@ TransactionDelegate 1.0 TransactionDelegate.qml
 TransactionDetailsHeader.qml 1.0 TransactionDetailsHeader.qml
 MockedKeycardReaderStateSelector 1.0 MockedKeycardReaderStateSelector.qml
 MockedKeycardStateSelector 1.0 MockedKeycardStateSelector.qml
+AssetsSectionDelegate 1.0 AssetsSectionDelegate.qml

--- a/ui/imports/shared/popups/CommunityAssetsInfoPopup.qml
+++ b/ui/imports/shared/popups/CommunityAssetsInfoPopup.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.14
+
+import StatusQ.Core 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    destroyOnClose: true
+    title: qsTr("What are community assets?")
+    standardButtons: Dialog.Ok
+    width: 520
+    contentItem: StatusBaseText {
+        wrapMode: Text.Wrap
+        text: qsTr("Community assets are assets that have been minted by a community. As these assets cannot be verified, always double check their origin and validity before interacting with them. If in doubt, ask a trusted member or admin of the relevant community.")
+    }
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -26,3 +26,4 @@ DeleteMessageConfirmationPopup 1.0 DeleteMessageConfirmationPopup.qml
 UserAgreementPopup 1.0 UserAgreementPopup.qml
 AlertPopup 1.0 AlertPopup.qml
 ConfirmExternalLinkPopup 1.0 ConfirmExternalLinkPopup.qml
+CommunityAssetsInfoPopup 1.0 CommunityAssetsInfoPopup.qml

--- a/ui/imports/shared/popups/send/panels/HoldingItemSelector.qml
+++ b/ui/imports/shared/popups/send/panels/HoldingItemSelector.qml
@@ -34,6 +34,7 @@ Item {
 
     property alias comboBoxControl: comboBox.control
     property alias comboBoxDelegate: comboBox.delegate
+    property alias comboBoxListViewSection: comboBox.comboBoxListViewSection
     property var comboBoxPopupHeader
 
     property int contentIconSize: 21

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -89,7 +89,6 @@ ColumnLayout {
             sourceModel: root.assets
             proxyRoles: [
                 FastExpressionRole {
-                    id: filter
                     name: "currentBalance"
                     expression: d.getTotalBalance(model.balances, model.decimals, root.addressFilters, root.networkFilters)
                     expectedRoles: ["balances", "decimals"]
@@ -240,35 +239,9 @@ ColumnLayout {
 
     Component {
         id: sectionDelegate
-        ColumnLayout {
+        AssetsSectionDelegate {
             width: parent.width
-            spacing: 0
-
-            StatusDialogDivider {
-                Layout.fillWidth: true
-                Layout.topMargin: Style.current.padding
-                Layout.bottomMargin: Style.current.halfPadding
-            }
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: Style.current.padding
-                Layout.rightMargin: Style.current.smallPadding
-                Layout.bottomMargin: 4
-                StatusBaseText {
-                    text: qsTr("Community assets")
-                    color: Theme.palette.baseColor1
-                }
-                Item { Layout.fillWidth: true }
-                StatusFlatButton {
-                    Layout.preferredWidth: 32
-                    Layout.preferredHeight: 32
-                    icon.name: "info"
-                    textColor: Theme.palette.baseColor1
-                    horizontalPadding: 0
-                    verticalPadding: 0
-                    onClicked: Global.openPopup(communityInfoPopupCmp)
-                }
-            }
+            onOpenInfoPopup: Global.openPopup(communityInfoPopupCmp)
         }
     }
 
@@ -307,7 +280,7 @@ ColumnLayout {
             }
             currencyBalance.text: {
                 let totalCurrencyBalance = modelData && modelData.currentCurrencyBalance ? modelData.currentCurrencyBalance : 0
-                return LocaleUtils.currencyAmountToLocaleString(root.currencyStore.getCurrentCurrencyAmount(totalCurrencyBalance))
+                return currencyStore.formatCurrencyAmount(totalCurrencyBalance, currencyStore.currentCurrency)
             }
             errorMode: !!networkConnectionStore ? networkConnectionStore.noBlockchainConnectionAndNoCache && !networkConnectionStore.noMarketConnectionAndNoCache : false
             errorIcon.tooltip.text: !!networkConnectionStore ? networkConnectionStore.noBlockchainConnectionAndNoCacheText : ""
@@ -380,16 +353,7 @@ ColumnLayout {
 
     Component {
         id: communityInfoPopupCmp
-        StatusDialog {
-            destroyOnClose: true
-            title: qsTr("What are community assets?")
-            standardButtons: Dialog.Ok
-            width: 520
-            contentItem: StatusBaseText {
-                wrapMode: Text.Wrap
-                text: qsTr("Community assets are assets that have been minted by a community. As these assets cannot be verified, always double check their origin and validity before interacting with them. If in doubt, ask a trusted member or admin of the relevant community.")
-            }
-        }
+        CommunityAssetsInfoPopup {}
     }
 
     Component {


### PR DESCRIPTION
fixes #12378

### What does the PR do

Implements the community assets section in the SendModal ->  https://www.figma.com/file/eM26pyHZUeAwMLviaS1KJn/%E2%9A%99%EF%B8%8F-Wallet-Settings%3A-Manage-Tokens?type=design&node-id=1-16520&mode=design&t=hfXbuGCnv4mpaHcF-4

Please note bacjend integration with advanced settings will happen under https://github.com/status-im/status-desktop/issues/13178

### Affected areas

SendModal, AssetsView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/c0f93959-6d9d-4fc7-9a34-1fb5acdbe3d2

