### PR TITLE
Fix/13550 wallet cannot sort collectibles by date added

### DIFF
--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -242,16 +242,6 @@ QtObject:
     read = getOwnershipModel
     notify = ownershipChanged
 
-  proc ownershipAddressesChanged*(self: CollectiblesEntry) {.signal.}
-  proc getOwnershipAddresses*(self: CollectiblesEntry): string {.slot.} =
-    if not self.hasOwnership():
-      return ""
-    return self.getOwnership().map(o => o.address).join(":")
-
-  QtProperty[string] ownershipAddresses:
-    read = getOwnershipAddresses
-    notify = ownershipAddressesChanged
-
   proc communityIdChanged*(self: CollectiblesEntry) {.signal.}
   proc getCommunityID*(self: CollectiblesEntry): string {.slot.} =
     if not self.hasCommunityData():

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -24,7 +24,6 @@ type
     CollectionSlug
     IsLoading
     Ownership
-    OwnershipAddresses
     # Community-related roles
     CommunityId
     CommunityName
@@ -146,7 +145,6 @@ QtObject:
       CollectibleRole.CollectionSlug.int:"collectionSlug",
       CollectibleRole.IsLoading.int:"isLoading",
       CollectibleRole.Ownership.int:"ownership",
-      CollectibleRole.OwnershipAddresses.int:"ownershipAddresses",
       CollectibleRole.CommunityId.int:"communityId",
       CollectibleRole.CommunityName.int:"communityName",
       CollectibleRole.CommunityColor.int:"communityColor",
@@ -193,8 +191,6 @@ QtObject:
         result = newQVariant(false)
       of CollectibleRole.Ownership:
         result = newQVariant(item.getOwnershipModel())
-      of CollectibleRole.OwnershipAddresses:
-        result = newQVariant(item.getOwnershipAddresses())
       of CollectibleRole.CommunityId:
         result = newQVariant(item.getCommunityId())
       of CollectibleRole.CommunityName:
@@ -222,7 +218,6 @@ QtObject:
       of "collectionName": result = item.getCollectionName()
       of "collectionSlug": result = item.getCollectionSlug()
       of "isLoading": result = $false
-      of "ownershipAddresses": result = item.getOwnershipAddresses()
       of "communityId": result = item.getCommunityID()
       of "communityName": result = item.getCommunityName()
       of "communityColor": result = item.getCommunityColor()

--- a/storybook/src/Models/ManageCollectiblesModel.qml
+++ b/storybook/src/Models/ManageCollectiblesModel.qml
@@ -28,7 +28,18 @@ ListModel {
             imageUrl: ModelsData.collectibles.cryptoPunks,
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240:0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 1
+                },
+                {
+                    accountAddress: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
+                    balance: 1,
+                    txTimestamp: 2
+                },
+            ]
         },
         {
             uid: "pp23",
@@ -42,7 +53,13 @@ ListModel {
             imageUrl: "https://i.seadn.io/s/raw/files/ba2811bb5cd0bed67529d69fa92ef5aa.jpg?auto=format&dpr=1&w=1000",
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 3
+                },
+            ]
         },
         {
             uid: "34545656768",
@@ -56,7 +73,13 @@ ListModel {
             imageUrl: ModelsData.collectibles.kitty1Big,
             isLoading: true,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
+                    balance: 1,
+                    txTimestamp: 3
+                },
+            ]
         },
         {
             uid: "123456",
@@ -70,7 +93,13 @@ ListModel {
             imageUrl: ModelsData.collectibles.kitty2Big,
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 6
+                },
+            ]
         },
         {
             uid: "12345645459537432",
@@ -84,7 +113,18 @@ ListModel {
             imageUrl: ModelsData.collectibles.kitty3Big,
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240:0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 50
+                },
+                {
+                    accountAddress: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
+                    balance: 1,
+                    txTimestamp: 10
+                },
+            ]
         },
         {
             uid: "pp21",
@@ -98,7 +138,13 @@ ListModel {
             imageUrl: "https://i.seadn.io/s/raw/files/cfa559bb63e4378f17649c1e3b8f18fe.jpg?auto=format&dpr=1&w=1000",
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
+                    balance: 1,
+                    txTimestamp: 16
+                },
+            ]
         },
         {
             uid: "lp#666a",
@@ -112,7 +158,13 @@ ListModel {
             imageUrl: "",
             isLoading: false,
             backgroundColor: "pink",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 19
+                },
+            ]
         },
     ]
 
@@ -129,7 +181,13 @@ ListModel {
             imageUrl: "https://i.seadn.io/gae/qPfQjj4P1w0xVQXAmQJLmQ4ZtLFAJU6oiH69Lsny82LFbipLAgXhHKrcLBx2U09SmRnzeHY0ygz-3NIb-JegE_hWrZquFeL-qUPXPdw",
             isLoading: false,
             backgroundColor: "pink",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 20
+                },
+            ]
         },
         {
             uid: "691",
@@ -143,7 +201,13 @@ ListModel {
             imageUrl: "https://assets.killabears.com/content/killabears/gif/691-e81f892696a8ae700e0dbc62eb072060679a2046d1ef5eb2671bdb1fad1f68e3.gif",
             isLoading: true,
             backgroundColor: "navy",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 21
+                },
+            ]
         },
         {
             uid: "8876",
@@ -157,7 +221,13 @@ ListModel {
             imageUrl: "https://assets.killabears.com/content/killabears/transparent-512/2385-86ba13cc6945ed0aea7c32a363a96be2f218898358745ae07b947452cb7e4e79.png",
             isLoading: false,
             backgroundColor: "pink",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 22
+                },
+            ]
         },
         {
             uid: "fp#3195",
@@ -171,7 +241,13 @@ ListModel {
             imageUrl: "https://i.seadn.io/s/raw/files/59ad1f2e3c5eb5d4b62c06e200076514.png",
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 23
+                },
+            ]
         },
         {
             uid: "fp#4297",
@@ -185,7 +261,13 @@ ListModel {
             imageUrl: "https://i.seadn.io/gae/K4_vmYtXAqU6LTnGDliLtJZc4UPmf9jUlk09_FDbXvSKKyUARyyV9RQEgXdb5bjje5OE9j9ZryC5pzcwBwH7TDOIl8oq7D2tSJ7p",
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 25
+                },
+            ]
         },
         {
             uid: "fp#909",
@@ -199,7 +281,13 @@ ListModel {
             imageUrl: "https://i.seadn.io/gae/cR-Bjmb6DsrywCJMOqEBPkkrMHjbTzeRSAKIvLpd7i8ss6raYZ3-doh8oF2z8bJsnmfC1oR3kllz6UxMfFaYAKdXYzXlhfVsDHo6bg",
             isLoading: false,
             backgroundColor: "",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 26
+                },
+            ]
         },
         {
             uid: "lb#666",
@@ -213,7 +301,13 @@ ListModel {
             imageUrl: "",
             isLoading: false,
             backgroundColor: "pink",
-            ownershipAddresses: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            ownership: [
+                {
+                    accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+                    balance: 1,
+                    txTimestamp: 27
+                },
+            ]
         },
     ]
 


### PR DESCRIPTION
### What does the PR do

Fixes #13550 
status-go part: https://github.com/status-im/status-go/pull/4734

Only the backend side of this had been implemented (provide the latest tx timestamp for each address owning a given collectible), this PR implements the UI-side.

On top of that, a missing notification was added on the status-go side.

NOTE: The Tx Timestamp value depends on the transfer detection module, which is a completely independent process. If the transfer doesn't show up in the Activity tab, the collectible will for sure not have the proper timestamp, so the sorting order for these won't be correct. Eventually, when the Tx gets detected, it should get re-sorted accordingly.

https://github.com/status-im/status-desktop/assets/11161531/4b8ddaed-d0fb-4325-ac84-46b82a532bc8



