### PR TITLE
fix: [Community Settings] Tokens page is not scrollable...

### DIFF
--- a/ui/app/AppLayouts/Communities/views/MintedTokensView.qml
+++ b/ui/app/AppLayouts/Communities/views/MintedTokensView.qml
@@ -167,13 +167,14 @@ StatusScrollView {
 
                 Layout.fillWidth: true
                 Layout.preferredHeight: contentHeight
+                interactive: false
 
                 visible: count > 0
                 model: assetsModel
 
                 delegate: StatusListItem {
                     height: 64
-                    width: mainLayout.width
+                    width: ListView.view.width
                     title: model.name ?? ""
                     subTitle: model.symbol ?? ""
                     asset.name: model.image ? model.image : ""
@@ -221,6 +222,7 @@ StatusScrollView {
 
                 Layout.fillWidth: true
                 Layout.preferredHeight: childrenRect.height
+                interactive: false
 
                 visible: count > 0
                 model: SortFilterProxyModel {


### PR DESCRIPTION
... from within the gridView

Set the ListView/GridView `interactive: false` to unbreak touchpad scrolling; those views are unrolled anyway

Fixes #11959

### What does the PR do

Fixes scrolling in MintedTokensView

### Affected areas

MintedTokensView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-02-05 12-21-47.webm](https://github.com/status-im/status-desktop/assets/5377645/bf38aeeb-cabd-46ef-aedc-54f79aff8081)

