### PR TITLE
feat(wallet): add notification to biometrics enable

### DIFF
--- a/storybook/pages/ChangePasswordViewPage.qml
+++ b/storybook/pages/ChangePasswordViewPage.qml
@@ -37,6 +37,23 @@ SplitView {
                     signal storeToKeychainError(errorDescription: string)
                     signal storeToKeychainSuccess()
                  }
+
+                 function tryStoreToKeyChain(errorDescription) {
+                    if (generateMacKeyChainStoreError.checked) {
+                        privacyModule.storeToKeychainError(errorDescription)
+                    } else {
+                        privacyModule.storeToKeychainSuccess()
+                        privacyModule.passwordChanged(true, "")
+                    }
+                 }
+
+                 function tryRemoveFromKeyChain() {
+                    if (generateMacKeyChainStoreError.checked) {
+                        privacyModule.storeToKeychainError(errorDescription)
+                    } else {
+                        privacyModule.storeToKeychainSuccess()
+                    }
+                 }
             }
 
             property QtObject localAccountSettings: QtObject {
@@ -54,7 +71,11 @@ SplitView {
         logsView.logText: logs.logText
 
         RowLayout {
-
+            Switch {
+                id: generateMacKeyChainStoreError
+                text: "Generate key chain error"
+                checked: false
+            }
         }
     }
 }

--- a/storybook/pages/ChangePasswordViewPage.qml
+++ b/storybook/pages/ChangePasswordViewPage.qml
@@ -42,6 +42,7 @@ SplitView {
                     if (generateMacKeyChainStoreError.checked) {
                         privacyModule.storeToKeychainError(errorDescription)
                     } else {
+                        passwordView.localAccountSettings.storeToKeychainValue = Constants.keychain.storedValue.store
                         privacyModule.storeToKeychainSuccess()
                         privacyModule.passwordChanged(true, "")
                     }
@@ -49,8 +50,9 @@ SplitView {
 
                  function tryRemoveFromKeyChain() {
                     if (generateMacKeyChainStoreError.checked) {
-                        privacyModule.storeToKeychainError(errorDescription)
+                        privacyModule.storeToKeychainError("Error removing from keychain")
                     } else {
+                        passwordView.localAccountSettings.storeToKeychainValue = Constants.keychain.storedValue.notNow
                         privacyModule.storeToKeychainSuccess()
                     }
                  }

--- a/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
+++ b/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
@@ -25,15 +25,20 @@ SettingsContentBase {
 
     readonly property bool biometricsEnabled: localAccountSettings.storeToKeychainValue === Constants.keychain.storedValue.store
 
+    readonly property StatusSwitch biometricsSwitch: titleRowComponentLoader.item.switchItem
     readonly property Connections privacyStoreConnections: Connections {
         target: Qt.platform.os === Constants.mac ? root.privacyStore.privacyModule : null
 
         function onStoreToKeychainError(errorDescription: string) {
-            biometricsSwitch.checked = Qt.binding(() => { return biometricsSwitch.currentStoredValue })
+            root.biometricsSwitch.checked = Qt.binding(() => {
+                return root.biometricsSwitch.currentStoredValue
+            })
         }
 
         function onStoreToKeychainSuccess() {
-            biometricsSwitch.checked = Qt.binding(() => { return biometricsSwitch.currentStoredValue })
+            root.biometricsSwitch.checked = Qt.binding(() => {
+                return root.biometricsSwitch.currentStoredValue
+            })
         }
     }
 
@@ -43,14 +48,22 @@ SettingsContentBase {
         implicitWidth: 226
         implicitHeight: 38
         visible: (Qt.platform.os === Constants.mac)
+
+        property StatusSwitch switchItem: biometricsSwitch
         StatusSwitch {
             id: biometricsSwitch
+
             LayoutMirroring.enabled: true
             LayoutMirroring.childrenInherit: true
+
             text: qsTr("Enable biometrics")
             textColor: Theme.palette.baseColor1
+
+            property bool currentStoredValue: false
+
             checked: root.biometricsEnabled
             onToggled: {
+                currentStoredValue = checked
                 enableBiometricsPopup.open();
             }
             StatusToolTip {


### PR DESCRIPTION
### Closes #13896, #13983 and #13898

- [x] on top of https://github.com/status-im/status-desktop/pull/13981

Add notification to biometrics enable
Also fix biometrics toggle button and popup dismissal for change password screen

| | Design | Implementation |
|-|-|-|
| Disabled | ![image](https://github.com/status-im/status-desktop/assets/47554641/f0af6e9e-f819-4444-bf65-864648881e91) | ![image](https://github.com/status-im/status-desktop/assets/47554641/1630bfdf-8034-49f6-95c3-0e70af776a2a) |
| Enabled | ![image](https://github.com/status-im/status-desktop/assets/47554641/461b3400-7207-46cb-a82a-d6868939d2ec) | ![image](https://github.com/status-im/status-desktop/assets/47554641/daf95971-c38c-486e-bc30-0dd9f987dd70) |