### PR TITLE
chore(nim): task simplification

### DIFF
--- a/src/app/core/tasks/common.nim
+++ b/src/app/core/tasks/common.nim
@@ -1,4 +1,4 @@
-import # vendor libs
+import
   json_serialization#, stint
 from eth/common/eth_types_json_serialization import writeValue, readValue
 
@@ -9,7 +9,7 @@ export json_serialization
 type
   Task* = proc(arg: string): void {.gcsafe, nimcall.}
   TaskArg* = ref object of RootObj
-    tptr*: ByteAddress
+    tptr* {.dontSerialize.}: Task # Only used during task creation (don't access in tasks)
 
 proc decode*[T](arg: string): T =
   Json.decode(arg, T, allowUnknownFields = true)

--- a/src/app_service/common/async_tasks.nim
+++ b/src/app_service/common/async_tasks.nim
@@ -7,7 +7,7 @@ type
     timeoutInMilliseconds: int
     reason: string
 
-const timerTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc timerTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[TimerTaskArg](argEncoded)
   sleep(arg.timeoutInMilliseconds)
   arg.finish(arg.reason)

--- a/src/app_service/service/accounts/async_tasks.nim
+++ b/src/app_service/service/accounts/async_tasks.nim
@@ -10,7 +10,7 @@ type
     hashedCurrentPassword: string
     newPassword: string
 
-const convertRegularProfileKeypairToKeycardTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc convertRegularProfileKeypairToKeycardTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ConvertRegularProfileKeypairToKeycardTaskArg](argEncoded)
   try:
     var errMsg: string
@@ -46,7 +46,7 @@ type
     currentPassword: string
     hashedNewPassword: string
 
-const convertKeycardProfileKeypairToRegularTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc convertKeycardProfileKeypairToRegularTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ConvertKeycardProfileKeypairToRegularTaskArg](argEncoded)
   try:
     var response: RpcResponse[JsonNode]
@@ -76,7 +76,7 @@ type
     mnemonic: string
     paths: seq[string]
 
-const fetchAddressesFromNotImportedMnemonicTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchAddressesFromNotImportedMnemonicTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchAddressesFromNotImportedMnemonicArg](argEncoded)
   var output = %*{
     "derivedAddress": "",

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -592,7 +592,7 @@ QtObject:
     let arg = FetchAddressesFromNotImportedMnemonicArg(
       mnemonic: mnemonic,
       paths: paths,
-      tptr: cast[ByteAddress](fetchAddressesFromNotImportedMnemonicTask),
+      tptr: fetchAddressesFromNotImportedMnemonicTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAddressesFromNotImportedMnemonicFetched",
     )
@@ -698,7 +698,7 @@ QtObject:
 
         # Start a 1 second timer for the loading screen to appear
         let arg = TimerTaskArg(
-          tptr: cast[ByteAddress](timerTask),
+          tptr: timerTask,
           vptr: cast[ByteAddress](self.vptr),
           slot: "onWaitForReencryptionTimeout",
           timeoutInMilliseconds: 1000
@@ -765,7 +765,7 @@ QtObject:
 
     let hashedCurrentPassword = hashPassword(currentPassword)
     let arg = ConvertRegularProfileKeypairToKeycardTaskArg(
-      tptr: cast[ByteAddress](convertRegularProfileKeypairToKeycardTask),
+      tptr: convertRegularProfileKeypairToKeycardTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onConvertRegularProfileKeypairToKeycard",
       accountDataJson: accountDataJson,
@@ -795,7 +795,7 @@ QtObject:
   proc convertKeycardProfileKeypairToRegular*(self: Service, mnemonic: string, currentPassword: string, newPassword: string) =
     let hashedNewPassword = hashPassword(newPassword)
     let arg = ConvertKeycardProfileKeypairToRegularTaskArg(
-      tptr: cast[ByteAddress](convertKeycardProfileKeypairToRegularTask),
+      tptr: convertKeycardProfileKeypairToRegularTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onConvertKeycardProfileKeypairToRegular",
       mnemonic: mnemonic,

--- a/src/app_service/service/activity_center/async_tasks.nim
+++ b/src/app_service/service/activity_center/async_tasks.nim
@@ -8,7 +8,7 @@ type
     group: ActivityCenterGroup
     readType: ActivityCenterReadType
 
-const asyncActivityNotificationLoadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncActivityNotificationLoadTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncActivityNotificationLoadTaskArg](argEncoded)
   try:
     let activityTypes = activityCenterNotificationTypesByGroup(arg.group)

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -139,7 +139,7 @@ QtObject:
 
   proc asyncActivityNotificationLoad*(self: Service) =
     let arg = AsyncActivityNotificationLoadTaskArg(
-      tptr: cast[ByteAddress](asyncActivityNotificationLoadTask),
+      tptr: asyncActivityNotificationLoadTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncActivityNotificationLoaded",
       cursor: self.cursor,

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -5,7 +5,7 @@
 type
   AsyncGetActiveChatsTaskArg = ref object of QObjectTaskArg
 
-const asyncGetActiveChatsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetActiveChatsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetActiveChatsTaskArg](argEncoded)
   try:
     let response = status_chat.getActiveChats()
@@ -24,7 +24,7 @@ type
     communityId: string
     chatId: string
 
-const asyncCheckChannelPermissionsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncCheckChannelPermissionsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckChannelPermissionsTaskArg](argEncoded)
   try:
     let response = status_communities.checkCommunityChannelPermissions(arg.communityId, arg.chatId).result
@@ -47,7 +47,7 @@ type
     communityId: string
     addresses: seq[string]
 
-const asyncCheckAllChannelsPermissionsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncCheckAllChannelsPermissionsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckAllChannelsPermissionsTaskArg](argEncoded)
   try:
     let result = status_communities.checkAllCommunityChannelsPermissions(arg.communityId, arg.addresses).result

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -184,7 +184,7 @@ QtObject:
 
   proc asyncGetActiveChats*(self: Service) =
     let arg = AsyncGetActiveChatsTaskArg(
-      tptr: cast[ByteAddress](asyncGetActiveChatsTask),
+      tptr: asyncGetActiveChatsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncGetActiveChatsResponse",
     )
@@ -677,7 +677,7 @@ QtObject:
 
   proc asyncCheckChannelPermissions*(self: Service, communityId: string, chatId: string) =
     let arg = AsyncCheckChannelPermissionsTaskArg(
-      tptr: cast[ByteAddress](asyncCheckChannelPermissionsTask),
+      tptr: asyncCheckChannelPermissionsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCheckChannelPermissionsDone",
       communityId: communityId,
@@ -704,7 +704,7 @@ QtObject:
 
   proc asyncCheckAllChannelsPermissions*(self: Service, communityId: string, addresses: seq[string]) =
     let arg = AsyncCheckAllChannelsPermissionsTaskArg(
-      tptr: cast[ByteAddress](asyncCheckAllChannelsPermissionsTask),
+      tptr: asyncCheckAllChannelsPermissionsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCheckAllChannelsPermissionsDone",
       communityId: communityId,

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -4,7 +4,7 @@ include ../../../app/core/tasks/common
 type
   AsyncLoadCommunitiesDataTaskArg = ref object of QObjectTaskArg
 
-const asyncLoadCommunitiesDataTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncLoadCommunitiesDataTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncLoadCommunitiesDataTaskArg](argEncoded)
   try:
     let responseTags = status_go.getCommunityTags()
@@ -32,7 +32,7 @@ type
     metricsType: CommunityMetricsType
     intervals: JsonNode
 
-const asyncCollectCommunityMetricsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncCollectCommunityMetricsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCollectCommunityMetricsTaskArg](argEncoded)
   try:
     let response = status_go.collectCommunityMetrics(arg.communityId, arg.metricsType.int, arg.intervals)
@@ -57,7 +57,7 @@ type
     shardCluster: int
     shardIndex: int
 
-const asyncRequestCommunityInfoTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncRequestCommunityInfoTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestCommunityInfoTaskArg](argEncoded)
   try:
     let response = status_go.requestCommunityInfo(arg.communityId, arg.tryDatabase, arg.shardCluster, arg.shardIndex)
@@ -77,7 +77,7 @@ const asyncRequestCommunityInfoTask: Task = proc(argEncoded: string) {.gcsafe, n
 type
   AsyncLoadCuratedCommunitiesTaskArg = ref object of QObjectTaskArg
 
-const asyncLoadCuratedCommunitiesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncLoadCuratedCommunitiesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncLoadCuratedCommunitiesTaskArg](argEncoded)
   try:
     let response = status_go.getCuratedCommunities()
@@ -95,7 +95,7 @@ type
     communityId: string
     requestId: string
 
-const asyncAcceptRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncAcceptRequestToJoinCommunityTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncAcceptRequestToJoinCommunityTaskArg](argEncoded)
   try:
     let response = status_go.acceptRequestToJoinCommunity(arg.requestId)
@@ -114,7 +114,7 @@ type
     pubKey: string
     deleteAllMessages: bool
 
-const asyncRemoveUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncRemoveUserFromCommunityTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCommunityMemberActionTaskArg](argEncoded)
   try:
     let response = status_go.removeUserFromCommunity(arg.communityId, arg.pubKey)
@@ -131,7 +131,7 @@ const asyncRemoveUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe
       "error": e.msg,
     })
 
-const asyncBanUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncBanUserFromCommunityTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCommunityMemberActionTaskArg](argEncoded)
   try:
     let response = status_go.banUserFromCommunity(arg.communityId, arg.pubKey, arg.deleteAllMessages)
@@ -145,7 +145,7 @@ const asyncBanUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, n
       "deleteAllMessages": arg.deleteAllMessages
     })
 
-const asyncUnbanUserFromCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncUnbanUserFromCommunityTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCommunityMemberActionTaskArg](argEncoded)
   try:
     let response = status_go.unbanUserFromCommunity(arg.communityId, arg.pubKey)
@@ -166,7 +166,7 @@ type
     signatures: seq[string]
     airdropAddress: string
 
-const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncRequestToJoinCommunityTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestToJoinCommunityTaskArg](argEncoded)
   try:
     let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.addressesToShare,
@@ -189,7 +189,7 @@ type
     signatures: seq[string]
     airdropAddress: string
 
-const asyncEditSharedAddressesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncEditSharedAddressesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncEditSharedAddressesTaskArg](argEncoded)
   try:
     let response = status_go.editSharedAddresses(arg.communityId, arg.addressesToShare, arg.signatures,
@@ -210,7 +210,7 @@ type
     communityId: string
     addresses: seq[string]
 
-const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncCheckPermissionsToJoinTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckPermissionsToJoinTaskArg](argEncoded)
   try:
     let response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses).result
@@ -231,7 +231,7 @@ type
     communityId: string
     memberPubkey: string
 
-const asyncGetRevealedAccountsForMemberTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetRevealedAccountsForMemberTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetRevealedAccountsArg](argEncoded)
   try:
     let response = status_go.getRevealedAccountsForMember(arg.communityId, arg.memberPubkey)
@@ -248,7 +248,7 @@ const asyncGetRevealedAccountsForMemberTask: Task = proc(argEncoded: string) {.g
       "error": e.msg,
     })
 
-const asyncGetRevealedAccountsForAllMembersTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetRevealedAccountsForAllMembersTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetRevealedAccountsArg](argEncoded)
   try:
     let response = status_go.getRevealedAccountsForAllMembers(arg.communityId)
@@ -267,7 +267,7 @@ type
   AsyncReevaluateCommunityMembersPermissionsArg = ref object of QObjectTaskArg
     communityId: string
 
-const asyncReevaluateCommunityMembersPermissionsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncReevaluateCommunityMembersPermissionsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncReevaluateCommunityMembersPermissionsArg](argEncoded)
   try:
     let response = status_go.reevaluateCommunityMembersPermissions(arg.communityId)
@@ -288,7 +288,7 @@ type
     communityId: string
     shardIndex: int
 
-const asyncSetCommunityShardTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncSetCommunityShardTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncSetCommunityShardArg](argEncoded)
   try:
     let response = status_go.setCommunityShard(arg.communityId, arg.shardIndex)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -169,7 +169,7 @@ type
 
   CommunityMemberReevaluationStatusArg* = ref object of Args
     communityId*: string
-    status*: CommunityMemberReevaluationStatus  
+    status*: CommunityMemberReevaluationStatus
 
 # Signals which may be emitted by this service:
 const SIGNAL_COMMUNITY_DATA_LOADED* = "communityDataLoaded"
@@ -424,7 +424,7 @@ QtObject:
           # Don't just emit this signal when all communities are done downloading history data,
           # but implement a solution for individual updates
           self.events.emit(SIGNAL_COMMUNITY_HISTORY_ARCHIVES_DOWNLOAD_FINISHED, CommunityIdArgs(communityId: receivedData.communityId))
-    
+
     self.events.on(SignalType.MemberReevaluationStatus.event) do(e: Args):
       var receivedData = CommunityMemberReevaluationStatusSignal(e)
       self.events.emit(SIGNAL_MEMBER_REEVALUATION_STATUS, CommunityMemberReevaluationStatusArg(
@@ -797,7 +797,7 @@ QtObject:
 
     try:
       let arg = AsyncLoadCommunitiesDataTaskArg(
-        tptr: cast[ByteAddress](asyncLoadCommunitiesDataTask),
+        tptr: asyncLoadCommunitiesDataTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "asyncCommunitiesDataLoaded",
       )
@@ -1476,7 +1476,7 @@ QtObject:
   proc toggleCollapsedCommunityCategory*(self: Service, communityId: string, categoryId: string, collapsed: bool) =
     try:
       let response = status_go.toggleCollapsedCommunityCategory(communityId, categoryId, collapsed)
-      
+
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)
         raise newException(RpcException, "Error toggling collapsed community category: " & error.message)
@@ -1621,7 +1621,7 @@ QtObject:
 
   proc asyncCheckPermissionsToJoin*(self: Service, communityId: string, addresses: seq[string]) =
     let arg = AsyncCheckPermissionsToJoinTaskArg(
-      tptr: cast[ByteAddress](asyncCheckPermissionsToJoinTask),
+      tptr: asyncCheckPermissionsToJoinTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCheckPermissionsToJoinDone",
       communityId: communityId,
@@ -1697,7 +1697,7 @@ QtObject:
     airdropAddress: string, signatures: seq[string]) =
     try:
       let arg = AsyncRequestToJoinCommunityTaskArg(
-        tptr: cast[ByteAddress](asyncRequestToJoinCommunityTask),
+        tptr: asyncRequestToJoinCommunityTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncRequestToJoinCommunityDone",
         communityId: communityId,
@@ -1732,7 +1732,7 @@ QtObject:
   proc asyncEditSharedAddresses*(self: Service, communityId: string, addressesToShare: seq[string], airdropAddress: string,
     signatures: seq[string]) =
     let arg = AsyncEditSharedAddressesTaskArg(
-      tptr: cast[ByteAddress](asyncEditSharedAddressesTask),
+      tptr: asyncEditSharedAddressesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncEditSharedAddressesDone",
       communityId: communityId,
@@ -1764,7 +1764,7 @@ QtObject:
       let userKey = self.getUserPubKeyFromPendingRequest(communityId, requestId)
       self.events.emit(SIGNAL_ACCEPT_REQUEST_TO_JOIN_LOADING, CommunityMemberArgs(communityId: communityId, pubKey: userKey))
       let arg = AsyncAcceptRequestToJoinCommunityTaskArg(
-        tptr: cast[ByteAddress](asyncAcceptRequestToJoinCommunityTask),
+        tptr: asyncAcceptRequestToJoinCommunityTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncAcceptRequestToJoinCommunityDone",
         communityId: communityId,
@@ -1821,7 +1821,7 @@ QtObject:
     self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADING, Args())
     try:
       let arg = AsyncLoadCuratedCommunitiesTaskArg(
-        tptr: cast[ByteAddress](asyncLoadCuratedCommunitiesTask),
+        tptr: asyncLoadCuratedCommunitiesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncLoadCuratedCommunitiesDone",
       )
@@ -1853,7 +1853,7 @@ QtObject:
 
   proc collectCommunityMetricsMessagesTimestamps*(self: Service, communityId: string, intervals: string) =
     let arg = AsyncCollectCommunityMetricsTaskArg(
-      tptr: cast[ByteAddress](asyncCollectCommunityMetricsTask),
+      tptr: asyncCollectCommunityMetricsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncCommunityMetricsLoaded",
       communityId: communityId,
@@ -1864,7 +1864,7 @@ QtObject:
 
   proc collectCommunityMetricsMessagesCount*(self: Service, communityId: string, intervals: string) =
     let arg = AsyncCollectCommunityMetricsTaskArg(
-      tptr: cast[ByteAddress](asyncCollectCommunityMetricsTask),
+      tptr: asyncCollectCommunityMetricsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncCommunityMetricsLoaded",
       communityId: communityId,
@@ -1887,7 +1887,7 @@ QtObject:
     self.communityInfoRequests[communityId] = now
 
     let arg = AsyncRequestCommunityInfoTaskArg(
-      tptr: cast[ByteAddress](asyncRequestCommunityInfoTask),
+      tptr: asyncRequestCommunityInfoTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncCommunityInfoLoaded",
       communityId: communityId,
@@ -2067,7 +2067,7 @@ QtObject:
 
   proc asyncRemoveUserFromCommunity*(self: Service, communityId, pubKey: string) =
     let arg = AsyncCommunityMemberActionTaskArg(
-      tptr: cast[ByteAddress](asyncRemoveUserFromCommunityTask),
+      tptr: asyncRemoveUserFromCommunityTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCommunityMemberActionCompleted",
       communityId: communityId,
@@ -2077,7 +2077,7 @@ QtObject:
 
   proc asyncBanUserFromCommunity*(self: Service, communityId, pubKey: string, deleteAllMessages: bool) =
     let arg = AsyncCommunityMemberActionTaskArg(
-      tptr: cast[ByteAddress](asyncBanUserFromCommunityTask),
+      tptr: asyncBanUserFromCommunityTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCommunityMemberActionCompleted",
       communityId: communityId,
@@ -2088,7 +2088,7 @@ QtObject:
 
   proc asyncUnbanUserFromCommunity*(self: Service, communityId, pubKey: string) =
     let arg = AsyncCommunityMemberActionTaskArg(
-      tptr: cast[ByteAddress](asyncUnbanUserFromCommunityTask),
+      tptr: asyncUnbanUserFromCommunityTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCommunityMemberActionCompleted",
       communityId: communityId,
@@ -2294,7 +2294,7 @@ QtObject:
 
   proc asyncGetRevealedAccountsForMember*(self: Service, communityId, memberPubkey: string) =
     let arg = AsyncGetRevealedAccountsArg(
-      tptr: cast[ByteAddress](asyncGetRevealedAccountsForMemberTask),
+      tptr: asyncGetRevealedAccountsForMemberTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncGetRevealedAccountsForMemberCompleted",
       communityId: communityId,
@@ -2325,7 +2325,7 @@ QtObject:
 
   proc asyncGetRevealedAccountsForAllMembers*(self: Service, communityId: string) =
     let arg = AsyncGetRevealedAccountsArg(
-      tptr: cast[ByteAddress](asyncGetRevealedAccountsForAllMembersTask),
+      tptr: asyncGetRevealedAccountsForAllMembersTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncGetRevealedAccountsForAllMembersCompleted",
       communityId: communityId,
@@ -2354,7 +2354,7 @@ QtObject:
 
   proc asyncReevaluateCommunityMembersPermissions*(self: Service, communityId: string) =
     let arg = AsyncGetRevealedAccountsArg(
-      tptr: cast[ByteAddress](asyncReevaluateCommunityMembersPermissionsTask),
+      tptr: asyncReevaluateCommunityMembersPermissionsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncReevaluateCommunityMembersPermissionsCompleted",
       communityId: communityId,
@@ -2374,7 +2374,7 @@ QtObject:
   proc asyncSetCommunityShard*(self: Service, communityId: string, shardIndex: int) =
     try:
       let arg = AsyncSetCommunityShardArg(
-        tptr: cast[ByteAddress](asyncSetCommunityShardTask),
+        tptr: asyncSetCommunityShardTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncSetCommunityShardDone",
         communityId: communityId,

--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -36,7 +36,7 @@ type
     communityId: string
     signerPubKey: string
 
-const asyncGetDeployOwnerContractsFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetDeployOwnerContractsFeesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncDeployOwnerContractsFeesArg](argEncoded)
   try:
     var gasTable: Table[ContractTuple, int] # gas per contract
@@ -67,7 +67,7 @@ type
     tokenType: TokenType
     requestId: string
 
-const asyncGetDeployFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetDeployFeesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetDeployFeesArg](argEncoded)
   try:
     var gasTable: Table[ContractTuple, int] # gas per contract
@@ -100,7 +100,7 @@ type
     newSignerPubKey: string
     requestId: string
 
-const asyncSetSignerFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncSetSignerFeesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncSetSignerFeesArg](argEncoded)
   try:
     var gasTable: Table[ContractTuple, int] # gas per contract
@@ -132,7 +132,7 @@ type
     addressFrom: string
     requestId: string
 
-const asyncGetRemoteBurnFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetRemoteBurnFeesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetRemoteBurnFees](argEncoded)
   try:
     var gasTable: Table[ContractTuple, int] # gas per contract
@@ -164,7 +164,7 @@ type
     addressFrom: string
     requestId: string
 
-const asyncGetBurnFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetBurnFeesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetBurnFees](argEncoded)
   try:
     var gasTable: Table[ContractTuple, int] # gas per contract
@@ -195,7 +195,7 @@ type
     addressFrom: string
     requestId: string
 
-const asyncGetMintFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetMintFeesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetMintFees](argEncoded)
   try:
     var gasTable: Table[ContractTuple, int] # gas per contract
@@ -229,7 +229,7 @@ type
     contractAddress*: string
     communityId*: string
 
-const fetchCollectibleOwnersTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchCollectibleOwnersTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchCollectibleOwnersArg](argEncoded)
   try:
     var response = collectibles.getCollectibleOwnersByContractAddress(arg.chainId, arg.contractAddress)
@@ -278,7 +278,7 @@ type
     contractAddress*: string
     communityId*: string
 
-const fetchAssetOwnersTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchAssetOwnersTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchAssetOwnersArg](argEncoded)
   try:
     let addressesResponse = communities_backend.getCommunityMembersForWalletAddresses(arg.communityId, arg.chainId)
@@ -326,7 +326,7 @@ type
   GetCommunityTokensDetailsArg = ref object of QObjectTaskArg
     communityId*: string
 
-const getCommunityTokensDetailsTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getCommunityTokensDetailsTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetCommunityTokensDetailsArg](argEncoded)
 
   try:
@@ -343,7 +343,7 @@ const getCommunityTokensDetailsTaskArg: Task = proc(argEncoded: string) {.gcsafe
 
     proc getCommunityTokenBurnState(chainId: int, contractAddress: string): ContractTransactionStatus =
       let allPendingTransactions = getPendingTransactions()
-      
+
       let burnTransactions = allPendingTransactions.filter(x => x.typeValue == $PendingTransactionTypeDto.BurnCommunityToken)
 
       for transaction in burnTransactions:
@@ -391,7 +391,7 @@ const getCommunityTokensDetailsTaskArg: Task = proc(argEncoded: string) {.gcsafe
 
           burnState = getCommunityTokenBurnState(tokenDto.chainId, tokenDto.address)
           remoteDestructedAddresses = getRemoteDestructedAddresses(tokenDto.chainId, tokenDto.address)
-        
+
           destructedAmount = getRemoteDestructedAmount(communityTokens, tokenDto.chainId, tokenDto.address)
 
         return %* {
@@ -437,7 +437,7 @@ const getCommunityTokensDetailsTaskArg: Task = proc(argEncoded: string) {.gcsafe
 type
   GetAllCommunityTokensArg = ref object of QObjectTaskArg
 
-const getAllCommunityTokensTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getAllCommunityTokensTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetAllCommunityTokensArg](argEncoded)
   try:
     let response = tokens_backend.getAllCommunityTokens()
@@ -458,7 +458,7 @@ type
     chainId*: int
     contractAddress*: string
 
-const getOwnerTokenOwnerAddressTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getOwnerTokenOwnerAddressTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetOwnerTokenOwnerAddressArgs](argEncoded)
   try:
     let response = tokens_backend.getOwnerTokenOwnerAddress(arg.chainId, arg.contractAddress)

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -170,7 +170,7 @@ type
     chainId*: int
     contractAddress*: string
 
-type 
+type
   CommunityTokenReceivedArgs* =  ref object of Args
     name*: string
     image*: string
@@ -296,7 +296,7 @@ QtObject:
       communityTokensCache: seq[CommunityTokenDto]
 
       # keep times when token holders list for contracts were updated
-      tokenHoldersLastUpdateMap: Table[ContractTuple, int64] 
+      tokenHoldersLastUpdateMap: Table[ContractTuple, int64]
       # timer which fetches token holders
       tokenHoldersTimer: QTimer
       # token for which token holders are fetched
@@ -354,7 +354,7 @@ QtObject:
   proc removeCommunityTokenAndUpdateCache(self: Service, chainId: int, contractAddress: string) =
     discard tokens_backend.removeCommunityToken(chainId, contractAddress)
     self.communityTokensCache = self.communityTokensCache.filter(x => ((x.chainId != chainId) or (x.address != contractAddress)))
-  
+
   # end of cache functions
 
   proc processReceivedCollectiblesWalletEvent(self: Service, jsonMessage: string, accounts: seq[string]) =
@@ -413,11 +413,11 @@ QtObject:
 
           let tokenReceivedArgs = CommunityTokenReceivedArgs(
             collectibleId: id,
-            communityId: communityId, 
-            communityName: communityData.name, 
-            chainId: id.contractID.chainID, 
+            communityId: communityId,
+            communityName: communityData.name,
+            chainId: id.contractID.chainID,
             txHash: txHash,
-            name: collectibleName, 
+            name: collectibleName,
             amount: amount,
             image: collectibleImage,
             isFirst: isFirst,
@@ -426,7 +426,7 @@ QtObject:
             accountName: accountName
           )
           self.events.emit(SIGNAL_COMMUNITY_TOKEN_RECEIVED, tokenReceivedArgs)
-          
+
           let response = tokens_backend.registerReceivedCommunityTokenNotification(communityId, isFirst, tokenReceivedArgs.toTokenData())
           checkAndEmitACNotificationsFromResponse(self.events, response.result{"activityCenterNotifications"})
     except Exception as e:
@@ -448,12 +448,12 @@ QtObject:
 
       let communityId = tokenDataPayload.communityId
       let tokenReceivedArgs = CommunityTokenReceivedArgs(
-        communityId: communityId, 
-        communityName: tokenDataPayload.communityName, 
-        chainId: tokenDataPayload.chainId, 
-        txHash: tokenDataPayload.txHash, 
+        communityId: communityId,
+        communityName: tokenDataPayload.communityName,
+        chainId: tokenDataPayload.chainId,
+        txHash: tokenDataPayload.txHash,
         address: "0x" & tokenDataPayload.address.toHex(),
-        name: tokenDataPayload.name, 
+        name: tokenDataPayload.name,
         amount: tokenDataPayload.amount,
         decimals: tokenDataPayload.decimals,
         verified: tokenDataPayload.verified,
@@ -467,7 +467,7 @@ QtObject:
         isWatchOnlyAccount: any(watchOnlyAccounts, proc (x: WalletAccountDto): bool = x.address == accounts[0])
       )
       self.events.emit(SIGNAL_COMMUNITY_TOKEN_RECEIVED, tokenReceivedArgs)
-      
+
       let response = tokens_backend.registerReceivedCommunityTokenNotification(communityId, tokenDataPayload.isFirst, tokenReceivedArgs.toTokenData())
       checkAndEmitACNotificationsFromResponse(self.events, response.result{"activityCenterNotifications"})
     except Exception as e:
@@ -512,7 +512,7 @@ QtObject:
     except Exception as e:
         error "Error processing airdrop pending transaction event", msg=e.msg
 
-  proc processRemoteDestructEvent(self: Service, signalArgs: CommunityTokenTransactionStatusChangedSignal) = 
+  proc processRemoteDestructEvent(self: Service, signalArgs: CommunityTokenTransactionStatusChangedSignal) =
     try:
       let transactionStatus = if signalArgs.success: ContractTransactionStatus.Completed else: ContractTransactionStatus.Failed
       let data = RemoteDestructArgs(communityToken: signalArgs.communityToken, transactionHash: signalArgs.hash, status: transactionStatus, remoteDestructAddresses: @[])
@@ -555,7 +555,7 @@ QtObject:
       let masterToken = signalArgs.masterToken
       if not signalArgs.success:
         error "Owner token contract not deployed", chainId=ownerToken.chainId, address=ownerToken.address
-      
+
       let temporaryMasterContractAddress = signalArgs.hash & "-master"
       let temporaryOwnerContractAddress = signalArgs.hash & "-owner"
       self.updateCommunityTokenCache(ownerToken.chainId, temporaryOwnerContractAddress, ownerToken)
@@ -700,7 +700,7 @@ QtObject:
 
   proc getCommunityTokensDetailsAsync*(self: Service, communityId: string) =
     let arg = GetCommunityTokensDetailsArg(
-      tptr: cast[ByteAddress](getCommunityTokensDetailsTaskArg),
+      tptr: getCommunityTokensDetailsTaskArg,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onCommunityTokensDetailsLoaded",
       communityId: communityId
@@ -728,7 +728,7 @@ QtObject:
 
   proc getAllCommunityTokensAsync*(self: Service) =
     let arg = GetAllCommunityTokensArg(
-      tptr: cast[ByteAddress](getAllCommunityTokensTaskArg),
+      tptr: getAllCommunityTokensTaskArg,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onGotAllCommunityTokens",
     )
@@ -851,7 +851,7 @@ QtObject:
     try:
       self.tempTokensAndAmounts = collectiblesAndAmounts
       let arg = AsyncGetMintFees(
-        tptr: cast[ByteAddress](asyncGetMintFeesTask),
+        tptr: asyncGetMintFeesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAirdropFees",
         collectiblesAndAmounts: collectiblesAndAmounts,
@@ -884,7 +884,7 @@ QtObject:
         error "Error loading fees: unknown token type", tokenType = tokenType
         return
       let arg = AsyncGetDeployFeesArg(
-        tptr: cast[ByteAddress](asyncGetDeployFeesTask),
+        tptr: asyncGetDeployFeesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onDeployFees",
         chainId: chainId,
@@ -900,7 +900,7 @@ QtObject:
   proc computeSetSignerFee*(self: Service, chainId: int, contractAddress: string, accountAddress: string, requestId: string) =
     try:
       let arg = AsyncSetSignerFeesArg(
-        tptr: cast[ByteAddress](asyncSetSignerFeesTask),
+        tptr: asyncSetSignerFeesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onSetSignerFees",
         chainId: chainId,
@@ -918,7 +918,7 @@ QtObject:
   proc computeDeployOwnerContractsFee*(self: Service, chainId: int, accountAddress: string, communityId: string, ownerDeploymentParams: DeploymentParameters, masterDeploymentParams: DeploymentParameters, requestId: string) =
     try:
       let arg = AsyncDeployOwnerContractsFeesArg(
-        tptr: cast[ByteAddress](asyncGetDeployOwnerContractsFeesTask),
+        tptr: asyncGetDeployOwnerContractsFeesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onDeployOwnerContractsFees",
         chainId: chainId,
@@ -991,7 +991,7 @@ QtObject:
         warn "token list is empty"
         return
       let arg = AsyncGetRemoteBurnFees(
-        tptr: cast[ByteAddress](asyncGetRemoteBurnFeesTask),
+        tptr: asyncGetRemoteBurnFeesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onSelfDestructFees",
         chainId: contract.chainId,
@@ -1067,7 +1067,7 @@ QtObject:
     try:
       let contract = self.findContractByUniqueId(contractUniqueKey)
       let arg = AsyncGetBurnFees(
-        tptr: cast[ByteAddress](asyncGetBurnFeesTask),
+        tptr: asyncGetBurnFeesTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onBurnFees",
         chainId: contract.chainId,
@@ -1263,7 +1263,7 @@ QtObject:
 
     if communityToken.tokenType == TokenType.ERC20:
       let arg = FetchAssetOwnersArg(
-        tptr: cast[ByteAddress](fetchAssetOwnersTaskArg),
+        tptr: fetchAssetOwnersTaskArg,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onCommunityTokenOwnersFetched",
         chainId: communityToken.chainId,
@@ -1274,7 +1274,7 @@ QtObject:
       return
     elif communityToken.tokenType == TokenType.ERC721:
       let arg = FetchCollectibleOwnersArg(
-        tptr: cast[ByteAddress](fetchCollectibleOwnersTaskArg),
+        tptr: fetchCollectibleOwnersTaskArg,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onCommunityTokenOwnersFetched",
         chainId: communityToken.chainId,
@@ -1345,7 +1345,7 @@ QtObject:
 
   proc asyncGetOwnerTokenOwnerAddress*(self: Service, chainId: int, contractAddress: string) =
     let arg = GetOwnerTokenOwnerAddressArgs(
-      tptr: cast[ByteAddress](getOwnerTokenOwnerAddressTask),
+      tptr: getOwnerTokenOwnerAddressTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onGetOwnerTokenOwner",
       chainId: chainId,

--- a/src/app_service/service/contacts/async_tasks.nim
+++ b/src/app_service/service/contacts/async_tasks.nim
@@ -18,7 +18,7 @@ type
     chainId: int
     reason: string
 
-const lookupContactTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc lookupContactTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[LookupContactTaskArg](argEncoded)
   var output = %*{
     "id": "",
@@ -61,7 +61,7 @@ type
   AsyncRequestContactInfoTaskArg = ref object of QObjectTaskArg
     pubkey: string
 
-const asyncRequestContactInfoTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncRequestContactInfoTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestContactInfoTaskArg](argEncoded)
   try:
     let response = status_go.requestContactInfo(arg.pubkey)
@@ -81,7 +81,7 @@ type
     pubkey: string
     validate: bool
 
-const asyncGetProfileShowcaseForContactTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetProfileShowcaseForContactTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetProfileShowcaseForContactTaskArg](argEncoded)
   try:
     let response = status_go.getProfileShowcaseForContact(arg.pubkey, arg.validate)
@@ -102,7 +102,7 @@ type
   FetchProfileShowcaseAccountsTaskArg = ref object of QObjectTaskArg
     address: string
 
-const fetchProfileShowcaseAccountsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchProfileShowcaseAccountsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchProfileShowcaseAccountsTaskArg](argEncoded)
   var response = %* {
     "response": "",

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -619,7 +619,7 @@ QtObject:
     if(self.closingApp):
       return
     let arg = LookupContactTaskArg(
-      tptr: cast[ByteAddress](lookupContactTask),
+      tptr: lookupContactTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "ensResolved",
       value: value,
@@ -881,7 +881,7 @@ QtObject:
   proc requestContactInfo*(self: Service, pubkey: string) =
     try:
       let arg = AsyncRequestContactInfoTaskArg(
-        tptr: cast[ByteAddress](asyncRequestContactInfoTask),
+        tptr: asyncRequestContactInfoTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "asyncContactInfoLoaded",
         pubkey: pubkey,
@@ -915,7 +915,7 @@ QtObject:
     let arg = AsyncGetProfileShowcaseForContactTaskArg(
       pubkey: contactId,
       validate: validate,
-      tptr: cast[ByteAddress](asyncGetProfileShowcaseForContactTask),
+      tptr: asyncGetProfileShowcaseForContactTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncProfileShowcaseForContactLoaded",
     )
@@ -942,7 +942,7 @@ QtObject:
   proc fetchProfileShowcaseAccountsByAddress*(self: Service, address: string) =
     let arg = FetchProfileShowcaseAccountsTaskArg(
       address: address,
-      tptr: cast[ByteAddress](fetchProfileShowcaseAccountsTask),
+      tptr: fetchProfileShowcaseAccountsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onProfileShowcaseAccountsByAddressFetched",
     )

--- a/src/app_service/service/currency/async_tasks.nim
+++ b/src/app_service/service/currency/async_tasks.nim
@@ -2,7 +2,7 @@ type
   FetchAllCurrencyFormatsTaskArg = ref object of QObjectTaskArg
     discard
 
-const fetchAllCurrencyFormatsTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchAllCurrencyFormatsTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchAllCurrencyFormatsTaskArg](argEncoded)
   let output = %* {
     "formats": ""

--- a/src/app_service/service/currency/service.nim
+++ b/src/app_service/service/currency/service.nim
@@ -96,7 +96,7 @@ QtObject:
 
   proc fetchAllCurrencyFormats(self: Service) =
     let arg = FetchAllCurrencyFormatsTaskArg(
-      tptr: cast[ByteAddress](fetchAllCurrencyFormatsTaskArg),
+      tptr: fetchAllCurrencyFormatsTaskArg,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAllCurrencyFormatsFetched",
     )

--- a/src/app_service/service/devices/async_tasks.nim
+++ b/src/app_service/service/devices/async_tasks.nim
@@ -9,8 +9,7 @@ type
     connectionString: string
     configJSON: string
 
-const asyncLoadDevicesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
-
+proc asyncLoadDevicesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncLoadDevicesTaskArg](argEncoded)
   try:
     let rpcResponse = status_installations.getOurInstallations()
@@ -24,7 +23,7 @@ const asyncLoadDevicesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
       "error": e.msg,
     })
 
-const asyncInputConnectionStringTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncInputConnectionStringTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncInputConnectionStringArg](argEncoded)
   try:
     let response = status_go.inputConnectionStringForBootstrapping(arg.connectionString, arg.configJSON)
@@ -34,7 +33,7 @@ const asyncInputConnectionStringTask: Task = proc(argEncoded: string) {.gcsafe, 
       "error": e.msg,
     })
 
-const asyncInputConnectionStringForImportingKeystoreTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncInputConnectionStringForImportingKeystoreTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncInputConnectionStringArg](argEncoded)
   try:
     let response = status_go.inputConnectionStringForImportingKeypairsKeystores(arg.connectionString, arg.configJSON)

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -112,7 +112,7 @@ QtObject:
 
   proc asyncLoadDevices*(self: Service) =
     let arg = AsyncLoadDevicesTaskArg(
-      tptr: cast[ByteAddress](asyncLoadDevicesTask),
+      tptr: asyncLoadDevicesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncDevicesLoaded",
     )
@@ -237,7 +237,7 @@ QtObject:
     self.localPairingStatus = newLocalPairingStatus(PairingType.AppSync, LocalPairingMode.Receiver)
 
     let arg = AsyncInputConnectionStringArg(
-      tptr: cast[ByteAddress](asyncInputConnectionStringTask),
+      tptr: asyncInputConnectionStringTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "inputConnectionStringForBootstrappingFinished",
       connectionString: connectionString,
@@ -359,7 +359,7 @@ QtObject:
     self.localPairingStatus = newLocalPairingStatus(PairingType.KeypairSync, LocalPairingMode.Receiver)
 
     let arg = AsyncInputConnectionStringArg(
-      tptr: cast[ByteAddress](asyncInputConnectionStringForImportingKeystoreTask),
+      tptr: asyncInputConnectionStringForImportingKeystoreTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "inputConnectionStringForImportingKeystoreFinished",
       connectionString: connectionString,

--- a/src/app_service/service/ens/async_tasks.nim
+++ b/src/app_service/service/ens/async_tasks.nim
@@ -10,7 +10,7 @@ type
     myPublicKey*: string
     myWalletAddress*: string
 
-const checkEnsAvailabilityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc checkEnsAvailabilityTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[CheckEnsAvailabilityTaskArg](argEncoded)
   try:
     var desiredEnsUsername = arg.ensUsername & (if(arg.isStatus): ens_utils.STATUS_DOMAIN else: "")
@@ -53,7 +53,7 @@ type
     isStatus*: bool
     chainId: int
 
-const ensUsernameDetailsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc ensUsernameDetailsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[EnsUsernamDetailsTaskArg](argEncoded)
   try:
 

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -227,7 +227,7 @@ QtObject:
       self.events.emit(SIGNAL_ENS_USERNAME_AVAILABILITY_CHECKED, data)
     else:
       let arg = CheckEnsAvailabilityTaskArg(
-        tptr: cast[ByteAddress](checkEnsAvailabilityTask),
+        tptr: checkEnsAvailabilityTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onEnsUsernameAvailabilityChecked",
         ensUsername: ensUsername,
@@ -268,7 +268,7 @@ QtObject:
       isStatus = true
 
     let arg = EnsUsernamDetailsTaskArg(
-      tptr: cast[ByteAddress](ensUsernameDetailsTask),
+      tptr: ensUsernameDetailsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onEnsUsernameDetailsFetched",
       ensUsername: username,

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -68,7 +68,7 @@ QtObject:
 
   proc runTimer(self: Service) =
     let arg = TimerTaskArg(
-      tptr: cast[ByteAddress](timerTask),
+      tptr: timerTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onTimeout",
       timeoutInMilliseconds: TimerIntervalInMilliseconds

--- a/src/app_service/service/gif/async_tasks.nim
+++ b/src/app_service/service/gif/async_tasks.nim
@@ -4,7 +4,7 @@ include ../../../app/core/tasks/common
 type
   AsyncGetRecentGifsTaskArg = ref object of QObjectTaskArg
 
-const asyncGetRecentGifsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetRecentGifsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetRecentGifsTaskArg](argEncoded)
   try:
     let response = status_go.getRecentGifs()
@@ -17,7 +17,7 @@ const asyncGetRecentGifsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.
 type
   AsyncGetFavoriteGifsTaskArg = ref object of QObjectTaskArg
 
-const asyncGetFavoriteGifsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetFavoriteGifsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetFavoriteGifsTaskArg](argEncoded)
   try:
     let response = status_go.getFavoriteGifs()
@@ -35,7 +35,7 @@ type
     event: string
     errorEvent: string
 
-const asyncTenorQuery: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncTenorQuery(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncTenorQueryArg](argEncoded)
   try:
 

--- a/src/app_service/service/gif/service.nim
+++ b/src/app_service/service/gif/service.nim
@@ -68,7 +68,7 @@ QtObject:
     self.events.emit(SIGNAL_LOAD_RECENT_GIFS_STARTED, Args())
     try:
       let arg = AsyncGetRecentGifsTaskArg(
-        tptr: cast[ByteAddress](asyncGetRecentGifsTask),
+        tptr: asyncGetRecentGifsTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncGetRecentGifsDone"
       )
@@ -91,7 +91,7 @@ QtObject:
     self.events.emit(SIGNAL_LOAD_FAVORITE_GIFS_STARTED, Args())
     try:
       let arg = AsyncGetFavoriteGifsTaskArg(
-        tptr: cast[ByteAddress](asyncGetFavoriteGifsTask),
+        tptr: asyncGetFavoriteGifsTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncGetFavoriteGifsDone"
       )
@@ -117,7 +117,7 @@ QtObject:
     try:
       self.events.emit(SIGNAL_SEARCH_GIFS_STARTED, Args())
       let arg = AsyncTenorQueryArg(
-        tptr: cast[ByteAddress](asyncTenorQuery),
+        tptr: asyncTenorQuery,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncTenorQueryDone",
         apiKeySet: self.apiKeySet,
@@ -137,7 +137,7 @@ QtObject:
     try:
       self.events.emit(SIGNAL_LOAD_TRENDING_GIFS_STARTED, Args())
       let arg = AsyncTenorQueryArg(
-        tptr: cast[ByteAddress](asyncTenorQuery),
+        tptr: asyncTenorQuery,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncTenorQueryDone",
         apiKeySet: self.apiKeySet,

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -250,7 +250,7 @@ QtObject:
       return
 
     let arg = TimerTaskArg(
-      tptr: cast[ByteAddress](timerTask),
+      tptr: timerTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onTimeout",
       timeoutInMilliseconds: timeoutInMilliseconds,

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -46,7 +46,7 @@ const SIGNAL_MAILSERVER_SYNCED* = "mailserverSynced"
 const SIGNAL_MAILSERVER_HISTORY_REQUEST_STARTED* = "historyRequestStarted"
 const SIGNAL_MAILSERVER_HISTORY_REQUEST_COMPLETED* = "historyRequestCompleted"
 
-const requestMoreMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc requestMoreMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[RequestMoreMessagesTaskArg](argEncoded)
   try:
     info "Requesting additional message history for chat", chatId=arg.chatId
@@ -65,7 +65,7 @@ const requestMoreMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall
       "error": e.msg
     })
 
-const fillGapsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fillGapsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FillGapsTaskArg](argEncoded)
   try:
     info "Requesting fill gaps", chatId=arg.chatId, messageIds=arg.messageIds
@@ -128,7 +128,7 @@ QtObject:
 
   proc requestMoreMessages*(self: Service, chatId: string) =
     let arg = RequestMoreMessagesTaskArg(
-      tptr: cast[ByteAddress](requestMoreMessagesTask),
+      tptr: requestMoreMessagesTask,
       vptr: cast[ByteAddress](self.vptr),
       chatId: chatId,
     )
@@ -136,7 +136,7 @@ QtObject:
 
   proc fillGaps*(self: Service, chatId: string, messageId: string) =
     let arg = FillGapsTaskArg(
-      tptr: cast[ByteAddress](fillGapsTask),
+      tptr: fillGapsTask,
       vptr: cast[ByteAddress](self.vptr),
       chatId: chatId,
       messageIds: @[messageId]

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -25,7 +25,7 @@ type
     msgCursor: string
     limit: int
 
-const asyncFetchChatMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncFetchChatMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncFetchChatMessagesTaskArg](argEncoded)
   try:
     var responseJson = %*{
@@ -66,7 +66,7 @@ const asyncFetchChatMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimc
 #################################################
 # Async load pinned messages
 #################################################
-const asyncFetchPinnedChatMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncFetchPinnedChatMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncFetchChatMessagesTaskArg](argEncoded)
 
   try:
@@ -111,7 +111,7 @@ type
   AsyncSearchMessagesInChatTaskArg = ref object of AsyncSearchMessagesTaskArg
     chatId: string
 
-const asyncSearchMessagesInChatTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncSearchMessagesInChatTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncSearchMessagesInChatTaskArg](argEncoded)
   try:
     let response = status_go.fetchAllMessagesFromChatWhichMatchTerm(arg.chatId, arg.searchTerm, arg.caseSensitive)
@@ -136,7 +136,7 @@ type
     communityIds: seq[string]
     chatIds: seq[string]
 
-const asyncSearchMessagesInChatsAndCommunitiesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncSearchMessagesInChatsAndCommunitiesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncSearchMessagesInChatsAndCommunitiesTaskArg](argEncoded)
 
   try:
@@ -162,7 +162,7 @@ type
   AsyncMarkAllMessagesReadTaskArg = ref object of QObjectTaskArg
     chatId: string
 
-const asyncMarkAllMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncMarkAllMessagesReadTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncMarkAllMessagesReadTaskArg](argEncoded)
 
   try:
@@ -191,7 +191,7 @@ type
     chatId: string
     messagesIds: seq[string]
 
-const asyncMarkCertainMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncMarkCertainMessagesReadTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncMarkCertainMessagesReadTaskArg](argEncoded)
 
   try:
@@ -236,7 +236,7 @@ type
   AsyncGetFirstUnseenMessageIdForTaskArg = ref object of QObjectTaskArg
     chatId: string
 
-const asyncGetFirstUnseenMessageIdForTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetFirstUnseenMessageIdForTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetFirstUnseenMessageIdForTaskArg](argEncoded)
 
   let responseJson = %*{
@@ -270,7 +270,7 @@ type
     text*: string
     requestUuid*: string
 
-const asyncGetTextURLsToUnfurlTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetTextURLsToUnfurlTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetTextURLsToUnfurlTaskArg](argEncoded)
   var output = %*{
     "error": "",
@@ -297,7 +297,7 @@ type
     urls*: seq[string]
     requestUuid*: string
 
-const asyncUnfurlUrlsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncUnfurlUrlsTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncUnfurlUrlsTaskArg](argEncoded)
   try:
     let response = status_go.unfurlUrls(arg.urls)
@@ -328,7 +328,7 @@ type
     requestId*: string
     messageId*: string
 
-const asyncGetMessageByMessageIdTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetMessageByMessageIdTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetMessageByMessageIdTaskArg](argEncoded)
   try:
     let response = status_go.getMessageByMessageId(arg.messageId)
@@ -358,7 +358,7 @@ type
       messageId*: string
       chatId*: string
 
-const asyncMarkMessageAsUnreadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncMarkMessageAsUnreadTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncMarkMessageAsUnreadTaskArg](argEncoded)
 
   var responseJson = %*{
@@ -399,7 +399,7 @@ type
     communityId*: string
     memberPubKey*: string
 
-const asyncLoadCommunityMemberAllMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncLoadCommunityMemberAllMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncLoadCommunityMemberAllMessagesTaskArg](argEncoded)
 
   var responseJson = %*{

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -235,7 +235,7 @@ QtObject:
     msgCursor.setPending()
 
     let arg = AsyncFetchChatMessagesTaskArg(
-      tptr: cast[ByteAddress](asyncFetchChatMessagesTask),
+      tptr: asyncFetchChatMessagesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncLoadMoreMessagesForChat",
       chatId: chatId,
@@ -259,7 +259,7 @@ QtObject:
     pinnedMsgCursor.setPending()
 
     let arg = AsyncFetchChatMessagesTaskArg(
-      tptr: cast[ByteAddress](asyncFetchPinnedChatMessagesTask),
+      tptr: asyncFetchPinnedChatMessagesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncLoadPinnedMessagesForChat",
       chatId: chatId,
@@ -284,7 +284,7 @@ QtObject:
     let arg = AsyncLoadCommunityMemberAllMessagesTaskArg(
       communityId: communityId,
       memberPubKey: memberPublicKey,
-      tptr: cast[ByteAddress](asyncLoadCommunityMemberAllMessagesTask),
+      tptr: asyncLoadCommunityMemberAllMessagesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncLoadCommunityMemberAllMessages"
     )
@@ -672,7 +672,7 @@ QtObject:
       return
 
     let arg = AsyncMarkMessageAsUnreadTaskArg(
-      tptr: cast[ByteAddress](asyncMarkMessageAsUnreadTask),
+      tptr: asyncMarkMessageAsUnreadTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncMarkMessageAsUnread",
       messageId: messageId,
@@ -723,7 +723,7 @@ QtObject:
   proc asyncGetMessageById*(self: Service, messageId: string): UUID =
     let requestId = genUUID()
     let arg = AsyncGetMessageByMessageIdTaskArg(
-      tptr: cast[ByteAddress](asyncGetMessageByMessageIdTask),
+      tptr: asyncGetMessageByMessageIdTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncGetMessageById",
       requestId: $requestId,
@@ -775,7 +775,7 @@ QtObject:
       return
 
     let arg = AsyncSearchMessagesInChatTaskArg(
-      tptr: cast[ByteAddress](asyncSearchMessagesInChatTask),
+      tptr: asyncSearchMessagesInChatTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncSearchMessages",
       chatId: chatId,
@@ -798,7 +798,7 @@ QtObject:
       return
 
     let arg = AsyncSearchMessagesInChatsAndCommunitiesTaskArg(
-      tptr: cast[ByteAddress](asyncSearchMessagesInChatsAndCommunitiesTask),
+      tptr: asyncSearchMessagesInChatsAndCommunitiesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncSearchMessages",
       communityIds: communityIds,
@@ -834,7 +834,7 @@ QtObject:
       return
 
     let arg = AsyncMarkAllMessagesReadTaskArg(
-      tptr: cast[ByteAddress](asyncMarkAllMessagesReadTask),
+      tptr: asyncMarkAllMessagesReadTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onMarkAllMessagesRead",
       chatId: chatId
@@ -919,7 +919,7 @@ QtObject:
       return
 
     let arg = AsyncMarkCertainMessagesReadTaskArg(
-      tptr: cast[ByteAddress](asyncMarkCertainMessagesReadTask),
+      tptr: asyncMarkCertainMessagesReadTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onMarkCertainMessagesRead",
       chatId: chatId,
@@ -930,7 +930,7 @@ QtObject:
 
   proc getAsyncFirstUnseenMessageId*(self: Service, chatId: string) =
     let arg = AsyncGetFirstUnseenMessageIdForTaskArg(
-      tptr: cast[ByteAddress](asyncGetFirstUnseenMessageIdForTaskArg),
+      tptr: asyncGetFirstUnseenMessageIdForTaskArg,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onGetFirstUnseenMessageIdFor",
       chatId: chatId,
@@ -993,7 +993,7 @@ QtObject:
   proc asyncGetTextURLsToUnfurl*(self: Service, text: string): string =
     let uuid = $genUUID()
     let arg = AsyncGetTextURLsToUnfurlTaskArg(
-      tptr: cast[ByteAddress](asyncGetTextURLsToUnfurlTask),
+      tptr: asyncGetTextURLsToUnfurlTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncGetTextURLsToUnfurl",
       text: text,
@@ -1049,7 +1049,7 @@ QtObject:
       return ""
     let uuid = $genUUID()
     let arg = AsyncUnfurlUrlsTaskArg(
-      tptr: cast[ByteAddress](asyncUnfurlUrlsTask),
+      tptr: asyncUnfurlUrlsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncUnfurlUrlsFinished",
       urls: urls,

--- a/src/app_service/service/privacy/async_tasks.nim
+++ b/src/app_service/service/privacy/async_tasks.nim
@@ -6,7 +6,7 @@ type
     currentPassword: string
     newPassword: string
 
-const changeDatabasePasswordTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc changeDatabasePasswordTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ChangeDatabasePasswordTaskArg](argEncoded)
   let output = %* {
     "error": "",

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -111,7 +111,7 @@ QtObject:
 
       let loggedInAccount = self.accountsService.getLoggedInAccount()
       let arg = ChangeDatabasePasswordTaskArg(
-        tptr: cast[ByteAddress](changeDatabasePasswordTask),
+        tptr: changeDatabasePasswordTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onChangeDatabasePasswordResponse",
         accountId: loggedInAccount.keyUid,

--- a/src/app_service/service/profile/async_tasks.nim
+++ b/src/app_service/service/profile/async_tasks.nim
@@ -5,7 +5,7 @@ include ../../../app/core/tasks/common
 
 import ../../../backend/accounts as status_accounts
 
-const asyncGetProfileShowcasePreferencesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetProfileShowcasePreferencesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[QObjectTaskArg](argEncoded)
   try:
     let response = status_accounts.getProfileShowcasePreferences()
@@ -22,7 +22,7 @@ type
   SaveProfileShowcasePreferencesTaskArg = ref object of QObjectTaskArg
     preferences: ProfileShowcasePreferencesDto
 
-const saveProfileShowcasePreferencesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc saveProfileShowcasePreferencesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[SaveProfileShowcasePreferencesTaskArg](argEncoded)
   try:
     let response = status_accounts.setProfileShowcasePreferences(arg.preferences.toJsonNode())

--- a/src/app_service/service/profile/service.nim
+++ b/src/app_service/service/profile/service.nim
@@ -115,7 +115,7 @@ QtObject:
 
   proc requestProfileShowcasePreferences*(self: Service) =
     let arg = QObjectTaskArg(
-      tptr: cast[ByteAddress](asyncGetProfileShowcasePreferencesTask),
+      tptr: asyncGetProfileShowcasePreferencesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncProfileShowcasePreferencesLoaded",
     )
@@ -138,7 +138,7 @@ QtObject:
   proc saveProfileShowcasePreferences*(self: Service, preferences: ProfileShowcasePreferencesDto) =
     let arg = SaveProfileShowcasePreferencesTaskArg(
       preferences: preferences,
-      tptr: cast[ByteAddress](saveProfileShowcasePreferencesTask),
+      tptr: saveProfileShowcasePreferencesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "asyncProfileShowcasePreferencesSaved",
     )

--- a/src/app_service/service/provider/async_tasks.nim
+++ b/src/app_service/service/provider/async_tasks.nim
@@ -7,7 +7,7 @@ type
     requestType: string
     message: string
 
-const postMessageTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc postMessageTask(argEncoded: string) {.gcsafe, nimcall.} =
   var chainId = ""
   let arg = decode[PostMessageTaskArg](argEncoded)
   try:

--- a/src/app_service/service/provider/service.nim
+++ b/src/app_service/service/provider/service.nim
@@ -67,7 +67,7 @@ QtObject:
 
   proc postMessage*(self: Service, payloadMethod: string, requestType: string, message: string) =
     let arg = PostMessageTaskArg(
-      tptr: cast[ByteAddress](postMessageTask),
+      tptr: postMessageTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "postMessageResolved",
       payloadMethod: payloadMethod,

--- a/src/app_service/service/saved_address/async_tasks.nim
+++ b/src/app_service/service/saved_address/async_tasks.nim
@@ -40,7 +40,7 @@ proc checkForEnsNameAndUpdate(chainId: int, savedAddress: var SavedAddressDto, u
   except Exception as e:
     raise newException(RpcException, e.msg)
 
-const fetchSavedAddressesAndResolveEnsNamesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchSavedAddressesAndResolveEnsNamesTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[SavedAddressesTaskArg](argEncoded)
   var response = %* {
     "response": [],
@@ -65,7 +65,7 @@ const fetchSavedAddressesAndResolveEnsNamesTask: Task = proc(argEncoded: string)
     response["error"] = %* e.msg
   arg.finish(response)
 
-const upsertSavedAddressTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc upsertSavedAddressTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[SavedAddressTaskArg](argEncoded)
   var response = %* {
     "response": "",
@@ -93,7 +93,7 @@ const upsertSavedAddressTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.
     response["error"] = %* e.msg
   arg.finish(response)
 
-const deleteSavedAddressTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc deleteSavedAddressTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[SavedAddressTaskArg](argEncoded)
   var response = %* {
     "response": "",

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -95,7 +95,7 @@ QtObject:
   proc fetchSavedAddressesAndResolveEnsNames(self: Service) =
     let arg = SavedAddressTaskArg(
       chainId: self.networkService.getAppNetwork().chainId,
-      tptr: cast[ByteAddress](fetchSavedAddressesAndResolveEnsNamesTask),
+      tptr: fetchSavedAddressesAndResolveEnsNamesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onSavedAddressesFetched",
     )
@@ -124,7 +124,7 @@ QtObject:
       colorId: colorId,
       chainShortNames: chainShortNames,
       isTestAddress: self.areTestNetworksEnabled(),
-      tptr: cast[ByteAddress](upsertSavedAddressTask),
+      tptr: upsertSavedAddressTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onSavedAddressCreatedOrUpdated",
     )
@@ -151,7 +151,7 @@ QtObject:
     let arg = SavedAddressTaskArg(
       address: address,
       isTestAddress: self.areTestNetworksEnabled(),
-      tptr: cast[ByteAddress](deleteSavedAddressTask),
+      tptr: deleteSavedAddressTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onDeleteSavedAddress",
     )

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -17,7 +17,7 @@ type
   AsyncGetRecentStickersTaskArg* = ref object of QObjectTaskArg
   AsyncGetInstalledStickerPacksTaskArg* = ref object of QObjectTaskArg
 
-const asyncGetRecentStickersTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetRecentStickersTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetRecentStickersTaskArg](argEncoded)
   try:
     let response = status_stickers.recent()
@@ -28,7 +28,7 @@ const asyncGetRecentStickersTask: Task = proc(argEncoded: string) {.gcsafe, nimc
     })
 
 
-const asyncGetInstalledStickerPacksTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc asyncGetInstalledStickerPacksTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetInstalledStickerPacksTaskArg](argEncoded)
   try:
     let response = status_stickers.installed()
@@ -55,7 +55,7 @@ proc getMarketStickerPacks*(chainId: int):
 # to accept unsafe code, rather they work in conjunction with the proc
 # signature for `type Task` in tasks/common.nim to ensure that the proc really
 # is gcsafe and that a helpful error message is displayed
-const estimateTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc estimateTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[EstimateTaskArg](argEncoded)
   var estimate = 325000
   try:
@@ -69,7 +69,7 @@ const estimateTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let tpl: tuple[estimate: int, uuid: string] = (estimate, arg.uuid)
   arg.finish(tpl)
 
-const obtainMarketStickerPacksTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc obtainMarketStickerPacksTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ObtainMarketStickerPacksTaskArg](argEncoded)
   let (marketStickerPacks, error) = getMarketStickerPacks(arg.chainId)
   var packs: seq[StickerPackDto] = @[]
@@ -78,7 +78,7 @@ const obtainMarketStickerPacksTask: Task = proc(argEncoded: string) {.gcsafe, ni
   let tpl: tuple[packs: seq[StickerPackDto], error: string] = (packs, error)
   arg.finish(tpl)
 
-const installStickerPackTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc installStickerPackTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[InstallStickerPackTaskArg](argEncoded)
 
   var installed = false

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -213,7 +213,7 @@ QtObject:
     let chainId = self.networkService.getAppNetwork().chainId
 
     let arg = ObtainMarketStickerPacksTaskArg(
-      tptr: cast[ByteAddress](obtainMarketStickerPacksTask),
+      tptr: obtainMarketStickerPacksTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "setMarketStickerPacks",
       chainId: chainId,
@@ -231,7 +231,7 @@ QtObject:
     let chainId = self.networkService.getAppNetwork().chainId
 
     let arg = EstimateTaskArg(
-      tptr: cast[ByteAddress](estimateTask),
+      tptr: estimateTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "setGasEstimate",
       packId: packId,
@@ -265,7 +265,7 @@ QtObject:
     self.events.emit(SIGNAL_LOAD_RECENT_STICKERS_STARTED, Args())
     try:
       let arg = AsyncGetRecentStickersTaskArg(
-        tptr: cast[ByteAddress](asyncGetRecentStickersTask),
+        tptr: asyncGetRecentStickersTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncGetRecentStickersDone"
       )
@@ -289,7 +289,7 @@ QtObject:
     self.events.emit(SIGNAL_LOAD_INSTALLED_STICKER_PACKS_STARTED, Args())
     try:
       let arg = AsyncGetInstalledStickerPacksTaskArg(
-        tptr: cast[ByteAddress](asyncGetInstalledStickerPacksTask),
+        tptr: asyncGetInstalledStickerPacksTask,
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAsyncGetInstalledStickerPacksDone"
       )
@@ -320,7 +320,7 @@ QtObject:
 
   proc installStickerPack*(self: Service, packId: string) =
     let arg = InstallStickerPackTaskArg(
-      tptr: cast[ByteAddress](installStickerPackTask),
+      tptr: installStickerPackTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onStickerPackInstalled",
       chainId: self.networkService.getAppNetwork().chainId,

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -9,7 +9,7 @@ include app_service/common/json_utils
 const DAYS_IN_WEEK = 7
 const HOURS_IN_DAY = 24
 
-const getSupportedTokenList*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getSupportedTokenList*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[QObjectTaskArg](argEncoded)
   var output = %*{
     "supportedTokensJson": "",
@@ -27,7 +27,7 @@ type
     symbols: seq[string]
     currency: string
 
-const fetchTokensMarketValuesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchTokensMarketValuesTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchTokensMarketValuesTaskArg](argEncoded)
   var output = %*{
     "tokenMarketValues": "",
@@ -44,7 +44,7 @@ type
   FetchTokensDetailsTaskArg = ref object of QObjectTaskArg
     symbols: seq[string]
 
-const fetchTokensDetailsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchTokensDetailsTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchTokensDetailsTaskArg](argEncoded)
   var output = %*{
     "tokensDetails": "",
@@ -62,7 +62,7 @@ type
     symbols: seq[string]
     currencies: seq[string]
 
-const fetchTokensPricesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchTokensPricesTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchTokensPricesTaskArg](argEncoded)
   var output = %*{
     "tokensPrices": "",
@@ -81,7 +81,7 @@ type
     currency: string
     range: int
 
-const getTokenHistoricalDataTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getTokenHistoricalDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetTokenHistoricalDataTaskArg](argEncoded)
   var response = %*{}
   try:

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -102,7 +102,7 @@ QtObject:
     self.tokensMarketDetailsLoading = true
     defer: self.events.emit(SIGNAL_TOKENS_MARKET_VALUES_ABOUT_TO_BE_UPDATED, Args())
     let arg = FetchTokensMarketValuesTaskArg(
-      tptr: cast[ByteAddress](fetchTokensMarketValuesTask),
+      tptr: fetchTokensMarketValuesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "tokensMarketValuesRetrieved",
       symbols: symbols,
@@ -145,7 +145,7 @@ QtObject:
   proc fetchTokensDetails(self: Service, symbols: seq[string]) =
     self.tokensDetailsLoading = true
     let arg = FetchTokensDetailsTaskArg(
-      tptr: cast[ByteAddress](fetchTokensDetailsTask),
+      tptr: fetchTokensDetailsTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "tokensDetailsRetrieved",
       symbols: symbols
@@ -185,7 +185,7 @@ QtObject:
     self.tokensPricesLoading = true
     defer: self.events.emit(SIGNAL_TOKENS_PRICES_ABOUT_TO_BE_UPDATED, Args())
     let arg = FetchTokensPricesTaskArg(
-      tptr: cast[ByteAddress](fetchTokensPricesTask),
+      tptr: fetchTokensPricesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "tokensPricesRetrieved",
       symbols: symbols,
@@ -356,7 +356,7 @@ QtObject:
 
   proc getSupportedTokensList*(self: Service) =
     let arg = QObjectTaskArg(
-      tptr: cast[ByteAddress](getSupportedTokenList),
+      tptr: getSupportedTokenList,
       vptr: cast[ByteAddress](self.vptr),
       slot: "supportedTokensListRetrieved",
     )
@@ -496,7 +496,7 @@ QtObject:
 
   proc getHistoricalDataForToken*(self: Service, symbol: string, currency: string, range: int) =
     let arg = GetTokenHistoricalDataTaskArg(
-      tptr: cast[ByteAddress](getTokenHistoricalDataTask),
+      tptr: getTokenHistoricalDataTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "tokenHistoricalDataResolved",
       symbol: symbol,

--- a/src/app_service/service/transaction/async_tasks.nim
+++ b/src/app_service/service/transaction/async_tasks.nim
@@ -77,7 +77,7 @@ proc addFirstSimpleBridgeTxFlag(paths: seq[TransactionPathDto]) : seq[Transactio
 
   return txPaths
 
-const getSuggestedRoutesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getSuggestedRoutesTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetSuggestedRoutesTaskArg](argEncoded)
 
   try:
@@ -128,7 +128,7 @@ type
     address: string
     trxType: string
 
-const watchTransactionTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc watchTransactionTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[WatchTransactionTaskArg](argEncoded)
   try:
     let output = %*{
@@ -154,7 +154,7 @@ type
   GetCryptoServicesTaskArg* = ref object of QObjectTaskArg
     discard
 
-const getCryptoServicesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getCryptoServicesTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetCryptoServicesTaskArg](argEncoded)
 
   try:
@@ -177,7 +177,7 @@ type
     txHash: string
     data: string
 
-const fetchDecodedTxDataTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchDecodedTxDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchDecodedTxDataTaskArg](argEncoded)
   var data = %* {
     "txHash": arg.txHash

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -208,7 +208,7 @@ QtObject:
       address: fromAddress,
       trxType: trxType,
       data: data,
-      tptr: cast[ByteAddress](watchTransactionTask),
+      tptr: watchTransactionTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "watchTransactionResult",
     )
@@ -228,7 +228,7 @@ QtObject:
 
   proc fetchDecodedTxData*(self: Service, txHash: string, data: string) =
     let arg = FetchDecodedTxDataTaskArg(
-      tptr: cast[ByteAddress](fetchDecodedTxDataTask),
+      tptr: fetchDecodedTxDataTask,
       vptr: cast[ByteAddress](self.vptr),
       data: data,
       txHash: txHash,
@@ -581,7 +581,7 @@ QtObject:
       if toToken != nil:
         toTokenId = toToken.symbol
     let arg = GetSuggestedRoutesTaskArg(
-      tptr: cast[ByteAddress](getSuggestedRoutesTask),
+      tptr: getSuggestedRoutesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "suggestedRoutesReady",
       accountFrom: accountFrom,
@@ -603,7 +603,7 @@ QtObject:
 
   proc fetchCryptoServices*(self: Service) =
     let arg = GetCryptoServicesTaskArg(
-      tptr: cast[ByteAddress](getCryptoServicesTask),
+      tptr: getCryptoServicesTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onFetchCryptoServices",
     )

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -10,7 +10,7 @@ type
     password: string
     derivedFrom: string
 
-const fetchDerivedAddressesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchDerivedAddressesTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchDerivedAddressesTaskArg](argEncoded)
   var output = %*{
     "derivedAddresses": "",
@@ -27,7 +27,7 @@ type
   FetchDerivedAddressesForMnemonicTaskArg* = ref object of FetchAddressesArg
     mnemonic: string
 
-const fetchDerivedAddressesForMnemonicTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchDerivedAddressesForMnemonicTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchDerivedAddressesForMnemonicTaskArg](argEncoded)
   var output = %*{
     "derivedAddresses": "",
@@ -46,7 +46,7 @@ type
     chainId: int
     addresses: seq[string]
 
-const fetchDetailsForAddressesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchDetailsForAddressesTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchDetailsForAddressesTaskArg](argEncoded)
   for address in arg.addresses:
     var data = %* {
@@ -84,7 +84,7 @@ type
     accounts: seq[string]
     storeResult: bool
 
-const prepareTokensTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc prepareTokensTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[BuildTokensTaskArg](argEncoded)
   var output = %*{
     "result": "",
@@ -107,7 +107,7 @@ type
     keycard: KeycardDto
     accountsComingFromKeycard: bool
 
-const saveOrUpdateKeycardTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc saveOrUpdateKeycardTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[SaveOrUpdateKeycardTaskArg](argEncoded)
   var responseJson = %*{
     "success": false,
@@ -139,7 +139,7 @@ type
   DeleteKeycardAccountsTaskArg* = ref object of QObjectTaskArg
     keycard: KeycardDto
 
-const deleteKeycardAccountsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc deleteKeycardAccountsTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[DeleteKeycardAccountsTaskArg](argEncoded)
   var responseJson = %*{
     "success": false,
@@ -166,7 +166,7 @@ type
     url: string
     isMainUrl: bool
 
-const fetchChainIdForUrlTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc fetchChainIdForUrlTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchChainIdForUrlTaskArg](argEncoded)
   try:
     let response = backend.fetchChainIDForURL(arg.url)
@@ -195,7 +195,7 @@ type
     seedPhrase: string
     password: string
 
-const migrateNonProfileKeycardKeypairToAppTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc migrateNonProfileKeycardKeypairToAppTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[MigrateNonProfileKeycardKeypairToAppTaskArg](argEncoded)
   var responseJson = %*{
     "success": false,
@@ -229,7 +229,7 @@ type
     currencySymbol: string
     timeInterval: BalanceHistoryTimeInterval
 
-const getTokenBalanceHistoryDataTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+proc getTokenBalanceHistoryDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetTokenBalanceHistoryDataTaskArg](argEncoded)
   var response = %*{}
   try:

--- a/src/app_service/service/wallet_account/balance_history.nim
+++ b/src/app_service/service/wallet_account/balance_history.nim
@@ -20,7 +20,7 @@ proc fetchHistoricalBalanceForTokenAsJson*(self: Service, addresses: seq[string]
     return
 
   let arg = GetTokenBalanceHistoryDataTaskArg(
-    tptr: cast[ByteAddress](getTokenBalanceHistoryDataTask),
+    tptr: getTokenBalanceHistoryDataTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "tokenBalanceHistoryDataResolved",
     chainIds: chainIds,

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -467,7 +467,7 @@ proc migrateNonProfileKeycardKeypairToAppAsync*(self: Service, keyUid, seedPhras
   if doPasswordHashing:
     finalPassword = utils.hashPassword(password)
   let arg = MigrateNonProfileKeycardKeypairToAppTaskArg(
-    tptr: cast[ByteAddress](migrateNonProfileKeycardKeypairToAppTask),
+    tptr: migrateNonProfileKeycardKeypairToAppTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onNonProfileKeycardKeypairMigratedToApp",
     keyUid: keyUid,
@@ -645,7 +645,7 @@ proc fetchDerivedAddresses*(self: Service, password: string, derivedFrom: string
     password: if hashPassword: utils.hashPassword(password) else: password,
     derivedFrom: derivedFrom,
     paths: paths,
-    tptr: cast[ByteAddress](fetchDerivedAddressesTask),
+    tptr: fetchDerivedAddressesTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onDerivedAddressesFetched",
   )
@@ -665,7 +665,7 @@ proc fetchDerivedAddressesForMnemonic*(self: Service, mnemonic: string, paths: s
   let arg = FetchDerivedAddressesForMnemonicTaskArg(
     mnemonic: mnemonic,
     paths: paths,
-    tptr: cast[ByteAddress](fetchDerivedAddressesForMnemonicTask),
+    tptr: fetchDerivedAddressesForMnemonicTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onDerivedAddressesForMnemonicFetched",
   )
@@ -687,7 +687,7 @@ proc fetchDetailsForAddresses*(self: Service, uniqueId: string, addresses: seq[s
     uniqueId: uniqueId,
     chainId: network.chainId,
     addresses: addresses,
-    tptr: cast[ByteAddress](fetchDetailsForAddressesTask),
+    tptr: fetchDetailsForAddressesTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onAddressDetailsFetched",
   )
@@ -752,7 +752,7 @@ proc onFetchChainIdForUrl*(self: Service, jsonString: string) {.slot.} =
 
 proc fetchChainIdForUrl*(self: Service, url: string, isMainUrl: bool) =
   let arg = FetchChainIdForUrlTaskArg(
-    tptr: cast[ByteAddress](fetchChainIdForUrlTask),
+    tptr: fetchChainIdForUrlTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onFetchChainIdForUrl",
     url: url,

--- a/src/app_service/service/wallet_account/service_keycard.nim
+++ b/src/app_service/service/wallet_account/service_keycard.nim
@@ -1,6 +1,6 @@
   proc addKeycardOrAccountsAsync*(self: Service, keycard: KeycardDto, accountsComingFromKeycard: bool = false) =
     let arg = SaveOrUpdateKeycardTaskArg(
-      tptr: cast[ByteAddress](saveOrUpdateKeycardTask),
+      tptr: saveOrUpdateKeycardTask,
       vptr: cast[ByteAddress](self.vptr),
       slot: "onKeycardAdded",
       keycard: keycard,
@@ -59,7 +59,7 @@ proc addKeycardOrAccounts*(self: Service, keycard: KeycardDto, accountsComingFro
 
 proc removeMigratedAccountsForKeycard*(self: Service, keyUid: string, keycardUid: string, accountsToRemove: seq[string]) =
   let arg = DeleteKeycardAccountsTaskArg(
-    tptr: cast[ByteAddress](deleteKeycardAccountsTask),
+    tptr: deleteKeycardAccountsTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onMigratedAccountsForKeycardRemoved",
     keycard: KeycardDto(keyUid: keyUid, keycardUid: keycardUid, accountsAddresses: accountsToRemove)

--- a/src/app_service/service/wallet_account/service_token.nim
+++ b/src/app_service/service/wallet_account/service_token.nim
@@ -87,7 +87,7 @@ proc buildAllTokens*(self: Service, accounts: seq[string], store: bool) =
     self.updateAssetsLoadingState(waddress, true)
 
   let arg = BuildTokensTaskArg(
-    tptr: cast[ByteAddress](prepareTokensTask),
+    tptr: prepareTokensTask,
     vptr: cast[ByteAddress](self.vptr),
     slot: "onAllTokensBuilt",
     accounts: accounts,


### PR DESCRIPTION
This PR slightly simplifies the way tasks are passed between threads, removing some unnecessary boilerplate while improving type safety by removing casts.

This approach works because `nimcall` turns a `proc` into a simple pointer which just like `cstring` is safe to pass between threads.

Further simplification is possible, but left for a future PR.
