### PR TITLE
feat: Add api for getting full pending CR object

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -3,6 +3,7 @@ import io_interface
 import ../../../../core/eventemitter
 import ../../../../../app_service/service/contacts/service as contacts_service
 import ../../../../../app_service/service/chat/service as chat_service
+import ../../../../../app_service/service/message/dto/message as message_dto
 
 type
   Controller* = ref object of RootObj
@@ -122,6 +123,9 @@ proc acceptContactRequest*(self: Controller, publicKey: string, contactRequestId
 
 proc dismissContactRequest*(self: Controller, publicKey: string, contactRequestId: string) =
   self.contactsService.dismissContactRequest(publicKey, contactRequestId)
+
+proc getLatestContactRequestForContact*(self: Controller, publicKey: string): message_dto.MessageDto =
+  self.contactsService.getLatestContactRequestForContact(publicKey)
 
 proc switchToOrCreateOneToOneChat*(self: Controller, chatId: string) =
   self.chatService.switchToOrCreateOneToOneChat(chatId, "")

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -39,6 +39,9 @@ method dismissContactRequest*(self: AccessInterface, publicKey: string, contactR
 method dismissContactRequests*(self: AccessInterface, publicKeysJSON: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getLatestContactRequestForContactAsJson*(self: AccessInterface, publicKey: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method changeContactNickname*(self: AccessInterface, publicKey: string, nickname: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -110,6 +110,17 @@ method acceptContactRequest*(self: Module, publicKey: string, contactRequestId: 
 method dismissContactRequest*(self: Module, publicKey: string, contactRequestId: string) =
   self.controller.dismissContactRequest(publicKey, contactRequestId)
 
+method getLatestContactRequestForContactAsJson*(self: Module, publicKey: string): string =
+  let contactRequest = self.controller.getLatestContactRequestForContact(publicKey)
+  let jsonObj = %* {
+    "id": contactRequest.id,
+    "from": contactRequest.from,
+    "clock": contactRequest.clock,
+    "text": contactRequest.text,
+    "contactRequestState": contactRequest.contactRequestState.int,
+  }
+  return $jsonObj
+
 method switchToOrCreateOneToOneChat*(self: Module, publicKey: string) =
   self.controller.switchToOrCreateOneToOneChat(publicKey)
 

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -143,6 +143,9 @@ QtObject:
   proc dismissContactRequest*(self: View, publicKey: string, contactRequestId: string) {.slot.} =
     self.delegate.dismissContactRequest(publicKey, contactRequestId)
 
+  proc getLatestContactRequestForContactAsJson*(self: View, publicKey: string): string {.slot.} =
+    self.delegate.getLatestContactRequestForContactAsJson(publicKey)
+
   proc changeContactNickname*(self: View, publicKey: string, nickname: string) {.slot.} =
     self.delegate.changeContactNickname(publicKey, nickname)
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -11,6 +11,7 @@ import ../../common/activity_center
 
 import ../settings/service as settings_service
 import ../network/service as network_service
+import ../message/dto/message as message_dto
 import ../visual_identity/service as procs_from_visual_identity_service
 
 import ./dto/contacts as contacts_dto
@@ -478,7 +479,7 @@ QtObject:
       checkAndEmitACNotificationsFromResponse(self.events, response.result{"activityCenterNotifications"})
 
     except Exception as e:
-      error "an error occurred while sending contact request", msg = e.msg
+      error "an error occurred while sending the contact request", msg = e.msg
 
   proc acceptContactRequest*(self: Service, publicKey: string, contactRequestId: string) =
     try:
@@ -501,7 +502,7 @@ QtObject:
       checkAndEmitACNotificationsFromResponse(self.events, response.result{"activityCenterNotifications"})
 
     except Exception as e:
-      error "an error occurred while accepting contact request", msg=e.msg
+      error "an error occurred while accepting the contact request", msg=e.msg
 
   proc dismissContactRequest*(self: Service, publicKey: string, contactRequestId: string) =
     try:
@@ -520,7 +521,25 @@ QtObject:
       checkAndEmitACNotificationsFromResponse(self.events, response.result{"activityCenterNotifications"})
 
     except Exception as e:
-      error "an error occurred while dismissing contact request", msg=e.msg
+      error "an error occurred while dismissing the contact request", msg=e.msg
+
+  proc getLatestContactRequestForContact*(self: Service, publicKey: string): message_dto.MessageDto =
+    try:
+      let response = status_contacts.getLatestContactRequestForContact(publicKey)
+
+      if not response.error.isNil:
+        error "error getting incoming contact request ", msg = response.error.message
+        return
+
+      let messages = response.result{"messages"}
+      if messages == nil or len(messages) < 1:
+        error "can't find incoming contact request for", publicKey
+        return
+
+      return messages[0].toMessageDto()
+
+    except Exception as e:
+      error "an error occurred while getting incoming contact request", msg=e.msg
 
   proc changeContactNickname*(self: Service, publicKey: string, nickname: string) =
     var contact = self.getContactById(publicKey)

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -59,6 +59,10 @@ proc declineContactRequest*(id: string): RpcResponse[JsonNode] {.raises: [Except
   }]
   result = callPrivateRPC("declineContactRequest".prefix, payload)
 
+proc getLatestContactRequestForContact*(id: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [id]
+  result = callPrivateRPC("getLatestContactRequestForContact".prefix, payload)
+
 proc sendContactUpdate*(publicKey, ensName, thumbnail: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [publicKey, ensName, thumbnail]
   result = callPrivateRPC("sendContactUpdate".prefix, payload)

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -91,6 +91,11 @@ QtObject {
         root.contactsModule.dismissContactRequest(pubKey, contactRequestId)
     }
 
+    function getLatestContactRequestForContactAsJson(pubKey) {
+        let resp = root.contactsModule.getLatestContactRequestForContactAsJson(pubKey)
+        return JSON.parse(resp)
+    }
+
     function markAsTrusted(pubKey) {
         root.contactsModule.markAsTrusted(pubKey)
     }


### PR DESCRIPTION
Close #13604
Waits https://github.com/status-im/status-go/pull/4819

### What does the PR do

Add endpoint for getting latest pending CR for a contact including message

### Affected areas

Contacts

### Example of data:
```
{
   "id":"0xb0ee14df8c433398fa017fd404fc535631889b2f73926d3973cafc3416ba0d5d",
   "from":"0x04effb663a86fcc5f7df47b2c945731789e338c7556cb30d935947be4db8be9e3c2791f8f8b19cd46758a887a22af09db522c98508ae0a6d79a2df33cb6468cd15",
   "parsedText":[
      {
         "type":"paragraph",
         "literal":"",
         "destination":"",
         "children":[
            {
               "type":"",
               "literal":"Hi Mishka,,, just testing :)",
               "destination":"",
               "children":[
                  
               ]
            }
         ]
      }
   ],
   "text":"Hi Mishka,,, just testing :)",
   "contactRequestState":2,
   "s
```