### PR TITLE
fix(wallet): Fix missing 'Community minted' section in AssetsView

### DIFF
--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -233,6 +233,7 @@ ColumnLayout {
         id: sectionDelegate
         AssetsSectionDelegate {
             width: parent.width
+            text: qsTr("Community minted")
             onOpenInfoPopup: Global.openPopup(communityInfoPopupCmp)
         }
     }


### PR DESCRIPTION
That is a regression caused by moving section text out of the component in one of my previous PRs