### PR TITLE
fix(ManageHiddenPanel): Disable displace Transition to fix positioning on unhiding

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/ManageHiddenPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageHiddenPanel.qml
@@ -205,9 +205,13 @@ Control {
 
             model: d.sfpm
 
-            displaced: Transition {
-                NumberAnimation { properties: "x,y"; easing.type: Easing.OutQuad }
-            }
+            // For some reason displaced transition doesn't work correctly in
+            // combination of delegate using Loader and leads to improper
+            // delegates positioning when the top-most item from the list is
+            // removed.
+            //displaced: Transition {
+            //    NumberAnimation { properties: "x,y" }
+            //}
 
             delegate: Loader {
                 required property var model


### PR DESCRIPTION
### What does the PR do

When removing the top-most item from the list, animation was ending with improper delegates' positioning. No workaround found, transition disabled.

Closes: #13392

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`ManageHiddenPanel`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00088.webm](https://github.com/status-im/status-desktop/assets/20650004/dadce093-5a91-458f-9801-f8db00e2f838)

