### PR TITLE
fix: fallback to default fleet when unknown value in settings

### DIFF
--- a/scripts/open_database.py
+++ b/scripts/open_database.py
@@ -1,5 +1,7 @@
 import sys, os, re
 import sqlcipher3
+import readline
+
 from getpass import getpass
 from common import PasswordFunctions
 

--- a/src/app/core/fleets/fleet_configuration.nim
+++ b/src/app/core/fleets/fleet_configuration.nim
@@ -1,4 +1,4 @@
-import json, typetraits, tables, sequtils
+import json, typetraits, tables, sequtils, strutils
 
 type
   Fleet* {.pure.} = enum
@@ -76,3 +76,9 @@ proc getMailservers*(self: FleetConfiguration, fleet: Fleet): Table[string, stri
     result = initTable[string,string]()
     return
   result = self.fleet[$fleet][fleetKey]
+
+proc fleetFromString*(fleet: string): Fleet {.inline.} =
+  try:
+    return parseEnum[Fleet](fleet)
+  except:
+    return Fleet.Undefined

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -35,7 +35,7 @@ proc init*(self: Controller) =
   discard
 
 proc getFleet*(self: Controller): string =
-  self.nodeConfigurationService.getFleetAsString()
+  return self.nodeConfigurationService.getFleetAsString()
 
 proc changeFleetTo*(self: Controller, fleet: string) =
   if (not self.nodeConfigurationService.setFleet(fleet)):

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -129,7 +129,7 @@ proc getFleet*(self: Service): Fleet =
   result = self.settingsService.getFleet()
   if result == Fleet.Undefined:
     let fleetFromNodeConfig = self.configuration.ClusterConfig.Fleet
-    result = parseEnum[Fleet](fleetFromNodeConfig)
+    result = fleetFromString(fleetFromNodeConfig)
 
 proc getFleetAsString*(self: Service): string =
   result = $self.getFleet()
@@ -148,7 +148,7 @@ proc setFleet*(self: Service, fleet: string): bool =
     error "error saving fleet ", procName="setFleet"
     return false
   
-  let fleetType = parseEnum[Fleet](fleet)
+  let fleetType = fleetFromString(fleet)
   var newConfiguration = self.configuration
   newConfiguration.ClusterConfig.Fleet = fleet
   newConfiguration.ClusterConfig.BootNodes = self.fleetConfiguration.getNodes(fleetType, FleetNodes.Bootnodes)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -18,7 +18,7 @@ export stickers_dto
 # Default values:
 const DEFAULT_CURRENCY* = "USD"
 const DEFAULT_TELEMETRY_SERVER_URL* = "https://telemetry.status.im"
-const DEFAULT_FLEET* = $Fleet.ShardsTest
+const DEFAULT_FLEET* = Fleet.ShardsTest
 
 # Signals:
 const SIGNAL_CURRENCY_UPDATED* = "currencyUpdated"
@@ -398,7 +398,7 @@ QtObject:
 
   proc getFleet*(self: Service): Fleet =
     let fleetAsString = self.getFleetAsString()
-    return parseEnum[Fleet](fleetAsString)
+    return fleetFromString(fleetAsString)
 
   proc getCurrentUserStatus*(self: Service): CurrentUserStatus =
     self.settings.currentUserStatus
@@ -413,6 +413,8 @@ QtObject:
     return ""
 
   proc pinMailserver*(self: Service, mailserverID: string, fleet: Fleet): bool =
+    if fleet == Fleet.Undefined:
+      return false
     var newMailserverJsonObj = self.settings.pinnedMailserver.pinnedMailserverToJsonNode()
     newMailserverJsonObj[$fleet] = %* mailserverID
     if(self.saveSetting(KEY_PINNED_MAILSERVERS, newMailserverJsonObj)):


### PR DESCRIPTION
Requires https://github.com/status-im/status-go/pull/4785

### What does the PR do

1. Update status-go to get https://github.com/status-im/status-go/pull/4785
2. Implement custom `fleetFromString` function to prevent panic for unknown enum values
3. Added `import readline` to `scripts/open_database.py`. This just improves the work of the script. Don't think it's worth a separate PR 😄 

### Screenshot of functionality

Tested with 2 cases:

1. case 1
- setup a new account with 0.14.0
- migrate to 2.27

2. case 2
- setup a new account with 0.14.0
- switch to `waku.test` fleet
- switch back to `status.prod` fleet 
(this is required for `status.prod` to appear in settings)
⚠️ Then this fix actually starts to work. If the `settings.fleet` is empty, `1701961850_shards_test.up.sql` migration does the job.

In both cases I end up with no crash and `shards.test` fleet.
