### PR TITLE
Remove new tests

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -60,15 +60,6 @@ pipeline {
         stage('Linux/E2E/old') { steps { script {
           linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e-old')
         } } }
-        stage('Linux/E2E/new') { steps { script {
-          linux_e2e = build(
-            job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
-            parameters: jenkins.mapToParams([
-              BUILD_SOURCE:       linux_x86_64.fullProjectName, 
-              TESTRAIL_RUN_NAME:  utils.pkgFilename()
-            ]),
-          )
-        } } }
       }
     }
     stage('Publish') {


### PR DESCRIPTION
### What does the PR do

New tests are timing out when executed as full regression run.
We either need to run the dedicated smoke set (could be run by `-m=critical`) or remove this step for now from release job (at still configure the step to run only smoke test for release job later)


<img width="1532" alt="Screenshot 2024-02-08 at 10 44 16" src="https://github.com/status-im/status-desktop/assets/82375995/c49a25ac-009d-40d0-a6e1-03937fbe4c5e">
