### PR TITLE
Feat: add `markAsTrusted` endpoint

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -126,6 +126,9 @@ proc dismissContactRequest*(self: Controller, publicKey: string, contactRequestI
 proc switchToOrCreateOneToOneChat*(self: Controller, chatId: string) =
   self.chatService.switchToOrCreateOneToOneChat(chatId, "")
 
+proc markAsTrusted*(self: Controller, publicKey: string) =
+  self.contactsService.markAsTrusted(publicKey)
+
 proc markUntrustworthy*(self: Controller, publicKey: string) =
   self.contactsService.markUntrustworthy(publicKey)
 

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -77,6 +77,9 @@ method contactUpdated*(self: AccessInterface, publicKey: string) {.base.} =
 method contactsStatusUpdated*(self: AccessInterface, statusUpdates: seq[StatusUpdateDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method markAsTrusted*(self: AccessInterface, publicKey: string): void {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method markUntrustworthy*(self: AccessInterface, publicKey: string): void {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -196,6 +196,9 @@ method contactTrustStatusChanged*(self: Module, publicKey: string, isUntrustwort
   self.view.myMutualContactsModel().updateTrustStatus(publicKey, isUntrustworthy)
   self.view.blockedContactsModel().updateTrustStatus(publicKey, isUntrustworthy)
 
+method markAsTrusted*(self: Module, publicKey: string): void =
+  self.controller.markAsTrusted(publicKey)
+
 method markUntrustworthy*(self: Module, publicKey: string): void =
   self.controller.markUntrustworthy(publicKey)
 

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -155,6 +155,9 @@ QtObject:
   proc removeContact*(self: View, publicKey: string) {.slot.} =
     self.delegate.removeContact(publicKey)
 
+  proc markAsTrusted*(self: View, publicKey: string) {.slot.} =
+    self.delegate.markAsTrusted(publicKey)
+
   proc markUntrustworthy*(self: View, publicKey: string) {.slot.} =
     self.delegate.markUntrustworthy(publicKey)
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -601,6 +601,19 @@ QtObject:
     let data = ContactsStatusUpdatedArgs(statusUpdates: @[currentUserStatusUpdate])
     self.events.emit(SIGNAL_CONTACTS_STATUS_UPDATED, data)
 
+
+  proc markAsTrusted*(self: Service, publicKey: string) =
+    let response = status_contacts.markAsTrusted(publicKey)
+    if not response.error.isNil:
+      error "error marking as trusted ", msg = response.error.message
+      return
+
+    if self.contacts.hasKey(publicKey):
+      self.contacts[publicKey].dto.trustStatus = TrustStatus.Trusted
+
+    self.events.emit(SIGNAL_CONTACT_TRUSTED,
+      TrustArgs(publicKey: publicKey, isUntrustworthy: false))
+
   proc markUntrustworthy*(self: Service, publicKey: string) =
     let response = status_contacts.markUntrustworthy(publicKey)
     if not response.error.isNil:

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -67,6 +67,10 @@ proc getImageServerURL*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []
   result = callPrivateRPC("imageServerURL".prefix, payload)
 
+proc markAsTrusted*(pubkey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [pubkey]
+  result = callPrivateRPC("markAsTrusted".prefix, payload)
+
 proc markUntrustworthy*(pubkey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [pubkey]
   result = callPrivateRPC("markAsUntrustworthy".prefix, payload)

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -91,6 +91,10 @@ QtObject {
         root.contactsModule.dismissContactRequest(pubKey, contactRequestId)
     }
 
+    function markAsTrusted(pubKey) {
+        root.contactsModule.markAsTrusted(pubKey)
+    }
+
     function markUntrustworthy(pubKey) {
         root.contactsModule.markUntrustworthy(pubKey)
     }


### PR DESCRIPTION
Close #13716

### What does the PR do

- Add `markAsTrusted` endpoint (already present in status-go)

### Affected areas

Contacts
