### PR TITLE
fix(StatusQ): Don't emit layoutChanged on source model reset in MovableModel

### DIFF
--- a/ui/StatusQ/include/StatusQ/movablemodel.h
+++ b/ui/StatusQ/include/StatusQ/movablemodel.h
@@ -55,6 +55,7 @@ private:
 
     // other
     void connectSignalsForSyncedState();
+    void syncOrderInternal();
 
     QPointer<QAbstractItemModel> m_sourceModel;
     bool m_synced = true;

--- a/ui/StatusQ/src/movablemodel.cpp
+++ b/ui/StatusQ/src/movablemodel.cpp
@@ -20,7 +20,7 @@ void MovableModel::setSourceModel(QAbstractItemModel* sourceModel)
         disconnect(m_sourceModel, nullptr, this, nullptr);
 
     m_sourceModel = sourceModel;
-    syncOrder();
+    syncOrderInternal();
     emit sourceModelChanged();
 
     endResetModel();
@@ -121,10 +121,18 @@ void MovableModel::desyncOrder()
 
 void MovableModel::syncOrder()
 {
+    if (m_synced || m_sourceModel == nullptr)
+        return;
+
+    emit layoutAboutToBeChanged();
+    syncOrderInternal();
+    emit layoutChanged();
+}
+
+void MovableModel::syncOrderInternal()
+{
     if (m_sourceModel)
     {
-        emit layoutAboutToBeChanged();
-
         auto sourceModel = m_sourceModel;
 
         disconnect(m_sourceModel, nullptr, this, nullptr);
@@ -138,8 +146,6 @@ void MovableModel::syncOrder()
 
             changePersistentIndex(index(i, 0), index(idx.row(), 0));
         }
-
-        emit layoutChanged();
     }
 
 

--- a/ui/StatusQ/tests/tst_MovableModel.cpp
+++ b/ui/StatusQ/tests/tst_MovableModel.cpp
@@ -647,11 +647,9 @@ private slots:
 
         model.setSourceModel(sourceModel2);
 
-        QCOMPARE(signalsSpy.count(), 4);
+        QCOMPARE(signalsSpy.count(), 2);
         QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
         QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
-        QCOMPARE(signalsSpy.layoutAboutToBeChangedSpy.count(), 1);
-        QCOMPARE(signalsSpy.layoutChangedSpy.count(), 1);
 
 
         QCOMPARE(syncedChangedSpy.count(), 1);
@@ -683,14 +681,18 @@ private slots:
             QCOMPARE(signalsSpy.count(), 0);
         }
 
-        model.setSourceModel(sourceModel);
+        {
+            ModelSignalsSpy signalsSpy(&model);
+            model.setSourceModel(sourceModel);
+            QCOMPARE(signalsSpy.count(), 2);
+            QCOMPARE(signalsSpy.modelAboutToBeResetSpy.count(), 1);
+            QCOMPARE(signalsSpy.modelResetSpy.count(), 1);
+        }
 
         {
             ModelSignalsSpy signalsSpy(&model);
             model.syncOrder();
-            QCOMPARE(signalsSpy.count(), 2);
-            QCOMPARE(signalsSpy.layoutAboutToBeChangedSpy.count(), 1);
-            QCOMPARE(signalsSpy.layoutChangedSpy.count(), 1);
+            QCOMPARE(signalsSpy.count(), 0); //already synced
         }
 
         PersistentIndexesTester indexesTester(&model);
@@ -759,7 +761,7 @@ private slots:
         QVERIFY(indexesTester.compare());
     }
     
-    void sourceModelReset()
+    void sourceModelResetTest()
     {
         QQmlEngine engine;
 


### PR DESCRIPTION
### What does the PR do

Don't emit `layoutChanged` when the source model changes.

+Update tests
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

MovableModel
<!-- List the affected areas (e.g wallet, browser, etc..) -->