### PR TITLE
fix[CI] PagesValidator UI test doesn't catch missing `required` properties

### DIFF
--- a/storybook/pages/FinaliseOwnershipDeclinePopupPage.qml
+++ b/storybook/pages/FinaliseOwnershipDeclinePopupPage.qml
@@ -37,6 +37,7 @@ SplitView {
                 closePolicy: Popup.NoAutoClose
                 visible: true
                 modal: false
+                communityId: "ddls"
 
                 communityName: communityNameText.text
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -73,8 +73,6 @@ StatusSectionLayout {
     QtObject {
         id: d
 
-        readonly property int leftMargin: 64
-
         readonly property int contentWidth: 560
         readonly property int rightPanelWidth: 768
 
@@ -105,7 +103,7 @@ StatusSectionLayout {
         readonly property var currentItem: (currentIndex >= 0 && currentIndex < children.length) ? children[currentIndex].item : null
 
         anchors.fill: parent
-        anchors.leftMargin: d.leftMargin
+        anchors.leftMargin: Constants.settingsSection.leftMargin
 
         currentIndex: Global.settingsSubsection
 
@@ -132,7 +130,6 @@ StatusSectionLayout {
             sourceComponent: MyProfileView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 walletAssetsStore: root.walletAssetsStore
                 currencyStore: root.currencyStore
@@ -154,7 +151,6 @@ StatusSectionLayout {
             sourceComponent: ChangePasswordView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
                 privacyStore: root.store.privacyStore
                 passwordStrengthScoreFunction: SharedStores.RootStore.getPasswordStrengthScore
                 contentWidth: d.contentWidth
@@ -168,7 +164,6 @@ StatusSectionLayout {
             sourceComponent: ContactsView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
                 contactsStore: root.store.contactsStore
                 sectionTitle: qsTr("Contacts")
                 contentWidth: d.contentWidth
@@ -201,7 +196,6 @@ StatusSectionLayout {
             sourceComponent: MessagingView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
                 advancedStore: root.store.advancedStore
                 messagingStore: root.store.messagingStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.messaging)
@@ -217,7 +211,6 @@ StatusSectionLayout {
             sourceComponent: WalletView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
                 rootStore: root.store
                 tokensStore: root.tokensStore
                 networkConnectionStore: root.networkConnectionStore
@@ -236,7 +229,6 @@ StatusSectionLayout {
             sourceComponent: AppearanceView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 appearanceStore: root.store.appearanceStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.appearance)
@@ -251,7 +243,6 @@ StatusSectionLayout {
             sourceComponent: LanguageView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 languageStore: root.store.languageStore
                 currencyStore: root.currencyStore
@@ -266,7 +257,6 @@ StatusSectionLayout {
             sourceComponent: NotificationsView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 notificationsStore: root.store.notificationsStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.notifications)
@@ -280,7 +270,6 @@ StatusSectionLayout {
             sourceComponent: SyncingView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 isProduction: production
                 profileStore: root.store.profileStore
@@ -298,7 +287,6 @@ StatusSectionLayout {
             sourceComponent: BrowserView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 store: root.store
                 accountSettings: localAccountSensitiveSettings
@@ -313,7 +301,6 @@ StatusSectionLayout {
             sourceComponent: AdvancedView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 messagingStore: root.store.messagingStore
                 advancedStore: root.store.advancedStore
@@ -332,7 +319,6 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.about)
                 contentWidth: d.contentWidth
-                leftParentLayoutMargin: d.leftMargin
 
                 store: QtObject {
                     readonly property bool isProduction: production
@@ -371,7 +357,6 @@ StatusSectionLayout {
             sourceComponent: CommunitiesView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 profileSectionStore: root.store
                 rootStore: root.globalStore
@@ -389,7 +374,6 @@ StatusSectionLayout {
             sourceComponent: KeycardView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
 
                 profileSectionStore: root.store
                 keycardStore: root.store.keycardStore
@@ -408,7 +392,6 @@ StatusSectionLayout {
             sourceComponent: SettingsContentBase {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
                 sectionTitle: "Status Software Terms of Use"
                 contentWidth: d.contentWidth
 
@@ -429,7 +412,6 @@ StatusSectionLayout {
             sourceComponent: SettingsContentBase {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
-                leftParentLayoutMargin: d.leftMargin
                 sectionTitle: "Status Software Privacy Statement"
                 contentWidth: d.contentWidth
 

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -23,11 +23,6 @@ FocusScope {
     default property alias content: contentWrapper.children
     property alias titleLayout: titleLayout
 
-    // This is the margin set up to the parent when using `SettingsContentBase` inside central
-    // panel property of `StatusSectionLayout` and needs to be taken into account to counteract it
-    // when trying to align horizontally the save toast component
-    required property int leftParentLayoutMargin
-
     property bool dirty: false
 
     // Used to configure the dirty behaviour of the settings page as a must blocker notification when
@@ -160,8 +155,11 @@ FocusScope {
 
         // Left anchors and margin added bc of the implementation of the `SettingsContentBase` parent margin and to avoid
         // this toast to be wrongly centered
+        // Constants.settingsSection.leftMargin is the margin set up to the parent when using `SettingsContentBase` inside central
+        // panel property of `StatusSectionLayout` and needs to be taken into account to counteract it
+        // when trying to align horizontally the save toast component
         anchors.left: root.left
-        anchors.leftMargin: -root.leftParentLayoutMargin / 2 + (root.width / 2 - width / 2)
+        anchors.leftMargin: -Constants.settingsSection.leftMargin / 2 + (root.width / 2 - width / 2)
 
         active: root.dirty
         flickable: root.autoscrollWhenDirty ? scrollView.flickable : null


### PR DESCRIPTION
### What does the PR do

- use the full `QQmlEngine` to test loading of the component
- separate commits to fix the failures and simplify SettingsContentsBase

Fixes #13901

### Affected areas

CI/StoryBook

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before:
![Snímek obrazovky z 2024-03-08 10-29-42](https://github.com/status-im/status-desktop/assets/5377645/216983d6-4ff6-4283-9e45-76fb3b62b881)

After:
![image](https://github.com/status-im/status-desktop/assets/5377645/c3736926-c314-4d64-bf97-1e92b9602656)
