### PR TITLE
ci: fix leftover to allow tests running in nightly

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -55,8 +55,8 @@ pipeline {
         } } }
       }
     }
-    stage('Tests') {
-      stage('Linux/E2E/new') { steps { script {
+    stage('E2E') {
+      steps { script {
         linux_e2e = build(
           job: 'status-desktop/systems/linux/x86_64/tests-e2e-new',
           parameters: jenkins.mapToParams([
@@ -65,7 +65,7 @@ pipeline {
             TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
           ]),
         )
-      } } }
+      } }
     }
     stage('Publish') {
       when { expression { params.PUBLISH } }


### PR DESCRIPTION
### What does the PR do

fix leftover to allow tests running in nightly. Nightly job https://ci.status.im/job/status-desktop/job/nightly/186/ failed with

```
WorkflowScript: 58: Unknown stage section "stage". Starting with version 0.5, steps in a stage must be in a ‘steps’ block. @ line 58, column 5.
       stage('Tests') {
       ^

WorkflowScript: 58: Expected one of "steps", "stages", or "parallel" for stage "Tests" @ line 58, column 5.
       stage('Tests') {
       ^
```

### Affected areas

`ci/Jenkinsfile.combined`
