### PR TITLE
feat(wallet) save/load collectibles user handled state in DB

### DIFF
--- a/src/app/modules/main/wallet_section/all_collectibles/controller.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/controller.nim
@@ -42,7 +42,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
     self.delegate.refreshWalletAccounts()
-    
+
   self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e: Args):
     self.delegate.refreshNetworks()
 

--- a/src/app/modules/main/wallet_section/all_collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/view.nim
@@ -32,6 +32,10 @@ QtObject:
   proc updateCollectiblePreferences*(self: View, collectiblePreferencesJson: string) {.slot.} =
     self.delegate.updateCollectiblePreferences(collectiblePreferencesJson)
 
+  proc clearCollectiblePreferences*(self: View) {.slot.} =
+    # There is no requirements of clearing the preferences yet but controller is expected to expose it
+    discard
+
   proc getCollectiblePreferencesJson(self: View): QVariant {.slot.} =
     let preferences = self.delegate.getCollectiblePreferencesJson()
     return newQVariant(preferences)

--- a/src/app_service/service/collectible/service.nim
+++ b/src/app_service/service/collectible/service.nim
@@ -12,7 +12,7 @@ logScope:
 # Signals which may be emitted by this service:
 const SIGNAL_COLLECTIBLE_PREFERENCES_UPDATED* = "collectiblePreferencesUpdated"
 
-type 
+type
   ResultArgs* = ref object of Args
     success*: bool
 

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -108,7 +108,7 @@ proc `$`*(self: ContractID): string =
     address:{self.address}
   )"""
 
-proc `==`*(a, b: ContractID): bool = 
+proc `==`*(a, b: ContractID): bool =
   result = a.chainID == b.chainID and
     a.address == b.address
 
@@ -116,7 +116,7 @@ proc `%`*(t: ContractID): JsonNode {.inline.} =
   result = newJObject()
   result["chainID"] = %(t.chainID)
   result["address"] = %(t.address)
-  
+
 proc `%`*(t: ref ContractID): JsonNode {.inline.} =
   return %(t[])
 
@@ -148,7 +148,7 @@ proc `$`*(self: CollectibleUniqueID): string =
     tokenID:{self.tokenID}
   )"""
 
-proc `==`*(a, b: CollectibleUniqueID): bool = 
+proc `==`*(a, b: CollectibleUniqueID): bool =
   result = a.contractID == b.contractID and
     a.tokenID == b.tokenID
 
@@ -156,7 +156,7 @@ proc `%`*(t: CollectibleUniqueID): JsonNode {.inline.} =
   result = newJObject()
   result["contractID"] = %(t.contractID)
   result["tokenID"] = %(t.tokenID.toString())
-  
+
 proc `%`*(t: ref CollectibleUniqueID): JsonNode {.inline.} =
   return %(t[])
 
@@ -176,7 +176,7 @@ proc toCollectibleUniqueID*(t: string): CollectibleUniqueID =
   var parts = t.split("+")
   return CollectibleUniqueID(
     contractID: ContractID(
-        chainID: parts[0].parseInt(), 
+        chainID: parts[0].parseInt(),
         address: parts[1]
       ),
     tokenID: stint.parse(parts[2], UInt256)
@@ -386,7 +386,7 @@ proc toIds(self: seq[Collectible]): seq[CollectibleUniqueID] =
 # CollectibleBalance
 proc `$`*(self: CollectibleBalance): string =
   return fmt"""CollectibleBalance(
-    tokenId:{self.tokenId}, 
+    tokenId:{self.tokenId},
     balance:{self.balance}
     """
 
@@ -402,7 +402,7 @@ proc getCollectibleBalances*(jsonAsset: JsonNode): seq[CollectibleBalance] =
 # CollectibleOwner
 proc `$`*(self: CollectibleOwner): string =
   return fmt"""CollectibleOwner(
-    address:{self.address}, 
+    address:{self.address},
     balances:{self.balances}
     """
 
@@ -426,7 +426,7 @@ proc getCollectibleOwners(jsonAsset: JsonNode): seq[CollectibleOwner] =
 # CollectibleContractOwnership
 proc `$`*(self: CollectibleContractOwnership): string =
   return fmt"""CollectibleContractOwnership(
-    contractAddress:{self.contractAddress}, 
+    contractAddress:{self.contractAddress},
     owners:{self.owners}
     """
 
@@ -439,9 +439,9 @@ proc fromJson*(t: JsonNode, T: typedesc[CollectibleContractOwnership]): Collecti
 # CollectiblePreferences
 proc `$`*(self: CollectiblePreferences): string =
   return fmt"""CollectiblePreferences(
-    type:{self.itemType}, 
-    key:{self.key}, 
-    position:{self.position}, 
+    type:{self.itemType},
+    key:{self.key},
+    position:{self.position},
     visible:{self.visible}
     """
 
@@ -451,3 +451,10 @@ proc fromJson*(t: JsonNode, T: typedesc[CollectiblePreferences]): CollectiblePre
   discard t.getProp("key", result.key)
   discard t.getProp("position", result.position)
   discard t.getProp("visible", result.visible)
+
+proc `%`*(cp: CollectiblePreferences): JsonNode {.inline.} =
+  result = newJObject()
+  result["type"] = %int(cp.itemType)
+  result["key"] = %cp.key
+  result["position"] = %cp.position
+  result["visible"] = %cp.visible

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -87,14 +87,14 @@ type
     contractAddress*: string
     owners*: seq[CollectibleOwner]
 
-  # see status-go/services/wallet/collectibles/service.go CollectibleDataType
+  # Mirrors status-go/multiaccounts/settings_wallet/database.go CollectiblePreferencesType
   CollectiblePreferencesItemType* {.pure.} = enum
-    NonCommunityCollectible = 1, 
-    CommunityCollectible, 
-    Collection, 
+    NonCommunityCollectible = 1,
+    CommunityCollectible,
+    Collection,
     Community
 
-  # Mirrors services/wallet/thirdparty/collectible_types.go CollectibleContractOwnership
+  # Mirrors status-go/multiaccounts/settings_wallet/database.go CollectiblePreferences
   CollectiblePreferences* = ref object of RootObj
     itemType* {.serializedFieldName("type").}: CollectiblePreferencesItemType
     key* {.serializedFieldName("key").}: string

--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -97,6 +97,12 @@ SplitView {
             controller: ManageTokensController {
                 sourceModel: d.walletAssetStore.groupedAccountAssetsModel
                 settingsKey: "WalletAssets"
+                serializeAsCollectibles: false
+
+                onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+                onRequestLoadSettings: loadFromQSettings()
+                onRequestClearSettings: clearQSettings()
+
                 onTokenHidden: (symbol, name) => Global.displayToastMessage(
                                    qsTr("%1 (%2) was successfully hidden").arg(name).arg(symbol), "", "checkmark-circle",
                                    false, Constants.ephemeralNotificationType.success, "")

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -82,6 +82,12 @@ SplitView {
         controller: ManageTokensController {
             sourceModel: renamedModel
             settingsKey: "WalletCollectibles"
+            serializeAsCollectibles: true
+
+            onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+            onRequestLoadSettings: loadFromQSettings()
+            onRequestClearSettings: clearQSettings()
+
             onTokenHidden: (symbol, name) => Global.displayToastMessage(
                                qsTr("%1 was successfully hidden").arg(name), "", "checkmark-circle",
                                false, Constants.ephemeralNotificationType.success, "")

--- a/storybook/pages/ManageAssetsPanelPage.qml
+++ b/storybook/pages/ManageAssetsPanelPage.qml
@@ -50,6 +50,11 @@ SplitView {
         controller: ManageTokensController {
             sourceModel: ctrlEmptyModel.checked ? null : walletAssetStore.groupedAccountAssetsModel
             settingsKey: "WalletAssets"
+            serializeAsCollectibles: false
+
+            onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+            onRequestLoadSettings: loadFromQSettings()
+            onRequestClearSettings: clearQSettings()
         }
     }
 

--- a/storybook/pages/ManageCollectiblesPanelPage.qml
+++ b/storybook/pages/ManageCollectiblesPanelPage.qml
@@ -44,6 +44,11 @@ SplitView {
         controller: ManageTokensController {
             sourceModel: renamedModel
             settingsKey: "WalletCollectibles"
+            serializeAsCollectibles: true
+
+            onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+            onRequestLoadSettings: loadFromQSettings()
+            onRequestClearSettings: clearQSettings()
         }
     }
 

--- a/storybook/pages/ManageHiddenPanelPage.qml
+++ b/storybook/pages/ManageHiddenPanelPage.qml
@@ -44,12 +44,22 @@ SplitView {
         id: assetsController
         sourceModel: ctrlEmptyModel.checked ? null : walletAssetStore.groupedAccountAssetsModel
         settingsKey: "WalletAssets"
+        serializeAsCollectibles: false
+
+        onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+        onRequestLoadSettings: loadFromQSettings()
+        onRequestClearSettings: clearQSettings()
     }
 
     ManageTokensController {
         id: collectiblesController
         sourceModel: ctrlEmptyModel.checked ? null : renamedModel
         settingsKey: "WalletCollectibles"
+        serializeAsCollectibles: true
+
+        onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+        onRequestLoadSettings: loadFromQSettings()
+        onRequestClearSettings: clearQSettings()
     }
 
     ManageHiddenPanel {

--- a/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
+++ b/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
@@ -37,9 +37,19 @@ Item {
             controller: ManageTokensController {
                 sourceModel: renamedModel
                 settingsKey: "WalletCollectibles"
+                serializeAsCollectibles: true
+
+                onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
+                onRequestLoadSettings: loadFromQSettings()
+                onRequestClearSettings: clearQSettings()
+
                 onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(
                                                  qsTr("%1 community collectibles successfully hidden").arg(communityName), "", "checkmark-circle",
                                                  false, Constants.ephemeralNotificationType.success, "")
+            }
+
+            function clearSettings() {
+                controller.clearQSettings()
             }
         }
     }

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -141,6 +141,8 @@ add_library(StatusQ SHARED
         src/wallet/managetokenscontroller.h
         src/wallet/managetokensmodel.cpp
         src/wallet/managetokensmodel.h
+        src/wallet/tokendata.cpp
+        src/wallet/tokendata.h
         )
 
 target_compile_features(StatusQ PRIVATE cxx_std_17)

--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -8,6 +8,12 @@
 
 class QAbstractItemModel;
 
+/// @brief Controller for managing visibility and order for all kind of tokens and groups.
+///
+/// There is an "abstraction" layer for saving data to different mediums and is controlled form QML.
+/// The QML implementation forwards data to current QSettings for storybook and nim controllers for the app.
+/// @see request* signals for triggering actions and start/finish methods for notifying about the process.
+/// @see *QSettings related methods for saving and loading data in user profile settings.
 class ManageTokensController : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
@@ -16,6 +22,7 @@ class ManageTokensController : public QObject, public QQmlParserStatus
     // input properties
     Q_PROPERTY(QAbstractItemModel* sourceModel READ sourceModel WRITE setSourceModel NOTIFY sourceModelChanged FINAL)
     Q_PROPERTY(QString settingsKey READ settingsKey WRITE setSettingsKey NOTIFY settingsKeyChanged FINAL REQUIRED)
+    Q_PROPERTY(bool serializeAsCollectibles READ serializeAsCollectibles WRITE setSerializeAsCollectibles NOTIFY serializeAsCollectiblesChanged FINAL REQUIRED)
 
     Q_PROPERTY(bool arrangeByCommunity READ arrangeByCommunity WRITE setArrangeByCommunity NOTIFY arrangeByCommunityChanged FINAL)
     Q_PROPERTY(bool arrangeByCollection READ arrangeByCollection WRITE setArrangeByCollection NOTIFY arrangeByCollectionChanged FINAL)
@@ -45,10 +52,18 @@ public:
     Q_INVOKABLE void showHideGroup(const QString& groupId, bool flag);
     Q_INVOKABLE void showHideCollectionGroup(const QString& groupId, bool flag);
 
-    Q_INVOKABLE void loadSettings();
-    Q_INVOKABLE void saveSettings();
-    Q_INVOKABLE void clearSettings();
+    Q_INVOKABLE void loadFromQSettings();
+    Q_INVOKABLE void saveToQSettings(const QString& json);
+    Q_INVOKABLE void clearQSettings();
     Q_INVOKABLE void revert();
+
+    /// required to be called before the saving is started
+    Q_INVOKABLE void savingStarted();
+    Q_INVOKABLE void savingFinished();
+    Q_INVOKABLE void loadingStarted();
+    Q_INVOKABLE void loadingFinished(const QString& jsonData);
+
+    Q_INVOKABLE QString serializeSettingsAsJson();
 
     Q_INVOKABLE int compareTokens(const QString& lhsSymbol, const QString& rhsSymbol) const;
     Q_INVOKABLE bool filterAcceptsSymbol(const QString& symbol) const;
@@ -64,6 +79,7 @@ signals:
     void arrangeByCollectionChanged();
     void settingsKeyChanged();
     void settingsDirtyChanged(bool dirty);
+    void serializeAsCollectiblesChanged();
 
     void tokenHidden(const QString& symbol, const QString& name);
     void tokenShown(const QString& symbol, const QString& name);
@@ -76,6 +92,17 @@ signals:
     void hiddenCollectionGroupsChanged();
 
     void revisionChanged();
+
+    /// Emitted when the settings are requested to be saved.
+    /// Receiver requires to call savingStarted and savingFinished to notify about the saving process.
+    /// @param jsonData serialized json data
+    void requestSaveSettings(const QString& jsonData);
+    /// Emitted when the settings are requested to be loaded. Client should call loadSettings as a response.
+    /// Receiver requires to call loadingStarted and loadingFinished to notify about the loading process.
+    void requestLoadSettings();
+    /// @brief Emitted when the settings are requested to be cleared.
+    /// Receiver requires to call loadingStarted and loadingFinished to notify about the loading process.
+    void requestClearSettings();
 
 private:
     QAbstractItemModel* m_sourceModel{nullptr};
@@ -128,6 +155,11 @@ private:
     QString settingsKey() const;
     QString settingsGroupName() const;
     void setSettingsKey(const QString& newSettingsKey);
+
+    bool m_serializeAsCollectibles{false};
+    bool serializeAsCollectibles() const;
+    void setSerializeAsCollectibles(const bool newSerializeAsCollectibles);
+
     QSettings m_settings;
     SerializedTokenData m_settingsData; // symbol -> {sortOrder, visible, groupId, isCommunityGroup, isCollectionGroup}
     bool hasSettings() const;

--- a/ui/StatusQ/src/wallet/managetokensmodel.cpp
+++ b/ui/StatusQ/src/wallet/managetokensmodel.cpp
@@ -4,8 +4,7 @@
 
 Q_LOGGING_CATEGORY(manageTokens, "status.models.manageTokens", QtInfoMsg)
 
-ManageTokensModel::ManageTokensModel(QObject* parent)
-    : QAbstractListModel(parent)
+ManageTokensModel::ManageTokensModel(QObject* parent) : QAbstractListModel(parent)
 {
     connect(this, &QAbstractItemModel::rowsInserted, this, &ManageTokensModel::countChanged);
     connect(this, &QAbstractItemModel::rowsRemoved, this, &ManageTokensModel::countChanged);
@@ -40,9 +39,8 @@ void ManageTokensModel::addItem(const TokenData& item, bool append)
 
 std::optional<TokenData> ManageTokensModel::takeItem(const QString& symbol)
 {
-    const auto token = std::find_if(m_data.cbegin(), m_data.cend(), [symbol](const auto& item) {
-        return symbol == item.symbol;
-    });
+    const auto token =
+        std::find_if(m_data.cbegin(), m_data.cend(), [symbol](const auto& item) { return symbol == item.symbol; });
     const auto row = std::distance(m_data.cbegin(), token);
 
     if (row < 0 || row >= rowCount())
@@ -60,7 +58,7 @@ QList<TokenData> ManageTokensModel::takeAllItems(const QString& groupId)
     QList<int> indexesToRemove;
 
     for (int i = 0; i < m_data.count(); i++) {
-        const auto &token = m_data.at(i);
+        const auto& token = m_data.at(i);
         if (token.communityId == groupId || token.collectionUid == groupId) {
             result.append(token);
             indexesToRemove.append(i);
@@ -68,7 +66,7 @@ QList<TokenData> ManageTokensModel::takeAllItems(const QString& groupId)
     }
 
     QList<int>::reverse_iterator its;
-    for(its = indexesToRemove.rbegin(); its != indexesToRemove.rend(); ++its) {
+    for (its = indexesToRemove.rbegin(); its != indexesToRemove.rend(); ++its) {
         const auto row = *its;
         beginRemoveRows({}, row, row);
         m_data.removeAt(row);
@@ -86,7 +84,7 @@ void ManageTokensModel::clear()
     setDirty(false);
 }
 
-SerializedTokenData ManageTokensModel::save(bool isVisible)
+SerializedTokenData ManageTokensModel::save(bool isVisible, bool itemsAreGroups)
 {
     saveCustomSortOrder();
     const auto size = rowCount();
@@ -96,21 +94,25 @@ SerializedTokenData ManageTokensModel::save(bool isVisible)
         const auto& token = itemAt(i);
         const auto isCommunityGroup = !token.communityId.isEmpty();
         const auto isCollectionGroup = !token.collectionUid.isEmpty();
-        const auto groupId = isCommunityGroup ? token.communityId : isCollectionGroup ? token.collectionUid : QString();
-        result.insert(token.symbol, {i, isVisible, groupId, isCommunityGroup, isCollectionGroup});
+        result.insert(token.symbol,
+                      TokenOrder{token.symbol,
+                                 i,
+                                 isVisible,
+                                 isCommunityGroup,
+                                 token.communityId,
+                                 isCollectionGroup,
+                                 token.collectionUid,
+                                 tokenDataToCollectiblePreferencesItemType(token, isCommunityGroup, itemsAreGroups)});
     }
     setDirty(false);
     return result;
 }
 
-int ManageTokensModel::rowCount(const QModelIndex& parent) const
-{
-    return m_data.size();
-}
+int ManageTokensModel::rowCount(const QModelIndex& parent) const { return m_data.size(); }
 
 QHash<int, QByteArray> ManageTokensModel::roleNames() const
 {
-    static const QHash<int, QByteArray> roles {
+    static const QHash<int, QByteArray> roles{
         {SymbolRole, kSymbolRoleName},
         {NameRole, kNameRoleName},
         {CommunityIdRole, kCommunityIdRoleName},
@@ -134,42 +136,57 @@ QHash<int, QByteArray> ManageTokensModel::roleNames() const
 
 QVariant ManageTokensModel::data(const QModelIndex& index, int role) const
 {
-    if (!checkIndex(index, QAbstractItemModel::CheckIndexOption::IndexIsValid | QAbstractItemModel::CheckIndexOption::ParentIsInvalid))
+    if (!checkIndex(index,
+                    QAbstractItemModel::CheckIndexOption::IndexIsValid |
+                        QAbstractItemModel::CheckIndexOption::ParentIsInvalid))
         return {};
 
     const auto& token = m_data.at(index.row());
 
-    switch(static_cast<TokenDataRoles>(role))
-    {
-    case SymbolRole: return token.symbol;
-    case NameRole: return token.name;
-    case CommunityIdRole: return token.communityId;
-    case CommunityNameRole: return token.communityName;
-    case CommunityImageRole: return token.communityImage;
-    case CollectionUidRole: return token.collectionUid;
-    case CollectionNameRole: return token.collectionName;
-    case BalanceRole: return token.balance;
-    case CurrencyBalanceRole: return token.currencyBalance;
-    case CustomSortOrderNoRole: return token.customSortOrderNo;
-    case TokenImageRole: return token.image;
-    case TokenBackgroundColorRole: return token.backgroundColor;
-    case TokenBalancesRole: return token.balances;
-    case TokenDecimalsRole: return token.decimals;
-    case TokenMarketDetailsRole: return token.marketDetails;
-    case IsSelfCollectionRole: return token.isSelfCollection;
+    switch (static_cast<TokenDataRoles>(role)) {
+    case SymbolRole:
+        return token.symbol;
+    case NameRole:
+        return token.name;
+    case CommunityIdRole:
+        return token.communityId;
+    case CommunityNameRole:
+        return token.communityName;
+    case CommunityImageRole:
+        return token.communityImage;
+    case CollectionUidRole:
+        return token.collectionUid;
+    case CollectionNameRole:
+        return token.collectionName;
+    case BalanceRole:
+        return token.balance;
+    case CurrencyBalanceRole:
+        return token.currencyBalance;
+    case CustomSortOrderNoRole:
+        return token.customSortOrderNo;
+    case TokenImageRole:
+        return token.image;
+    case TokenBackgroundColorRole:
+        return token.backgroundColor;
+    case TokenBalancesRole:
+        return token.balances;
+    case TokenDecimalsRole:
+        return token.decimals;
+    case TokenMarketDetailsRole:
+        return token.marketDetails;
+    case IsSelfCollectionRole:
+        return token.isSelfCollection;
     }
 
     return {};
 }
 
-bool ManageTokensModel::dirty() const
-{
-    return m_dirty;
-}
+bool ManageTokensModel::dirty() const { return m_dirty; }
 
 void ManageTokensModel::setDirty(bool flag)
 {
-    if (m_dirty == flag) return;
+    if (m_dirty == flag)
+        return;
     m_dirty = flag;
     emit dirtyChanged();
 }

--- a/ui/StatusQ/src/wallet/managetokensmodel.h
+++ b/ui/StatusQ/src/wallet/managetokensmodel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "tokendata.h"
+
 #include <QAbstractListModel>
 #include <QColor>
 #include <QLoggingCategory>
@@ -29,18 +31,6 @@ const auto kMarketDetailsRoleName = QByteArrayLiteral("marketDetails");
 const auto kIsSelfCollectionRoleName = QByteArrayLiteral("isSelfCollection");
 // TODO add communityPrivilegesLevel for collectibles
 } // namespace
-
-struct TokenData {
-    QString symbol, name, communityId, communityName, communityImage, collectionUid, collectionName, image;
-    QColor backgroundColor{Qt::transparent};
-    QVariant balance, currencyBalance;
-    QVariant balances, marketDetails, decimals;
-    int customSortOrderNo{INT_MAX};
-    bool isSelfCollection{false};
-};
-
-// symbol -> {sortOrder, visible, groupId, isCommunityGroup, isCollectionGroup}
-using SerializedTokenData = QHash<QString, std::tuple<int, bool, QString, bool, bool>>;
 
 class ManageTokensModel : public QAbstractListModel
 {
@@ -78,7 +68,7 @@ public:
     QList<TokenData> takeAllItems(const QString& groupId);
     void clear();
 
-    SerializedTokenData save(bool isVisible = true);
+    SerializedTokenData save(bool isVisible = true, bool itemsAreGroups = false);
 
     bool dirty() const;
     void setDirty(bool flag);

--- a/ui/StatusQ/src/wallet/tokendata.cpp
+++ b/ui/StatusQ/src/wallet/tokendata.cpp
@@ -1,0 +1,124 @@
+#include "tokendata.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QList>
+
+CollectiblePreferencesItemType tokenDataToCollectiblePreferencesItemType(const TokenData& token, bool isCommunity, bool itemsAreGroups)
+{
+    if (itemsAreGroups) {
+        if (isCommunity) {
+            return CollectiblePreferencesItemType::Community;
+        } else {
+            return CollectiblePreferencesItemType::Collection;
+        }
+    } else {
+        if (isCommunity) {
+            return CollectiblePreferencesItemType::CommunityCollectible;
+        } else {
+            return CollectiblePreferencesItemType::NonCommunityCollectible;
+        }
+    }
+}
+
+TokenOrder::TokenOrder() : sortOrder(undefinedTokenOrder) {}
+
+TokenOrder::TokenOrder(const QString& symbol,
+                       int sortOrder,
+                       bool visible,
+                       bool isCommunityGroup,
+                       const QString& communityId,
+                       bool isCollectionGroup,
+                       const QString& collectionUid,
+                       CollectiblePreferencesItemType type)
+    : symbol(symbol)
+    , sortOrder(sortOrder)
+    , visible(visible)
+    , isCommunityGroup(isCommunityGroup)
+    , communityId(communityId)
+    , isCollectionGroup(isCollectionGroup)
+    , collectionUid(collectionUid)
+    , type(type)
+{
+}
+
+/// reverse of \c tokenOrdersFromJson
+///
+/// for protocol structure, see:
+/// \see CollectiblePreferences in src/backend/collectibles_types.nim
+/// \see TokenPreferences in src/backend/backend.nim
+QString tokenOrdersToJson(const SerializedTokenData& dataList, bool areCollectible)
+{
+    QJsonArray jsonArray;
+    for (const TokenOrder& data : dataList) {
+        QJsonObject obj;
+        obj["key"] = data.symbol;
+        obj["position"] = data.sortOrder;
+        obj["visible"] = data.visible;
+        if (data.isCommunityGroup) {
+            obj["isCommunityGroup"] = true;
+            obj["communityId"] = data.communityId;
+        }
+        if (data.isCollectionGroup) {
+            obj["isCollectionGroup"] = true;
+            obj["collectionUid"] = data.collectionUid;
+        }
+
+        if (areCollectible) {
+            // see CollectiblePreferences in src/backend/collectibles_types.nim
+            // type cover separation of groups and collectibles
+            obj["type"] = static_cast<int>(data.type);
+        } else { // is asset
+            // see TokenPreferences in src/backend/backend.nim
+            // TODO #13312: handle "groupPosition" for asset
+        }
+        jsonArray.append(obj);
+    }
+
+    QJsonDocument doc(jsonArray);
+    QString json_string = doc.toJson(QJsonDocument::Compact);
+
+    return json_string;
+}
+
+/// reverse of \c tokenOrdersToJson
+///
+/// for protocol structure, see:
+/// \see CollectiblePreferences in src/backend/collectibles_types.nim
+/// \see TokenPreferences in src/backend/backend.nim
+SerializedTokenData tokenOrdersFromJson(const QString& json_string, bool areCollectibles)
+{
+    QJsonDocument doc = QJsonDocument::fromJson(json_string.toUtf8());
+    QJsonArray jsonArray = doc.array();
+
+    SerializedTokenData dataList;
+    for (const QJsonValue& value : jsonArray) {
+        QJsonObject obj = value.toObject();
+        TokenOrder data;
+
+        data.symbol = obj["key"].toString();
+        data.sortOrder = obj["position"].toInt();
+        data.visible = obj["visible"].toBool();
+        if (obj.contains("isCommunityGroup")) {
+            data.isCommunityGroup = obj["isCommunityGroup"].toBool();
+            data.communityId = obj["communityId"].toString();
+        }
+        if (obj.contains("isCollectionGroup")) {
+            data.isCollectionGroup = obj["isCollectionGroup"].toBool();
+            data.collectionUid = obj["collectionUid"].toString();
+        }
+
+        if (areCollectibles) {
+            // see CollectiblePreferences in src/backend/collectibles_types.nim
+            data.type = static_cast<CollectiblePreferencesItemType>(obj["type"].toInt());
+        } else { // is asset
+            // see TokenPreferences in src/backend/backend.nim
+            // TODO #13312: handle "groupPosition" for assets
+        }
+
+        dataList.insert(data.symbol, data);
+    }
+
+    return dataList;
+}

--- a/ui/StatusQ/src/wallet/tokendata.h
+++ b/ui/StatusQ/src/wallet/tokendata.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QColor>
+#include <QString>
+#include <QVariant>
+
+static const auto undefinedTokenOrder = INT_MAX;
+
+// Generic structure representing an asset, collectible, collection or community token
+struct TokenData {
+    QString symbol, name, communityId, communityName, communityImage, collectionUid, collectionName, image;
+    QColor backgroundColor{Qt::transparent};
+    QVariant balance, currencyBalance;
+    QVariant balances, marketDetails, decimals;
+    int customSortOrderNo{undefinedTokenOrder};
+    bool isSelfCollection{false};
+};
+
+// mirrors CollectiblePreferencesItemType from src/backend/collectibles_types.nim
+enum class CollectiblePreferencesItemType { NonCommunityCollectible = 1, CommunityCollectible, Collection, Community };
+
+CollectiblePreferencesItemType tokenDataToCollectiblePreferencesItemType(const TokenData& tokenData, bool isCommunity, bool itemsAreGroups);
+
+struct TokenOrder {
+    QString symbol;
+    int sortOrder;
+    bool visible;
+    bool isCommunityGroup;
+    QString communityId;
+    bool isCollectionGroup;
+    QString collectionUid;
+    /// covers separation of groups (collection or community) and collectibles (regular or community)
+    CollectiblePreferencesItemType type;
+
+    // Defines a default TokenOrder, order is not set (undefinedTokenOrder) and visible is false
+    TokenOrder();
+    TokenOrder(const QString& symbol,
+               int sortOrder,
+               bool visible,
+               bool isCommunityGroup,
+               const QString& communityId,
+               bool isCollectionGroup,
+               const QString& collectionUid,
+               CollectiblePreferencesItemType type);
+
+    bool operator==(const TokenOrder& rhs) const
+    {
+        return symbol == rhs.symbol && sortOrder == rhs.sortOrder && visible == rhs.visible &&
+               isCommunityGroup == rhs.isCommunityGroup && (!isCommunityGroup || communityId == rhs.communityId) &&
+               isCollectionGroup == rhs.isCollectionGroup && (!isCollectionGroup || collectionUid == rhs.collectionUid) && type == rhs.type;
+    }
+
+    QString getGroupId() const { return !communityId.isEmpty() ? communityId : collectionUid; }
+};
+
+using SerializedTokenData = QHash<QString, TokenOrder>;
+
+QString tokenOrdersToJson(const SerializedTokenData& data, bool areCollectibles);
+SerializedTokenData tokenOrdersFromJson(const QString& json_string, bool areCollectibles);

--- a/ui/app/AppLayouts/Wallet/panels/ManageAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageAssetsPanel.qml
@@ -22,7 +22,8 @@ DoubleFlickableWithFolding {
     property var getCurrentCurrencyAmount: function(balance) {}
 
     function saveSettings() {
-        root.controller.saveSettings();
+        let jsonSettings = root.controller.serializeSettingsAsJson()
+        root.controller.requestSaveSettings(jsonSettings);
     }
 
     function revert() {
@@ -30,7 +31,7 @@ DoubleFlickableWithFolding {
     }
 
     function clearSettings() {
-        root.controller.clearSettings();
+        root.controller.requestClearSettings()
     }
 
     clip: true

--- a/ui/app/AppLayouts/Wallet/panels/ManageCollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageCollectiblesPanel.qml
@@ -19,7 +19,8 @@ DoubleFlickableWithFolding {
     readonly property bool hasSettings: root.controller.hasSettings
 
     function saveSettings() {
-        root.controller.saveSettings();
+        let jsonSettings = root.controller.serializeSettingsAsJson()
+        root.controller.requestSaveSettings(jsonSettings)
     }
 
     function revert() {
@@ -27,7 +28,7 @@ DoubleFlickableWithFolding {
     }
 
     function clearSettings() {
-        root.controller.clearSettings();
+        root.controller.requestClearSettings()
     }
 
     clip: true

--- a/ui/app/AppLayouts/Wallet/panels/ManageHiddenPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageHiddenPanel.qml
@@ -31,8 +31,8 @@ Control {
     background: null
 
     function clearSettings() {
-        root.assetsController.clearSettings();
-        root.collectiblesController.clearSettings();
+        root.assetsController.requestClearSettings();
+        root.collectiblesController.requestClearSettings();
     }
 
     QtObject {

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -29,6 +29,24 @@ QtObject {
     readonly property var collectiblesController: ManageTokensController {
         sourceModel: allCollectiblesModel
         settingsKey: "WalletCollectibles"
+        serializeAsCollectibles: true
+
+        onRequestSaveSettings: (jsonData) => {
+            savingStarted()
+            _allCollectiblesModule.updateCollectiblePreferences(jsonData)
+            savingFinished()
+        }
+        onRequestLoadSettings: {
+            loadingStarted()
+            let jsonData = _allCollectiblesModule.getCollectiblePreferencesJson()
+            loadingFinished(jsonData)
+        }
+        onRequestClearSettings: {
+            savingStarted()
+            _allCollectiblesModule.clearCollectiblePreferences()
+            savingFinished()
+        }
+
         onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(
                                          qsTr("%1 community collectibles successfully hidden").arg(communityName), "", "checkmark-circle",
                                          false, Constants.ephemeralNotificationType.success, "")

--- a/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -18,6 +18,25 @@ QtObject {
     readonly property var assetsController: ManageTokensController {
         sourceModel: groupedAccountAssetsModel
         settingsKey: "WalletAssets"
+        serializeAsCollectibles: false
+
+        // TODO #13312: call the assets controller for all events
+        onRequestSaveSettings: (jsonData) => {
+            // savingStarted()
+            saveToQSettings(jsonData)
+            // savingFinished()
+        }
+        onRequestLoadSettings: {
+            // loadingStarted()
+            loadFromQSettings()
+            // loadingFinished()
+        }
+        onRequestClearSettings: {
+            // savingStarted()
+            clearQSettings()
+            // savingFinished()
+        }
+
         onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(
                                          qsTr("%1 community assets successfully hidden").arg(communityName), "", "checkmark-circle",
                                          false, Constants.ephemeralNotificationType.success, "")


### PR DESCRIPTION
### Closes #13313, #13971 and Updates #13312

- [x] rebase on top of master
- [x] fix collectibles type

Add a separation layer for save/load/clear to `ManageTokensModel` so that we can save/load from external sources.
The separate layer is composed of JSON as protocol, a set of signals and slots for interface. The implementation forwards data to current `QSettings` for storybook and nim controllers for the app.

Groups are not handled in this PR

Note: I auto formatted some C++ files by mistake using vscode, please use ignore spaces in diff for easier review :(