### PR TITLE
StatusQ(LeftJoinModel): Handling of `layoutChanged` emitted by source models fixed

### DIFF
--- a/ui/StatusQ/include/StatusQ/leftjoinmodel.h
+++ b/ui/StatusQ/include/StatusQ/leftjoinmodel.h
@@ -60,4 +60,8 @@ private:
     bool m_initialized = false;
 
     mutable QPersistentModelIndex m_lastUsedRightModelIndex;
+
+    // helpers for handling layoutChanged from source
+    QList<QPersistentModelIndex> m_layoutChangePersistentIndexes;
+    QModelIndexList m_proxyIndexes;
 };

--- a/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.cpp
@@ -10,6 +10,8 @@ PersistentIndexesTester::PersistentIndexesTester(QAbstractItemModel* model)
     storeIndexesAndData();
 }
 
+PersistentIndexesTester::~PersistentIndexesTester() = default;
+
 void PersistentIndexesTester::storeIndexesAndData()
 {
     if (m_model == nullptr) {

--- a/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.h
+++ b/ui/StatusQ/tests/src/TestHelpers/persistentindexestester.h
@@ -19,6 +19,7 @@ class PersistentIndexesTester
 {
 public:
     explicit PersistentIndexesTester(QAbstractItemModel* model);
+    ~PersistentIndexesTester();
 
     void storeIndexesAndData();
     bool compare();

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
@@ -1,5 +1,6 @@
 #include "testmodel.h"
 
+#include <algorithm>
 
 TestModel::TestModel(QList<QPair<QString, QVariantList>> data)
     : m_data(std::move(data))
@@ -80,6 +81,22 @@ void TestModel::remove(int index)
     }
 
     endRemoveRows();
+}
+
+void TestModel::invert()
+{
+    emit layoutAboutToBeChanged();
+
+    for (auto& entry : m_data)
+        std::reverse(entry.second.begin(), entry.second.end());
+
+    const auto persistentIndexes = persistentIndexList();
+    const auto count = rowCount();
+
+    for (const QModelIndex& index: persistentIndexes)
+        changePersistentIndex(index, createIndex(count - index.row() - 1, 0));
+
+    emit layoutChanged();
 }
 
 void TestModel::initRoles()

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.h
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.h
@@ -8,13 +8,16 @@ public:
     explicit TestModel(QList<QPair<QString, QVariantList>> data);
     explicit TestModel(QList<QString> roles);
 
-    int rowCount(const QModelIndex& parent) const override;
+    int rowCount(const QModelIndex& parent = {}) const override;
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
 
     void insert(int index, QVariantList row);
     void update(int index, int role, QVariant value);
     void remove(int index);
+
+    // inverts order of items, emits layoutAboutToBeChanged / layoutChanged
+    void invert();
 
 private:
     void initRoles();


### PR DESCRIPTION
### What does the PR do

It fixes 2 issues in `LeftJoinModel`:
- When left model emitted `layoutAboutToBeChanged`/`layoutChanged`, `LeftJoinModel` didn't update own persistent indexes properly leading to segfault in worst case.
- When right model emitted `layoutChanged`, `LeftJoinModel` was emitting `dataChanged` unnecesarily
- both scenarios covered with tests

Moreover:
- small extension to `TestModel` allowing testing behavior on layoutChanged emitted from source model.

### Affected areas
`LeftJoinModel`