### PR TITLE
fix(SharedAddresses): fix airdrop address not being reflected in popup

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
@@ -46,8 +46,8 @@ StatusDialog {
     }
 
     function setOldAirdropAddress(oldAirdropAddress) {
+        d.oldAirdropAddress = oldAirdropAddress
         if (!d.displaySigningPanel && !!loader.item) {
-            d.oldAirdropAddress = oldAirdropAddress
             loader.item.setOldAirdropAddress(oldAirdropAddress)
         }
     }


### PR DESCRIPTION
Fixes #13618

[shared-airdrop.webm](https://github.com/status-im/status-desktop/assets/11926403/8453ca00-d46a-4276-9d1f-1930b33bfac9)
