### PR TITLE
StatusQ(WritableProxyModel): Handling of layoutChanged/rowsMoved from source models fixed

### DIFF
--- a/ui/StatusQ/include/StatusQ/writableproxymodel.h
+++ b/ui/StatusQ/include/StatusQ/writableproxymodel.h
@@ -88,8 +88,9 @@ private:
     void onModelReset();
     void onLayoutAboutToBeChanged(const QList<QPersistentModelIndex>& sourceParents, QAbstractItemModel::LayoutChangeHint hint);
     void onLayoutChanged(const QList<QPersistentModelIndex>& sourceParents, QAbstractItemModel::LayoutChangeHint hint);
+    void onRowsAboutToBeMoved(const QModelIndex& sourceParent, int sourceStart, int sourceEnd, const QModelIndex& destinationParent, int destinationRow);
     void onRowsMoved(const QModelIndex& sourceParent, int sourceStart, int sourceEnd, const QModelIndex& destinationParent, int destinationRow);
-    
+
     QScopedPointer<WritableProxyModelPrivate> d;
     friend class WritableProxyModelPrivate;
 };


### PR DESCRIPTION
### What does the PR do

1. Fixes improper intermediate state on move (`onRowsAboutToBeMoved` handler), added test covering this case
2. Added proper handling of layoutAboutToBeChanged/layoutChanged (also for move operation)

Closes: #13601

### Affected areas
`WritableProxyModel`