### PR TITLE
chore(nim): use compile-time string formatting

### DIFF
--- a/src/app/core/tasks/marathon.nim
+++ b/src/app/core/tasks/marathon.nim
@@ -1,5 +1,5 @@
 import # std libs
-  strformat, tables
+  stew/shims/strformat, tables
 
 import # vendor libs
   chronicles

--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, uri, strformat, strutils, stint, re
+import NimQml, strutils, uri, stew/shims/strformat, strutils, stint, re
 import stew/byteutils
 import ./utils/qrcodegen
 import ./utils/time_utils

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import ../../shared_models/message_item_qobject
 import ../../../../app_service/service/activity_center/dto/notification
 import ../../../../app_service/service/chat/dto/chat

--- a/src/app/modules/main/activity_center/token_data_item.nim
+++ b/src/app/modules/main/activity_center/token_data_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, strformat
+import NimQml, strutils, stew/shims/strformat
 
 QtObject:
   type TokenDataItem* = ref object of QObject

--- a/src/app/modules/main/app_search/location_menu_item.nim
+++ b/src/app/modules/main/app_search/location_menu_item.nim
@@ -1,5 +1,5 @@
 
-import json, strformat
+import json, stew/shims/strformat
 import base_item, location_menu_sub_model, location_menu_sub_item
 
 type

--- a/src/app/modules/main/app_search/location_menu_sub_item.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_item.nim
@@ -1,4 +1,4 @@
-import json, strformat, sequtils, sugar
+import json, stew/shims/strformat, sequtils, sugar
 import base_item
 import ../../shared_models/[color_hash_item, color_hash_model]
 

--- a/src/app/modules/main/app_search/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import location_menu_sub_item
 

--- a/src/app/modules/main/app_search/result_item.nim
+++ b/src/app/modules/main/app_search/result_item.nim
@@ -1,4 +1,4 @@
-import strformat, sequtils, sugar
+import stew/shims/strformat, sequtils, sugar
 
 import ../../shared_models/[color_hash_item, color_hash_model]
 

--- a/src/app/modules/main/app_search/result_model.nim
+++ b/src/app/modules/main/app_search/result_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import result_item
 

--- a/src/app/modules/main/browser_section/bookmark/item.nim
+++ b/src/app/modules/main/browser_section/bookmark/item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   Item* = object

--- a/src/app/modules/main/browser_section/bookmark/model.nim
+++ b/src/app/modules/main/browser_section/bookmark/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import item
 

--- a/src/app/modules/main/browser_section/dapps/accounts.nim
+++ b/src/app/modules/main/browser_section/dapps/accounts.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 
 type

--- a/src/app/modules/main/browser_section/dapps/dapps.nim
+++ b/src/app/modules/main/browser_section/dapps/dapps.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, json
+import NimQml, Tables, strutils, stew/shims/strformat, json
 import ./item
 
 type

--- a/src/app/modules/main/browser_section/dapps/item.nim
+++ b/src/app/modules/main/browser_section/dapps/item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import ./permissions
 import ./accounts
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service

--- a/src/app/modules/main/browser_section/dapps/permissions.nim
+++ b/src/app/modules/main/browser_section/dapps/permissions.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 type
   ModelRole {.pure.} = enum

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -1,4 +1,4 @@
-import sequtils, sugar, strformat, json
+import sequtils, sugar, stew/shims/strformat, json
 
 import ../../../../app_service/common/types
 import ../../../../app_service/service/contacts/dto/contacts

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, json, sequtils, system
+import NimQml, Tables, strutils, stew/shims/strformat, json, sequtils, system
 import ../../../../app_service/common/types
 import ../../../../app_service/service/chat/dto/chat
 from ../../../../app_service/service/contacts/dto/contacts import TrustStatus

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, sequtils, strformat, sugar, marshal
+import NimQml, Tables, chronicles, json, sequtils, stew/shims/strformat, sugar, marshal
 
 import io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import ../../../shared_models/[token_permissions_model, token_permission_item]
 
 type

--- a/src/app/modules/main/communities/models/discord_category_item.nim
+++ b/src/app/modules/main/communities/models/discord_category_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   DiscordCategoryItem* = object

--- a/src/app/modules/main/communities/models/discord_channel_item.nim
+++ b/src/app/modules/main/communities/models/discord_channel_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   DiscordChannelItem* = object

--- a/src/app/modules/main/communities/models/discord_file_item.nim
+++ b/src/app/modules/main/communities/models/discord_file_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 type
   DiscordFileItem* = object
     filePath*: string

--- a/src/app/modules/main/communities/models/discord_import_error_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_error_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 type
   DiscordImportErrorItem* = object
     taskId*: string

--- a/src/app/modules/main/communities/models/discord_import_progress_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_progress_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 type
   DiscordImportProgressItem* = object
     communityId*: string

--- a/src/app/modules/main/communities/models/discord_import_task_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_task_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import discord_import_errors_model, discord_import_error_item
 import ../../../../../app_service/service/community/dto/community
 

--- a/src/app/modules/main/communities/models/pending_request_item.nim
+++ b/src/app/modules/main/communities/models/pending_request_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   PendingRequestItem* = ref object

--- a/src/app/modules/main/communities/tokens/models/token_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_item.nim
@@ -1,4 +1,4 @@
-import strformat, sequtils, stint
+import stew/shims/strformat, sequtils, stint
 import ../../../../../../app_service/service/community_tokens/dto/community_token
 import ../../../../../../app_service/service/community_tokens/community_collectible_owner
 import ../../../../../../app_service/service/network/dto

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, sequtils, stint
+import NimQml, Tables, stew/shims/strformat, sequtils, stint
 import token_item
 import token_owners_item
 import token_owners_model

--- a/src/app/modules/main/communities/tokens/models/token_owners_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_item.nim
@@ -1,4 +1,4 @@
-import strformat, stint
+import stew/shims/strformat, stint
 import backend/collectibles_types
 import ../../../../../../app_service/common/types
 

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, stint
+import NimQml, Tables, stew/shims/strformat, stint
 import token_owners_item
 
 type

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, sugar, sequtils, strformat, marshal, times, chronicles, stint
+import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint
 
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model

--- a/src/app/modules/main/network_connection/network_connection_item.nim
+++ b/src/app/modules/main/network_connection/network_connection_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat
+import NimQml, stew/shims/strformat
 
 QtObject:
   type NetworkConnectionItem* = ref object of QObject

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -1,4 +1,4 @@
-import NimQml, json, stint, sequtils, strutils, sugar, strformat, parseutils, chronicles
+import NimQml, json, stint, sequtils, strutils, sugar, stew/shims/strformat, parseutils, chronicles
 
 import io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
+++ b/src/app/modules/main/profile_section/profile/models/profile_preferences_collectible_item.nim
@@ -1,4 +1,4 @@
-import json, strutils, strformat, stint, json_serialization, tables
+import json, strutils, stew/shims/strformat, stint, json_serialization, tables
 
 import profile_preferences_base_item
 

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, strformat
+import NimQml, Tables, strutils, sequtils, stew/shims/strformat
 
 import ../../../../shared_models/wallet_account_item
 

--- a/src/app/modules/main/profile_section/wallet/networks/combined_item.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/combined_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 import ./item
 

--- a/src/app/modules/main/profile_section/wallet/networks/combined_model.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/combined_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import ./combined_item
 

--- a/src/app/modules/main/profile_section/wallet/networks/item.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat
+import NimQml, stew/shims/strformat
 
 QtObject:
   type Item* = ref object of QObject

--- a/src/app/modules/main/profile_section/wallet/networks/model.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import ./item
 

--- a/src/app/modules/main/stickers/item.nim
+++ b/src/app/modules/main/stickers/item.nim
@@ -1,4 +1,4 @@
-import strformat, stint
+import stew/shims/strformat, stint
 
 #####
 # Sticker Item

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stint, sugar, sequtils, json, strutils, strformat, parseutils, chronicles
+import NimQml, Tables, stint, sugar, sequtils, json, strutils, stew/shims/strformat, parseutils, chronicles
 import ./io_interface, ./view, ./controller, ./item, ./models/sticker_pack_list
 import ../io_interface as delegate_interface
 import app/global/global_singleton

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import ./item
 import ../../../shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/activity/collectibles_item.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_item.nim
@@ -1,4 +1,4 @@
-import strformat, stint
+import stew/shims/strformat, stint
 import backend/activity as backend
 
 type

--- a/src/app/modules/main/wallet_section/activity/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils, stint
+import NimQml, Tables, strutils, stew/shims/strformat, sequtils, stint
 import logging
 
 import ./collectibles_item

--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strformat, sequtils, strutils, logging, stint
+import NimQml, json, stew/shims/strformat, sequtils, strutils, logging, stint
 
 import backend/activity as backend
 import app/modules/shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils, logging, options
+import NimQml, Tables, strutils, stew/shims/strformat, sequtils, logging, options
 
 import ./entry
 

--- a/src/app/modules/main/wallet_section/activity/multi_transaction_item.nim
+++ b/src/app/modules/main/wallet_section/activity/multi_transaction_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 import ./backend/transactions
 

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/item.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
   
 type Item* = object
   name: string

--- a/src/app/modules/main/wallet_section/filter.nim
+++ b/src/app/modules/main/wallet_section/filter.nim
@@ -1,4 +1,4 @@
-import strformat, sequtils, sugar
+import stew/shims/strformat, sequtils, sugar
 
 import ./controller
 

--- a/src/app/modules/main/wallet_section/networks/item.nim
+++ b/src/app/modules/main/wallet_section/networks/item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   UxEnabledState* {.pure.} = enum

--- a/src/app/modules/main/wallet_section/networks/model.nim
+++ b/src/app/modules/main/wallet_section/networks/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils, sugar
+import NimQml, Tables, strutils, stew/shims/strformat, sequtils, sugar
 
 import app_service/service/network/types
 import ./item

--- a/src/app/modules/main/wallet_section/overview/item.nim
+++ b/src/app/modules/main/wallet_section/overview/item.nim
@@ -1,4 +1,4 @@
-import strformat, strutils
+import stew/shims/strformat, strutils
 
 type
   Item* = object

--- a/src/app/modules/main/wallet_section/saved_addresses/item.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 import app_service/common/account_constants
 

--- a/src/app/modules/main/wallet_section/saved_addresses/model.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import item
 import app_service/common/account_constants

--- a/src/app/modules/main/wallet_section/send/accounts_model.nim
+++ b/src/app/modules/main/wallet_section/send/accounts_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import ./account_item
 import ../../../shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/send/network_item.nim
+++ b/src/app/modules/main/wallet_section/send/network_item.nim
@@ -1,4 +1,4 @@
-import strformat, strutils
+import stew/shims/strformat, strutils
 
 import app/modules/shared_models/currency_amount
 

--- a/src/app/modules/main/wallet_section/send/network_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils, sugar, json, stint
+import NimQml, Tables, strutils, stew/shims/strformat, sequtils, sugar, json, stint
 
 import app_service/service/network/types
 import app/modules/shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/send/suggested_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import ./suggested_route_item
 

--- a/src/app/modules/main/wallet_section/send/transaction_routes.nim
+++ b/src/app/modules/main/wallet_section/send/transaction_routes.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat, stint
+import NimQml, stew/shims/strformat, stint
 
 import ./gas_estimate_item, ./suggested_route_model, ./network_model
 

--- a/src/app/modules/shared_models/collectible_ownership_model.nim
+++ b/src/app/modules/shared_models/collectible_ownership_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 import stint
 
 import backend/collectibles_types as backend

--- a/src/app/modules/shared_models/collectible_trait_model.nim
+++ b/src/app/modules/shared_models/collectible_trait_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import backend/collectibles as backend
 

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strformat, sequtils, strutils, stint, strutils
+import NimQml, json, stew/shims/strformat, sequtils, strutils, stint, strutils
 import options
 
 import backend/collectibles as backend

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils, stint, json
+import NimQml, Tables, strutils, stew/shims/strformat, sequtils, stint, json
 import logging
 
 import ./collectibles_entry

--- a/src/app/modules/shared_models/collectibles_nested_item.nim
+++ b/src/app/modules/shared_models/collectibles_nested_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import app_service/common/types
 
 type

--- a/src/app/modules/shared_models/collectibles_nested_model.nim
+++ b/src/app/modules/shared_models/collectibles_nested_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils
+import NimQml, Tables, strutils, stew/shims/strformat, sequtils
 
 import ./collectibles_model as flat_model
 import ./collectibles_entry as flat_item

--- a/src/app/modules/shared_models/color_hash_item.nim
+++ b/src/app/modules/shared_models/color_hash_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   Item* = ref object

--- a/src/app/modules/shared_models/currency_amount.nim
+++ b/src/app/modules/shared_models/currency_amount.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat, json
+import NimQml, stew/shims/strformat, json
 
 include app_service/common/json_utils
 

--- a/src/app/modules/shared_models/derived_address_item.nim
+++ b/src/app/modules/shared_models/derived_address_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat
+import NimQml, stew/shims/strformat
 
 QtObject:
   type DerivedAddressItem* = ref object of QObject

--- a/src/app/modules/shared_models/derived_address_model.nim
+++ b/src/app/modules/shared_models/derived_address_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, sugar, strformat
+import NimQml, Tables, strutils, sequtils, sugar, stew/shims/strformat
 
 import ./derived_address_item
 

--- a/src/app/modules/shared_models/discord_message_item.nim
+++ b/src/app/modules/shared_models/discord_message_item.nim
@@ -1,4 +1,4 @@
-import Nimqml, json, strformat
+import Nimqml, json, stew/shims/strformat
 
 import ../../../app_service/service/message/dto/message
 

--- a/src/app/modules/shared_models/keypair_account_item.nim
+++ b/src/app/modules/shared_models/keypair_account_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat
+import NimQml, stew/shims/strformat
 import app_service/service/wallet_account/dto/account_dto as wa_dto
 import ./currency_amount
 

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, strutils
+import NimQml, Tables, stew/shims/strformat, strutils
 import keypair_account_item
 import ./currency_amount
 

--- a/src/app/modules/shared_models/keypair_item.nim
+++ b/src/app/modules/shared_models/keypair_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat, sequtils, sugar
+import NimQml, stew/shims/strformat, sequtils, sugar
 import keypair_account_model
 import ./currency_amount
 

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, sequtils, sugar
+import NimQml, Tables, stew/shims/strformat, sequtils, sugar
 import keypair_item
 import ./currency_amount
 

--- a/src/app/modules/shared_models/link_preview_item.nim
+++ b/src/app/modules/shared_models/link_preview_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import ../../../app_service/service/message/dto/link_preview
 
 type

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat, tables, sequtils, sets
+import NimQml, stew/shims/strformat, tables, sequtils, sets
 import ./link_preview_item
 import ../../../app_service/service/message/dto/link_preview
 import ../../../app_service/service/message/dto/standard_link_preview

--- a/src/app/modules/shared_models/member_item.nim
+++ b/src/app/modules/shared_models/member_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import user_item
 
 import ../../../app_service/common/types

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, sequtils, sugar
+import NimQml, Tables, stew/shims/strformat, sequtils, sugar
 
 # TODO: use generics to remove duplication between user_model and member_model
 

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -1,4 +1,4 @@
-import json, strformat, strutils
+import json, stew/shims/strformat, strutils
 import ../../../app_service/common/types
 import ../../../app_service/service/contacts/dto/contact_details
 import ../../../app_service/service/message/dto/message

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sets, algorithm, sequtils, strutils, strformat, sugar
+import NimQml, Tables, json, sets, algorithm, sequtils, strutils, stew/shims/strformat, sugar
 
 import message_item, message_reaction_item, message_transaction_parameters_item
 

--- a/src/app/modules/shared_models/message_reaction_item.nim
+++ b/src/app/modules/shared_models/message_reaction_item.nim
@@ -1,4 +1,4 @@
-import json, strformat
+import json, stew/shims/strformat
 
 type
   EmojiId* {.pure.} = enum

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, strutils, strformat
+import NimQml, Tables, json, strutils, stew/shims/strformat
 
 import message_reaction_item
 

--- a/src/app/modules/shared_models/message_transaction_parameters_item.nim
+++ b/src/app/modules/shared_models/message_transaction_parameters_item.nim
@@ -1,4 +1,4 @@
-import Nimqml, json, strformat
+import Nimqml, json, stew/shims/strformat
 
 QtObject:
   type

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -1,4 +1,4 @@
-import strformat, stint
+import stew/shims/strformat, stint
 import ./member_model, ./member_item
 import ../main/communities/models/[pending_request_item, pending_request_model]
 import ../main/communities/tokens/models/token_model as community_tokens_model

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import json
 

--- a/src/app/modules/shared_models/token_criteria_item.nim
+++ b/src/app/modules/shared_models/token_criteria_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   TokenCriteriaItem* = object

--- a/src/app/modules/shared_models/token_list_item.nim
+++ b/src/app/modules/shared_models/token_list_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type TokenListItemCategory* {.pure.}= enum
   Community = 0,

--- a/src/app/modules/shared_models/token_permission_chat_list_item.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   TokenPermissionChatListItem* = object

--- a/src/app/modules/shared_models/token_permission_item.nim
+++ b/src/app/modules/shared_models/token_permission_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import ../../../app_service/service/community/dto/community
 import ../../../app_service/service/chat/dto/chat
 import token_criteria_model

--- a/src/app/modules/shared_models/user_item.nim
+++ b/src/app/modules/shared_models/user_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 import ../../../app_service/common/types
 import ../../../app_service/service/contacts/dto/contacts
 

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, sequtils, sugar
+import NimQml, Tables, stew/shims/strformat, sequtils, sugar
 import user_item
 
 import ../../../app_service/common/types

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat
+import NimQml, stew/shims/strformat
 import app_service/service/wallet_account/dto/account_dto as wa_dto
 
 export wa_dto

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strformat
+import NimQml, stew/shims/strformat
 import ../../../shared_models/keypair_item
 
 export keypair_item

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, sequtils
+import NimQml, Tables, stew/shims/strformat, sequtils
 import keycard_item
 
 export keycard_item

--- a/src/app/modules/startup/models/fetching_data_item.nim
+++ b/src/app/modules/startup/models/fetching_data_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   Item* = ref object

--- a/src/app/modules/startup/models/fetching_data_model.nim
+++ b/src/app/modules/startup/models/fetching_data_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat
+import NimQml, Tables, strutils, stew/shims/strformat
 
 import fetching_data_item
 

--- a/src/app_service/common/conversion.nim
+++ b/src/app_service/common/conversion.nim
@@ -1,4 +1,4 @@
-import strutils, strformat, stint, chronicles
+import strutils, stew/shims/strformat, stint, chronicles
 from web3 import Address, fromHex
 
 const CompressedKeyChars* = {'0'..'9', 'A','B','C','D','E','F','G','H','J','K','L','M','N','P','Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','m','n','o','p','q','r','s','t','u','v','w','x','y','z'}

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, os, json, strformat, sequtils, strutils, uuids, times
+import NimQml, Tables, os, json, stew/shims/strformat, sequtils, strutils, uuids, times
 import json_serialization, chronicles
 
 import ../../../app/global/global_singleton

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, strformat, strutils, stint, json_serialization
+import json, stew/shims/strformat, strutils, stint, json_serialization
 import ../../message/dto/message
 import ../../contacts/dto/contacts
 import token_data

--- a/src/app_service/service/activity_center/dto/token_data.nim
+++ b/src/app_service/service/activity_center/dto/token_data.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, strformat
+import json, stew/shims/strformat
 
 include ../../../common/json_utils
 include ../../../common/utils

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, strformat, strutils, tables
+import json, stew/shims/strformat, strutils, tables
 import ../../community/dto/community
 import ../../shared_urls/dto/url_data
 

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strformat, chronicles, os, std/algorithm, strutils, uuids, base64
+import NimQml, Tables, json, sequtils, stew/shims/strformat, chronicles, os, std/algorithm, strutils, uuids, base64
 import std/[times, os]
 
 import ../../../app/core/tasks/[qt, threadpool]

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, std/sets, std/algorithm, strformat, strutils, chronicles, json_serialization, sugar, times
+import NimQml, Tables, json, sequtils, std/sets, std/algorithm, stew/shims/strformat, strutils, chronicles, json_serialization, sugar, times
 import json_serialization/std/tables as ser_tables
 
 import ./dto/community as community_dto

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, stint, strutils, sugar, sequtils, strformat
+import NimQml, Tables, chronicles, json, stint, strutils, sugar, sequtils, stew/shims/strformat
 import ../../../app/global/global_singleton
 import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, strformat, strutils
+import json, stew/shims/strformat, strutils
 import ../../../common/social_links
 
 include ../../../common/json_utils

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strformat, chronicles, strutils, times, std/times
+import NimQml, Tables, json, sequtils, stew/shims/strformat, chronicles, strutils, times, std/times
 
 import ../../../app/global/global_singleton
 import ../../../app/core/signals/types

--- a/src/app_service/service/ens/dto/ens_username_dto.nim
+++ b/src/app_service/service/ens/dto/ens_username_dto.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, strformat, hashes
+import json, stew/shims/strformat, hashes
 include ../../../common/json_utils
 
 type EnsUsernameDto* = ref object

--- a/src/app_service/service/ens/utils.nim
+++ b/src/app_service/service/ens/utils.nim
@@ -1,5 +1,5 @@
 import Tables, json, chronicles, strutils
-import strformat, sets, options
+import stew/shims/strformat, sets, options
 import chronicles, libp2p/[multihash, multicodec, cid]
 import nimcrypto, stint
 import ../../common/conversion as common_conversion

--- a/src/app_service/service/eth/utils.nim
+++ b/src/app_service/service/eth/utils.nim
@@ -1,6 +1,6 @@
 import
   json, tables, sequtils, httpclient, net
-import json, strutils, strformat, tables, chronicles, unicode, times
+import json, strutils, stew/shims/strformat, tables, chronicles, unicode, times
 import
   json_serialization, chronicles, libp2p/[multihash, multicodec, cid], stint, nimcrypto
 from sugar import `=>`, `->`

--- a/src/app_service/service/gif/dto.nim
+++ b/src/app_service/service/gif/dto.nim
@@ -1,4 +1,4 @@
-import json, strformat
+import json, stew/shims/strformat
 
 type
   GifDto* = object

--- a/src/app_service/service/gif/service.nim
+++ b/src/app_service/service/gif/service.nim
@@ -1,5 +1,5 @@
 import json
-import strformat
+import stew/shims/strformat
 import os
 import uri
 import chronicles

--- a/src/app_service/service/language/service.nim
+++ b/src/app_service/service/language/service.nim
@@ -1,5 +1,5 @@
 import NimQml
-import chronicles, os, strformat, re
+import chronicles, os, stew/shims/strformat, re
 
 import ../../../constants as main_constants
 import ../../../app/global/global_singleton

--- a/src/app_service/service/message/dto/link_preview.nim
+++ b/src/app_service/service/message/dto/link_preview.nim
@@ -1,4 +1,4 @@
-import json, strformat, tables
+import json, stew/shims/strformat, tables
 import ./status_link_preview, ./standard_link_preview
 import ./status_contact_link_preview, ./status_community_link_preview, ./status_community_channel_link_preview
 import ../../contacts/dto/contact_details

--- a/src/app_service/service/message/dto/link_preview_thumbnail.nim
+++ b/src/app_service/service/message/dto/link_preview_thumbnail.nim
@@ -1,4 +1,4 @@
-import json, strformat, NimQml, chronicles
+import json, stew/shims/strformat, NimQml, chronicles
 include ../../../common/json_utils
 
 QtObject:

--- a/src/app_service/service/message/dto/standard_link_preview.nim
+++ b/src/app_service/service/message/dto/standard_link_preview.nim
@@ -1,4 +1,4 @@
-import json, strformat, NimQml
+import json, stew/shims/strformat, NimQml
 import ./link_preview_thumbnail
 include ../../../common/json_utils
 

--- a/src/app_service/service/message/dto/status_community_channel_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_channel_link_preview.nim
@@ -1,4 +1,4 @@
-import json, strformat, NimQml, chronicles
+import json, stew/shims/strformat, NimQml, chronicles
 import link_preview_thumbnail
 import status_community_link_preview
 import ../../community/dto/community

--- a/src/app_service/service/message/dto/status_community_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_link_preview.nim
@@ -1,4 +1,4 @@
-import json, strformat, NimQml, chronicles
+import json, stew/shims/strformat, NimQml, chronicles
 import link_preview_thumbnail
 import ../../community/dto/community
 

--- a/src/app_service/service/message/dto/status_contact_link_preview.nim
+++ b/src/app_service/service/message/dto/status_contact_link_preview.nim
@@ -1,4 +1,4 @@
-import json, strformat, NimQml, chronicles
+import json, stew/shims/strformat, NimQml, chronicles
 import link_preview_thumbnail
 import ../../contacts/dto/contact_details
 

--- a/src/app_service/service/message/dto/urls_unfurling_plan.nim
+++ b/src/app_service/service/message/dto/urls_unfurling_plan.nim
@@ -1,4 +1,4 @@
-import json, strformat, chronicles, Tables
+import json, stew/shims/strformat, chronicles, Tables
 include ../../../common/json_utils
 
 type 

--- a/src/app_service/service/message/message_cursor.nim
+++ b/src/app_service/service/message/message_cursor.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 type
   CursorValue* = string

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, re, sequtils, strformat, strutils, chronicles, times, oids, uuids
+import NimQml, tables, json, re, sequtils, stew/shims/strformat, strutils, chronicles, times, oids, uuids
 
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/core/signals/types

--- a/src/app_service/service/network/dto.nim
+++ b/src/app_service/service/network/dto.nim
@@ -1,5 +1,5 @@
 
-import hashes, strformat, json_serialization
+import hashes, stew/shims/strformat, json_serialization
 
 import ./types
 

--- a/src/app_service/service/profile/dto/profile_showcase_preferences.nim
+++ b/src/app_service/service/profile/dto/profile_showcase_preferences.nim
@@ -1,4 +1,4 @@
-import json, strutils, strformat, stint, sequtils, json_serialization
+import json, strutils, stew/shims/strformat, stint, sequtils, json_serialization
 
 include ../../../common/json_utils
 include ../../../common/utils

--- a/src/app_service/service/stickers/dto/stickers.nim
+++ b/src/app_service/service/stickers/dto/stickers.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, strformat, strutils, stint, json_serialization, chronicles
+import json, stew/shims/strformat, strutils, stint, json_serialization, chronicles
 
 include ../../../common/json_utils
 include ../../../common/utils

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -1,4 +1,4 @@
-import times, strformat
+import times, stew/shims/strformat
 import backend/backend as backend
 
 include app_service/common/json_utils

--- a/src/app_service/service/token/dto.nim
+++ b/src/app_service/service/token/dto.nim
@@ -1,4 +1,4 @@
-import json, strformat
+import json, stew/shims/strformat
 
 include app_service/common/json_utils
 

--- a/src/app_service/service/token/service_items.nim
+++ b/src/app_service/service/token/service_items.nim
@@ -1,4 +1,4 @@
-import strformat
+import stew/shims/strformat
 
 import app_service/common/types as common_types
 

--- a/src/app_service/service/transaction/cryptoRampDto.nim
+++ b/src/app_service/service/transaction/cryptoRampDto.nim
@@ -1,4 +1,4 @@
-import json, strformat
+import json, stew/shims/strformat
 
 include  ../../common/json_utils
 

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -1,4 +1,4 @@
-import json, strutils, stint, json_serialization, strformat, sugar, sequtils
+import json, strutils, stint, json_serialization, stew/shims/strformat, sugar, sequtils
 
 import
   web3/ethtypes

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -1,4 +1,4 @@
-import Tables, NimQml, chronicles, sequtils, sugar, stint, strutils, json, strformat, algorithm
+import Tables, NimQml, chronicles, sequtils, sugar, stint, strutils, json, stew/shims/strformat, algorithm
 
 import ../../../backend/collectibles as collectibles
 import ../../../backend/transactions as transactions

--- a/src/app_service/service/wallet_account/dto/account_dto.nim
+++ b/src/app_service/service/wallet_account/dto/account_dto.nim
@@ -1,4 +1,4 @@
-import tables, json, strformat, strutils
+import tables, json, stew/shims/strformat, strutils
 
 import account_token_item
 

--- a/src/app_service/service/wallet_account/dto/account_token_item.nim
+++ b/src/app_service/service/wallet_account/dto/account_token_item.nim
@@ -1,4 +1,4 @@
-import stint, strformat
+import stint, stew/shims/strformat
 
 type BalanceItem* = ref object of RootObj
   account*: string

--- a/src/app_service/service/wallet_account/dto/keypair_dto.nim
+++ b/src/app_service/service/wallet_account/dto/keypair_dto.nim
@@ -1,4 +1,4 @@
-import tables, json, strformat, strutils, sequtils, sugar, chronicles
+import tables, json, stew/shims/strformat, strutils, sequtils, sugar, chronicles
 
 import account_dto, keycard_dto
 

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, sugar, chronicles, strformat, stint, httpclient
+import NimQml, Tables, json, sequtils, sugar, chronicles, stew/shims/strformat, stint, httpclient
 import net, strutils, os, times, algorithm, options
 import web3/ethtypes
 

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -1,4 +1,4 @@
-import times, strformat, options, logging
+import times, stew/shims/strformat, options, logging
 import json, json_serialization
 import core, response_type
 import stint

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, strformat
+import json, json_serialization, stew/shims/strformat
 import hashes
 import ./core, ./response_type
 import app_service/service/saved_address/dto as saved_address_dto

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -1,4 +1,4 @@
-import json, strformat
+import json, stew/shims/strformat
 import stint, Tables, strutils
 import core
 import response_type, collectibles_types

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -1,4 +1,4 @@
-import json, strformat, json_serialization
+import json, stew/shims/strformat, json_serialization
 import stint, Tables, options, strutils
 import community_tokens_types
 

--- a/src/backend/connection_status.nim
+++ b/src/backend/connection_status.nim
@@ -1,4 +1,4 @@
-import json, strformat, tables
+import json, stew/shims/strformat, tables
 
 const INVALID_TIMESTAMP* = -1
 

--- a/src/backend/core.nim
+++ b/src/backend/core.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, strformat, chronicles
+import json, json_serialization, stew/shims/strformat, chronicles
 import status_go
 import response_type
 

--- a/src/backend/response_type.nim
+++ b/src/backend/response_type.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import strformat
+import stew/shims/strformat
 
 type
   RpcException* = object of CatchableError

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -1,4 +1,4 @@
-import Tables, json, stint, json_serialization, strformat
+import Tables, json, stint, json_serialization, stew/shims/strformat
 
 import ../app_service/service/eth/dto/transaction
 import ./core as core

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -1,4 +1,4 @@
-import os, sequtils, strutils, strformat, chronicles
+import os, sequtils, strutils, stew/shims/strformat, chronicles
 
 import # vendor libs
   confutils

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, os, strformat, strutils, times, md5, json
+import NimQml, chronicles, os, stew/shims/strformat, strutils, times, md5, json
 
 import status_go
 import keycard_go


### PR DESCRIPTION
Nim 2.2 comes with compile-time string formatting that doesn't raise exceptions if the format string is invalid - instead a compile-time error is given.

This PR introduces a backport of that feature which improves performance and reduces the risk that formatting causes the app to crash and will help migrating the codebase to newer nim versions that track exceptions more carefully.

There should be no change in runtime behavior (except formatting being a bit faster)
