### PR TITLE
feat(ProfileShowcase): Drop area behaviour / design when sections expanded

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusDraggableListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusDraggableListItem.qml
@@ -218,6 +218,13 @@ ItemDelegate {
     */
     readonly property alias containsMouse: dragHandler.containsMouse
 
+    /*!
+       \qmlproperty bool StatusDraggableListItem::changeColorOnDragActive
+       This property holds if background color will be changed on drag active or not
+       Defaults to "dragActive" (ie background will change on dragActive = true)
+    */
+    property bool changeColorOnDragActive: dragActive
+
     Drag.dragType: Drag.Automatic
     Drag.hotSpot.x: dragHandler.mouseX
     Drag.hotSpot.y: dragHandler.mouseY
@@ -252,7 +259,7 @@ ItemDelegate {
     ]
 
     background: Rectangle {
-        color: root.dragActive && !root.customizable ? Theme.palette.alphaColor(Theme.palette.baseColor2, 0.7) : root.bgColor
+        color: root.changeColorOnDragActive && !root.customizable? Theme.palette.alphaColor(Theme.palette.baseColor2, 0.7) : root.bgColor
         border.width: root.customizable ? 0 : 1
         border.color: Theme.palette.baseColor2
         radius: root.customizable ? 0 : 8

--- a/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
@@ -26,6 +26,12 @@ StatusDraggableListItem {
         icon.color: Theme.palette.primaryColor1
     }
 
+    height: ProfileUtils.defaultDelegateHeight
+    topInset: 0
+    bottomInset: 0
+    changeColorOnDragActive: false
+    bgColor: Theme.palette.getColor(Theme.palette.statusAppLayout.rightPanelBackgroundColor, 0.7)
+
     icon.width: 40
     icon.height: 40
 

--- a/ui/imports/shared/controls/EmptyShapeRectangleFooterListView.qml
+++ b/ui/imports/shared/controls/EmptyShapeRectangleFooterListView.qml
@@ -11,7 +11,8 @@ StatusListView {
     id: root
 
     property string placeholderText
-    property int placeholderHeight: 44
+    property int footerHeight: 44
+    property bool footerContentVisible: true
     property Component additionalFooterComponent
 
     // TO BE REMOVE: #13498
@@ -22,16 +23,21 @@ StatusListView {
     footer: ColumnLayout {
         width: root.width
 
-        ShapeRectangle {
-            id: shapeRectangle
-
-            Layout.preferredHeight: root.placeholderHeight
+        Item {
+            Layout.preferredHeight: root.footerHeight
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignHCenter
-            Layout.margins: 1
 
-            visible: root.empty// TO BE REPLACE by (#13498):  root.model && root.count === 0
-            text: root.placeholderText
+            visible: root.empty// TO BE REPLACE root.empty in (#13498):  root.empty = root.model && root.count === 0
+
+            ShapeRectangle {
+                id: shapeRectangle
+
+                anchors.fill: parent
+                anchors.margins: 1
+
+                visible: root.footerContentVisible
+                text: root.placeholderText
+            }
         }
 
         Loader {

--- a/ui/imports/utils/ProfileUtils.qml
+++ b/ui/imports/utils/ProfileUtils.qml
@@ -5,6 +5,9 @@ import QtQml 2.14
 import StatusQ.Core.Theme 0.1
 
 QtObject {
+
+    readonly property int defaultDelegateHeight: 76
+
     function displayName(nickName, ensName, displayName, aliasName)
     {
         return nickName || ensName || displayName || aliasName


### PR DESCRIPTION
Closes #13509

### What does the PR do

- It updates `ProfileShowcasePanel` with new drop area design adding shadows, changing drop areas design and sizes.
- It adjusts `ShowcaseDelegate` according to design, ie: heigh and background colour on dragActive.
- SQ / `StatusDraggableListItem`: Added new property `colorOnDragActive ` that holds if background color will be changed on drag active or not.

### Affected areas

Profile showcase tabs: Communities, Accounts, Collectibles and Assets

StatusQ / StatusDraggableListItem

### Screenshot of functionality 

https://github.com/status-im/status-desktop/assets/97019400/0169c764-fc95-4da1-abc7-8ec91b19a477


