### PR TITLE
feat(ProfileShowcase): Dirty state management for communities/accounts/collectibles

### DIFF
--- a/storybook/pages/MovableModelPage.qml
+++ b/storybook/pages/MovableModelPage.qml
@@ -119,7 +119,7 @@ Item {
             Layout.fillHeight: true
 
             Label {
-                text: "DETACHED-ORDER MODEL"
+                text: "MOVABLE MODEL (press to drag&drop)"
 
                 font.bold: true
                 font.pixelSize: 17
@@ -234,15 +234,23 @@ Item {
         }
 
         Button {
-            text: "detach order explicitely"
+            text: "desynchronize"
 
             onClicked: {
-                movableModel.detach()
+                movableModel.desyncOrder()
+            }
+        }
+
+        Button {
+            text: "synchronize"
+
+            onClicked: {
+                movableModel.syncOrder()
             }
         }
 
         Label {
-            text: "Detached: " + movableModel.detached
+            text: "Synchronized: " + movableModel.synced
         }
     }
 }

--- a/storybook/pages/MovableModelWithSfpmPage.qml
+++ b/storybook/pages/MovableModelWithSfpmPage.qml
@@ -460,13 +460,19 @@ Item {
             }
 
             Button {
-                text: "detach order explicitely"
+                text: "desynchronize"
 
-                onClicked: movableModel.detach()
+                onClicked: movableModel.desyncOrder()
+            }
+
+            Button {
+                text: "synchronize"
+
+                onClicked: movableModel.syncOrder()
             }
 
             Label {
-                text: `Detached: <b>${movableModel.detached}</b>`
+                text: `Synchronized: <b>${movableModel.synced}</b>`
             }
         }
     }

--- a/storybook/pages/ProfileShowcaseDirtyStatePage.qml
+++ b/storybook/pages/ProfileShowcaseDirtyStatePage.qml
@@ -1,0 +1,197 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import Storybook 1.0
+
+import AppLayouts.Profile.helpers 1.0
+
+Item {
+    id: root
+
+    ListModel {
+        id: communitiesModel
+
+        ListElement { key: "1"; name: "Crypto Kitties" }
+        ListElement { key: "2"; name: "Status" }
+        ListElement { key: "3"; name: "Fun Stuff" }
+        ListElement { key: "4"; name: "Other Stuff" }
+    }
+
+    ListModel {
+        id: communitiesShowcaseModel
+
+        ListElement { key: "1"; visibility: 1; position: 0 }
+        ListElement { key: "3"; visibility: 2; position: 9 }
+    }
+
+    ProfileShowcaseDirtyState {
+        id: dirtyState
+
+        sourceModel: communitiesModel
+        showcaseModel: communitiesShowcaseModel
+    }
+
+    MovableModel {
+        id: movableModel
+
+        sourceModel: dirtyState.visibleModel
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        Grid {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.margins: 10
+
+            rows: 3
+            columns: 3
+
+            spacing: 10
+
+            flow: Grid.TopToBottom
+
+            Label {
+                text: "Backend models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 200
+                height: 300
+
+                model: communitiesModel
+                label: "COMMUNITIES MODEL"
+            }
+
+            GenericListView {
+                width: 200
+                height: 300
+
+                model: communitiesShowcaseModel
+                label: "SHOWCASE MODEL"
+                roles: ["key", "visibility", "position"]
+            }
+
+            Label {
+                text: "Internal models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 350
+                height: 300
+
+                model: dirtyState.joined_
+                label: "JOINED MODEL"
+            }
+
+            GenericListView {
+                width: 350
+                height: 300
+
+                model: dirtyState.writable_
+                label: "WRITABLE MODEL"
+                roles: ["key", "visibility", "position", "name"]
+            }
+
+
+            Label {
+                text: "Display models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 450
+                height: 300
+
+                model: movableModel
+                label: "IN SHOWCASE"
+                movable: true
+                roles: ["key", "visibility", "position"]
+
+                onMoveRequested: {
+                    movableModel.move(from, to)
+
+                    const key = ModelUtils.get(movableModel, to, "key")
+                    dirtyState.changePosition(key, to);
+                }
+
+                insetComponent: RowLayout {
+                    readonly property var topModel: model
+
+                    RoundButton {
+                        text: "❌"
+                        onClicked: dirtyState.setVisibility(model.key, 0)
+                    }
+
+                    ComboBox {
+                        id: combo
+
+                        model: ListModel {
+                            ListElement { text: "contacts"; value: 1 }
+                            ListElement { text: "verified"; value: 2 }
+                            ListElement { text: "all"; value: 3 }
+                        }
+
+                        onCurrentValueChanged: {
+                            if (!completed || topModel.index < 0)
+                                return
+
+                            dirtyState.setVisibility(topModel.key, currentValue)
+                        }
+
+                        property bool completed: false
+
+                        Component.onCompleted: {
+                            currentIndex = indexOfValue(topModel.visibility)
+                            completed = true
+                        }
+
+                        textRole: "text"
+                        valueRole: "value"
+                    }
+                }
+            }
+
+            GenericListView {
+                width: 450
+                height: 300
+
+                model: dirtyState.hiddenModel
+                label: "HIDDEN"
+
+                roles: ["key", "visibility", "position"]
+
+                insetComponent: Button {
+                    text: "unhide"
+
+                    onClicked: dirtyState.setVisibility(model.key, 1)
+                }
+            }
+        }
+
+        Button {
+            text: "SAVE"
+            onClicked: {
+                const toBeSaved = dirtyState.currentState()
+
+                communitiesShowcaseModel.clear()
+                communitiesShowcaseModel.append(toBeSaved)
+            }
+
+            Layout.alignment: Qt.AlignHCenter
+            Layout.margins: 10
+        }
+    }
+}
+
+// category: Models

--- a/storybook/pages/ProfileShowcaseDirtyStatePage.qml
+++ b/storybook/pages/ProfileShowcaseDirtyStatePage.qml
@@ -9,6 +9,8 @@ import Storybook 1.0
 
 import AppLayouts.Profile.helpers 1.0
 
+import utils 1.0
+
 Item {
     id: root
 
@@ -24,8 +26,33 @@ Item {
     ListModel {
         id: communitiesShowcaseModel
 
-        ListElement { key: "1"; visibility: 1; position: 0 }
-        ListElement { key: "3"; visibility: 2; position: 9 }
+        ListElement {
+            key: "1"
+            visibility: Constants.ShowcaseVisibility.IdVerifiedContacts
+            position: 0
+        }
+        ListElement {
+            key: "3"
+            visibility: Constants.ShowcaseVisibility.Contacts
+            position: 9
+        }
+    }
+
+    ListModel {
+        id: comboBoxModel
+
+        ListElement {
+            text: "verified"
+            value: Constants.ShowcaseVisibility.IdVerifiedContacts
+        }
+        ListElement {
+            text: "contacts"
+            value: Constants.ShowcaseVisibility.Contacts
+        }
+        ListElement {
+            text: "all"
+            value: Constants.ShowcaseVisibility.Everyone
+        }
     }
 
     ProfileShowcaseDirtyState {
@@ -130,17 +157,13 @@ Item {
 
                     RoundButton {
                         text: "❌"
-                        onClicked: dirtyState.setVisibility(model.key, 0)
+                        onClicked: dirtyState.setVisibility(
+                                       model.key,
+                                       Constants.ShowcaseVisibility.NoOne)
                     }
 
                     ComboBox {
-                        id: combo
-
-                        model: ListModel {
-                            ListElement { text: "contacts"; value: 1 }
-                            ListElement { text: "verified"; value: 2 }
-                            ListElement { text: "all"; value: 3 }
-                        }
+                        model: comboBoxModel
 
                         onCurrentValueChanged: {
                             if (!completed || topModel.index < 0)
@@ -174,7 +197,9 @@ Item {
                 insetComponent: Button {
                     text: "unhide"
 
-                    onClicked: dirtyState.setVisibility(model.key, 1)
+                    onClicked: dirtyState.setVisibility(
+                                   model.key,
+                                   Constants.ShowcaseVisibility.IdVerifiedContacts)
                 }
             }
         }

--- a/storybook/pages/ProfileShowcaseModelsPage.qml
+++ b/storybook/pages/ProfileShowcaseModelsPage.qml
@@ -25,8 +25,16 @@ ColumnLayout {
     ListModel {
         id: accountsShowcaseModel
 
-        ListElement { key: "1"; visibility: 1; position: 0 }
-        ListElement { key: "3"; visibility: 2; position: 9 }
+        ListElement {
+            key: "1"
+            visibility: Constants.ShowcaseVisibility.IdVerifiedContacts
+            position: 0
+        }
+        ListElement {
+            key: "3"
+            visibility: Constants.ShowcaseVisibility.Contacts
+            position: 9
+        }
     }
 
     ListModel {
@@ -41,9 +49,21 @@ ColumnLayout {
     ListModel {
         id: collectiblesShowcaseModel
 
-        ListElement { key: "1"; visibility: 1; position: 0 }
-        ListElement { key: "2"; visibility: 2; position: 2 }
-        ListElement { key: "3"; visibility: 2; position: 1 }
+        ListElement {
+            key: "1"
+            visibility: Constants.ShowcaseVisibility.IdVerifiedContacts
+            position: 0
+        }
+        ListElement {
+            key: "2"
+            visibility: Constants.ShowcaseVisibility.Contacts
+            position: 2
+        }
+        ListElement {
+            key: "3"
+            visibility: Constants.ShowcaseVisibility.Contacts
+            position: 1
+        }
     }
 
     ProfileShowcaseModels {
@@ -68,12 +88,25 @@ ColumnLayout {
         sourceModel: showcaseModels.collectiblesVisibleModel
     }
 
-    component VisibilityComboBox: ComboBox {
-        model: ListModel {
-            ListElement { text: "contacts"; value: 1 }
-            ListElement { text: "verified"; value: 2 }
-            ListElement { text: "all"; value: 3 }
+    ListModel {
+        id: comboBoxModel
+
+        ListElement {
+            text: "verified"
+            value: Constants.ShowcaseVisibility.IdVerifiedContacts
         }
+        ListElement {
+            text: "contacts"
+            value: Constants.ShowcaseVisibility.Contacts
+        }
+        ListElement {
+            text: "all"
+            value: Constants.ShowcaseVisibility.Everyone
+        }
+    }
+
+    component VisibilityComboBox: ComboBox {
+        model: comboBoxModel
 
         textRole: "text"
         valueRole: "value"
@@ -150,7 +183,8 @@ ColumnLayout {
                     RoundButton {
                         text: "❌"
                         onClicked: showcaseModels.setAccountVisibility(
-                                       model.key, 0)
+                                       model.key,
+                                       Constants.ShowcaseVisibility.NoOne)
                     }
 
                     VisibilityComboBox {
@@ -185,8 +219,10 @@ ColumnLayout {
                 insetComponent: Button {
                     text: "unhide"
 
-                    onClicked: showcaseModels.setAccountVisibility(
-                                   model.key, 1)
+                    onClicked:
+                        showcaseModels.setAccountVisibility(
+                            model.key,
+                            Constants.ShowcaseVisibility.IdVerifiedContacts)
                 }
             }
 
@@ -243,7 +279,8 @@ ColumnLayout {
                     RoundButton {
                         text: "❌"
                         onClicked: showcaseModels.setCollectibleVisibility(
-                                       model.key, 0)
+                                       model.key,
+                                       Constants.ShowcaseVisibility.NoOne)
                     }
 
                     VisibilityComboBox {
@@ -279,8 +316,10 @@ ColumnLayout {
                 insetComponent: Button {
                     text: "unhide"
 
-                    onClicked: showcaseModels.setCollectibleVisibility(
-                                   model.key, 1)
+                    onClicked:
+                        showcaseModels.setCollectibleVisibility(
+                            model.key,
+                            Constants.ShowcaseVisibility.IdVerifiedContacts)
                 }
             }
         }

--- a/storybook/pages/ProfileShowcaseModelsPage.qml
+++ b/storybook/pages/ProfileShowcaseModelsPage.qml
@@ -1,0 +1,324 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import Storybook 1.0
+
+import utils 1.0
+
+import AppLayouts.Profile.helpers 1.0
+
+ColumnLayout {
+    ListModel {
+        id: accountsModel
+
+        ListElement { key: "1"; name: "Crypto Kitties" }
+        ListElement { key: "2"; name: "Status" }
+        ListElement { key: "3"; name: "Fun Stuff" }
+        ListElement { key: "4"; name: "Other Stuff" }
+    }
+
+    ListModel {
+        id: accountsShowcaseModel
+
+        ListElement { key: "1"; visibility: 1; position: 0 }
+        ListElement { key: "3"; visibility: 2; position: 9 }
+    }
+
+    ListModel {
+        id: collectiblesModel
+
+        ListElement { key: "1"; name: "Collectible 1"; accounts: "1:3" }
+        ListElement { key: "2"; name: "Collectible 2"; accounts: "3" }
+        ListElement { key: "3"; name: "Collectible 3"; accounts: "1:2:3" }
+        ListElement { key: "4"; name: "Collectible 4"; accounts: "1:4" }
+    }
+
+    ListModel {
+        id: collectiblesShowcaseModel
+
+        ListElement { key: "1"; visibility: 1; position: 0 }
+        ListElement { key: "2"; visibility: 2; position: 2 }
+        ListElement { key: "3"; visibility: 2; position: 1 }
+    }
+
+    ProfileShowcaseModels {
+        id: showcaseModels
+
+        accountsSourceModel: accountsModel
+        accountsShowcaseModel: accountsShowcaseModel
+
+        collectiblesSourceModel: collectiblesModel
+        collectiblesShowcaseModel: collectiblesShowcaseModel
+    }
+
+    MovableModel {
+        id: accountsMovableModel
+
+        sourceModel: showcaseModels.accountsVisibleModel
+    }
+
+    MovableModel {
+        id: collectiblesMovableModel
+
+        sourceModel: showcaseModels.collectiblesVisibleModel
+    }
+
+    component VisibilityComboBox: ComboBox {
+        model: ListModel {
+            ListElement { text: "contacts"; value: 1 }
+            ListElement { text: "verified"; value: 2 }
+            ListElement { text: "all"; value: 3 }
+        }
+
+        textRole: "text"
+        valueRole: "value"
+    }
+
+    Flickable {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.margins: 10
+
+        contentWidth: grid.width
+        contentHeight: grid.height
+
+        clip: true
+
+        Grid {
+            id: grid
+
+            rows: 3
+            columns: 4
+
+            spacing: 10
+
+            flow: Grid.TopToBottom
+
+            Label {
+                text: "Backend models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 200
+                height: 300
+
+                model: accountsModel
+                label: "ACCOUNTS MODEL"
+            }
+
+            GenericListView {
+                width: 200
+                height: 300
+
+                model: accountsShowcaseModel
+                label: "SHOWCASE MODEL"
+                roles: ["key", "visibility", "position"]
+            }
+
+            Label {
+                text: "Display models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 420
+                height: 300
+
+                model: accountsMovableModel
+                label: "IN SHOWCASE"
+                movable: true
+                roles: ["key", "visibility", "position"]
+
+                onMoveRequested: {
+                    accountsMovableModel.move(from, to)
+
+                    const key = ModelUtils.get(accountsMovableModel, to, "key")
+                    showcaseModels.changeAccountPosition(key, to);
+                }
+
+                insetComponent: RowLayout {
+                    readonly property var topModel: model
+
+                    RoundButton {
+                        text: "❌"
+                        onClicked: showcaseModels.setAccountVisibility(
+                                       model.key, 0)
+                    }
+
+                    VisibilityComboBox {
+                        property bool completed: false
+
+                        onCurrentValueChanged: {
+                            if (!completed || topModel.index < 0)
+                                return
+
+                            showcaseModels.setAccountVisibility(
+                                        topModel.key, currentValue)
+                        }
+
+                        Component.onCompleted: {
+                            currentIndex = indexOfValue(topModel.visibility)
+                            completed = true
+                        }
+                    }
+                }
+            }
+
+            GenericListView {
+                width: 420
+                height: 300
+
+                model: showcaseModels.accountsHiddenModel
+
+                label: "HIDDEN"
+
+                roles: ["key", "visibility", "position"]
+
+                insetComponent: Button {
+                    text: "unhide"
+
+                    onClicked: showcaseModels.setAccountVisibility(
+                                   model.key, 1)
+                }
+            }
+
+            Label {
+                text: "Backend models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 270
+                height: 300
+
+                model: collectiblesModel
+                label: "COLLECTIBLES MODEL"
+
+                roles: ["key", "name", "accounts"]
+            }
+
+            GenericListView {
+                width: 270
+                height: 300
+
+                model: collectiblesShowcaseModel
+                label: "SHOWCASE MODEL"
+                roles: ["key", "visibility", "position"]
+            }
+
+            Label {
+                text: "Display models"
+                font.pixelSize: 22
+                padding: 10
+            }
+
+            GenericListView {
+                width: 610
+                height: 300
+
+                model: collectiblesMovableModel
+                label: "IN SHOWCASE"
+                movable: true
+                roles: ["key", "visibility", "position", "accounts", "maxVisibility"]
+
+                onMoveRequested: {
+                    collectiblesMovableModel.move(from, to)
+
+                    const key = ModelUtils.get(collectiblesMovableModel, to, "key")
+                    showcaseModels.changeCollectiblePosition(key, to);
+                }
+
+                insetComponent: RowLayout {
+                    readonly property var topModel: model
+
+                    RoundButton {
+                        text: "❌"
+                        onClicked: showcaseModels.setCollectibleVisibility(
+                                       model.key, 0)
+                    }
+
+                    VisibilityComboBox {
+                        property bool completed: false
+
+                        onCurrentValueChanged: {
+                            if (!completed || topModel.index < 0)
+                                return
+
+                            showcaseModels.setCollectibleVisibility(
+                                        topModel.key, currentValue)
+                        }
+
+                        Component.onCompleted: {
+                            currentIndex = indexOfValue(topModel.visibility)
+                            completed = true
+                        }
+                    }
+                }
+            }
+
+            GenericListView {
+                width: 610
+                height: 300
+
+                model: showcaseModels.collectiblesHiddenModel
+
+                label: "HIDDEN"
+
+                roles: ["key", "visibility", "position",
+                    "accounts", "maxVisibility"]
+
+                insetComponent: Button {
+                    text: "unhide"
+
+                    onClicked: showcaseModels.setCollectibleVisibility(
+                                   model.key, 1)
+                }
+            }
+        }
+    }
+
+    Label {
+        text: `accounts in showcase: [${showcaseModels.visibleAccountsList}]`
+        Layout.alignment: Qt.AlignHCenter
+    }
+
+    Label {
+        readonly property string visibilities:
+            JSON.stringify(showcaseModels.accountsVisibilityMap)
+
+        text: `accounts visibilities: [${visibilities}]`
+        Layout.alignment: Qt.AlignHCenter
+    }
+
+    Button {
+        text: "SAVE"
+
+        onClicked: {
+            const accountsToBeSaved = showcaseModels.accountsCurrentState()
+            const collectiblesToBeSaved = showcaseModels.collectiblesCurrentState()
+
+            accountsMovableModel.syncOrder()
+            collectiblesMovableModel.syncOrder()
+
+            accountsShowcaseModel.clear()
+            accountsShowcaseModel.append(accountsToBeSaved)
+
+            collectiblesShowcaseModel.clear()
+            collectiblesShowcaseModel.append(collectiblesToBeSaved)
+        }
+
+        Layout.alignment: Qt.AlignHCenter
+        Layout.margins: 10
+    }
+}
+
+// category: Models

--- a/storybook/src/Storybook/GenericListView.qml
+++ b/storybook/src/Storybook/GenericListView.qml
@@ -1,0 +1,162 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core.Utils 0.1
+
+import utils 1.0
+
+ListView {
+    id: root
+
+    // adds drag handler to every row, emits moveRequested when item is moved
+    property bool movable: false
+
+    // roles intended to be visualized, all roles when empty
+    property var roles: []
+
+    // custom delegate height, when set to 0, delegate's implicitHeight is used
+    property int delegateHeight: 0
+
+    // text to be displayed in a list view's header
+    property string label
+
+    // additional component to be instantiated within every delegate
+    property Component insetComponent
+
+    property int margin: 5
+
+    ScrollBar.vertical: ScrollBar {}
+
+    clip: true
+    spacing: 5
+
+    leftMargin: margin
+    rightMargin: margin
+    topMargin: margin
+    bottomMargin: margin
+
+    signal moveRequested(int from, int to)
+
+    ListModel {
+        id: rowModel
+
+        function initialize() {
+            const roleNames = roles.length ? roles
+                                           : ModelUtils.roleNames(root.model)
+            const modelContent = roleNames.map(roleName => ({ roleName }))
+
+            clear()
+            append(modelContent)
+        }
+
+        Component.onCompleted: initialize()
+    }
+
+    Rectangle {
+        border.color: "lightgray"
+        color: "transparent"
+        anchors.fill: parent
+    }
+
+    header: Label {
+        visible: !!text
+        height: visible ? undefined : 0
+        text: root.label
+        font.bold: true
+        font.pixelSize: 16
+        bottomPadding: 20
+    }
+
+    delegate: Item {
+        id: delegateRoot
+
+        width: ListView.view.width
+        height: root.delegateHeight || delegateRow.implicitHeight
+
+        readonly property var topModel: model
+
+        RowLayout {
+            id: delegateRow
+
+            Drag.active: dragArea.pressed
+            Drag.source: dragArea
+            Drag.hotSpot.x: width / 2
+            Drag.hotSpot.y: height / 2
+
+            states: State {
+                when: dragArea.pressed
+
+                ParentChange {
+                    target: delegateRow
+                    parent: root
+                }
+
+                AnchorChanges {
+                    target: delegateRow
+                    anchors {
+                        horizontalCenter: undefined
+                        verticalCenter: undefined
+                    }
+                }
+            }
+
+            RoundButton {
+                text: "↕️"
+                visible: root.movable
+
+                MouseArea {
+                    id: dragArea
+
+                    property bool held: pressed
+                    readonly property int idx: model.index
+
+                    anchors.fill: parent
+
+                    drag.target: pressed ? delegateRow : undefined
+                    drag.axis: Drag.YAxis
+                }
+            }
+
+            Repeater {
+                model: rowModel
+
+                Label {
+                    readonly property var value:
+                        delegateRoot.topModel[roleName]
+
+                    readonly property var valueSanitized:
+                        value === undefined ? "-" : value
+
+                    readonly property bool last: index === rowModel.count - 1
+                    readonly property string separator: last ? "" : ","
+
+                    text: `${roleName}: ${valueSanitized}${separator}`
+                }
+            }
+
+            Loader {
+                readonly property var model: delegateRoot.topModel
+                sourceComponent: insetComponent
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+        }
+
+        DropArea {
+            anchors { fill: parent; margins: 10 }
+
+            onEntered: {
+                const from = drag.source.idx
+                const to = dragArea.idx
+
+                if (from === to)
+                    return
+
+                root.moveRequested(from, to)
+            }
+        }
+    }
+}

--- a/storybook/src/Storybook/qmldir
+++ b/storybook/src/Storybook/qmldir
@@ -4,6 +4,7 @@ FigmaLinksCache 1.0 FigmaLinksCache.qml
 FigmaPreviewWindow 1.0 FigmaPreviewWindow.qml
 FilteredPagesList 1.0 FilteredPagesList.qml
 FlickableImage 1.0 FlickableImage.qml
+GenericListView 1.0 GenericListView.qml
 HotComponentFromSource 1.0 HotComponentFromSource.qml
 HotLoader 1.0 HotLoader.qml
 HotReloader 1.0 HotReloader.qml

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(StatusQ SHARED
         include/StatusQ/stringutilsinternal.h
         include/StatusQ/submodelproxymodel.h
         include/StatusQ/sumaggregator.h
+        include/StatusQ/undefinedfilter.h
         include/StatusQ/writableproxymodel.h
         src/QClipboardProxy.cpp
         src/aggregator.cpp
@@ -132,6 +133,7 @@ add_library(StatusQ SHARED
         src/stringutilsinternal.cpp
         src/submodelproxymodel.cpp
         src/sumaggregator.cpp
+        src/undefinedfilter.cpp
         src/writableproxymodel.cpp
 
         # wallet

--- a/ui/StatusQ/include/StatusQ/movablemodel.h
+++ b/ui/StatusQ/include/StatusQ/movablemodel.h
@@ -23,6 +23,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     Q_INVOKABLE void detach();
+    Q_INVOKABLE void attach();
     Q_INVOKABLE void move(int from, int to, int count = 1);
     Q_INVOKABLE QVector<int> order() const;
 
@@ -37,6 +38,8 @@ protected slots:
 
 private:
     QPointer<QAbstractItemModel> m_sourceModel;
+
+    void connectSignalsForAttachedState();
 
     bool m_detached = false;
     std::vector<QPersistentModelIndex> m_indexes;

--- a/ui/StatusQ/include/StatusQ/movablemodel.h
+++ b/ui/StatusQ/include/StatusQ/movablemodel.h
@@ -11,7 +11,7 @@ class MovableModel : public QAbstractListModel
     Q_PROPERTY(QAbstractItemModel* sourceModel READ sourceModel
                WRITE setSourceModel NOTIFY sourceModelChanged)
 
-    Q_PROPERTY(bool detached READ detached NOTIFY detachedChanged)
+    Q_PROPERTY(bool synced READ synced NOTIFY syncedChanged)
 public:
     explicit MovableModel(QObject *parent = nullptr);
 
@@ -22,16 +22,16 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     QHash<int, QByteArray> roleNames() const override;
 
-    Q_INVOKABLE void detach();
-    Q_INVOKABLE void attach();
+    Q_INVOKABLE void desyncOrder();
+    Q_INVOKABLE void syncOrder();
     Q_INVOKABLE void move(int from, int to, int count = 1);
     Q_INVOKABLE QVector<int> order() const;
 
-    bool detached() const;
+    bool synced() const;
 
 signals:
     void sourceModelChanged();
-    void detachedChanged();
+    void syncedChanged();
 
 protected slots:
     void resetInternalData();
@@ -41,6 +41,6 @@ private:
 
     void connectSignalsForAttachedState();
 
-    bool m_detached = false;
+    bool m_synced = true;
     std::vector<QPersistentModelIndex> m_indexes;
 };

--- a/ui/StatusQ/include/StatusQ/undefinedfilter.h
+++ b/ui/StatusQ/include/StatusQ/undefinedfilter.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <filters/rolefilter.h>
+
+class UndefinedFilter : public qqsfpm::RoleFilter
+{
+    Q_OBJECT
+
+public:
+    using RoleFilter::RoleFilter;
+
+protected:
+    bool filterRow(
+            const QModelIndex &sourceIndex,
+            const  qqsfpm::QQmlSortFilterProxyModel& proxyModel) const override;
+};

--- a/ui/StatusQ/src/StatusQ/Core/Utils/QObject.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/QObject.qml
@@ -1,0 +1,7 @@
+import QtQml 2.15
+
+// Simple utility allowing to declare children within QtObject without having
+// to assigne them to properties, like `QtObject { ListModel {} }`
+QtObject {
+    default property list<QtObject> children
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -8,6 +8,7 @@ JSONListModel 0.1 JSONListModel.qml
 ModelChangeGuard 0.1 ModelChangeGuard.qml
 ModelChangeTracker 0.1 ModelChangeTracker.qml
 ModelsComparator 0.1 ModelsComparator.qml
+QObject 0.1 QObject.qml
 StackViewStates 0.1 StackViewStates.qml
 StatesStack 0.1 StatesStack.qml
 Subscription 0.1 Subscription.qml

--- a/ui/StatusQ/src/movablemodel.cpp
+++ b/ui/StatusQ/src/movablemodel.cpp
@@ -20,41 +20,7 @@ void MovableModel::setSourceModel(QAbstractItemModel* sourceModel)
         disconnect(m_sourceModel, nullptr, this, nullptr);
 
     m_sourceModel = sourceModel;
-
-    if (sourceModel != nullptr) {
-        connect(sourceModel, &QAbstractItemModel::rowsAboutToBeInserted, this,
-                &MovableModel::beginInsertRows);
-
-        connect(sourceModel, &QAbstractItemModel::rowsInserted, this,
-                &MovableModel::endInsertRows);
-
-        connect(sourceModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
-                &MovableModel::beginRemoveRows);
-
-        connect(sourceModel, &QAbstractItemModel::rowsRemoved, this,
-                &MovableModel::endRemoveRows);
-
-        connect(sourceModel, &QAbstractItemModel::rowsAboutToBeMoved, this,
-                &MovableModel::beginMoveRows);
-
-        connect(sourceModel, &QAbstractItemModel::rowsMoved, this,
-                &MovableModel::endMoveRows);
-
-        connect(sourceModel, &QAbstractItemModel::dataChanged, this,
-                &MovableModel::dataChanged);
-
-        connect(sourceModel, &QAbstractItemModel::layoutAboutToBeChanged, this,
-                &MovableModel::layoutAboutToBeChanged);
-
-        connect(sourceModel, &QAbstractItemModel::layoutChanged, this,
-                &MovableModel::layoutChanged);
-
-        connect(sourceModel, &QAbstractItemModel::modelAboutToBeReset, this,
-                &MovableModel::beginResetModel);
-
-        connect(sourceModel, &QAbstractItemModel::modelReset, this,
-                &MovableModel::endResetModel);
-    }
+    connectSignalsForAttachedState();
 
     emit sourceModelChanged();
 
@@ -213,6 +179,23 @@ void MovableModel::detach()
     emit detachedChanged();
 }
 
+void MovableModel::attach()
+{
+    if (!m_detached || m_sourceModel == nullptr)
+        return;
+
+    emit layoutAboutToBeChanged();
+
+    auto sourceModel = m_sourceModel;
+
+    disconnect(m_sourceModel, nullptr, this, nullptr);
+    connectSignalsForAttachedState();
+
+    resetInternalData();
+
+    emit layoutChanged();
+}
+
 void MovableModel::move(int from, int to, int count)
 {
     const int rows = rowCount();
@@ -277,4 +260,43 @@ void MovableModel::resetInternalData()
         m_detached = false;
         emit detachedChanged();
     }
+}
+
+void MovableModel::connectSignalsForAttachedState()
+{
+    if (m_sourceModel == nullptr)
+        return;
+
+    connect(m_sourceModel, &QAbstractItemModel::rowsAboutToBeInserted, this,
+            &MovableModel::beginInsertRows);
+
+    connect(m_sourceModel, &QAbstractItemModel::rowsInserted, this,
+            &MovableModel::endInsertRows);
+
+    connect(m_sourceModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
+            &MovableModel::beginRemoveRows);
+
+    connect(m_sourceModel, &QAbstractItemModel::rowsRemoved, this,
+            &MovableModel::endRemoveRows);
+
+    connect(m_sourceModel, &QAbstractItemModel::rowsAboutToBeMoved, this,
+            &MovableModel::beginMoveRows);
+
+    connect(m_sourceModel, &QAbstractItemModel::rowsMoved, this,
+            &MovableModel::endMoveRows);
+
+    connect(m_sourceModel, &QAbstractItemModel::dataChanged, this,
+            &MovableModel::dataChanged);
+
+    connect(m_sourceModel, &QAbstractItemModel::layoutAboutToBeChanged, this,
+            &MovableModel::layoutAboutToBeChanged);
+
+    connect(m_sourceModel, &QAbstractItemModel::layoutChanged, this,
+            &MovableModel::layoutChanged);
+
+    connect(m_sourceModel, &QAbstractItemModel::modelAboutToBeReset, this,
+            &MovableModel::beginResetModel);
+
+    connect(m_sourceModel, &QAbstractItemModel::modelReset, this,
+            &MovableModel::endResetModel);
 }

--- a/ui/StatusQ/src/plugin.cpp
+++ b/ui/StatusQ/src/plugin.cpp
@@ -8,6 +8,7 @@
 #include "StatusQ/fastexpressionfilter.h"
 #include "StatusQ/fastexpressionrole.h"
 #include "StatusQ/fastexpressionsorter.h"
+#include "StatusQ/formatteddoubleproperty.h"
 #include "StatusQ/leftjoinmodel.h"
 #include "StatusQ/modelutilsinternal.h"
 #include "StatusQ/movablemodel.h"
@@ -19,8 +20,8 @@
 #include "StatusQ/stringutilsinternal.h"
 #include "StatusQ/submodelproxymodel.h"
 #include "StatusQ/sumaggregator.h"
+#include "StatusQ/undefinedfilter.h"
 #include "StatusQ/writableproxymodel.h"
-#include "StatusQ/formatteddoubleproperty.h"
 
 #include "wallet/managetokenscontroller.h"
 #include "wallet/managetokensmodel.h"
@@ -48,6 +49,7 @@ public:
         qmlRegisterType<FastExpressionFilter>("StatusQ", 0, 1, "FastExpressionFilter");
         qmlRegisterType<FastExpressionRole>("StatusQ", 0, 1, "FastExpressionRole");
         qmlRegisterType<FastExpressionSorter>("StatusQ", 0, 1, "FastExpressionSorter");
+        qmlRegisterType<UndefinedFilter>("StatusQ", 0, 1, "UndefinedFilter");
 
         qmlRegisterType<LeftJoinModel>("StatusQ", 0, 1, "LeftJoinModel");
         qmlRegisterType<SubmodelProxyModel>("StatusQ", 0, 1, "SubmodelProxyModel");

--- a/ui/StatusQ/src/undefinedfilter.cpp
+++ b/ui/StatusQ/src/undefinedfilter.cpp
@@ -1,0 +1,11 @@
+#include "StatusQ/undefinedfilter.h"
+
+#include <qqmlsortfilterproxymodel.h>
+
+using namespace qqsfpm;
+
+bool UndefinedFilter::filterRow(const QModelIndex& sourceIndex,
+                                const QQmlSortFilterProxyModel& proxyModel) const
+{
+    return !sourceData(sourceIndex, proxyModel).isValid();
+}

--- a/ui/StatusQ/tests/tst_MovableModel.cpp
+++ b/ui/StatusQ/tests/tst_MovableModel.cpp
@@ -47,11 +47,11 @@ private slots:
         MovableModel model;
         model.setSourceModel(sourceModel);
 
-        QCOMPARE(model.detached(), false);
+        QCOMPARE(model.synced(), true);
         QVERIFY(isSame(&model, sourceModel));
     }
 
-    void detachTest()
+    void desyncOrderTest()
     {
         QQmlEngine engine;
 
@@ -67,16 +67,16 @@ private slots:
         MovableModel model;
         model.setSourceModel(sourceModel);
 
-        QSignalSpy detachChangedSpy(&model, &MovableModel::detachedChanged);
-        model.detach();
+        QSignalSpy syncedChangedSpy(&model, &MovableModel::syncedChanged);
+        model.desyncOrder();
 
-        QCOMPARE(detachChangedSpy.count(), 1);
-        QCOMPARE(model.detached(), true);
+        QCOMPARE(syncedChangedSpy.count(), 1);
+        QCOMPARE(model.synced(), false);
         QVERIFY(isSame(&model, sourceModel));
 
         model.setSourceModel(nullptr);
-        QCOMPARE(detachChangedSpy.count(), 2);
-        QCOMPARE(model.detached(), false);
+        QCOMPARE(syncedChangedSpy.count(), 2);
+        QCOMPARE(model.synced(), true);
         QCOMPARE(model.rowCount(), 0);
     }
 
@@ -98,7 +98,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel);
-        model.detach();
+        model.desyncOrder();
 
         ModelSignalsSpy signalsSpy(&model);
         ModelSignalsSpy referenceSignalsSpy(sourceModelCopy);
@@ -150,7 +150,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel);
-        model.detach();
+        model.desyncOrder();
 
         ModelSignalsSpy signalsSpy(&model);
         ModelSignalsSpy referenceSignalsSpy(sourceModelCopy);
@@ -202,7 +202,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel);
-        model.detach();
+        model.desyncOrder();
 
         ModelSignalsSpy signalsSpy(&model);
         ModelSignalsSpy referenceSignalsSpy(sourceModelCopy);
@@ -249,7 +249,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel);
-        model.detach();
+        model.desyncOrder();
 
         ModelSignalsSpy signalsSpy(&model);
         ModelSignalsSpy referenceSignalsSpy(sourceModelCopy);
@@ -299,7 +299,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(&sfpm);
-        model.detach();
+        model.desyncOrder();
 
         model.move(2, 1);
         sourceModelCopy.move(2, 1);
@@ -340,7 +340,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel);
-        model.detach();
+        model.desyncOrder();
         model.move(4, 1);
 
         SnapshotModel snapshot(model);
@@ -459,7 +459,7 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel);
-        model.detach();
+        model.desyncOrder();
 
         ModelSignalsSpy signalsSpy(&model);
 
@@ -594,12 +594,12 @@ private slots:
 
         MovableModel model;
         model.setSourceModel(sourceModel1);
-        model.detach();
+        model.desyncOrder();
 
-        QCOMPARE(model.detached(), true);
+        QCOMPARE(model.synced(), false);
 
         ModelSignalsSpy signalsSpy(&model);
-        QSignalSpy detachChangedSpy(&model, &MovableModel::detachedChanged);
+        QSignalSpy syncedChangedSpy(&model, &MovableModel::syncedChanged);
 
         model.setSourceModel(sourceModel2);
 
@@ -607,14 +607,14 @@ private slots:
         QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
         QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
 
-        QCOMPARE(detachChangedSpy.count(), 1);
-        QCOMPARE(model.detached(), false);
+        QCOMPARE(syncedChangedSpy.count(), 1);
+        QCOMPARE(model.synced(), true);
         QCOMPARE(model.rowCount(), 2);
 
         QVERIFY(isSame(&model, sourceModel2));
     }
 
-    void attachTest()
+    void syncOrderTest()
     {
         QQmlEngine engine;
 
@@ -632,7 +632,7 @@ private slots:
 
         {
             ModelSignalsSpy signalsSpy(&model);
-            model.attach();
+            model.syncOrder();
             QCOMPARE(signalsSpy.count(), 0);
         }
 
@@ -640,26 +640,26 @@ private slots:
 
         {
             ModelSignalsSpy signalsSpy(&model);
-            model.attach();
+            model.syncOrder();
             QCOMPARE(signalsSpy.count(), 0);
         }
 
-        model.detach();
+        model.desyncOrder();
         sourceModel.move(0, 2, 2);
 
         QVERIFY(!isSame(&model, sourceModel));
 
         ModelSignalsSpy signalsSpy(&model);
-        QSignalSpy detachChangedSpy(&model, &MovableModel::detachedChanged);
+        QSignalSpy syncedChangedSpy(&model, &MovableModel::syncedChanged);
 
-        model.attach();
+        model.syncOrder();
 
         QCOMPARE(signalsSpy.count(), 2);
         QCOMPARE(signalsSpy.layoutAboutToBeChangedSpy.count(), 1);
         QCOMPARE(signalsSpy.layoutChangedSpy.count(), 1);
 
-        QCOMPARE(detachChangedSpy.count(), 1);
-        QCOMPARE(model.detached(), false);
+        QCOMPARE(syncedChangedSpy.count(), 1);
+        QCOMPARE(model.synced(), true);
 
         QVERIFY(isSame(&model, sourceModel));
     }

--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseDirtyState.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseDirtyState.qml
@@ -1,0 +1,83 @@
+import QtQml 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import SortFilterProxyModel 0.2
+
+/**
+  * Building block for managing temporary state in the "Profile Showcase"
+  * functionality. Provides combining raw source model (like e.g. communities
+  * model or accounts model) with lean showcase model (providing info regarding
+  * visibility and position), managing dirty state (visibility, position) and
+  * providing two output models - one containing visible items sorted by
+  * position, second one containing hidden items.
+  */
+QObject {
+    property alias sourceModel: joined.leftModel
+    property alias showcaseModel: joined.rightModel
+
+    /**
+      * Model holding elements from 'sourceModel' intended to be visible in the
+      * showcase, sorted by 'position' role. Includes roles from both input models.
+      */
+    readonly property alias visibleModel: visible
+
+    /**
+      * Model holding elements from 'sourceModel' intended to be hidden, no
+      * sorting applied. Includes roles from both input models.
+      */
+    readonly property alias hiddenModel: hidden
+
+    function currentState() {
+        return writable.currentState()
+    }
+
+    function setVisibility(key, visibility) {
+        writable.setVisibility(key, visibility)
+    }
+
+    function changePosition(key, to) {
+        writable.changePosition(key, to)
+    }
+
+    // internals, debug purpose only
+    readonly property alias writable_: writable
+    readonly property alias joined_: joined
+
+    component VisibilityFilter: RangeFilter {
+        roleName: "visibility"
+        minimumValue: 1
+    }
+
+    LeftJoinModel {
+        id: joined
+
+        joinRole: "key"
+    }
+
+    VisibilityAndPositionDirtyStateModel {
+        id: writable
+
+        sourceModel: joined
+    }
+
+    SortFilterProxyModel {
+        id: visible
+
+        sourceModel: writable
+        delayed: true
+
+        filters: VisibilityFilter {}
+        sorters: RoleSorter { roleName: "position" }
+    }
+
+    SortFilterProxyModel {
+        id: hidden
+
+        sourceModel: writable
+        delayed: true
+
+        filters: VisibilityFilter { inverted: true}
+    }
+}

--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseDirtyState.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseDirtyState.qml
@@ -5,6 +5,8 @@ import StatusQ.Core.Utils 0.1
 
 import SortFilterProxyModel 0.2
 
+import utils 1.0
+
 /**
   * Building block for managing temporary state in the "Profile Showcase"
   * functionality. Provides combining raw source model (like e.g. communities
@@ -45,9 +47,15 @@ QObject {
     readonly property alias writable_: writable
     readonly property alias joined_: joined
 
-    component VisibilityFilter: RangeFilter {
-        roleName: "visibility"
-        minimumValue: 1
+    component HiddenFilter: AnyOf {
+        UndefinedFilter {
+            roleName: "visibility"
+        }
+
+        ValueFilter {
+            roleName: "visibility"
+            value: Constants.ShowcaseVisibility.NoOne
+        }
     }
 
     LeftJoinModel {
@@ -60,6 +68,7 @@ QObject {
         id: writable
 
         sourceModel: joined
+        visibilityHidden: Constants.ShowcaseVisibility.NoOne
     }
 
     SortFilterProxyModel {
@@ -68,7 +77,7 @@ QObject {
         sourceModel: writable
         delayed: true
 
-        filters: VisibilityFilter {}
+        filters: HiddenFilter { inverted: true }
         sorters: RoleSorter { roleName: "position" }
     }
 
@@ -78,6 +87,6 @@ QObject {
         sourceModel: writable
         delayed: true
 
-        filters: VisibilityFilter { inverted: true}
+        filters: HiddenFilter {}
     }
 }

--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseModels.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseModels.qml
@@ -5,6 +5,8 @@ import StatusQ.Core.Utils 0.1
 
 import SortFilterProxyModel 0.2
 
+import utils 1.0
+
 QObject {
     id: root
 
@@ -106,20 +108,25 @@ QObject {
         proxyRoles: FastExpressionRole {
             name: "maxVisibility"
 
-            expression: {
-                const m = root.accountsVisibilityMap
-                const accounts = model.accounts.split(":")
-                const visibilities = accounts.map(e => m[e]).filter(e => e)
+            // singletons cannot be used in expressions
+            readonly property int hidden: Constants.ShowcaseVisibility.NoOne
 
-                return visibilities.length ? Math.min(...visibilities) : 0
+            expression: {
+                const visibilityMap = root.accountsVisibilityMap
+                const accounts = model.accounts.split(":")
+                const visibilities = accounts.map(a => visibilityMap[a]).filter(
+                                       v => v !== undefined)
+
+                return visibilities.length ? Math.min(...visibilities) : hidden
             }
 
             expectedRoles: ["accounts"]
         }
 
-        filters: RangeFilter {
+        filters: ValueFilter {
             roleName: "maxVisibility"
-            minimumValue: 1
+            value: Constants.ShowcaseVisibility.NoOne
+            inverted: true
         }
     }
 

--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseModels.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseModels.qml
@@ -1,0 +1,163 @@
+import QtQml 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import SortFilterProxyModel 0.2
+
+QObject {
+    id: root
+
+    // COMMUNITIES
+
+    // Input models
+    property alias communitiesSourceModel: communities.sourceModel
+    property alias communitiesShowcaseModel: communities.showcaseModel
+
+    // Output models
+    readonly property alias communitiesVisibleModel: communities.visibleModel
+    readonly property alias communitiesHiddenModel: communities.hiddenModel
+
+    // Methods
+    function communitiesCurrentState() {
+        return communities.currentState()
+    }
+
+    function setCommunityVisibility(key, visibility) {
+        communities.setVisibility(key, visibility)
+    }
+
+    function changeCommunityPosition(key, to) {
+        communities.changePosition(key, to)
+    }
+
+    // ACCOUNTS
+
+    // Input models
+    property alias accountsSourceModel: accounts.sourceModel
+    property alias accountsShowcaseModel: accounts.showcaseModel
+
+    // Output models
+    readonly property alias accountsVisibleModel: accounts.visibleModel
+    readonly property alias accountsHiddenModel: accounts.hiddenModel
+
+    // Methods
+    function accountsCurrentState() {
+        return accounts.currentState()
+    }
+
+    function setAccountVisibility(key, visibility) {
+        accounts.setVisibility(key, visibility)
+    }
+
+    function changeAccountPosition(key, to) {
+        accounts.changePosition(key, to)
+    }
+
+    // Other
+    readonly property alias visibleAccountsList:
+        visibleAccountsConnections.visibleAccountsList
+
+    readonly property alias accountsVisibilityMap:
+        visibleAccountsConnections.accountsVisibilityMap
+
+    // COLLECTIBLES
+
+    // Input models
+    property alias collectiblesSourceModel: collectiblesFilter.sourceModel
+    property alias collectiblesShowcaseModel: collectibles.showcaseModel
+
+    // Output models
+    readonly property alias collectiblesVisibleModel: collectibles.visibleModel
+    readonly property alias collectiblesHiddenModel: collectibles.hiddenModel
+
+    // Methods
+    function collectiblesCurrentState() {
+        return collectibles.currentState()
+    }
+
+    function setCollectibleVisibility(key, visibility) {
+        collectibles.setVisibility(key, visibility)
+    }
+
+    function changeCollectiblePosition(key, to) {
+        collectibles.changePosition(key, to)
+    }
+
+    ProfileShowcaseDirtyState {
+        id: communities
+    }
+
+    ProfileShowcaseDirtyState {
+        id: accounts
+    }
+
+    ProfileShowcaseDirtyState {
+        id: collectibles
+
+        sourceModel: collectiblesFilter
+    }
+
+    SortFilterProxyModel {
+        id: collectiblesFilter
+
+        delayed: true
+
+        proxyRoles: FastExpressionRole {
+            name: "maxVisibility"
+
+            expression: {
+                const m = root.accountsVisibilityMap
+                const accounts = model.accounts.split(":")
+                const visibilities = accounts.map(e => m[e]).filter(e => e)
+
+                return visibilities.length ? Math.min(...visibilities) : 0
+            }
+
+            expectedRoles: ["accounts"]
+        }
+
+        filters: RangeFilter {
+            roleName: "maxVisibility"
+            minimumValue: 1
+        }
+    }
+
+    Connections {
+        id: visibleAccountsConnections
+
+        target: accounts.visibleModel
+
+        property var visibleAccountsList: []
+        property var accountsVisibilityMap: ({})
+
+        function updateAccountsList() {
+            const keysAndVisibility = ModelUtils.modelToArray(
+                        accounts.visibleModel, ["key", "visibility"])
+
+            visibleAccountsList = keysAndVisibility.map(e => e.key)
+
+            accountsVisibilityMap = keysAndVisibility.reduce(
+                        (acc, val) => Object.assign(
+                            acc, {[val.key]: val.visibility}), {})
+        }
+
+        function onDataChanged() {
+            updateAccountsList()
+        }
+
+        function onRowsInserted() {
+            updateAccountsList()
+        }
+
+        function onRowsRemoved() {
+            updateAccountsList()
+        }
+
+        function onModelReset() {
+            updateAccountsList()
+        }
+
+        Component.onCompleted: updateAccountsList()
+    }
+}

--- a/ui/app/AppLayouts/Profile/helpers/VisibilityAndPositionDirtyStateModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/VisibilityAndPositionDirtyStateModel.qml
@@ -1,0 +1,106 @@
+import QtQml 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+/**
+  * Basic building block for storing temporary state in the "Profile Showcase"
+  * functionality. Allows to store on the UI side the temporary position and
+  * visibility level. Can store temporary state for Communities, Accounts,
+  * Collectibles and Assets.
+  */
+WritableProxyModel {
+    id: root
+
+    /* Provides the list of objects representing the current state in the
+     * in the following format:
+     * [ {
+     *     key: <string or integer>
+     *     position: <integer>
+     *     visibility: <integer>
+     *   }
+     * ]
+     *
+     * The entries with visibility 0 (hidden) are not included in the list.
+     */
+    function currentState() {
+        const visible = d.getVisibleEntries()
+        const minPos = Math.min(...visible.map(e => e.position))
+
+        return visible.map(e => { e.position -= minPos; return e })
+    }
+
+    /* Sets the visibility of the given item. If the element was hidden, it is
+     * positioned last.
+     */
+    function setVisibility(key, visibility) {
+        const sourceIdx = d.indexByKey(key)
+        const oldVisibility = d.getVisibility(sourceIdx)
+
+        if (oldVisibility === visibility)
+            return
+
+        // hiding, changing visibility level
+        if (visibility === 0 || (visibility > 0 && oldVisibility > 0)) {
+            set(sourceIdx, { visibility: visibility })
+            return
+        }
+
+        // unhiding
+        const positions = d.getVisibleEntries().map(e => e.position)
+        const position = Math.max(-1, ...positions) + 1
+        set(sourceIdx, { visibility, position })
+    }
+
+    /* Sets the position of the item. The "to" parameter is expected to be
+     * a target index in the list and must be in range [0; count - 1].
+     */
+    function changePosition(key, to) {
+        const visible = d.getVisibleEntries()
+        visible.sort((a, b) => a.position - b.position)
+
+        const idx = visible.findIndex(item => item.key === key)
+
+        if (idx === -1) {
+            console.warn(`Entry with key ${key} not found`)
+            return
+        }
+
+        const count = visible.length
+
+        if (to < 0 || to >= count) {
+            console.warn(`Destination position out of range: ${to}`)
+            return
+        }
+
+        // swap
+        [visible[idx], visible[to]] = [visible[to], visible[idx]]
+
+        visible.forEach((e, i) => {
+            if (e.position === i)
+                return
+
+            const idx = d.indexByKey(e.key)
+            set(idx, { position: i })
+        })
+    }
+
+    readonly property QtObject d_: QtObject {
+        id: d
+
+        function indexByKey(key) {
+            return ModelUtils.indexOf(root, "key", key)
+        }
+
+        function getVisibleEntries() {
+            const roles = ["key", "position", "visibility"]
+            const keysAndPos = ModelUtils.modelToArray(root, roles)
+
+            return keysAndPos.filter(p => p.visibility)
+        }
+
+        function getVisibility(idx) {
+            return ModelUtils.get(root, idx, "visibility") || 0
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/helpers/VisibilityAndPositionDirtyStateModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/VisibilityAndPositionDirtyStateModel.qml
@@ -12,6 +12,14 @@ import StatusQ.Core.Utils 0.1
 WritableProxyModel {
     id: root
 
+    /**
+      * "Hidden" is a special type of visibility that requires special
+      * treatment. When the visibility is changed from hidden to other type
+      * of visibility, in addition to changing the visibility, the appropriate
+      * position is also set.
+      */
+    property int visibilityHidden: 0
+
     /* Provides the list of objects representing the current state in the
      * in the following format:
      * [ {
@@ -41,7 +49,8 @@ WritableProxyModel {
             return
 
         // hiding, changing visibility level
-        if (visibility === 0 || (visibility > 0 && oldVisibility > 0)) {
+        if (visibility === visibilityHidden
+                || oldVisibility !== visibilityHidden) {
             set(sourceIdx, { visibility: visibility })
             return
         }
@@ -96,11 +105,13 @@ WritableProxyModel {
             const roles = ["key", "position", "visibility"]
             const keysAndPos = ModelUtils.modelToArray(root, roles)
 
-            return keysAndPos.filter(p => p.visibility)
+            return keysAndPos.filter(p => p.visibility
+                                     && p.visibility !== root.visibilityHidden)
         }
 
         function getVisibility(idx) {
-            return ModelUtils.get(root, idx, "visibility") || 0
+            return ModelUtils.get(root, idx, "visibility")
+                    || root.visibilityHidden
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/helpers/qmldir
+++ b/ui/app/AppLayouts/Profile/helpers/qmldir
@@ -1,2 +1,3 @@
 ProfileShowcaseDirtyState 1.0 ProfileShowcaseDirtyState.qml
+ProfileShowcaseModels 1.0 ProfileShowcaseModels.qml
 VisibilityAndPositionDirtyStateModel 1.0 VisibilityAndPositionDirtyStateModel.qml

--- a/ui/app/AppLayouts/Profile/helpers/qmldir
+++ b/ui/app/AppLayouts/Profile/helpers/qmldir
@@ -1,0 +1,2 @@
+ProfileShowcaseDirtyState 1.0 ProfileShowcaseDirtyState.qml
+VisibilityAndPositionDirtyStateModel 1.0 VisibilityAndPositionDirtyStateModel.qml


### PR DESCRIPTION
### What does the PR do

This PR provides basic building blocks necessary to build ui-side dirty state management for Profile Showcase functionality (settings part):

- reusable `ProfileShowcaseDirtyState` for managing `visibility` and `position` in showcase tabs
- `ProfileShowcaseModel` providing all showcase-related models needed by the UI, managing dependencies between them internally (like accounts selection affecting collectibles). Those models are intended to be consumed by the UI according to specification described in #13498
- simple referencial UI showing the dirty state management in action, integrated in the same way as it will be done with the real UI accordign to #13498 The UI is integrated with models using workaround (calling `movableModel.syncOrder()` to avoid crash caused by https://github.com/status-im/status-desktop/issues/13601

[Kazam_screencast_00094.webm](https://github.com/status-im/status-desktop/assets/20650004/58c8f290-3c01-44de-9a4e-56a6678f23c4)

Moreover:
- simple utility allowing to declare children within `QtObject` without having to assign them to properties
- `MovableModel`
  - naming refactored to be more intuitive
  - added method `syncOrder` allowing to drop custom order and track order of the source
  - `GenericListView` - list view displaying arbitrary model, used to build the referential UI


Closes: #13435
Closes: #13490
Closes: #13494
Closes: #13342
Closes: #13599
Closes: #13638

Next steps:
- data flow for `assets`
- integration with UI components according to #13498
- integration with the backend
- profile showcase model shouldn't retain items removed from source models, the current behavior should be adjusted (https://github.com/status-im/status-desktop/issues/13603)

### Affected areas
`ProfileShowcase` settings
