### PR TITLE
fix(TokenManagement): Asset balance threshold value not reflected in main wallet view

### DIFF
--- a/src/app/modules/main/wallet_section/all_tokens/view.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/view.nim
@@ -203,8 +203,14 @@ QtObject:
   proc getDisplayAssetsBelowBalanceThreshold(self: View): QVariant {.slot.} =
     return newQVariant(self.delegate.getDisplayAssetsBelowBalanceThreshold())
 
-  proc setDisplayAssetsBelowBalanceThreshold(self: View, threshold: int) {.slot.} =
-    if not self.delegate.setDisplayAssetsBelowBalanceThreshold(int64(threshold)):
+  proc setDisplayAssetsBelowBalanceThreshold(self: View, threshold: string) {.slot.} =
+    var num: int64
+    try:
+      num = parseInt(threshold)
+    except ValueError:
+      error "Failed to parse displayAssetsBelowBalanceThreshold"
+      return
+    if not self.delegate.setDisplayAssetsBelowBalanceThreshold(num):
       error "Failed to set displayAssetsBelowBalanceThreshold"
       return
     self.displayAssetsBelowBalanceThresholdChanged()

--- a/storybook/src/Models/GroupedAccountsAssetsModel.qml
+++ b/storybook/src/Models/GroupedAccountsAssetsModel.qml
@@ -8,7 +8,7 @@ ListModel {
             tokensKey: "DAI",
             balances: [
                 { account: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", chainId: 5, balance: "0"},
-                { account: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", chainId: 5, balance: "0"}
+                { account: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", chainId: 5, balance: "123456789123456789"}
             ]
         },
         {

--- a/storybook/stubs/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/storybook/stubs/AppLayouts/Wallet/stores/TokensStore.qml
@@ -2,4 +2,7 @@ import QtQuick 2.15
 
 QtObject {
     id: root
+
+    property bool displayAssetsBelowBalance: false
+    property var getDisplayAssetsBelowBalanceThresholdDisplayAmount
 }

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -173,7 +173,7 @@ Item {
 
                 property bool dirty: false
 
-                property var thresholdCurrency: root.tokensStore.getDisplayAssetsBelowBalanceThresholdCurrency()
+                readonly property var thresholdCurrency: root.tokensStore.getDisplayAssetsBelowBalanceThresholdCurrency()
 
                 spacing: 8
                 StatusListItem {

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -149,6 +149,7 @@ RightTabBaseView {
                         overview: RootStore.overview
                         currencyStore: RootStore.currencyStore
                         networkConnectionStore: root.networkConnectionStore
+                        tokensStore: RootStore.tokensStore
                         assetDetailsLaunched: stack.currentIndex === 2
                         filterVisible: filterButton.checked
                         onAssetClicked: {

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -303,7 +303,7 @@ QtObject {
                     }
                     return 0
                 }
-                expectedRoles: ["marketDetails", "currentBalance", "symbol"]
+                expectedRoles: ["marketDetails", "currentBalance"]
             }
         ]
         filters: [
@@ -324,12 +324,17 @@ QtObject {
             },
             FastExpressionFilter {
                 expression: {
+                    root.walletAssetStore.assetsController.revision
+
+                    if (!root.walletAssetStore.assetsController.filterAcceptsSymbol(model.symbol)) // explicitely hidden
+                        return false
                     if (model.isCommunityAsset)
                         return true
-                    return model.currentCurrencyBalance > processedAssetsModel.displayAssetsBelowBalanceThresholdAmount
+                    if (tokensStore.displayAssetsBelowBalance)
+                        return model.currentCurrencyBalance > processedAssetsModel.displayAssetsBelowBalanceThresholdAmount
+                    return true
                 }
-                expectedRoles: ["isCommunityAsset", "currentCurrencyBalance"]
-                enabled: tokensStore.displayAssetsBelowBalance
+                expectedRoles: ["symbol", "isCommunityAsset", "currentCurrencyBalance"]
             }
         ]
         sorters: RoleSorter {


### PR DESCRIPTION
### What does the PR do

- take the balance threshold value into account when presenting the assets in the main wallet view
- additional fix from Emil for storing the threshold value
- storybook fixes to display the correct `currentCurrencyBalance` values based on the address/wallet filters and mocking the threshold values using TransactionStore

Needs: https://github.com/status-im/status-go/pull/4960
Fixes: #14017

### Affected areas

AssetsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-20 17-14-58.webm](https://github.com/status-im/status-desktop/assets/5377645/802d016e-4981-421a-9c1e-4871889137a4)
