### PR TITLE
chore: show "Fetch messages" chat context menu action when in debug mode

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -141,6 +141,7 @@ Item {
                 id: contextMenu
                 objectName: "moreOptionsContextMenu"
                 emojiPopup: root.emojiPopup
+                showDebugOptions: root.rootStore.isDebugEnabled
                 openHandler: function () {
                     if(!chatContentModule) {
                         console.debug("error on open chat context menu handler - chat content module is not set")

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -142,6 +142,7 @@ Item {
                 popupMenu: ChatContextMenuView {
                     id: chatContextMenuView
                     emojiPopup: root.emojiPopup
+                    showDebugOptions: root.store.isDebugEnabled
 
                     openHandler: function (id) {
                         let jsonObj = root.chatSectionModule.getItemAsJson(id)

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -298,6 +298,7 @@ Item {
             chatListPopupMenu: ChatContextMenuView {
                 id: chatContextMenuView
                 emojiPopup: root.emojiPopup
+                showDebugOptions: root.store.isDebugEnabledfir 
 
                 // TODO pass the chatModel in its entirety instead of fetching the JSOn using just the id
                 openHandler: function (id) {

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -27,6 +27,7 @@ StatusMenu {
     property int channelPosition: -1
     property string chatCategoryId: ""
     property var emojiPopup
+    property bool showDebugOptions: false
 
     signal displayProfilePopup(string publicKey)
     signal requestAllHistoricMessages(string chatId)
@@ -127,7 +128,7 @@ StatusMenu {
         objectName: "chatFetchMessagesMenuItem"
         text: qsTr("Fetch messages")
         icon.name: "download"
-        enabled: !production
+        enabled: root.showDebugOptions
         onTriggered: {
             root.requestMoreMessages(root.chatId)
         }


### PR DESCRIPTION
# Description

Just show `Fetch messages` option when `Debug` mode is enabled instead of showing this option in production builds.