### PR TITLE
(CHERRY-PICK) fix: open activity center mentions messages (#14075)

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -10,7 +10,6 @@ import ../../../../../../app_service/service/mailservers/service as mailservers_
 import ../../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../../../app_service/service/shared_urls/service as shared_urls_service
 import ../../../../../../app_service/common/types
-import ../../../../../global/app_signals
 import ../../../../../core/eventemitter
 import ../../../../../core/unique_event_emitter
 
@@ -204,12 +203,6 @@ proc init*(self: Controller) =
     if(self.chatId != args.chatId):
       return
     self.delegate.onHistoryCleared()
-
-  self.events.on(SIGNAL_MAKE_SECTION_CHAT_ACTIVE) do(e: Args):
-    let args = ActiveSectionChatArgs(e)
-    if(self.sectionId != args.sectionId or self.chatId != args.chatId):
-      return
-    self.delegate.scrollToMessage(args.messageId)
 
   self.events.on(SIGNAL_CHAT_MEMBER_UPDATED) do(e: Args):
     let args = ChatMemberUpdatedArgs(e)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1549,6 +1549,6 @@ method communityContainsChat*(self: Module, chatId: string): bool =
   return self.chatContentModules.hasKey(chatId)
 
 method openCommunityChatAndScrollToMessage*(self: Module, chatId: string, messageId: string) =
-  self.delegate.setActiveSectionById(self.getMySectionId())
-  self.setActiveItem(chatId)
-  self.chatContentModules[chatId].scrollToMessage(messageId)
+  if chatId in self.chatContentModules:
+    self.setActiveItem(chatId)
+    self.chatContentModules[chatId].scrollToMessage(messageId)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -148,7 +148,7 @@ method emitMailserverWorking*(self: AccessInterface) {.base.} =
 method emitMailserverNotWorking*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method activeSectionSet*(self: AccessInterface, sectionId: string) {.base.} =
+method activeSectionSet*(self: AccessInterface, sectionId: string, skipSavingInSettings: bool = false) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method toggleSection*(self: AccessInterface, sectionType: SectionType) {.base.} =
@@ -419,6 +419,9 @@ method addressWasShown*(self: AccessInterface, address: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method checkIfAddressWasCopied*(self: AccessInterface, value: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method openSectionChatAndMessage*(self: AccessInterface, sectionId: string, chatId: string, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -821,7 +821,7 @@ method setActiveSection*[T](self: Module[T], item: SectionItem, skipSavingInSett
   if(item.isEmpty()):
     echo "section is empty and cannot be made as active one"
     return
-  self.controller.setActiveSection(item.id, skipSavingInSettings)
+  self.activeSectionSet(item.id, skipSavingInSettings)
 
 method setActiveSectionById*[T](self: Module[T], id: string) =
   let item = self.view.model().getItemById(id)
@@ -836,7 +836,7 @@ proc notifySubModulesAboutChange[T](self: Module[T], sectionId: string) =
 
   # If there is a need other section may be notified the same way from here...
 
-method activeSectionSet*[T](self: Module[T], sectionId: string) =
+method activeSectionSet*[T](self: Module[T], sectionId: string, skipSavingInSettings: bool = false) =
   if self.view.activeSection.getId() == sectionId:
     return
   let item = self.view.model().getItemById(sectionId)
@@ -854,6 +854,9 @@ method activeSectionSet*[T](self: Module[T], sectionId: string) =
 
   self.view.model().setActiveSection(sectionId)
   self.view.activeSectionSet(item)
+
+  if not skipSavingInSettings:
+    singletonInstance.localAccountSensitiveSettings.setActiveSection(sectionId)
 
   self.notifySubModulesAboutChange(sectionId)
 
@@ -1635,6 +1638,10 @@ method checkIfAddressWasCopied*[T](self: Module[T], value: string) =
   if walletAcc.isNil:
     return
   self.addressWasShown(value)
+
+method openSectionChatAndMessage*[T](self: Module[T], sectionId: string, chatId: string, messageId: string) =
+  if sectionId in self.channelGroupModules:
+    self.channelGroupModules[sectionId].openCommunityChatAndScrollToMessage(chatId, messageId)
 
 proc createMemberItem*[T](self: Module[T], memberId: string, state: MembershipRequestState, role: MemberRole): MemberItem =
   let contactDetails = self.controller.getContactDetails(memberId)


### PR DESCRIPTION
### What does the PR do

During clicking on AC mention message
- open section
- open chat
- scroll and highlight the message

Closes: https://github.com/status-im/status-desktop/issues/14063

### Affected areas

- selecting the section
- storing the last visited section
- opening the necessary chat and scrolling to the message