### PR TITLE
fix: display name width calculation

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -45,7 +45,7 @@ Item {
             objectName: "StatusMessageHeader_DisplayName"
             verticalAlignment: Text.AlignVCenter
             Layout.fillWidth: true
-            Layout.maximumWidth: implicitWidth
+            Layout.maximumWidth: Math.ceil(implicitWidth)
             Layout.bottomMargin: 2 // offset for the underline to stay vertically centered
             font.weight: Font.Medium
             font.underline: mouseArea.containsMouse


### PR DESCRIPTION
### What does the PR do

[This PR](https://github.com/status-im/status-desktop/pull/13372/files) introduced a small bug.

Some user names ended up in text wrapping. Added a `+1px` hack to prevent this.

| Mark Cub | Mark Cuba | Mark Cuban |
|-|-|-|
| <img width="441" alt="Screenshot 2024-02-07 at 11 17 26" src="https://github.com/status-im/status-desktop/assets/25482501/cc9bb7d1-def3-42bf-b1f6-1dbb7b6baa11"> | <img width="441" alt="Screenshot 2024-02-07 at 11 17 38" src="https://github.com/status-im/status-desktop/assets/25482501/378186b1-d71f-4c73-ba68-98c9ab65892d"> | <img width="441" alt="Screenshot 2024-02-07 at 11 17 43" src="https://github.com/status-im/status-desktop/assets/25482501/cf5cd05b-f16f-4541-be13-f23843539a5e"> |

Fixed looks like this:

<img width="441" alt="Screenshot 2024-02-07 at 11 17 56 1" src="https://github.com/status-im/status-desktop/assets/25482501/9586ba55-8966-4197-9082-0f2d889baea8">

