### PR TITLE
feat(@desktop/wallet): implement jump to activity details screen from…

### DIFF
--- a/src/app/modules/main/wallet_section/activity/details_controller.nim
+++ b/src/app/modules/main/wallet_section/activity/details_controller.nim
@@ -1,0 +1,75 @@
+import NimQml, logging, stint
+
+import entry
+import entry_details
+
+import app_service/service/currency/service as currency_service
+
+import app/modules/shared/wallet_utils
+import app/modules/shared_models/currency_amount
+
+QtObject:
+  type
+    Controller* = ref object of QObject
+      activityEntry: ActivityEntry
+      activityDetails: ActivityDetails
+      currencyService: currency_service.Service
+
+  proc setup(self: Controller) =
+    self.QObject.setup
+
+  proc delete*(self: Controller) =
+    self.QObject.delete
+
+  proc newController*(currencyService: currency_service.Service): Controller =
+    new(result, delete)
+
+    result.currencyService = currencyService
+
+    result.setup()
+
+  proc activityEntryChanged*(self: Controller) {.signal.}
+  proc getActivityEntry(self: Controller): QVariant {.slot.} =
+    if self.activityEntry == nil:
+      return newQVariant()
+    return newQVariant(self.activityEntry)
+
+  QtProperty[QVariant] activityEntry:
+    read = getActivityEntry
+    notify = activityEntryChanged
+
+  proc activityDetailsChanged*(self: Controller) {.signal.}
+  proc getActivityDetails(self: Controller): QVariant {.slot.} =
+    if self.activityDetails == nil:
+      return newQVariant()
+    return newQVariant(self.activityDetails)
+
+  QtProperty[QVariant] activityDetails:
+    read = getActivityDetails
+    notify = activityDetailsChanged
+
+  proc setActivityEntry*(self: Controller, entry: ActivityEntry) =
+    self.activityEntry = entry
+    self.activityEntryChanged()
+
+    if self.activityDetails != nil:
+      self.activityDetails = nil
+      self.activityDetailsChanged()    
+
+  proc resetActivityEntry*(self: Controller) {.slot.} =
+    self.setActivityEntry(nil)
+
+  proc fetchExtraTxDetails*(self: Controller) {.slot.} =
+    let amountToCurrencyConvertor = proc(amount: UInt256, symbol: string): CurrencyAmount =
+      return currencyAmountToItem(self.currencyService.parseCurrencyValue(symbol, amount),
+                                    self.currencyService.getCurrencyFormat(symbol))
+    if self.activityEntry == nil:
+      error "activity entry is not set"
+      return
+
+    try:
+      self.activityDetails = newActivityDetails(self.activityEntry.getMetadata(), amountToCurrencyConvertor)
+      self.activityDetailsChanged()
+    except Exception as e:
+      error "error: ", e.msg
+      return

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -1,6 +1,7 @@
 import NimQml, json
 
 import ./activity/controller as activityc
+import ./activity/details_controller as activity_detailsc
 import app/modules/shared_modules/collectible_details/controller as collectible_detailsc
 import ./io_interface
 import ../../shared_models/currency_amount
@@ -20,6 +21,7 @@ QtObject:
       tmpSymbol: string # shouldn't be used anywhere except in prepare*/getPrepared* procs
       activityController: activityc.Controller
       tmpActivityControllers: ActivityControllerArray
+      activityDetailsController: activity_detailsc.Controller
       collectibleDetailsController: collectible_detailsc.Controller
       isNonArchivalNode: bool
       keypairOperabilityForObservedAccount: string
@@ -34,11 +36,17 @@ QtObject:
   proc delete*(self: View) =
     self.QObject.delete
 
-  proc newView*(delegate: io_interface.AccessInterface, activityController: activityc.Controller, tmpActivityControllers: ActivityControllerArray, collectibleDetailsController: collectible_detailsc.Controller, wcController: wcc.Controller): View =
+  proc newView*(delegate: io_interface.AccessInterface, 
+    activityController: activityc.Controller, 
+    tmpActivityControllers: ActivityControllerArray, 
+    activityDetailsController: activity_detailsc.Controller, 
+    collectibleDetailsController: collectible_detailsc.Controller, 
+    wcController: wcc.Controller): View =
     new(result, delete)
     result.delegate = delegate
     result.activityController = activityController
     result.tmpActivityControllers = tmpActivityControllers
+    result.activityDetailsController = activityDetailsController
     result.collectibleDetailsController = collectibleDetailsController
     result.wcController = wcController
 
@@ -163,6 +171,11 @@ QtObject:
     return newQVariant(self.tmpActivityControllers[1])
   QtProperty[QVariant] tmpActivityController1:
     read = getTmpActivityController1
+
+  proc getActivityDetailsController(self: View): QVariant {.slot.} =
+    return newQVariant(self.activityDetailsController)
+  QtProperty[QVariant] activityDetailsController:
+    read = getActivityDetailsController
 
   proc getLatestBlockNumber*(self: View, chainId: int): string {.slot.} =
     return self.delegate.getLatestBlockNumber(chainId)

--- a/storybook/pages/TransactionDetailViewPage.qml
+++ b/storybook/pages/TransactionDetailViewPage.qml
@@ -137,21 +137,16 @@ SplitView {
         id: transactionData
 
         property int chainId: 1
-        property string blockNumber: "0x124"
         property int timestamp: Date.now() / 1000
         property int txStatus: 0
         property string type: "eth"
-        property string nonce: "0x123"
         property string from: "0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B"
         property string to: "0x4de3f6278C0DdFd3F29df9DcD979038F5c7bbc35"
-        property string contract: "0x4de3f6278C0DdFd3F29df9DcD979038F5c7bbc35"
         property bool isNFT: false
-        property string input: "0x40e8d703000000000000000000000000670dca62b3418bddd08cbc69cb4490a5a3382a9f0000000000000000000000000000000000000000000000000000000000000064ddd08cbc69cb4490a5a3382a9f0000000000"
         property string tokenID: "4981676894159712808201908443964193325271219637660871887967796332739046670337"
         property string nftName: "Happy Meow"
         property string nftImageUrl: Style.png("collectibles/HappyMeow")
         property string symbol: "ETH"
-        property string txHash: "0x4de3f6278C0DdFd3F29df9DcD979038F5c7bbc35"
 
         readonly property var value: QtObject {
             property real amount: amountSpinbox.realValue
@@ -159,6 +154,17 @@ SplitView {
             property int displayDecimals: 5
             property bool stripTrailingZeroes: true
         }
+    }
+
+    QtObject {
+        id: transactionDetails
+
+        property string nonce: "0x123"
+        property string blockNumber: "0x124"
+        property string txHash: "0x4de3f6278C0DdFd3F29df9DcD979038F5c7bbc35"
+        property string txHashOut: "0x4de3f6278C0DdFd3F29df9DcD979038F5c7bbc35"
+        property string input: "0x40e8d703000000000000000000000000670dca62b3418bddd08cbc69cb4490a5a3382a9f0000000000000000000000000000000000000000000000000000000000000064ddd08cbc69cb4490a5a3382a9f0000000000"
+        property string contract: "0x4de3f6278C0DdFd3F29df9DcD979038F5c7bbc35"
 
         readonly property var totalFees: QtObject {
             property real amount: (transactionData.value / 15) * Math.pow(10, 9)
@@ -167,16 +173,31 @@ SplitView {
             property bool stripTrailingZeroes: true
         }
 
-        readonly property var gasPrice: QtObject {
-            property real amount: 0.0000005
-            property string symbol: "ETH"
-        }
     }
 
     QtObject {
         id: overviewMockup
 
         property var mixedcaseAddress: root.isIncoming ? transactionData.to : transactionData.from
+    }
+
+    QtObject {
+        id: controllerMockup
+
+        property var activityEntry: transactionData
+        property var activityDetails
+
+        function fetchExtraTxDetails() {
+            extraDetailsTimer.start()
+        }
+
+        readonly property Timer extraDetailsTimer: Timer {
+            id: extraDetailsTimer
+            interval: 1000
+            onTriggered: {
+                controllerMockup.activityDetails = transactionDetails
+            }
+        }
     }
 
     SplitView {
@@ -203,7 +224,7 @@ SplitView {
                 active: root.globalUtilsReady && root.mainModuleReady && root.rootStoreReady
                 sourceComponent: TransactionDetailView {
                     contactsStore: contactsStoreMockup
-                    transaction: transactionData
+                    controller: controllerMockup
                     overview: overviewMockup
                 }
             }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -52,6 +52,7 @@ QtObject {
     property var activityController: walletSectionInst.activityController
     property var tmpActivityController0: walletSectionInst.tmpActivityController0
     property var tmpActivityController1: walletSectionInst.tmpActivityController1
+    property var activityDetailsController: walletSectionInst.activityDetailsController
     property string signingPhrase: walletSectionInst.signingPhrase
     property string mnemonicBackedUp: walletSectionInst.isMnemonicBackedUp
     property var walletConnectController: walletSectionInst.walletConnectController

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -208,9 +208,8 @@ RightTabBaseView {
                         showAllAccounts: RootStore.showAllAccounts
                         sendModal: root.sendModal
                         filterVisible: filterButton.checked
-                        onLaunchTransactionDetail: function (entryIndex) {
-                            transactionDetailView.transactionIndex = entryIndex
-                            transactionDetailView.transaction = Qt.binding(() => selectedTransaction)
+                        onLaunchTransactionDetail: function (txID) {
+                            RootStore.activityController.fetchTxDetails(txID)
                             stack.currentIndex = 3
                         }
                     }
@@ -218,6 +217,10 @@ RightTabBaseView {
             }
         }
         CollectibleDetailView {
+            id: collectibleDetailView
+
+            visible : (stack.currentIndex === 1)
+
             collectible: RootStore.collectiblesStore.detailedCollectible
             isCollectibleLoading: RootStore.collectiblesStore.isDetailedCollectibleLoading
             activityModel: d.detailedCollectibleActivityController.model
@@ -229,6 +232,14 @@ RightTabBaseView {
                 if (!visible) {
                     RootStore.resetCurrentViewedHolding(Constants.TokenType.ERC721)
                 }
+            }
+
+            onLaunchTransactionDetail: function (txID) {
+                d.detailedCollectibleActivityController.fetchTxDetails(txID)
+                stack.currentIndex = 3
+
+                // Take user to the activity view when they press the "Back" button
+                walletTabBar.currentIndex = 2
             }
         }
         AssetsDetailView {
@@ -252,6 +263,7 @@ RightTabBaseView {
 
         TransactionDetailView {
             id: transactionDetailView
+            controller: RootStore.activityDetailsController
             onVisibleChanged: {
                 if (visible) {
                     if (!!transaction) {
@@ -261,7 +273,7 @@ RightTabBaseView {
                         }
                     }
                 } else {
-                    transaction = null
+                    controller.resetActivityEntry()
                 }
             }
             showAllAccounts: RootStore.showAllAccounts

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
@@ -19,6 +19,8 @@ import "../../controls"
 Item {
     id: root
 
+    signal launchTransactionDetail(string txID)
+
     required property var rootStore
     required property var walletRootStore
     required property var communitiesStore
@@ -212,7 +214,11 @@ Item {
                             community: isModelDataValid && !!communityId && !!root.communitiesStore ? root.communitiesStore.getCommunityDetailsAsJson(communityId) : null
                             loading: false
                             onClicked: {
-                                // TODO: Implement switch to transaction details screen
+                                if (mouse.button === Qt.RightButton) {
+                                    // TODO: Implement context menu
+                                } else {
+                                    root.launchTransactionDetail(modelData.id)
+                                }
                             }
                         }
                     }

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -50,6 +50,7 @@ StatusListItem {
 
     readonly property bool isModelDataValid: modelData !== undefined && !!modelData
 
+    readonly property string txID: isModelDataValid ? modelData.id : "INVALID"
     readonly property int transactionStatus: isModelDataValid ? modelData.status : Constants.TransactionStatus.Pending
     readonly property bool isMultiTransaction: isModelDataValid && modelData.isMultiTransaction
     readonly property string currentCurrency: rootStore.currentCurrency
@@ -176,11 +177,6 @@ StatusListItem {
     }
 
     function getDetailsString(detailsObj) {
-        if (!detailsObj) {
-            rootStore.fetchTxDetails(index)
-            detailsObj = rootStore.getTxDetails()
-        }
-
         let details = ""
         const endl = "\n"
         const endl2 = endl + endl

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -208,12 +208,13 @@ QtObject {
         walletSectionInst.fetchDecodedTxData(txHash, input)
     }
 
-    function fetchTxDetails(modelIndex) {
-        walletSectionInst.activityController.fetchTxDetails(modelIndex)
+    function fetchTxDetails(txID) {
+        walletSectionInst.activityController.fetchTxDetails(txID)
+        walletSectionInst.activityDetailsController.fetchExtraTxDetails()
     }
 
     function getTxDetails() {
-        return walletSectionInst.activityController.activityDetails
+        return walletSectionInst.activityDetailsController.activityDetails
     }
 
     property bool marketHistoryIsLoading: Global.appIsReady? walletSectionAllTokens.marketHistoryIsLoading : false


### PR DESCRIPTION
… collectible details activity tab

Fixes #13721

### What does the PR do

Rework some parts of the Activity Details code so it can be reused by both the main Activity controllers and the temp ones.

Implement jump to Activity Details screen from the Collectible Details screen's Activity tab.

As discussed with Ben, the "Back" button from that screen should take the user to the main Activity tab.


https://github.com/status-im/status-desktop/assets/11161531/f6e22578-caf1-4784-923a-922fa9dba7c3

