### PR TITLE
feat(wallet): ReceiveModal dialog UI tweaks

### DIFF
--- a/storybook/pages/CopyButtonPage.qml
+++ b/storybook/pages/CopyButtonPage.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import shared.controls 1.0
+
+Item {
+    RowLayout {
+        anchors.centerIn: parent
+
+        CopyButton {
+            textToCopy: "Some text"
+        }
+
+        CopyButtonWithCircle {
+            textToCopy: "Some text"
+            successCircleVisible: true
+        }
+    }
+}
+
+// category: Controls

--- a/storybook/pages/ReceiveModalPage.qml
+++ b/storybook/pages/ReceiveModalPage.qml
@@ -1,0 +1,100 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+import Models 1.0
+import AppLayouts.Wallet.popups 1.0
+
+SplitView {
+    orientation: Qt.Horizontal
+
+    PopupBackground {
+        id: popupBg
+
+        property var popupIntance: null
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Button {
+            id: reopenButton
+            anchors.centerIn: parent
+            text: "Reopen"
+            enabled: !dialog.visible
+
+            onClicked: dialog.open()
+        }
+
+        ReceiveModal {
+            id: dialog
+
+            visible: true
+            accounts: ListModel {
+                ListElement {
+                    position: 0
+                    name: "My account"
+                }
+            }
+            selectedAccount: {
+                "name": "My account",
+                "emoji": "",
+                "address": "0x1234567890123456789012345678901234567890",
+                "preferredSharingChainIds": "opt:eth:"
+            }
+            switchingAccounsEnabled: true
+            changingPreferredChainsEnabled: true
+            hasFloatingButtons: true
+            qrImageSource: "https://upload.wikimedia.org/wikipedia/commons/4/41/QR_Code_Example.svg"
+            getNetworkShortNames: function (chainIDsString) {
+                return networksNames
+            }
+
+            property string networksNames: "opt:arb:eth:"
+
+            store: NetworksModel
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        Column {
+            spacing: 12
+
+            Label {
+                text: "Test extended footer"
+                font.bold: true
+            }
+
+            Column {
+                RadioButton {
+                    text: "Medium length address"
+                    onCheckedChanged: {
+                        dialog.networksNames = "opt:arb:eth:arb:solana:status:other:"
+                    }
+                }
+
+                RadioButton {
+                    text: "Super long address"
+                    onCheckedChanged: {
+                        dialog.networksNames = "opt:arb:eth:arb:solana:status:other:something:hey:whatsapp:tele:viber:do:it:now:blackjack:some:black:number:check:it:out:heyeey:dosay:what:are:you:going:to:do:with:me:forever:young:michael:jackson:super:long:string:crasy:daisy:this:is:amazing:whatever:you:do:whenever:you:go:"
+                    }
+                }
+
+                RadioButton {
+                    checked: true
+                    text: "Short address"
+                    onCheckedChanged: {
+                        dialog.networksNames = "opt:arb:eth:"
+                    }
+                }
+            }
+        }
+    }
+}
+
+// category: Popups
+
+// https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?type=design&node-id=20734-337595&mode=design&t=2O68lxNGG9g1b1tx-4

--- a/ui/app/AppLayouts/Wallet/controls/qmldir
+++ b/ui/app/AppLayouts/Wallet/controls/qmldir
@@ -11,3 +11,4 @@ ManageTokensCommunityTag 1.0 ManageTokensCommunityTag.qml
 ManageTokensDelegate 1.0 ManageTokensDelegate.qml
 ManageTokensGroupDelegate 1.0 ManageTokensGroupDelegate.qml
 InformationTileAssetDetails 1.0 InformationTileAssetDetails.qml
+StatusNetworkListItemTag 1.0 StatusNetworkListItemTag.qml

--- a/ui/imports/shared/controls/CopyButtonWithCircle.qml
+++ b/ui/imports/shared/controls/CopyButtonWithCircle.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.15
+import QtQml 2.15
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import utils 1.0
+import shared.stores 1.0
+
+StatusRoundButton {
+    id: root
+
+    required property string textToCopy
+
+    icon.name: d.copied ? "tiny/checkmark" : "copy"
+    icon.width: 20
+    icon.height: 20
+
+    type: StatusRoundButton.Type.Tertiary
+
+    property bool successCircleVisible: false
+
+    implicitWidth: 32
+    implicitHeight: 32
+
+    Binding on icon.color {
+        when: successCircleVisible && d.copied
+        value: Theme.palette.successColor1
+        restoreMode: Binding.RestoreBindingOrValue
+    }
+
+    Binding on icon.hoverColor {
+        when: successCircleVisible && d.copied
+        value: Theme.palette.successColor1
+        restoreMode: Binding.RestoreBindingOrValue
+    }
+
+    Binding on color {
+        when: successCircleVisible && d.copied
+        value: Theme.palette.successColor2
+        restoreMode: Binding.RestoreBindingOrValue
+    }
+
+    Rectangle {
+        id: greenCircleAroundIcon
+
+        anchors.centerIn: parent
+        width: icon.width
+        height: width
+        radius: width / 2
+        border.width: 1
+        border.color: d.copied ? Theme.palette.successColor1 : "transparent"
+        color: "transparent"
+        visible: root.successCircleVisible
+    }
+
+    QtObject {
+        id: d
+        property bool copied: false
+    }
+
+    onClicked: {
+        RootStore.copyToClipboard(root.textToCopy)
+        d.copied = true
+        Backpressure.debounce(root, 1500, function () {
+            d.copied = false
+        })()
+    }
+}

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -6,6 +6,7 @@ AssetsDetailsHeader 1.0 AssetsDetailsHeader.qml
 ContactSelector 1.0 ContactSelector.qml
 ContactsListAndSearch 1.0 ContactsListAndSearch.qml
 CopyButton 1.0 CopyButton.qml
+CopyButtonWithCircle 1.0 CopyButtonWithCircle.qml
 CopyToClipBoardButton 1.0 CopyToClipBoardButton.qml
 CurrencyAmountInput 1.0 CurrencyAmountInput.qml
 DisabledTooltipButton 1.0 DisabledTooltipButton.qml


### PR DESCRIPTION
Closes #13386

### Affected areas

Wallet->Click on address -> Share address with QR code dialog

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [x] update storybook app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/15627093/a0ba4fec-dd0e-42a1-abff-df92a9d9d3b2

https://github.com/status-im/status-desktop/assets/15627093/a5c0550e-737e-4293-8882-71f1333441b5

https://github.com/status-im/status-desktop/assets/15627093/f64d796e-c547-43fb-85fb-12ecc18a9084

NOTE: I added one more copy button as per design. I asked @benjthayer to revise the design of copy button because now we have at least 2 icon copy buttons variants. When Ben finishes, we can fix/remove one of the buttons if needed.


