### PR TITLE
chore: force some warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -546,9 +546,6 @@ $(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSG
 		--passL:"-lkeycard" \
 		--passL:"$(QRCODEGEN)" \
 		--passL:"-lm" \
-		--warning:UnreachableElse:off \
-		--warningAsError:UseBase:on \
-		--warningAsError:UnusedImport:on \
 		$(NIM_EXTRA_PARAMS) src/nim_status_client.nim
 ifeq ($(detected_OS),Darwin)
 	install_name_tool -change \

--- a/config.nims
+++ b/config.nims
@@ -48,3 +48,14 @@ switch("warning", "LockLevel:off")
 
 # No clean workaround for this warning in certain cases, waiting for better upstream support
 switch("warning", "BareExcept:off")
+
+# We assume this as a good practive to keep `else` even if all cases are covered
+switch("warning", "UnreachableElse:off")
+
+# Those are popular to miss in our app, and quickly make build log unreadable, so we want to prevent them
+switch("warningAsError", "UseBase:on")
+switch("warningAsError", "UnusedImport:on")
+
+# Workaround for https://github.com/nim-lang/Nim/issues/23429
+switch("warning", "UseBase:on")
+switch("warning", "UnusedImport:on")

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -1,5 +1,5 @@
 import chronicles, tables, strutils, sequtils, stint
-import uuids, sets, sugar
+import uuids
 import io_interface
 
 import app/global/app_sections_config as conf


### PR DESCRIPTION
### What does the PR do

1. Added a workaround to make `--warningAsError` work.
Context: https://github.com/nim-lang/Nim/issues/23429

2. Moved config parameters to `config.nims` 

3. Removed some unused imports.