### PR TITLE
feat: Save profile identity in one json

### DIFF
--- a/src/app/modules/main/profile_section/profile/io_interface.nim
+++ b/src/app/modules/main/profile_section/profile/io_interface.nim
@@ -10,7 +10,7 @@ import models/profile_preferences_account_item
 import models/profile_preferences_collectible_item
 import models/profile_preferences_asset_item
 
-import models/showcase_save_data
+import models/profile_save_data
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -31,12 +31,6 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method getCollectiblesModel*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method storeIdentityImage*(self: AccessInterface, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method deleteIdentityImage*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method getBio*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -53,6 +47,9 @@ method saveSocialLinks*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onSocialLinksUpdated*(self: AccessInterface, socialLinks: SocialLinks, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method saveProfileIdentityInfo*(self: AccessInterface, identity: IdentitySaveData) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method saveProfileShowcasePreferences*(self: AccessInterface, showcase: ShowcaseSaveData) {.base.} =

--- a/src/app/modules/main/profile_section/profile/models/profile_save_data.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_save_data.nim
@@ -23,6 +23,18 @@ type ShowcaseSaveData* = ref object of RootObj
   assets*: seq[ShowcaseSaveEntry]
   socialLinks*: seq[ShowcaseSaveSocialLink]
 
+type IdentityImage* = ref object of RootObj
+  source*: string
+  aX*: int
+  aY*: int
+  bX*: int
+  bY*: int
+
+type IdentitySaveData* = ref object of RootObj
+  displayName*: string
+  bio*: string
+  image*: IdentityImage
+
 proc toShowcaseSaveEntry*(jsonObj: JsonNode): ShowcaseSaveEntry =
   result = ShowcaseSaveEntry()
   discard jsonObj.getProp("showcaseKey", result.showcaseKey)
@@ -57,3 +69,20 @@ proc toShowcaseSaveData*(jsonObj: JsonNode): ShowcaseSaveData =
   result.collectibles = toShowcaseSaveEntries(jsonObj, "collectibles")
   result.assets = toShowcaseSaveEntries(jsonObj, "assets")
   result.socialLinks = toShowcaseSaveSocialLinks(jsonObj)
+
+proc toIdentityImage*(jsonObj: JsonNode): IdentityImage =
+  result = IdentityImage()
+  discard jsonObj.getProp("source", result.source)
+  discard jsonObj.getProp("aX", result.aX)
+  discard jsonObj.getProp("aY", result.aY)
+  discard jsonObj.getProp("bX", result.bX)
+  discard jsonObj.getProp("bY", result.bY)
+
+proc toIdentitySaveData*(jsonObj: JsonNode): IdentitySaveData =
+  result = IdentitySaveData()
+  discard jsonObj.getProp("displayName", result.displayName)
+  discard jsonObj.getProp("bio", result.bio)
+  if jsonObj{"image"} != nil and jsonObj{"image"}.kind != JNull:
+    result.image = jsonObj{"image"}.toIdentityImage()
+  else:
+    result.image = nil

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -14,7 +14,7 @@ import models/profile_preferences_collectible_item
 import models/profile_preferences_assets_model
 import models/profile_preferences_asset_item
 
-import models/showcase_save_data
+import models/profile_save_data
 import models/showcase_preferences_generic_model
 import models/showcase_preferences_social_links_model
 
@@ -106,21 +106,6 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  proc upload*(self: View, imageUrl: string, aX: int, aY: int, bX: int, bY: int): string {.slot.} =
-    # var image = singletonInstance.utils.formatImagePath(imageUrl)
-    # FIXME the function to get the file size is messed up
-    # var size = image_getFileSize(image)
-    # TODO find a way to i18n this (maybe send just a code and then QML sets the right string)
-    # return "Max file size is 20MB"
-
-    self.delegate.storeIdentityImage(imageUrl, aX, aY, bX, bY)
-
-  proc remove*(self: View): string {.slot.} =
-    self.delegate.deleteIdentityImage()
-
-  proc setDisplayName(self: View, displayName: string) {.slot.} =
-    self.delegate.setDisplayName(displayName)
-
   proc socialLinksModel*(self: View): SocialLinksModel =
     return self.socialLinksModel
 
@@ -209,9 +194,6 @@ QtObject:
     read = getBio
     notify = bioChanged
 
-  proc setBio(self: View, bio: string) {.slot.} =
-    self.delegate.setBio(bio)
-
   proc emitBioChangedSignal*(self: View) =
     self.bioChanged()
 
@@ -276,20 +258,16 @@ QtObject:
   QtProperty[QVariant] showcasePreferencesSocialLinksModel:
     read = getProfileShowcasePreferencesSocialLinksModel
 
-  # TODO: remove old save preferences api
-  proc storeProfileShowcasePreferences(self: View) {.slot.} =
-    let communities = self.profileShowcaseCommunitiesModel.items()
-    let accounts = self.profileShowcaseAccountsModel.items()
-    let collectibles = self.profileShowcaseCollectiblesModel.items()
-    let assets = self.profileShowcaseAssetsModel.items()
-
-    self.delegate.storeProfileShowcasePreferences(communities, accounts, collectibles, assets)
-
   proc clearModels*(self: View) {.slot.} =
     self.profileShowcaseCommunitiesModel.clear()
     self.profileShowcaseAccountsModel.clear()
     self.profileShowcaseCollectiblesModel.clear()
     self.profileShowcaseAssetsModel.clear()
+
+  proc saveIdentityInfo(self: View, profileData: string) {.slot.} =
+    let profileDataObj = profileData.parseJson
+    let identityInfo = profileDataObj.toIdentitySaveData()
+    self.delegate.saveProfileIdentityInfo(identityInfo)
 
   proc saveProfileShowcasePreferences(self: View, profileData: string) {.slot.} =
     let profileDataObj = profileData.parseJson

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -63,35 +63,19 @@ QtObject {
 
     // Identity related:
     function saveIdentityInfo(displayName, bio, source, aX, aY, bX, bY) {
-        // TODO: Update according to issue #13767
-        _setDisplayName(displayName)
-        _setBio(bio)
-        if(source)
-            _uploadImage(source, aX, aY, bX, bY)
-        else
-            _removeImage()
-    }
-
-    function _setDisplayName(displayName) {
-        root.profileModule.setDisplayName(displayName)
-    }
-
-    function _setBio(bio) {
-        root.profileModule.setBio(bio)
-    }
-
-    function _uploadImage(source, aX, aY, bX, bY) {
-        return root.profileModule.upload(source, aX, aY, bX, bY)
-    }
-
-    function _removeImage() {
-        return root.profileModule.remove()
-    }
-
-    // Preferences (Accounts, Communities, Collectibles, Assets and social links):
-    // TO BE REMOVED: Deprecated --> Issue #13688
-    function storeProfileShowcasePreferences() {
-        root.profileModule.storeProfileShowcasePreferences()
+        var identityInfo = {
+            "displayName": displayName,
+            "bio": bio,
+            "image": source ? {
+                "source": source,
+                "aX": aX,
+                "aY": aY,
+                "bX": bX,
+                "bY": bY
+            } : null
+        }
+        let json = JSON.stringify(identityInfo)
+        root.profileModule.saveIdentityInfo(json)
     }
 
     function getProfileShowcaseEntriesLimit() {

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -123,10 +123,10 @@ SettingsContentBase {
 
         property bool hasAnyProfileShowcaseChanges: showcaseModels.dirty
         property bool isIdentityTabDirty: (!descriptionPanel.isEnsName &&
-                                           descriptionPanel.displayName.text !== profileStore.displayName) ||
-                                          descriptionPanel.bio.text !== profileStore.bio ||
-                                          profileStore.socialLinksDirty ||
-                                          profileHeader.icon !== profileStore.profileLargeImage
+                                            descriptionPanel.displayName.text !== profileStore.displayName) ||
+                                            descriptionPanel.bio.text !== profileStore.bio ||
+                                            profileStore.socialLinksDirty ||
+                                            profileHeader.icon !== profileStore.profileLargeImage
 
         property ProfileShowcaseModels showcaseModels: ProfileShowcaseModels {
             communitiesSourceModel: root.communitiesModel
@@ -154,18 +154,21 @@ SettingsContentBase {
 
         function save() {
             // Accounts, Communities, Assets, Collectibles and social links info
-            if (hasAnyProfileShowcaseChanges)
+            if (hasAnyProfileShowcaseChanges) {
                 root.profileStore.saveProfileShowcasePreferences(showcaseModels.buildJSONModelsCurrentState())
+            }
 
             // Identity info
-            if(isIdentityTabDirty)
+            if (isIdentityTabDirty) {
                 root.profileStore.saveIdentityInfo(descriptionPanel.displayName.text,
                                                    descriptionPanel.bio.text.trim(),
                                                    profileHeader.icon,
-                                                   profileHeader.cropRect.x.toFixed(),
-                                                   profileHeader.cropRect.y.toFixed(),
-                                                   (profileHeader.cropRect.x + profileHeader.cropRect.width).toFixed(),
-                                                   (profileHeader.cropRect.y + profileHeader.cropRect.height).toFixed())
+                                                   profileHeader.cropRect.x,
+                                                   profileHeader.cropRect.y,
+                                                   (profileHeader.cropRect.x + profileHeader.cropRect.width),
+                                                   (profileHeader.cropRect.y + profileHeader.cropRect.height))
+                profileHeader.icon = Qt.binding(() => { return profileStore.profileLargeImage })
+            }
         }
     }
 


### PR DESCRIPTION
Close #13767

### What does the PR do

- [x] Store identity data in json (dedicated from profile showcase data)
- [x] Remove some deprecated code

### Affected areas

Profile

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/2522130/fda799a4-792c-4afa-95ef-31364ed09f6f

