### PR TITLE
chore: allow squish accessing the imageCropper

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -238,6 +238,8 @@ Item {
 
         ImageCropWorkflow {
             id: cropperModal
+            // is needed for e2e to access the crop function
+            anchors.fill: parent
             objectName: "imageCropWorkflow"
             imageFileDialogTitle: qsTr("Choose an image for profile picture")
             title: qsTr("Profile picture")


### PR DESCRIPTION
### What does the PR do

Allow e2e to access ImageCropWorkflow and its functions (to allow me bypass the file upload dialog in tests)

### Affected areas

`ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml`