### PR TITLE
feat(Profile flow): Remove a contact

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -220,14 +220,17 @@ SplitView {
 
                             function removeContact(publicKey) {
                                 logs.logEvent("contactsStore::removeContact", ["publicKey"], arguments)
+                                ctrlContactRequestState.currentIndex = ctrlContactRequestState.indexOfValue(Constants.ContactRequestState.None)
                             }
 
                             function acceptContactRequest(publicKey, contactRequestId) {
                                 logs.logEvent("contactsStore::acceptContactRequest", ["publicKey, contactRequestId"], arguments)
+                                ctrlContactRequestState.currentIndex = ctrlContactRequestState.indexOfValue(Constants.ContactRequestState.Mutual)
                             }
 
                             function dismissContactRequest(publicKey, contactRequestId) {
                                 logs.logEvent("contactsStore::dismissContactRequest", ["publicKey, contactRequestId"], arguments)
+                                ctrlContactRequestState.currentIndex = ctrlContactRequestState.indexOfValue(Constants.ContactRequestState.Dismissed)
                             }
 
                             function removeTrustStatus(publicKey) {

--- a/ui/imports/shared/popups/RemoveContactPopup.qml
+++ b/ui/imports/shared/popups/RemoveContactPopup.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import utils 1.0
+
+CommonContactDialog {
+    id: root
+
+    readonly property bool removeIDVerification: ctrlRemoveIDVerification.checked
+    readonly property bool markAsUntrusted: ctrlMarkAsUntrusted.checked
+
+    title: qsTr("Remove contact")
+
+    readonly property var d: QtObject {
+        id: d
+        readonly property int outgoingVerificationStatus: contactDetails.verificationStatus
+        readonly property int incomingVerificationStatus: contactDetails.incomingVerificationStatus
+        readonly property bool isVerificationRequestReceived: incomingVerificationStatus === Constants.verificationStatus.verifying ||
+                                                              incomingVerificationStatus === Constants.verificationStatus.verified
+        readonly property bool isTrusted: outgoingVerificationStatus === Constants.verificationStatus.trusted ||
+                                          incomingVerificationStatus === Constants.verificationStatus.trusted
+    }
+
+    StatusBaseText {
+        Layout.fillWidth: true
+        Layout.bottomMargin: Style.current.halfPadding
+        text: qsTr("You and %1 will no longer be contacts").arg(mainDisplayName)
+        wrapMode: Text.WordWrap
+    }
+
+    StatusCheckBox {
+        id: ctrlRemoveIDVerification
+        visible: contactDetails.isContact && !d.isTrusted && d.isVerificationRequestReceived
+        checked: visible
+        enabled: false
+        text: qsTr("Remove ID verification")
+    }
+
+    StatusCheckBox {
+        id: ctrlMarkAsUntrusted
+        visible: contactDetails.trustStatus !== Constants.trustStatus.untrustworthy
+        text: qsTr("Mark %1 as untrusted").arg(mainDisplayName)
+    }
+
+    rightButtons: ObjectModel {
+        StatusFlatButton {
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
+        StatusButton {
+            type: StatusBaseButton.Type.Danger
+            text: qsTr("Remove contact")
+            onClicked: root.accepted()
+        }
+    }
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -28,3 +28,4 @@ AlertPopup 1.0 AlertPopup.qml
 ConfirmExternalLinkPopup 1.0 ConfirmExternalLinkPopup.qml
 CommunityAssetsInfoPopup 1.0 CommunityAssetsInfoPopup.qml
 MarkAsUntrustedPopup 1.0 MarkAsUntrustedPopup.qml
+RemoveContactPopup 1.0 RemoveContactPopup.qml

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -80,7 +80,6 @@ Pane {
 
         readonly property bool isTrusted: outgoingVerificationStatus === Constants.verificationStatus.trusted ||
                                           incomingVerificationStatus === Constants.verificationStatus.trusted
-        readonly property bool isVerified: outgoingVerificationStatus === Constants.verificationStatus.verified
 
         readonly property string linkToProfile: root.contactsStore.getLinkToProfile(root.publicKey)
 
@@ -484,7 +483,7 @@ Pane {
                         type: StatusAction.Type.Danger
                         enabled: d.isContact && !d.isBlocked && d.contactRequestState !== Constants.ContactRequestState.Sent
                         onTriggered: {
-                            Global.removeContactRequested(d.mainDisplayName, root.publicKey)
+                            Global.removeContactRequested(root.publicKey, d.contactDetails)
                         }
                     }
                     StatusAction {

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -242,10 +242,7 @@ StatusMenu {
         icon.name: "remove-contact"
         type: StatusAction.Type.Danger
         enabled: root.isContact && !root.isBlockedContact && !root.hasPendingContactRequest && !root.isBridgedAccount
-        onTriggered: {
-            Global.removeContactRequested(root.selectedUserDisplayName, root.selectedUserPublicKey)
-            root.close()
-        }
+        onTriggered: Global.removeContactRequested(root.selectedUserPublicKey, root.contactDetails)
     }
 
     StatusAction {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -41,7 +41,7 @@ QtObject {
     signal openSendIDRequestPopup(string publicKey, var contactDetails, var cb)
     signal openContactRequestPopup(string publicKey, var contactDetails, var cb)
     signal markAsUntrustedRequested(string publicKey, var contactDetails)
-    signal removeContactRequested(string displayName, string publicKey)
+    signal removeContactRequested(string publicKey, var contactDetails)
     signal openInviteFriendsToCommunityPopup(var community, var communitySectionModule, var cb)
     signal openIncomingIDRequestPopup(string publicKey, var cb)
     signal openOutgoingIDRequestPopup(string publicKey, var cb)


### PR DESCRIPTION
### What does the PR do

- implement the new remove contact confirmation popup

Fixes #13521

### Affected areas

RemoveContactPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Coming from ProfileDialog:
![image](https://github.com/status-im/status-desktop/assets/5377645/67bcec88-c450-453d-9b50-1d93e2de6d07)

Chat context menu:
![image](https://github.com/status-im/status-desktop/assets/5377645/4dfa19ca-10f5-4107-a3f1-4592da1f4325)

