### PR TITLE
13291 hide channels

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -24,6 +24,7 @@ QtObject:
     active: bool
     blocked: bool
     canPostReactions: bool
+    hideIfPermissionsNotMet: bool
 
   proc delete*(self: ChatDetails) =
     self.QObject.delete
@@ -50,6 +51,7 @@ QtObject:
       isContact: bool = false,
       blocked: bool = false,
       canPostReactions: bool = true,
+      hideIfPermissionsNotMet: bool
     ) =
     self.id = id
     self.`type` = `type`
@@ -70,6 +72,7 @@ QtObject:
     self.active = false
     self.blocked = blocked
     self.canPostReactions = canPostReactions
+    self.hideIfPermissionsNotMet = hideIfPermissionsNotMet
 
   proc getId(self: ChatDetails): string {.slot.} =
     return self.id
@@ -255,3 +258,14 @@ QtObject:
   proc setCanPostReactions*(self: ChatDetails, value: bool) =
     self.canPostReactions = value
     self.canPostReactionsChanged()
+  
+  proc hideIfPermissionsNotMetChanged(self: ChatDetails) {.signal.}
+  proc getHideIfPermissionsNotMet(self: ChatDetails): bool {.slot.} =
+    return self.hideIfPermissionsNotMet
+  QtProperty[bool] hideIfPermissionsNotMet:
+    read = getHideIfPermissionsNotMet
+    notify = hideIfPermissionsNotMetChanged
+
+  proc setHideIfPermissionsNotMet*(self: ChatDetails, value: bool) =
+    self.hideIfPermissionsNotMet = value
+    self.hideIfPermissionsNotMetChanged()

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -95,7 +95,7 @@ method load*(self: Module, chatItem: chat_item.Item) =
     self.controller.isUsersListAvailable(), chatName, chatImage,
     chatItem.color, chatItem.description, chatItem.emoji, chatItem.hasUnreadMessages, chatItem.notificationsCount,
     chatItem.highlight, chatItem.muted, chatItem.position, isUntrustworthy = trustStatus == TrustStatus.Untrustworthy,
-    isContact, chatItem.blocked, chatItem.canPostReactions)
+    isContact, chatItem.blocked, chatItem.canPostReactions, chatItem.hideIfPermissionsNotMet)
 
   self.inputAreaModule.load()
   self.messagesModule.load()

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -40,10 +40,10 @@ QtObject:
   proc load*(self: View, id: string, `type`: int, belongsToCommunity, isUsersListAvailable: bool,
       name, icon: string, color, description, emoji: string, hasUnreadMessages: bool,
       notificationsCount: int, highlight, muted: bool, position: int, isUntrustworthy: bool,
-      isContact: bool, blocked: bool, canPostReactions: bool) =
+      isContact: bool, blocked: bool, canPostReactions: bool, hideIfPermissionsNotMet: bool) =
     self.chatDetails.setChatDetails(id, `type`, belongsToCommunity, isUsersListAvailable, name,
       icon, color, description, emoji, hasUnreadMessages, notificationsCount, highlight, muted, position,
-      isUntrustworthy, isContact, blocked, canPostReactions)
+      isUntrustworthy, isContact, blocked, canPostReactions, hideIfPermissionsNotMet)
     self.delegate.viewDidLoad()
     self.chatDetailsChanged()
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -566,9 +566,10 @@ proc createCommunityChannel*(
     color: string,
     categoryId: string,
     viewersCanPostReactions: bool,
+    hideIfPermissionsNotMet: bool,
     ) =
   self.communityService.createCommunityChannel(self.sectionId, name, description, emoji, color,
-    categoryId, viewersCanPostReactions)
+    categoryId, viewersCanPostReactions, hideIfPermissionsNotMet)
 
 proc editCommunityChannel*(
     self: Controller,
@@ -580,6 +581,7 @@ proc editCommunityChannel*(
     categoryId: string,
     position: int,
     viewersCanPostReactions: bool,
+    hideIfPermissionsNotMet: bool,
     ) =
   self.communityService.editCommunityChannel(
     self.sectionId,
@@ -590,8 +592,8 @@ proc editCommunityChannel*(
     color,
     categoryId,
     position,
-    viewersCanPostReactions
-  )
+    viewersCanPostReactions,
+    hideIfPermissionsNotMet)
 
 proc createCommunityCategory*(self: Controller, name: string, channels: seq[string]) =
   self.communityService.createCommunityCategory(self.sectionId, name, channels)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -266,11 +266,11 @@ method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string, 
   raise newException(ValueError, "No implementation available")
 
 method createCommunityChannel*(self: AccessInterface, name: string, description: string,
-    emoji: string, color: string, categoryId: string, viewersCanPostReactions: bool) {.base.} =
+    emoji: string, color: string, categoryId: string, viewersCanPostReactions: bool, hideIfPermissionsNotMet: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editCommunityChannel*(self: AccessInterface, channelId, name, description, emoji, color,
-    categoryId: string, position: int, viewersCanPostReactions: bool) {.base.} =
+    categoryId: string, position: int, viewersCanPostReactions: bool, hideIfPermissionsNotMet: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method leaveCommunity*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -37,6 +37,9 @@ type
     requiresPermissions: bool
     canPostReactions: bool
     viewersCanPostReactions: bool
+    hideIfPermissionsNotMet: bool
+    viewOnlyPermissionsSatisfied: bool
+    viewAndPostPermissionsSatisfied: bool
 
 proc initItem*(
     id,
@@ -67,6 +70,9 @@ proc initItem*(
     requiresPermissions = false,
     canPostReactions = true,
     viewersCanPostReactions = true,
+    hideIfPermissionsNotMet: bool,
+    viewOnlyPermissionsSatisfied: bool,
+    viewAndPostPermissionsSatisfied: bool
     ): Item =
   result = Item()
   result.id = id
@@ -98,6 +104,9 @@ proc initItem*(
   result.requiresPermissions = requiresPermissions
   result.canPostReactions = canPostReactions
   result.viewersCanPostReactions = viewersCanPostReactions
+  result.hideIfPermissionsNotMet = hideIfPermissionsNotMet
+  result.viewOnlyPermissionsSatisfied = viewOnlyPermissionsSatisfied
+  result.viewAndPostPermissionsSatisfied = viewAndPostPermissionsSatisfied
 
 proc `$`*(self: Item): string =
   result = fmt"""chat_section/Item(
@@ -128,6 +137,9 @@ proc `$`*(self: Item): string =
     requiresPermissions: {$self.requiresPermissions},
     canPostReactions: {$self.canPostReactions},
     viewersCanPostReactions: {$self.viewersCanPostReactions},
+    hideIfPermissionsNotMet: {$self.hideIfPermissionsNotMet},
+    viewOnlyPermissionsSatisfied: {$self.viewOnlyPermissionsSatisfied},
+    viewAndPostPermissionsSatisfied: {$self.viewAndPostPermissionsSatisfied}
     ]"""
 
 proc toJsonNode*(self: Item): JsonNode =
@@ -159,6 +171,9 @@ proc toJsonNode*(self: Item): JsonNode =
     "requiresPermissions": self.requiresPermissions,
     "canPostReactions": self.canPostReactions,
     "viewersCanPostReactions": self.viewersCanPostReactions,
+    "hideIfPermissionsNotMet": self.hideIfPermissionsNotMet,
+    "viewOnlyPermissionsSatisfied": self.viewOnlyPermissionsSatisfied,
+    "viewAndPostPermissionsSatisfied": self.viewAndPostPermissionsSatisfied
   }
 
 proc delete*(self: Item) =
@@ -257,6 +272,24 @@ proc categoryId*(self: Item): string =
 proc `categoryId=`*(self: var Item, value: string) =
   self.categoryId = value
 
+proc hideIfPermissionsNotMet*(self: Item): bool =
+  self.hideIfPermissionsNotMet
+
+proc `hideIfPermissionsNotMet=`*(self: var Item, value: bool) =
+  self.hideIfPermissionsNotMet = value
+
+proc viewAndPostPermissionsSatisfied*(self: Item): bool =
+  self.viewAndPostPermissionsSatisfied
+
+proc `viewAndPostPermissionsSatisfied=`*(self: var Item, value: bool) =
+  self.viewAndPostPermissionsSatisfied = value
+
+proc viewOnlyPermissionsSatisfied*(self: Item): bool =
+  self.viewOnlyPermissionsSatisfied
+
+proc `viewOnlyPermissionsSatisfied=`*(self: var Item, value: bool) =
+  self.viewOnlyPermissionsSatisfied = value
+
 proc categoryPosition*(self: Item): int =
   self.categoryPosition
 
@@ -322,3 +355,6 @@ proc viewersCanPostReactions*(self: Item): bool =
 
 proc `viewersCanPostReactions=`*(self: Item, value: bool) =
   self.viewersCanPostReactions = value
+
+proc hideBecausePermissionsAreNotMet*(self: Item): bool =
+  self.hideIfPermissionsNotMet and not self.viewOnlyPermissionsSatisfied and not self.viewAndPostPermissionsSatisfied

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -31,6 +31,7 @@ QtObject:
       permissionsCheckOngoing: bool
       isWaitingOnNewCommunityOwnerToConfirmRequestToRejoin: bool
       shardingInProgress: bool
+      allChannelsAreHiddenBecauseNotPermitted: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -269,9 +270,10 @@ QtObject:
       emoji: string,
       color: string,
       categoryId: string,
-      viewersCanPostReactions: bool
+      viewersCanPostReactions: bool,
+      hideIfPermissionsNotMet: bool,
       ) {.slot.} =
-    self.delegate.createCommunityChannel(name, description, emoji, color, categoryId, viewersCanPostReactions)
+    self.delegate.createCommunityChannel(name, description, emoji, color, categoryId, viewersCanPostReactions, hideIfPermissionsNotMet)
 
   proc editCommunityChannel*(
       self: View,
@@ -283,6 +285,7 @@ QtObject:
       categoryId: string,
       position: int,
       viewersCanPostReactions: bool,
+      hideIfPermissionsNotMet: bool
     ) {.slot.} =
     self.delegate.editCommunityChannel(
       channelId,
@@ -293,6 +296,7 @@ QtObject:
       categoryId,
       position,
       viewersCanPostReactions,
+      hideIfPermissionsNotMet
     )
 
   proc leaveCommunity*(self: View) {.slot.} =
@@ -490,3 +494,18 @@ QtObject:
     self.setShardingInProgress(true)
     self.delegate.setCommunityShard(shardIndex)
 
+  proc allChannelsAreHiddenBecauseNotPermittedChanged*(self: View) {.signal.}
+
+  proc getAllChannelsAreHiddenBecauseNotPermitted*(self: View): bool {.slot.} =
+    return self.allChannelsAreHiddenBecauseNotPermitted
+
+  QtProperty[bool] allChannelsAreHiddenBecauseNotPermitted:
+    read = getAllChannelsAreHiddenBecauseNotPermitted
+    notify = allChannelsAreHiddenBecauseNotPermittedChanged
+
+  proc refreshAllChannelsAreHiddenBecauseNotPermittedChanged*(self: View) =
+    let allAreHidden = self.model.allChannelsAreHiddenBecauseNotPermitted()
+    if (allAreHidden == self.allChannelsAreHiddenBecauseNotPermitted):
+      return
+    self.allChannelsAreHiddenBecauseNotPermitted = allAreHidden
+    self.allChannelsAreHiddenBecauseNotPermittedChanged()

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -89,6 +89,7 @@ type ChatDto* = object
   categoryId*: string
   highlight*: bool
   permissions*: Permission
+  hideIfPermissionsNotMet*: bool
 
 type ChannelGroupDto* = object
   id*: string
@@ -152,7 +153,8 @@ proc `$`*(self: ChatDto): string =
     firstMessageTimestamp: {self.firstMessageTimestamp},
     categoryId: {self.categoryId},
     position: {self.position},
-    highlight: {self.highlight}
+    highlight: {self.highlight},
+    hideIfPermissionsNotMet: {self.hideIfPermissionsNotMet}
     )"""
 
 proc toCheckPermissionsResultDto*(jsonObj: JsonNode): CheckPermissionsResultDto =
@@ -280,6 +282,7 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
     # Communities have `categoryID` and chats have `categoryId`
     # This should be fixed in status-go, but would be a breaking change
     discard jsonObj.getProp("categoryID", result.categoryId)
+  discard jsonObj.getProp("hideIfPermissionsNotMet", result.hideIfPermissionsNotMet)
   discard jsonObj.getProp("position", result.position)
   discard jsonObj.getProp("communityId", result.communityId)
   discard jsonObj.getProp("profile", result.profile)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -304,6 +304,7 @@ proc createCommunityChannel*(
     color: string,
     categoryId: string,
     viewersCanPostReactions: bool,
+    hideIfPermissionsNotMet: bool
     ): RpcResponse[JsonNode] =
   result = callPrivateRPC("createCommunityChat".prefix, %*[
     communityId,
@@ -319,6 +320,7 @@ proc createCommunityChannel*(
       },
       "category_id": categoryId,
       "viewers_can_post_reactions": viewersCanPostReactions,
+      "hide_if_permissions_not_met": hideIfPermissionsNotMet
     }])
 
 proc editCommunityChannel*(
@@ -331,6 +333,7 @@ proc editCommunityChannel*(
     categoryId: string,
     position: int,
     viewersCanPostReactions: bool,
+    hideIfPermissionsNotMet: bool
     ): RpcResponse[JsonNode] =
   result = callPrivateRPC("editCommunityChat".prefix, %*[
     communityId,
@@ -348,6 +351,7 @@ proc editCommunityChannel*(
       "category_id": categoryId,
       "position": position,
       "viewers_can_post_reactions": viewersCanPostReactions,
+      "hide_if_permissions_not_met": hideIfPermissionsNotMet
     }])
 
 proc reorderCommunityCategories*(communityId: string, categoryId: string, position: int): RpcResponse[JsonNode] =

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -56,6 +56,12 @@ Item {
 
             model: SortFilterProxyModel {
                 sourceModel: root.model
+                filters: [
+                    ValueFilter {
+                        roleName: "shouldBeHiddenBecausePermissionsAreNotMet"
+                        value: false
+                    }
+                ]
                 sorters: [
                     RoleSorter {
                         roleName: "categoryPosition"

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -61,6 +61,8 @@ QtObject {
         root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
     }
 
+    readonly property bool allChannelsAreHiddenBecauseNotPermitted: root.chatCommunitySectionModule.allChannelsAreHiddenBecauseNotPermitted
+
     readonly property bool requirementsCheckPending: root.communitiesModuleInst.requirementsCheckPending
 
     readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?
@@ -336,13 +338,13 @@ QtObject {
     }
 
     function createCommunityChannel(channelName, channelDescription, channelEmoji, channelColor,
-            categoryId, viewersCanPostReactions) {
+            categoryId, viewersCanPostReactions, hideIfPermissionsNotMet) {
         chatCommunitySectionModule.createCommunityChannel(channelName, channelDescription,
-            channelEmoji.trim(), channelColor, categoryId, viewersCanPostReactions);
+            channelEmoji.trim(), channelColor, categoryId, viewersCanPostReactions, hideIfPermissionsNotMet);
     }
 
     function editCommunityChannel(chatId, newName, newDescription, newEmoji, newColor,
-            newCategory, channelPosition, viewOnlyCanAddReaction) {
+            newCategory, channelPosition, viewOnlyCanAddReaction, hideIfPermissionsNotMet) {
         chatCommunitySectionModule.editCommunityChannel(
                     chatId,
                     newName,
@@ -351,7 +353,8 @@ QtObject {
                     newColor,
                     newCategory,
                     channelPosition,
-                    viewOnlyCanAddReaction
+                    viewOnlyCanAddReaction,
+                    hideIfPermissionsNotMet
                 )
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -34,7 +34,8 @@ Item {
                                    string chatColor,
                                    string chatCategoryId,
                                    int channelPosition,
-                                   var deleteDialog)
+                                   var deleteDialog,
+                                   bool hideIfPermissionsNotMet)
 
     function addRemoveGroupMember() {
         root.state = d.stateMembersSelectorContent
@@ -166,6 +167,7 @@ Item {
                     chatType = chatContentModule.chatDetails.type
                     chatMuted = chatContentModule.chatDetails.muted
                     channelPosition = chatContentModule.chatDetails.position
+                    hideIfPermissionsNotMet = chatContentModule.chatDetails.hideIfPermissionsNotMet
                 }
 
                 onMuteChat: {
@@ -229,7 +231,8 @@ Item {
                     root.displayEditChannelPopup(chatId, chatName, chatDescription,
                                                  chatEmoji, chatColor,
                                                  chatCategoryId, channelPosition,
-                                                 contextMenu.deleteChatConfirmationDialog);
+                                                 contextMenu.deleteChatConfirmationDialog,
+                                                 hideIfPermissionsNotMet);
                 }
                 onAddRemoveGroupMember: {
                     root.addRemoveGroupMember()

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -12,9 +12,11 @@ import shared.views.chat 1.0
 import shared.stores.send 1.0
 import SortFilterProxyModel 0.2
 
+import StatusQ.Core 0.1
 import StatusQ.Layout 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Controls 0.1
+import QtQuick.Layouts 1.15
 
 import "."
 import "../panels"
@@ -52,6 +54,7 @@ StatusSectionLayout {
     property bool hasViewAndPostPermissions: false
     property bool amIMember: false
     property bool amISectionAdmin: false
+    readonly property bool allChannelsAreHiddenBecauseNotPermitted: rootStore.allChannelsAreHiddenBecauseNotPermitted
 
     property bool isInvitationPending: false
 
@@ -139,6 +142,7 @@ StatusSectionLayout {
     hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
 
     headerContent: Loader {
+        visible: !root.allChannelsAreHiddenBecauseNotPermitted
         id: headerContentLoader
         sourceComponent: root.contentLocked ? joinCommunityHeaderPanelComponent : chatHeaderContentViewComponent
     }
@@ -152,7 +156,8 @@ StatusSectionLayout {
 
     centerPanel: Loader {
         anchors.fill: parent
-        sourceComponent: root.contentLocked ? joinCommunityCenterPanelComponent : chatColumnViewComponent
+        sourceComponent: root.allChannelsAreHiddenBecauseNotPermitted ? allChatsAreHiddenComponent :
+                                      (root.contentLocked ? joinCommunityCenterPanelComponent : chatColumnViewComponent)
     }
 
     showRightPanel: {
@@ -201,7 +206,8 @@ StatusSectionLayout {
                     channelColor: chatColor,
                     categoryId: chatCategoryId,
                     channelPosition: channelPosition,
-                    deleteChatConfirmationDialog: deleteDialog
+                    deleteChatConfirmationDialog: deleteDialog,
+                    hideIfPermissionsNotMet: hideIfPermissionsNotMet
                 });
             }
         }
@@ -257,6 +263,18 @@ StatusSectionLayout {
             requirementsCheckPending: root.chatContentModule.permissionsCheckOngoing
             onRevealAddressClicked: root.revealAddressClicked()
             onInvitationPendingClicked: root.invitationPendingClicked()
+        }
+    }
+
+    Component {
+        id: allChatsAreHiddenComponent
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            visible: root.allChannelsAreHiddenBecauseNotPermitted
+            text: qsTr("Sorry, you don't hodl the necessary tokens to view or post in any of <b>%1</b> channels").arg(sectionItemModel.name)
+            color: Theme.palette.dangerColor1
         }
     }
 

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -32,7 +32,7 @@ StatusStackModal {
     property bool isEdit: false
     property bool isDeleteable: false
     property bool viewOnlyCanAddReaction
-    property bool hideIfPermissionsNotMet
+    property bool hideIfPermissionsNotMet: false
 
     property string communityId: ""
     property string chatId: "_newChannel"
@@ -58,8 +58,8 @@ StatusStackModal {
     readonly property int maxChannelDescLength: 140
 
     // channel signals
-    signal createCommunityChannel(string chName, string chDescription, string chEmoji, string chColor, string chCategoryId, bool viewOnlyCanAddReaction)
-    signal editCommunityChannel(string chName, string chDescription, string chEmoji, string chColor, string chCategoryId, bool viewOnlyCanAddReaction)
+    signal createCommunityChannel(string chName, string chDescription, string chEmoji, string chColor, string chCategoryId, bool viewOnlyCanAddReaction, bool hideIfPermissionsNotMet)
+    signal editCommunityChannel(string chName, string chDescription, string chEmoji, string chColor, string chCategoryId, bool viewOnlyCanAddReaction, bool hideIfPermissionsNotMet)
     signal deleteCommunityChannel()
 
     // Permissions signals:
@@ -187,14 +187,16 @@ StatusStackModal {
                                             emoji,
                                             colorPanel.color.toString().toUpperCase(),
                                             root.categoryId,
-                                            d.viewOnlyCanAddReaction)
+                                            d.viewOnlyCanAddReaction,
+                                            d.hideIfPermissionsNotMet)
             } else {
                 root.editCommunityChannel(StatusQUtils.Utils.filterXSS(nameInput.input.text),
                                             StatusQUtils.Utils.filterXSS(descriptionTextArea.text),
                                             emoji,
                                             colorPanel.color.toString().toUpperCase(),
                                             root.categoryId,
-                                            d.viewOnlyCanAddReaction)
+                                            d.viewOnlyCanAddReaction,
+                                            d.hideIfPermissionsNotMet)
             }
 
             if (d.channelEditModel.dirtyPermissions) {
@@ -795,7 +797,6 @@ StatusStackModal {
                     Layout.rightMargin: Style.current.padding
                     leftSide: false
                     text: qsTr("Hide channel from members who don't have permissions to view the channel")
-                    visible: false //TODO: Enable connect to the backend when it's ready https://github.com/status-im/status-desktop/issues/13291
                     checked: d.hideIfPermissionsNotMet
                     onToggled: {
                         d.hideIfPermissionsNotMet = checked;

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -332,6 +332,7 @@ Item {
                         channelPosition = obj.position
                         chatCategoryId = obj.categoryId
                         viewersCanPostReactions = obj.viewersCanPostReactions
+                        hideIfPermissionsNotMet = obj.hideIfPermissionsNotMet
                     } catch (e) {
                         console.error("error parsing chat item json object, id: ", id, " error: ", e)
                         close()
@@ -387,7 +388,8 @@ Item {
                         chatId: chatContextMenuView.chatId,
                         channelPosition: channelPosition,
                         viewOnlyCanAddReaction: viewersCanPostReactions,
-                        deleteChatConfirmationDialog: deleteChatConfirmationDialog
+                        deleteChatConfirmationDialog: deleteChatConfirmationDialog,
+                        hideIfPermissionsNotMet: hideIfPermissionsNotMet
                     });
                 }
             }
@@ -628,9 +630,9 @@ Item {
             property var deleteChatConfirmationDialog
             
             onCreateCommunityChannel: function (chName, chDescription, chEmoji, chColor,
-                                                chCategoryId) {
+                                                chCategoryId, hideIfPermissionsNotMet) {
                 root.store.createCommunityChannel(chName, chDescription, chEmoji, chColor,
-                                                  chCategoryId, viewOnlyCanAddReaction)
+                                                  chCategoryId, viewOnlyCanAddReaction, hideIfPermissionsNotMet)
                 chatId = root.store.currentChatContentModule().chatDetails.id
             }
             onEditCommunityChannel: {
@@ -641,7 +643,8 @@ Item {
                                                 chColor,
                                                 chCategoryId,
                                                 channelPosition,
-                                                viewOnlyCanAddReaction);
+                                                viewOnlyCanAddReaction,
+                                                hideIfPermissionsNotMet);
             }
 
             onAddPermissions: function (permissions) {

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -29,6 +29,7 @@ StatusMenu {
     property bool viewersCanPostReactions: true
     property bool showDebugOptions: false
     property alias deleteChatConfirmationDialog: deleteChatConfirmationDialogComponent
+    property bool hideIfPermissionsNotMet: false
 
     signal displayProfilePopup(string publicKey)
     signal displayEditChannelPopup(string chatId)


### PR DESCRIPTION
### What does the PR do

Extend chats model with channel permissions info and hideIfPermissionsNotMet.
Visibility of chat item is based on: member roles, channel permissions, hideIfPermissionsNotMet.
If all channels from category are hidden, category item is also hidden.
If all channels in community are hidden, information label is displayed.

Related status-go [pr](https://github.com/status-im/status-go/pull/4884)

Issue #13291 

https://github.com/status-im/status-desktop/assets/61889657/6cc6ada3-f811-45a9-b252-13bf91171033

