### PR TITLE
fix(ci): run only critical path of new e2e for releases

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -64,8 +64,9 @@ pipeline {
           linux_e2e = build(
             job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
             parameters: jenkins.mapToParams([
-              BUILD_SOURCE:       linux_x86_64.fullProjectName, 
-              TESTRAIL_RUN_NAME:  utils.pkgFilename()
+              BUILD_SOURCE:       linux_x86_64.fullProjectName,
+              TESTRAIL_RUN_NAME:  utils.pkgFilename(),
+              TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
             ]),
           )
         } } }


### PR DESCRIPTION
The full suite is unstable and causes frequent timeouts currently.