### PR TITLE
fix: App crash while switching wallet accounts

### DIFF
--- a/ui/StatusQ/src/concatmodel.cpp
+++ b/ui/StatusQ/src/concatmodel.cpp
@@ -685,6 +685,9 @@ QVector<int> ConcatModel::mapFromSourceRoles(
         int sourceIndex, const QVector<int>& sourceRoles) const
 {
     QVector<int> mapped;
+    if (sourceIndex < 0 || sourceIndex >= m_rolesMappingFromSource.size())
+        return mapped;
+
     mapped.reserve(sourceRoles.size());
 
     auto& mapping = m_rolesMappingFromSource[sourceIndex];


### PR DESCRIPTION
### What does the PR do

Closes #13585 

Check vector boundaries.
The app is crashing when mapFromSourceRoles is called with 0 m_rolesMappingFromSource length.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

ConcatModel
