### PR TITLE
feat(@desktop/activity): Handle token received notification

### DIFF
--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -3,6 +3,7 @@ import ../../shared_models/message_item_qobject
 import ../../../../app_service/service/activity_center/dto/notification
 import ../../../../app_service/service/chat/dto/chat
 import ../../../../app_service/service/contacts/dto/contacts
+import ./token_data_item
 
 const CONTACT_REQUEST_PENDING_STATE = 1
 
@@ -23,6 +24,7 @@ type Item* = ref object
   messageItem: MessageItem
   repliedMessageItem: MessageItem
   chatType: ChatType
+  tokenDataItem: TokenDataItem
 
 proc initItem*(
   id: string,
@@ -40,7 +42,8 @@ proc initItem*(
   accepted: bool,
   messageItem: MessageItem,
   repliedMessageItem: MessageItem,
-  chatType: ChatType
+  chatType: ChatType,
+  tokenDataItem: TokenDataItem
 ): Item =
   result = Item()
   result.id = id
@@ -59,6 +62,7 @@ proc initItem*(
   result.messageItem = messageItem
   result.repliedMessageItem = repliedMessageItem
   result.chatType = chatType
+  result.tokenDataItem = tokenDataItem
 
 proc `$`*(self: Item): string =
   result = fmt"""activity_center/Item(
@@ -77,6 +81,7 @@ proc `$`*(self: Item): string =
     accepted: {$self.accepted},
     # messageItem: {$self.messageItem},
     # repliedMessageItem: {$self.repliedMessageItem},
+    tokenData: {$self.tokenDataItem}
     ]"""
 
 proc id*(self: Item): string =
@@ -129,3 +134,6 @@ proc messageItem*(self: Item): MessageItem =
 
 proc repliedMessageItem*(self: Item): MessageItem =
   return self.repliedMessageItem
+
+proc tokenDataItem*(self: Item): TokenDataItem =
+  return self.tokenDataItem

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -20,6 +20,7 @@ type
     Author
     RepliedMessage
     ChatType
+    TokenData
 
 QtObject:
   type
@@ -87,6 +88,7 @@ QtObject:
       of NotifRoles.Accepted: result = newQVariant(activityNotificationItem.accepted.bool)
       of NotifRoles.RepliedMessage: result = newQVariant(activityNotificationItem.repliedMessageItem)
       of NotifRoles.ChatType: result = newQVariant(activityNotificationItem.chatType.int)
+      of NotifRoles.TokenData: result = newQVariant(activityNotificationItem.tokenDataItem)
 
   method roleNames(self: Model): Table[int, string] =
     {
@@ -106,7 +108,8 @@ QtObject:
       NotifRoles.Dismissed.int: "dismissed",
       NotifRoles.Accepted.int: "accepted",
       NotifRoles.RepliedMessage.int: "repliedMessage",
-      NotifRoles.ChatType.int: "chatType"
+      NotifRoles.ChatType.int: "chatType",
+      NotifRoles.TokenData.int: "tokenData"
     }.toTable
 
   proc markActivityCenterNotificationUnread*(self: Model, notificationId: string) =

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -1,6 +1,6 @@
 import NimQml, Tables, json, stint, sequtils
 
-import ./io_interface, ./view, ./controller
+import ./io_interface, ./view, ./controller, ./token_data_item
 import ../io_interface as delegate_interface
 import ./item as notification_item
 import ../../shared_models/message_item as msg_item
@@ -175,6 +175,19 @@ method convertToItems*(
         if (notification.notificationType == ActivityCenterNotificationType.ContactVerification):
           repliedMessageItem = self.createMessageItemFromDto(notification.replyMessage, communityId, @[])
 
+      var tokenDataItem = token_data_item.newTokenDataItem(
+          notification.tokenData.chainId,
+          notification.tokenData.txHash,
+          notification.tokenData.walletAddress,
+          notification.tokenData.isFirst,
+          notification.tokenData.communiyId,
+          notification.tokenData.amount,
+          notification.tokenData.name,
+          notification.tokenData.symbol,
+          notification.tokenData.imageUrl,
+          notification.tokenData.tokenType
+      )
+
       let chatDetails = self.controller.getChatDetails(notification.chatId)
 
       return notification_item.initItem(
@@ -193,7 +206,8 @@ method convertToItems*(
         notification.accepted,
         messageItem,
         repliedMessageItem,
-        chatDetails.chatType
+        chatDetails.chatType,
+        tokenDataItem
       )
     )
 

--- a/src/app/modules/main/activity_center/token_data_item.nim
+++ b/src/app/modules/main/activity_center/token_data_item.nim
@@ -1,0 +1,98 @@
+import NimQml, strutils, strformat
+
+QtObject:
+  type TokenDataItem* = ref object of QObject
+    chainId*: int
+    txHash*: string
+    walletAddress*: string
+    isFirst*: bool
+    communiyId*: string
+    amount*: string
+    name*: string
+    symbol*: string
+    imageUrl*: string
+    tokenType*: int
+
+  proc setup(self: TokenDataItem) =
+    self.QObject.setup
+
+  proc delete*(self: TokenDataItem) =
+    self.QObject.delete
+
+  proc newTokenDataItem*(
+    chainId: int,
+    txHash: string,
+    walletAddress: string,
+    isFirst: bool,
+    communiyId: string,
+    amount: string,
+    name: string,
+    symbol: string,
+    imageUrl: string,
+    tokenType: int): TokenDataItem =
+      new(result, delete)
+      result.setup
+      result.chainId = chainId
+      result.txHash = txHash
+      result.walletAddress = walletAddress
+      result.isFirst = isFirst
+      result.communiyId = communiyId
+      result.amount = amount
+      result.name = name
+      result.symbol = symbol
+      result.imageUrl = imageUrl
+      result.tokenType = tokenType
+
+  proc `$`*(self: TokenDataItem): string =
+    result = fmt"""
+      chainId: {self.chainId},
+      txHash: {self.txHash},
+      walletAddress: {self.walletAddress},
+      isFirst: {self.isFirst},
+      communiyId: {self.communiyId},
+      amount: {self.amount},
+      name: {self.name},
+      symbol: {self.symbol},
+      imageUrl: {self.imageUrl},
+      tokenType: {self.tokenType}
+    """
+
+  proc chainId*(self: TokenDataItem): int {.slot.} = result = self.chainId
+  QtProperty[int] chainId:
+    read = chainId
+
+  proc txHash*(self: TokenDataItem): string {.slot.} = result = self.txHash
+  QtProperty[string] txHash:
+    read = txHash
+
+  proc walletAddress*(self: TokenDataItem): string {.slot.} = result = self.walletAddress
+  QtProperty[string] walletAddress:
+    read = walletAddress
+
+  proc isFirst*(self: TokenDataItem): bool {.slot.} = result = self.isFirst
+  QtProperty[bool] isFirst:
+    read = isFirst
+
+  proc communiyId*(self: TokenDataItem): string {.slot.} = result = self.communiyId
+  QtProperty[string] communiyId:
+    read = communiyId
+
+  proc amount*(self: TokenDataItem): string {.slot.} = result = self.amount
+  QtProperty[string] amount:
+    read = amount
+
+  proc name*(self: TokenDataItem): string {.slot.} = result = self.name
+  QtProperty[string] name:
+    read = name
+
+  proc symbol*(self: TokenDataItem): string {.slot.} = result = self.symbol
+  QtProperty[string] symbol:
+    read = symbol
+
+  proc imageUrl*(self: TokenDataItem): string {.slot.} = result = self.imageUrl
+  QtProperty[string] imageUrl:
+    read = imageUrl
+
+  proc tokenType*(self: TokenDataItem): int {.slot.} = result = self.tokenType
+  QtProperty[int] tokenType:
+    read = tokenType

--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -88,7 +88,7 @@ proc init*(self: Controller) =
     self.communityTokensModule.onOwnerTokenReceived(args.communityId, args.communityName, args.chainId, args.contractAddress)
   self.events.on(SIGNAL_COMMUNITY_TOKEN_RECEIVED) do(e: Args):
     let args = CommunityTokenReceivedArgs(e)
-    self.communityTokensModule.onCommunityTokenReceived(args.name, args.image, args.communityId, args.communityName, args.communityColor, $args.balance, args.chainId, args.txHash)
+    self.communityTokensModule.onCommunityTokenReceived(args.name, args.symbol, args.image, args.communityId, args.communityName, $args.amount, args.chainId, args.txHash, args.isFirst, args.tokenType, args.accountName)
   self.events.on(SIGNAL_SET_SIGNER_STATUS) do(e: Args):
     let args = SetSignerArgs(e)
     self.communityTokensModule.onSetSignerStateChanged(args.communityId, args.chainId, args.transactionHash, args.status)

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -96,7 +96,7 @@ method removeCommunityToken*(self: AccessInterface, communityId: string, chainId
 method onOwnerTokenReceived*(self: AccessInterface, communityId: string, communityName: string, chainId: int, contractAddress: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityTokenReceived*(self: AccessInterface, name: string, image: string, communityId: string, communityName: string, communityColor: string, balance: string, chainId: int, txHash: string) {.base.} =
+method onCommunityTokenReceived*(self: AccessInterface, name: string, symbol: string, image: string, communityId: string, communityName: string, balance: string, chainId: int, txHash: string, isFirst: bool, tokenType: int, accountName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onSendOwnerTokenStateChanged*(self: AccessInterface, chainId: int, transactionHash: string, tokenName: string, status: ContractTransactionStatus) {.base.} =

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -334,8 +334,8 @@ method onAirdropStateChanged*(self: Module, communityId: string, tokenName: stri
 method onOwnerTokenReceived*(self: Module, communityId: string, communityName: string, chainId: int, contractAddress: string) =
   self.view.emitOwnerTokenReceived(communityId, communityName, chainId, contractAddress)
 
-method onCommunityTokenReceived*(self: Module, name: string, image: string, communityId: string, communityName: string, communityColor: string, balance: string, chainId: int, txHash: string) =
-  self.view.emitCommunityTokenReceived(name, image, communityId, communityName, communityColor, balance, chainId, txHash)
+method onCommunityTokenReceived*(self: Module, name: string, symbol: string, image: string, communityId: string, communityName: string, balance: string, chainId: int, txHash: string, isFirst: bool, tokenType: int, accountName: string) =
+  self.view.emitCommunityTokenReceived(name, symbol, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, accountName)
 
 method onSetSignerStateChanged*(self: Module, communityId: string, chainId: int, transactionHash: string, status: ContractTransactionStatus) =
   let communityDto = self.controller.getCommunityById(communityId)

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -55,7 +55,7 @@ QtObject:
   proc burnFeeUpdated*(self: View, ethCurrency: QVariant, fiatCurrency: QVariant, errorCode: int, responseId: string) {.signal.}
   proc setSignerFeeUpdated*(self: View, ethCurrency: QVariant, fiatCurrency: QVariant, errorCode: int, responseId: string) {.signal.}
   proc ownerTokenReceived*(self: View, communityId: string, communityName: string, chainId: int, contractAddress: string) {.signal.}
-  proc communityTokenReceived*(self: View, name: string, image: string, communityId: string, communityName: string, communityColor: string, balance: string, chainId: int, txHash: string) {.signal.}
+  proc communityTokenReceived*(self: View, name: string, symbol: string, image: string, communityId: string, communityName: string, balance: string, chainId: int, txHash: string, isFirst: bool, tokenType: int, accountName: string) {.signal.}
   proc setSignerStateChanged*(self: View, communityId: string, communityName: string, status: int, url: string) {.signal.}
   proc ownershipNodeLost*(self: View, communityId: string, communityName: string) {.signal.}
   proc sendOwnerTokenStateChanged*(self: View, tokenName: string, status: int, url: string) {.signal.}
@@ -117,8 +117,8 @@ QtObject:
   proc emitOwnerTokenReceived*(self: View, communityId: string, communityName: string, chainId: int, contractAddress: string) =
     self.ownerTokenReceived(communityId, communityName, chainId, contractAddress)
 
-  proc emitCommunityTokenReceived*(self: View, name: string, image: string, communityId: string, communityName: string, communityColor: string, balance: string, chainId: int, txHash: string) =
-    self.communityTokenReceived(name, image, communityId, communityName, communityColor, balance, chainId, txHash)
+  proc emitCommunityTokenReceived*(self: View, name: string, symbol: string, image: string, communityId: string, communityName: string, balance: string, chainId: int, txHash: string, isFirst: bool, tokenType: int, accountName: string) =
+    self.communityTokenReceived(name, symbol, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, accountName)
 
   proc emitSetSignerStateChanged*(self: View, communityId: string, communityName: string, status: int, url: string) =
     self.setSignerStateChanged(communityId, communityName, status, url)

--- a/src/app_service/service/activity_center/dto/token_data.nim
+++ b/src/app_service/service/activity_center/dto/token_data.nim
@@ -1,0 +1,52 @@
+{.used.}
+
+import json, strformat
+
+include ../../../common/json_utils
+include ../../../common/utils
+
+include backend/collectibles_types
+
+type TokenDataDto* = object
+  chainId*: int
+  collectibleId*: CollectibleUniqueID
+  txHash*: string
+  walletAddress*: string
+  isFirst*: bool
+  communiyId*: string
+  amount*: string
+  name*: string
+  symbol*: string
+  imageUrl*: string
+  tokenType*: int
+
+proc `$`*(self: TokenDataDto): string =
+  result = fmt"""TokenDataDto(
+    chainId: {$self.chainId},
+    collectibleId: {self.collectibleId},
+    txHash: {self.txHash},
+    walletAddress: {self.walletAddress},
+    isFirst: {$self.isFirst},
+    communiyId: {self.communiyId},
+    amount: {self.amount},
+    name: {self.name},
+    symbol: {self.symbol},
+    imageUrl: {self.imageUrl},
+    tokenType: {$self.tokenType}
+    )"""
+
+proc toTokenDataDto*(jsonObj: JsonNode): TokenDataDto =
+  result = TokenDataDto()
+  discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("txHash", result.txHash)
+  discard jsonObj.getProp("walletAddress", result.walletAddress)
+  discard jsonObj.getProp("isFirst", result.isFirst)
+  discard jsonObj.getProp("communiyId", result.communiyId)
+  discard jsonObj.getProp("amount", result.amount)
+  discard jsonObj.getProp("name", result.name)
+  discard jsonObj.getProp("symbol", result.symbol)
+  discard jsonObj.getProp("imageUrl", result.imageUrl)
+  discard jsonObj.getProp("tokenType", result.tokenType)
+
+  if jsonObj.contains("collectibleId") and jsonObj{"collectibleId"}.kind != JNull:
+      result.collectibleId = fromJson(jsonObj["collectibleId"], CollectibleUniqueID)

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -60,6 +60,9 @@ type
     collectionData*: Option[CollectionData]
     communityData*: Option[CommunityData]
     ownership*: Option[seq[AccountBalance]]
+    isFirst*: Option[bool]
+    latestTxHash*: Option[string]
+    receivedAmount*: Option[float64]
 
   # Mirrors services/wallet/thirdparty/collectible_types.go TokenBalance
   CollectibleBalance* = ref object
@@ -297,7 +300,9 @@ proc `$`*(self: Collectible): string =
     collectibleData:{self.collectibleData},
     collectionData:{self.collectionData},
     communityData:{self.communityData},
-    ownership:{self.ownership}
+    ownership:{self.ownership},
+    isFist:{self.isFirst},
+    latestTxHash:{self.latestTxHash}
   )"""
 
 proc fromJson*(t: JsonNode, T: typedesc[Collectible]): Collectible {.inline.} =
@@ -324,6 +329,21 @@ proc fromJson*(t: JsonNode, T: typedesc[Collectible]): Collectible {.inline.} =
     result.ownership = some(getAccountBalances(ownershipNode))
   else:
     result.ownership = none(seq[AccountBalance])
+  let isFirstNode = t{"is_first"}
+  if isFirstNode != nil and isFirstNode.kind != JNull:
+    result.isFirst = some(isFirstNode.getBool())
+  else:
+    result.isFirst = none(bool)
+  let latestTxHashNode = t{"latest_tx_hash"}
+  if latestTxHashNode != nil and latestTxHashNode.kind != JNull:
+    result.latestTxHash = some(latestTxHashNode.getStr())
+  else:
+    result.latestTxHash = none(string)
+  let receivedAmountNode = t{"received_amount"}
+  if receivedAmountNode != nil and receivedAmountNode.kind != JNull:
+    result.receivedAmount = some(receivedAmountNode.getFloat())
+  else:
+    result.receivedAmount = none(float64)
 
 proc toIds(self: seq[Collectible]): seq[CollectibleUniqueID] =
   result = @[]

--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -150,3 +150,5 @@ proc getOwnerTokenOwnerAddress*(chainId: int, contractAddress: string): RpcRespo
 
 rpc(registerReceivedCommunityTokenNotification, "wakuext"):
   communityId: string
+  isFirst: bool
+  toTokenData: string

--- a/src/backend/community_tokens_types.nim
+++ b/src/backend/community_tokens_types.nim
@@ -18,8 +18,9 @@ type
     communityName*: string
     communityColor*: string
     communityImage*: string
-    balance*: int
+    amount*: float
     txHash*: string
+    isFirst*: bool
 
 proc fromJson*(t: JsonNode, T: typedesc[CommunityTokenReceivedPayload]): CommunityTokenReceivedPayload {.inline.}=
   let addressField = "address"
@@ -28,7 +29,8 @@ proc fromJson*(t: JsonNode, T: typedesc[CommunityTokenReceivedPayload]): Communi
   discard t.getProp("image", result.image)
   discard t.getProp("chainId", result.chainId)
   discard t.getProp("txHash", result.txHash)
-  result.balance = t{"balance"}.getInt()
+  discard t.getProp("isFirst", result.isFirst)
+  discard t.getProp("amount", result.amount)
 
   fromJson(t[addressField], addressField, result.address)
 

--- a/storybook/pages/ActivityNotificationCommunityTokenReceivedPage.qml
+++ b/storybook/pages/ActivityNotificationCommunityTokenReceivedPage.qml
@@ -13,6 +13,9 @@ SplitView {
 
     orientation: Qt.Vertical
 
+    readonly property int assetType: 1
+    readonly property int collectibleType: 2
+
     Logs { id: logs }
 
     Popups {
@@ -70,7 +73,7 @@ SplitView {
 
             // Notification type related properties:
             isFirstTokenReceived: true
-            isAssetType: true
+            tokenType: root.assetType
 
             // Token related properties:
             tokenAmount: assetMock.amount
@@ -97,7 +100,7 @@ SplitView {
 
             // Notification type related properties:
             isFirstTokenReceived: false
-            isAssetType: true
+            tokenType: root.assetType
 
             // Token related properties:
             tokenAmount: assetMock.amount
@@ -124,7 +127,7 @@ SplitView {
 
             // Notification type related properties:
             isFirstTokenReceived: true
-            isAssetType: false
+            tokenType: root.assetType
 
             // Token related properties:
             tokenAmount: collectibleMock.amount
@@ -151,7 +154,7 @@ SplitView {
 
             // Notification type related properties:
             isFirstTokenReceived: false
-            isAssetType: false
+            tokenType: root.collectibleType
 
             // Token related properties:
             tokenAmount: collectibleMock.amount

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -11,6 +11,7 @@ QtObject {
 
     property var contactsStore
     property var communityTokensStore
+    property var walletStore
 
     property var networkConnectionStore
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1453,6 +1453,7 @@ Item {
                     communityTokensStore: appMain.communityTokensStore
                     emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                     openCreateChat: createChatView.opened
+                    walletStore: WalletStore.RootStore
                     chatCommunitySectionModule: appMain.rootStore.mainModuleInst.getChatSectionModule()
                 }
                 activityCenterStore: appMain.activityCenterStore

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -129,12 +129,21 @@ QtObject {
         }
 
         // Community token received in the user wallet:
-        function onCommunityTokenReceived(name, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, walletAccountName, symbol) {
+        function onCommunityTokenReceived(name, symbol, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, walletAccountName) {
 
             // Some error control:
             if(tokenType !== Constants.TokenType.ERC20 && tokenType !== Constants.TokenType.ERC721) {
                 console.warn("Community token Received: Unexpected token type while creating a toast message: " + tokenType)
                 return
+            }
+
+            // Double check if balance is string, then strip ending zeros (e.g. 1.0 -> 1)
+            if (typeof balance === 'string' && balance.endsWith('0')) {
+                balance = parseFloat(balance)
+                if (isNaN(balance))
+                    balance = "1"
+                // Cast to Number to drop trailing zeros
+                balance = Number(balance).toString()
             }
 
             var data = {

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -292,6 +292,8 @@ Popup {
             communityName: community ? community.name : ""
             communityImage: community ? community.image : ""
 
+            store: root.store
+
             filteredIndex: parent.filteredIndex
             notification: parent.notification
             onCloseActivityCenter: root.close()

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityTokenReceived.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityTokenReceived.qml
@@ -13,24 +13,41 @@ import AppLayouts.Wallet 1.0
 ActivityNotificationBase {
     id: root
 
+    property var community: null
+    property var store: null
+
+    property var tokenData: root.notification.tokenData
+
     // Community properties:
     required property string communityId
     required property string communityName
     required property string communityImage
 
     // Notification type related properties:
-    property bool isFirstTokenReceived: root.notification.isFirstTokenReceived
-    property bool isAssetType: root.notification.tokenType === Constants.TokenType.ERC20
+    property bool isFirstTokenReceived: root.tokenData.isFirst
+    readonly property bool isAssetType: root.tokenType === Constants.TokenType.ERC20
 
     // Token related properties:
-    property string tokenAmount: root.notification.tokenAmount
-    property string tokenName: root.notification.tokenName
-    property string tokenSymbol: root.notification.tokenSymbol
-    property string tokenImage: root.notification.tokenImage
+    property string tokenAmount: {
+        let amount = root.tokenData.amount
+        // Double check if balance is string, then strip ending zeros (e.g. 1.0 -> 1)
+        if (typeof amount === 'string' && amount.endsWith('0')) {
+            amount = parseFloat(root.tokenData.amount)
+            if (isNaN(amount))
+                amount = "1"
+            // Cast to Number to drop trailing zeros
+            amount = Number(amount).toString()
+        }
+        return amount
+    }
+    property string tokenName: root.tokenData.name
+    property string tokenSymbol: root.tokenData.symbol
+    property string tokenImage: root.tokenData.imageUrl
+    property int tokenType: root.tokenData.tokenType
 
     // Wallet related:
-    property string walletAccountName: root.notification.walletAccountName
-    property string txHash: root.notification.txHash
+    property string walletAccountName: !!root.store ? root.store.walletStore.getNameForWalletAddress(root.tokenData.walletAddress) : ""
+    property string txHash: root.tokenData.txHash
 
     QtObject {
         id: d
@@ -99,7 +116,7 @@ ActivityNotificationBase {
                                                    root.tokenSymbol,
                                                    root.tokenName,
                                                    root.tokenAmount,
-                                                   root.notification.tokenType,
+                                                   root.tokenType,
                                                    root.tokenImage);
             }
             else {

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -34,12 +34,11 @@ QtObject {
     signal communityOwnershipDeclined(string communityName)
     signal sendOwnerTokenStateChanged(string tokenName, int status, string url)
     signal ownerTokenReceived(string communityId, string communityName)
-    signal communityTokenReceived(string name, string image,
+    signal communityTokenReceived(string name, string symbol, string image,
                                   string communityId, string communityName,
                                   string balance, int chainId,
                                   string txHash, bool isFirst,
-                                  int tokenType, string walletAccountName,
-                                  string symbol)
+                                  int tokenType, string walletAccountName)
 
     // Minting tokens:
     function deployCollectible(communityId, collectibleItem)
@@ -137,18 +136,8 @@ QtObject {
             root.ownerTokenReceived(communityId, communityName)
         }
 
-        function onCommunityTokenReceived(name, image, communityId, communityName, communityColor /*Unused, can be removed*/, balance, chainId, txHash/*, isFirst, tokenType, walletAccountName, symbol*/) {
-            // TODO BACKEND: #13250
-            // ** `isFirst` property will be true if it's the first time the user receives a community asset and  a community collectible
-            // ** `tokenType` property will determine if the received minted token is an ERC20 or an ERC720
-            // ** `walletAccountName` property will provide the wallet account name where the token was received
-            // ** `symbol` property will provide the token symbol
-
-            var isFirst = false
-            var tokenType = Constants.TokenType.ERC20
-            var walletAccountName = "Status account"
-            var symbol = "NON"
-            root.communityTokenReceived(name, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, walletAccountName, symbol)
+        function onCommunityTokenReceived(name, symbol, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, walletAccountName) {
+            root.communityTokenReceived(name, symbol, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, walletAccountName)
         }
 
         function onSetSignerStateChanged(communityId, communityName, status, url) {


### PR DESCRIPTION
Tasks 
* https://github.com/status-im/status-desktop/issues/13123
* https://github.com/status-im/status-desktop/issues/13250

Related status-go change: https://github.com/status-im/status-go/pull/4682

### What does the PR do

* Added handling of activity center notification `tokenData` property
* Added TokenData objects for activity center model
* Added handling for community collectible received notification
* Updated UI elemenets to work with updated backend

### Affected areas

* Toast messages
* Activity Center

### Screenshot of functionality (including design for comparison)

## Toast Messages

### Collectibles

![image](https://github.com/status-im/status-desktop/assets/11396062/8bfe4a70-27cd-418c-9fe2-6bf69f20f770)

![image](https://github.com/status-im/status-desktop/assets/11396062/1a7c2052-131c-45b3-a7f3-239e4cf72a52)


### Assets

![image](https://github.com/status-im/status-desktop/assets/11396062/46187686-538a-4481-831c-eb2591212065)

![image](https://github.com/status-im/status-desktop/assets/11396062/f36c9fe4-b545-434a-9b91-69219471fb41)


## Activity Center

### Collectibles

![receive_community_collectibles](https://github.com/status-im/status-desktop/assets/11396062/87498367-d0a8-43f9-bdda-5806be9b71e7)

### Assets
![receive_community_tokens](https://github.com/status-im/status-desktop/assets/11396062/ec4cdc75-9301-4828-8870-1d72547552a9)
