### PR TITLE
feat(Profile): Add `hiddenCount` property for profile showcase models

### DIFF
--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_accounts_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_accounts_model.nim
@@ -36,6 +36,16 @@ QtObject:
     read = getCount
     notify = countChanged
 
+  proc hiddenCountChanged(self: ProfileShowcaseAccountsModel) {.signal.}
+  proc getHiddenCount(self: ProfileShowcaseAccountsModel): int {.slot.} =
+    result = 0
+    for i, item in self.items:
+      if item.showcaseVisibility == ProfileShowcaseVisibility.ToNoOne:
+        result += 1
+  QtProperty[int] hiddenCount:
+    read = getHiddenCount
+    notify = hiddenCountChanged
+
   proc recalcOrder(self: ProfileShowcaseAccountsModel) =
     for order, item in self.items:
       item.order = order
@@ -102,6 +112,7 @@ QtObject:
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc upsertItemImpl(self: ProfileShowcaseAccountsModel, item: ProfileShowcaseAccountItem) =
@@ -114,6 +125,7 @@ QtObject:
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
       self.dataChanged(index, index)
+      self.hiddenCountChanged()
 
   proc upsertItemJson(self: ProfileShowcaseAccountsModel, itemJson: string) {.slot.} =
     self.upsertItemImpl(itemJson.parseJson.toProfileShowcaseAccountItem())
@@ -136,6 +148,7 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc clear*(self: ProfileShowcaseAccountsModel) {.slot.} =
@@ -151,6 +164,7 @@ QtObject:
     self.items.delete(index)
     self.endRemoveRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc removeEntry*(self: ProfileShowcaseAccountsModel, address: string) {.slot.} =
@@ -187,6 +201,7 @@ QtObject:
       defer: index.delete
       self.dataChanged(index, index, @[ModelRole.ShowcaseVisibility.int])
       self.baseModelFilterConditionsMayHaveChanged()
+      self.hiddenCountChanged()
 
   proc setVisibility*(self: ProfileShowcaseAccountsModel, address: string, visibility: int) {.slot.} =
     let index = self.findIndexForAccount(address)

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_assets_model.nim
@@ -38,6 +38,16 @@ QtObject:
     read = getCount
     notify = countChanged
 
+  proc hiddenCountChanged(self: ProfileShowcaseAssetsModel) {.signal.}
+  proc getHiddenCount(self: ProfileShowcaseAssetsModel): int {.slot.} =
+    result = 0
+    for i, item in self.items:
+      if item.showcaseVisibility == ProfileShowcaseVisibility.ToNoOne:
+        result += 1
+  QtProperty[int] hiddenCount:
+    read = getHiddenCount
+    notify = hiddenCountChanged
+
   proc recalcOrder(self: ProfileShowcaseAssetsModel) =
     for order, item in self.items:
       item.order = order
@@ -110,6 +120,7 @@ QtObject:
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc upsertItemImpl(self: ProfileShowcaseAssetsModel, item: ProfileShowcaseAssetItem) =
@@ -122,6 +133,7 @@ QtObject:
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
       self.dataChanged(index, index)
+      self.hiddenCountChanged()
 
   proc upsertItemJson(self: ProfileShowcaseAssetsModel, itemJson: string) {.slot.} =
     self.upsertItemImpl(itemJson.parseJson.toProfileShowcaseAssetItem())
@@ -144,6 +156,7 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc clear*(self: ProfileShowcaseAssetsModel) {.slot.} =
@@ -159,6 +172,7 @@ QtObject:
     self.items.delete(index)
     self.endRemoveRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc removeEntry*(self: ProfileShowcaseAssetsModel, symbol: string) {.slot.} =
@@ -195,6 +209,7 @@ QtObject:
       defer: index.delete
       self.dataChanged(index, index, @[ModelRole.ShowcaseVisibility.int])
       self.baseModelFilterConditionsMayHaveChanged()
+      self.hiddenCountChanged()
 
   proc setVisibility*(self: ProfileShowcaseAssetsModel, symbol: string, visibility: int) {.slot.} =
     let index = self.findIndexForAsset(symbol)

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectibles_model.nim
@@ -42,6 +42,16 @@ QtObject:
     read = getCount
     notify = countChanged
 
+  proc hiddenCountChanged(self: ProfileShowcaseCollectiblesModel) {.signal.}
+  proc getHiddenCount(self: ProfileShowcaseCollectiblesModel): int {.slot.} =
+    result = 0
+    for i, item in self.items:
+      if item.showcaseVisibility == ProfileShowcaseVisibility.ToNoOne:
+        result += 1
+  QtProperty[int] hiddenCount:
+    read = getHiddenCount
+    notify = hiddenCountChanged
+
   proc recalcOrder(self: ProfileShowcaseCollectiblesModel) =
     for order, item in self.items:
       item.order = order
@@ -127,6 +137,7 @@ QtObject:
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc upsertItemImpl(self: ProfileShowcaseCollectiblesModel, item: ProfileShowcaseCollectibleItem) =
@@ -139,6 +150,7 @@ QtObject:
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
       self.dataChanged(index, index)
+      self.hiddenCountChanged()
 
   proc upsertItemJson(self: ProfileShowcaseCollectiblesModel, itemJson: string) {.slot.} =
     self.upsertItemImpl(itemJson.parseJson.toProfileShowcaseCollectibleItem())
@@ -161,6 +173,7 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc clear*(self: ProfileShowcaseCollectiblesModel) {.slot.} =
@@ -176,6 +189,7 @@ QtObject:
     self.items.delete(index)
     self.endRemoveRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc removeEntry*(self: ProfileShowcaseCollectiblesModel, uid: string) {.slot.} =
@@ -212,6 +226,7 @@ QtObject:
       defer: index.delete
       self.dataChanged(index, index, @[ModelRole.ShowcaseVisibility.int])
       self.baseModelFilterConditionsMayHaveChanged()
+      self.hiddenCountChanged()
 
   proc setVisibility*(self: ProfileShowcaseCollectiblesModel, uid: string, visibility: int) {.slot.} =
     let index = self.findIndexForCollectible(uid)

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_communities_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_communities_model.nim
@@ -40,6 +40,16 @@ QtObject:
     read = getCount
     notify = countChanged
 
+  proc hiddenCountChanged(self: ProfileShowcaseCommunitiesModel) {.signal.}
+  proc getHiddenCount(self: ProfileShowcaseCommunitiesModel): int {.slot.} =
+    result = 0
+    for i, item in self.items:
+      if item.showcaseVisibility == ProfileShowcaseVisibility.ToNoOne:
+        result += 1
+  QtProperty[int] hiddenCount:
+    read = getHiddenCount
+    notify = hiddenCountChanged
+
   proc recalcOrder(self: ProfileShowcaseCommunitiesModel) =
     for order, item in self.items:
       item.order = order
@@ -117,6 +127,7 @@ QtObject:
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc upsertItemImpl(self: ProfileShowcaseCommunitiesModel, item: ProfileShowcaseCommunityItem) =
@@ -129,6 +140,7 @@ QtObject:
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
       self.dataChanged(index, index)
+      self.hiddenCountChanged()
 
   proc upsertItemJson(self: ProfileShowcaseCommunitiesModel, itemJson: string) {.slot.} =
     self.upsertItemImpl(itemJson.parseJson.toProfileShowcaseCommunityItem())
@@ -151,6 +163,7 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc clear*(self: ProfileShowcaseCommunitiesModel) {.slot.} =
@@ -166,6 +179,7 @@ QtObject:
     self.items.delete(index)
     self.endRemoveRows()
     self.countChanged()
+    self.hiddenCountChanged()
     self.baseModelFilterConditionsMayHaveChanged()
 
   proc removeEntry*(self: ProfileShowcaseCommunitiesModel, id: string) {.slot.} =
@@ -202,6 +216,7 @@ QtObject:
       defer: index.delete
       self.dataChanged(index, index, @[ModelRole.ShowcaseVisibility.int])
       self.baseModelFilterConditionsMayHaveChanged()
+      self.hiddenCountChanged()
 
   proc setVisibility*(self: ProfileShowcaseCommunitiesModel, id: string, visibility: int) {.slot.} =
     let index = self.findIndexForCommunity(id)


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/pull/13489

- Add one more dirty state property. 

Temporary changes. These models are going to be wiped in a few weeks