### PR TITLE
fix(StatusImageModal): Added min width and height

### DIFF
--- a/ui/imports/shared/status/StatusImageModal.qml
+++ b/ui/imports/shared/status/StatusImageModal.qml
@@ -17,9 +17,11 @@ StatusDialog {
     property string url: ""
 
     width: (root.image.sourceSize.width > d.maxWidth) ?
-            d.maxWidth : root.image.sourceSize.width
+            d.maxWidth : (root.image.sourceSize.width < d.minWidth) ?
+            d.minWidth : root.image.sourceSize.width
     height: (root.image.sourceSize.height > d.maxHeight) ?
-            d.maxHeight : root.image.sourceSize.height
+            d.maxHeight : (root.image.sourceSize.height < d.minHeight) ?
+            d.minHeight : root.image.sourceSize.height
 
     padding: 0
     background: null
@@ -31,6 +33,8 @@ StatusDialog {
 
         property int maxHeight: Global.applicationWindow.height - 80
         property int maxWidth: Global.applicationWindow.width - 80
+        property int minHeight: 320
+        property int minWidth: 320
     }
 
     onOpened: {


### PR DESCRIPTION
Closes #13539

### What does the PR do
StatusImageModal: Added min width and height

### Affected areas
StatusImageModal

### Screenshot of functionality (including design for comparison)

![qw](https://github.com/status-im/status-desktop/assets/31625338/eeefcc6d-0de3-4420-acb6-f079641c8fb5)


