### PR TITLE
chore: remove pokt goerli

### DIFF
--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -22,8 +22,8 @@ var NETWORKS* = %* [
   {
     "chainId": 5,
     "chainName": "Mainnet",
-    "rpcUrl": "https://goerli-archival.rpc.grove.city/v1/" & POKT_TOKEN_RESOLVED,
-    "fallbackUrl": "https://goerli.infura.io/v3/" & INFURA_TOKEN_RESOLVED,
+    "rpcUrl": "https://goerli.infura.io/v3/" & INFURA_TOKEN_RESOLVED,
+    "fallbackUrl": "",
     "blockExplorerUrl": "https://goerli.etherscan.io/",
     "iconUrl": "network/Network=Ethereum",
     "chainColor": "#627EEA",


### PR DESCRIPTION
Make goerli only via infura and no fallback as a result of POKT removing support for goerli next week