### PR TITLE
chore(ci): do full Windows workspace cleanup

### DIFF
--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -118,7 +118,7 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh './scripts/clean-git.sh' }
+    cleanup { cleanWs() }
   }
 }
 


### PR DESCRIPTION
If we don't we regularly get weird Git failures on Windows like:
```
fatal: Unable to find current revision in submodule path 'vendor/qzxing/tests/resources'
fatal: Failed to recurse into submodule path 'vendor/qzxing'
```
Or
```
stderr: fatal: Unable to create '.../.git/index.lock': File exists.
```
Which are very annoying and require manual workspace purge by infra team.

Many of you will get annoyed with resulting slower checkouts on subsequent builds, but that's a price I'm willing to pay.