### PR TITLE
feat(CollectiblesLayout): Always visualize section header if community minted collectibles are present

### DIFF
--- a/storybook/src/Models/ManageCollectiblesModel.qml
+++ b/storybook/src/Models/ManageCollectiblesModel.qml
@@ -311,7 +311,7 @@ ListModel {
                     accountAddress: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
                     balance: "70",
                     txTimestamp: 60
-                },
+                }
             ]
         },
         {
@@ -329,7 +329,7 @@ ListModel {
             ownership: [
                 {
                     accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
-                    balance: 1,
+                    balance: "1",
                     txTimestamp: 27
                 },
             ]

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
@@ -63,6 +63,8 @@ Control {
             Layout.fillWidth: true
 
             StatusBaseText {
+                Layout.fillWidth: true
+
                 font.pixelSize: Style.current.tertiaryTextFontSize
                 font.weight: Font.Medium
                 text:  {
@@ -87,12 +89,13 @@ Control {
             }
 
             CopyToClipBoardButton {
+                Layout.preferredWidth: 16
+                Layout.preferredHeight: 16
+
                 visible: d.unknownCommunityName && root.hovered
                 icon.height: Style.current.tertiaryTextFontSize
                 icon.width: Style.current.tertiaryTextFontSize
                 icon.color: Theme.palette.directColor1
-                Layout.preferredWidth: 16
-                Layout.preferredHeight: 16
                 color: Style.current.transparent
                 textToCopy: root.communityName
                 onCopyClicked: {

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
@@ -36,8 +36,9 @@ Control {
                                               (privilegesLevel === Constants.TokenPrivilegesLevel.TMaster)
     property color ornamentColor // Relevant color for these special tokens (community color)
 
-    readonly property var d: QtObject {
+   QtObject {
         id: d
+
         readonly property bool unknownCommunityName: root.communityName.startsWith("0x") && root.communityId === root.communityName
     }
 

--- a/ui/imports/shared/controls/FoldableHeader.qml
+++ b/ui/imports/shared/controls/FoldableHeader.qml
@@ -10,6 +10,7 @@ Rectangle {
 
     property bool folded: false
     property alias title: label.text
+    property alias titleColor: label.color
     property alias switchText: modeSwitch.text
     property alias checked: modeSwitch.checked
     property Component rightAdditionalComponent


### PR DESCRIPTION
Closes #13315

### What does the PR do

It closes previous mentioned issue but also some other fixes:
-  Some strange layout behaviour in `CollectiblesView` caused by a wrong syntax.
- Storybook waring cleanup.
- Collectible community tag elided correctly.
- Visualize section header when only community collectibles present.

### Affected areas

Main wallet collectibles layout

### Screenshot of functionality 

- Fix in layout due to some syntax error:

_Before:_
![image](https://github.com/status-im/status-desktop/assets/97019400/2530972a-c704-4125-808c-ec3fe0bff3ba)

_After:_
![Screenshot 2024-03-13 at 11 24 44](https://github.com/status-im/status-desktop/assets/97019400/1dcd7f9e-e1b0-4c77-a450-14bca3814469)

- Community tag:
![Screenshot 2024-03-13 at 11 25 06](https://github.com/status-im/status-desktop/assets/97019400/363c6f4e-8991-4aa9-a5dc-34dae50e0dc3)

- Header visible/hidden depending on collectibles type:

https://github.com/status-im/status-desktop/assets/97019400/dd17faff-93ef-4939-b83b-c69b55857c22