### PR TITLE
feat(ChannelPermissions): Show confirmation dialog before closing the channel edit popup

### DIFF
--- a/storybook/pages/CreateChannelPopupPage.qml
+++ b/storybook/pages/CreateChannelPopupPage.qml
@@ -48,8 +48,6 @@ SplitView {
             CreateChannelPopup {
                 id: dialog
                 anchors.centerIn: parent
-                modal: false
-                closePolicy: Popup.NoAutoClose
                 destroyOnClose: true
                 isEdit: true
                 isDeleteable: isDeleteableCheckBox.checked

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -22,6 +22,11 @@ Dialog {
         This property decides the modal background color
     */
     property string backgroundColor: Theme.palette.statusModal.backgroundColor
+    /*!
+       \qmlproperty closeHandler
+        This property decides the action to be performed when the close button is clicked. It allows to define
+    */
+    property var closeHandler: root.close
 
     anchors.centerIn: Overlay.overlay
 
@@ -57,7 +62,7 @@ Dialog {
         visible: root.title || root.subtitle
         headline.title: root.title
         headline.subtitle: root.subtitle
-        actions.closeButton.onClicked: root.close()
+        actions.closeButton.onClicked: root.closeHandler()
     }
 
     footer: StatusDialogFooter {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusConfirmationDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusConfirmationDialog.qml
@@ -1,0 +1,46 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import QtQml.Models 2.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    id: root
+
+    property alias body: bodyItem.text
+    property alias acceptButtonText: acceptButton.text
+    property alias rejectButtonText: rejectButton.text
+
+    implicitWidth: 480
+    closePolicy: Popup.NoAutoClose
+    
+    footer: StatusDialogFooter {
+        spacing: 16
+        rightButtons: ObjectModel {
+            StatusButton {
+                id: rejectButton
+                type: StatusButton.Danger
+                onClicked: {
+                    root.reject();
+                }
+            }
+            StatusButton {
+                id: acceptButton
+                onClicked: {
+                    root.accept();
+                }
+            }
+        }
+    }
+
+    StatusBaseText {
+        id: bodyItem
+        anchors.fill: parent
+        verticalAlignment: Text.AlignVCenter
+        wrapMode: Text.WordWrap
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -215,7 +215,7 @@ StatusDialog {
 
             onEditButtonClicked: root.editButtonClicked()
             onHeaderImageClicked: root.headerImageClicked()
-            onClose: root.close()
+            onClose: root.closeHandler()
         }
 
         Loader {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -45,7 +45,7 @@ StatusModal {
 
     property Item finishButton: StatusButton {
         text: qsTr("Finish")
-        onClicked: root.close()
+        onClicked: root.closeHandler()
     }
 
     function replace(item) { replaceItem = item; }
@@ -127,7 +127,7 @@ StatusModal {
                 onItemChanged: {
                     root.rightButtons = item ? item.rightButtons : [ nextButton, finishButton ]
                     if (!item && root.itemsCount == 0) {
-                        root.close();
+                        root.closeHandler();
                     }
                 }
             }

--- a/ui/StatusQ/src/StatusQ/Popups/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/qmldir
@@ -1,17 +1,18 @@
 module StatusQ.Popups
 
-StatusMenuSeparator 0.1 StatusMenuSeparator.qml
 StatusAction 0.1 StatusAction.qml
-StatusSuccessAction 0.1 StatusSuccessAction.qml
+StatusColorDialog 0.1 StatusColorDialog.qml
+StatusConfirmationDialog 0.1 StatusConfirmationDialog.qml
+StatusDialog 0.1 StatusDialog.qml
 StatusMenu 0.1 StatusMenu.qml
+StatusMenuHeadline 0.1 StatusMenuHeadline.qml
 StatusMenuItem 0.1 StatusMenuItem.qml
 StatusMenuInstantiator 0.1 StatusMenuInstantiator.qml
-StatusMenuHeadline 0.1 StatusMenuHeadline.qml
+StatusMenuSeparator 0.1 StatusMenuSeparator.qml
 StatusModal 0.1 StatusModal.qml
-StatusStackModal 0.1 StatusStackModal.qml
-StatusDialog 0.1 StatusDialog.qml
-StatusSearchPopup 0.1 StatusSearchPopup.qml
 StatusModalDivider 0.1 StatusModalDivider.qml
-StatusSearchPopupMenuItem 0.1 StatusSearchPopupMenuItem.qml
 StatusSearchLocationMenu 0.1 StatusSearchLocationMenu.qml
-StatusColorDialog 0.1 StatusColorDialog.qml
+StatusSearchPopup 0.1 StatusSearchPopup.qml
+StatusSearchPopupMenuItem 0.1 StatusSearchPopupMenuItem.qml
+StatusStackModal 0.1 StatusStackModal.qml
+StatusSuccessAction 0.1 StatusSuccessAction.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -220,6 +220,7 @@
         <file>StatusQ/Popups/Dialog/qmldir</file>
         <file>StatusQ/Popups/StatusAction.qml</file>
         <file>StatusQ/Popups/StatusColorDialog.qml</file>
+        <file>StatusQ/Popups/StatusConfirmationDialog.qml</file>
         <file>StatusQ/Popups/StatusMenu.qml</file>
         <file>StatusQ/Popups/StatusMenuHeadline.qml</file>
         <file>StatusQ/Popups/StatusMenuInstantiator.qml</file>


### PR DESCRIPTION
### What does the PR do
Closing #13463 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Changes:
1. Added StatusConfirmationDialog
2. Add NoAutoClose to the `CreateChannelPopup`
3. Updated the StatusStackModal tree to support custom close handler
4. Add the dirty state flag in the `CreateChannelPopup` to include all fields

### Affected areas

Edit channel popup
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/4f4c98f1-9145-41fb-8972-e04dd6c0b3a5

