### PR TITLE
fix(discord_import): fix community not cleaned up when it fails

### DIFF
--- a/src/app/core/signals/remote_signals/community.nim
+++ b/src/app/core/signals/remote_signals/community.nim
@@ -50,6 +50,9 @@ type DiscordChannelImportProgressSignal* = ref object of Signal
 type DiscordCommunityImportCancelledSignal* = ref object of Signal
   communityId*: string
 
+type DiscordCommunityImportCleanedUpSignal* = ref object of Signal
+  communityId*: string
+
 type DiscordCommunityImportFinishedSignal* = ref object of Signal
   communityId*: string
 
@@ -153,6 +156,11 @@ proc fromEvent*(T: type DiscordCommunityImportFinishedSignal, event: JsonNode): 
 proc fromEvent*(T: type DiscordCommunityImportCancelledSignal, event: JsonNode): DiscordCommunityImportCancelledSignal =
   result = DiscordCommunityImportCancelledSignal()
   result.signalType = SignalType.DiscordCommunityImportCancelled
+  result.communityId = event["event"]{"communityId"}.getStr()
+
+proc fromEvent*(T: type DiscordCommunityImportCleanedUpSignal, event: JsonNode): DiscordCommunityImportCleanedUpSignal =
+  result = DiscordCommunityImportCleanedUpSignal()
+  result.signalType = SignalType.DiscordCommunityImportCleanedUp
   result.communityId = event["event"]{"communityId"}.getStr()
 
 proc fromEvent*(T: type DiscordChannelImportFinishedSignal, event: JsonNode): DiscordChannelImportFinishedSignal =

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -48,6 +48,7 @@ type SignalType* {.pure.} = enum
   DiscordCommunityImportFinished = "community.discordCommunityImportFinished"
   DiscordCommunityImportProgress = "community.discordCommunityImportProgress"
   DiscordCommunityImportCancelled = "community.discordCommunityImportCancelled"
+  DiscordCommunityImportCleanedUp = "community.discordCommunityImportCleanedUp"
   DiscordChannelImportFinished = "community.discordChannelImportFinished"
   DiscordChannelImportProgress = "community.discordChannelImportProgress"
   DiscordChannelImportCancelled = "community.discordChannelImportCancelled"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -117,6 +117,7 @@ QtObject:
       of SignalType.DiscordCommunityImportFinished: DiscordCommunityImportFinishedSignal.fromEvent(jsonSignal)
       of SignalType.DiscordCommunityImportProgress: DiscordCommunityImportProgressSignal.fromEvent(jsonSignal)
       of SignalType.DiscordCommunityImportCancelled: DiscordCommunityImportCancelledSignal.fromEvent(jsonSignal)
+      of SignalType.DiscordCommunityImportCleanedUp: DiscordCommunityImportCleanedUpSignal.fromEvent(jsonSignal)
       of SignalType.DiscordChannelImportFinished: DiscordChannelImportFinishedSignal.fromEvent(jsonSignal)
       of SignalType.DiscordChannelImportProgress: DiscordChannelImportProgressSignal.fromEvent(jsonSignal)
       of SignalType.DiscordChannelImportCancelled: DiscordChannelImportCancelledSignal.fromEvent(jsonSignal)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -655,6 +655,9 @@ QtObject:
     self.delegate.removeCommunityChat(self.discordImportedChannelCommunityId, self.discordImportedChannelId)
     self.resetDiscordImport(true)
 
+  proc resetImport*(self: View) {.slot.} =
+    self.resetDiscordImport(true)
+
   proc toggleDiscordCategory*(self: View, id: string, selected: bool) {.slot.} =
     if selected:
       self.discordCategoriesModel.selectItem(id)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1062,8 +1062,6 @@ method communityLeft*[T](self: Module[T], communityId: string) =
     echo "main-module, unexisting community key to leave: ", communityId
     return
 
-  self.channelGroupModules.del(communityId)
-
   self.view.model().removeItem(communityId)
 
   singletonInstance.localAccountSensitiveSettings.removeSectionChatRecord(communityId)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -358,6 +358,10 @@ QtObject:
       var receivedData = DiscordCommunityImportCancelledSignal(e)
       self.events.emit(SIGNAL_DISCORD_COMMUNITY_IMPORT_CANCELED, CommunityIdArgs(communityId: receivedData.communityId))
 
+    self.events.on(SignalType.DiscordCommunityImportCleanedUp.event) do(e: Args):
+      var receivedData = DiscordCommunityImportCleanedUpSignal(e)
+      self.events.emit(SIGNAL_COMMUNITY_LEFT, CommunityIdArgs(communityId: receivedData.communityId))
+
     self.events.on(SignalType.DiscordChannelImportFinished.event) do(e: Args):
       var receivedData = DiscordChannelImportFinishedSignal(e)
       self.events.emit(SIGNAL_DISCORD_CHANNEL_IMPORT_FINISHED, CommunityChatIdArgs(chatId: receivedData.channelId, communityId: receivedData.communityId))

--- a/ui/app/AppLayouts/Communities/popups/DiscordImportProgressContents.qml
+++ b/ui/app/AppLayouts/Communities/popups/DiscordImportProgressContents.qml
@@ -38,12 +38,12 @@ StatusScrollView {
             visible: d.status === DiscordImportProgressContents.ImportStatus.CompletedWithWarnings ||
                      d.status === DiscordImportProgressContents.ImportStatus.StoppedWithErrors
             type: StatusButton.Danger
-            text: root.importingSingleChannel ? qsTr("Delete channel & restart import") : qsTr("Delete community & restart import")
+            text: root.importingSingleChannel ? qsTr("Delete channel & restart import") : qsTr("Close & restart import")
             onClicked: {
                 if (root.importingSingleChannel) {
-                    Global.openPopup(deleteAndRestartConfirmationPopupCmp)
+                    Global.openPopup(deleteChannelAndRestartConfirmationPopupCmp)
                 } else {
-                    // TODO do similar for community import
+                    root.store.resetImport()
                     root.close()
                 }
             }
@@ -370,9 +370,9 @@ StatusScrollView {
     }
 
     Component {
-        id: deleteAndRestartConfirmationPopupCmp
+        id: deleteChannelAndRestartConfirmationPopupCmp
         ConfirmationDialog {
-            id: deleteAndRestartConfirmationPopup
+            id: deleteChannelAndRestartConfirmationPopup
             headerSettings.title: qsTr("Are you sure you want to delete the channel?")
             confirmationText: qsTr("Your new Status channel will be deleted and all information entered will be lost.")
             showCancelButton: true
@@ -381,11 +381,11 @@ StatusScrollView {
             cancelButtonLabel: qsTr("Cancel")
             onConfirmButtonClicked: {
                 root.store.removeImportedDiscordChannel()
-                deleteAndRestartConfirmationPopup.close()
+                deleteChannelAndRestartConfirmationPopup.close()
                 root.close()
             }
             onCancelButtonClicked: {
-                deleteAndRestartConfirmationPopup.close()
+                deleteChannelAndRestartConfirmationPopup.close()
             }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -193,6 +193,10 @@ QtObject {
         root.communitiesModuleInst.requestCancelDiscordChannelImport(id)
     }
 
+    function resetImport() {
+        root.communitiesModuleInst.resetImport()
+    }
+
     function removeImportedDiscordChannel() {
         root.communitiesModuleInst.removeImportedDiscordChannel()
     }


### PR DESCRIPTION
Fixes #12724

The actual issue wasn't reproducible, even if I removed the guards against duplicate names. But I did find that the community wasn't cleaned up correctly, so I fixed it in this PR. It should limit the confusion and possible issues that could arise.

You can see the fixed behaviour in the video below.
Do note, I removed the duplicate name guards in status-go to create the video. Normally, the import would have worked.
[import.webm](https://github.com/status-im/status-desktop/assets/11926403/11510d74-bb58-437f-a226-de878e1ebbf2)


status-go PR https://github.com/status-im/status-go/pull/4693