### PR TITLE
remove warningAsError unusedImport attempt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,6 @@ $(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSG
 		--passL:"-lm" \
 		--warning:UnreachableElse:off \
 		--warningAsError:UseBase:on \
-		--warningAsError:UnusedImport:on \
 		$(NIM_EXTRA_PARAMS) src/nim_status_client.nim
 ifeq ($(detected_OS),Darwin)
 	install_name_tool -change \

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -1,5 +1,5 @@
 import chronicles, tables, strutils, sequtils, stint
-import uuids, sets, sugar
+import uuids
 import io_interface
 
 import app/global/app_sections_config as conf


### PR DESCRIPTION
`--warningAsError:UnusedImport:on` makes all `[UnusedImport]` warnings just disappear.  Looks like a Nim bug.
We want this `--warningAsError` flag, but right now it makes things even worse.

cc @arnetheduck 

