### PR TITLE
fix(ProfileShowcase): Fix blinking when hovering over an address

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusDraggableListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusDraggableListItem.qml
@@ -216,7 +216,7 @@ ItemDelegate {
        \qmlproperty alias StatusDraggableListItem::containsMouse
        Used to read if the component cotains mouse
     */
-    readonly property alias containsMouse: dragHandler.containsMouse
+    readonly property alias containsMouse: hoverHandler.hovered
 
     /*!
        \qmlproperty bool StatusDraggableListItem::changeColorOnDragActive
@@ -270,7 +270,6 @@ ItemDelegate {
             drag.target: root.dragEnabled ? root : null
             drag.axis: root.dragAxis
             preventStealing: true // otherwise DND is broken inside a Flickable/ScrollView
-            hoverEnabled: true
             cursorShape: {
                 if (!root.enabled)
                     return undefined
@@ -416,5 +415,8 @@ ItemDelegate {
             asset.bgHeight: 40
             asset.bgWidth: 40
         }
+    }
+    HoverHandler {
+        id: hoverHandler
     }
 }


### PR DESCRIPTION
#13681

### What does the PR do
Fixes blinking when hovering over an address

### Affected areas
ProfileShowcase

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/1083341/c7f8650e-4271-4d00-91ea-6f03988264b1

and the same component is used here
https://github.com/status-im/status-desktop/assets/1083341/3182c88b-1e38-437d-8ec0-f8deeb4a2aad

### Cool Spaceship Picture

<!-- optional but cool ->
