### PR TITLE
fix(TokenManagement): Fix sorting grouped positions

### DIFF
--- a/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
+++ b/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
@@ -246,6 +246,40 @@ Item {
             tryCompare(findChild(lvCommunity, "manageTokensGroupDelegate-0"), "title", titleToTest)
         }
 
+        function test_arrangeByCommunity() {
+            const communityHeader = findChild(controlUnderTest, "communityHeader")
+            verify(!!communityHeader)
+            const switchArrangeByCommunity = findChild(communityHeader, "switch")
+            verify(!!switchArrangeByCommunity)
+            waitForRendering(switchArrangeByCommunity)
+            mouseClick(switchArrangeByCommunity)
+
+            const lvCommunity = findChild(controlUnderTest, "communityTokensListView")
+            verify(!!lvCommunity)
+            waitForItemPolished(lvCommunity)
+
+            const pandasGroup = findChild(lvCommunity, "manageTokensGroupDelegate-0")
+            tryCompare(pandasGroup, "title", "Frenly Pandas")
+            tryCompare(pandasGroup, "childCount", 4)
+        }
+
+        function test_arrangeByCollection() {
+            const collectionsHeader = findChild(controlUnderTest, "nonCommunityHeader")
+            verify(!!collectionsHeader)
+            const switchArrangeByCollection = findChild(collectionsHeader, "switch")
+            verify(!!switchArrangeByCollection)
+            waitForRendering(switchArrangeByCollection)
+            mouseClick(switchArrangeByCollection)
+
+            const lvCollections = findChild(controlUnderTest, "otherTokensListView")
+            verify(!!lvCollections)
+            waitForItemPolished(lvCollections)
+
+            const kittiesGroup = findChild(lvCollections, "manageTokensGroupDelegate-0")
+            tryCompare(kittiesGroup, "title", "Kitties")
+            tryCompare(kittiesGroup, "childCount", 3)
+        }
+
         function test_moveOperations() {
             verify(!controlUnderTest.dirty)
 

--- a/storybook/src/Models/ManageCollectiblesModel.qml
+++ b/storybook/src/Models/ManageCollectiblesModel.qml
@@ -157,7 +157,7 @@ ListModel {
             communityImage: "",
             imageUrl: "",
             isLoading: false,
-            backgroundColor: "pink",
+            backgroundColor: "ivory",
             ownership: [
                 {
                     accountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -143,6 +143,8 @@ add_library(StatusQ SHARED
         src/wallet/managetokensmodel.h
         )
 
+target_compile_features(StatusQ PRIVATE cxx_std_17)
+
 set_target_properties(StatusQ PROPERTIES
     ADDITIONAL_CLEAN_FILES bin/StatusQ/qmldir
     RUNTIME_OUTPUT_DIRECTORY ${STATUSQ_MODULE_PATH}

--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -116,22 +116,20 @@ private:
     bool arrangeByCollection() const;
     void setArrangeByCollection(bool newArrangeByCollection);
 
-    QStringList m_communityIds;
-    void reloadCommunityIds();
     void rebuildCommunityTokenGroupsModel();
     void rebuildHiddenCommunityTokenGroupsModel();
     void rebuildCollectionGroupsModel();
     void rebuildHiddenCollectionGroupsModel();
 
     const std::array<ManageTokensModel*, 7> m_allModels {m_regularTokensModel, m_collectionGroupsModel, m_communityTokensModel, m_communityTokenGroupsModel,
-                                                        m_hiddenTokensModel, m_hiddenCommunityTokenGroupsModel, m_hiddenCollectionGroupsModel};
+                                                         m_hiddenTokensModel, m_hiddenCommunityTokenGroupsModel, m_hiddenCollectionGroupsModel};
 
     QString m_settingsKey;
     QString settingsKey() const;
     QString settingsGroupName() const;
     void setSettingsKey(const QString& newSettingsKey);
     QSettings m_settings;
-    SerializedTokenData m_settingsData; // symbol -> {sortOrder, visible, groupId}
+    SerializedTokenData m_settingsData; // symbol -> {sortOrder, visible, groupId, isCommunityGroup, isCollectionGroup}
     bool hasSettings() const;
     void loadSettingsData(bool withGroup = false);
 
@@ -145,7 +143,7 @@ private:
 
     bool m_modelConnectionsInitialized{false};
 
-    // explicitely mass-hidden community asset/collectible groups
+    // explicitely mass-hidden asset/collectible groups
     QSet<QString> m_hiddenCommunityGroups;
     QStringList hiddenCommunityGroups() const;
 

--- a/ui/StatusQ/src/wallet/managetokensmodel.h
+++ b/ui/StatusQ/src/wallet/managetokensmodel.h
@@ -39,13 +39,13 @@ struct TokenData {
     bool isSelfCollection{false};
 };
 
-// symbol -> {sortOrder, visible, groupId}
-using SerializedTokenData = QHash<QString, std::tuple<int, bool, QString>>;
+// symbol -> {sortOrder, visible, groupId, isCommunityGroup, isCollectionGroup}
+using SerializedTokenData = QHash<QString, std::tuple<int, bool, QString, bool, bool>>;
 
 class ManageTokensModel : public QAbstractListModel
 {
     Q_OBJECT
-    Q_PROPERTY(int count READ count NOTIFY countChanged FINAL)
+    Q_PROPERTY(int count READ rowCount NOTIFY countChanged FINAL)
     Q_PROPERTY(bool dirty READ dirty NOTIFY dirtyChanged FINAL)
 
 public:
@@ -87,12 +87,8 @@ public:
     void applySort();
     void applySortByTokensAmount();
 
-    int count() const { return rowCount(); }
     const TokenData& itemAt(int row) const { return m_data.at(row); }
     TokenData& itemAt(int row) { return m_data[row]; }
-
-    void setCommunityIds(const QStringList& ids) { m_communityIds = ids; }; // FIXME remove; sort by number of tokens inside
-    bool hasCommunityIdToken(const QString& communityId) const; // FIXME remove
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
@@ -103,8 +99,6 @@ signals:
     void dirtyChanged();
 
 private:
-    QStringList m_communityIds;
-
     bool m_dirty{false};
 
     QList<TokenData> m_data;

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -71,9 +71,10 @@ SettingsContentBase {
         manageTokensView.saveChanges()
     }
     onSaveChangesClicked: {
+        manageTokensView.saveChanges()
+
         if (manageTokensView.advancedTabVisible) {
-            // Save changes only when tab is active
-            manageTokensView.saveChanges()
+            // don't emit toasts when the Advanced tab is visible
             return
         }
 

--- a/ui/imports/shared/controls/FoldableHeader.qml
+++ b/ui/imports/shared/controls/FoldableHeader.qml
@@ -55,7 +55,7 @@ Rectangle {
             id: modeSwitch
             objectName: "switch"
 
-            visible: !!text
+            visible: !!text && !!root.ListView.view && root.ListView.view.model && root.ListView.view.model.count
             LayoutMirroring.enabled: true
             LayoutMirroring.childrenInherit: true
             textColor: Theme.palette.baseColor1

--- a/ui/imports/shared/popups/CommunityAssetsInfoPopup.qml
+++ b/ui/imports/shared/popups/CommunityAssetsInfoPopup.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Popups.Dialog 0.1


### PR DESCRIPTION
### What does the PR do

- keep track of the grouped item kind (community vs. collection)
- when the "arrange by" mode is active, use it for sorting the tokens in the main wallet view
- change the behavior to always sort by the number of tokens inside the group when entering the grouped (arrange by...) mode + add tests
- remove unused code dealing with handling of community IDs
- separate commits to fix some smaller UI issues in the group delegate

Fixes #13276

### Affected areas

ManageTokensController,ManageTokensGroupDelegate

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

