### PR TITLE
feat(ProfileShowcase): Align UI save flow according to backend response

### DIFF
--- a/storybook/pages/CommunitiesViewPage.qml
+++ b/storybook/pages/CommunitiesViewPage.qml
@@ -5,6 +5,7 @@ import StatusQ.Core 0.1
 
 import AppLayouts.Profile.views 1.0
 import AppLayouts.Wallet.stores 1.0
+import AppLayouts.Profile.stores 1.0
 import mainui 1.0
 import utils 1.0
 
@@ -44,7 +45,7 @@ SplitView {
         SplitView.preferredHeight: 400
 
         contentWidth: 664
-        profileSectionStore: QtObject {
+        profileSectionStore: ProfileSectionStore {
             property var communitiesProfileModule: QtObject {
                 function setCommunityMuted(communityId, mutedType) {
                     logs.logEvent("profileSectionStore::communitiesProfileModule::setCommunityMuted", ["communityId", "mutedType"], arguments)

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -78,6 +78,10 @@ StatusSectionLayout {
 
         readonly property bool isProfilePanelActive: profileContainer.currentIndex === Constants.settingsSubsection.profile
         readonly property bool sideBySidePreviewAvailable: root.Window.width >= 1840 // design
+
+        // Used to alternatively add an error message to the dirty bubble if ephemeral notification
+        // can clash at smaller viewports
+        readonly property bool toastClashesWithDirtyBubble: root.Window.width <= 1650 // design
     }
 
     headerBackground: AccountHeaderGradient {
@@ -142,6 +146,7 @@ StatusSectionLayout {
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.profile)
                 contentWidth: d.contentWidth
                 sideBySidePreview: d.sideBySidePreviewAvailable
+                toastClashesWithDirtyBubble: d.toastClashesWithDirtyBubble
             }
         }
 

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -45,13 +45,37 @@ QtObject {
 
     readonly property bool isFirstShowcaseInteraction: localAccountSettings.isFirstShowcaseInteraction
 
-    onUserDeclinedBackupBannerChanged: {
-        if (userDeclinedBackupBanner !== localAccountSensitiveSettings.userDeclinedBackupBanner) {
-            localAccountSensitiveSettings.userDeclinedBackupBanner = userDeclinedBackupBanner
+    property var details: Utils.getContactDetailsAsJson(pubkey)
+
+    // The following signals wrap the settings / preferences save request responses in one unique result (identity + preferences result)
+    signal profileSettingsSaveSucceeded()
+    signal profileSettingsSaveFailed()
+
+    // The following signals describe separate save request responses between identity and preferences
+    signal profileIdentitySaveSucceeded()
+    signal profileIdentitySaveFailed()
+    signal profileShowcasePreferencesSaveSucceeded()
+    signal profileShowcasePreferencesSaveFailed()
+
+    readonly property Connections profileModuleConnections: Connections {
+        target: root.profileModule
+
+        function onProfileIdentitySaveSucceeded() {
+            root.profileIdentitySaveSucceeded()
+        }
+
+        function onProfileIdentitySaveFailed() {
+            root.profileIdentitySaveFailed()
+        }
+
+        function onProfileShowcasePreferencesSaveSucceeded() {
+            root.profileShowcasePreferencesSaveSucceeded()
+        }
+
+        function onProfileShowcasePreferencesSaveFailed() {
+            root.profileShowcasePreferencesSaveFailed()
         }
     }
-
-    property var details: Utils.getContactDetailsAsJson(pubkey)
 
     function getQrCodeSource(text) {
         return globalUtils.qrCode(text)
@@ -67,12 +91,12 @@ QtObject {
             "displayName": displayName,
             "bio": bio,
             "image": source ? {
-                "source": source,
-                "aX": aX,
-                "aY": aY,
-                "bX": bX,
-                "bY": bY
-            } : null
+                                  "source": source,
+                                  "aX": aX,
+                                  "aY": aY,
+                                  "bX": bX,
+                                  "bY": bY
+                              } : null
         }
         let json = JSON.stringify(identityInfo)
         root.profileModule.saveProfileIdentity(json)
@@ -100,28 +124,6 @@ QtObject {
 
     function setIsFirstShowcaseInteraction() {
         root.profileModule.setIsFirstShowcaseInteraction()
-    }
-
-    signal profileIdentitySaveSucceeded()
-    signal profileIdentitySaveFailed()
-    signal profileShowcasePreferencesSaveSucceeded()
-    signal profileShowcasePreferencesSaveFailed()
-
-    readonly property Connections profileModuleConnections: Connections {
-        target: root.profileModule
-
-        function onProfileIdentitySaveSucceeded() {
-            root.profileIdentitySaveSucceeded()
-        }
-        function onProfileIdentitySaveFailed() {
-            root.profileIdentitySaveFailed()
-        }
-        function onProfileShowcasePreferencesSaveSucceeded() {
-            root.profileShowcasePreferencesSaveSucceeded()
-        }
-        function onProfileShowcasePreferencesSaveFailed() {
-            root.profileShowcasePreferencesSaveFailed()
-        }
     }
 
     // Social links related: All to be removed: Deprecated --> Issue #13688
@@ -153,4 +155,10 @@ QtObject {
         root.profileModule.saveSocialLinks(silent)
     }
     // End of social links to be removed
+
+    onUserDeclinedBackupBannerChanged: {
+        if (userDeclinedBackupBanner !== localAccountSensitiveSettings.userDeclinedBackupBanner) {
+            localAccountSensitiveSettings.userDeclinedBackupBanner = userDeclinedBackupBanner
+        }
+    }
 }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -19,13 +19,14 @@ import SortFilterProxyModel 0.2
 import "../panels"
 import AppLayouts.Communities.popups 1.0
 import AppLayouts.Communities.panels 1.0
+import AppLayouts.Profile.stores 1.0
 import AppLayouts.Wallet.stores 1.0 as WalletStore
 import AppLayouts.Chat.stores 1.0 as ChatStore
 
 SettingsContentBase {
     id: root
 
-    property var profileSectionStore
+    property ProfileSectionStore profileSectionStore
     property var rootStore
     required property WalletStore.WalletAssetsStore walletAssetsStore
     required property CurrenciesStore currencyStore

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -39,6 +39,7 @@ SettingsContentBase {
     property var communitiesModel
 
     property bool sideBySidePreview
+    property bool toastClashesWithDirtyBubble
 
     property QtObject dirtyValues: QtObject {
         property string displayName: descriptionPanel.displayName.text
@@ -72,7 +73,10 @@ SettingsContentBase {
     toast.saveChangesTooltipText: saveChangesButtonEnabled ? "" : qsTr("Invalid changes made to Identity")
     autoscrollWhenDirty: profileTabBar.currentIndex === MyProfileView.Identity
     toast.loading: priv.expectedBackendResponses > 0
-    
+    toast.additionalComponent.visible: false // TODO:Issue #13997 // !toast.loading && root.toastClashesWithDirtyBubble && priv.saveRequestFailed
+    toast.additionalComponent.text: qsTr("Changes could not be saved. Try again")
+    toast.additionalComponent.color: Theme.palette.dangerColor1
+
     onResetChangesClicked: priv.reset()
 
     onSaveChangesClicked: priv.save()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -89,6 +89,7 @@ Item {
         rootStore: appMain.rootStore
         rootChatStore: appMain.rootChatStore
         communityTokensStore: appMain.communityTokensStore
+        profileStore: appMain.rootStore.profileSectionStore.profileStore
 
         sendModalPopup: sendModal
     }

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -6,6 +6,7 @@ import AppLayouts.Wallet 1.0
 
 import AppLayouts.stores 1.0
 import AppLayouts.Chat.stores 1.0 as ChatStores
+import AppLayouts.Profile.stores 1.0
 
 import shared.stores 1.0 as SharedStores
 
@@ -31,6 +32,7 @@ QtObject {
     required property RootStore rootStore
     required property ChatStores.RootStore rootChatStore
     required property SharedStores.CommunityTokensStore communityTokensStore
+    required property ProfileStore profileStore
 
     // Properties:
     required property var sendModalPopup
@@ -39,6 +41,7 @@ QtObject {
     readonly property string viewOptimismExplorerText: qsTr("View on Optimism Explorer")
     readonly property string checkmarkCircleAssetName: "checkmark-circle"
     readonly property string crownOffAssetName: "crown-off"
+    readonly property string warningAssetName: "warning"
 
     // Community Transfer Ownership related toasts:
     readonly property Connections _communityTokensStoreConnections: Connections {
@@ -76,7 +79,7 @@ QtObject {
             } else if (status === Constants.ContractTransactionStatus.Failed) {
                 Global.displayToastMessage(qsTr("%1 smart contract update failed").arg(communityName),
                                            root.viewOptimismExplorerText,
-                                           "warning",
+                                           root.warningAssetName,
                                            false,
                                            Constants.ephemeralNotificationType.danger,
                                            url)
@@ -202,6 +205,29 @@ QtObject {
 
         function onDisplayImageToastWithActionMessage(title: string, subTitle: string, image: string, ephNotifType: int, actionType: int, actionData: string) {
             root.rootStore.mainModuleInst.displayEphemeralImageWithActionNotification(title, subTitle, image, ephNotifType, actionType, actionData)
+        }
+    }
+
+    // Profile settings related toasts:
+    readonly property Connections _profileStoreConnections: Connections {
+        target: root.profileStore
+
+        function onProfileSettingsSaveSucceeded() {
+            Global.displayToastMessage(qsTr("Profile changes saved"),
+                                       "",
+                                       root.checkmarkCircleAssetName,
+                                       false,
+                                       Constants.ephemeralNotificationType.success,
+                                       "")
+        }
+
+        function onProfileSettingsSaveFailed() {
+            Global.displayToastMessage(qsTr("Profile changes could not be saved"),
+                                       "",
+                                       root.warningAssetName,
+                                       false,
+                                        Constants.ephemeralNotificationType.danger,
+                                       "")
         }
     }
 

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -13,6 +13,7 @@ import StatusQ.Controls 0.1
 Rectangle {
     id: root
 
+    property bool loading: false
     property bool active: false
     property bool cancelButtonVisible: true
     property bool saveChangesButtonEnabled: false
@@ -133,7 +134,7 @@ Rectangle {
         StatusButton {
             id: cancelChangesButton
             text: root.defaultCancelChangesText
-            enabled: root.active
+            enabled: !root.loading && root.active
             visible: root.cancelButtonVisible
             type: StatusBaseButton.Type.Danger
             onClicked: root.resetChangesClicked()
@@ -142,6 +143,7 @@ Rectangle {
         StatusFlatButton {
             id: saveForLaterButton
             text: root.defaultSaveForLaterText
+            loading: root.loading
             enabled: root.active && root.saveChangesButtonEnabled
             visible: root.saveForLaterButtonVisible
             onClicked: root.saveForLaterClicked()
@@ -149,7 +151,9 @@ Rectangle {
 
         StatusButton {
             id: saveChangesButton
+
             objectName: "settingsDirtyToastMessageSaveButton"
+            loading: root.loading
             text: root.defaultSaveChangesText
             interactive: root.active && root.saveChangesButtonEnabled
             tooltip.text: root.saveChangesTooltipText

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -5,6 +5,7 @@ import QtGraphicalEffects 1.15
 import utils 1.0
 
 import shared.controls 1.0
+import shared.panels 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -23,6 +24,7 @@ Rectangle {
     property alias saveForLaterText: saveForLaterButton.text
     property alias cancelChangesText: cancelChangesButton.text
     property alias changesDetectedText: changesDetectedTextItem.text
+    property alias additionalComponent: additionalTextComponent
 
     readonly property string defaultChangesDetectedText: qsTr("Changes detected")
     readonly property string defaultSaveChangesText: qsTr("Save changes")
@@ -114,50 +116,68 @@ Rectangle {
         hoverEnabled: true
     }
 
-    RowLayout {
+    ColumnLayout {
         id: toastContent
+        anchors.fill: parent
+        anchors.margins: Style.current.padding
+        spacing: Style.current.padding
 
-        anchors {
-            fill: parent
-            margins: 16
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+
+            StatusBaseText {
+                id: changesDetectedTextItem
+                Layout.fillWidth: true
+                padding: 8
+                horizontalAlignment: Text.AlignHCenter
+                color: Theme.palette.directColor1
+                text: root.defaultChangesDetectedText
+            }
+
+            StatusButton {
+                id: cancelChangesButton
+                text: root.defaultCancelChangesText
+                enabled: !root.loading && root.active
+                visible: root.cancelButtonVisible
+                type: StatusBaseButton.Type.Danger
+                onClicked: root.resetChangesClicked()
+            }
+
+            StatusFlatButton {
+                id: saveForLaterButton
+                text: root.defaultSaveForLaterText
+                loading: root.loading
+                enabled: root.active && root.saveChangesButtonEnabled
+                visible: root.saveForLaterButtonVisible
+                onClicked: root.saveForLaterClicked()
+            }
+
+            StatusButton {
+                id: saveChangesButton
+
+                objectName: "settingsDirtyToastMessageSaveButton"
+                loading: root.loading
+                text: root.defaultSaveChangesText
+                interactive: root.active && root.saveChangesButtonEnabled
+                tooltip.text: root.saveChangesTooltipText
+                onClicked: root.saveChangesClicked()
+            }
+        }
+
+        Separator {
+            id: separator
+            Layout.fillWidth: true
+
+            visible: additionalTextComponent.visible
         }
 
         StatusBaseText {
-            id: changesDetectedTextItem
-            Layout.fillWidth: true
-            padding: 8
-            horizontalAlignment: Text.AlignHCenter
-            color: Theme.palette.directColor1
-            text: root.defaultChangesDetectedText
-        }
+            id: additionalTextComponent
 
-        StatusButton {
-            id: cancelChangesButton
-            text: root.defaultCancelChangesText
-            enabled: !root.loading && root.active
-            visible: root.cancelButtonVisible
-            type: StatusBaseButton.Type.Danger
-            onClicked: root.resetChangesClicked()
-        }
+            Layout.alignment: Qt.AlignHCenter
 
-        StatusFlatButton {
-            id: saveForLaterButton
-            text: root.defaultSaveForLaterText
-            loading: root.loading
-            enabled: root.active && root.saveChangesButtonEnabled
-            visible: root.saveForLaterButtonVisible
-            onClicked: root.saveForLaterClicked()
-        }
-
-        StatusButton {
-            id: saveChangesButton
-
-            objectName: "settingsDirtyToastMessageSaveButton"
-            loading: root.loading
-            text: root.defaultSaveChangesText
-            interactive: root.active && root.saveChangesButtonEnabled
-            tooltip.text: root.saveChangesTooltipText
-            onClicked: root.saveChangesClicked()
+            font.pixelSize: Theme.tertiaryTextFontSize
+            visible: false
         }
     }
 }

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -10,7 +10,7 @@ QtObject {
 
     // Some token+currency-related functions are implemented in the profileSectionModule.
     // We should probably refactor this and move those functions to some Wallet module.
-    property ProfileSectionStore profileSectionStore: ProfileSectionStore {}
+    property var _profileSectionModuleInst: profileSectionModule
 
     function getModelIndexForKey(key) {
         for (var i=0; i<currenciesModel.count; i++) {
@@ -989,17 +989,17 @@ QtObject {
     }
 
     function getFiatValue(cryptoAmount, cryptoSymbol) {
-        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getFiatValue(cryptoAmount, cryptoSymbol)
+        var amount = _profileSectionModuleInst.ensUsernamesModule.getFiatValue(cryptoAmount, cryptoSymbol)
         return parseFloat(amount)
     }
 
     function getCryptoValue(fiatAmount, cryptoSymbol) {
-        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getCryptoValue(fiatAmount, cryptoSymbol)
+        var amount = _profileSectionModuleInst.ensUsernamesModule.getCryptoValue(fiatAmount, cryptoSymbol)
         return parseFloat(amount)
     }
 
     function getGasEthValue(gweiValue, gasLimit) {
-        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
+        var amount = _profileSectionModuleInst.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
         return parseFloat(amount)
     }
 


### PR DESCRIPTION
Closes #13950

### What does the PR do

- Added loading state in dirty toast message.
- Added store connections in `MyProfileView` and save loading logic.
- Added toasts notifications.
- `ProfileSectionStore` only instanciated once
- `SettingsDirtyToastMessage` extended with additional information in bottom needed for task [#13997](https://github.com/status-im/status-desktop/issues/13997)
- Added some needed properties for task [#13997](https://github.com/status-im/status-desktop/issues/13997)

### Affected areas

**Profile Showcase** settings and `SettingsDirtyToastMessage`

### Screenshot of functionality 

- **Scenario 1**: Success changing both identity and preferences alone and / or together

https://github.com/status-im/status-desktop/assets/97019400/6d45a762-f08e-4d03-aeeb-dda517fd2587

- **Scenario 2**: Forcing backend failure by sending multiple times same account

https://github.com/status-im/status-desktop/assets/97019400/d3533c45-b332-4a22-8dc9-125f90e15737

- **Scenario 3**: Forcing timeout. No backend response received

https://github.com/status-im/status-desktop/assets/97019400/5dd7ccd9-9889-4e59-b133-d884ebffba96

- **Scenario 4**: Forcing timeout. Preferences response success received but identity response never received

https://github.com/status-im/status-desktop/assets/97019400/c7da637d-0a34-4c2b-a522-233fb51bf01d