### PR TITLE
fix(airdrop): fix decimals validation

### DIFF
--- a/storybook/pages/AirdropsSettingsPanelPage.qml
+++ b/storybook/pages/AirdropsSettingsPanelPage.qml
@@ -178,6 +178,10 @@ SplitView {
                             expression: model.index ? "Ethereum Mainnet" : "Goerli"
                         },
                         ExpressionRole {
+                            name: "decimals"
+                            expression: decimalsText.text
+                        },
+                        ExpressionRole {
 
                             readonly property string icon1: "network/Network=Ethereum"
                             readonly property string icon2: "network/Network=Testnet"
@@ -191,7 +195,6 @@ SplitView {
                         roleName: "category"
                         value: TokenCategories.Category.Community
                     }
-
 
                     Component.onCompleted: {
                         Qt.callLater(() => airdropsSettingsPanel.assetsModel = this)
@@ -249,6 +252,19 @@ SplitView {
                 checked: false
 
                 text: "Owner and TMaster tokens deployed"
+            }
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Assets Decimals"
+                }
+
+                TextField {
+                    id: decimalsText
+                    text: "2"
+                    width: 50
+                }
             }
         }
     }

--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -119,7 +119,10 @@ SplitView {
                         expression: model.index ? "Ethereum Mainnet" : "Goerli"
                     },
                     ExpressionRole {
-
+                        name: "decimals"
+                        expression: decimalsText.text
+                    },
+                    ExpressionRole {
                         readonly property string icon1: "network/Network=Ethereum"
                         readonly property string icon2: "network/Network=Testnet"
 
@@ -168,6 +171,16 @@ SplitView {
             CheckBox {
                 id: ctrlAllTokensMode
                 text: "All tokens mode"
+            }
+
+            Label {
+                text: "Assets Decimals"
+            }
+
+            TextField {
+                id: decimalsText
+                Layout.preferredWidth: 50
+                text: "2"
             }
         }
     }

--- a/storybook/pages/TokenPanelPage.qml
+++ b/storybook/pages/TokenPanelPage.qml
@@ -24,28 +24,32 @@ SplitView {
                 icon: Style.svg(ModelsData.networks.optimism),
                 amount: "300",
                 multiplierIndex: 0,
-                infiniteAmount: false
+                infiniteAmount: false,
+                decimals: 6
             },
             {
                 name: "Arbitrum",
                 icon: Style.svg(ModelsData.networks.arbitrum),
                 amount: "400000",
                 multiplierIndex: 3,
-                infiniteAmount: false
+                infiniteAmount: false,
+                decimals: 9
             },
             {
                 name: "Hermez",
                 icon: Style.svg(ModelsData.networks.hermez),
                 amount: "0",
                 multiplierIndex: 0,
-                infiniteAmount: true
+                infiniteAmount: true,
+                decimals: 0
             },
             {
                 name: "Ethereum",
                 icon: Style.svg(ModelsData.networks.ethereum),
                 amount: "12" + "0".repeat(18),
                 multiplierIndex: 18,
-                infiniteAmount: false
+                infiniteAmount: false,
+                decimals: 9
             }
         ]
 
@@ -130,10 +134,24 @@ SplitView {
 
                     text: "∞"
                 }
+
+                Label {
+                    text: "Decimals:"
+                }
+                TextField {
+                    id: decimalsTextField
+
+                    text: "0"
+                }
             }
 
-            Label {
-                text: "amount: " + tokenPanel.amount
+            RowLayout {
+                Label {
+                    text: "amount: " + tokenPanel.amount
+                }
+                Label {
+                    text: "decimals: " + tokenPanel.decimals
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Communities/controls/InlineNetworksComboBox.qml
+++ b/ui/app/AppLayouts/Communities/controls/InlineNetworksComboBox.qml
@@ -15,6 +15,7 @@ StatusComboBox {
 
     readonly property string currentName: control.currentText
     readonly property alias currentAmount: instantiator.amount
+    readonly property alias decimals: instantiator.decimals
     readonly property alias currentMultiplierIndex: instantiator.multiplierIndex
     readonly property alias currentInfiniteAmount: instantiator.infiniteAmount
     readonly property alias currentIcon: instantiator.icon
@@ -100,6 +101,7 @@ StatusComboBox {
         property string amount
         property int multiplierIndex
         property bool infiniteAmount
+        property int decimals
 
         model: SortFilterProxyModel {
             sourceModel: root.model
@@ -113,6 +115,7 @@ StatusComboBox {
             readonly property list<Binding> bindings: [
                 Bind { property: "icon"; value: model.icon },
                 Bind { property: "amount"; value: model.amount },
+                Bind { property: "decimals"; value: model.decimals },
                 Bind { property: "multiplierIndex"; value: model.multiplierIndex },
                 Bind { property: "infiniteAmount"; value: model.infiniteAmount }
             ]

--- a/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
@@ -21,6 +21,7 @@ ColumnLayout {
     property alias tokenImage: item.iconSource
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
+    property alias decimals: amountInput.tokenDecimals
     property alias multiplierIndex: amountInput.multiplierIndex
     property alias tokenCategoryText: tokenLabel.text
     property alias networkLabelText: d.networkLabelText
@@ -88,6 +89,7 @@ ColumnLayout {
             spacing: 10
 
             property alias currentAmount: inlineNetworksComboBox.currentAmount
+            property alias decimals: inlineNetworksComboBox.decimals
             property alias currentMultiplierIndex:
                 inlineNetworksComboBox.currentMultiplierIndex
             property alias currentInfiniteAmount:
@@ -128,7 +130,8 @@ ColumnLayout {
 
         maximumAmount: !!networksComboBoxLoader.item
                        ? networksComboBoxLoader.item.currentAmount : "0"
-
+        tokenDecimals: !!networksComboBoxLoader.item
+                       ? networksComboBoxLoader.item.decimals : 0
         multiplierIndex: !!networksComboBoxLoader.item
                          ? networksComboBoxLoader.item.currentMultiplierIndex : 0
 

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -425,6 +425,7 @@ StatusDropdown {
                         name: chainName,
                         icon: chainIcon,
                         amount: asset.remainingSupply,
+                        decimals: asset.decimals,
                         multiplierIndex: asset.multiplierIndex,
                         infiniteAmount: asset.infiniteSupply
                     })

--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -177,9 +177,10 @@ Item {
         id: validationErrorText
         visible: !!validationError
         text: validationError
+        anchors.left: inputField.left
+        anchors.leftMargin: 2
         anchors.top: inputField.bottom
         anchors.topMargin: validationErrorTopMargin
-        width: parent.width
         horizontalAlignment: Text.AlignRight
         font.pixelSize: 12
         height: 16


### PR DESCRIPTION
Fixes #11918

### What does the PR do

1) HoldingsDropdown.qml - add "decimal" to assetPanel ListModel
2) InlineNetworksComboBox.qml - propogate "decimal" from the model  
3) TokenPanel.qml - propogate "decimal" from to AmountInput
4) AmountInput.qml - validate number of digits in franctional part of entered amount
### Affected areas

Community/Airdrop

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
<kbd>
<img width="317" alt="image" src="https://github.com/status-im/status-desktop/assets/1083341/39eecb5e-859f-458d-8704-6fcfc6aaf368"></kbd>

- [ ] I've checked the design and this PR matches it
