### PR TITLE
fix(StatusDialogFooter/StatusModalFooter): Prevent footer's buttons overflow

### DIFF
--- a/storybook/pages/StatusDialogFooterPage.qml
+++ b/storybook/pages/StatusDialogFooterPage.qml
@@ -1,0 +1,89 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import Storybook 1.0
+
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Rectangle {
+            border.color: "lightgray"
+            anchors.fill: footer
+            anchors.margins: -5
+        }
+
+        StatusDialogFooter {
+            id: footer
+
+            anchors.centerIn: parent
+            width: widthNotSpecifiedCheckBox.checked
+                   ? undefined
+                   : Math.floor(root.width * slider.value)
+
+            rightButtons: ObjectModel {
+                StatusButton {
+                    id: rejectBtn
+
+                    text: qsTr("I  I don't want to be the owner")
+                }
+
+                StatusButton {
+                    id: acceptBtn
+
+                    text: qsTr("Finalize owhership")
+                }
+            }
+            leftButtons: ObjectModel {
+                StatusBackButton {
+                    id: backButton
+
+                    Layout.minimumWidth: implicitWidth
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        SplitView.fillWidth: true
+
+        ColumnLayout {
+            Label {
+                text: `Footer width: ${footer.width}`
+            }
+            Label {
+                text: `Footer implicitWidth: ${footer.implicitWidth}`
+            }
+
+            Slider {
+                id: slider
+
+                enabled: !widthNotSpecifiedCheckBox.checked
+
+                from: 0.2
+                to: 1
+                value: 0.5
+            }
+            CheckBox {
+                id: widthNotSpecifiedCheckBox
+
+                text: "width not specified"
+            }
+        }
+    }
+}
+
+// category: Components

--- a/storybook/pages/StatusModalFooterPage.qml
+++ b/storybook/pages/StatusModalFooterPage.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        StatusModal {
+            id: footer
+
+            anchors.centerIn: parent
+            height: 300
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+
+            title: "Some modal"
+
+            width: Math.floor(root.width * slider.value)
+
+            rightButtons: [
+                StatusButton {
+                    text: qsTr("Some button")
+                },
+
+                StatusButton {
+                    text: qsTr("Some other button")
+                }
+            ]
+            leftButtons: StatusBackButton {
+                Layout.minimumWidth: implicitWidth
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        SplitView.fillWidth: true
+
+        ColumnLayout {
+            Label {
+                text: `Popup width: ${footer.width}`
+            }
+
+            Slider {
+                id: slider
+
+                from: 0.2
+                to: 1
+                value: 0.5
+            }
+        }
+    }
+}
+
+// category: Components

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogFooter.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
-import QtQml.Models 2.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -31,7 +31,10 @@ Rectangle {
 
         Repeater {
             model: root.leftButtons
-            onItemAdded: item.Layout.fillHeight = true
+            onItemAdded: {
+                item.Layout.fillHeight = true
+                item.Layout.fillWidth = Qt.binding(() => root.width < root.implicitWidth)
+            }
         }
 
         Item {
@@ -40,7 +43,10 @@ Rectangle {
 
         Repeater {
             model: root.rightButtons
-            onItemAdded: item.Layout.fillHeight = true
+            onItemAdded: {
+                item.Layout.fillHeight = true
+                item.Layout.fillWidth = Qt.binding(() => root.width < root.implicitWidth)
+            }
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -34,6 +34,8 @@ StatusModal {
                 }
             }
         }
+
+        Layout.minimumWidth: implicitWidth
     }
 
     property Item nextButton: StatusButton {

--- a/ui/StatusQ/src/StatusQ/Popups/statusModal/StatusModalFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/statusModal/StatusModalFooter.qml
@@ -9,7 +9,7 @@ import StatusQ.Popups 0.1
 
 
 Rectangle {
-    id: statusModalFooter
+    id: root
 
     property list<Item> leftButtons
     property list<StatusBaseButton> rightButtons
@@ -22,15 +22,21 @@ Rectangle {
     onLeftButtonsChanged: {
         for (let idx in leftButtons) {
             leftButtons[idx].parent = leftButtonsLayout
+            leftButtons[idx].Layout.fillWidth
+                    = Qt.binding(() => root.width < root.implicitWidth)
         }
     }
 
     onRightButtonsChanged: {
         for (let idx in rightButtons) {
             rightButtons[idx].parent = rightButtonsLayout
+            rightButtons[idx].Layout.fillWidth
+                    = Qt.binding(() => root.width < root.implicitWidth)
         }
     }
 
+    implicitWidth: rootLayout.implicitWidth + rootLayout.anchors.leftMargin
+                   + rootLayout.anchors.rightMargin
     implicitHeight: rootLayout.implicitHeight + 30
 
     RowLayout {
@@ -45,19 +51,20 @@ Rectangle {
         RowLayout {
             id: leftButtonsLayout
             Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-            visible: statusModalFooter.showFooter
+            visible: root.showFooter
 
             spacing: 16
         }
 
         Item {
             Layout.fillWidth: true
+            Layout.minimumWidth: 16
         }
 
         RowLayout {
             id: rightButtonsLayout
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-            visible: statusModalFooter.showFooter
+            visible: root.showFooter
 
             spacing: 16
         }
@@ -70,7 +77,7 @@ Rectangle {
         color: parent.color
 
         StatusModalDivider {
-            visible: (statusModalFooter.leftButtons.length || statusModalFooter.rightButtons.length) && rootLayout.height > 1
+            visible: (root.leftButtons.length || root.rightButtons.length) && rootLayout.height > 1
             anchors.top: parent.top
             width: parent.width
         }

--- a/ui/app/AppLayouts/Communities/popups/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityProfilePopup.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.12
-import QtQuick.Controls 2.12
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
@@ -79,6 +80,8 @@ StatusModal {
             onClicked: {
                 contentItem.pop()
             }
+
+            Layout.minimumWidth: implicitWidth
         }
     ]
 }

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -286,6 +286,8 @@ StatusStackModal {
             d.currentPage = (d.currentPage === CreateChannelPopup.CurrentPage.DiscordImportUploadStart) ?
                         CreateChannelPopup.CurrentPage.DiscordImportUploadFile : CreateChannelPopup.CurrentPage.ChannelDetails
         }
+
+        Layout.minimumWidth: implicitWidth
     }
 
 

--- a/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
@@ -132,6 +132,7 @@ StatusDialog {
 
     footer: StatusDialogFooter {
         spacing: Style.current.padding
+
         rightButtons: ObjectModel {
             StatusFlatButton {
                 id: rejectBtn
@@ -149,7 +150,11 @@ StatusDialog {
             }
         }
         leftButtons: ObjectModel {
-            StatusBackButton { id: backButton }
+            StatusBackButton {
+                id: backButton
+
+                Layout.minimumWidth: implicitWidth
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
-import QtQml.Models 2.15
 import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Popups.Dialog 0.1
@@ -94,6 +94,8 @@ StatusDialog {
                 onClicked: {
                     d.displaySigningPanel = false
                 }
+
+                Layout.minimumWidth: implicitWidth
             }
         }
     }

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Popups 0.1
@@ -201,8 +202,9 @@ StatusModal {
             objectName: "AddAccountPopup-BackButton"
             visible: root.store.currentState.displayBackButton
             enabled: !root.store.disablePopup
-            height: Constants.addAccountPopup.footerButtonsHeight
-            width: height
+
+            Layout.minimumWidth: implicitWidth
+
             onClicked: {
                 if (root.store.currentState.stateType === Constants.addAccountPopup.state.confirmAddingNewMasterKey) {
                     root.store.addingNewMasterKeyConfirmed = false

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
@@ -58,8 +59,9 @@ QtObject {
             id: backButton
             visible: root.sharedKeycardModule.currentState.displayBackButton
             enabled: !root.disableActionPopupButtons
-            height: Constants.keycard.general.footerButtonsHeight
-            width: height
+
+            Layout.minimumWidth: implicitWidth
+
             onClicked: {
                 root.sharedKeycardModule.currentState.doBackAction()
             }

--- a/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
+++ b/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Popups 0.1
@@ -150,8 +151,9 @@ StatusModal {
         StatusBackButton {
             id: backButton
             visible: root.store.currentState.displayBackButton
-            height: Constants.keypairImportPopup.footerButtonsHeight
-            width: height
+
+            Layout.minimumWidth: implicitWidth
+
             onClicked: {
                 root.store.currentState.doBackAction()
             }


### PR DESCRIPTION
### What does the PR do

When there is no room for footer buttons in their full width, they are shrank and elided instead of going outside the popup.

Closes: #11449

### Affected areas
`StatusDialogFooter`, `StatusModalFooter`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00091.webm](https://github.com/status-im/status-desktop/assets/20650004/84e0df31-af9f-4daf-9770-2873eb7df10d)


