### PR TITLE
upgrade Nim-build-system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,6 +548,7 @@ $(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSG
 		--passL:"-lm" \
 		--warning:UnreachableElse:off \
 		--warningAsError:UseBase:on \
+		--warningAsError:UnusedImport:on \
 		$(NIM_EXTRA_PARAMS) src/nim_status_client.nim
 ifeq ($(detected_OS),Darwin)
 	install_name_tool -change \

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -1,5 +1,5 @@
 import chronicles, tables, strutils, sequtils, stint
-import uuids
+import uuids, sets, sugar
 import io_interface
 
 import app/global/app_sections_config as conf


### PR DESCRIPTION
As @arnetheduck recommended, I upgraded `nimbus-build-sytem` to the one that uses latest `Nim 1.6.18`.

This is to try to make `--warningAsError:UnusedImport:on` work.