### PR TITLE
fix: Incorrect margins when collection group name is long

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensGroupDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensGroupDelegate.qml
@@ -81,6 +81,7 @@ DropArea {
             }
 
             StatusBaseText {
+                Layout.fillWidth: true
                 text: groupedCommunityTokenDelegate.title
                 elide: Text.ElideRight
                 maximumLineCount: 1


### PR DESCRIPTION
- set width for the text so that the elision works correctly

Fixes #13396
Cherry pick to: 2.27.0 Alpha RC

### Affected areas

Token management

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/8bb63b20-2e87-401e-bff1-17c41fa01931)

