### PR TITLE
feat(@wallet): update collectibles model only with changes

### DIFF
--- a/src/app/modules/shared_models/collectibles_nested_model.nim
+++ b/src/app/modules/shared_models/collectibles_nested_model.nim
@@ -38,7 +38,7 @@ QtObject:
     result.setup
 
     signalConnect(result.flatModel, "countChanged()", result, "refreshItems()")
-    signalConnect(result.flatModel, "itemsUpdated()", result, "refreshItems()")
+    signalConnect(result.flatModel, "itemsDataUpdated()", result, "refreshItems()")
 
   # Forward declaration
   proc refreshItems*(self: Model)

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -181,7 +181,7 @@ QtObject:
         self.setTempItems(items, res.offset)
         # If we reached the end of the list, commit the items to the model
         if not res.hasMore:
-          self.model.setItems(self.tempItems, 0, false)
+          self.model.updateItems(self.tempItems)
           self.tempItems = @[]
     except Exception as e:
       error "Error converting activity entries: ", e.msg
@@ -207,7 +207,7 @@ QtObject:
       for jsonCollectible in jsonObj.getElems():
         let collectible = fromJson(jsonCollectible, backend_collectibles.Collectible)
         collectibles.add(collectible)
-      self.model.updateItems(collectibles)
+      self.model.updateItemsData(collectibles)
       if not self.loadType.isPaginated():
         self.updateTempItems(collectibles)
 

--- a/test/nim/collectibles_model_test.nim
+++ b/test/nim/collectibles_model_test.nim
@@ -1,0 +1,82 @@
+import unittest
+
+import stint, strutils, random
+
+import backend/collectibles_types
+import app/modules/shared_models/collectibles_model
+import app/modules/shared_models/collectibles_entry
+    
+proc createTestCollectible(seed: int): CollectiblesEntry =
+    let data = Collectible(
+        dataType: UniqueID,
+        id: CollectibleUniqueID(
+            contractID: ContractID(
+                address: seed.toHex,
+                chainID: seed mod 4
+            ),
+            tokenID: u256(seed)
+        )
+    )
+    let extradata = ExtraData(
+        networkShortName: "Chain" & seed.toHex,
+        networkColor: "Color" & seed.toHex,
+        networkIconURL: "URL" & seed.toHex,
+    )
+    return newCollectibleDetailsFullEntry(data, extradata)
+
+proc createTestCollectibles(seed: int, count: int): seq[CollectiblesEntry] =
+    result = @[]
+    for i in 0..<count:
+        result.add(createTestCollectible(seed + i))
+
+suite "collectibles model":
+  test "Collectible list set":
+    let collectibles = createTestCollectibles(0, 15)
+    let moreCollectibles = createTestCollectibles(100, 10)
+    let model = newModel()
+
+    model.setItems(collectibles, 0, false)
+    check(model.getItems() == collectibles)
+
+    # Wrong offset, should not change the list
+    model.setItems(collectibles, 20, false)
+    check(model.getItems() == collectibles)
+
+    # Right offset, should append
+    model.setItems(moreCollectibles, 15, false)
+    check(model.getItems() == collectibles & moreCollectibles)
+
+    # 0 offset, should replace
+    model.setItems(moreCollectibles, 0, false)
+    check(model.getItems() == moreCollectibles)
+
+  test "Collectible list update":
+    let oldCollectibles = createTestCollectibles(0, 15)
+    let model = newModel()
+
+    model.updateItems(oldCollectibles)
+    check(model.getItems() == oldCollectibles)
+
+    model.updateItems(oldCollectibles)
+    check(model.getItems() == oldCollectibles)
+
+    var newCollectibles = oldCollectibles
+    newCollectibles.del(0)
+    newCollectibles.del(2)
+    newCollectibles.del(7)
+    for newC in createTestCollectibles(100, 7):
+        newCollectibles.add(newC)
+    
+    var r = initRand(678)
+    r.shuffle(newCollectibles)
+    
+    model.updateItems(newCollectibles)
+
+    for c in model.getItems():
+        check(c in newCollectibles)
+    
+    for c in newCollectibles:
+        check(c in model.getItems())
+    
+    model.updateItems(@[])
+    check(model.getItems().len == 0)


### PR DESCRIPTION
Fixes #13254

### What does the PR do

Whenever a change in the list of owned collectibles is reported by status-go, we now update the model with the delta (added/removed items) instead of doing a full reset, which should help avoid doing unnecessary work in the SFPM.

This is a straightforward approach, and there's room for improvement still:
- Don't re-request the full list from status-go, only request new items and remove what's needed.
- - I considered this originally, but the complexity became quite high (similar to what Stefan's doing for the Session-Based Activity API). It was taking too long and I feared inconsistencies between the two lists, so I abandoned this idea for now.
- Separate models with collectibles metadata (most of what we currently have) and ownership (accounts + uids), which can be combined with the LeftJoin proxy model. 
- - Follows what was done for Tokens, complexity is not too high, so I'd like to do this.