### PR TITLE
fix(chat_section): fix changing active chat on leaving another group chat

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -738,7 +738,6 @@ method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   self.view.chatsModel().removeItemById(chatId)
   self.removeSubmodule(chatId)
 
-  # check if the currently active chat has been deleted
   let activeChatId = self.controller.getActiveChatId()
   if chatId == activeChatId:
     self.setFirstChannelAsActive()

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -738,7 +738,10 @@ method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   self.view.chatsModel().removeItemById(chatId)
   self.removeSubmodule(chatId)
 
-  self.setFirstChannelAsActive()
+  # check if the currently active chat has been deleted
+  let activeChatId = self.controller.getActiveChatId()
+  if chatId == activeChatId:
+    self.setFirstChannelAsActive()
 
 proc refreshHiddenBecauseNotPermittedState(self: Module) =
   self.view.refreshAllChannelsAreHiddenBecauseNotPermittedChanged()


### PR DESCRIPTION
Fixes #9147

### What does the PR do
when handling SIGNAL_CHAT_LEFT and SIGNAL_COMMUNITY_CHANNEL_DELETED signals
the currently active chat will be kept as active if another chat has been deleted

### Affected areas

chat_section

### StatusQ checklist
no UI changes

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/0e300696-5b35-41df-9f93-3ef0df1f53c1
