### PR TITLE
fix(permissions): Unable to Confirm Changes to Existing Community Permission

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
@@ -198,12 +198,12 @@ StackView {
                     return false
                 }
 
-                permissionTypeLimitReached: {
+                readonly property var permissionTypeLimitReachedOrExceeded: {
                     const type = dirtyValues.permissionType
                     const limit = PermissionTypes.getPermissionsCountLimit(type)
 
                     if (limit === -1)
-                        return false
+                        return [false, false]
 
                     const model = root.permissionsModel
                     const count = model.rowCount()
@@ -213,8 +213,11 @@ StackView {
                         if (type === ModelUtils.get(model, i, "permissionType"))
                             sameTypeCount++
 
-                    return limit <= sameTypeCount
+                    return [sameTypeCount >= limit, sameTypeCount > limit]
                 }
+
+                permissionTypeLimitReached: permissionTypeLimitReachedOrExceeded[0]
+                permissionTypeLimitExceeded: permissionTypeLimitReachedOrExceeded[1]
 
                 onCreatePermissionClicked: {
                     const holdings = dirtyValues.holdingsRequired ?

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -28,7 +28,7 @@ StatusScrollView {
 
     readonly property bool saveEnabled: root.isFullyFilled
                      && !root.permissionDuplicated
-                     && !root.permissionTypeLimitReached
+                     && (isEditState ? !root.permissionTypeLimitExceeded : !root.permissionTypeLimitReached)
 
     property int viewWidth: 560 // by design
     property bool isEditState: false
@@ -59,6 +59,7 @@ StatusScrollView {
 
     property bool permissionDuplicated: false
     property bool permissionTypeLimitReached: false
+    property bool permissionTypeLimitExceeded
 
     signal createPermissionClicked
     signal navigateToMintTokenSettings(bool isAssetType)
@@ -119,8 +120,7 @@ StatusScrollView {
             property bool holdingsRequired: true
 
             Binding on isPrivate {
-                value: (d.dirtyValues.permissionType === PermissionTypes.Type.Admin) ||
-                       (d.dirtyValues.permissionType === PermissionTypes.Type.Moderator)
+                value: d.dirtyValues.permissionType === PermissionTypes.Type.Admin
             }
 
             function getHoldingIndex(key) {
@@ -404,17 +404,17 @@ StatusScrollView {
                 leftPadding: 6
 
                 Binding on bgColor {
-                    when: root.permissionTypeLimitReached
+                    when: root.permissionTypeLimitReached && !root.isEditState
                     value: Theme.palette.dangerColor3
                 }
 
                 Binding on titleText.color {
-                    when: root.permissionTypeLimitReached
+                    when: root.permissionTypeLimitReached && !root.isEditState
                     value: Theme.palette.dangerColor1
                 }
 
                 Binding on asset.color {
-                    when: root.permissionTypeLimitReached
+                    when: root.permissionTypeLimitReached && !root.isEditState
                     value: Theme.palette.dangerColor1
                 }
 
@@ -603,7 +603,7 @@ StatusScrollView {
                 return ""
             }
 
-            visible: root.permissionDuplicated || root.permissionTypeLimitReached
+            visible: root.permissionDuplicated || (root.permissionTypeLimitReached && !root.isEditState)
         }
 
         StatusWarningBox {


### PR DESCRIPTION
### What does the PR do

- distinguish between `permissionTypeLimitReached` and the new `permissionTypeLimitExceeded`
- the latter is used to enable/disable the "Save" button when editting the permissions as we're not going to add a new one (going over the limit), and to also hide the warning texts

Fixes #13989

### Affected areas

PermissionsSettingsPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-18 18-32-49.webm](https://github.com/status-im/status-desktop/assets/5377645/3990511d-9e8e-4a04-9183-9a5509e630b8)
