### PR TITLE
feat(ProfileShowcase): Add network prefixes and filter watch only accounts

### DIFF
--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -13,6 +13,7 @@ type
     KeyUid,
     Position,
     KeycardAccount,
+    PreferredSharingChainIds
 
 QtObject:
   type
@@ -57,6 +58,7 @@ QtObject:
       ModelRole.KeyUid.int: "keyUid",
       ModelRole.Position.int: "position",
       ModelRole.KeycardAccount.int: "keycardAccount",
+      ModelRole.PreferredSharingChainIds.int: "preferredSharingChainIds"
     }.toTable
 
 
@@ -108,6 +110,8 @@ QtObject:
       result = newQVariant(item.getPosition())
     of ModelRole.KeycardAccount:
       result = newQVariant(item.keycardAccount())
+    of ModelRole.PreferredSharingChainIds:
+      result = newQVariant(item.preferredSharingChainIds())
 
   proc moveItem*(self: Model, fromRow: int, toRow: int): bool =
     if toRow < 0 or toRow > self.items.len - 1:

--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseModels.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseModels.qml
@@ -169,9 +169,10 @@ QObject {
             expression: {
                 root.accountsSearcherText
                 return (address.toLowerCase().includes(root.accountsSearcherText.toLowerCase()) ||
-                        name.toLowerCase().includes( root.accountsSearcherText.toLowerCase()))
+                        name.toLowerCase().includes(root.accountsSearcherText.toLowerCase()) ||
+                        preferredSharingChainShortNames.toLowerCase().includes(root.accountsSearcherText.toLowerCase()))
             }
-            expectedRoles: ["address", "name"]
+            expectedRoles: ["address", "name", "preferredSharingChainShortNames"]
         }
     }
 

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAccountsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseAccountsPanel.qml
@@ -20,7 +20,10 @@ ProfileShowcasePanel {
     searchPlaceholderText: qsTr("Search account name or address")
     delegate: ProfileShowcasePanelDelegate {
         title: model ? model.name : ""
-        secondaryTitle: WalletUtils.addressToDisplay(model ? model.address ?? "" : "", "", true, containsMouse)
+        secondaryTitle: WalletUtils.addressToDisplay(model ? model.address ?? "" : "",
+                                                     model ? model.preferredSharingChainShortNames ?? "" : "",
+                                                     true,
+                                                     containsMouse)
         hasEmoji: model && !!model.emoji
         hasIcon: !hasEmoji
         icon.name: hasEmoji ? model.emoji : "filled-account"

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -2,6 +2,10 @@ import QtQuick 2.13
 
 import utils 1.0
 
+import StatusQ 0.1
+
+import SortFilterProxyModel 0.2
+
 QtObject {
     id: root
 
@@ -29,6 +33,21 @@ QtObject {
     property var overview: walletSectionOverview
     property var accounts: Global.appIsReady? accountsModule.accounts : null
     property var originModel: accountsModule.keyPairModel
+    property var ownAccounts: SortFilterProxyModel {
+        sourceModel: root.accounts
+        proxyRoles:  FastExpressionRole {
+            name: "preferredSharingChainShortNames"
+            expression: {
+                return root.networksModule.getNetworkShortNames(preferredSharingChainIds)
+            }
+            expectedRoles: ["preferredSharingChainIds"]
+        }
+        filters: ValueFilter {
+            roleName: "walletType"
+            value: Constants.watchWalletType
+            inverted: true
+        }
+    }
 
     property string userProfilePublicKey: userProfile.pubKey
 
@@ -87,7 +106,7 @@ QtObject {
     }
 
     function getNetworkShortNames(chainIds) {
-       return networksModule.getNetworkShortNames(chainIds)
+        return networksModule.getNetworkShortNames(chainIds)
     }
 
     function processPreferredSharingNetworkToggle(preferredSharingNetworks, toggledNetwork) {

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -133,7 +133,7 @@ SettingsContentBase {
             communitiesShowcaseModel: root.profileStore.showcasePreferencesCommunitiesModel
             communitiesSearcherText: profileShowcaseCommunitiesPanel.searcherText
             
-            accountsSourceModel: root.walletStore.accounts
+            accountsSourceModel: root.walletStore.ownAccounts
             accountsShowcaseModel: root.profileStore.showcasePreferencesAccountsModel
             accountsSearcherText: profileShowcaseAccountsPanel.searcherText
 


### PR DESCRIPTION
Closes #13899

### What does the PR do

- Added network prefixes in profile showcase accounts delegate and included them in the searcher.
- Added filter to just display own accounts in profile showcase accounts tab.

### Affected areas

Profile Showcase / accounts tab

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/7eccb7f8-002a-4999-83b4-d510badde691
