### PR TITLE
11588 fix permissions values

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -19,6 +19,7 @@ import ../../../global/global_singleton
 import ../../../core/eventemitter
 import ../../../core/unique_event_emitter
 import ../../../core/notifications/details as notification_details
+import ../../../../app_service/common/conversion
 import ../../../../app_service/common/types
 import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/node_configuration/service as node_configuration_service
@@ -1307,10 +1308,8 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
     tokenPermission.chatIDs = @[]
 
   let tokenCriteriaJsonObj = tokenCriteriaJson.parseJson
-
   for tokenCriteria in tokenCriteriaJsonObj:
 
-    let viewAmount = tokenCriteria{"amount"}.getFloat
     var tokenCriteriaDto = tokenCriteria.toTokenCriteriaDto
     if tokenCriteriaDto.`type` == TokenType.ERC20:
       tokenCriteriaDto.decimals = self.controller.getTokenDecimals(tokenCriteriaDto.symbol)
@@ -1323,7 +1322,7 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
       self.onCommunityTokenPermissionUpdateFailed(communityId)
       return
 
-    tokenCriteriaDto.amount = viewAmount.formatBiggestFloat(ffDecimal)
+    tokenCriteriaDto.amountInWei = tokenCriteria{"amount"}.getStr
     tokenCriteriaDto.contractAddresses = contractAddresses
     tokenPermission.tokenCriteria.add(tokenCriteriaDto)
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -549,6 +549,7 @@ method requestCancelDiscordChannelImport*(self: Module, discordChannelId: string
 
 proc createCommunityTokenItem(self: Module, token: CommunityTokensMetadataDto, communityId: string, supply: string,
     infiniteSupply: bool): TokenListItem =
+  let communityTokenDecimals = if token.tokenType == TokenType.ERC20: 18 else: 0
   result = initTokenListItem(
     key = token.symbol,
     name = token.name,
@@ -559,6 +560,7 @@ proc createCommunityTokenItem(self: Module, token: CommunityTokensMetadataDto, c
     communityId = communityId,
     supply,
     infiniteSupply,
+    communityTokenDecimals
   )
 
 proc buildTokensAndCollectiblesFromCommunities(self: Module) =
@@ -613,6 +615,7 @@ proc buildTokensAndCollectiblesFromWallet(self: Module) =
       communityId = token.communityId,
       image = "",
       category = ord(TokenListItemCategory.General),
+      decimals = token.decimals
     )
     tokenListItems.add(tokenListItem)
 

--- a/src/app/modules/shared_models/token_criteria_item.nim
+++ b/src/app/modules/shared_models/token_criteria_item.nim
@@ -4,7 +4,7 @@ type
   TokenCriteriaItem* = object
     symbol*: string
     name*: string
-    amount*: float64
+    amount*: string
     `type`*: int
     ensPattern*: string
     criteriaMet*: bool
@@ -12,7 +12,7 @@ type
 proc initTokenCriteriaItem*(
   symbol: string,
   name: string,
-  amount: float64,
+  amount: string,
   `type`: int,
   ensPattern: string,
   criteriaMet: bool
@@ -43,7 +43,7 @@ proc getSymbol*(self: TokenCriteriaItem): string =
 proc getName*(self: TokenCriteriaItem): string =
   return self.name
 
-proc getAmount*(self: TokenCriteriaItem): float64 =
+proc getAmount*(self: TokenCriteriaItem): string =
   return self.amount
 
 proc getEnsPattern*(self: TokenCriteriaItem): string =

--- a/src/app/modules/shared_models/token_list_item.nim
+++ b/src/app/modules/shared_models/token_list_item.nim
@@ -16,6 +16,7 @@ type
     communityId*: string
     supply*: string
     infiniteSupply*: bool
+    decimals*: int
 
 proc initTokenListItem*(
   key: string,
@@ -27,6 +28,7 @@ proc initTokenListItem*(
   communityId: string = "",
   supply: string = "1",
   infiniteSupply: bool = true,
+  decimals: int
 ): TokenListItem =
   result.key = key
   result.symbol = symbol
@@ -37,6 +39,7 @@ proc initTokenListItem*(
   result.communityId = communityId
   result.supply = supply
   result.infiniteSupply = infiniteSupply
+  result.decimals = decimals
 
 proc `$`*(self: TokenListItem): string =
   result = fmt"""TokenListItem(
@@ -48,6 +51,7 @@ proc `$`*(self: TokenListItem): string =
     communityId: {self.communityId},
     supply: {self.supply},
     infiniteSupply: {self.infiniteSupply},
+    decimals: {self.decimals},
     ]"""
 
 proc getKey*(self: TokenListItem): string =
@@ -76,3 +80,6 @@ proc getSupply*(self: TokenListItem): string =
 
 proc getInfiniteSupply*(self: TokenListItem): bool =
   return self.infiniteSupply
+
+proc getDecimals*(self: TokenListItem): int =
+  return self.decimals

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -13,6 +13,7 @@ type
     CommunityId
     Supply
     InfiniteSupply
+    Decimals
 
 QtObject:
   type TokenListModel* = ref object of QAbstractListModel
@@ -91,6 +92,7 @@ QtObject:
       ModelRole.CommunityId.int:"communityId",
       ModelRole.Supply.int:"supply",
       ModelRole.InfiniteSupply.int:"infiniteSupply",
+      ModelRole.Decimals.int:"decimals",
     }.toTable
 
   method rowCount(self: TokenlistModel, index: QModelIndex = nil): int =
@@ -124,3 +126,5 @@ QtObject:
         result = newQVariant(item.getSupply())
       of ModelRole.InfiniteSupply:
         result = newQVariant(item.getInfiniteSupply())
+      of ModelRole.Decimals:
+        result = newQVariant(item.getDecimals())

--- a/src/app/modules/shared_models/token_permission_item.nim
+++ b/src/app/modules/shared_models/token_permission_item.nim
@@ -80,7 +80,7 @@ proc buildTokenPermissionItem*(tokenPermission: CommunityTokenPermissionDto, cha
     let tokenCriteriaItem = initTokenCriteriaItem(
       tc.symbol,
       tc.name,
-      tc.amount.parseFloat,
+      tc.amountInWei,
       tc.`type`.int,
       tc.ensPattern,
       false # tokenCriteriaMet will be updated by a call to checkPermissionsToJoin

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -82,6 +82,7 @@ type TokenCriteriaDto* = object
   decimals* {.serializedFieldName("decimals").}: int
   tokenIds* {.serializedFieldName("tokenIds").}: seq[string]
   ensPattern* {.serializedFieldName("ens_pattern").}: string
+  amountInWei* {.serializedFieldName("amountInWei").}: string
 
 type CommunityTokenPermissionDto* = object
   id*: string
@@ -258,6 +259,7 @@ proc toDiscordImportTaskProgress*(jsonObj: JsonNode): DiscordImportTaskProgress 
 proc toTokenCriteriaDto*(jsonObj: JsonNode): TokenCriteriaDto =
   result = TokenCriteriaDto()
   discard jsonObj.getProp("amount", result.amount)
+  discard jsonObj.getProp("amountInWei", result.amountInWei)
   discard jsonObj.getProp("decimals", result.decimals)
   discard jsonObj.getProp("symbol", result.symbol)
   discard jsonObj.getProp("name", result.name)

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -82,9 +82,10 @@ QtObject {
         return Internal.PermissionUtils.getUniquePermissionChannels(model, channelKey)
     }
 
-    function setHoldingsTextFormat(type, name, amount) {
-        if (typeof amount === "string")
-            amount = AmountsArithmetic.toNumber(AmountsArithmetic.fromString(amount))
+    function setHoldingsTextFormat(type, name, amount, decimals) {
+        if (typeof amount === "string") {
+            amount = AmountsArithmetic.toNumber(AmountsArithmetic.fromString(amount), decimals)
+        }
 
         switch (type) {
             case Constants.TokenType.ERC20:

--- a/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
@@ -50,10 +50,6 @@ Control {
         readonly property string channelMembershipRequestPendingText: qsTr("Channel Membership Request Pending...")
         readonly property string memberchipRequestRejectedText: qsTr("Membership Request Rejected")
 
-        function holdingsTextFormat(name, amount) {
-            return PermissionsHelpers.setHoldingsTextFormat(Constants.TokenType.ERC20, name, amount)
-        }
-
         function getInvitationPendingText() {
             return root.joinCommunity ? d.communityMembershipRequestPendingText : d.channelMembershipRequestPendingText
         }

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -246,7 +246,7 @@ StatusScrollView {
                     const key = item.key
 
                     d.dirtyValues.selectedHoldingsModel.append(
-                                { type, key, amount: parseFloat(amount) })
+                                { type, key, amount })
                 }
 
                 function prepareUpdateIndex(key) {
@@ -275,7 +275,7 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.assetsModel, key)
 
-                    addItem(Constants.TokenType.ERC20, modelItem, amount)
+                    addItem(Constants.TokenType.ERC20, modelItem, String(AmountsArithmetic.fromNumber(amount, modelItem.decimals)))
                     dropdown.close()
                 }
 
@@ -283,13 +283,13 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.collectiblesModel, key)
 
-                    addItem(Constants.TokenType.ERC721, modelItem, amount)
+                    addItem(Constants.TokenType.ERC721, modelItem, String(amount))
                     dropdown.close()
                 }
 
                 onAddEns: {
                     d.dirtyValues.selectedHoldingsModel.append(
-                                { type: Constants.TokenType.ENS, key: domain, amount: 1 })
+                                { type: Constants.TokenType.ENS, key: domain, amount: "1" })
                     dropdown.close()
                 }
 
@@ -298,7 +298,7 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(root.assetsModel, key)
 
                     d.dirtyValues.selectedHoldingsModel.set(
-                                itemIndex, { type: Constants.TokenType.ERC20, key, amount: parseFloat(amount) })
+                                itemIndex, { type: Constants.TokenType.ERC20, key, amount: String(AmountsArithmetic.fromNumber(amount, modelItem.decimals)) })
                     dropdown.close()
                 }
 
@@ -309,14 +309,14 @@ StatusScrollView {
 
                     d.dirtyValues.selectedHoldingsModel.set(
                                 itemIndex,
-                                { type: Constants.TokenType.ERC721, key, amount: parseFloat(amount) })
+                                { type: Constants.TokenType.ERC721, key, amount: String(amount) })
                     dropdown.close()
                 }
 
                 onUpdateEns: {
                     d.dirtyValues.selectedHoldingsModel.set(
                                 tokensSelector.editedIndex,
-                                { type: Constants.TokenType.ENS, key: domain, amount: 1 })
+                                { type: Constants.TokenType.ENS, key: domain, amount: "1" })
                     dropdown.close()
                 }
 
@@ -353,7 +353,8 @@ StatusScrollView {
                 switch(modelItem.type) {
                     case Constants.TokenType.ERC20:
                         dropdown.assetKey = modelItem.key
-                        dropdown.assetAmount = modelItem.amount
+                        const decimals = PermissionsHelpers.getTokenByKey(root.assetsModel, modelItem.key).decimals
+                        dropdown.assetAmount = AmountsArithmetic.toNumber(modelItem.amount, decimals)
                         break
                     case Constants.TokenType.ERC721:
                         dropdown.collectibleKey = modelItem.key

--- a/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
+++ b/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
@@ -37,11 +37,20 @@ SortFilterProxyModel {
                 return item ? item.symbol || item.shortName || item.name : ""
             }
 
+            function getDecimals(type, key) {
+                if (type !== Constants.TokenType.ERC20) {
+                    return 0
+                }
+                const item = PermissionsHelpers.getTokenByKey(assetsModel, key)
+                return item.decimals
+            }
+
             function getText(type, key, amount) {
                 const name = getName(type, key)
+                const decimals = getDecimals(type, key)
 
                 return PermissionsHelpers.setHoldingsTextFormat(
-                            type, name, amount)
+                            type, name, amount, decimals)
             }
 
             // Direct call for singleton function is not handled properly by


### PR DESCRIPTION
Handle correct values in permissions.

Add a new field AmountInWeis to token criteria dto.
Keep strings instead of floats in token_criteria_item.
HoldingSelectionModel keeps amount in wei-like units but they are displayed in permissions as floats (divided by decimals).
Add decimals to token_list_model.

status-go [pr](https://github.com/status-im/status-go/pull/4727)

Issue #11588