### PR TITLE
fix(@desktop/wallet): Fix link out to blockchain explorer from collectibles details view

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -60,7 +60,7 @@ QtObject {
     property CollectiblesStore collectiblesStore: CollectiblesStore {}
 
     readonly property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
-    readonly property bool isGoerliEnabled: networksModule.isGoerliEnabled
+    readonly property bool isGoerliEnabled: profileSectionModule.walletModule.networksModule.isGoerliEnabled
 
     property var savedAddresses: SortFilterProxyModel {
         sourceModel: walletSectionSavedAddresses.model
@@ -488,16 +488,39 @@ QtObject {
         return root.mainModuleInst.addressWasShown(address)
     }
 
-    function getExplorerUrl() {
+    function getExplorerUrl(networkShortName, contractAddress, tokenId) {
         let link = Constants.networkExplorerLinks.etherscan
-        if (root.areTestNetworksEnabled) {
-            if (root.isGoerliEnabled) {
-                link = Constants.networkExplorerLinks.goerliEtherscan
-            } else {
-                link = Constants.networkExplorerLinks.sepoliaEtherscan
+        if (networkShortName === Constants.networkShortChainNames.mainnet) {
+            if (root.areTestNetworksEnabled) {
+                if (!root.isGoerliEnabled) {
+                    link = Constants.networkExplorerLinks.sepoliaEtherscan
+                } else {
+                    link = Constants.networkExplorerLinks.goerliEtherscan
+                }
             }
+            return "%1/nft/%2/%3".arg(link).arg(contractAddress).arg(tokenId)
         }
-        return link
+        if (networkShortName === Constants.networkShortChainNames.arbitrum) {
+            link = Constants.networkExplorerLinks.arbiscan
+            if (root.areTestNetworksEnabled) {
+                if (!root.isGoerliEnabled) {
+                    link = Constants.networkExplorerLinks.sepoliaArbiscan
+                } else {
+                    link = Constants.networkExplorerLinks.goerliArbiscan
+                }
+            }
+            return "%1/token/%2?a=%3".arg(link).arg(contractAddress).arg(tokenId)
+        } else if (networkShortName === Constants.networkShortChainNames.optimism) {
+            link = Constants.networkExplorerLinks.optimism
+            if (root.areTestNetworksEnabled) {
+                if (!root.isGoerliEnabled) {
+                    link = Constants.networkExplorerLinks.sepoliaOptimism
+                } else {
+                    link = Constants.networkExplorerLinks.goerliOptimism
+                }
+            }
+            return "%1/token/%2?a=%3".arg(link).arg(contractAddress).arg(tokenId)
+        }
     }
 
     function getExplorerNameForNetwork(networkShortName)  {

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
@@ -62,7 +62,7 @@ Item {
             /* TODO add link out to opensea
             https://github.com/status-im/status-desktop/issues/13918 */
         }
-        onOpenCollectibleOnExplorer: Global.openLink("%1/nft/%2/%3".arg(root.walletRootStore.getExplorerUrl()).arg(collectible.contractAddress).arg(collectible.tokenId))
+        onOpenCollectibleOnExplorer: Global.openLink(root.walletRootStore.getExplorerUrl(collectible.networkShortName, collectible.contractAddress, collectible.tokenId))
     }
 
     ColumnLayout {


### PR DESCRIPTION
fix(@desktop/wallet): Fix link out to blockchain explorer from collectibles details view

### What does the PR do

Fixes the url to link out to a blockchain explorer from the collectible detailsview

### Affected areas

CollectibleDetailsView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Mainnet linkout


https://github.com/status-im/status-desktop/assets/60327365/9e6925c3-1690-4e2d-8d4f-5a3facd181d9

Testnet linkout

https://github.com/status-im/status-desktop/assets/60327365/c070935e-d03e-473b-8e75-94b53b95d7ac







