### PR TITLE
fix(@desktop/communities): Fix joining community

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -530,12 +530,14 @@ QtObject:
 
       let prevCommunity = self.communities[community.id]
 
-      let currOwner = community.findOwner()
-      let prevOwner = prevCommunity.findOwner()
-
-      if currOwner.id != prevOwner.id:
-        for chat in community.chats:
-          self.updateMemberRole(chat.id, currOwner)
+      try:
+        let currOwner = community.findOwner()
+        let prevOwner = prevCommunity.findOwner()
+        if currOwner.id != prevOwner.id:
+          for chat in community.chats:
+            self.updateMemberRole(chat.id, currOwner)
+      except Exception:
+        discard
 
       # ownership lost
       if prevCommunity.isOwner and not community.isOwner:


### PR DESCRIPTION
Unexpected exception (from findOwner() function) broke handleCommunityUpdates.
Exception was raised, because previous community did not have a member list (there was join permission).

Fix #13958


https://github.com/status-im/status-desktop/assets/61889657/78b92c63-d38d-43fb-ae51-46b62fead903

