### PR TITLE
fix: Collapse / expand section header icons in collectibles view

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -400,7 +400,7 @@ ColumnLayout {
 
                 checkable: true
                 size: StatusBaseButton.Size.Small
-                icon.name: checked ? "chevron-down" : "next"
+                icon.name: checked ? "next" : "chevron-down"
                 textColor: Theme.palette.baseColor1
                 textHoverColor: Theme.palette.directColor1
 
@@ -503,7 +503,7 @@ ColumnLayout {
                 onTriggered: root.manageTokensRequested()
             }
             StatusAction {
-                enabled: symbol !== "ETH"
+                enabled: symbol !== Constants.ethToken
                 type: StatusAction.Type.Danger
                 icon.name: "hide"
                 text: qsTr("Hide collectible")


### PR DESCRIPTION
### What does the PR do

- use the right icons for collapsed/expanded state (this should probably use the existing `FoldableHeader` component, with some modifications)

Fixes #13774

### Affected areas

CollectiblesView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/5ddff89f-837f-4d4d-a4b6-0c21899f8501)