### PR TITLE
chore: clean up build log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -546,6 +546,8 @@ $(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSG
 		--passL:"-lkeycard" \
 		--passL:"$(QRCODEGEN)" \
 		--passL:"-lm" \
+		--warning:UnreachableElse:off \
+		--warningAsError:UseBase:on \
 		$(NIM_EXTRA_PARAMS) src/nim_status_client.nim
 ifeq ($(detected_OS),Darwin)
 	install_name_tool -change \

--- a/src/app/core/eventemitter.nim
+++ b/src/app/core/eventemitter.nim
@@ -17,7 +17,7 @@ proc createEventEmitter*(): EventEmitter =
 
 proc on(this: EventEmitter, name: string, handlerId: UUID, handler: Handler): void =
   if this.events.hasKey(name):
-    this.events[name].add handlerId, handler
+    this.events[name][handlerId] = handler
     return
 
   this.events[name] = [(handlerId, handler)].toOrderedTable

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -1,4 +1,3 @@
-import stint
 import ./io_interface
 
 import ../../../global/app_signals

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, stint, sequtils
+import NimQml, Tables, json, sequtils
 
 import ./io_interface, ./view, ./controller, ./token_data_item
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/browser_section/current_account/module.nim
+++ b/src/app/modules/main/browser_section/current_account/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils, strutils, sugar
+import NimQml, strutils
 
 import app/global/global_singleton
 import app/core/eventemitter

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, uuids, sets, times, tables, strutils, system
+import NimQml, chronicles, sequtils, uuids, sets, times, tables, system
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -19,7 +19,6 @@ import ../../../../app_service/service/shared_urls/service as shared_urls_servic
 import backend/collectibles as backend_collectibles
 
 import ../../../core/signals/types
-import ../../../global/app_signals
 import ../../../core/eventemitter
 import ../../../core/unique_event_emitter
 

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, json, sequtils, times, system
+import NimQml, Tables, strutils, strformat, json, sequtils, system
 import ../../../../app_service/common/types
 import ../../../../app_service/service/chat/dto/chat
 from ../../../../app_service/service/contacts/dto/contacts import TrustStatus

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, sequtils, strutils, strformat, sugar, marshal
+import NimQml, Tables, chronicles, json, sequtils, strformat, sugar, marshal
 
 import io_interface
 import ../io_interface as delegate_interface
@@ -19,7 +19,6 @@ import ../../../global/global_singleton
 import ../../../core/eventemitter
 import ../../../core/unique_event_emitter
 import ../../../core/notifications/details as notification_details
-import ../../../../app_service/common/conversion
 import ../../../../app_service/common/types
 import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/node_configuration/service as node_configuration_service

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -586,7 +586,7 @@ proc addNewChat*(
     chatDto.color,
     chatDto.emoji,
     chatDto.description,
-    ChatType(chatDto.chatType).int,
+    chatDto.chatType.int,
     memberRole,
     chatDto.timestamp.int,
     hasNotification,

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -1,4 +1,4 @@
-import stint, std/strutils, uuids
+import std/strutils, uuids
 import ./io_interface
 
 import app/core/signals/types

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -1,7 +1,6 @@
 import tables
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/chat/service as chat_service
-import ../../../../app_service/service/community_tokens/dto/community_token
 import app_service/common/types
 import ../../shared_models/section_item
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -44,7 +44,7 @@ method load*(
   {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getAppNetwork*(self: AccessInterface): NetworkDto =
+method getAppNetwork*(self: AccessInterface): NetworkDto {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onAppNetworkChanged*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1625,7 +1625,7 @@ method checkIfAddressWasCopied*[T](self: Module[T], value: string) =
     return
   self.addressWasShown(value)
 
-method createMemberItem*[T](self: Module[T], memberId: string, state: MembershipRequestState, role: MemberRole): MemberItem =
+proc createMemberItem*[T](self: Module[T], memberId: string, state: MembershipRequestState, role: MemberRole): MemberItem =
   let contactDetails = self.controller.getContactDetails(memberId)
   let status = self.controller.getStatusForContactWithId(memberId)
   return initMemberItem(

--- a/src/app/modules/main/node_section/controller.nim
+++ b/src/app/modules/main/node_section/controller.nim
@@ -6,7 +6,6 @@ import ../../../../app_service/service/node_configuration/service as node_config
 
 import ../../../core/signals/types
 import ../../../core/eventemitter
-import ../../../core/fleets/fleet_configuration
 
 type
   Controller* = ref object of RootObj

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -91,7 +91,7 @@ method viewDidLoad*(self: Module) =
     if receivedVerificationRequest.status == VerificationStatus.Verifying or
         receivedVerificationRequest.status == VerificationStatus.Verified:
       let contactItem = self.createItemFromPublicKey(receivedVerificationRequest.fromID)
-      contactItem.incomingVerificationStatus = VerificationRequestStatus(receivedVerificationRequest.status)
+      contactItem.incomingVerificationStatus = toVerificationRequestStatus(receivedVerificationRequest.status)
       receivedVerificationRequestItems.add(contactItem)
   self.view.receivedContactRequestsModel().addItems(receivedVerificationRequestItems)
 
@@ -276,7 +276,7 @@ method onVerificationRequestCanceled*(self: Module, publicKey: string) =
 
 method onVerificationRequestUpdatedOrAdded*(self: Module, request: VerificationRequest) =
   let item =  self.createItemFromPublicKey(request.fromID)
-  item.incomingVerificationStatus = VerificationRequestStatus(request.status)
+  item.incomingVerificationStatus = toVerificationRequestStatus(request.status)
   if (self.view.receivedContactRequestsModel.containsItemWithPubKey(request.fromID)):
     if request.status != VerificationStatus.Verifying and
         request.status != VerificationStatus.Verified:

--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -1,4 +1,4 @@
-import Tables, uuids, chronicles, json
+import uuids, chronicles, json
 import io_interface
 
 import app/global/global_singleton

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -4,7 +4,6 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model
 
-import app/global/global_singleton
 import app/core/eventemitter
 import app_service/common/conversion as service_conversion
 import app_service/common/utils as common_utils

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
@@ -1,7 +1,5 @@
 import NimQml, tables, strutils, sequtils, json
 
-import app_service/service/profile/dto/profile_showcase_preferences
-
 type
   ShowcasePreferencesSocialLinkItem* = object of RootObj
     url*: string

--- a/src/app/modules/main/profile_section/profile/module.nim
+++ b/src/app/modules/main/profile_section/profile/module.nim
@@ -18,7 +18,6 @@ import app_service/common/social_links
 import app/modules/shared_models/social_links_model
 import app/modules/shared_models/social_link_item
 import app/modules/shared_modules/collectibles/controller as collectiblesc
-import app/modules/shared_models/collectibles_entry
 
 # TODO: remove usage of old models
 import models/profile_preferences_community_item

--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar, tables
+import NimQml, sequtils, sugar
 
 import ./io_interface, ./view
 import ./controller as accountsc

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -3,7 +3,6 @@ import Tables, uuids, stint, json
 import ./io_interface
 
 import app/core/eventemitter
-import app_service/service/node/service as node_service
 import app_service/service/stickers/service as stickers_service
 import app_service/service/token/service
 import app_service/service/settings/service as settings_service

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -1,7 +1,6 @@
 import Tables, stint
 import ./item
 
-import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/stickers/service as stickers_service
 from app_service/service/keycard/service import KeycardEvent
 

--- a/src/app/modules/main/wallet_section/activity/status.nim
+++ b/src/app/modules/main/wallet_section/activity/status.nim
@@ -1,5 +1,5 @@
 import NimQml, std/json, sequtils, strutils, times
-import stint, atomics
+import atomics
 
 import app/core/signals/types
 

--- a/src/app/modules/main/wallet_section/all_collectibles/io_interface.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/io_interface.nim
@@ -34,14 +34,14 @@ method getCollectiblePreferencesJson*(self: AccessInterface): string {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getCollectibleGroupByCommunity*(self: AccessInterface): bool =
+method getCollectibleGroupByCommunity*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleCollectibleGroupByCommunity*(self: AccessInterface): bool =
+method toggleCollectibleGroupByCommunity*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getCollectibleGroupByCollection*(self: AccessInterface): bool =
+method getCollectibleGroupByCollection*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleCollectibleGroupByCollection*(self: AccessInterface): bool =
+method toggleCollectibleGroupByCollection*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/all_tokens/controller.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/controller.nim
@@ -53,7 +53,7 @@ proc init*(self: Controller) =
 proc getHistoricalDataForToken*(self: Controller, symbol: string, currency: string, range: int) =
   self.tokenService.getHistoricalDataForToken(symbol, currency, range)
 
-method fetchHistoricalBalanceForTokenAsJson*(self: Controller, addresses: seq[string], allAddresses: bool, tokenSymbol: string, currencySymbol: string, timeIntervalEnum: int) =
+proc fetchHistoricalBalanceForTokenAsJson*(self: Controller, addresses: seq[string], allAddresses: bool, tokenSymbol: string, currencySymbol: string, timeIntervalEnum: int) =
   self.walletAccountService.fetchHistoricalBalanceForTokenAsJson(addresses, allAddresses, tokenSymbol, currencySymbol, BalanceHistoryTimeInterval(timeIntervalEnum))
 
 proc getSourcesOfTokensList*(self: Controller): var seq[SupportedSourcesItem] =

--- a/src/app/modules/main/wallet_section/all_tokens/io_interface.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/io_interface.nim
@@ -78,29 +78,29 @@ method getTokenPreferencesJson*(self: AccessInterface): string {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string]) =
+method filterChanged*(self: AccessInterface, addresses: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getTokenGroupByCommunity*(self: AccessInterface): bool =
+method getTokenGroupByCommunity*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleTokenGroupByCommunity*(self: AccessInterface): bool =
+method toggleTokenGroupByCommunity*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getShowCommunityAssetWhenSendingTokens*(self: AccessInterface): bool =
+method getShowCommunityAssetWhenSendingTokens*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleShowCommunityAssetWhenSendingTokens*(self: AccessInterface): bool =
+method toggleShowCommunityAssetWhenSendingTokens*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getDisplayAssetsBelowBalance*(self: AccessInterface): bool =
+method getDisplayAssetsBelowBalance*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleDisplayAssetsBelowBalance*(self: AccessInterface): bool =
+method toggleDisplayAssetsBelowBalance*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getDisplayAssetsBelowBalanceThreshold*(self: AccessInterface): CurrencyAmount =
+method getDisplayAssetsBelowBalanceThreshold*(self: AccessInterface): CurrencyAmount {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setDisplayAssetsBelowBalanceThreshold*(self: AccessInterface, threshold: int64): bool =
+method setDisplayAssetsBelowBalanceThreshold*(self: AccessInterface, threshold: int64): bool {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
@@ -1,7 +1,6 @@
 import NimQml, strutils
 
 import ./io_interface
-import app/modules/shared_models/currency_amount
 import app/modules/shared/wallet_utils
 import app_service/service/currency/dto
 

--- a/src/app/modules/main/wallet_section/assets/balances_model.nim
+++ b/src/app/modules/main/wallet_section/assets/balances_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, sugar, stint
+import NimQml, Tables, strutils, sequtils, stint
 
 import ./io_interface
 

--- a/src/app/modules/main/wallet_section/assets/io_interface.nim
+++ b/src/app/modules/main/wallet_section/assets/io_interface.nim
@@ -1,5 +1,4 @@
 import app_service/service/wallet_account/dto/account_token_item
-import app_service/service/currency/dto
 
 type
   GroupedAccountAssetsDataSource* = tuple[

--- a/src/app/modules/main/wallet_section/assets/module.nim
+++ b/src/app/modules/main/wallet_section/assets/module.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar
+import NimQml
 
 import app/global/global_singleton
 import app/core/eventemitter
@@ -6,9 +6,6 @@ import app_service/service/token/service as token_service
 import app_service/service/currency/service as currency_service
 import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/network/service as network_service
-import app_service/service/network_connection/service as network_connection
-import app_service/service/node/service as node_service
-import app/modules/shared/wallet_utils
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/wallet_section/assets/view.nim
+++ b/src/app/modules/main/wallet_section/assets/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, stint, strutils
+import NimQml, json, strutils
 
 import ./io_interface
 import ./grouped_account_assets_model as grouped_account_assets_model

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -18,7 +18,6 @@ import ./activity/controller as activityc
 import ./activity/details_controller as activity_detailsc
 import ./wallet_connect/controller as wcc
 
-import app/modules/shared_models/collectibles_model as collectiblesm
 import app/modules/shared_modules/collectible_details/controller as collectible_detailsc
 
 import app/global/global_singleton
@@ -41,8 +40,6 @@ import app_service/service/devices/service as devices_service
 import app_service/service/community_tokens/service as community_tokens_service
 
 import backend/collectibles as backend_collectibles
-import backend/activity as backend_activity
-
 
 logScope:
   topics = "wallet-section-module"

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar
+import NimQml
 
 import app/global/global_singleton
 import app/core/eventemitter

--- a/src/app/modules/main/wallet_section/wallet_connect/controller.nim
+++ b/src/app/modules/main/wallet_section/wallet_connect/controller.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, logging, json, options, chronicles
+import NimQml, strutils, json, chronicles
 
 import backend/wallet as backend_wallet
 import backend/wallet_connect as backend_wallet_connect

--- a/src/app/modules/shared/wallet_utils.nim
+++ b/src/app/modules/shared/wallet_utils.nim
@@ -1,5 +1,3 @@
-import tables, sequtils, stint, sugar
-
 import ../shared_models/[currency_amount, wallet_account_item]
 
 import app_service/service/currency/dto as currency_dto

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strformat, sequtils, sugar, strutils, stint, strutils
+import NimQml, json, strformat, sequtils, strutils, stint, strutils
 import options
 
 import backend/collectibles as backend

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -3,8 +3,6 @@ import logging
 
 import ./collectibles_entry
 import backend/collectibles as backend_collectibles
-import app_service/common/utils as common_utils
-import app_service/common/types
 
 type
   CollectibleRole* {.pure.} = enum
@@ -273,7 +271,7 @@ QtObject:
 
     var newTable = initTable[string, int](len(newItems))
     for i in 0 ..< len(newItems):
-      newTable.add(newItems[i].getIDAsString(), i)
+      newTable[newItems[i].getIDAsString()] = i
 
     # Needs to be built in sequential index order
     var oldIndicesToRemove: seq[int] = @[]

--- a/src/app/modules/shared_models/emoji_reactions_item.nim
+++ b/src/app/modules/shared_models/emoji_reactions_item.nim
@@ -1,5 +1,3 @@
-import NimQml
-
 type
     EmojiReactionItem* = ref object
         emojiId: int

--- a/src/app/modules/shared_models/token_permission_item.nim
+++ b/src/app/modules/shared_models/token_permission_item.nim
@@ -1,4 +1,4 @@
-import strformat, strutils
+import strformat
 import ../../../app_service/service/community/dto/community
 import ../../../app_service/service/chat/dto/chat
 import token_criteria_model

--- a/src/app/modules/shared_models/user_item.nim
+++ b/src/app/modules/shared_models/user_item.nim
@@ -1,5 +1,6 @@
 import strformat
 import ../../../app_service/common/types
+import ../../../app_service/service/contacts/dto/contacts
 
 type
   ContactRequest* {.pure.} = enum
@@ -17,6 +18,17 @@ type
     Canceled
     Trusted
     Untrustworthy
+
+proc toVerificationRequestStatus*(value: VerificationStatus): VerificationRequestStatus =
+  case value:
+  of VerificationStatus.Unverified: return VerificationRequestStatus.None
+  of VerificationStatus.Verifying: return VerificationRequestStatus.Pending
+  of VerificationStatus.Verified: return VerificationRequestStatus.Answered
+  of VerificationStatus.Declined: return VerificationRequestStatus.Declined
+  of VerificationStatus.Canceled: return VerificationRequestStatus.Canceled
+  of VerificationStatus.Trusted: return VerificationRequestStatus.Trusted
+  of VerificationStatus.Untrustworthy: return VerificationRequestStatus.Untrustworthy
+  else: return VerificationRequestStatus.None
 
 type
   UserItem* = ref object of RootObj

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -34,7 +34,7 @@ const NumOfGeneratedAddressesRegular = MaxNumOfGeneratedAddresses
 const NumOfGeneratedAddressesKeycard = 10
 
 
-logScope: 
+logScope:
   topics = "wallet-add-account-module"
 
 type

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -13,6 +13,8 @@ import app/modules/shared_models/[keypair_model, derived_address_model]
 import app/modules/shared_modules/keycard_popup/module as keycard_shared_module
 
 import app_service/common/account_constants
+const dummyUsage = account_constants.ZERO_ADDRESS # dummy usage to prevent false-alarm warning
+
 import app_service/service/accounts/service as accounts_service
 import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/saved_address/service as saved_address_service
@@ -32,7 +34,7 @@ const NumOfGeneratedAddressesRegular = MaxNumOfGeneratedAddresses
 const NumOfGeneratedAddressesKeycard = 10
 
 
-logScope:
+logScope: 
   topics = "wallet-add-account-module"
 
 type

--- a/src/app/modules/shared_modules/collectible_details/events_handler.nim
+++ b/src/app/modules/shared_modules/collectible_details/events_handler.nim
@@ -1,5 +1,5 @@
 import NimQml, logging, std/json, sequtils, strutils, options
-import tables, stint
+import tables
 
 import app/core/eventemitter
 import app/core/signals/types

--- a/src/app/modules/shared_modules/collectibles/events_handler.nim
+++ b/src/app/modules/shared_modules/collectibles/events_handler.nim
@@ -1,5 +1,5 @@
-import NimQml, logging, std/json, sequtils, strutils, options
-import tables, stint, sets
+import NimQml, std/json, sequtils, strutils, options
+import tables, sets
 
 import app/core/eventemitter
 import app/core/signals/types

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -1,4 +1,4 @@
-import chronicles, tables, strutils, sequtils, sugar, stint
+import chronicles, tables, strutils, sequtils, stint
 import uuids
 import io_interface
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_success_state.nim
@@ -14,13 +14,13 @@ method executeCancelCommand*(self: KeyPairMigrateSuccessState, controller: Contr
     if profileMigrated:
       info "quit the app cause this is not an available option in the context of SetupNewKeycard flow for profile keypair"
       quit() # quit the app
-      return
+
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
   if self.flowType == FlowType.MigrateFromKeycardToApp:
     if controller.getKeyPairForProcessing().getKeyUid() == singletonInstance.userProfile.getKeyUid():
       info "quit the app cause this is not an available option in the context of MigrateFromKeycardToApp flow for profile keypair"
       quit() # quit the app
-      return
+
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
   if self.flowType == FlowType.MigrateFromAppToKeycard:
     info "quit the app cause this is not an available option in the context of MigrateFromAppToKeycard"

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -5,9 +5,11 @@ import view, controller
 import internal/[state, state_factory]
 import app/modules/shared/[keypairs, wallet_utils]
 import app/modules/shared_models/[keypair_model, keypair_item, currency_amount]
-import app/global/app_translatable_constants as atc
 import app/global/global_singleton
 import app/core/eventemitter
+
+import app/global/app_translatable_constants as atc
+const dummyUsage = atc.KEYCARD_ACCOUNT_NAME_OF_UNKNOWN_WALLET_ACCOUNT # dummy usage to prevent false-alarm warning
 
 import app_service/common/utils
 import app_service/service/keycard/constants

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -6,10 +6,14 @@ import internal/[state, state_factory]
 import models/generated_account_item as gen_acc_item
 import models/login_account_item as login_acc_item
 import models/fetching_data_model as fetch_model
-import constants as main_constants
 import app/global/global_singleton
-import app/global/app_translatable_constants as atc
 import app/core/eventemitter
+
+import constants as main_constants
+import app/global/app_translatable_constants as atc
+
+const dummyUsage = main_constants.IS_MACOS # dummy usage to prevent false-alarm warning
+const dummyUsage2 = atc.LOGIN_ACCOUNTS_LIST_ADD_NEW_USER # dummy usage to prevent false-alarm warning
 
 import app_service/service/keychain/service as keychain_service
 import app_service/service/accounts/service as accounts_service

--- a/src/app_service/service/collectible/service.nim
+++ b/src/app_service/service/collectible/service.nim
@@ -1,9 +1,9 @@
-import NimQml, Tables, json, sequtils, chronicles, strutils, algorithm, sugar
+import NimQml, json, sequtils, chronicles, strutils
 
 import backend/collectibles as backend
 
 import app/core/eventemitter
-import app/core/tasks/[qt, threadpool]
+import app/core/tasks/threadpool
 import app/core/signals/types
 
 logScope:

--- a/src/app_service/service/ens/utils.nim
+++ b/src/app_service/service/ens/utils.nim
@@ -4,7 +4,6 @@ import chronicles, libp2p/[multihash, multicodec, cid]
 import nimcrypto, stint
 import ../../common/conversion as common_conversion
 import ../eth/dto/transaction as eth_transaction_dto
-import ../../../backend/eth as status_eth
 import ../../../backend/ens as status_ens
 import ../../common/account_constants
 import ../../common/utils

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -1,4 +1,4 @@
-import chronicles, strutils
+import chronicles
 
 import ./dto/node_config
 import ../settings/service as settings_service

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -12,20 +12,16 @@ import backend/chat as status_chat
 import backend/response_type
 import backend/eth as status_eth
 import backend/backend as status_go_backend
-import backend/wallet_connect as status_wallet_connect
 import backend/wallet as status_wallet
 
 import ./dto/stickers
-import ../ens/utils as ens_utils
 import ../token/service as token_service
 import ../settings/service as settings_service
-import ../eth/dto/transaction
 import ../wallet_account/service as wallet_account_service
 import ../transaction/service as transaction_service
 import ../network/service as network_service
 import ../chat/service as chat_service
 import app_service/common/types
-import app_service/common/utils as common_utils
 import ../eth/utils as status_utils
 
 export StickerDto

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -1,7 +1,6 @@
 import NimQml, Tables, json, sequtils, chronicles, strutils, algorithm, sugar
 
 import web3/ethtypes
-from web3/conversions import `$`
 import backend/backend as backend
 
 import app_service/service/network/service as network_service
@@ -12,7 +11,6 @@ import app/core/tasks/[qt, threadpool]
 import app/core/signals/types
 import app_service/common/cache
 import app_service/common/wallet_constants
-import constants as main_constants
 import ./dto, ./service_items
 
 export dto, service_items

--- a/src/backend/core.nim
+++ b/src/backend/core.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, strformat, chronicles, nimcrypto
+import json, json_serialization, strformat, chronicles
 import status_go
 import response_type
 

--- a/src/backend/eth.nim
+++ b/src/backend/eth.nim
@@ -1,4 +1,4 @@
-import json, stint, tables
+import json, tables
 import ./core, ./response_type
 from ./gen import rpc
 

--- a/src/backend/wallet.nim
+++ b/src/backend/wallet.nim
@@ -1,7 +1,6 @@
-import json, json_serialization, logging
+import json, logging
 import core, response_type
 from ./gen import rpc
-import status_go
 
 rpc(signMessage, "wallet"):
   message: string


### PR DESCRIPTION
1. Treat `[UseBase]` warnings as error.
This looks like this in build log
```log
/src/app/boot/app_controller.nim(252, 44) template/generic instantiation of `newModule` from here
/src/app/modules/main/module.nim(664, 32) template/generic instantiation of `createChannelGroupItem` from here
/src/app/modules/main/module.nim(1628, 8) Error: use {.base.} for base methods; baseless methods are deprecated [UseBase]
make: *** [bin/nim_status_client] Error 1
```

I also tried to add this for `[UnusedImport]`, but there's some error in `nim-build-system`.

2. Disable `UnreachableElse` warning.
We do keep `else` in case of future changes. And I find it a right thing to do.

3. Cleaned up all unused warnings

-----

There're just 2 warnings left:
```log
/src/app_service/service/chat/dto/chat.nim(296, 33) Warning: conversion to enum with holes is unsafe: ChatType(chatTypeInt) [HoleEnumConv]
/src/app/modules/shared_modules/keycard_popup/controller.nim(654, 21) Warning: Number of spaces around '..<' is not consistent [Spacing]
```

I'll probably fix them at some point 😄 