### PR TITLE
fix(AppMain): display a badge for Settings icon with incoming CR

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -716,7 +716,9 @@ Item {
                     tooltip.text: Utils.translatedSectionName(model.sectionType, model.name)
                     checked: model.active
                     badge.value: model.notificationsCount
-                    badge.visible: model.hasNotification
+                    badge.visible: model.sectionType === Constants.appSection.profile &&
+                                   appMain.rootStore.contactStore.receivedContactRequestsModel.count ? true // pending CR request
+                                                                                                     : model.hasNotification
                     badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusBadge.borderColor
                     badge.border.width: 2
                     onClicked: {


### PR DESCRIPTION
### What does the PR do

Displays a notification badge over the Settings cog when we have an incoming/pending Contact Request (CR)

Fixes #9779

### Affected areas

AppMain

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Incoming CR:
![Snímek obrazovky z 2024-02-08 13-50-41](https://github.com/status-im/status-desktop/assets/5377645/163c3a70-ea89-4632-a279-5ebcf4857f18)

CR accepted:
![Snímek obrazovky z 2024-02-08 13-52-18](https://github.com/status-im/status-desktop/assets/5377645/c967b4f0-2750-4fee-8630-0c54eb693037)



