### PR TITLE
13603 statusqwritablemodel add option allowing to remove items always when removed in source

### DIFF
--- a/src/app_service/service/profile/service.nim
+++ b/src/app_service/service/profile/service.nim
@@ -193,6 +193,7 @@ QtObject:
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
         error "Error saving profile showcase preferences", msg = rpcResponseObj{"error"}
         return
+      self.requestProfileShowcasePreferences()
     except Exception as e:
       error "Error saving profile showcase preferences", msg = e.msg
 

--- a/ui/StatusQ/include/StatusQ/writableproxymodel.h
+++ b/ui/StatusQ/include/StatusQ/writableproxymodel.h
@@ -26,6 +26,9 @@ class WritableProxyModel : public QAbstractProxyModel
     Q_OBJECT
 
     Q_PROPERTY(bool dirty READ dirty NOTIFY dirtyChanged)
+    //If true, the removals are synced with the source model. Removing an edited item from source will also remove it from proxy
+    //If false, eemoving an edited item from source will not remove it from proxy. It will become a newly inserted row
+    Q_PROPERTY(bool syncedRemovals READ syncedRemovals WRITE setSyncedRemovals NOTIFY syncedRemovalsChanged)
 
 public:
     explicit WritableProxyModel(QObject* parent = nullptr);
@@ -48,6 +51,7 @@ public:
     Q_INVOKABLE bool set(int at, const QVariantMap& data);
 
     bool dirty() const;
+    bool syncedRemovals() const;
 
     //QAbstractProxyModel overrides
     void setSourceModel(QAbstractItemModel* sourceModel) override;
@@ -75,9 +79,11 @@ public:
 
 signals:
     void dirtyChanged();
+    void syncedRemovalsChanged();
 
 private:
     void setDirty(bool flag);
+    void setSyncedRemovals(bool syncedRemovals);
 
     void onSourceDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles);
     void onRowsAboutToBeInserted(const QModelIndex& parent, int start, int end);

--- a/ui/StatusQ/src/writableproxymodel.cpp
+++ b/ui/StatusQ/src/writableproxymodel.cpp
@@ -192,7 +192,7 @@ void WritableProxyModelPrivate::createProxyToSourceRowMap()
 bool WritableProxyModelPrivate::contains(const QModelIndex& sourceIndex, const QVector<int>& roles) const {
     if (cache.contains(sourceIndex)) {
         auto valueMap = cache[sourceIndex];
-        return std::all_of(roles.begin(), roles.end(), [&valueMap](int role) { return valueMap.contains(role); });
+        return std::any_of(roles.begin(), roles.end(), [&valueMap](int role) { return valueMap.contains(role); });
     }
 
     if (insertedRows.contains(q.mapFromSource(sourceIndex))) {
@@ -289,7 +289,7 @@ void WritableProxyModelPrivate::checkForDirtyRemoval(const QModelIndex& sourceIn
         {
             if (cachedData.contains(role) && cachedData[role] == q.sourceModel()->data(sourceIndex, role))
                 cachedData.remove(role);
-            }
+        }
 
         if (cachedData.isEmpty()) {
             cache.remove(sourceIndex);
@@ -605,7 +605,7 @@ bool WritableProxyModel::set(int at, const QVariantMap& data)
         return false;
 
     auto index = this->index(at, 0);
-    auto itemData = this->itemData(index);
+    QMap<int, QVariant> itemData;
     auto roleNames = this->roleNames();
 
     for (auto it = data.begin(); it != data.end(); ++it)

--- a/ui/StatusQ/tests/tst_WritableProxyModel.cpp
+++ b/ui/StatusQ/tests/tst_WritableProxyModel.cpp
@@ -732,6 +732,66 @@ private slots:
         QCOMPARE(model.data(model.index(3, 0), 1), {});
     }
 
+    void updaedDataIsNotKeptAfterSourceRemove()
+    {
+        WritableProxyModel model;
+        QAbstractItemModelTester tester(&model);
+
+        TestSourceModel sourceModel({
+           { "title", { "Token 1", "Token 2", "Token3" }},
+           { "communityId", { "community_1", "community_2", "community_3" }}});
+
+        model.setSourceModel(&sourceModel);
+        model.setProperty("syncedRemovals", true);
+
+        QSignalSpy rowsRemovedSpy(&model, &WritableProxyModel::rowsRemoved);
+        QSignalSpy modelResetSpy(&model, &WritableProxyModel::modelReset);
+        QSignalSpy dataChangedSpy(&model, &WritableProxyModel::dataChanged);
+        QSignalSpy rowsInsertedSpy(&model, &WritableProxyModel::rowsInserted);
+
+        QCOMPARE(model.dirty(), false);
+        QCOMPARE(model.syncedRemovals(), true);
+
+        model.setData(model.index(0, 0), "Token 1.1", 0);
+        
+        QCOMPARE(model.dirty(), true);
+        QCOMPARE(model.rowCount(), 3);
+
+        QCOMPARE(model.data(model.index(0, 0), 0), "Token 1.1");
+        QCOMPARE(dataChangedSpy.count(), 1);
+
+        sourceModel.remove(0);
+
+        QCOMPARE(model.dirty(), false);
+        QCOMPARE(model.rowCount(), 2);
+        QCOMPARE(model.data(model.index(0, 0), 0), "Token 2");
+
+        QCOMPARE(rowsRemovedSpy.count(), 1);
+        QCOMPARE(rowsRemovedSpy.first().at(1), 0);
+        QCOMPARE(rowsRemovedSpy.first().at(2), 0);
+        QCOMPARE(modelResetSpy.count(), 0);
+        QCOMPARE(rowsInsertedSpy.count(), 0);
+
+        model.setData(model.index(0, 0), "Token 2.1", 0);
+
+        QCOMPARE(model.dirty(), true);
+
+        QCOMPARE(model.data(model.index(0, 0), 0), "Token 2.1");
+
+        sourceModel.reset({
+           { "title", { "Token 3", "Token 4" }},
+           { "communityId", { "community_3", "community_4" }}
+        });
+
+        QCOMPARE(model.dirty(), false);
+        QCOMPARE(model.rowCount(), 2);
+
+        QCOMPARE(rowsRemovedSpy.count(), 1);
+        QCOMPARE(modelResetSpy.count(), 1);
+        QCOMPARE(dataChangedSpy.count(), 2);
+        QCOMPARE(rowsInsertedSpy.count(), 0);
+    }
+
     void dataIsAccessibleAfterSourceModelMove()
     {
         WritableProxyModel model;

--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseDirtyState.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseDirtyState.qml
@@ -36,7 +36,7 @@ QObject {
     /**
       * Returns dirty state of the showcase model.
       */
-    readonly property bool dirty: writable.dirty || !visibleModel.synced
+    readonly property bool dirty: writable.dirty
 
     /**
       * It sets up a searcher filter on top of both the visible and hidden models.
@@ -49,9 +49,6 @@ QObject {
     }
 
     function currentState() {
-        if (visible.synced) {
-            return writable.currentState()
-        }
         return writable.currentState()
     }
 

--- a/ui/app/AppLayouts/Profile/helpers/VisibilityAndPositionDirtyStateModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/VisibilityAndPositionDirtyStateModel.qml
@@ -49,17 +49,24 @@ WritableProxyModel {
             return
 
         // hiding, changing visibility level
-        if (visibility === visibilityHidden
-                || oldVisibility !== visibilityHidden) {
-            set(sourceIdx, { showcaseVisibility: visibility })
+        if (visibility === visibilityHidden) {
+            set(sourceIdx, { showcaseVisibility: undefined, showcasePosition: undefined})
             return
         }
 
-        // unhiding
-        const positions = d.getVisibleEntries().map(e => e.showcasePosition)
-        const position = Math.max(-1, ...positions) + 1
-        set(sourceIdx, { showcaseVisibility: visibility, showcasePosition: position })
+        if (oldVisibility === visibilityHidden || oldVisibility === undefined) {
+            // unhiding
+            const positions = d.getVisibleEntries().map(e => e.showcasePosition)
+            const position = Math.max(-1, ...positions) + 1
+            set(sourceIdx, { showcaseVisibility: visibility, showcasePosition: position })
+            return
+        }
+
+        // changing visibility level
+        set(sourceIdx, { showcaseVisibility: visibility })
     }
+
+    syncedRemovals: true
 
     readonly property QtObject d_: QtObject {
         id: d

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -166,7 +166,6 @@ SettingsContentBase {
                                                    profileHeader.cropRect.y.toFixed(),
                                                    (profileHeader.cropRect.x + profileHeader.cropRect.width).toFixed(),
                                                    (profileHeader.cropRect.y + profileHeader.cropRect.height).toFixed())
-            reset()
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Closing #13603 

Changes:
1. Adding `syncedRemovals` flag to the WritableProxyModel. This flag enables the source model to remove dirty rows
2. Fix the WritableProxyModel to allow full dirty state synchronisation with the model chains and properly remove the dirty state
3. Update the Profile Showcase qml components to use `syncedRemovals` and fix the dirty state after save
4. Removed the `reset` call after `save`
5. Added a call to fetch the newly saved showcase models from the backend to update the models
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

WritableProxyModel
ProfileShowcase
<!-- List the affected areas (e.g wallet, browser, etc..) -->

https://github.com/status-im/status-desktop/assets/47811206/addadca2-891f-46a8-b954-a5197f5e5d4d


