### PR TITLE
fix(settings) fix popup spacing for change password modal

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
@@ -52,7 +52,6 @@ StatusDialog {
 
     Column {
         anchors.fill: parent
-        anchors.margins: 16
         spacing: 20
         StatusBaseText {
             width: parent.width


### PR DESCRIPTION
### Closes: #13894 

The extra space was not needed given that modal has a padding of 16 already

| Design | Implementation |
|-|-|
| ![image](https://github.com/status-im/status-desktop/assets/47554641/b91e20b8-6d80-4f0c-83dc-99ea4d433ab3) | ![image](https://github.com/status-im/status-desktop/assets/47554641/c26d7725-8ed3-41ae-96cf-3880586cb21f) |