### PR TITLE
feat(SettingsContentBase): Save changes bubble overlapping by default

### DIFF
--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -132,6 +132,7 @@ StatusSectionLayout {
             sourceComponent: MyProfileView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 walletAssetsStore: root.walletAssetsStore
                 currencyStore: root.currencyStore
@@ -153,6 +154,7 @@ StatusSectionLayout {
             sourceComponent: ChangePasswordView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
                 privacyStore: root.store.privacyStore
                 passwordStrengthScoreFunction: SharedStores.RootStore.getPasswordStrengthScore
                 contentWidth: d.contentWidth
@@ -166,6 +168,7 @@ StatusSectionLayout {
             sourceComponent: ContactsView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
                 contactsStore: root.store.contactsStore
                 sectionTitle: qsTr("Contacts")
                 contentWidth: d.contentWidth
@@ -198,6 +201,7 @@ StatusSectionLayout {
             sourceComponent: MessagingView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
                 advancedStore: root.store.advancedStore
                 messagingStore: root.store.messagingStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.messaging)
@@ -213,6 +217,7 @@ StatusSectionLayout {
             sourceComponent: WalletView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
                 rootStore: root.store
                 tokensStore: root.tokensStore
                 networkConnectionStore: root.networkConnectionStore
@@ -231,6 +236,7 @@ StatusSectionLayout {
             sourceComponent: AppearanceView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 appearanceStore: root.store.appearanceStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.appearance)
@@ -245,6 +251,7 @@ StatusSectionLayout {
             sourceComponent: LanguageView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 languageStore: root.store.languageStore
                 currencyStore: root.currencyStore
@@ -259,6 +266,7 @@ StatusSectionLayout {
             sourceComponent: NotificationsView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 notificationsStore: root.store.notificationsStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.notifications)
@@ -272,6 +280,7 @@ StatusSectionLayout {
             sourceComponent: SyncingView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 isProduction: production
                 profileStore: root.store.profileStore
@@ -289,6 +298,7 @@ StatusSectionLayout {
             sourceComponent: BrowserView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 store: root.store
                 accountSettings: localAccountSensitiveSettings
@@ -303,6 +313,7 @@ StatusSectionLayout {
             sourceComponent: AdvancedView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 messagingStore: root.store.messagingStore
                 advancedStore: root.store.advancedStore
@@ -320,6 +331,7 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.about)
                 contentWidth: d.contentWidth
+                leftParentLayoutMargin: d.leftMargin
 
                 store: QtObject {
                     readonly property bool isProduction: production
@@ -358,6 +370,7 @@ StatusSectionLayout {
             sourceComponent: CommunitiesView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 profileSectionStore: root.store
                 rootStore: root.globalStore
@@ -375,6 +388,7 @@ StatusSectionLayout {
             sourceComponent: KeycardView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
 
                 profileSectionStore: root.store
                 keycardStore: root.store.keycardStore
@@ -393,6 +407,7 @@ StatusSectionLayout {
             sourceComponent: SettingsContentBase {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
                 sectionTitle: "Status Software Terms of Use"
                 contentWidth: d.contentWidth
 
@@ -413,6 +428,7 @@ StatusSectionLayout {
             sourceComponent: SettingsContentBase {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                leftParentLayoutMargin: d.leftMargin
                 sectionTitle: "Status Software Privacy Statement"
                 contentWidth: d.contentWidth
 

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -68,6 +68,7 @@ SettingsContentBase {
 
     toast.saveChangesTooltipVisible: root.dirty
     toast.saveChangesTooltipText: qsTr("Invalid changes made to Identity")
+    autoscrollWhenDirty: profileTabBar.currentIndex === MyProfileView.Identity
 
     onResetChangesClicked: priv.reset()
 

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -23,6 +23,11 @@ FocusScope {
     default property alias content: contentWrapper.children
     property alias titleLayout: titleLayout
 
+    // This is the margin set up to the parent when using `SettingsContentBase` inside central
+    // panel property of `StatusSectionLayout` and needs to be taken into account to counteract it
+    // when trying to align horizontally the save toast component
+    required property int leftParentLayoutMargin
+
     property bool dirty: false
 
     // Used to configure the dirty behaviour of the settings page as a must blocker notification when
@@ -152,7 +157,12 @@ FocusScope {
         id: settingsDirtyToastMessage
         anchors.bottom: scrollView.bottom
         anchors.bottomMargin: d.bottomDirtyToastMargin
-        anchors.horizontalCenter: scrollView.horizontalCenter
+
+        // Left anchors and margin added bc of the implementation of the `SettingsContentBase` parent margin and to avoid
+        // this toast to be wrongly centered
+        anchors.left: root.left
+        anchors.leftMargin: -root.leftParentLayoutMargin / 2 + (root.width / 2 - width / 2)
+
         active: root.dirty
         flickable: root.autoscrollWhenDirty ? scrollView.flickable : null
         saveChangesButtonEnabled: root.saveChangesButtonEnabled

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -24,9 +24,16 @@ FocusScope {
     property alias titleLayout: titleLayout
 
     property bool dirty: false
-    property bool ignoreDirty // ignore dirty state and do not notifyDirty()
+
+    // Used to configure the dirty behaviour of the settings page as a must blocker notification when
+    // user wants to leave the current page or just, ignore the changes done. Default: blocker
+    property bool ignoreDirty: false
+
     property bool saveChangesButtonEnabled: false
     readonly property alias toast: settingsDirtyToastMessage
+
+    // Used to configure the dirty toast behaviour (by default overlay on top of content)
+    property bool autoscrollWhenDirty: false
 
     readonly property real availableHeight:
         scrollView.availableHeight - settingsDirtyToastMessagePlaceholder.height
@@ -45,6 +52,7 @@ FocusScope {
         id: d
 
         readonly property int titleRowHeight: 56
+        readonly property int bottomDirtyToastMargin: 36
     }
 
     MouseArea {
@@ -121,14 +129,16 @@ FocusScope {
                 }
             }
 
+            // Used only when dirty toast visible and in case of autoscrolling configuration
             Item {
                 id: settingsDirtyToastMessagePlaceholder
 
                 width: settingsDirtyToastMessage.implicitWidth
-                height: settingsDirtyToastMessage.active && !root.ignoreDirty ? settingsDirtyToastMessage.implicitHeight : 0
+                height: settingsDirtyToastMessage.active && root.autoscrollWhenDirty ?
+                            (settingsDirtyToastMessage.implicitHeight + d.bottomDirtyToastMargin) : 0 /*Overlay on top of content*/
 
                 Behavior on implicitHeight {
-                    enabled: !root.ignoreDirty
+                    enabled: root.autoscrollWhenDirty
                     NumberAnimation {
                         duration: 150
                         easing.type: Easing.InOutQuad
@@ -141,10 +151,10 @@ FocusScope {
     SettingsDirtyToastMessage {
         id: settingsDirtyToastMessage
         anchors.bottom: scrollView.bottom
-        anchors.bottomMargin: root.ignoreDirty ? 40 : 0
+        anchors.bottomMargin: d.bottomDirtyToastMargin
         anchors.horizontalCenter: scrollView.horizontalCenter
         active: root.dirty
-        flickable: root.ignoreDirty ? null : scrollView.flickable
+        flickable: root.autoscrollWhenDirty ? scrollView.flickable : null
         saveChangesButtonEnabled: root.saveChangesButtonEnabled
         onResetChangesClicked: root.resetChangesClicked()
         onSaveChangesClicked: root.saveChangesClicked()

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -57,9 +57,9 @@ SettingsContentBase {
         }
     }
 
-    dirty: manageTokensView.dirty
+    // Dirty state will be just ignored when user leaves manage tokens settings (excluding advanced settings that needs user action)
     ignoreDirty: stackContainer.currentIndex === manageTokensViewIndex && !manageTokensView.advancedTabVisible
-
+    dirty: manageTokensView.dirty
     saveChangesButtonEnabled: dirty
     toast.type: SettingsDirtyToastMessage.Type.Info
     toast.cancelButtonVisible: manageTokensView.advancedTabVisible


### PR DESCRIPTION
Closes #13517

### What does the PR do

- Added `autoscrollWhenDirty` property to be able to configure the settings content base as autoscroll mode when dirty toast appears. Otherwise, the toast will be shown overlaid on top of the view content.
- Updated profile view to setup autoscroll on `Identity` tab. Rest of app cases are setup with the overlay mode.

### Affected areas

Setting pages

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/204f6d01-49df-43f0-b9bf-d4e4e470713f