### PR TITLE
fix: Hide fleet selection from settings

### DIFF
--- a/src/constants.nim
+++ b/src/constants.nim
@@ -41,6 +41,7 @@ let
   WAKU_V2_PORT* = desktopConfig.defaultWakuV2Port
   STATUS_PORT* = desktopConfig.statusPort
   LOG_LEVEL* = desktopConfig.logLevel
+  FLEET_SELECTION_ENABLED* = desktopConfig.enableFleetSelection
 
   # build variables
   POKT_TOKEN_RESOLVED* = desktopConfig.poktToken

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -212,6 +212,11 @@ type StatusDesktopConfig = object
     longdesc: "Can be one of: \"ERROR\", \"WARN\", \"INFO\", \"DEBUG\", \"TRACE\". \"INFO\" in production build, otherwise \"DEBUG\""
     name: "LOG_LEVEL"
     abbr: "log-level" .}: string
+  enableFleetSelection* {.
+    defaultValue: false
+    desc: "Determines if the fleet selection UI is enabled"
+    name: "ENABLE_FLEET_SELECTION"
+    abbr: "enable-fleet-selection" .}: bool
 
 
 # On macOS the first time when a user gets the "App downloaded from the

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -163,6 +163,7 @@ proc mainProc() =
   singletonInstance.engine.setRootContextProperty("uiScaleFilePath", newQVariant(uiScaleFilePath))
   singletonInstance.engine.setRootContextProperty("singleInstance", newQVariant(singleInstance))
   singletonInstance.engine.setRootContextProperty("isExperimental", isExperimentalQVariant)
+  singletonInstance.engine.setRootContextProperty("fleetSelectionEnabled", newQVariant(FLEET_SELECTION_ENABLED))
   singletonInstance.engine.setRootContextProperty("signals", signalsManagerQVariant)
   singletonInstance.engine.setRootContextProperty("production", isProductionQVariant)
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -318,6 +318,7 @@ StatusSectionLayout {
                 messagingStore: root.store.messagingStore
                 advancedStore: root.store.advancedStore
                 walletStore: root.store.walletStore
+                isFleetSelectionEnabled: fleetSelectionEnabled
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.advanced)
                 contentWidth: d.contentWidth
             }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -36,6 +36,8 @@ SettingsContentBase {
     property AdvancedStore advancedStore
     property WalletStore walletStore
 
+    property bool isFleetSelectionEnabled
+
     Item {
         id: advancedContainer
         width: root.contentWidth
@@ -59,6 +61,7 @@ SettingsContentBase {
                 text: qsTr("Fleet")
                 currentValue: root.advancedStore.fleet
                 onClicked: fleetModal.open()
+                visible: root.isFleetSelectionEnabled
             }
 
             StatusSettingsLineButton {


### PR DESCRIPTION
### What does the PR do

- introduce `ENABLE_FLEET_SELECTION` desktop config entry to control the Fleet selection UI availability
- UI can be enabled with envvar `STATUS_RUNTIME_ENABLE_FLEET_SELECTION=1`

Fixes #13848

### Affected areas

Settings/Advanced

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Disabled by default:
![image](https://github.com/status-im/status-desktop/assets/5377645/429e7506-0c42-4654-8c7b-6b3888824435)

With `ENABLE_FLEET_SELECTION=1`:
![image](https://github.com/status-im/status-desktop/assets/5377645/ef2ed5cc-c29c-49b0-beaa-cf6ba53785ce)
