### PR TITLE
fix: invalid message header size

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -39,12 +39,13 @@ Item {
         id: layout
         spacing: 4
         width: parent.width
-        StatusBaseText {
 
+        StatusBaseText {
             id: primaryDisplayName
-            Layout.fillWidth: true
             objectName: "StatusMessageHeader_DisplayName"
             verticalAlignment: Text.AlignVCenter
+            Layout.fillWidth: true
+            Layout.maximumWidth: implicitWidth
             Layout.bottomMargin: 2 // offset for the underline to stay vertically centered
             font.weight: Font.Medium
             font.underline: mouseArea.containsMouse
@@ -191,6 +192,10 @@ Item {
                 color: Theme.palette.baseColor1
                 text: "•"
             }
+        }
+
+        Item {
+            Layout.fillWidth: true
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13279

# Description

The bug appeared with this fix: https://github.com/status-im/status-desktop/pull/12957
I kept the fix working and fixed the part not to expand the header if not needed.

<img width="947" alt="Screenshot 2024-01-31 at 18 18 12" src="https://github.com/status-im/status-desktop/assets/25482501/fa883340-28e9-4b4a-bee7-e0588a00938a">

-----

And activity center is still ok:

<img width="793" alt="Screenshot 2024-01-31 at 18 17 54" src="https://github.com/status-im/status-desktop/assets/25482501/7f605938-6bb9-415f-a77c-292b24d8b623">
<img width="468" alt="Screenshot 2024-01-31 at 18 18 03" src="https://github.com/status-im/status-desktop/assets/25482501/4457f9f3-dccb-40ec-9883-7c0798cbbe4f">
