### PR TITLE
fix(community_tokens): ignore wallet events from watch only accounts

### DIFF
--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -334,6 +334,12 @@ QtObject:
     try:
       let dataMessageJson = parseJson(jsonMessage)
       let tokenDataPayload = fromJson(dataMessageJson, CommunityCollectiblesReceivedPayload)
+
+      let watchOnlyAccounts = self.walletAccountService.getWatchOnlyAccounts()
+      if any(watchOnlyAccounts, proc (x: WalletAccountDto): bool = x.address == accounts[0]):
+        # skip events on watch-only accounts
+        return
+
       for coll in tokenDataPayload.collectibles:
         if not coll.communityData.isSome():
           continue
@@ -404,6 +410,11 @@ QtObject:
       let dataMessageJson = parseJson(jsonMessage)
       let tokenDataPayload = fromJson(dataMessageJson, CommunityTokenReceivedPayload)
       if len(tokenDataPayload.communityId) == 0:
+        return
+
+      let watchOnlyAccounts = self.walletAccountService.getWatchOnlyAccounts()
+      if any(watchOnlyAccounts, proc (x: WalletAccountDto): bool = x.address == accounts[0]):
+        # skip events on watch-only accounts
         return
 
       var accountName, accountAddress: string


### PR DESCRIPTION
Fixes #13407

We were processing all wallet events received as if they were from us, so I skip the ones from watch only accounts.

I assumed that `accounts` always contains one address (it seems it's assumed as such in the code later too). Let me know if that's now the case and I'll make it smarter if needed.