### PR TITLE
fix(ProfileShowcase): Add live preview support in the profile view

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -44,6 +44,10 @@ SettingsContentBase {
         property string displayName: descriptionPanel.displayName.text
         property string bio: descriptionPanel.bio.text
         property url profileLargeImage: profileHeader.previewIcon
+        property var socialLinks: priv.showcaseModels.socialLinksVisibleModel
+        property var communitiesModel: priv.showcaseModels.communitiesVisibleModel
+        property var accountsModel: priv.showcaseModels.accountsVisibleModel
+        property var collectiblesModel: priv.showcaseModels.collectiblesVisibleModel
     }
 
     enum TabIndex {
@@ -323,6 +327,8 @@ SettingsContentBase {
                 contactsStore: root.contactsStore
                 networkConnectionStore: root.networkConnectionStore
                 onClosed: destroy()
+                dirtyValues: root.dirtyValues
+                dirty: root.dirty
             }
         }
 

--- a/ui/imports/shared/popups/ProfileDialog.qml
+++ b/ui/imports/shared/popups/ProfileDialog.qml
@@ -15,6 +15,9 @@ StatusDialog {
     property var contactsStore
     property var networkConnectionStore
 
+    property var dirtyValues: ({})
+    property bool dirty: false
+
     width: 640
     padding: 0
 
@@ -27,5 +30,7 @@ StatusDialog {
         contactsStore: root.contactsStore
         networkConnectionStore: root.networkConnectionStore
         onCloseRequested: root.close()
+        dirtyValues: root.dirtyValues
+        dirty: root.dirty
     }
 }

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -618,6 +618,9 @@ Pane {
                     profileStore: root.profileStore
                     walletStore: root.walletStore
                     networkConnectionStore: root.networkConnectionStore
+                    
+                    livePreview: root.dirty
+                    livePreviewValues: root.dirtyValues
 
                     onCloseRequested: root.closeRequested()
                 }

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -53,7 +53,7 @@ Control {
         readonly property var collectiblesModel: root.livePreview ? root.livePreviewValues.collectiblesModel
                                                                   : collectiblesStoreModel
         // TODO: add dirty values to the livePreviewValues once assets are supported
-        // readonly property assetsModel: root.livePeview ? root.livePreviewValues.assetsModel
+        // readonly property assetsModel: root.livePreview ? root.livePreviewValues.assetsModel
         //                                                     : root.profileStore.profileShowcaseAssetsModel
         readonly property var assetsModel: root.profileStore.profileShowcaseAssetsModel
         readonly property var socialLinksModel: root.livePreview ? root.livePreviewValues.socialLinksModel

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
@@ -26,20 +27,83 @@ Control {
     property var walletStore
     property var networkConnectionStore
 
+    property bool livePreview: false
+    property var livePreviewValues: ({})
+
     signal closeRequested()
 
-    onVisibleChanged: if (visible) profileStore.requestProfileShowcase(publicKey)
+    onVisibleChanged: if (visible && !livePreview) profileStore.requestProfileShowcase(publicKey)
 
     horizontalPadding: readOnly ? 20 : 40 // smaller in settings/preview
     topPadding: Style.current.bigPadding
 
-    QtObject {
+    StatusQUtils.QObject {
         id: d
 
         readonly property string copyLiteral: qsTr("Copy")
 
         readonly property var timer: Timer {
             id: timer
+        }
+
+        readonly property var communitiesModel: root.livePreview ? liveCommunitiesModel
+                                                                 : communitiesStoreModel
+        readonly property var accountsModel: root.livePreview ? root.livePreviewValues.accountsModel
+                                                              : accountsStoreModel
+        readonly property var collectiblesModel: root.livePreview ? root.livePreviewValues.collectiblesModel
+                                                                  : collectiblesStoreModel
+        // TODO: add dirty values to the livePreviewValues once assets are supported
+        // readonly property assetsModel: root.livePeview ? root.livePreviewValues.assetsModel
+        //                                                     : root.profileStore.profileShowcaseAssetsModel
+        readonly property var assetsModel: root.profileStore.profileShowcaseAssetsModel
+        readonly property var socialLinksModel: root.livePreview ? root.livePreviewValues.socialLinksModel
+                                                            : root.profileStore.socialLinksModel
+        SortFilterProxyModel {
+            id: liveCommunitiesModel
+            sourceModel: root.livePreviewValues.communitiesModel
+            proxyRoles: [
+                FastExpressionRole {
+                    name: "membersCount"
+                    expression: model.members.count
+                    expectedRoles: ["members"]
+                }
+            ]
+        }
+
+        SortFilterProxyModel {
+            id: communitiesStoreModel
+            sourceModel: root.profileStore.profileShowcaseCommunitiesModel
+            filters: [
+                ValueFilter {
+                    roleName: "showcaseVisibility"
+                    value: Constants.ShowcaseVisibility.NoOne
+                    inverted: true
+                },
+                ValueFilter {
+                    roleName: "loading"
+                    value: false
+                }
+            ]
+        }
+
+        SortFilterProxyModel {
+            id: accountsStoreModel
+            sourceModel: root.profileStore.profileShowcaseAccountsModel
+            filters: ValueFilter {
+                roleName: "showcaseVisibility"
+                value: Constants.ShowcaseVisibility.NoOne
+                inverted: true
+            }
+        }
+
+        SortFilterProxyModel {
+            id: collectiblesStoreModel
+            sourceModel: root.profileStore.profileShowcaseCollectiblesModel
+            filters: ValueFilter {
+                roleName: "showcaseVisibility"
+                value: Constants.ShowcaseVisibility.NoOne
+                inverted: true
+            }
         }
     }
 
@@ -79,20 +143,7 @@ Control {
                 cellWidth: (width-rightMargin)/2
                 cellHeight: cellWidth/2
                 visible: count
-                model: SortFilterProxyModel {
-                    sourceModel: root.profileStore.profileShowcaseCommunitiesModel
-                    filters: [
-                        ValueFilter {
-                            roleName: "showcaseVisibility"
-                            value: Constants.ShowcaseVisibility.NoOne
-                            inverted: true
-                        },
-                        ValueFilter {
-                            roleName: "loading"
-                            value: false
-                        }
-                    ]
-                }
+                model: d.communitiesModel
                 ScrollBar.vertical: StatusScrollBar { }
                 delegate: StatusListItem { // TODO custom delegate
                     width: GridView.view.cellWidth - Style.current.smallPadding
@@ -149,14 +200,7 @@ Control {
                 id: accountsView
                 spacing: Style.current.halfPadding
                 visible: count
-                model: SortFilterProxyModel {
-                    sourceModel: root.profileStore.profileShowcaseAccountsModel
-                    filters: ValueFilter {
-                        roleName: "showcaseVisibility"
-                        value: Constants.ShowcaseVisibility.NoOne
-                        inverted: true
-                    }
-                }
+                model: d.accountsModel
                 delegate: StatusListItem {
                     id: accountDelegate
                     property bool saved: {
@@ -253,14 +297,7 @@ Control {
                 cellHeight: cellWidth
                 visible: count
                 // TODO Issue #11637: Dedicated controller for user's list of collectibles (no watch-only entries)
-                model: SortFilterProxyModel {
-                    sourceModel: root.profileStore.profileShowcaseCollectiblesModel
-                    filters: ValueFilter {
-                        roleName: "showcaseVisibility"
-                        value: Constants.ShowcaseVisibility.NoOne
-                        inverted: true
-                    }
-                }
+                model: d.collectiblesModel
                 ScrollBar.vertical: StatusScrollBar { }
                 delegate: StatusRoundedImage {
                     width: GridView.view.cellWidth - Style.current.smallPadding
@@ -347,7 +384,7 @@ Control {
                 cellHeight: cellWidth/2.5
                 visible: count
                 model: SortFilterProxyModel {
-                    sourceModel: root.profileStore.profileShowcaseAssetsModel
+                    sourceModel: d.assetsModel
                     filters: ValueFilter {
                         roleName: "showcaseVisibility"
                         value: Constants.ShowcaseVisibility.NoOne


### PR DESCRIPTION
### What does the PR do

Closes: #13949 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Adding live preview support in the profile view.
Changes:
1. Propagate the dirty models from the profile showcase to the profile view
2. Adding live preview support in the ProfileShowcaseView. We're swapping the models when the live preview is active
3. Adapt the community model to support `membersCount` role needed in the `ProfileShowcaseView `

### Affected areas

Profile showcase
Profile view
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

#### Side by side preview

https://github.com/status-im/status-desktop/assets/47811206/19906cde-fb2f-42b4-a777-f590638c48a6

#### Popup view

https://github.com/status-im/status-desktop/assets/47811206/d08908be-361b-4a7f-b384-e5a2e5e21efb
