### PR TITLE
feat(wallet): naming of first and subsequent wallet accounts

### DIFF
--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -132,6 +132,9 @@ proc getKeypairs*(self: Controller): seq[KeypairDto] =
 proc getKeypairByKeyUid*(self: Controller, keyUid: string): KeypairDto =
   return self.walletAccountService.getKeypairByKeyUid(keyUid)
 
+proc getIndexForNextAccountNameSuggestion*(self: Controller): int =
+  return wallet_account_service.getIndexForNextAccountNameSuggestion()
+
 proc getSavedAddress*(self: Controller, address: string): SavedAddressDto =
   return self.savedAddressService.getSavedAddress(address)
 

--- a/src/app/modules/shared_modules/add_account/io_interface.nim
+++ b/src/app/modules/shared_modules/add_account/io_interface.nim
@@ -107,6 +107,9 @@ method removingSavedAddressConfirmed*(self: AccessInterface, address: string) {.
 method savedAddressDeleted*(self: AccessInterface, address: string, errorMsg: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getIndexForNextAccountNameSuggestion*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   DelegateInterface* = concept c
     c.onAddAccountModuleLoaded()

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -352,6 +352,9 @@ proc isAuthenticationNeededForSelectedOrigin[T](self: Module[T]): bool =
     return false
   return true
 
+method getIndexForNextAccountNameSuggestion*[T](self: Module[T]): int =
+  return self.controller.getIndexForNextAccountNameSuggestion()
+
 method changeDerivationPath*[T](self: Module[T], derivationPath: string) =
   self.view.setDerivationPath(derivationPath)
   if self.isAuthenticationNeededForSelectedOrigin():

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -363,3 +363,6 @@ QtObject:
 
   proc removingSavedAddressRejected*(self: View) {.slot.} =
     self.setDisablePopup(false)
+
+  proc getIndexForNextAccountNameSuggestion*(self: View): int {.slot.} =
+    return self.delegate.getIndexForNextAccountNameSuggestion()

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -25,6 +25,7 @@ export dto_generated_accounts
 logScope:
   topics = "accounts-service"
 
+const DEFAULT_WALLET_ACCOUNT_NAME = "Account 1"
 const PATHS = @[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET, PATH_ENCRYPTION]
 const ACCOUNT_ALREADY_EXISTS_ERROR* =  "account already exists"
 const KDF_ITERATIONS* {.intdefine.} = 256_000
@@ -240,7 +241,7 @@ QtObject:
         "colorId": DEFAULT_COLORID_FOR_DEFAULT_WALLET_ACCOUNT,
         "wallet": true,
         "path": PATH_DEFAULT_WALLET,
-        "name": "Status account",
+        "name": DEFAULT_WALLET_ACCOUNT_NAME,
         "derived-from": account.address,
         "emoji": self.defaultWalletEmoji
       },
@@ -493,7 +494,7 @@ QtObject:
           "colorId": DEFAULT_COLORID_FOR_DEFAULT_WALLET_ACCOUNT,
           "wallet": true,
           "path": PATH_DEFAULT_WALLET,
-          "name": "Status account",
+          "name": DEFAULT_WALLET_ACCOUNT_NAME,
           "derived-from": address,
           "emoji": self.defaultWalletEmoji,
         },

--- a/src/app_service/service/wallet_account/utils.nim
+++ b/src/app_service/service/wallet_account/utils.nim
@@ -66,6 +66,15 @@ proc getKeypairByKeyUidFromDb(keyUid: string): KeypairDto =
   except Exception as e:
     info "no known keypair", keyUid=keyUid, procName="getKeypairByKeyUid", errName = e.name, errDesription = e.msg
 
+proc getIndexForNextAccountNameSuggestion*(): int =
+  try:
+    let response = status_go_accounts.getIndexForNextAccountNameSuggestion()
+    if not response.error.isNil:
+      return
+    return response.result.getInt
+  except Exception as e:
+    error "error: ", procName="getIndexForNextAccountNameSuggestion", errName = e.name, errDesription = e.msg
+
 proc getEnsName(address: string, chainId: int): string =
   try:
     let response = backend.getName(chainId, address)

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -28,6 +28,9 @@ proc getWatchOnlyAccounts*(): RpcResponse[JsonNode] {.raises: [Exception].} =
 proc getKeypairs*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   return core.callPrivateRPC("accounts_getKeypairs")
 
+proc getIndexForNextAccountNameSuggestion*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  return core.callPrivateRPC("accounts_getIndexForNextAccountNameSuggestion")
+
 proc getKeypairByKeyUid*(keyUid: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [keyUid]
   return core.callPrivateRPC("accounts_getKeypairByKeyUID", payload)

--- a/test/ui-test/src/constants/wallet.py
+++ b/test/ui-test/src/constants/wallet.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from enum import Enum
 
-DEFAULT_ACCOUNT_NAME = 'Status account'
+DEFAULT_ACCOUNT_NAME = 'Account 1'
 
 account_list_item = namedtuple('AccountListItem', ['name', 'color', 'emoji'])
 

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
@@ -15,7 +15,7 @@ Feature: Status Desktop Wallet Section Wallet Account Management
         Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
         Examples:
             | name           | new_name         | new_color | new_emoji  | new_emoji_unicode |
-            | Status account | MyPrimaryAccount | 216266    | sunglasses | 1f60e             |
+            | Account 1 | MyPrimaryAccount | 216266    | sunglasses | 1f60e             |
 
     	Scenario Outline: The user can add, edit and remove a watch only account
         When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>"

--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -34,12 +34,15 @@ Item {
             root.store.addAccountModule.selectedEmoji = StatusQUtils.Emoji.getRandomEmoji(StatusQUtils.Emoji.size.verySmall)
         }
 
-        accountName.text = root.store.addAccountModule.accountName
         if (d.isEdit) {
+            accountName.placeholderText = qsTr("Enter an account name...")
+            accountName.text = root.store.addAccountModule.accountName
             accountName.input.asset.emoji = root.store.addAccountModule.selectedEmoji;
         } else {
+            accountName.placeholderText = root.store.getNextAccountNameSuggestion()
             accountName.input.asset.isLetterIdenticon = true;
         }
+        accountName.input.edit.cursorPosition = accountName.text.length
         accountName.input.edit.forceActiveFocus()
         accountName.validate(true)
     }
@@ -102,7 +105,6 @@ Item {
                 id: accountName
                 objectName: "AddAccountPopup-AccountName"
                 anchors.horizontalCenter: parent.horizontalCenter
-                placeholderText: qsTr("Enter an account name...")
                 label: qsTr("Name")
                 charLimit: 20
                 text: root.store.addAccountModule.accountName

--- a/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
+++ b/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
@@ -75,6 +75,11 @@ BasePopupStore {
         return root.addAccountModule.getStoredAccountName()
     }
 
+    function getNextAccountNameSuggestion() {
+        let index = root.addAccountModule.getIndexForNextAccountNameSuggestion()
+        return qsTr("Account %1").arg(index)
+    }
+
     function getStoredSelectedEmoji() {
         return root.addAccountModule.getStoredSelectedEmoji()
     }


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/4811

Closes #12693

In the video below we can see the account naming suggestion behavior, which increments for any new account. Also we can see that name indexing differs from derivation path indexing (derivation path indexing fills empty paths). 

In the desktop app wallet account name suggestion "Account XX" is translatable.

https://github.com/status-im/status-desktop/assets/86303051/18e514c1-28e3-445f-9ac6-cd50722c1eb1


