### PR TITLE
ci: make release param defaulted to True

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -19,7 +19,7 @@ pipeline {
     booleanParam(
       name: 'RELEASE',
       description: 'Decides whether binaries are built with debug symbols.',
-      defaultValue: params.RELEASE ?: false
+      defaultValue: params.RELEASE ?: true
     )
     choice(
       name: 'VERBOSE',


### PR DESCRIPTION
### What does the PR do

Default Linux build to be built with Release flag = True

### Affected areas

`ci/Jenkinsfile.linux`