### PR TITLE
feat(ProfileShowcase): Save changes tooltip when disabled

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -57,6 +57,9 @@ SettingsContentBase {
             priv.hasAnyProfileShowcaseChanges
     saveChangesButtonEnabled: !!descriptionPanel.displayName.text && descriptionPanel.displayName.valid
 
+    toast.saveChangesTooltipVisible: root.dirty
+    toast.saveChangesTooltipText: qsTr("Invalid changes made to Identity")
+
     onResetChangesClicked: priv.reset()
 
     onSaveChangesClicked: priv.save()

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -4,6 +4,8 @@ import QtGraphicalEffects 1.15
 
 import utils 1.0
 
+import shared.controls 1.0
+
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
@@ -16,6 +18,8 @@ Rectangle {
     property bool saveChangesButtonEnabled: false
     property bool saveForLaterButtonVisible
     property alias saveChangesText: saveChangesButton.text
+    property alias saveChangesTooltipText: saveChangesButton.tooltipText
+    property alias saveChangesTooltipVisible: saveChangesButton.enabled
     property alias saveForLaterText: saveForLaterButton.text
     property alias cancelChangesText: cancelChangesButton.text
     property alias changesDetectedText: changesDetectedTextItem.text
@@ -139,11 +143,13 @@ Rectangle {
             onClicked: root.saveForLaterClicked()
         }
 
-        StatusButton {
+        DisabledTooltipButton {
             id: saveChangesButton
             objectName: "settingsDirtyToastMessageSaveButton"
-            enabled: root.active && root.saveChangesButtonEnabled
+            buttonType: DisabledTooltipButton.Normal
             text: qsTr("Save changes")
+            enabled: false
+            interactive: root.active && root.saveChangesButtonEnabled
             onClicked: root.saveChangesClicked()
         }
     }


### PR DESCRIPTION
Closes #13334

### What does the PR do

- Replaced current `StatusButton` type to `DisabledTootipButton` to allow the tooltip being displayed when button is disabled, in dirty toast message.
- Added needed conditions in `MyProfileView` where the tooltip, in save changes button, is shown in disable condition.

### Affected areas

Settings / Save changes toast button

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/96b6da44-163f-4217-8f32-463d56ae808d