### PR TITLE
fix: timestamp shows yesterday for a message received 3 days ago

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusTimeStampLabel.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.14
+import QtQuick 2.15
+import QtQml 2.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
@@ -12,7 +13,24 @@ StatusBaseText {
     color: Theme.palette.baseColor1
     font.pixelSize: 10
     visible: !!text
-    text: showFullTimestamp ? LocaleUtils.formatDateTime(timestamp) : LocaleUtils.formatRelativeTimestamp(timestamp)
+    text: d.formattedLabel
+
+    QtObject {
+        id: d
+        // initial value
+        property string formattedLabel: root.showFullTimestamp ? LocaleUtils.formatDateTime(root.timestamp) : LocaleUtils.formatRelativeTimestamp(root.timestamp)
+
+        // updates
+        Binding on formattedLabel {
+            when: !root.showFullTimestamp && root.timestamp && root.visible
+            value: {
+                StatusSharedUpdateTimer.secondsActive
+                return LocaleUtils.formatRelativeTimestamp(root.timestamp)
+            }
+            restoreMode: Binding.RestoreBinding
+        }
+    }
+
     StatusToolTip {
         id: tooltip
         visible: hhandler.hovered && !!text
@@ -22,8 +40,8 @@ StatusBaseText {
         id: hhandler
         enabled: !root.showFullTimestamp
         onHoveredChanged: {
-            if(hhandler.hovered && timestamp) {
-                tooltip.text = LocaleUtils.formatDateTime(timestamp)
+            if(hhandler.hovered && root.timestamp) {
+                tooltip.text = LocaleUtils.formatDateTime(root.timestamp)
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Core/StatusSharedUpdateTimer.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusSharedUpdateTimer.qml
@@ -1,0 +1,29 @@
+pragma Singleton
+
+import QtQml 2.15
+
+QtObject {
+    id: root
+
+    readonly property alias secondsActive: d.secondsActive
+
+    signal triggered()
+
+    readonly property Timer d: Timer {
+        id: d
+        property int secondsActive: 0
+        interval: 1000
+        running: Qt.application.state === Qt.ApplicationActive
+        repeat: true
+        onTriggered: {
+            d.secondsActive++
+            root.triggered()
+        }
+        onRunningChanged: {
+            if (running) {
+                d.secondsActive++
+                root.triggered()
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/qmldir
@@ -13,5 +13,6 @@ StatusModalHeaderSettings 0.1 StatusModalHeaderSettings.qml
 StatusProfileImageSettings 0.1 StatusProfileImageSettings.qml
 StatusRollArea 0.1 StatusRollArea.qml
 StatusScrollView 0.1 StatusScrollView.qml
+singleton StatusSharedUpdateTimer 0.1 StatusSharedUpdateTimer.qml
 StatusTooltipSettings 0.1 StatusTooltipSettings.qml
 singleton LocaleUtils 0.1 LocaleUtils.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -170,6 +170,7 @@
         <file>StatusQ/Core/StatusModalHeaderSettings.qml</file>
         <file>StatusQ/Core/StatusProfileImageSettings.qml</file>
         <file>StatusQ/Core/StatusRollArea.qml</file>
+        <file>StatusQ/Core/StatusSharedUpdateTimer.qml</file>
         <file>StatusQ/Core/StatusScrollView.qml</file>
         <file>StatusQ/Core/StatusTooltipSettings.qml</file>
         <file>StatusQ/Core/Theme/StatusColors.qml</file>


### PR DESCRIPTION
### What does the PR do

Fixes wrong message timestamp in a channel when the relative date changes (due to time going over midnight, HW clock skews or timezone/DST changes)

- introduce one global update timer, to be used in various components for date/time sensitive updates
- this timer runs only when the app is/becomes active
- use the timer's `triggered()` signal to update the timestamp label when needed; ie. if it's to display a relative timestamp and it's currently visible

Fixes #11460

### Affected areas

StatusTimeStampLabel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before midnight:
![Snímek obrazovky z 2024-02-11 23-59-58](https://github.com/status-im/status-desktop/assets/5377645/fc09a0be-3f01-4118-8d45-37b73aba416d)

After midnight:
![Snímek obrazovky z 2024-02-12 00-00-06](https://github.com/status-im/status-desktop/assets/5377645/6c8edbd1-1f78-4312-a4e3-cbeef433f21b)
