### PR TITLE
fix: missing clusterID in node config

### DIFF
--- a/src/app_service/service/node_configuration/dto/node_config.nim
+++ b/src/app_service/service/node_configuration/dto/node_config.nim
@@ -43,6 +43,7 @@ type
     RendezvousNodes*: seq[string]
     WakuNodes*: seq[string]
     DiscV5BootstrapNodes*: seq[string]
+    ClusterID*: int
 
 
   LightEthConfig* = object
@@ -249,6 +250,7 @@ proc toNetwork*(jsonObj: JsonNode): Network =
 proc toClusterConfig*(jsonObj: JsonNode): ClusterConfig =
   discard jsonObj.getProp("Enabled", result.Enabled)
   discard jsonObj.getProp("Fleet", result.Fleet)
+  discard jsonObj.getProp("ClusterID", result.ClusterID)
 
   var arr: JsonNode
   if(jsonObj.getProp("StaticNodes", arr)):


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13355

The clusterID was not being sent when a change related to the node config was executed.
This issue is related to https://github.com/status-im/status-desktop/issues/12918 and should be fixed once proper endpoints for status-go node configuration changes are created