### PR TITLE
feat(Profile flow) Mark as ID verified / remove verification

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -149,6 +149,16 @@ SplitView {
                     logs.logEvent("rootStore::contactStore::removeContact", ["publicKey"], arguments)
                     ctrlContactRequestState.currentIndex = ctrlContactRequestState.indexOfValue(Constants.ContactRequestState.None)
                 }
+
+                function verifiedTrusted(publicKey) {
+                    logs.logEvent("rootStore::contactStore::verifiedTrusted", ["publicKey"], arguments)
+                    ctrlTrustStatus.currentIndex = ctrlTrustStatus.indexOfValue(Constants.trustStatus.trusted)
+                }
+
+                function removeTrustStatus(publicKey) {
+                    logs.logEvent("rootStore::contactStore::removeTrustStatus", ["publicKey"], arguments)
+                    ctrlTrustStatus.currentIndex = ctrlTrustStatus.indexOfValue(Constants.trustStatus.unknown)
+                }
             }
         }
         communityTokensStore: CommunityTokensStore {}
@@ -244,6 +254,7 @@ SplitView {
 
                             function verifiedTrusted(publicKey) {
                                 logs.logEvent("contactsStore::verifiedTrusted", ["publicKey"], arguments)
+                                ctrlTrustStatus.currentIndex = ctrlTrustStatus.indexOfValue(Constants.trustStatus.trusted)
                             }
 
                             function getLinkToProfile(publicKey) {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -102,7 +102,7 @@ Button {
         case StatusBaseButton.Size.Tiny:
             return 5
         case StatusBaseButton.Size.Small:
-            return 10
+            return 8
         case StatusBaseButton.Size.Large:
         default:
             return 11

--- a/ui/imports/shared/popups/CommonContactDialog.qml
+++ b/ui/imports/shared/popups/CommonContactDialog.qml
@@ -27,12 +27,15 @@ StatusDialog {
     readonly property string optionalDisplayName: ProfileUtils.displayName("", contactDetails.name, contactDetails.displayName, contactDetails.alias)
 
     width: 480
-    horizontalPadding: 16
-    verticalPadding: 20
+    horizontalPadding: 0
+    topPadding: 20
+    bottomPadding: 0
 
     contentItem: ColumnLayout {
         RowLayout {
             Layout.fillWidth: true
+            Layout.leftMargin: Style.current.padding
+            Layout.rightMargin: Style.current.padding
             spacing: Style.current.padding
 
             UserImage {
@@ -114,12 +117,21 @@ StatusDialog {
 
         StatusDialogDivider {
             Layout.fillWidth: true
-            Layout.topMargin: 15
-            Layout.bottomMargin: 15
+            Layout.topMargin: Style.current.padding
+            Layout.leftMargin: Style.current.padding
+            Layout.rightMargin: Style.current.padding
         }
 
-        ColumnLayout {
-            id: contentLayout
+        StatusScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            contentWidth: availableWidth
+            id: scrollView
+
+            ColumnLayout {
+                width: scrollView.availableWidth
+                id: contentLayout
+            }
         }
     }
 

--- a/ui/imports/shared/popups/MarkAsIDVerifiedDialog.qml
+++ b/ui/imports/shared/popups/MarkAsIDVerifiedDialog.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import utils 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+
+CommonContactDialog {
+    id: root
+
+    title: qsTr("Mark as ID verified")
+
+    StatusBaseText {
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+        text: qsTr("Mark users as ID verified only if you’re 100% sure who they are. Otherwise, it’s safer to send %1 an ID verification request.").arg(mainDisplayName)
+    }
+
+    rightButtons: ObjectModel {
+        StatusFlatButton {
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
+        StatusButton {
+            text: qsTr("Mark as ID verified")
+            onClicked: root.accepted()
+        }
+    }
+}

--- a/ui/imports/shared/popups/RemoveIDVerificationDialog.qml
+++ b/ui/imports/shared/popups/RemoveIDVerificationDialog.qml
@@ -1,0 +1,47 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import utils 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+
+CommonContactDialog {
+    id: root
+
+    readonly property bool markAsUntrusted: ctrlMarkAsUntrusted.checked
+    readonly property bool removeContact: ctrlRemoveContact.checked
+
+    title: qsTr("Remove ID verification")
+
+    StatusBaseText {
+        Layout.fillWidth: true
+        Layout.bottomMargin: Style.current.halfPadding
+        wrapMode: Text.WordWrap
+        text: qsTr("%1’s identity will no longer be verified. This is only visible to you.").arg(mainDisplayName)
+    }
+
+    StatusCheckBox {
+        id: ctrlMarkAsUntrusted
+        text: qsTr("Mark %1 as untrusted").arg(mainDisplayName)
+    }
+
+    StatusCheckBox {
+        id: ctrlRemoveContact
+        text: qsTr("Remove contact")
+    }
+
+    rightButtons: ObjectModel {
+        StatusFlatButton {
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
+        StatusButton {
+            type: StatusBaseButton.Type.Danger
+            text: qsTr("Remove ID verification")
+            onClicked: root.accepted()
+        }
+    }
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -29,3 +29,5 @@ ConfirmExternalLinkPopup 1.0 ConfirmExternalLinkPopup.qml
 CommunityAssetsInfoPopup 1.0 CommunityAssetsInfoPopup.qml
 MarkAsUntrustedPopup 1.0 MarkAsUntrustedPopup.qml
 RemoveContactPopup 1.0 RemoveContactPopup.qml
+MarkAsIDVerifiedDialog 1.0 MarkAsIDVerifiedDialog.qml
+RemoveIDVerificationDialog 1.0 RemoveIDVerificationDialog.qml

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -79,6 +79,7 @@ StatusMenu {
 
     readonly property bool userTrustIsUnknown: contactDetails && contactDetails.trustStatus === Constants.trustStatus.unknown
     readonly property bool userIsUntrustworthy: contactDetails && contactDetails.trustStatus === Constants.trustStatus.untrustworthy
+    readonly property bool userIsLocallyTrusted: contactDetails && contactDetails.trustStatus === Constants.trustStatus.trusted
 
     signal openProfileClicked(string publicKey)
     signal createOneToOneChat(string communityId, string chatId, string ensName)
@@ -152,13 +153,20 @@ StatusMenu {
         objectName: "verifyIdentity_StatusItem"
         icon.name: "checkmark-circle"
         enabled: !root.isMe && root.isContact
-                                && !root.isBlockedContact
-                                && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
-                                && !root.hasActiveReceivedVerificationRequestFrom
-                                && !root.isBridgedAccount
+                 && !root.isBlockedContact
+                 && !root.userIsLocallyTrusted
+                 && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
+                 && !root.hasActiveReceivedVerificationRequestFrom
+                 && !root.isBridgedAccount
         onTriggered: Global.openSendIDRequestPopup(root.selectedUserPublicKey, root.contactDetails, null)
     }
-    // TODO Mark as ID verified
+    StatusAction {
+        text: qsTr("Mark as ID verified")
+        objectName: "markAsVerified_StatusItem"
+        icon.name: "checkmark-circle"
+        enabled: !root.isMe && root.isContact && !root.isBridgedAccount && !root.isBlockedContact && !(root.isTrusted || root.userIsLocallyTrusted)
+        onTriggered: Global.openMarkAsIDVerifiedPopup(root.selectedUserPublicKey, root.contactDetails, null)
+    }
     StatusAction {
         id: pendingIdentityAction
         objectName: "pendingIdentity_StatusItem"
@@ -214,7 +222,14 @@ StatusMenu {
         onTriggered: Global.unblockContactRequested(root.selectedUserPublicKey, root.contactDetails)
     }
 
-    // TODO Remove ID verification + confirmation dialog
+    StatusAction {
+        objectName: "removeIDVerification_StatusItem"
+        text: qsTr("Remove ID verification")
+        icon.name: "delete"
+        type: StatusAction.Type.Danger
+        enabled: !root.isMe && root.isContact && !root.isBridgedAccount && (root.isTrusted || root.userIsLocallyTrusted)
+        onTriggered: Global.openRemoveIDVerificationDialog(root.selectedUserPublicKey, root.contactDetails, null)
+    }
 
     StatusAction {
         id: markUntrustworthyMenuItem

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -39,6 +39,8 @@ QtObject {
     signal openProfilePopupRequested(string publicKey, var parentPopup, var cb)
     signal openActivityCenterPopupRequested()
     signal openSendIDRequestPopup(string publicKey, var contactDetails, var cb)
+    signal openMarkAsIDVerifiedPopup(string publicKey, var contactDetails, var cb)
+    signal openRemoveIDVerificationDialog(string publicKey, var contactDetails, var cb)
     signal openContactRequestPopup(string publicKey, var contactDetails, var cb)
     signal markAsUntrustedRequested(string publicKey, var contactDetails)
     signal removeContactRequested(string publicKey, var contactDetails)


### PR DESCRIPTION
> [!NOTE]
> This won't work directly in the app as of now, needs the appropriate backend: https://github.com/status-im/status-desktop/issues/13716

### What does the PR do

- implement two new actions and popups to directly mark a contact as "ID verified" and remove the verification thereof respectively
- do not hardcode the secondary button inside ProfileDialogView and make it a Loader
- make the CommonContactDialog contents scrollable

Fixes #13711

### Affected areas

ProfileDialogView, ProfileContextMenu

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Optional secondary button for a contact ("Request ID verification):
![image](https://github.com/status-im/status-desktop/assets/5377645/a6e7f258-4972-49a0-95f3-0775b03bc223)

Mark as ID verified popup:
![image](https://github.com/status-im/status-desktop/assets/5377645/1b273dc1-e67d-430c-8d97-925a3fd838ef)

ID verified + action to remove:
![image](https://github.com/status-im/status-desktop/assets/5377645/7c9cb180-3ed9-477c-9e81-021d9f3ef032)

Popup to remove the ID verified status (+ optionally mark as untrusted or remove the contact):
![image](https://github.com/status-im/status-desktop/assets/5377645/6ce6f3e6-7301-4983-b19f-40fecbcf4207)
