### PR TITLE
feat(ProfileShowcase): Display counter in `In showcase` section header a… …nd elements limit

### DIFF
--- a/storybook/pages/ProfileShowcaseAccountsPanelPage.qml
+++ b/storybook/pages/ProfileShowcaseAccountsPanelPage.qml
@@ -99,6 +99,7 @@ SplitView {
         inShowcaseModel: emptyModelChecker.checked ? emptyModel : inShowcaseModelItem
         hiddenModel: emptyModelChecker.checked ? emptyModel : hiddenModelItem
         currentWallet: root.currentWallet
+        showcaseLimit: 5
     }
 
     LogsAndControlsPanel {

--- a/storybook/pages/ProfileShowcaseAssetsPanelPage.qml
+++ b/storybook/pages/ProfileShowcaseAssetsPanelPage.qml
@@ -66,6 +66,7 @@ SplitView {
         SplitView.preferredHeight: 500
         inShowcaseModel: inShowcaseModelItem
         hiddenModel: hiddenShowcaseModelItem
+        showcaseLimit: 8
 
         addAccountsButtonVisible: !hasAllAccountsChecker.checked
 

--- a/storybook/pages/ProfileShowcaseCollectiblesPanelPage.qml
+++ b/storybook/pages/ProfileShowcaseCollectiblesPanelPage.qml
@@ -211,6 +211,7 @@ SplitView {
         SplitView.preferredHeight: 500
         inShowcaseModel: emptyModelChecker.checked ? emptyModelItem : joinedInShowcase
         hiddenModel: emptyModelChecker.checked ? emptyModelItem : joinedHiddenModel
+        showcaseLimit: 8
 
         addAccountsButtonVisible: !hasAllAccountsChecker.checked
 

--- a/storybook/pages/ProfileShowcaseCommunitiesPanelPage.qml
+++ b/storybook/pages/ProfileShowcaseCommunitiesPanelPage.qml
@@ -129,6 +129,7 @@ SplitView {
 
         inShowcaseModel: emptyModelChecker.checked ? emptyModel : inShowcaseModelItem
         hiddenModel: emptyModelChecker.checked ? emptyModel : hiddenModelItem
+        showcaseLimit: 5
     }
 
     LogsAndControlsPanel {

--- a/storybook/pages/ProfileShowcasePanelPage.qml
+++ b/storybook/pages/ProfileShowcasePanelPage.qml
@@ -70,6 +70,7 @@ SplitView {
         SplitView.fillHeight: true
         emptyInShowcasePlaceholderText: "No items in showcase"
         emptyHiddenPlaceholderText: "No hidden items"
+        showcaseLimit: limitCounter.value
         onChangePositionRequested: function (from, to) {
             inShowcaseModelItem.move(from, to, 1)
         }
@@ -100,6 +101,8 @@ SplitView {
         }
 
         delegate: ProfileShowcasePanelDelegate {
+            id: delegate
+
             title: model ? model.title : ""
             secondaryTitle: model ? model.secondaryTitle : ""
             hasImage: model ? model.hasImage : false
@@ -137,11 +140,13 @@ SplitView {
                 Slider {
                     id: inShowcaseCounter
                     from: 0
-                    to: 200
+                    to: limitCounter.value
                     stepSize: 1
-                    value: 25
+                    value: limitCounter.value > 0 ? limitCounter.value - 1 : 0
                 }
+            }
 
+            ColumnLayout {
                 Label {
                     text: "Hidden: " + hiddenCounter.value
                 }
@@ -153,31 +158,43 @@ SplitView {
                     value: 25
                 }
             }
+            ColumnLayout {
+                Label {
+                    text: "Showcase limit: " + limitCounter.value
+                }
+                Slider {
+                    id: limitCounter
+                    from: 0
+                    to: 200
+                    stepSize: 1
+                    value: 5
+                }
+            }
         }
     }
 
     onInShowcaseModelCountChanged: {
         let count = inShowcaseModelCount - inShowcaseModelItem.count;
         let operation = count > 0 ? (i) =>{
-                                   inShowcaseModelItem.append({
-                                       showcaseKey: Math.random() * Math.random() * Math.random() * 1000,
-                                       title: "Item " + i,
-                                       secondaryTitle: "Description " + i,
-                                       hasImage: true,
-                                       image: "https://picsum.photos/200/300?random=" + i,
-                                       iconName: "https://picsum.photos/40/40?random=" + i,
-                                       showcaseVisibility: Math.ceil(Math.random() * 3),
-                                        name: "Test community",
-                                        joined: true,
-                                        isControlNode: true,
-                                        color: "yellow",
-                                        hasTag: Math.random() > 0.5,
-                                        tagText: "New " + 1,
-                                        tagAsset: "https://picsum.photos/40/40?random=" + i,
-                                        tagLoading: Math.random() > 0.5
-                                   })} : (i) => {
-                                       inShowcaseModelItem.remove(inShowcaseModelItem.count - 1);
-                                   }
+                                        inShowcaseModelItem.append({
+                                                                       showcaseKey: Math.random() * Math.random() * Math.random() * 1000,
+                                                                       title: "Item " + i,
+                                                                       secondaryTitle: "Description " + i,
+                                                                       hasImage: true,
+                                                                       image: "https://picsum.photos/200/300?random=" + i,
+                                                                       iconName: "https://picsum.photos/40/40?random=" + i,
+                                                                       showcaseVisibility: Math.ceil(Math.random() * 3),
+                                                                       name: "Test community",
+                                                                       joined: true,
+                                                                       isControlNode: true,
+                                                                       color: "yellow",
+                                                                       hasTag: Math.random() > 0.5,
+                                                                       tagText: "New " + 1,
+                                                                       tagAsset: "https://picsum.photos/40/40?random=" + i,
+                                                                       tagLoading: Math.random() > 0.5
+                                                                   })} : (i) => {
+            inShowcaseModelItem.remove(inShowcaseModelItem.count - 1);
+        }
 
         for (var i = 0; i < Math.abs(count); i++) {
             operation(i)
@@ -187,26 +204,26 @@ SplitView {
     onHiddenModelCountChanged: {
         let count = hiddenModelCount - hiddenModelItem.count;
         let operation = count > 0 ? (i) =>{
-                                   hiddenModelItem.append({
-                                       showcaseKey: Math.random() * Math.random() * Math.random() * 1000,
-                                       title: "Item " + i,
-                                       secondaryTitle: "Description " + i,
-                                       hasImage: true,
-                                       image: "https://picsum.photos/200/300?random=" + i,
-                                       iconName: "https://picsum.photos/40/40?random=" + i,
-                                       showcaseVisibility: 0,
-                                        name: "Test community",
-                                        joined: true,
-                                        memberRole: Constants.memberRole.owner,
-                                        isControlNode: true,
-                                        color: "yellow",
-                                        hasTag: Math.random() > 0.5,
-                                        tagText: "New " + i,
-                                        tagAsset: "https://picsum.photos/40/40?random=" + i,
-                                        tagLoading: Math.random() > 0.8
-                                   })} : (i) => {
-                                       hiddenModelItem.remove(hiddenModelItem.count - 1);
-                                   }
+                                        hiddenModelItem.append({
+                                                                   showcaseKey: Math.random() * Math.random() * Math.random() * 1000,
+                                                                   title: "Item " + i,
+                                                                   secondaryTitle: "Description " + i,
+                                                                   hasImage: true,
+                                                                   image: "https://picsum.photos/200/300?random=" + i,
+                                                                   iconName: "https://picsum.photos/40/40?random=" + i,
+                                                                   showcaseVisibility: 0,
+                                                                   name: "Test community",
+                                                                   joined: true,
+                                                                   memberRole: Constants.memberRole.owner,
+                                                                   isControlNode: true,
+                                                                   color: "yellow",
+                                                                   hasTag: Math.random() > 0.5,
+                                                                   tagText: "New " + i,
+                                                                   tagAsset: "https://picsum.photos/40/40?random=" + i,
+                                                                   tagLoading: Math.random() > 0.8
+                                                               })} : (i) => {
+            hiddenModelItem.remove(hiddenModelItem.count - 1);
+        }
 
         for (var i = 0; i < Math.abs(count); i++) {
             operation(i)

--- a/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
@@ -13,6 +13,7 @@ import StatusQ.Core.Theme 0.1
 import AppLayouts.Wallet.controls 1.0
 
 import utils 1.0
+import shared.controls 1.0
 
 StatusDraggableListItem {
     id: root
@@ -20,6 +21,8 @@ StatusDraggableListItem {
     property alias actionComponent: additionalActionsLoader.sourceComponent
     property int showcaseVisibility: Constants.ShowcaseVisibility.NoOne
     property bool blurState: false
+    property bool contextMenuEnabled: true
+    property string tooltipTextWhenContextMenuDisabled
 
     signal showcaseVisibilityRequested(int value)
 
@@ -46,66 +49,71 @@ StatusDraggableListItem {
 
     actions: [
         Loader {
-            Layout.maximumWidth: root.width *.4
             id: additionalActionsLoader
-        }
-        ,
-        StatusRoundButton {
-            icon.name: ProfileUtils.visibilityIcon(root.showcaseVisibility)
-            Layout.preferredWidth: 58
-            Layout.preferredHeight: 28
-            border.width: 1
-            border.color: Theme.palette.directColor7
-            radius: 14
-            highlighted: menuLoader.item && menuLoader.item.opened
-            onClicked: {
-                menuLoader.active = true
-                menuLoader.item.popup(width - menuLoader.item.width, height)
-            }
 
-            ButtonGroup {
-                id: showcaseVisibilityGroup
-                exclusive: true
-                onClicked: function(button) {
-                    const newVisibility = (button as ShowcaseVisibilityAction).showcaseVisibility
-                    if (newVisibility !== root.showcaseVisibility)
-                        root.showcaseVisibilityRequested(newVisibility)
+            Layout.maximumWidth: root.width *.4
+        },
+        DisabledTooltipButton {
+            interactive: root.contextMenuEnabled
+            tooltipText: root.tooltipTextWhenContextMenuDisabled
+            buttonComponent: StatusRoundButton {
+                enabled: root.contextMenuEnabled
+                icon.name: ProfileUtils.visibilityIcon(root.showcaseVisibility)
+                width: 58
+                height: 30
+                border.width: 1
+                border.color: Theme.palette.directColor7
+                radius: 14
+                highlighted: menuLoader.item && menuLoader.item.opened
+                onClicked: {
+                    menuLoader.active = true
+                    menuLoader.item.popup(width - menuLoader.item.width, height)
                 }
-            }
 
-            Loader {
-                id: menuLoader
-                active: false
-                sourceComponent: StatusMenu {
-                    onClosed: menuLoader.active = false
-                    StatusMenuHeadline { text: qsTr("Show to") }
-
-                    ShowcaseVisibilityAction {
-                        ButtonGroup.group: showcaseVisibilityGroup
-                        showcaseVisibility: Constants.ShowcaseVisibility.Everyone
-                        text: qsTr("Everyone")
-                        checked: root.showcaseVisibility === showcaseVisibility
+                ButtonGroup {
+                    id: showcaseVisibilityGroup
+                    exclusive: true
+                    onClicked: function(button) {
+                        const newVisibility = (button as ShowcaseVisibilityAction).showcaseVisibility
+                        if (newVisibility !== root.showcaseVisibility)
+                            root.showcaseVisibilityRequested(newVisibility)
                     }
-                    ShowcaseVisibilityAction {
-                        ButtonGroup.group: showcaseVisibilityGroup
-                        showcaseVisibility: Constants.ShowcaseVisibility.Contacts
-                        text: qsTr("Contacts")
-                        checked: root.showcaseVisibility === showcaseVisibility
-                    }
-                    ShowcaseVisibilityAction {
-                        ButtonGroup.group: showcaseVisibilityGroup
-                        showcaseVisibility: Constants.ShowcaseVisibility.IdVerifiedContacts
-                        text: qsTr("ID verified contacts")
-                        checked: root.showcaseVisibility === showcaseVisibility
-                    }
+                }
 
-                    StatusMenuSeparator {}
+                Loader {
+                    id: menuLoader
+                    active: false
+                    sourceComponent: StatusMenu {
+                        onClosed: menuLoader.active = false
+                        StatusMenuHeadline { text: qsTr("Show to") }
 
-                    ShowcaseVisibilityAction {
-                        ButtonGroup.group: showcaseVisibilityGroup
-                        showcaseVisibility: Constants.ShowcaseVisibility.NoOne
-                        text: qsTr("No one")
-                        checked: root.showcaseVisibility === showcaseVisibility
+                        ShowcaseVisibilityAction {
+                            ButtonGroup.group: showcaseVisibilityGroup
+                            showcaseVisibility: Constants.ShowcaseVisibility.Everyone
+                            text: qsTr("Everyone")
+                            checked: root.showcaseVisibility === showcaseVisibility
+                        }
+                        ShowcaseVisibilityAction {
+                            ButtonGroup.group: showcaseVisibilityGroup
+                            showcaseVisibility: Constants.ShowcaseVisibility.Contacts
+                            text: qsTr("Contacts")
+                            checked: root.showcaseVisibility === showcaseVisibility
+                        }
+                        ShowcaseVisibilityAction {
+                            ButtonGroup.group: showcaseVisibilityGroup
+                            showcaseVisibility: Constants.ShowcaseVisibility.IdVerifiedContacts
+                            text: qsTr("ID verified contacts")
+                            checked: root.showcaseVisibility === showcaseVisibility
+                        }
+
+                        StatusMenuSeparator {}
+
+                        ShowcaseVisibilityAction {
+                            ButtonGroup.group: showcaseVisibilityGroup
+                            showcaseVisibility: Constants.ShowcaseVisibility.NoOne
+                            text: qsTr("No one")
+                            checked: root.showcaseVisibility === showcaseVisibility
+                        }
                     }
                 }
             }

--- a/ui/imports/shared/controls/DisabledTooltipButton.qml
+++ b/ui/imports/shared/controls/DisabledTooltipButton.qml
@@ -36,6 +36,7 @@ Item {
     StatusToolTip {
         id: tooltip
         visible: hoverHandler.hovered && !!text
+        offset: -(tooltip.x + tooltip.width/2 - root.width/2)
     }
 
     Component{

--- a/ui/imports/utils/ProfileUtils.qml
+++ b/ui/imports/utils/ProfileUtils.qml
@@ -7,6 +7,7 @@ import StatusQ.Core.Theme 0.1
 QtObject {
 
     readonly property int defaultDelegateHeight: 76
+    readonly property int showcaseLimit: 100
 
     function displayName(nickName, ensName, displayName, aliasName)
     {


### PR DESCRIPTION
Closes #13507 

### What does the PR do

- Added counter in showcase header.
- Added placeholder when limit reached and section expanded.
- Added placeholder when limit reached and section collapsed.
- Added green animation when section collapsed and element added.
- Disabled showcase delegate context menu when limit reached.
- Added model changes tracker to track the in showcase count.

### Affected areas

Profile Showcase / Community, Assets, Accounts and Collectibles tabs

### Screenshot of functionality

- App fixed limit to 2 for testing:

https://github.com/status-im/status-desktop/assets/97019400/fdea4cc0-adb6-4589-aaf0-b0447dd988c5

- Storybook:

https://github.com/status-im/status-desktop/assets/97019400/c53e148a-fe6f-424a-b9c2-6aaee4126f29
