### PR TITLE
feat(Profile flow): Block/unblock user

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
@@ -31,7 +31,7 @@ import StatusQ.Core.Theme 0.1
 Control {
     id: root
     implicitWidth: 614
-    implicitHeight: rowContent.height
+    padding: 16
 
     /*!
         \qmlproperty alias StatusWarningBox::text
@@ -64,7 +64,10 @@ Control {
         This property sets the StatusWarningBox text color.
     */
     property color textColor: Theme.palette.warningColor1
-
+    /*!
+        \qmlproperty int StatusWarningBox::textSize
+        This property sets the StatusWarningBox text pixel size
+    */
     property int textSize: Theme.primaryTextFontSize
 
     background: Rectangle {
@@ -80,33 +83,21 @@ Control {
         }
     }
 
-    contentItem: Item {
-        id: rowContent
-        width: parent.width
-        height: (row.height+32)//xlPadding
-        RowLayout {
-            id: row
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.leftMargin: 16
-            anchors.rightMargin: 16
-            anchors.verticalCenter: parent.verticalCenter
-            height: warningText.contentHeight
-            spacing: 6
-            StatusIcon {
-                Layout.alignment: Qt.AlignTop
-                icon: root.icon
-                color: root.iconColor
-            }
-            StatusBaseText {
-                id: warningText
-                Layout.fillWidth: true
-                Layout.preferredHeight: contentHeight
-                wrapMode: Text.WordWrap
-                verticalAlignment: Text.AlignVCenter
-                font.pixelSize: root.textSize
-                color: root.textColor
-            }
+    contentItem: RowLayout {
+        spacing: 8
+        StatusIcon {
+            Layout.alignment: Qt.AlignTop
+            icon: root.icon
+            color: root.iconColor
+        }
+        StatusBaseText {
+            id: warningText
+            Layout.fillWidth: true
+            Layout.preferredHeight: contentHeight
+            wrapMode: Text.WordWrap
+            verticalAlignment: Text.AlignVCenter
+            font.pixelSize: root.textSize
+            color: root.textColor
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
@@ -45,25 +45,27 @@ Control {
     */
     property string icon
     /*!
-        \qmlproperty string StatusWarningBox::iconColor
+        \qmlproperty color StatusWarningBox::iconColor
         This property sets the StatusWarningBox icon color.
     */
-    property string iconColor: "transparent"
+    property color iconColor: "transparent"
     /*!
-        \qmlproperty string StatusWarningBox::bgColor
+        \qmlproperty color StatusWarningBox::bgColor
         This property sets the StatusWarningBox background color.
     */
-    property string bgColor: "transparent"
+    property color bgColor: "transparent"
     /*!
-        \qmlproperty string StatusWarningBox::borderColor
+        \qmlproperty color StatusWarningBox::borderColor
         This property sets the StatusWarningBox border color.
     */
-    property string borderColor: Theme.palette.warningColor1
+    property color borderColor: Theme.palette.warningColor1
     /*!
-        \qmlproperty string StatusWarningBox::textColor
+        \qmlproperty color StatusWarningBox::textColor
         This property sets the StatusWarningBox text color.
     */
-    property string textColor: Theme.palette.warningColor1
+    property color textColor: Theme.palette.warningColor1
+
+    property int textSize: Theme.primaryTextFontSize
 
     background: Rectangle {
         radius: 8
@@ -102,7 +104,7 @@ Control {
                 Layout.preferredHeight: contentHeight
                 wrapMode: Text.WordWrap
                 verticalAlignment: Text.AlignVCenter
-                font.pixelSize: Theme.primaryTextFontSize
+                font.pixelSize: root.textSize
                 color: root.textColor
             }
         }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -141,12 +141,12 @@ QtObject {
         openPopup(markAsUntrustedComponent, {publicKey, contactDetails})
     }
 
-    function openBlockContactPopup(publicKey: string, contactName: string) {
-        openPopup(blockContactConfirmationComponent, {contactName: contactName, contactAddress: publicKey})
+    function openBlockContactPopup(publicKey: string, contactDetails) {
+        openPopup(blockContactConfirmationComponent, {publicKey, contactDetails})
     }
 
-    function openUnblockContactPopup(publicKey: string, contactName: string) {
-        openPopup(unblockContactConfirmationComponent, {contactName: contactName, contactAddress: publicKey})
+    function openUnblockContactPopup(publicKey: string, contactDetails) {
+        openPopup(unblockContactConfirmationComponent, {publicKey, contactDetails})
     }
 
     function openChangeProfilePicPopup(cb) {
@@ -546,8 +546,9 @@ QtObject {
         Component {
             id: unblockContactConfirmationComponent
             UnblockContactConfirmationDialog {
-                onUnblockButtonClicked: {
-                    rootStore.contactStore.unblockContact(contactAddress)
+                onAccepted: {
+                    rootStore.contactStore.unblockContact(publicKey)
+                    Global.displaySuccessToastMessage(qsTr("%1 unblocked").arg(mainDisplayName))
                     close()
                 }
                 onClosed: destroy()
@@ -557,8 +558,13 @@ QtObject {
         Component {
             id: blockContactConfirmationComponent
             BlockContactConfirmationDialog {
-                onBlockButtonClicked: {
-                    rootStore.contactStore.blockContact(contactAddress)
+                onAccepted: {
+                    rootStore.contactStore.blockContact(publicKey)
+                    if (removeIDVerification)
+                        rootStore.contactStore.cancelVerificationRequest(publicKey)
+                    if (removeContact)
+                        rootStore.contactStore.removeContact(publicKey)
+                    Global.displaySuccessToastMessage(qsTr("%1 blocked").arg(mainDisplayName))
                     close()
                 }
                 onClosed: destroy()

--- a/ui/imports/shared/popups/MarkAsUntrustedPopup.qml
+++ b/ui/imports/shared/popups/MarkAsUntrustedPopup.qml
@@ -8,7 +8,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 import utils 1.0
-import shared.controls 1.0
 
 CommonContactDialog {
     id: root

--- a/ui/imports/shared/popups/UnblockContactConfirmationDialog.qml
+++ b/ui/imports/shared/popups/UnblockContactConfirmationDialog.qml
@@ -1,49 +1,33 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
 
 import utils 1.0
 
+import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 
-import "../panels"
-import "./"
+CommonContactDialog {
+    id: root
 
-// TODO: replace with StatusModal
-ModalPopup {
-    id: unblockContactConfirmationDialog
-    height: 237
-    width: 400
+    title: qsTr("Unblock user")
 
-    property string contactAddress: ""
-    property string contactName: ""
-
-    signal unblockButtonClicked()
-
-    title: qsTr("Unblock User")
-
-    StyledText {
-        text: qsTr("Unblocking will allow new messages you received from %1 to reach you.").arg(contactName)
-        font.pixelSize: 15
-        anchors.left: parent.left
-        anchors.right: parent.right
+    StatusBaseText {
+        Layout.fillWidth: true
         wrapMode: Text.WordWrap
+        text: qsTr("Unblocking %1 will allow new messages you receive from %1 to reach you.").arg(mainDisplayName)
     }
 
-
-    footer: Item {
-        id: footerContainer
-        width: parent.width
-        height: children[0].height
-
+    rightButtons: ObjectModel {
+        StatusFlatButton {
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
         StatusButton {
-            anchors.right: parent.right
-            anchors.rightMargin: Style.current.smallPadding
             type: StatusBaseButton.Type.Danger
-            text: qsTr("Unblock User")
-            anchors.bottom: parent.bottom
-            onClicked: unblockContactConfirmationDialog.unblockButtonClicked()
+            text: qsTr("Unblock")
+            onClicked: root.accepted()
         }
     }
 }
-

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -49,10 +49,10 @@ Pane {
 
     QtObject {
         id: d
-        property var contactDetails: Utils.getContactDetailsAsJson(root.publicKey, !isCurrentUser, !isCurrentUser)
+        property var contactDetails: Utils.getContactDetailsAsJson(root.publicKey, !isCurrentUser, !isCurrentUser, true)
 
         function reload() {
-            contactDetails = Utils.getContactDetailsAsJson(root.publicKey, !isCurrentUser, !isCurrentUser)
+            contactDetails = Utils.getContactDetailsAsJson(root.publicKey, !isCurrentUser, !isCurrentUser, true)
         }
 
         readonly property bool isCurrentUser: root.profileStore.pubkey === root.publicKey
@@ -183,8 +183,8 @@ Pane {
         StatusButton {
             size: StatusButton.Size.Small
             type: StatusBaseButton.Type.Danger
-            text: qsTr("Block User")
-            onClicked: Global.blockContactRequested(root.publicKey, d.mainDisplayName)
+            text: qsTr("Block user")
+            onClicked: Global.blockContactRequested(root.publicKey, d.contactDetails)
         }
     }
 
@@ -192,8 +192,8 @@ Pane {
         id: btnUnblockUserComponent
         StatusButton {
             size: StatusButton.Size.Small
-            text: qsTr("Unblock")
-            onClicked: Global.unblockContactRequested(root.publicKey, d.mainDisplayName)
+            text: qsTr("Unblock user")
+            onClicked: Global.unblockContactRequested(root.publicKey, d.contactDetails)
         }
     }
 
@@ -327,17 +327,13 @@ Pane {
                     if (d.isCurrentUser)
                         return btnEditProfileComponent
 
-                    // blocked contact
+                    // blocked user
                     if (d.isBlocked)
                         return btnUnblockUserComponent
 
                     // accept incoming CR
                     if (d.contactRequestState === Constants.ContactRequestState.Received)
                         return btnAcceptContactRequestComponent
-
-                    // block user
-                    if (d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy)
-                        return btnBlockUserComponent
 
                     // mutual contact
                     if (d.isContact || d.contactRequestState === Constants.ContactRequestState.Mutual)
@@ -435,20 +431,20 @@ Pane {
                     }
                     StatusMenuSeparator {}
                     StatusAction {
+                        text: qsTr("Remove ID verification")
+                        icon.name: "warning"
+                        type: StatusAction.Type.Danger
+                        enabled: d.isContact && d.isTrusted
+                        onTriggered: {
+                            removeVerificationConfirmationDialog.open()
+                        }
+                    }
+                    StatusAction {
                         text: qsTr("Remove nickname")
                         icon.name: "delete"
                         type: StatusAction.Type.Danger
                         enabled: !d.isCurrentUser && !!d.contactDetails.localNickname
                         onTriggered: root.contactsStore.changeContactNickname(root.publicKey, "", d.optionalDisplayName, true)
-                    }
-                    StatusAction {
-                        text: qsTr("Unblock user")
-                        icon.name: "cancel"
-                        type: StatusAction.Type.Danger
-                        enabled: d.isBlocked
-                        onTriggered: {
-                            Global.unblockContactRequested(root.publicKey, d.mainDisplayName)
-                        }
                     }
                     StatusAction {
                         text: qsTr("Mark as untrusted")
@@ -469,15 +465,6 @@ Pane {
                         }
                     }
                     StatusAction {
-                        text: qsTr("Remove ID verification")
-                        icon.name: "warning"
-                        type: StatusAction.Type.Danger
-                        enabled: d.isContact && d.isTrusted
-                        onTriggered: {
-                            removeVerificationConfirmationDialog.open()
-                        }
-                    }
-                    StatusAction {
                         text: qsTr("Remove contact")
                         icon.name: "remove-contact"
                         type: StatusAction.Type.Danger
@@ -492,7 +479,7 @@ Pane {
                         type: StatusAction.Type.Danger
                         enabled: !d.isBlocked
                         onTriggered: {
-                            Global.blockContactRequested(root.publicKey, d.mainDisplayName)
+                            Global.blockContactRequested(root.publicKey, d.contactDetails)
                         }
                     }
                 }

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -211,7 +211,7 @@ StatusMenu {
         icon.name: "cancel"
         type: StatusAction.Type.Danger
         enabled: !root.isMe && root.isBlockedContact && !root.isBridgedAccount
-        onTriggered: Global.unblockContactRequested(root.selectedUserPublicKey, root.selectedUserDisplayName)
+        onTriggered: Global.unblockContactRequested(root.selectedUserPublicKey, root.contactDetails)
     }
 
     // TODO Remove ID verification + confirmation dialog
@@ -252,6 +252,6 @@ StatusMenu {
         icon.name: "cancel"
         type: StatusAction.Type.Danger
         enabled: !root.isMe && !root.isBlockedContact && !root.isBridgedAccount
-        onTriggered: Global.blockContactRequested(root.selectedUserPublicKey, root.selectedUserDisplayName)
+        onTriggered: Global.blockContactRequested(root.selectedUserPublicKey, root.contactDetails)
     }
 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -22,8 +22,8 @@ QtObject {
     signal openCreateChatView()
     signal closeCreateChatView()
 
-    signal blockContactRequested(string publicKey, string contactName)
-    signal unblockContactRequested(string publicKey, string contactName)
+    signal blockContactRequested(string publicKey, var contactDetails)
+    signal unblockContactRequested(string publicKey, var contactDetails)
 
     signal displayToastMessage(string title, string subTitle, string icon, bool loading, int ephNotifType, string url)
     signal displayToastWithActionMessage(string title, string subTitle, string icon, string iconColor, bool loading, int ephNotifType, int actionType, string data)


### PR DESCRIPTION
### What does the PR do

- implement block and unblock user popups with optional "Remove contact" and "Remove ID verification" check boxes
- emit (combined) toasts
- separate commit to expose text size from `StatusWarningBox`

Fixes #13522

### Affected areas

[Un]BlockConfirmationDialog

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Block:
![image](https://github.com/status-im/status-desktop/assets/5377645/269d3f5d-89e3-4263-950b-0f3430eb9f5a)
