### PR TITLE
fix(profile/qr) add Copy/Download menu for QR code

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -40,6 +40,14 @@ SplitView {
             return url
         }
 
+        function copyImageToClipboardByUrl(data) {
+            logs.logEvent("Utils::copyImageToClipboardByUrl", ["data"], arguments)
+        }
+
+        function downloadImageByUrl(url, path) {
+            logs.logEvent("Utils::downloadImageByUrl", ["url", "path"], arguments)
+        }
+
         Component.onCompleted: {
             Utils.globalUtilsInst = this
             root.globalUtilsReady = true

--- a/ui/imports/shared/views/profile/ShareProfileDialog.qml
+++ b/ui/imports/shared/views/profile/ShareProfileDialog.qml
@@ -9,6 +9,7 @@ import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared.controls 1.0
+import shared.views.chat 1.0
 
 StatusDialog {
     id: root
@@ -37,6 +38,18 @@ StatusDialog {
             mipmap: true
             smooth: false
             source: root.qrCode
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.RightButton
+                cursorShape: Qt.PointingHandCursor
+                onClicked: qrContextMenu.popup()
+            }
+
+            ImageContextMenu {
+                id: qrContextMenu
+                imageSource: root.qrCode
+            }
         }
 
         StatusBaseText {


### PR DESCRIPTION
### What does the PR do
add a regular image context menu with:
- "Copy image" -> copy the image to clipboard
- "Download image" -> downloads the image in the user specified folder

Fixes #13479

### Affected areas

ShareProfileDialog

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/6f23a650-03c6-4432-9c39-ea2c22c5f408)


