### PR TITLE
fix(wallet): Add token data when new token is added

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -88,6 +88,8 @@ proc init*(self: Controller) =
     self.communityTokensModule.onOwnerTokenReceived(args.communityId, args.communityName, args.chainId, args.contractAddress)
   self.events.on(SIGNAL_COMMUNITY_TOKEN_RECEIVED) do(e: Args):
     let args = CommunityTokenReceivedArgs(e)
+    if args.isWatchOnlyAccount:
+      return
     self.communityTokensModule.onCommunityTokenReceived(args.name, args.symbol, args.image, args.communityId, args.communityName, $args.amount, args.chainId, args.txHash, args.isFirst, args.tokenType, args.accountName, args.accountAddress)
   self.events.on(SIGNAL_SET_SIGNER_STATUS) do(e: Args):
     let args = SetSignerArgs(e)

--- a/src/app/modules/main/wallet_section/all_tokens/controller.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/controller.nim
@@ -48,6 +48,19 @@ proc init*(self: Controller) =
     let args = TokenBalanceHistoryDataArgs(e)
     self.delegate.tokenBalanceHistoryDataResolved(args.result)
 
+  self.events.on(SIGNAL_COMMUNITY_TOKEN_RECEIVED) do(e: Args):
+    let args = CommunityTokenReceivedArgs(e)
+    let token = TokenDto(
+        address: args.address,
+        name: args.name,
+        symbol: args.symbol,
+        decimals: args.decimals,
+        chainID: args.chainId,
+        communityID: args.communityId,
+        image: args.image,
+    )
+    self.tokenService.addNewCommunityToken(token)
+
   self.tokenService.getSupportedTokensList()
 
 proc getHistoricalDataForToken*(self: Controller, symbol: string, currency: string, range: int) =

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -174,6 +174,7 @@ type
   CommunityTokenReceivedArgs* =  ref object of Args
     name*: string
     image*: string
+    address*: string
     collectibleId*: CollectibleUniqueID
     communityId*: string
     communityName*: string
@@ -181,25 +182,33 @@ type
     amount*: float64
     txHash*: string
     symbol*: string
+    decimals*: int
+    verified*: bool
+    tokenListID*: string
     isFirst*: bool
     tokenType*: int
     accountAddress*: string
     accountName*: string
+    isWatchOnlyAccount*: bool
 
 proc `$`*(self: CommunityTokenReceivedArgs): string =
   return fmt"""CommunityTokenReceivedArgs(
-    name: {self.name}
-    image: {self.image}
-    communityId: {self.communityId}
-    communityName: {self.communityName}
-    chainId: {self.chainId}
-    amount: {self.amount}
-    txHash: {self.txHash}
-    symbol: {self.symbol}
-    isFirst: {self.isFirst}
-    tokenType: {self.tokenType}
-    accountAddress: {self.accountAddress}
-    accountName: {self.accountName}
+    name: {self.name},
+    image: {self.image},
+    communityId: {self.communityId},
+    communityName: {self.communityName},
+    chainId: {self.chainId},
+    amount: {self.amount},
+    decimals: {self.decimals},
+    verified: {self.verified},
+    tokenListID: {self.tokenListID},
+    txHash: {self.txHash},
+    symbol: {self.symbol},
+    isFirst: {self.isFirst},
+    tokenType: {self.tokenType},
+    accountAddress: {self.accountAddress},
+    accountName: {self.accountName},
+    isWatchOnlyAccount: {self.isWatchOnlyAccount}
   )"""
 
 proc toTokenData*(self: CommunityTokenReceivedArgs): string =
@@ -413,10 +422,6 @@ QtObject:
         return
 
       let watchOnlyAccounts = self.walletAccountService.getWatchOnlyAccounts()
-      if any(watchOnlyAccounts, proc (x: WalletAccountDto): bool = x.address == accounts[0]):
-        # skip events on watch-only accounts
-        return
-
       var accountName, accountAddress: string
       if len(accounts) > 0:
         accountAddress = accounts[0]
@@ -429,14 +434,19 @@ QtObject:
         communityName: tokenDataPayload.communityName, 
         chainId: tokenDataPayload.chainId, 
         txHash: tokenDataPayload.txHash, 
+        address: "0x" & tokenDataPayload.address.toHex(),
         name: tokenDataPayload.name, 
         amount: tokenDataPayload.amount,
+        decimals: tokenDataPayload.decimals,
+        verified: tokenDataPayload.verified,
+        tokenListID: tokenDataPayload.tokenListID,
         image: tokenDataPayload.image,
         symbol: tokenDataPayload.symbol,
         isFirst: tokenDataPayload.isFirst,
         tokenType: int(TokenType.ERC20),
         accountAddress: accountAddress,
-        accountName: accountName
+        accountName: accountName,
+        isWatchOnlyAccount: any(watchOnlyAccounts, proc (x: WalletAccountDto): bool = x.address == accounts[0])
       )
       self.events.emit(SIGNAL_COMMUNITY_TOKEN_RECEIVED, tokenReceivedArgs)
       

--- a/src/backend/community_tokens_types.nim
+++ b/src/backend/community_tokens_types.nim
@@ -14,6 +14,9 @@ type
     symbol*: string
     image*: string
     chainId*: int
+    decimals*: int
+    verified*: bool
+    tokenListID*: string
     communityId*: string
     communityName*: string
     communityColor*: string
@@ -28,6 +31,9 @@ proc fromJson*(t: JsonNode, T: typedesc[CommunityTokenReceivedPayload]): Communi
   discard t.getProp("symbol", result.symbol)
   discard t.getProp("image", result.image)
   discard t.getProp("chainId", result.chainId)
+  discard t.getProp("decimals", result.decimals)
+  discard t.getProp("verified", result.verified)
+  discard t.getProp("tokenListID", result.tokenListID)
   discard t.getProp("txHash", result.txHash)
   discard t.getProp("isFirst", result.isFirst)
   discard t.getProp("amount", result.amount)

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -55,6 +55,7 @@ StatusListItem {
             return "▴"
         return ""
     }
+    readonly property bool isUndefined: modelData && !modelData.marketDetailsLoading && title === ""
 
     signal switchToCommunityRequested(string communityId)
 
@@ -65,6 +66,8 @@ StatusListItem {
     asset.width: 32
     asset.height: 32
     errorIcon.tooltip.maxWidth: 300
+    height: isUndefined ? 0 : implicitHeight
+    visible: !isUndefined
 
     statusListItemTitleIcons.sourceComponent: StatusFlatRoundButton {
         width: 14


### PR DESCRIPTION
Task: https://github.com/status-im/status-desktop/issues/13631

Status-go change: https://github.com/status-im/status-go/pull/4954

### What does the PR do

* Handle additional data passed for community token received event
* Added slot to add new token to token list. This list is refreshed only on startup, so it was missing data when new token was discovered
* Hide token where right side model has no data. It might be the case when data for left model is refreshed earlier than right side model

### Affected areas

Wallet token list

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/8e8d8501-30ba-4f66-8ca1-d811ddcbadff