### PR TITLE
chore: add object name for EditCroppedImage item

### DIFF
--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -49,6 +49,7 @@ Item {
     implicitWidth: mainLayout.implicitWidth
     implicitHeight: mainLayout.implicitHeight
 
+    objectName: "editCroppedImageItem_" + root.title
 
     states: [
         State {


### PR DESCRIPTION
### What does the PR do

add object name for EditCroppedImage item

### Affected areas

`ui/imports/shared/panels/EditCroppedImagePanel.qml`