### PR TITLE
chore: object names added for wallet right tab buttons and filter button

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -96,15 +96,18 @@ RightTabBaseView {
                     Layout.topMargin: Style.current.padding
 
                     StatusTabButton {
+                        objectName: "assetsTabButton"
                         leftPadding: 0
                         width: implicitWidth
                         text: qsTr("Assets")
                     }
                     StatusTabButton {
+                        objectName: "collectiblesTabButton"
                         width: implicitWidth
                         text: qsTr("Collectibles")
                     }
                     StatusTabButton {
+                        objectName: "activityTabButton"
                         rightPadding: 0
                         width: implicitWidth
                         text: qsTr("Activity")
@@ -116,6 +119,7 @@ RightTabBaseView {
                 StatusFlatButton {
                     Layout.alignment: Qt.AlignTop
                     id: filterButton
+                    objectName: "filterButton"
                     icon.name: "filter"
                     checkable: true
                     icon.color: checked ? Theme.palette.primaryColor1 : Theme.palette.baseColor1

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -194,6 +194,7 @@ ColumnLayout {
 
             SortOrderComboBox {
                 id: cmbTokenOrder
+                objectName: "cmbTokenOrder"
                 hasCustomOrderDefined: root.controller.hasSettings
                 model: [
                     { value: SortOrderComboBox.TokenOrderCurrencyBalance, text: qsTr("Asset balance value"), icon: "token-sale", sortRoleName: "currentCurrencyBalance" }, // custom SFPM ExpressionRole on "enabledNetworkCurrencyBalance" amount


### PR DESCRIPTION
### What does the PR do

Add object names for wallet right tab view

### Affected areas

ui/app/AppLayouts/Wallet/views/RightTabView.qml
ui/imports/shared/views/AssetsView.qml