### PR TITLE
fix(WalletView): `Apply to my wallet` doesn't save or apply the order

### DIFF
--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -71,9 +71,10 @@ SettingsContentBase {
         manageTokensView.saveChanges()
     }
     onSaveChangesClicked: {
+        manageTokensView.saveChanges()
+
         if (manageTokensView.advancedTabVisible) {
-            // Save changes only when tab is active
-            manageTokensView.saveChanges()
+            // don't emit toasts when the Advanced tab is visible
             return
         }
 


### PR DESCRIPTION
### What does the PR do

- we _always_ want to save the changes, it's the toasts that we don't want to see when looking at the Advanced tab

Fixes #14016

### Affected areas

Settings/Wallet/Manage tokens

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-18 19-01-24.webm](https://github.com/status-im/status-desktop/assets/5377645/e9d3086f-c714-4295-88c0-a8ee4603964f)

