### PR TITLE
fix(chat input): should be disabled if user is not able to post

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -168,7 +168,7 @@ QtObject:
     self.viewOnlyPermissionsSatisfiedChanged()
 
   proc getViewOnlyPermissionsSatisfied*(self: View): bool {.slot.} =
-    return self.viewOnlyPermissionsSatisfied
+    return self.viewOnlyPermissionsSatisfied or self.amIChatAdmin()
   QtProperty[bool] viewOnlyPermissionsSatisfied:
     read = getViewOnlyPermissionsSatisfied
     notify = viewOnlyPermissionsSatisfiedChanged
@@ -180,7 +180,7 @@ QtObject:
     self.viewAndPostPermissionsSatisfiedChanged()
 
   proc getViewAndPostPermissionsSatisfied*(self: View): bool {.slot.} =
-    return self.viewAndPostPermissionsSatisfied
+    return self.viewAndPostPermissionsSatisfied or self.amIChatAdmin()
   QtProperty[bool] viewAndPostPermissionsSatisfied:
     read = getViewAndPostPermissionsSatisfied
     notify = viewAndPostPermissionsSatisfiedChanged

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
@@ -155,6 +155,7 @@ Item {
         Item {
             width: addEmojiButton.width + addEmojiButton.anchors.leftMargin // there is more margin between the button and the emojis than between each emoji
             height: addEmojiButton.height
+            visible: root.enabled
 
             StatusIcon {
                 id: addEmojiButton

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -589,6 +589,7 @@ QtObject {
     }
 
     readonly property QtObject _d: QtObject {
+        id: _d
         readonly property var sectionDetailsInstantiator: Instantiator {
             model: SortFilterProxyModel {
                 sourceModel: mainModuleInst.sectionsModel
@@ -655,9 +656,10 @@ QtObject {
         readonly property bool isUserAllowedToSendMessage: {
             if (_d.activeChatType === Constants.chatType.oneToOne && _d.oneToOneChatContact) {
                 return _d.oneToOneChatContact.contactRequestState === Constants.ContactRequestState.Mutual
-            }
-            else if(_d.activeChatType === Constants.chatType.privateGroupChat) {
+            } else if (_d.activeChatType === Constants.chatType.privateGroupChat) {
                 return _d.amIMember
+            } else if (_d.activeChatType === Constants.chatType.communityChat) {
+                return currentChatContentModule().viewAndPostPermissionsSatisfied
             }
 
             return true

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -278,7 +278,7 @@ Item {
                                 return qsTr("You need to join this community to send messages")
                             }
                             if (!root.viewAndPostPermissionsSatisfied) {
-                                return qsTr("Sorry, you don't have the tokens needed to post in this channel.")
+                                return qsTr("Sorry, you don't have permissions to post in this channel.")
                             }
                             return root.rootStore.chatInputPlaceHolderText
                         } else {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -205,7 +205,7 @@ StatusSectionLayout {
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             viewAndPostHoldingsModel: root.viewAndPostPermissionsModel
-            viewAndPostPermissionsSatisfied: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.amISectionAdmin || root.viewAndPostPermissionsSatisfied
+            viewAndPostPermissionsSatisfied: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.viewAndPostPermissionsSatisfied
             amISectionAdmin: root.amISectionAdmin
             onOpenStickerPackPopup: {
                 Global.openPopup(statusStickerPackClickPopup, {packId: stickerPackId, store: root.stickersPopup.store} )

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1226,7 +1226,7 @@ Rectangle {
 
                             objectName: "messageInputField"
 
-                            property var lastClick: 0
+                            property double lastClick: 0
                             property int cursorWhenPressed: 0
                             property int previousCursorPosition: 0
 
@@ -1246,7 +1246,7 @@ Rectangle {
                             padding: 0
                             // This is needed to make sure the text area is disabled when the input is disabled
                             Binding on enabled {
-                                value: root.enabled
+                                value: control.enabled
                             }
                             Keys.onUpPressed: {
                                 if (isEdit && !activeFocus) {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -651,7 +651,7 @@ Loader {
                               (root.chatLogView && root.chatLogView.moving) ||
                               Global.activityPopupOpened
 
-                disableEmojis: root.isChatBlocked
+                disableEmojis: !d.addReactionAllowed
                 hideMessage: d.hideMessage
 
                 overrideBackground: root.placeholderMessage


### PR DESCRIPTION
### What does the PR do

- extend `isUserAllowedToSendMessage` to also cover `Constants.chatType.communityChat`
- let `admin` always satisfy the permissions
- hide the add emoji/reaction button instead of disabling it when the permissions are not met
- adjust the error msg to better reflect the reality (tokens vs. permissions)

Fixes #13777

### Affected areas

StatusChatInput,ChatColumnView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-04 11-17-37.webm](https://github.com/status-im/status-desktop/assets/5377645/0009cdbc-6538-4a5d-a085-ca83093b2674)
