### PR TITLE
feat(ProfileShowcase): Enable add more accounts component

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAssetsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAssetsPanel.qml
@@ -52,17 +52,15 @@ ProfileShowcasePanel {
             root.showcaseEntryChanged()
         }
     }
+    additionalFooterComponent: root.addAccountsButtonVisible ? addMoreAccountsComponent : null
 
-// TODO: Issue #13590
-//    additionalComponent: root.addAccountsButtonVisible ? addMoreAccountsComponent : null
+    Component {
+        id: addMoreAccountsComponent
 
-//    Component {
-//        id: addMoreAccountsComponent
-
-//        AddMoreAccountsLink {
-//             visible: root.addAccountsButtonVisible
-//             text: qsTr("Don’t see some of your assets?")
-//             onClicked: root.navigateToAccountsTab()
-//        }
-//    }
+        AddMoreAccountsLink {
+             visible: root.addAccountsButtonVisible
+             text: qsTr("Don’t see some of your assets?")
+             onClicked: root.navigateToAccountsTab()
+        }
+    }
 }

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCollectiblesPanel.qml
@@ -47,17 +47,15 @@ ProfileShowcasePanel {
             root.showcaseEntryChanged()
         }
     }
+    additionalFooterComponent: root.addAccountsButtonVisible ? addMoreAccountsComponent : null
 
-// TODO: Issue #13590
-//    additionalComponent: root.addAccountsButtonVisible ? addMoreAccountsComponent : null
+    Component {
+        id: addMoreAccountsComponent
 
-//    Component {
-//        id: addMoreAccountsComponent
-
-//        AddMoreAccountsLink {
-//             visible: root.addAccountsButtonVisible
-//             text: qsTr("Don’t see some of your collectibles?")
-//             onClicked: root.navigateToAccountsTab()
-//        }
-//    }
+        AddMoreAccountsLink {
+             visible: root.addAccountsButtonVisible
+             text: qsTr("Don’t see some of your collectibles?")
+             onClicked: root.navigateToAccountsTab()
+        }
+    }
 }

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -28,6 +28,8 @@ DoubleFlickableWithFolding {
     property Component showcaseDraggableDelegateComponent
     property Component hiddenDraggableDelegateComponent
 
+    property Component additionalFooterComponent
+
     property string emptyInShowcasePlaceholderText
     property string emptyHiddenPlaceholderText
 
@@ -179,6 +181,7 @@ DoubleFlickableWithFolding {
         placeholderText: root.emptyHiddenPlaceholderText
         placeholderHeight: d.shapeRectangleHeight
         empty: root.showcaseModel.hiddenCount === 0 && !root.flickable2Folded // TO BE REMOVE: #13498
+        additionalFooterComponent: root.additionalFooterComponent
 
         header: FoldableHeader {
             width: ListView.view.width

--- a/ui/imports/shared/controls/EmptyShapeRectangleFooterListView.qml
+++ b/ui/imports/shared/controls/EmptyShapeRectangleFooterListView.qml
@@ -1,40 +1,43 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import QtQml 2.15
 
 import StatusQ.Core 0.1
+
+import utils 1.0
 
 StatusListView {
     id: root
 
     property string placeholderText
     property int placeholderHeight: 44
+    property Component additionalFooterComponent
 
     // TO BE REMOVE: #13498
     property bool empty: root.model && root.count === 0
 
     ScrollBar.vertical: null
 
-    Binding {
-        when: root.empty// TO BE REPLACE by (#13498):  root.model && root.count === 0
-        target: root
-        property: "footer"
-        restoreMode: Binding.RestoreBindingOrValue
+    footer: ColumnLayout {
+        width: root.width
 
-        value: Component {
-            Item {
-                height: root.placeholderHeight
-                width: root.width
+        ShapeRectangle {
+            id: shapeRectangle
 
-                ShapeRectangle {
-                    id: shapeRectangle
+            Layout.preferredHeight: root.placeholderHeight
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
+            Layout.margins: 1
 
-                    text: root.placeholderText
+            visible: root.empty// TO BE REPLACE by (#13498):  root.model && root.count === 0
+            text: root.placeholderText
+        }
 
-                    anchors.fill: parent
-                    anchors.margins: 1
-                }
-            }
+        Loader {
+            Layout.preferredWidth: root.width
+
+            sourceComponent: root.additionalFooterComponent
         }
     }
 


### PR DESCRIPTION
Closes #13590

### What does the PR do

- Added new additional footer component in `EmptyShapeRectangleFooterListView`.
- Enabled more accounts component in profile **showcase assets** and **collectibles** panel.

### Affected areas

Profile showcase assets and collectibles tabs

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/256dfee4-d6a9-437e-b48b-5a9d8bd82705