### PR TITLE
fix(ProfileShowcase|): Change stroke position from the outside to inside of the drop area

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -321,22 +321,31 @@ DoubleFlickableWithFolding {
 
         visible: d.dragItem && d.dragItem.showcaseMaxVisibility >= showcaseVisibility
 
-        background: ShapeRectangle {
-            path.strokeColor: dropArea.containsDrag ? Theme.palette.primaryColor2 : Theme.palette.directColor7
-            path.fillColor: dropArea.containsDrag ? Theme.palette.primaryColor3 : Theme.palette.getColor(Theme.palette.baseColor4, 0.7)
+        background: Rectangle {
+            id: shapeWrapper
 
-            DropArea {
-                id: dropArea
-
+            color: dropArea.containsDrag ? Theme.palette.primaryColor3 : Theme.palette.getColor(Theme.palette.baseColor4, 0.7)
+            radius: Style.current.radius
+            
+            ShapeRectangle {
                 anchors.fill: parent
-                keys: visibilityDropAreaButton.dropAreaKeys
+                anchors.margins: path.strokeWidth / 2
+                radius: shapeWrapper.radius
+                path.strokeColor: dropArea.containsDrag ? Theme.palette.primaryColor3 : Theme.palette.directColor7
+                path.fillColor: "transparent"
+                DropArea {
+                    id: dropArea
 
-                onEntered: function(drag) {
-                    drag.accept()
-                }
+                    anchors.fill: parent
+                    keys: visibilityDropAreaButton.dropAreaKeys
 
-                onDropped: function(drop) {
-                    d.setVisibilityInternalRequested(drop.source.key, visibilityDropAreaButton.showcaseVisibility)
+                    onEntered: function(drag) {
+                        drag.accept()
+                    }
+
+                    onDropped: function(drop) {
+                        d.setVisibilityInternalRequested(drop.source.key, visibilityDropAreaButton.showcaseVisibility)
+                    }
                 }
             }
         }


### PR DESCRIPTION
### What does the PR do

Fixes #13693 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Add a rectangle wrapper to ShapeRectangle to fill the dash border area as well.


<img width="1138" alt="Screenshot 2024-03-18 at 10 17 06" src="https://github.com/status-im/status-desktop/assets/47811206/6d1c3727-6ae9-4b2c-97f8-6eb25a57562b">
