### PR TITLE
fix(SettingsDirtyToastMessage): Save changes always disabled

### DIFF
--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -148,7 +148,7 @@ Rectangle {
             objectName: "settingsDirtyToastMessageSaveButton"
             buttonType: DisabledTooltipButton.Normal
             text: qsTr("Save changes")
-            enabled: false
+            enabled: root.active && root.saveChangesButtonEnabled
             interactive: root.active && root.saveChangesButtonEnabled
             onClicked: root.saveChangesClicked()
         }


### PR DESCRIPTION
### What does the PR do

It fixes issue with save changes button introduced in commit edf7e82.

### Affected areas

Settings / Save changes bubble button

### Screenshot of functionality 

https://github.com/status-im/status-desktop/assets/97019400/7f26bf54-c96d-41e5-bb30-3190c8300825


