### PR TITLE
fix: [Profile flow] Nickname not updated after it was added, edited or removed

### DIFF
--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -136,8 +136,8 @@ QtObject {
         openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup}, cb)
     }
 
-    function openNicknamePopup(publicKey: string, contactDetails) {
-        openPopup(nicknamePopupComponent, {publicKey, contactDetails})
+    function openNicknamePopup(publicKey: string, contactDetails, cb) {
+        openPopup(nicknamePopupComponent, {publicKey, contactDetails}, cb)
     }
 
     function openMarkAsUntrustedPopup(publicKey: string, contactDetails) {

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -161,7 +161,7 @@ Pane {
             size: StatusButton.Size.Small
             text: qsTr("Send contact request")
             onClicked: Global.openContactRequestPopup(root.publicKey, d.contactDetails,
-                                                      popup => popup.closed.connect(d.reload))
+                                                      popup => popup.accepted.connect(d.reload))
         }
     }
 
@@ -402,7 +402,8 @@ Pane {
                         text: d.userNickName ? qsTr("Edit nickname") : qsTr("Add nickname")
                         icon.name: "edit_pencil"
                         onTriggered: {
-                            Global.openNicknamePopupRequested(root.publicKey, d.contactDetails)
+                            Global.openNicknamePopupRequested(root.publicKey, d.contactDetails,
+                                                              popup => popup.closed.connect(d.reload))
                         }
                     }
                     StatusAction {
@@ -427,7 +428,7 @@ Pane {
                         type: StatusAction.Type.Danger
                         enabled: d.isContact && (d.isTrusted || d.isLocallyTrusted)
                         onTriggered: Global.openRemoveIDVerificationDialog(root.publicKey, d.contactDetails,
-                                                                           popup => popup.closed.connect(d.reload))
+                                                                           popup => popup.accepted.connect(d.reload))
                     }
                     StatusAction {
                         text: qsTr("Remove nickname")

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -206,7 +206,7 @@ StatusMenu {
         text: contactDetails.localNickname ? qsTr("Edit nickname") : qsTr("Add nickname")
         icon.name: "edit_pencil"
         enabled: !root.isMe && !root.isBridgedAccount
-        onTriggered: Global.openNicknamePopupRequested(root.selectedUserPublicKey, root.contactDetails)
+        onTriggered: Global.openNicknamePopupRequested(root.selectedUserPublicKey, root.contactDetails, null)
     }
 
     StatusMenuSeparator {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -31,7 +31,7 @@ QtObject {
 
     signal openPopupRequested(var popupComponent, var params)
     signal closePopupRequested()
-    signal openNicknamePopupRequested(string publicKey, var contactDetails)
+    signal openNicknamePopupRequested(string publicKey, var contactDetails, var cb)
     signal openDownloadModalRequested(bool available, string version, string url)
     signal openChangeProfilePicPopup(var cb)
     signal openBackUpSeedPopup()


### PR DESCRIPTION
### What does the PR do

- trigger a reload of contact details when the secondary popup has been closed

Fixes #13870

### Affected areas

ProfileDialog

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-07 11-12-43.webm](https://github.com/status-im/status-desktop/assets/5377645/ba919f19-1c1d-472f-a67c-d95f5a932aec)
