### PR TITLE
Chore/add object name activity center

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
@@ -40,6 +40,7 @@ StatusFlatRoundButton {
     icon.name: "notification"
     icon.height: 21
     type: StatusFlatRoundButton.Type.Secondary
+    objectName: "activityCenterNotificationsButton"
 
     // initializing the tooltip
     tooltip.text: qsTr("Notifications")

--- a/ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
+++ b/ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
@@ -60,6 +60,7 @@ Item {
                              { text: qsTr("System"), group: ActivityCenterStore.ActivityCenterGroup.System, visible: false, enabled: true } ]
 
                     StatusFlatButton {
+                        objectName: "activityCenterGroupButton"
                         enabled: modelData.enabled
                         visible: modelData.visible
                         text: modelData.text
@@ -75,6 +76,7 @@ Item {
 
         StatusFlatRoundButton {
             id: markAllReadBtn
+            objectName: "markAllReadButton"
             enabled: root.unreadNotificationsCount > 0
             icon.name: "double-checkmark"
             onClicked: root.markAllReadClicked()
@@ -87,6 +89,7 @@ Item {
 
         StatusFlatRoundButton {
             id: hideReadNotificationsBtn
+            objectName: "hideReadNotificationsButton"
             icon.name: root.hideReadNotifications ? "hide" : "show"
             onClicked: root.showHideReadNotifications(!root.hideReadNotifications)
 


### PR DESCRIPTION
### What does the PR do

Added object names for some activity center elements

### Affected areas

ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
