### PR TITLE
(desktop/fix) Fix Owner token holder representation

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -50,6 +50,7 @@ StackView {
 
     // Models:
     property var tokensModel
+    property var membersModel
     property var accounts // Expected roles: address, name, color, emoji, walletType
     required property var referenceAssetsBySymbolModel
 
@@ -481,6 +482,7 @@ StackView {
         property TokenObject token: TokenObject {}
         readonly property bool deploymentFailed: view.deployState === Constants.ContractTransactionStatus.Failed
 
+        property var membersModel
         property var tokenOwnersModel
         property string airdropKey
         // Owner and TMaster related props
@@ -547,7 +549,9 @@ StackView {
             viewWidth: root.viewWidth
 
             token: tokenViewPage.token
+            membersModel: tokenViewPage.membersModel
             tokenOwnersModel: tokenViewPage.tokenOwnersModel
+            isOwnerTokenItem: tokenViewPage.isOwnerTokenItem
 
             onGeneralAirdropRequested: {
                 root.airdropToken(view.airdropKey,
@@ -942,6 +946,7 @@ StackView {
                     anchors.fill: parent
 
                     tokenOwnersModel: model.tokenOwnersModel
+                    membersModel: root.membersModel
                     airdropKey: model.symbol // TO BE REMOVED: When airdrop backend is ready to use token key instead of symbol
 
                     token.privilegesLevel: model.privilegesLevel

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -349,6 +349,7 @@ StatusSectionLayout {
 
             // Models
             tokensModel: root.community.communityTokens
+            membersModel: root.community.members
             layer1Networks: communityTokensStore.layer1Networks
             layer2Networks: communityTokensStore.layer2Networks
             enabledNetworks: communityTokensStore.enabledNetworks


### PR DESCRIPTION
### Description

Fix #12065 token owner presentation in Token section by displaying the owner token holder as contact

### What does the PR do

Fetch the contactDetails for the token owner found in the tokenOwnerModel.

### Affected areas

MintedTokenView page

### Screenshot of functionality (including design for comparison)

Figma:
![Screenshot from 2023-09-01 13-27-18](https://github.com/status-im/status-desktop/assets/20650004/d8306dfd-66bf-42cb-b253-5dc9b3ec9964)

The following match the UI expectations

![Screenshot from 2024-02-25 14-58-20](https://github.com/status-im/status-desktop/assets/2589171/451a3adf-917f-4c65-8682-b9068e2d5989)
![Screenshot from 2024-02-25 14-58-10](https://github.com/status-im/status-desktop/assets/2589171/8d877485-8f9c-41f1-82cf-016f2278eb97)

