### PR TITLE
feat(wallet): resize saved address popup to remove network selection

### DIFF
--- a/storybook/pages/SavedAddressPopupPage.qml
+++ b/storybook/pages/SavedAddressPopupPage.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+import Models 1.0
+import AppLayouts.Wallet.popups 1.0
+
+import utils 1.0
+
+SplitView {
+    orientation: Qt.Horizontal
+
+    PopupBackground {
+        id: popupBg
+
+        property var popupIntance: null
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Button {
+            id: reopenButton
+            anchors.centerIn: parent
+            text: "Reopen"
+            enabled: !dialog.visible
+
+            onClicked: dialog.open()
+        }
+
+        AddEditSavedAddressPopup {
+            id: dialog
+
+            visible: true
+            store: QtObject {
+                property var savedAddressNameExists: function() { return false }
+            }
+
+            // Emulate resoling ENS by simple validation
+            QtObject {
+                id: mainModule
+
+                function resolveENS(name, uuid) {
+                    if (Utils.isValidEns(name)) {
+                        resolvedENS("", "0x1234567890123456789012345678901234567890", uuid)
+                    }
+                    else {
+                        resolvedENS("", "", uuid)
+                    }
+                }
+
+                signal resolvedENS(string pubkey, string address, string uuid)
+            }
+
+            Component.onCompleted: initWithParams()
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+    }
+}
+
+// category: Popups
+
+// https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?type=design&node-id=23256-263282&mode=design&t=0DRwQJKDGYJPHkq1-4

--- a/ui/imports/shared/popups/send/views/RecipientView.qml
+++ b/ui/imports/shared/popups/send/views/RecipientView.qml
@@ -44,8 +44,11 @@ Loader {
             }
             case TabAddressSelectorView.Type.SavedAddress: {
                 root.addressText = root.selectedRecipient.address
+
+                // Resolve before using
                 if (!!root.selectedRecipient.ens && root.selectedRecipient.ens.length > 0) {
-                    root.resolvedENSAddress = root.selectedRecipient.ens
+                    d.isPending = true
+                    d.resolveENS(root.selectedRecipient.ens)
                 }
                 preferredChainIds = store.getShortChainIds(root.selectedRecipient.chainShortNames)
                 break


### PR DESCRIPTION
when ENS name is resolved.
- Resolve ENS name before used in SendModal
- UI tweaks:
  - red stroke on address input in case of error
  - smaller tick for validation address input
  - added validation spinner to address input, removed from the button (Ben updated design)
  - handled tab key to move focus between inputs
  - animation for resizing the dialog

### Affected areas

Saved address popup

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [x] update storybook app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/15627093/39604d4a-a6af-4f10-a6b2-c8f1c492148c



[x ] I've checked the design and this PR matches it

Closed #13381 


