### PR TITLE
Fix saved addresses in activity 13663

### DIFF
--- a/storybook/stubs/nim/sectionmocks/WalletSectionAccounts.qml
+++ b/storybook/stubs/nim/sectionmocks/WalletSectionAccounts.qml
@@ -10,13 +10,4 @@ Item {
     function getNameByAddress(address) {
         return "Name Mock " + address.substring(0, 5)
     }
-
-    //
-    // Silence warnings
-    readonly property QtObject overview: QtObject {
-        readonly property string mixedcaseAddress: ""
-    }
-    readonly property ListModel mixedcaseAddress: ListModel {}
-
-    signal walletAccountRemoved(string address)
 }

--- a/ui/app/AppLayouts/Wallet/panels/ActivityFilterPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ActivityFilterPanel.qml
@@ -192,9 +192,15 @@ Column {
 
         Repeater {
             model: activityFilterStore.recentsFilters
-            delegate: ActivityFilterTagItem {
-                tagPrimaryLabel.text: root.store.getNameForAddress(modelData) || StatusQUtils.Utils.elideText(modelData,6,4)
-                onClosed: activityFilterStore.toggleRecents(modelData)
+
+            // Use lazy loading as a workaround to refresh the list when the model is updated
+            // to force an address lookup to all delegates
+            delegate: Loader {
+                active: parent.visible
+                sourceComponent: ActivityFilterTagItem {
+                    tagPrimaryLabel.text: root.store.getNameForAddress(modelData) || StatusQUtils.Utils.elideText(modelData,6,4)
+                    onClosed: activityFilterStore.toggleRecents(modelData)
+                }
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -2,7 +2,8 @@ pragma Singleton
 
 import QtQuick 2.13
 
-import shared.stores 1.0
+// Aliasing not to conflict with the shared.stores.RootStore
+import shared.stores 1.0 as Stores
 
 import utils 1.0
 
@@ -482,7 +483,7 @@ QtObject {
         walletSectionAccounts.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
     }
 
-    property CurrenciesStore currencyStore: CurrenciesStore {}   
+    property Stores.CurrenciesStore currencyStore: Stores.CurrenciesStore {}
 
     function addressWasShown(address) {
         return root.mainModuleInst.addressWasShown(address)

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -73,6 +73,7 @@ RightTabBaseView {
             readonly property var detailedCollectibleActivityController: RootStore.tmpActivityController0
         }
 
+        // StackLayout.currentIndex === 0
         ColumnLayout {
             spacing: 0
 
@@ -263,27 +264,30 @@ RightTabBaseView {
             }
         }
 
-        TransactionDetailView {
-            id: transactionDetailView
-            controller: RootStore.activityDetailsController
-            onVisibleChanged: {
-                if (visible) {
-                    if (!!transaction) {
-                        RootStore.addressWasShown(transaction.sender)
-                        if (transaction.sender !== transaction.recipient) {
-                            RootStore.addressWasShown(transaction.recipient)
+        Loader {
+            active: stack.currentIndex === 3
+
+            sourceComponent: TransactionDetailView {
+                controller: RootStore.activityDetailsController
+                onVisibleChanged: {
+                    if (visible) {
+                        if (!!transaction) {
+                            RootStore.addressWasShown(transaction.sender)
+                            if (transaction.sender !== transaction.recipient) {
+                                RootStore.addressWasShown(transaction.recipient)
+                            }
                         }
+                    } else {
+                        controller.resetActivityEntry()
                     }
-                } else {
-                    controller.resetActivityEntry()
                 }
+                showAllAccounts: RootStore.showAllAccounts
+                communitiesStore: root.communitiesStore
+                sendModal: root.sendModal
+                contactsStore: root.contactsStore
+                networkConnectionStore: root.networkConnectionStore
+                visible: (stack.currentIndex === 3)
             }
-            showAllAccounts: RootStore.showAllAccounts
-            communitiesStore: root.communitiesStore
-            sendModal: root.sendModal
-            contactsStore: root.contactsStore
-            networkConnectionStore: root.networkConnectionStore
-            visible: (stack.currentIndex === 3)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -299,7 +299,7 @@ Item {
                         width: parent.width
                         title: d.transactionType === Constants.TransactionType.Swap || d.transactionType === Constants.TransactionType.Bridge ?
                                    qsTr("In") : qsTr("From")
-                        addresses: d.isTransactionValid && d.reEvaluateSender? [d.transaction.from] : []
+                        addresses: d.isTransactionValid && d.reEvaluateSender? [d.transaction.sender] : []
                         contactsStore: root.contactsStore
                         rootStore: WalletStores.RootStore
                         onButtonClicked: {
@@ -342,7 +342,7 @@ Item {
                     TransactionAddressTile {
                         width: parent.width
                         title: qsTr("To")
-                        addresses: d.isTransactionValid && visible && d.reEvaluateRecipient? [d.transaction.to] : []
+                        addresses: d.isTransactionValid && visible && d.reEvaluateRecipient? [d.transaction.recipient] : []
                         contactsStore: root.contactsStore
                         rootStore: WalletStores.RootStore
                         onButtonClicked: addressMenu.openReceiverMenu(this, addresses[0], [d.networkShortName])


### PR DESCRIPTION
### Closes #13663

Refresh recipients in menu for activity filter

- [ ] cherry pick fix for to/from on the release branch

Also

- fix namespace clash in wallet RootStore
- lazy load `TransactionDetailView`
- wrong properties referenced in `TransactionDetailView`