### PR TITLE
fix: category item style

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -139,6 +139,7 @@ Item {
                         showAddButton: showCategoryActionButtons
                         showMenuButton: !!root.popupMenu
                         hasUnreadMessages: model.hasUnreadMessages
+                        muted: model.muted
                         onClicked: {
                             if (mouse.button === Qt.RightButton && showCategoryActionButtons && !!root.categoryPopupMenu) {
                                 statusChatListCategoryItem.setupPopup()

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml
@@ -21,6 +21,7 @@ Control {
     property bool showMenuButton: showActionButtons
     property bool showAddButton: showActionButtons
     property bool hasUnreadMessages: false
+    property bool muted: false
     property alias addButton: addButton
     property alias menuButton: menuButton
     property alias toggleButton: toggleButton
@@ -44,10 +45,19 @@ Control {
         StatusBaseText {
             width: Math.min(implicitWidth, parent.width)
             anchors.verticalCenter: parent.verticalCenter
-            font.weight: Font.Medium
+            font.weight: root.hasUnreadMessages ? Font.Bold : Font.Medium
             font.pixelSize: 15
             elide: Text.ElideRight
-            color: Theme.palette.directColor4
+            color: {
+                if (root.muted && !hoverHandler.hovered && !root.highlighted) {
+                    return Theme.palette.directColor5
+                }
+                if (root.hasUnreadMessages || root.highlighted || hoverHandler.hovered) {
+                    return Theme.palette.directColor1
+                }
+                return Theme.palette.directColor4
+            }
+
             text: root.text
         }
         Row {
@@ -80,3 +90,4 @@ Control {
         }
     }
 }
+


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13959

Fixed the styling of community category. This now considers:
- `muted`
- `hadUnreadMessages`
- `highlighted`

Which follows the same logic as for channels.

https://github.com/status-im/status-desktop/assets/25482501/c7eb7c56-75d6-45f5-89b3-92f00d7f2c58

