### PR TITLE
feat(wallet): simplify loading items mechanism for collectibles model

### DIFF
--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -130,7 +130,7 @@ QtObject:
     var offset = 0
     if not self.fetchFromStart:
       if self.loadType.isPaginated():
-        offset = self.model.getCollectiblesCount()
+        offset = self.model.getCount()
       else:
         offset = self.tempItems.len
     self.fetchFromStart = false

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -102,6 +102,9 @@ SplitView {
         onReceiveRequested: logs.logEvent("onReceiveRequested", ["symbol"], arguments)
         onSwitchToCommunityRequested: logs.logEvent("onSwitchToCommunityRequested", ["communityId"], arguments)
         onManageTokensRequested: logs.logEvent("onManageTokensRequested")
+        isUpdating: ctrlUpdatingCheckbox.checked
+        isFetching: ctrlFetchingCheckbox.checked
+        isError: ctrlErrorCheckbox.checked
     }
 
     LogsAndControlsPanel {
@@ -133,9 +136,19 @@ SplitView {
             }
 
             CheckBox {
-                id: loadingCheckbox
+                id: ctrlUpdatingCheckbox
                 checked: false
-                text: "loading"
+                text: "isUpdating"
+            }
+            CheckBox {
+                id: ctrlFetchingCheckbox
+                checked: false
+                text: "isFetching"
+            }
+            CheckBox {
+                id: ctrlErrorCheckbox
+                checked: false
+                text: "isError"
             }
 
             ColumnLayout {

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -38,6 +38,10 @@ QtObject {
                                         qsTr("%1 community collectibles are now visible").arg(communityName), "", "checkmark-circle",
                                         false, Constants.ephemeralNotificationType.success, "")
     }
+    readonly property bool areCollectiblesFetching: !!root._allCollectiblesModel ? root._allCollectiblesModel.isFetching : true
+    readonly property bool areCollectiblesUpdating: !!root._allCollectiblesModel ? root._allCollectiblesModel.isUpdating : false
+    readonly property bool areCollectiblesError: !!root._allCollectiblesModel ? root._allCollectiblesModel.isError : false
+
 
     /* The following are used to display the detailed view of a collectible */
     readonly property var detailedCollectible: Global.appIsReady ? walletSection.collectibleDetailsController.detailedEntry : null

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -186,6 +186,9 @@ RightTabBaseView {
                         onSwitchToCommunityRequested: (communityId) => Global.switchToCommunity(communityId)
                         onManageTokensRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.wallet,
                                                                                       Constants.walletSettingsSubsection.manageCollectibles)
+                        isFetching: RootStore.collectiblesStore.areCollectiblesFetching
+                        isUpdating: RootStore.collectiblesStore.areCollectiblesUpdating
+                        isError: RootStore.collectiblesStore.areCollectiblesError
                     }
                 }
                 Component {


### PR DESCRIPTION
Fixes #11802

### What does the PR do

Moves the "Loading Items" logic from the Collectibles model to the CollectiblesView, making use of the new ConcatModel util. 

Perhaps a smoother animation can be introduced in the future when a state change occurs.

https://github.com/status-im/status-desktop/assets/11161531/18ca5663-cccd-49dd-91f1-5beca8a59337


https://github.com/status-im/status-desktop/assets/11161531/655c2df1-6b59-484b-a167-d1143de1a549


