### PR TITLE
feat(profile): Place user image/identicon onto the QR code

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -29,7 +29,7 @@ SplitView {
 
         function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
 
-        function getColorHashAsJson(publicKey) {
+        function getColorHashAsJson(publicKey, skipEnsVerification=false) {
             return JSON.stringify([{colorId: 0, segmentLength: 1},
                                    {colorId: 19, segmentLength: 2}])
         }
@@ -61,6 +61,10 @@ SplitView {
 
     // mainModuleInst mock
     QtObject {
+        function isEnsVerified(publicKey) {
+            return ensVerified.checked
+        }
+
         function getContactDetailsAsJson(publicKey, getVerificationRequest=true, getOnlineStatus=false, includeDetails=false) {
             return JSON.stringify({ displayName: displayName.text,
                                       optionalName: "",

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -52,8 +52,8 @@ QtObject {
         return root.profileModule.remove()
     }
 
-    function getQrCodeSource(publicKey) {
-        return globalUtils.qrCode(publicKey)
+    function getQrCodeSource(text) {
+        return globalUtils.qrCode(text)
     }
 
     function copyToClipboard(value) {

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -269,8 +269,10 @@ Pane {
             destroyOnClose: true
             title: d.isCurrentUser ? qsTr("Share your profile") : qsTr("%1's profile").arg(d.mainDisplayName)
             publicKey: root.publicKey
-            qrCode: root.profileStore.getQrCodeSource(Utils.getCompressedPk(root.publicKey))
             linkToProfile: d.linkToProfile
+            qrCode: root.profileStore.getQrCodeSource(linkToProfile)
+            displayName: userImage.name
+            largeImage: userImage.image
         }
     }
 
@@ -288,6 +290,7 @@ Pane {
             spacing: Style.current.halfPadding
 
             UserImage {
+                id: userImage
                 Layout.alignment: Qt.AlignTop
                 objectName: "ProfileDialog_userImage"
                 name: root.dirty ? root.dirtyValues.displayName

--- a/ui/imports/shared/views/profile/ShareProfileDialog.qml
+++ b/ui/imports/shared/views/profile/ShareProfileDialog.qml
@@ -10,6 +10,7 @@ import StatusQ.Popups.Dialog 0.1
 import utils 1.0
 import shared.controls 1.0
 import shared.views.chat 1.0
+import shared.controls.chat 1.0
 
 StatusDialog {
     id: root
@@ -17,6 +18,9 @@ StatusDialog {
     required property string publicKey
     required property string qrCode
     required property string linkToProfile
+
+    required property string displayName
+    required property string largeImage
 
     footer: null
 
@@ -29,26 +33,44 @@ StatusDialog {
     contentItem: ColumnLayout {
         spacing: Style.current.halfPadding
 
-        Image {
-            Layout.preferredWidth: 290
-            Layout.preferredHeight: 290
-            Layout.alignment: Qt.AlignHCenter
-            asynchronous: true
-            fillMode: Image.PreserveAspectFit
-            mipmap: true
-            smooth: false
-            source: root.qrCode
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: width
+            color: Theme.palette.white
 
-            MouseArea {
+            Image {
                 anchors.fill: parent
-                acceptedButtons: Qt.RightButton
-                cursorShape: Qt.PointingHandCursor
-                onClicked: qrContextMenu.popup()
-            }
+                asynchronous: true
+                fillMode: Image.PreserveAspectFit
+                mipmap: true
+                smooth: false
+                source: root.qrCode
 
-            ImageContextMenu {
-                id: qrContextMenu
-                imageSource: root.qrCode
+                UserImage {
+                    anchors.centerIn: parent
+                    name: root.displayName
+                    pubkey: root.publicKey
+                    image: root.largeImage
+                    interactive: false
+                    imageWidth: 78
+                    imageHeight: 78
+
+                    // show a hardcoded white ring
+                    showRing: true
+                    colorHash: JSON.stringify([{colorId: 4, segmentLength: 32}])
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.RightButton
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: qrContextMenu.popup()
+                }
+
+                ImageContextMenu {
+                    id: qrContextMenu
+                    imageSource: root.qrCode
+                }
             }
         }
 


### PR DESCRIPTION
- fix the QR code to generate a URL with the link to the profile instead of just the user key
- reuse the `UserImage` component and place it on top of the existing QR code
- put a white rectangle behind the QR code image and white ring around
the user image

Fixes #13482

### What does the PR do

Adds a user image on top of the QR code

### Affected areas

ShareProfileDialog

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

QR code displayed in the app:
![Snímek obrazovky z 2024-02-13 14-53-55](https://github.com/status-im/status-desktop/assets/5377645/ac5d4133-5c9c-4946-bdf4-455250616ea0)

QR code scanned on phone:
![photo_2024-02-13_14-56-18](https://github.com/status-im/status-desktop/assets/5377645/46d6e09a-0640-458f-8f6d-4ab7bffe320c)
