### PR TITLE
fix: 150% and 200% zoom levels prevent the user from logging in

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml
@@ -1,44 +1,26 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-
-import utils 1.0
+import QtQuick 2.15
+import QtQml.Models 2.15
 
 import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Popups.Dialog 0.1
 
-import shared 1.0
-import shared.panels 1.0
-import shared.popups 1.0
-
-// TODO: replace with StatusModal
-ModalPopup {
-    height: 237
-    width: 400
-
-    property Popup parentPopup
-
+StatusDialog {
+    id: root
     title: qsTr("Application Restart")
 
-    StyledText {
+    contentItem: StatusBaseText {
         text: qsTr("Please restart the application to apply the changes.")
-        font.pixelSize: 15
-        anchors.left: parent.left
-        anchors.right: parent.right
         wrapMode: Text.WordWrap
     }
 
-    footer: Item {
-        id: footerContainer
-        width: parent.width
-        height: children[0].height
-
-        StatusButton {
-            anchors.right: parent.right
-            anchors.rightMargin: Style.current.smallPadding
-            type: StatusBaseButton.Type.Danger
-            text: qsTr("Restart")
-            anchors.bottom: parent.bottom
-            onClicked: Utils.restartApplication();
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusButton {
+                type: StatusBaseButton.Type.Danger
+                text: qsTr("Restart")
+                onClicked: root.accepted()
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/LanguageView.qml
+++ b/ui/app/AppLayouts/Profile/views/LanguageView.qml
@@ -189,13 +189,12 @@ SettingsContentBase {
             sourceComponent: ConfirmationDialog {
                 headerSettings.title: qsTr("Change language")
                 confirmationText: qsTr("Display language has been changed. You must restart the application for changes to take effect.")
-                confirmButtonLabel: qsTr("Close the app now")
+                confirmButtonLabel: qsTr("Restart")
                 onConfirmButtonClicked: {
                     languageConfirmationDialog.active = false
-                    Qt.quit()
+                    Utils.restartApplication()
                 }
             }
         }
     }
 }
-

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -1,11 +1,11 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import Qt.labs.platform 1.1
-import Qt.labs.settings 1.0
-import QtQuick.Window 2.12
-import QtQml 2.13
-import QtQuick.Controls.Universal 2.12
+import Qt.labs.settings 1.1
+import QtQuick.Window 2.15
+import QtQml 2.15
+import QtQuick.Controls.Universal 2.15
 
 import utils 1.0
 import shared 1.0
@@ -25,8 +25,8 @@ StatusWindow {
 
     id: applicationWindow
     objectName: "mainWindow"
-    minimumWidth: 1200
-    minimumHeight: 680
+    minimumWidth: 1200 / Screen.devicePixelRatio
+    minimumHeight: 680 / Screen.devicePixelRatio
     color: Style.current.background
     title: {
         // Set application settings


### PR DESCRIPTION
### What does the PR do

The long story:
- since Qt treats the various scale factors in a multiplicative way (see https://www.qt.io/blog/2016/01/26/high-dpi-support-in-qt-5-6 for explanation) and there's no way to get the screen's baseline scale factor programatically, we also have to export `QT_SCREEN_SCALE_FACTORS` to something that's not equal to `0` or `1` to force the monitor scale factor to `100%` and then compensate for it when exporting our own scale
value using `QT_SCALE_FACTOR`
- make the UI slider values go in `25%` steps, allowing for more fine grained control; with `100%` we fallback to the Qt's native handling of highdpi 
- raised the maximum to `300%` since on highres displays, one wouldn't be able to go over the implicit maximum of `200%` (due to the internal scaling being 2x)
- scale our main window's minimum width/height so that we don't overflow the monitor's available space
- modernize the `ConfirmAppRestartModal` to use `StatusDialog`
- use the new `Utils.restartApplication()` when changing the UI language as well
- remove some dead code

In the (very) long term, we should take a different approach of scaling our app independently of Qt, just taking the monitor `Screen.devicePixelRatio` into account, similar to what other apps like Telegram do

Fixes #13484

### Affected areas

AppearanceView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-02-23 09-34-50.webm](https://github.com/status-im/status-desktop/assets/5377645/481eff26-b6cf-4470-b880-f6aabe934da6)
