### PR TITLE
feat(@desktop/community): allow owner delete all messages during the ban and ban/unban AC notifications

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -1,5 +1,4 @@
-import NimQml
-import json
+import NimQml, tables, json
 import io_interface
 
 import ../../../../../app_service/service/settings/service as settings_service
@@ -153,12 +152,19 @@ proc init*(self: Controller) =
         self.delegate.onMutualContactChanged()
         self.delegate.onContactDetailsUpdated(args.contactId)
 
-  self.events.on(SIGNAL_MESSAGE_DELETION) do(e: Args):
-    let args = MessageDeletedArgs(e)
+  self.events.on(SIGNAL_MESSAGE_REMOVED) do(e: Args):
+    let args = MessageRemovedArgs(e)
     if(self.chatId != args.chatId):
       return
     # remove from pinned messages model
     self.delegate.onUnpinMessage(args.messageId)
+
+  self.events.on(SIGNAL_MESSAGES_DELETED) do(e: Args):
+    let args = MessagesDeletedArgs(e)
+    if self.chatId in args.deletedMessages:
+      for deletedMessage in args.deletedMessages[self.chatId]:
+        # delete from pinned messages model
+        self.delegate.onUnpinMessage(deletedMessage)
 
   self.events.on(SIGNAL_COMMUNITY_CHANNEL_EDITED) do(e:Args):
     let args = CommunityChatArgs(e)

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -131,7 +131,7 @@ proc getChatId*(self: Controller): string =
 
 proc belongsToCommunity*(self: Controller): bool =
   return self.belongsToCommunity
-  
+
 proc setLinkPreviewEnabledForThisMessage*(self: Controller, enabled: bool) =
   self.linkPreviewCurrentMessageSetting = if enabled: UrlUnfurlingMode.Enabled else: UrlUnfurlingMode.Disabled
   self.delegate.setAskToEnableLinkPreview(false)
@@ -142,18 +142,18 @@ proc resetLinkPreviews(self: Controller) =
   self.linkPreviewCurrentMessageSetting = self.linkPreviewPersistentSetting
   self.delegate.setAskToEnableLinkPreview(false)
 
-proc sendImages*(self: Controller, 
-                 imagePathsAndDataJson: string, 
-                 msg: string, 
-                 replyTo: string, 
+proc sendImages*(self: Controller,
+                 imagePathsAndDataJson: string,
+                 msg: string,
+                 replyTo: string,
                  preferredUsername: string = "",
                  linkPreviews: seq[LinkPreview]): string =
   self.resetLinkPreviews()
   self.chatService.sendImages(
-    self.chatId, 
-    imagePathsAndDataJson, 
-    msg, 
-    replyTo, 
+    self.chatId,
+    imagePathsAndDataJson,
+    msg,
+    replyTo,
     preferredUsername,
     linkPreviews
   )
@@ -165,10 +165,10 @@ proc sendChatMessage*(self: Controller,
                       preferredUsername: string = "",
                       linkPreviews: seq[LinkPreview]) =
   self.resetLinkPreviews()
-  self.chatService.sendChatMessage(self.chatId, 
-    msg, 
-    replyTo, 
-    contentType, 
+  self.chatService.sendChatMessage(self.chatId,
+    msg,
+    replyTo,
+    contentType,
     preferredUsername,
     linkPreviews
   )
@@ -288,7 +288,7 @@ proc asyncUnfurlUrls(self: Controller, urls: seq[string]) =
 proc asyncUnfurlUnknownUrls(self: Controller, urls: seq[string]) =
   let newUrls = self.linkPreviewCache.unknownUrls(urls)
   self.asyncUnfurlUrls(newUrls)
-    
+
 proc linkPreviewsFromCache*(self: Controller, urls: seq[string]): Table[string, LinkPreview] =
   return self.linkPreviewCache.linkPreviews(urls)
 

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -123,7 +123,10 @@ method getNumberOfPinnedMessages*(self: AccessInterface): int {.base.} =
 method deleteMessage*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onMessageDeleted*(self: AccessInterface, messageId, deletedBy: string) {.base.} =
+method onMessageRemoved*(self: AccessInterface, messageId, removedBy: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onMessagesDeleted*(self: AccessInterface, messageIds: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editMessage*(self: AccessInterface, messageId: string, contentType: int, updatedMsg: string) {.base.} =

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -600,8 +600,8 @@ proc leaveCommunity*(self: Controller) =
 proc removeUserFromCommunity*(self: Controller, pubKey: string) =
   self.communityService.asyncRemoveUserFromCommunity(self.sectionId, pubKey)
 
-proc banUserFromCommunity*(self: Controller, pubKey: string) =
-  self.communityService.asyncBanUserFromCommunity(self.sectionId, pubKey)
+proc banUserFromCommunity*(self: Controller, pubKey: string, deleteAllMessages: bool) =
+  self.communityService.asyncBanUserFromCommunity(self.sectionId, pubKey, deleteAllMessages)
 
 proc unbanUserFromCommunity*(self: Controller, pubKey: string) =
   self.communityService.asyncUnbanUserFromCommunity(self.sectionId, pubKey)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -279,7 +279,7 @@ method leaveCommunity*(self: AccessInterface) {.base.} =
 method removeUserFromCommunity*(self: AccessInterface, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method banUserFromCommunity*(self: AccessInterface, pubKey: string) {.base.} =
+method banUserFromCommunity*(self: AccessInterface, pubKey: string, deleteAllMessages: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editCommunity*(self: AccessInterface, name: string, description, introMessage, outroMessage: string,

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1097,8 +1097,8 @@ method leaveCommunity*(self: Module) =
 method removeUserFromCommunity*(self: Module, pubKey: string) =
   self.controller.removeUserFromCommunity(pubKey)
 
-method banUserFromCommunity*(self: Module, pubKey: string) =
-  self.controller.banUserFromCommunity(pubkey)
+method banUserFromCommunity*(self: Module, pubKey: string, deleteAllMessages: bool) =
+  self.controller.banUserFromCommunity(pubkey, deleteAllMessages)
 
 method unbanUserFromCommunity*(self: Module, pubKey: string) =
   self.controller.unbanUserFromCommunity(pubkey)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -298,8 +298,8 @@ QtObject:
   proc removeUserFromCommunity*(self: View, pubKey: string) {.slot.} =
     self.delegate.removeUserFromCommunity(pubKey)
 
-  proc banUserFromCommunity*(self: View, pubKey: string) {.slot.} =
-    self.delegate.banUserFromCommunity(pubKey)
+  proc banUserFromCommunity*(self: View, pubKey: string, deleteAllMessages: bool) {.slot.} =
+    self.delegate.banUserFromCommunity(pubKey, deleteAllMessages)
 
   proc editCommunity*(self: View, name: string, description: string, introMessage: string, outroMessage: string, access: int,
                       color: string, tags: string, logoJsonData: string, bannerJsonData: string, historyArchiveSupportEnabled: bool,

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -498,7 +498,7 @@ QtObject:
     self.countChanged()
     self.updateMessagesWhenQuotedMessageDeleted(messageId)
 
-  proc messageDeleted*(self: Model, messageId: string, deletedBy: string, deletedByContactDetails: ContactDetails) =
+  proc messageRemoved*(self: Model, messageId: string, deletedBy: string, deletedByContactDetails: ContactDetails) =
     let i = self.findIndexForMessageId(messageId)
     if(i == -1):
       return
@@ -846,7 +846,7 @@ QtObject:
         albumImages.add(messageImage)
         item.albumMessageImages = albumImages
         item.albumMessageIds = albumMessagesIds
-        
+
         let index = self.createIndex(i, 0, nil)
         defer: index.delete
         self.dataChanged(index, index, @[ModelRole.AlbumMessageImages.int])

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -30,6 +30,8 @@ type ActivityCenterNotificationType* {.pure.}= enum
   ShareAccounts = 18
   CommunityTokenReceived = 19
   FirstCommunityTokenReceived = 20
+  CommunityBanned = 21
+  CommunityUnbanned = 22
 
 type ActivityCenterGroup* {.pure.}= enum
   All = 0,
@@ -174,7 +176,9 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
         ActivityCenterNotificationType.OwnershipLost.int,
         ActivityCenterNotificationType.ShareAccounts.int,
         ActivityCenterNotificationType.CommunityTokenReceived.int,
-        ActivityCenterNotificationType.FirstCommunityTokenReceived.int
+        ActivityCenterNotificationType.FirstCommunityTokenReceived.int,
+        ActivityCenterNotificationType.CommunityBanned.int,
+        ActivityCenterNotificationType.CommunityUnbanned.int
       ]
     of ActivityCenterGroup.Mentions:
       return @[ActivityCenterNotificationType.Mention.int]
@@ -186,7 +190,9 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
         ActivityCenterNotificationType.CommunityInvitation.int,
         ActivityCenterNotificationType.CommunityRequest.int,
         ActivityCenterNotificationType.CommunityMembershipRequest.int,
-        ActivityCenterNotificationType.CommunityKicked.int
+        ActivityCenterNotificationType.CommunityKicked.int,
+        ActivityCenterNotificationType.CommunityBanned.int,
+        ActivityCenterNotificationType.CommunityUnbanned.int
       ]
     of ActivityCenterGroup.Admin:
       return @[ActivityCenterNotificationType.CommunityMembershipRequest.int]

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -240,9 +240,9 @@ proc toChannelMember*(jsonObj: JsonNode, memberId: string, joined: bool): ChatMe
   if(jsonObj.getProp("roles", rolesObj)):
     for roleObj in rolesObj:
       roles.add(roleObj.getInt)
-  
+
   result.role = MemberRole.None
-  if roles.contains(MemberRole.Owner.int): 
+  if roles.contains(MemberRole.Owner.int):
     result.role = MemberRole.Owner
   elif roles.contains(MemberRole.Admin.int):
     result.role = MemberRole.Admin

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -110,6 +110,7 @@ type
   AsyncCommunityMemberActionTaskArg = ref object of QObjectTaskArg
     communityId: string
     pubKey: string
+    deleteAllMessages: bool
 
 const asyncRemoveUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCommunityMemberActionTaskArg](argEncoded)
@@ -131,14 +132,15 @@ const asyncRemoveUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe
 const asyncBanUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCommunityMemberActionTaskArg](argEncoded)
   try:
-    let response = status_go.banUserFromCommunity(arg.communityId, arg.pubKey)
+    let response = status_go.banUserFromCommunity(arg.communityId, arg.pubKey, arg.deleteAllMessages)
     let tpl: tuple[communityId: string, pubKey: string, response: RpcResponse[JsonNode], error: string] = (arg.communityId, arg.pubKey, response, "")
     arg.finish(tpl)
   except Exception as e:
     arg.finish(%* {
       "error": e.msg,
       "communityId": arg.communityId,
-      "pubKey": arg.pubKey
+      "pubKey": arg.pubKey,
+      "deleteAllMessages": arg.deleteAllMessages
     })
 
 const asyncUnbanUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2059,13 +2059,14 @@ QtObject:
     )
     self.threadpool.start(arg)
 
-  proc asyncBanUserFromCommunity*(self: Service, communityId, pubKey: string) =
+  proc asyncBanUserFromCommunity*(self: Service, communityId, pubKey: string, deleteAllMessages: bool) =
     let arg = AsyncCommunityMemberActionTaskArg(
       tptr: cast[ByteAddress](asyncBanUserFromCommunityTask),
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCommunityMemberActionCompleted",
       communityId: communityId,
       pubKey: pubKey,
+      deleteAllMessages: deleteAllMessages
     )
     self.threadpool.start(arg)
 

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -86,9 +86,9 @@ proc sendChatMessage*(
     }
   ])
 
-proc sendImages*(chatId: string, 
-                 images: var seq[string], 
-                 msg: string, 
+proc sendImages*(chatId: string,
+                 images: var seq[string],
+                 msg: string,
                  replyTo: string,
                  preferredUsername: string,
                  linkPreviews: seq[LinkPreview],

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -460,10 +460,11 @@ proc declineRequestToJoinCommunity*(requestId: string): RpcResponse[JsonNode] {.
     "id": requestId
   }])
 
-proc banUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[JsonNode] {.raises: [Exception].}  =
+proc banUserFromCommunity*(communityId: string, pubKey: string, deleteAllMessages: bool): RpcResponse[JsonNode] {.raises: [Exception].}  =
   return callPrivateRPC("banUserFromCommunity".prefix, %*[{
     "communityId": communityId,
-    "user": pubKey
+    "user": pubKey,
+    "deleteAllMessages": deleteAllMessages,
   }])
 
 proc unbanUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[JsonNode] {.raises: [Exception].}  =

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -327,8 +327,8 @@ QtObject {
         chatCommunitySectionModule.removeUserFromCommunity(pubKey);
     }
 
-    function banUserFromCommunity(pubKey) {
-        chatCommunitySectionModule.banUserFromCommunity(pubKey);
+    function banUserFromCommunity(pubKey, deleteAllMessages) {
+        chatCommunitySectionModule.banUserFromCommunity(pubKey, deleteAllMessages);
     }
 
     function unbanUserFromCommunity(pubKey) {

--- a/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
@@ -22,7 +22,7 @@ SettingsPage {
 
     signal membershipRequestsClicked()
     signal kickUserClicked(string id)
-    signal banUserClicked(string id)
+    signal banUserClicked(string id, bool deleteAllMessages)
     signal unbanUserClicked(string id)
     signal acceptRequestToJoin(string id)
     signal declineRequestToJoin(string id)
@@ -193,11 +193,7 @@ SettingsPage {
 
         communityName: root.communityName
 
-        onAccepted: {
-            if (mode === KickBanPopup.Mode.Kick)
-                root.kickUserClicked(userId)
-            else
-                root.banUserClicked(userId)
-        }
+        onBanUserClicked: root.banUserClicked(userId, deleteAllMessages)
+        onKickUserClicked: root.kickUserClicked(userId)
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/KickBanPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/KickBanPopup.qml
@@ -1,9 +1,11 @@
 import QtQuick 2.15
 import QtQml.Models 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Popups.Dialog 0.1
+import StatusQ.Components 0.1
 
 import utils 1.0
 
@@ -15,6 +17,9 @@ StatusDialog {
     property string communityName: ""
     property int mode: KickBanPopup.Mode.Kick
 
+    signal banUserClicked(bool deleteAllMessages)
+    signal kickUserClicked()
+
     enum Mode {
         Kick, Ban
     }
@@ -25,17 +30,40 @@ StatusDialog {
            ? qsTr("Kick %1").arg(root.username)
            : qsTr("Ban %1").arg(root.username)
 
-    contentItem: StatusBaseText {
+    contentItem: ColumnLayout {
         anchors.centerIn: parent
-        font.pixelSize: Style.current.primaryTextFontSize
-        wrapMode: Text.Wrap
 
-        text: root.mode === KickBanPopup.Mode.Kick
-              ? qsTr("Are you sure you kick <b>%1</b> from %2?")
-                .arg(root.username).arg(root.communityName)
-              : qsTr("Are you sure you ban <b>%1</b> from %2?")
-                .arg(root.username).arg(root.communityName)
-    }
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            font.pixelSize: Style.current.primaryTextFontSize
+            wrapMode: Text.Wrap
+
+            text: root.mode === KickBanPopup.Mode.Kick
+                  ? qsTr("Are you sure you want to kick <b>%1</b> from %2?")
+                    .arg(root.username).arg(root.communityName)
+                  : qsTr("Are you sure you want to ban <b>%1</b> from %2? This means that they will be kicked from this community and banned from re-joining.")
+            .arg(root.username).arg(root.communityName)
+        }
+
+            RowLayout {
+                visible: root.mode === KickBanPopup.Mode.Ban
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+
+                    text: qsTr("Delete all messages posted by the user")
+                    font.pixelSize: Style.current.primaryTextFontSize
+                }
+
+                StatusSwitch {
+                    id: deleteAllMessagesSwitch
+
+                    checked: false
+                }
+            }
+        }
 
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
@@ -51,14 +79,17 @@ StatusDialog {
                             ? "CommunityMembers_KickModal_KickButton"
                             : "CommunityMembers_BanModal_BanButton"
 
-                text: root.mode === KickBanPopup.Mode.Kick ? qsTr("Kick")
-                                                           : qsTr("Ban")
+                text: root.mode === KickBanPopup.Mode.Kick ? qsTr("Kick %1").arg(root.username)
+                                                           : qsTr("Ban %1").arg(root.username)
                 type: StatusBaseButton.Type.Danger
                 onClicked: {
-                    root.accept()
+                    root.mode === KickBanPopup.Mode.Kick ? root.kickUserClicked()
+                                                         : root.banUserClicked(deleteAllMessagesSwitch.checked)
                     root.close()
                 }
             }
         }
     }
+
+    onClosed: deleteAllMessagesSwitch.checked = false
 }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -72,6 +72,8 @@ Item {
         property bool invitationPending: root.store.isMyCommunityRequestPending(communityData.id)
 
         property bool joiningCommunityInProgress: false
+
+        onShowJoinButtonChanged: invitationPending = root.store.isMyCommunityRequestPending(communityData.id)
     }
 
     ColumnHeaderPanel {

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -273,7 +273,7 @@ StatusSectionLayout {
             communityName: root.community.name
 
             onKickUserClicked: root.rootStore.removeUserFromCommunity(id)
-            onBanUserClicked: root.rootStore.banUserFromCommunity(id)
+            onBanUserClicked: root.rootStore.banUserFromCommunity(id, deleteAllMessages)
             onUnbanUserClicked: root.rootStore.unbanUserFromCommunity(id)
             onAcceptRequestToJoin: root.rootStore.acceptRequestToJoinCommunity(id, root.community.id)
             onDeclineRequestToJoin: root.rootStore.declineRequestToJoinCommunity(id, root.community.id)

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -140,6 +140,10 @@ Popup {
                     return ownerTokenReceivedNotificationComponent
                 case ActivityCenterStore.ActivityCenterNotificationType.ShareAccounts:
                     return shareAccountsNotificationComponent
+                case ActivityCenterStore.ActivityCenterNotificationType.CommunityBanned:
+                    return communityBannedNotificationComponent
+                case ActivityCenterStore.ActivityCenterNotificationType.CommunityUnbanned:
+                    return communityUnbannedNotificationComponent
                 default:
                     return null
                 }
@@ -228,6 +232,32 @@ Popup {
         id: communityKickedNotificationComponent
 
         ActivityNotificationCommunityKicked {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+
+    Component {
+        id: communityBannedNotificationComponent
+
+        ActivityNotificationCommunityBanUnban {
+            banned: true
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+
+    Component {
+        id: communityUnbannedNotificationComponent
+
+        ActivityNotificationCommunityBanUnban {
+            banned: false
             filteredIndex: parent.filteredIndex
             notification: parent.notification
             store: root.store

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -38,7 +38,9 @@ QtObject {
         OwnershipDeclined = 17,
         ShareAccounts = 18,
         CommunityTokenReceived = 19,
-        FirstCommunityTokenReceived = 20
+        FirstCommunityTokenReceived = 20,
+        CommunityBanned = 21,
+        CommunityUnbanned = 22
     }
 
     enum ActivityCenterReadType {

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityBanUnban.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityBanUnban.qml
@@ -1,0 +1,78 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import shared 1.0
+import shared.panels 1.0
+import shared.controls 1.0
+import utils 1.0
+
+import "../controls"
+
+ActivityNotificationBase {
+    id: root
+    property bool banned: true
+
+    bodyComponent: RowLayout {
+        width: parent.width
+        height: 50
+        readonly property var community: notification ?
+                                root.store.getCommunityDetailsAsJson(notification.communityId) :
+                                null
+
+        StatusSmartIdenticon {
+            Layout.preferredWidth: 40
+            Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignTop
+            Layout.leftMargin: Style.current.padding
+            Layout.topMargin: 2
+
+            asset {
+                width: 24
+                height: width
+                name: "communities"
+                color: root.banned ? "red" : "green"
+                bgWidth: 40
+                bgHeight: 40
+                bgColor: Theme.palette.getColor(asset.color, 0.1)
+            }
+        }
+
+        StatusBaseText {
+            text: root.banned ? qsTr("You were banned from") : qsTr("You've been unbanned from")
+            Layout.alignment: Qt.AlignVCenter
+            font.italic: true
+            color: Theme.palette.baseColor1
+        }
+
+        CommunityBadge {
+            communityName: community ? community.name : ""
+            communityImage: community ? community.image : ""
+            communityColor: community ? community.color : "black"
+            onCommunityNameClicked: root.store.setActiveCommunity(notification.communityId)
+            Layout.alignment: Qt.AlignVCenter
+            Layout.maximumWidth: 190
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+    }
+
+    ctaComponent: root.banned ? undefined : visitCommunityCta
+
+    Component {
+        id: visitCommunityCta
+        StatusLinkText {
+            text: qsTr("Visit Community")
+            onClicked: {
+                root.store.setActiveCommunity(notification.communityId)
+                root.closeActivityCenter()
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does the PR do

- extend the Ban/Unban popup with the "Delete all messages" option
- delete all messages during the ban functionality
- AC notification for ban/unban
- refactor names for functionality to split messages remove and delete  
- fixed bug when kicking user results to "Pending request" state

status-go PR: https://github.com/status-im/status-go/pull/4743

Closes:
- https://github.com/status-im/status-desktop/issues/13610
- https://github.com/status-im/status-desktop/issues/13608
- https://github.com/status-im/status-desktop/issues/12063

### Affected areas

- Messages deletion
- AC notifications

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/117639195/35256183-8001-4927-8077-f029c4e1ae35

