### PR TITLE
Fix/disable send buttons on no internet

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusAction.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusAction.qml
@@ -14,6 +14,7 @@ Action {
     }
 
     property int type: StatusAction.Type.Normal
+    property bool visibleOnDisabled: false
 
     property StatusAssetSettings assetSettings: StatusAssetSettings {
         width: 18

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -103,7 +103,7 @@ Menu {
     }
 
     delegate: StatusMenuItem {
-        visible: root.hideDisabledItems ? enabled : true
+        visible: root.hideDisabledItems && !visibleOnDisabled ? enabled : true
         height: visible ? implicitHeight : 0
         onImplicitWidthChanged: {
             if (visible)

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -9,11 +9,13 @@ import StatusQ.Popups 0.1
 
 MenuItem {
     id: root
-    
+
     objectName: action ? action.objectName : "StatusMenuItemDelegate"
 
     spacing: 4
     horizontalPadding: 8
+
+    property bool visibleOnDisabled: d.isStatusAction ? action.visibleOnDisabled : false
 
     QtObject {
         id: d

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -132,6 +132,7 @@ StatusSectionLayout {
                 profileStore: root.store.profileStore
                 privacyStore: root.store.privacyStore
                 contactsStore: root.store.contactsStore
+                networkConnectionStore: root.networkConnectionStore
                 communitiesModel: root.store.communitiesList
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.profile)
                 contentWidth: d.contentWidth
@@ -193,6 +194,7 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 rootStore: root.store
                 tokensStore: root.tokensStore
+                networkConnectionStore: root.networkConnectionStore
                 emojiPopup: root.emojiPopup
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.wallet)
                 contentWidth: d.contentWidth

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -28,6 +28,7 @@ SettingsContentBase {
     property ProfileStore profileStore
     property PrivacyStore privacyStore
     property ContactsStore contactsStore
+    property NetworkConnectionStore networkConnectionStore
     required property WalletAssetsStore walletAssetsStore
     required property CurrenciesStore currencyStore
 
@@ -93,6 +94,7 @@ SettingsContentBase {
 
                 profileStore: root.profileStore
                 contactsStore: root.contactsStore
+                networkConnectionStore: root.networkConnectionStore
                 communitiesModel: root.communitiesModel
                 dirtyValues: settingsView.dirtyValues
                 dirty: settingsView.dirty

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -33,6 +33,7 @@ SettingsContentBase {
     property ProfileSectionStore rootStore
     property var walletStore: rootStore.walletStore
     required property TokensStore tokensStore
+    property var networkConnectionStore
 
     readonly property int mainViewIndex: 0
     readonly property int networksViewIndex: 1
@@ -344,6 +345,7 @@ SettingsContentBase {
         SavedAddressesView {
             id: savedAddressesView
             contactsStore: root.rootStore.contactsStore
+            networkConnectionStore: root.networkConnectionStore
             sendModal: root.rootStore.sendModalPopup
         }
 

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfilePreview.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfilePreview.qml
@@ -8,6 +8,7 @@ import StatusQ.Core.Theme 0.1
 Item {
     property alias profileStore: profilePreview.profileStore
     property alias contactsStore: profilePreview.contactsStore
+    property alias networkConnectionStore: profilePreview.networkConnectionStore
     property alias communitiesModel: profilePreview.communitiesModel
     property alias dirtyValues: profilePreview.dirtyValues
     property alias dirty: profilePreview.dirty

--- a/ui/app/AppLayouts/Profile/views/wallet/SavedAddressesView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/SavedAddressesView.qml
@@ -9,10 +9,12 @@ ColumnLayout {
     id: root
 
     property ContactsStore contactsStore
+    property var networkConnectionStore
     property var sendModal
 
     SavedAddresses {
         sendModal: root.sendModal
         contactsStore: root.contactsStore
+        networkConnectionStore: root.networkConnectionStore
     }
 }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -161,6 +161,7 @@ Item {
         SavedAddressesView {
             store: root.store
             contactsStore: root.contactsStore
+            networkConnectionStore: root.networkConnectionStore
             sendModal: root.sendModalPopup
 
             networkFilter.visible: false

--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -20,6 +20,7 @@ StatusListItem {
 
     property var store
     property var contactsStore
+    property var networkConnectionStore
     property string name
     property string address
     property string ens
@@ -79,6 +80,7 @@ StatusListItem {
             type: StatusRoundButton.Type.Quinary
             radius: 8
             icon.name: "send"
+            enabled: root.networkConnectionStore.sendBuyBridgeEnabled
             onClicked: root.openSendModal(d.visibleAddress)
         },
         StatusRoundButton {

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -66,7 +66,7 @@ Rectangle {
             tooltipText: networkConnectionStore.sendBuyBridgeToolTipText
             visible: !walletStore.overview.isWatchOnlyAccount && !root.isCommunityOwnershipTransfer && walletStore.overview.canSend
         }
-        
+
         StatusFlatButton {
             id: buySellBtn
 

--- a/ui/app/AppLayouts/Wallet/popups/TransactionAddressMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/TransactionAddressMenu.qml
@@ -31,6 +31,7 @@ StatusMenu {
     id: root
 
     property var contactsStore
+    property var networkConnectionStore
     property bool areTestNetworksEnabled: false
     property bool isSepoliaEnabled: false
 
@@ -156,7 +157,10 @@ StatusMenu {
         d.refreshShowOnActionsVisiblity(chainShortNameList)
         saveAddressAction.enabled = d.addressName.length === 0
         editAddressAction.enabled = !isWalletAccount && !isContact && d.addressName.length > 0
-        sendToAddressAction.enabled = true
+
+        if (root.networkConnectionStore.sendBuyBridgeEnabled)
+            sendToAddressAction.enabled = true
+
         showQrAction.enabled = true
 
         d.openMenu(delegate)
@@ -343,6 +347,7 @@ StatusMenu {
     StatusAction {
         id: sendToAddressAction
         enabled: false
+        visibleOnDisabled: true
         text: {
             switch(d.addressType) {
             case TransactionAddressMenu.AddressType.Sender:

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -434,6 +434,7 @@ ColumnLayout {
 
             StatusAction {
                 enabled: root.sendEnabled
+                visibleOnDisabled: true
                 icon.name: "send"
                 text: qsTr("Send")
                 onTriggered: root.sendRequested(symbol)

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -250,6 +250,7 @@ RightTabBaseView {
             showAllAccounts: RootStore.showAllAccounts
             sendModal: root.sendModal
             contactsStore: root.contactsStore
+            networkConnectionStore: root.networkConnectionStore
             visible: (stack.currentIndex === 3)
         }
     }

--- a/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
@@ -20,6 +20,7 @@ ColumnLayout {
 
     property var sendModal
     property var contactsStore
+    property var networkConnectionStore
 
     QtObject {
         id: d
@@ -148,6 +149,7 @@ ColumnLayout {
             colorId: model.colorId
             store: RootStore
             contactsStore: root.contactsStore
+            networkConnectionStore: root.networkConnectionStore
             areTestNetworksEnabled: RootStore.areTestNetworksEnabled
             isSepoliaEnabled: RootStore.isSepoliaEnabled
             onOpenSendModal: root.sendModal.open(recipient);

--- a/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
@@ -10,5 +10,6 @@ RightTabBaseView {
 
         sendModal: root.sendModal
         contactsStore: root.contactsStore
+        networkConnectionStore: root.networkConnectionStore
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -27,6 +27,7 @@ Item {
 
     property var overview: WalletStores.RootStore.overview
     property var contactsStore
+    property var networkConnectionStore
     property var transaction
     property int transactionIndex
     property var sendModal
@@ -787,6 +788,7 @@ Item {
         areTestNetworksEnabled: WalletStores.RootStore.areTestNetworksEnabled
         isSepoliaEnabled: WalletStores.RootStore.isSepoliaEnabled
         contactsStore: root.contactsStore
+        networkConnectionStore: root.networkConnectionStore
         onOpenSendModal: (address) => root.sendModal.open(address)
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -257,6 +257,7 @@ Item {
         devicesStore: appMain.rootStore.profileSectionStore.devicesStore
         currencyStore: appMain.currencyStore
         walletAssetsStore: appMain.walletAssetsStore
+        networkConnectionStore: appMain.networkConnectionStore
         isDevBuild: !production
 
         onOpenExternalLink: globalConns.onOpenLink(link)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -35,6 +35,7 @@ QtObject {
     property var devicesStore
     property CurrenciesStore currencyStore
     property WalletStore.WalletAssetsStore walletAssetsStore
+    property var networkConnectionStore
     property bool isDevBuild
 
     signal openExternalLink(string link)
@@ -448,6 +449,7 @@ QtObject {
                 id: profilePopup
                 profileStore: rootStore.profileSectionStore.profileStore
                 contactsStore: rootStore.profileSectionStore.contactsStore
+                networkConnectionStore: root.networkConnectionStore
                 communitiesModel: rootStore.profileSectionStore.communitiesList
 
                 onClosed: {

--- a/ui/imports/shared/popups/ProfileDialog.qml
+++ b/ui/imports/shared/popups/ProfileDialog.qml
@@ -13,6 +13,7 @@ StatusDialog {
 
     property var profileStore
     property var contactsStore
+    property var networkConnectionStore
     property var communitiesModel
 
     width: 640
@@ -25,6 +26,7 @@ StatusDialog {
         publicKey: root.publicKey
         profileStore: root.profileStore
         contactsStore: root.contactsStore
+        networkConnectionStore: root.networkConnectionStore
         communitiesModel: root.communitiesModel
         onCloseRequested: root.close()
     }

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -320,6 +320,7 @@ ColumnLayout {
 
             StatusAction {
                 enabled: root.networkConnectionStore.sendBuyBridgeEnabled && !root.overview.isWatchOnlyAccount && root.overview.canSend
+                visibleOnDisabled: true
                 icon.name: "send"
                 text: qsTr("Send")
                 onTriggered: root.sendRequested(symbol)

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -33,6 +33,7 @@ Pane {
     property var profileStore
     property var contactsStore
     property var walletStore: WalletNS.RootStore
+    property var networkConnectionStore
     property var communitiesModel
 
     property QtObject dirtyValues: null
@@ -699,6 +700,7 @@ Pane {
                     readOnly: root.readOnly
                     profileStore: root.profileStore
                     walletStore: root.walletStore
+                    networkConnectionStore: root.networkConnectionStore
                     communitiesModel: root.communitiesModel
 
                     onCloseRequested: root.closeRequested()

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -24,6 +24,7 @@ Control {
     property bool readOnly
     property var profileStore
     property var walletStore
+    property var networkConnectionStore
     property var communitiesModel
 
     signal closeRequested()
@@ -208,6 +209,7 @@ Control {
                             type: StatusFlatRoundButton.Type.Secondary
                             icon.name: "send"
                             tooltip.text: qsTr("Send")
+                            enabled: root.networkConnectionStore.sendBuyBridgeEnabled
                             onClicked: {
                                 Global.openSendModal(model.address)
                             }


### PR DESCRIPTION
### What does the PR do

Disables "Send" button at all places when there is no internet connection.
In transaction details address menu we need to disable the icon instead of hiding it, as it is done by previous implementation.

### Affected areas

Wallet->Activities->To->menu->"Send to this address"
Saved addresses (Both in Wallet and Profile settings) -> send button

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
https://github.com/status-im/status-desktop/assets/15627093/332572ef-e999-46bf-b722-5fa53ee039ca

https://github.com/status-im/status-desktop/assets/15627093/da8e8883-2d45-43c0-a9f5-93c7e05f11dd



### Note
Tooltip "Requires internet connection" was not added because I could not add it within a reasonable time - the tooltip does not show up, not matter where I try to place it - directly inside of StatusMenuItem, inside its contentItem, inside its background. The only option when it was displayed was via attached `ToolTip` property, but it uses default style and it is not possible to reuse StatusToolTip for this purpose unless you define it as Style (for Qt 6 it is described [here](https://doc.qt.io/qt-6/qml-qtquick-controls-tooltip.html#attached-tool-tips)) 
