### PR TITLE
fix(chat_section): main module should open section+chatId when handli…

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -62,7 +62,7 @@ type
     sharedUrlsService: urls_service.Service
 
 # Forward declaration
-proc setActiveSection*(self: Controller, sectionId: string, skipSavingInSettings: bool = false)
+proc setActiveSection*(self: Controller, sectionId: string, chatId: string = "", skipSavingInSettings: bool = false)
 proc getRemainingSupply*(self: Controller, chainId: int, contractAddress: string): Uint256
 proc getRemoteDestructedAmount*(self: Controller, chainId: int, contractAddress: string): Uint256
 
@@ -498,12 +498,12 @@ proc getChannelGroups*(self: Controller): seq[ChannelGroupDto] =
 proc getActiveSectionId*(self: Controller): string =
   result = self.activeSectionId
 
-proc setActiveSection*(self: Controller, sectionId: string, skipSavingInSettings: bool = false) =
+proc setActiveSection*(self: Controller, sectionId: string, chatId: string = "", skipSavingInSettings: bool = false) =
   self.activeSectionId = sectionId
   if not skipSavingInSettings:
     let sectionIdToSave = if (sectionId == conf.SETTINGS_SECTION_ID): "" else: sectionId
     singletonInstance.localAccountSensitiveSettings.setActiveSection(sectionIdToSave)
-  self.delegate.activeSectionSet(self.activeSectionId)
+  self.delegate.activeSectionSet(self.activeSectionId, chatId)
 
 proc getAllChats*(self: Controller): seq[ChatDto] =
   result = self.chatService.getAllChats()

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -148,7 +148,10 @@ method emitMailserverWorking*(self: AccessInterface) {.base.} =
 method emitMailserverNotWorking*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method activeSectionSet*(self: AccessInterface, sectionId: string) {.base.} =
+method activeSectionSet*(self: AccessInterface, sectionId: string, chatId: string = "") {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setActiveChat*(self: AccessInterface, sectionId: string, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method toggleSection*(self: AccessInterface, sectionType: SectionType) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -818,7 +818,7 @@ method setActiveSection*[T](self: Module[T], item: SectionItem, skipSavingInSett
   if(item.isEmpty()):
     echo "section is empty and cannot be made as active one"
     return
-  self.controller.setActiveSection(item.id, skipSavingInSettings)
+  self.controller.setActiveSection(item.id, skipSavingInSettings = skipSavingInSettings)
 
 method setActiveSectionById*[T](self: Module[T], id: string) =
   let item = self.view.model().getItemById(id)
@@ -833,8 +833,18 @@ proc notifySubModulesAboutChange[T](self: Module[T], sectionId: string) =
 
   # If there is a need other section may be notified the same way from here...
 
-method activeSectionSet*[T](self: Module[T], sectionId: string) =
+method setActiveChat*[T](self: Module[T], sectionId: string, chatId: string) =
+  if chatId == "":
+    return
+
+  if not self.channelGroupModules.contains(sectionId):
+    return
+
+  self.channelGroupModules[sectionId].setActiveItem(chatId)
+
+method activeSectionSet*[T](self: Module[T], sectionId: string, chatId: string = "") =
   if self.view.activeSection.getId() == sectionId:
+    self.setActiveChat(sectionId, chatId)
     return
   let item = self.view.model().getItemById(sectionId)
 
@@ -851,7 +861,7 @@ method activeSectionSet*[T](self: Module[T], sectionId: string) =
 
   self.view.model().setActiveSection(sectionId)
   self.view.activeSectionSet(item)
-
+  self.setActiveChat(sectionId, chatId)
   self.notifySubModulesAboutChange(sectionId)
 
 proc setSectionAvailability[T](self: Module[T], sectionType: SectionType, available: bool) =


### PR DESCRIPTION
(parseSharedUrl, switchTo)

Fixes #13553
see also #12719

### What does the PR do

1. When Deeplink is activated, SIGNAL_MAKE_SECTION_CHAT_ACTIVE is emited
2. It is handled by main/controller.nim (activates the community) and chat_section/chat_content/messages/controller.nim (scrolls to the bottom)
3. There used to be a handler in chat_section/controller.nim, but it was removed in #12719
4. As suggested in comment 12719, this PR opens the requested chat ID when SIGNAL_MAKE_SECTION_CHAT_ACTIVE is processed

### Affected areas
main module, chat_section

### StatusQ checklist

- [ x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/c075f73c-b692-45e8-88ff-61415c9ce05f

