### PR TITLE
StatusQ(MovableModel): layoutChanged handling fixed 

### DIFF
--- a/ui/StatusQ/include/StatusQ/movablemodel.h
+++ b/ui/StatusQ/include/StatusQ/movablemodel.h
@@ -13,13 +13,13 @@ class MovableModel : public QAbstractListModel
 
     Q_PROPERTY(bool synced READ synced NOTIFY syncedChanged)
 public:
-    explicit MovableModel(QObject *parent = nullptr);
+    explicit MovableModel(QObject* parent = nullptr);
 
     void setSourceModel(QAbstractItemModel *sourceModel);
-    QAbstractItemModel *sourceModel() const;
+    QAbstractItemModel* sourceModel() const;
 
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-    QVariant data(const QModelIndex &index, int role) const override;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
     QHash<int, QByteArray> roleNames() const override;
 
     Q_INVOKABLE void desyncOrder();
@@ -37,10 +37,30 @@ protected slots:
     void resetInternalData();
 
 private:
+    // source signals handling for synced state
+    void syncedSourceDataChanged(const QModelIndex& topLeft,
+                           const QModelIndex& bottomRight,
+                           const QVector<int>& roles);
+    void sourceLayoutAboutToBeChanged(const QList<QPersistentModelIndex>& parents,
+                                      QAbstractItemModel::LayoutChangeHint hint);
+    void sourceLayoutChanged(const QList<QPersistentModelIndex>& parents,
+                             QAbstractItemModel::LayoutChangeHint hint);
+
+    // source signals handling for desynced state
+    void desyncedSourceDataChanged(const QModelIndex& topLeft,
+                                   const QModelIndex& bottomRight,
+                                   const QVector<int>& roles);
+    void sourceRowsInserted(const QModelIndex &parent, int first, int last);
+    void sourceRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
+
+    // other
+    void connectSignalsForSyncedState();
+
     QPointer<QAbstractItemModel> m_sourceModel;
-
-    void connectSignalsForAttachedState();
-
     bool m_synced = true;
     std::vector<QPersistentModelIndex> m_indexes;
+
+    // helpers for handling layoutChanged from source when synced
+    QList<QPersistentModelIndex> m_layoutChangePersistentIndexes;
+    QModelIndexList m_proxyIndexes;
 };

--- a/ui/StatusQ/src/movablemodel.cpp
+++ b/ui/StatusQ/src/movablemodel.cpp
@@ -20,7 +20,7 @@ void MovableModel::setSourceModel(QAbstractItemModel* sourceModel)
         disconnect(m_sourceModel, nullptr, this, nullptr);
 
     m_sourceModel = sourceModel;
-    connectSignalsForAttachedState();
+    connectSignalsForSyncedState();
 
     emit sourceModelChanged();
 
@@ -89,83 +89,22 @@ void MovableModel::desyncOrder()
                &MovableModel::endMoveRows);
 
     disconnect(m_sourceModel, &QAbstractItemModel::dataChanged, this,
-               &MovableModel::dataChanged);
+               &MovableModel::syncedSourceDataChanged);
 
     disconnect(m_sourceModel, &QAbstractItemModel::layoutAboutToBeChanged, this,
-               &MovableModel::layoutAboutToBeChanged);
+               &MovableModel::sourceLayoutAboutToBeChanged);
 
     disconnect(m_sourceModel, &QAbstractItemModel::layoutChanged, this,
-               &MovableModel::layoutChanged);
+               &MovableModel::sourceLayoutChanged);
 
     connect(m_sourceModel, &QAbstractItemModel::dataChanged, this,
-            [this](const QModelIndex& topLeft, const QModelIndex& bottomRight,
-            const QVector<int>& roles) {
-        emit dataChanged(index(0), index(rowCount() - 1), roles);
-    });
+            &MovableModel::desyncedSourceDataChanged);
 
     connect(m_sourceModel, &QAbstractItemModel::rowsInserted, this,
-            [this](const QModelIndex &parent, int first, int last) {
-
-        beginInsertRows({}, first, last);
-
-        int oldCount = m_indexes.size();
-        int insertCount = last - first + 1;
-
-        m_indexes.reserve(m_indexes.size() + insertCount);
-
-        for (auto i = first; i <= last; i++)
-            m_indexes.emplace_back(m_sourceModel->index(i, 0));
-
-        std::rotate(m_indexes.begin() + first, m_indexes.begin() + oldCount,
-                    m_indexes.end());
-
-        endInsertRows();
-    });
+            &MovableModel::sourceRowsInserted);
 
     connect(m_sourceModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
-            [this] (const QModelIndex &parent, int first, int last) {
-        std::vector<int> indicesToRemove;
-        indicesToRemove.reserve(last - first + 1);
-
-        for (auto i = 0; i < m_indexes.size(); i++) {
-            const QPersistentModelIndex& idx = m_indexes.at(i);
-
-            if (idx.row() >= first && idx.row() <= last)
-                indicesToRemove.push_back(i);
-        }
-
-        std::vector<std::pair<int, int>> sequences;
-        auto sequenceBegin = indicesToRemove.front();
-        auto sequenceEnd = sequenceBegin;
-
-        for (auto i = 1; i < indicesToRemove.size(); i++) {
-            auto idxToRemove = indicesToRemove[i];
-
-            auto idxDiff = idxToRemove - sequenceEnd;
-            if (idxDiff == 1)
-                sequenceEnd = idxToRemove;
-
-            if (idxDiff != 1 || i == indicesToRemove.size() - 1) {
-                sequences.emplace_back(sequenceBegin, sequenceEnd);
-                sequenceBegin = idxToRemove;
-                sequenceEnd = idxToRemove;
-            }
-        }
-
-        if (sequences.empty())
-            sequences.emplace_back(sequenceBegin, sequenceEnd);
-
-        auto end = sequences.crend();
-
-        for (auto it = sequences.crbegin(); it != end; it++) {
-            beginRemoveRows({}, it->first, it->second);
-
-            m_indexes.erase(m_indexes.begin() + it->first,
-                            m_indexes.begin() + it->second + 1);
-
-            endRemoveRows();
-        }
-    });
+            &MovableModel::sourceRowsAboutToBeRemoved);
 
     auto count = m_sourceModel->rowCount();
 
@@ -189,10 +128,18 @@ void MovableModel::syncOrder()
     auto sourceModel = m_sourceModel;
 
     disconnect(m_sourceModel, nullptr, this, nullptr);
-    connectSignalsForAttachedState();
+    connectSignalsForSyncedState();
+
+    for (int i = 0; i < m_indexes.size(); ++i) {
+        const QModelIndex idx = m_indexes[i];
+
+        if (i == idx.row())
+            continue;
+
+        changePersistentIndex(index(i, 0), index(idx.row(), 0));
+    }
 
     resetInternalData();
-
     emit layoutChanged();
 }
 
@@ -262,7 +209,130 @@ void MovableModel::resetInternalData()
     }
 }
 
-void MovableModel::connectSignalsForAttachedState()
+void MovableModel::syncedSourceDataChanged(const QModelIndex& topLeft,
+                                           const QModelIndex& bottomRight,
+                                           const QVector<int>& roles)
+{
+    emit dataChanged(index(topLeft.row(), topLeft.column()),
+                     index(bottomRight.row(), bottomRight.column()), roles);
+}
+
+void MovableModel::sourceLayoutAboutToBeChanged(
+        const QList<QPersistentModelIndex>& parents,
+        QAbstractItemModel::LayoutChangeHint hint)
+{
+    emit layoutAboutToBeChanged();
+
+    const auto persistentIndexes = persistentIndexList();
+
+    for (const QModelIndex& persistentIndex: persistentIndexes) {
+        m_proxyIndexes << persistentIndex;
+        Q_ASSERT(persistentIndex.isValid());
+        const auto srcIndex = m_sourceModel->index(
+                    persistentIndex.row(),
+                    persistentIndex.column());
+
+        Q_ASSERT(srcIndex.isValid());
+        m_layoutChangePersistentIndexes << srcIndex;
+    }
+}
+
+void MovableModel::sourceLayoutChanged(
+        const QList<QPersistentModelIndex>& parents,
+        QAbstractItemModel::LayoutChangeHint hint)
+{
+    for (int i = 0; i < m_proxyIndexes.size(); ++i) {
+        auto p = m_layoutChangePersistentIndexes.at(i);
+        changePersistentIndex(m_proxyIndexes.at(i), index(
+                                  p.row(), p.column(), p.parent()));
+    }
+
+    m_layoutChangePersistentIndexes.clear();
+    m_proxyIndexes.clear();
+
+    emit layoutChanged();
+}
+
+void MovableModel::desyncedSourceDataChanged(const QModelIndex& topLeft,
+                                     const QModelIndex& bottomRight,
+                                     const QVector<int>& roles)
+{
+    Q_UNUSED(topLeft)
+    Q_UNUSED(bottomRight)
+
+    emit dataChanged(index(0), index(rowCount() - 1), roles);
+}
+
+void MovableModel::sourceRowsInserted(const QModelIndex& parent, int first,
+                                      int last)
+{
+    Q_ASSERT(!parent.isValid());
+
+    beginInsertRows({}, first, last);
+
+    int oldCount = m_indexes.size();
+    int insertCount = last - first + 1;
+
+    m_indexes.reserve(m_indexes.size() + insertCount);
+
+    for (auto i = first; i <= last; i++)
+        m_indexes.emplace_back(m_sourceModel->index(i, 0));
+
+    std::rotate(m_indexes.begin() + first, m_indexes.begin() + oldCount,
+                m_indexes.end());
+
+    endInsertRows();
+}
+
+void MovableModel::sourceRowsAboutToBeRemoved(const QModelIndex& parent,
+                                              int first, int last)
+{
+    Q_ASSERT(!parent.isValid());
+
+    std::vector<int> indicesToRemove;
+    indicesToRemove.reserve(last - first + 1);
+
+    for (auto i = 0; i < m_indexes.size(); i++) {
+        const QPersistentModelIndex& idx = m_indexes.at(i);
+
+        if (idx.row() >= first && idx.row() <= last)
+            indicesToRemove.push_back(i);
+    }
+
+    std::vector<std::pair<int, int>> sequences;
+    auto sequenceBegin = indicesToRemove.front();
+    auto sequenceEnd = sequenceBegin;
+
+    for (auto i = 1; i < indicesToRemove.size(); i++) {
+        auto idxToRemove = indicesToRemove[i];
+
+        auto idxDiff = idxToRemove - sequenceEnd;
+        if (idxDiff == 1)
+            sequenceEnd = idxToRemove;
+
+        if (idxDiff != 1 || i == indicesToRemove.size() - 1) {
+            sequences.emplace_back(sequenceBegin, sequenceEnd);
+            sequenceBegin = idxToRemove;
+            sequenceEnd = idxToRemove;
+        }
+    }
+
+    if (sequences.empty())
+        sequences.emplace_back(sequenceBegin, sequenceEnd);
+
+    auto end = sequences.crend();
+
+    for (auto it = sequences.crbegin(); it != end; it++) {
+        beginRemoveRows({}, it->first, it->second);
+
+        m_indexes.erase(m_indexes.begin() + it->first,
+                        m_indexes.begin() + it->second + 1);
+
+        endRemoveRows();
+    }
+}
+
+void MovableModel::connectSignalsForSyncedState()
 {
     if (m_sourceModel == nullptr)
         return;
@@ -286,13 +356,13 @@ void MovableModel::connectSignalsForAttachedState()
             &MovableModel::endMoveRows);
 
     connect(m_sourceModel, &QAbstractItemModel::dataChanged, this,
-            &MovableModel::dataChanged);
+            &MovableModel::syncedSourceDataChanged);
 
     connect(m_sourceModel, &QAbstractItemModel::layoutAboutToBeChanged, this,
-            &MovableModel::layoutAboutToBeChanged);
+            &MovableModel::sourceLayoutAboutToBeChanged);
 
     connect(m_sourceModel, &QAbstractItemModel::layoutChanged, this,
-            &MovableModel::layoutChanged);
+            &MovableModel::sourceLayoutChanged);
 
     connect(m_sourceModel, &QAbstractItemModel::modelAboutToBeReset, this,
             &MovableModel::beginResetModel);

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(StatusQTestLib
     src/TestHelpers/modelsignalsspy.h
     src/TestHelpers/modeltestutils.cpp
     src/TestHelpers/modeltestutils.h
+    src/TestHelpers/persistentindexestester.cpp
+    src/TestHelpers/persistentindexestester.h
     src/TestHelpers/snapshotmodel.cpp
     src/TestHelpers/snapshotmodel.h
     src/TestHelpers/testmodel.cpp

--- a/ui/StatusQ/tests/src/TestHelpers/modelsignalsspy.h
+++ b/ui/StatusQ/tests/src/TestHelpers/modelsignalsspy.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QAbstractListModel>
+#include <QAbstractItemModel>
 #include <QSignalSpy>
 
 class ModelSignalsSpy

--- a/ui/StatusQ/tests/src/TestHelpers/modeltestutils.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/modeltestutils.cpp
@@ -2,9 +2,10 @@
 
 #include <QDebug>
 
+namespace {
 
 bool isSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
-            bool recursive)
+            bool recursive, bool printWarning)
 {
     auto count1 = model1.rowCount();
     auto count2 = model2.rowCount();
@@ -35,15 +36,17 @@ bool isSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
                 auto submodel2 = data2.value<QAbstractItemModel*>();
 
                 if (!isSame(*submodel1, *submodel2, true)) {
-                    qDebug() << "submodels are not the same, index:"
-                             << i << roleNames1[role];
+                    if (printWarning)
+                        qWarning() << "submodels are not the same, index:"
+                                   << i << roleNames1[role];
                     return false;
                 }
             } else if (data1 != data2) {
-                qWarning()
-                        << QString("Mismatch at row %1, role '%2'. Model 1: %3, model 2: %4")
-                           .arg(QString::number(i), QString(roleNames1[role]),
-                                data1.toString(), data2.toString());
+                if (printWarning)
+                    qWarning()
+                            << QString("Mismatch at row %1, role '%2'. Model 1: %3, model 2: %4")
+                               .arg(QString::number(i), QString(roleNames1[role]),
+                                    data1.toString(), data2.toString());
                 return false;
             }
         }
@@ -52,8 +55,29 @@ bool isSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
     return true;
 }
 
+} // unnamed namespace
+
+bool isSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
+            bool recursive)
+{
+    return isSame(model1, model2, recursive, true);
+}
+
 bool isSame(const QAbstractItemModel* model1, const QAbstractItemModel* model2,
             bool recursive)
 {
     return isSame(*model1, *model2, recursive);
 }
+
+bool isNotSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
+            bool recursive)
+{
+    return !isSame(model1, model2, recursive, false);
+}
+
+bool isNotSame(const QAbstractItemModel* model1, const QAbstractItemModel* model2,
+            bool recursive)
+{
+    return isNotSame(*model1, *model2, recursive);
+}
+

--- a/ui/StatusQ/tests/src/TestHelpers/modeltestutils.h
+++ b/ui/StatusQ/tests/src/TestHelpers/modeltestutils.h
@@ -7,3 +7,8 @@ bool isSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
             bool recursive = true);
 bool isSame(const QAbstractItemModel* model1, const QAbstractItemModel* model2,
             bool recursive = true);
+
+bool isNotSame(const QAbstractItemModel& model1, const QAbstractItemModel& model2,
+               bool recursive = true);
+bool isNotSame(const QAbstractItemModel* model1, const QAbstractItemModel* model2,
+               bool recursive = true);

--- a/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.cpp
@@ -1,0 +1,61 @@
+#include "persistentindexestester.h"
+
+#include <TestHelpers/snapshotmodel.h>
+
+#include <QDebug>
+
+PersistentIndexesTester::PersistentIndexesTester(QAbstractItemModel* model)
+    : m_model(model)
+{
+    storeIndexesAndData();
+}
+
+void PersistentIndexesTester::storeIndexesAndData()
+{
+    if (m_model == nullptr) {
+        qWarning() << "PersistentIndexesTester: model cannot be null.";
+        return;
+    }
+
+    m_snapshot = std::make_unique<SnapshotModel>(*m_model);
+
+    const int count = m_model->rowCount();
+    m_persistentIndexes.clear();
+    m_persistentIndexes.reserve(count);
+
+    for (auto i = 0; i < count; i++)
+        m_persistentIndexes << m_model->index(i, 0);
+}
+
+bool PersistentIndexesTester::compare()
+{
+    if (m_model == nullptr) {
+        qWarning() << "PersistentIndexesTester: model cannot be null.";
+        return false;
+    }
+
+    const auto count = m_model->rowCount();
+    const auto roles = m_model->roleNames().keys();
+
+    for (auto i = 0; i < count; i++) {
+
+        const auto idx = m_persistentIndexes[i];
+
+        for (auto role : roles) {
+            if (idx.data(role) != m_snapshot->data(i, role)) {
+                auto roleName = QString::fromUtf8(m_model->roleNames()
+                                                  .value(role));
+
+                qWarning() << QString("Mismatch detected. Persistent index "
+                                      "data: %1, snapshot data: %2, idx: %3, "
+                                      "role: %4")
+                              .arg(idx.data(role).toString(),
+                                   m_snapshot->data(i, role).toString(),
+                                   QString::number(i), roleName);
+                return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.h
+++ b/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QAbstractItemModel>
+#include <QPointer>
+
+#include <memory>
+
+class SnapshotModel;
+
+/**
+ * @brief The PersistentIndexesTester class is a simple utility for persistent
+ * indexes validation.
+ *
+ * It stores persistent indexes for all items and snapshot of the model's data.
+ * Using compare() method it can be checked if data indicated by persistent
+ * indexes match the snapshot.
+ */
+class PersistentIndexesTester
+{
+public:
+    explicit PersistentIndexesTester(QAbstractItemModel* model);
+
+    void storeIndexesAndData();
+    bool compare();
+
+private:
+    QPointer<QAbstractItemModel> m_model;
+    QList<QPersistentModelIndex> m_persistentIndexes;
+    std::unique_ptr<SnapshotModel> m_snapshot;
+};


### PR DESCRIPTION
### What does the PR do

`MovableModel` wasn't updating own persistent indexes when layoutChanged was emitted from the source and within `syncOrder` method. I could lead to data corruption in models relying on this model by taking persistent indexes.

- persistent indexes handling fixed
- utility for persistent indexes validation added
- some other improvements in `ModelTestUtils` - `isNotSame(...)` method added
- `MovableModel`'s code structure improved

Closes: #13602
