### PR TITLE
fix(savedaddresses): saved addresses should be displayed in mixed cases format

### DIFF
--- a/src/app/modules/main/wallet_section/saved_addresses/item.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/item.nim
@@ -6,6 +6,7 @@ type
   Item* = object
     name: string
     address: string
+    mixedcaseAddress: string
     ens: string
     colorId: string
     chainShortNames: string
@@ -14,6 +15,7 @@ type
 proc initItem*(
   name: string,
   address: string,
+  mixedcaseAddress: string,
   ens: string,
   colorId: string,
   chainShortNames: string,
@@ -21,6 +23,7 @@ proc initItem*(
 ): Item =
   result.name = name
   result.address = address
+  result.mixedcaseAddress = mixedcaseAddress
   result.ens = ens
   result.colorId = colorId
   result.chainShortNames = chainShortNames
@@ -30,6 +33,7 @@ proc `$`*(self: Item): string =
   result = fmt"""SavedAddressItem(
     name: {self.name},
     address: {self.address},
+    mixedcaseAddress: {self.mixedcaseAddress},
     ens: {self.ens},
     colorId: {self.colorId},
     chainShortNames: {self.chainShortNames},
@@ -47,6 +51,9 @@ proc getEns*(self: Item): string =
 
 proc getAddress*(self: Item): string =
   return self.address
+
+proc getMixedcaseAddress*(self: Item): string =
+  return self.mixedcaseAddress
 
 proc getColorId*(self: Item): string =
   return self.colorId

--- a/src/app/modules/main/wallet_section/saved_addresses/model.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/model.nim
@@ -9,6 +9,7 @@ type
   ModelRole {.pure.} = enum
     Name = UserRole + 1,
     Address
+    MixedcaseAddress
     Ens
     ColorId
     ChainShortNames
@@ -51,6 +52,7 @@ QtObject:
     {
       ModelRole.Name.int:"name",
       ModelRole.Address.int:"address",
+      ModelRole.MixedcaseAddress.int:"mixedcaseAddress",
       ModelRole.Ens.int:"ens",
       ModelRole.ColorId.int:"colorId",
       ModelRole.ChainShortNames.int:"chainShortNames",
@@ -72,6 +74,8 @@ QtObject:
       result = newQVariant(item.getName())
     of ModelRole.Address:
       result = newQVariant(item.getAddress())
+    of ModelRole.MixedcaseAddress:
+      result = newQVariant(item.getMixedcaseAddress())
     of ModelRole.Ens:
       result = newQVariant(item.getEns())
     of ModelRole.ColorId:

--- a/src/app/modules/main/wallet_section/saved_addresses/module.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/module.nim
@@ -36,6 +36,7 @@ method loadSavedAddresses*(self: Module) =
     savedAddresses.map(s => initItem(
       s.name,
       s.address,
+      s.mixedcaseAddress,
       s.ens,
       s.colorId,
       s.chainShortNames,

--- a/src/app_service/service/saved_address/dto.nim
+++ b/src/app_service/service/saved_address/dto.nim
@@ -6,6 +6,7 @@ type
   SavedAddressDto* = ref object of RootObj
     name*: string
     address*: string
+    mixedcaseAddress*: string
     ens*: string
     colorId*: string
     chainShortNames*: string
@@ -17,6 +18,7 @@ proc toSavedAddressDto*(jsonObj: JsonNode): SavedAddressDto =
   result = SavedAddressDto()
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("address", result.address)
+  discard jsonObj.getProp("mixedcaseAddress", result.mixedcaseAddress)
   discard jsonObj.getProp("ens", result.ens)
   discard jsonObj.getProp("colorId", result.colorId)
   result.colorId = result.colorId.toUpper() # to match `preDefinedWalletAccountColors` on the qml side
@@ -29,6 +31,7 @@ proc toJsonNode*(self: SavedAddressDto): JsonNode =
   result = %* {
     "name": self.name,
     "address": self.address,
+    "mixedcaseAddress": self.mixedcaseAddress,
     "ens": self.ens,
     "colorId": self.colorId,
     "chainShortNames": self.chainShortNames,

--- a/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
@@ -143,7 +143,7 @@ ColumnLayout {
             id: savedAddressDelegate
             objectName: "savedAddressView_Delegate_" + name
             name: model.name
-            address: model.address
+            address: model.mixedcaseAddress
             chainShortNames: model.chainShortNames
             ens: model.ens
             colorId: model.colorId


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/4791

Fixes #13665