### PR TITLE
fix(showcase): unbreak drag and drop reordering

### DIFF
--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
@@ -121,16 +121,7 @@ QtObject:
 
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
-      self.dataChanged(index, index, @[
-        ModelRole.ShowcaseVisibility.int,
-        ModelRole.Order.int,
-        ModelRole.Address.int,
-        ModelRole.CommunityId.int,
-        ModelRole.Symbol.int,
-        ModelRole.Name.int,
-        ModelRole.EnabledNetworkBalance.int,
-        ModelRole.Decimals.int,
-      ])
+      self.dataChanged(index, index)
 
   proc upsertItemJson(self: ProfileShowcaseAssetsModel, itemJson: string) {.slot.} =
     self.upsertItemImpl(itemJson.parseJson.toProfileShowcaseAssetItem())
@@ -175,16 +166,25 @@ QtObject:
     if ind != -1:
       self.remove(ind)
 
-  proc move*(self: ProfileShowcaseAssetsModel, fromIndex: int, toIndex: int) {.slot.} =
-    if fromIndex < 0 or fromIndex >= self.items.len:
+  proc move*(self: ProfileShowcaseAssetsModel, fromRow: int, toRow: int, dummyCount: int = 1) {.slot.} =
+    if fromRow < 0 or fromRow >= self.items.len:
       return
 
-    self.beginResetModel()
-    let item = self.items[fromIndex]
-    self.items.delete(fromIndex)
-    self.items.insert(@[item], toIndex)
+    let sourceIndex = newQModelIndex()
+    defer: sourceIndex.delete
+    let destIndex = newQModelIndex()
+    defer: destIndex.delete
+
+    var destRow = toRow
+    if toRow > fromRow:
+      inc(destRow)
+
+    self.beginMoveRows(sourceIndex, fromRow, fromRow, destIndex, destRow)
+    let item = self.items[fromRow]
+    self.items.delete(fromRow)
+    self.items.insert(@[item], toRow)
     self.recalcOrder()
-    self.endResetModel()
+    self.endMoveRows()
 
   proc setVisibilityByIndex*(self: ProfileShowcaseAssetsModel, ind: int, visibility: int) {.slot.} =
     if (visibility >= ord(low(ProfileShowcaseVisibility)) and

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_communities_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_communities_model.nim
@@ -128,18 +128,7 @@ QtObject:
 
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
-      self.dataChanged(index, index, @[
-        ModelRole.ShowcaseVisibility.int,
-        ModelRole.Order.int,
-        ModelRole.Id.int,
-        ModelRole.Name.int,
-        ModelRole.MemberRole.int,
-        ModelRole.Image.int,
-        ModelRole.Color.int,
-        ModelRole.Description.int,
-        ModelRole.MembersCount.int,
-        ModelRole.Loading.int,
-      ])
+      self.dataChanged(index, index)
 
   proc upsertItemJson(self: ProfileShowcaseCommunitiesModel, itemJson: string) {.slot.} =
     self.upsertItemImpl(itemJson.parseJson.toProfileShowcaseCommunityItem())
@@ -184,16 +173,25 @@ QtObject:
     if ind != -1:
       self.remove(ind)
 
-  proc move*(self: ProfileShowcaseCommunitiesModel, fromIndex: int, toIndex: int) {.slot.} =
-    if fromIndex < 0 or fromIndex >= self.items.len:
+  proc move*(self: ProfileShowcaseCommunitiesModel, fromRow: int, toRow: int, dummyCount: int = 1) {.slot.} =
+    if fromRow < 0 or fromRow >= self.items.len:
       return
 
-    self.beginResetModel()
-    let item = self.items[fromIndex]
-    self.items.delete(fromIndex)
-    self.items.insert(@[item], toIndex)
+    let sourceIndex = newQModelIndex()
+    defer: sourceIndex.delete
+    let destIndex = newQModelIndex()
+    defer: destIndex.delete
+
+    var destRow = toRow
+    if toRow > fromRow:
+      inc(destRow)
+
+    self.beginMoveRows(sourceIndex, fromRow, fromRow, destIndex, destRow)
+    let item = self.items[fromRow]
+    self.items.delete(fromRow)
+    self.items.insert(@[item], toRow)
     self.recalcOrder()
-    self.endResetModel()
+    self.endMoveRows()
 
   proc setVisibilityByIndex*(self: ProfileShowcaseCommunitiesModel, ind: int, visibility: int) {.slot.} =
     if (visibility >= ord(low(ProfileShowcaseVisibility)) and

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -172,7 +172,7 @@ Control {
                     if (to === from)
                         return
                     root.showcaseEntryChanged()
-                    showcaseModel.move(from, to)
+                    showcaseModel.move(from, to, 1)
                     drag.accept()
                 }
 


### PR DESCRIPTION
- unify the signature of the method to `move(from, to, count)` so that both ListModel and NIM have it the same
- realize the move operation using the proper `begin/endMoveRows` instead of doing a full model reset
- simplify signaling `dataChanged()` for all model roles (nimqml now follows the C++ impl)

Fixes #13329

### What does the PR do

Fixes DND in profile showcase settings

### Affected areas

Settings/Profile/showcase tabs

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-02-06 09-19-17.webm](https://github.com/status-im/status-desktop/assets/5377645/0dc3b5b0-2eb1-418d-8a62-53fde7ca7777)
