### PR TITLE
feat(profileShowcase): Sync collectibles context menu with account visibility

### DIFF
--- a/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
@@ -19,7 +19,10 @@ StatusDraggableListItem {
     id: root
 
     property alias actionComponent: additionalActionsLoader.sourceComponent
+
     property int showcaseVisibility: Constants.ShowcaseVisibility.NoOne
+    property int showcaseMaxVisibility: Constants.ShowcaseVisibility.Everyone
+
     property bool blurState: false
     property bool contextMenuEnabled: true
     property string tooltipTextWhenContextMenuDisabled
@@ -27,9 +30,15 @@ StatusDraggableListItem {
     signal showcaseVisibilityRequested(int value)
 
     component ShowcaseVisibilityAction: StatusMenuItem {
-        property int showcaseVisibility: Constants.ShowcaseVisibility.NoOne
+        id: menuItem
+        required property int showcaseVisibility
+
+        ButtonGroup.group: showcaseVisibilityGroup
         icon.name: ProfileUtils.visibilityIcon(showcaseVisibility)
         icon.color: Theme.palette.primaryColor1
+        checked: root.showcaseVisibility === showcaseVisibility
+        
+        enabled: root.showcaseMaxVisibility >= showcaseVisibility
     }
 
     layer.enabled: root.blurState
@@ -87,32 +96,32 @@ StatusDraggableListItem {
                         onClosed: menuLoader.active = false
                         StatusMenuHeadline { text: qsTr("Show to") }
 
+                        Binding on width {
+                            value: Math.max(implicitWidth, everyoneAction.implicitWidth, contactsAction.implicitWidth, idVerifiedContactsAction.implicitWidth) + margins * 2
+                            delayed: true
+                        }
+
                         ShowcaseVisibilityAction {
-                            ButtonGroup.group: showcaseVisibilityGroup
+                            id: everyoneAction
                             showcaseVisibility: Constants.ShowcaseVisibility.Everyone
-                            text: qsTr("Everyone")
-                            checked: root.showcaseVisibility === showcaseVisibility
+                            text: enabled ? qsTr("Everyone") : qsTr("Everyone (set account to Everyone)")
                         }
                         ShowcaseVisibilityAction {
-                            ButtonGroup.group: showcaseVisibilityGroup
+                            id: contactsAction
                             showcaseVisibility: Constants.ShowcaseVisibility.Contacts
-                            text: qsTr("Contacts")
-                            checked: root.showcaseVisibility === showcaseVisibility
+                            text: enabled ? qsTr("Contacts") : qsTr("Contacts (set account to Contacts)")
                         }
                         ShowcaseVisibilityAction {
-                            ButtonGroup.group: showcaseVisibilityGroup
+                            id: idVerifiedContactsAction
                             showcaseVisibility: Constants.ShowcaseVisibility.IdVerifiedContacts
-                            text: qsTr("ID verified contacts")
-                            checked: root.showcaseVisibility === showcaseVisibility
+                            text: enabled ? qsTr("ID verified contacts") : qsTr("ID verified contacts (set account to ID verified contacts)")
                         }
 
                         StatusMenuSeparator {}
 
                         ShowcaseVisibilityAction {
-                            ButtonGroup.group: showcaseVisibilityGroup
                             showcaseVisibility: Constants.ShowcaseVisibility.NoOne
                             text: qsTr("No one")
-                            checked: root.showcaseVisibility === showcaseVisibility
                         }
                     }
                 }

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCollectiblesPanel.qml
@@ -25,6 +25,7 @@ ProfileShowcasePanel {
     additionalFooterComponent: root.addAccountsButtonVisible ? addMoreAccountsComponent : null
 
     delegate: ProfileShowcasePanelDelegate {
+        id: delegate
         title: !!model ? `${model.name}` || `#${model.id}` : ""
         secondaryTitle: !!model && !!model.collectionName ? model.collectionName : ""
         hasImage: !!model && !!model.imageUrl
@@ -34,6 +35,12 @@ ProfileShowcasePanel {
         assetBgColor: !!model && !!model.backgroundColor ? model.backgroundColor : "transparent"
 
         actionComponent: model && !!model.communityId ? communityTokenTagComponent : null
+        showcaseMaxVisibility: model ? model.maxVisibility : Constants.ShowcaseVisibility.Everyone
+        onShowcaseMaxVisibilityChanged: {
+            if (delegate.showcaseVisibility > delegate.showcaseMaxVisibility) {
+               root.setVisibilityRequested(delegate.key, delegate.showcaseMaxVisibility)
+            }
+        }
 
         Component {
             id: communityTokenTagComponent

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -69,6 +69,8 @@ DoubleFlickableWithFolding {
 
         property bool startAnimation: false
 
+        property var dragItem: null
+
         signal setVisibilityInternalRequested(var key, int toVisibility)
         onSetVisibilityInternalRequested: {
             if(toVisibility !== Constants.ShowcaseVisibility.NoOne) {
@@ -297,6 +299,7 @@ DoubleFlickableWithFolding {
                 height: ProfileUtils.defaultDelegateHeight - Style.current.padding
                 text: qsTr("Hide")
                 dropAreaKeys: d.dragShowcaseItemKey
+                
             }
         }
     }
@@ -315,6 +318,8 @@ DoubleFlickableWithFolding {
         spacing: padding/2
 
         icon.color: Theme.palette.primaryColor1
+
+        visible: d.dragItem && d.dragItem.showcaseMaxVisibility >= showcaseVisibility
 
         background: ShapeRectangle {
             path.strokeColor: dropArea.containsDrag ? Theme.palette.primaryColor2 : Theme.palette.directColor7
@@ -500,6 +505,14 @@ DoubleFlickableWithFolding {
                 target: showcaseDraggableDelegateLoader.item
                 property: "tooltipTextWhenContextMenuDisabled"
                 value: qsTr("Showcase limit of %1 reached. <br>Remove item from showcase to add more.").arg(root.showcaseLimit)
+                restoreMode: Binding.RestoreBindingOrValue
+            }
+
+            Binding {
+                when: showcaseDraggableDelegateLoader.item && showcaseDraggableDelegateLoader.item.dragActive
+                target: d
+                property: "dragItem"
+                value: showcaseDraggableDelegateLoader.item
                 restoreMode: Binding.RestoreBindingOrValue
             }
 


### PR DESCRIPTION
### What does the PR do

Closing #13343 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Changes: 
1. Update drop area to show only the drop available items
2. Update the context menu to disable unavailable options
3. Add dynamic width to the context menu

### Affected areas

ProfileShowcase



https://github.com/status-im/status-desktop/assets/47811206/6659c5e4-0393-47c6-8e83-aa06af73092d

