### PR TITLE
fix: draw community select bubble after community create (CHERRY-PICK)

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -500,6 +500,9 @@ proc getChannelGroups*(self: Controller): seq[ChannelGroupDto] =
 proc getActiveSectionId*(self: Controller): string =
   result = self.activeSectionId
 
+proc setActiveSectionId*(self: Controller, sectionId: string) =
+  self.activeSectionId = sectionId
+
 proc getAllChats*(self: Controller): seq[ChatDto] =
   result = self.chatService.getAllChats()
 
@@ -593,4 +596,3 @@ proc asyncGetRevealedAccountsForAllMembers*(self: Controller, communityId: strin
 
 proc asyncReevaluateCommunityMembersPermissions*(self: Controller, communityId: string) =
   self.communityService.asyncReevaluateCommunityMembersPermissions(communityId)
-

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -821,6 +821,7 @@ method setActiveSection*[T](self: Module[T], item: SectionItem, skipSavingInSett
   if(item.isEmpty()):
     echo "section is empty and cannot be made as active one"
     return
+  self.controller.setActiveSectionId(item.id)
   self.activeSectionSet(item.id, skipSavingInSettings)
 
 method setActiveSectionById*[T](self: Module[T], id: string) =


### PR DESCRIPTION
### What does the PR do

Fix community selection bubble display in sections panel after creating the community
