### PR TITLE
fix(async_tasks): add try catch to getChannelGroups async task

### DIFF
--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -6,13 +6,18 @@ type
 
 const asyncGetChannelGroupsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetChannelGroupsTaskArg](argEncoded)
+  try:
+    let response = status_chat.getChannelGroups()
 
-  let response = status_chat.getChannelGroups()
-
-  let responseJson = %*{
-    "channelGroups": response.result
-  }
-  arg.finish(responseJson)
+    let responseJson = %*{
+      "channelGroups": response.result,
+      "error": "",
+    }
+    arg.finish(responseJson)
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })
 
 type
   AsyncCheckChannelPermissionsTaskArg = ref object of QObjectTaskArg

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -240,6 +240,9 @@ QtObject:
     try:
       let rpcResponseObj = response.parseJson
 
+      if (rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != ""):
+        raise newException(CatchableError, rpcResponseObj{"error"}.getStr)
+
       if(rpcResponseObj["channelGroups"].kind == JNull):
         raise newException(RpcException, "No channel groups returned")
 


### PR DESCRIPTION
Kind of fixes #13640

The issue itself was no reproducible even after dozens of restarts and following of the repro steps. It seems like this was an unfortunate DB close event that caused the app to close.

Adding a try catch won't actually fix that, since the DB is closed and also the `communtiies`already had a try/catch, but it will help for later.