### PR TITLE
fix: fix token master can't send a message on permissioned channel

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -45,6 +45,7 @@ Item {
     property int chatsCount: parentModule && parentModule.model ? parentModule.model.count : 0
     property int activeChatType: parentModule && parentModule.activeItem.type
     property bool stickersLoaded: false
+    property bool permissionUpdatePending: false
     property bool viewAndPostPermissionsSatisfied: true
     property var viewAndPostHoldingsModel
 
@@ -258,6 +259,7 @@ Item {
                                  && root.rootStore.sectionDetails.joined
                                  && !root.rootStore.sectionDetails.amIBanned
                                  && root.rootStore.isUserAllowedToSendMessage
+                                 && !root.permissionUpdatePending
                     }
 
                     store: root.rootStore
@@ -276,6 +278,9 @@ Item {
                                 return qsTr("This user has been blocked.")
                             if (!root.rootStore.sectionDetails.joined || root.rootStore.sectionDetails.amIBanned) {
                                 return qsTr("You need to join this community to send messages")
+                            }
+                            if (root.permissionUpdatePending) {
+                                return qsTr("Some permissions are being updated. You will be able to send messages once the control node is back online.")
                             }
                             if (!root.viewAndPostPermissionsSatisfied) {
                                 return qsTr("Sorry, you don't have permissions to post in this channel.")

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -10,6 +10,7 @@ import shared.status 1.0
 import shared.stores 1.0
 import shared.views.chat 1.0
 import shared.stores.send 1.0
+import SortFilterProxyModel 0.2
 
 import StatusQ.Layout 0.1
 import StatusQ.Popups 0.1
@@ -19,6 +20,7 @@ import "."
 import "../panels"
 import AppLayouts.Communities.panels 1.0
 import AppLayouts.Communities.views 1.0
+import AppLayouts.Communities.controls 1.0
 import AppLayouts.Wallet.stores 1.0 as WalletStore
 import "../popups"
 import "../helpers"
@@ -57,6 +59,29 @@ StatusSectionLayout {
     property var viewAndPostPermissionsModel
     property var assetsModel
     property var collectiblesModel
+
+    readonly property var pendingViewOnlyPermissionsModel: SortFilterProxyModel {
+            sourceModel: root.viewOnlyPermissionsModel
+        filters: [
+            ValueFilter {
+                roleName: "permissionState"
+                value: PermissionTypes.State.Approved
+                inverted: true
+            }
+        ]
+    }
+    readonly property var pendingViewAndPostPermissionsModel: SortFilterProxyModel {
+            sourceModel: root.viewAndPostPermissionsModel
+        filters: [
+            ValueFilter {
+                roleName: "permissionState"
+                value: PermissionTypes.State.Approved
+                inverted: true
+            }
+        ]
+    }
+
+    readonly property bool permissionUpdatePending: pendingViewOnlyPermissionsModel.count > 0 || pendingViewAndPostPermissionsModel.count > 0
 
     readonly property bool contentLocked: {
         if (!rootStore.chatCommunitySectionModule.isCommunity()) {
@@ -204,6 +229,7 @@ StatusSectionLayout {
             stickersLoaded: root.stickersLoaded
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
+            permissionUpdatePending: root.permissionUpdatePending
             viewAndPostHoldingsModel: root.viewAndPostPermissionsModel
             viewAndPostPermissionsSatisfied: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.viewAndPostPermissionsSatisfied
             amISectionAdmin: root.amISectionAdmin


### PR DESCRIPTION
Fixes #13779

The problem was that the permission update some times takes time to get propagated and get back, or even the control node is offline, so the TM would not be able to post, because the backend would detect that there is a permission and that we don't have the key for it.

The solution is to block the UI when a permission update is pending, since we can't post correctly while it is not processed by he control node.

See in this video how it looks like. Do note that there is still the bug that the input isn't disabled when there is this message. That's fixed somewhere else.
[TM-posting.webm](https://github.com/status-im/status-desktop/assets/11926403/76d2a002-a7c9-49ca-aa5a-44da2ff35402)
