### PR TITLE
fix(@desktop/messages) Bridge messages will always have headers

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -642,6 +642,7 @@ Loader {
                             root.prevMessageContentType === Constants.messageContentType.systemMessageMutualEventSent ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessageMutualEventAccepted ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessageMutualEventRemoved ||
+                            root.prevMessageContentType === Constants.messageContentType.bridgeMessageType ||
                             root.senderId !== root.prevMessageSenderId || root.prevMessageDeleted
                 isActiveMessage: d.isMessageActive
                 topPadding: showHeader ? Style.current.halfPadding : 0


### PR DESCRIPTION
Bridge messages will always have headers.

Fix #13736
