### PR TITLE
ci: fix left lock file issue

### DIFF
--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -118,7 +118,9 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+    }
   }
 }
 


### PR DESCRIPTION
When build is cancelled during the checkout phase - cleanWs doesn't clean the workspace.
What's even worse - next build will fail due to  left git lock files.

See https://github.com/status-im/status-desktop/pull/13910