### PR TITLE
(fix/biometrics) Fix biometric authentication

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -180,6 +180,7 @@ proc checkKeycardAvailability*(self: Controller) =
 
 proc init*(self: Controller, fullConnect = true) =
   self.connectKeycardReponseSignal()
+  self.connectKeychainSignals()
 
   var handlerId = self.events.onWithUUID(SIGNAL_SHARED_KEYCARD_MODULE_USER_AUTHENTICATED) do(e: Args):
     let args = SharedKeycarModuleArgs(e)


### PR DESCRIPTION
### Description

fixes #13051 User blocked in model when using biometrics to share address when joining a community. 

### What does the PR do

There was a missing connection of the connect signal coming from the Key chain after entering a password and correctly obtaining data from the Keychain service. So this PR just connects the signal to the already existing signal processor

### Affected areas

NA

### Screenshot of functionality (including design for comparison)

![output](https://github.com/status-im/status-desktop/assets/2589171/c6495cd1-200a-4569-98c1-81193fe99fd9)
