### PR TITLE
fix[StatusChatMenu]: updated menu options as per designs

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusAction.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusAction.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml
+++ b/ui/imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import utils 1.0
 
@@ -29,6 +29,11 @@ StatusMenu {
     StatusAction {
         text: qsTr("For 8 hours")
         onTriggered: muteTriggered(Constants.MutingVariations.For8hr)
+    }
+
+    StatusAction {
+        text: qsTr("For 24 hours")
+        onTriggered: muteTriggered(Constants.MutingVariations.For24hr)
     }
 
     StatusAction {

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -55,6 +55,15 @@ StatusMenu {
     }
 
     StatusAction {
+        text: qsTr("View Members")
+        icon.name: "group-chat"
+        enabled: root.chatType === Constants.chatType.privateGroupChat
+        onTriggered: {
+            localAccountSensitiveSettings.expandUsersList = !localAccountSensitiveSettings.expandUsersList;
+        }
+    }
+
+    StatusAction {
         text: root.amIChatAdmin ? qsTr("Add / remove from group") : qsTr("Add to group")
         icon.name: "add-to-dm"
         enabled: (root.chatType === Constants.chatType.privateGroupChat)
@@ -92,6 +101,7 @@ StatusMenu {
     Component {
         id: renameGroupPopupComponent
         RenameGroupPopup {
+            destroyOnClose: true
             onUpdateGroupChatDetails: {
                 root.updateGroupChatDetails(root.chatId, groupName, groupColor, groupImage)
                 close()
@@ -126,7 +136,16 @@ StatusMenu {
         }
     }
 
-    
+    StatusAction {
+        objectName: "editChannelMenuItem"
+        text: qsTr("Edit Channel")
+        icon.name: "edit"
+        enabled: root.isCommunityChat && root.amIChatAdmin
+        onTriggered: {
+            root.displayEditChannelPopup(root.chatId);
+        }
+    }
+
     StatusMenu {
         title: qsTr("Debug actions")
         enabled: root.showDebugOptions
@@ -148,16 +167,6 @@ StatusMenu {
     }
 
     StatusAction {
-        objectName: "editChannelMenuItem"
-        text: qsTr("Edit Channel")
-        icon.name: "edit"
-        enabled: root.isCommunityChat && root.amIChatAdmin
-        onTriggered: {
-            root.displayEditChannelPopup(root.chatId);
-        }
-    }
-
-    StatusAction {
         text: qsTr("Download")
         enabled: localAccountSensitiveSettings.downloadChannelMessagesEnabled
         icon.name: "download"
@@ -165,15 +174,16 @@ StatusMenu {
     }
 
     StatusMenuSeparator {
-        visible: clearHistoryMenuItem.enabled || deleteOrLeaveMenuItem.enabled
+        visible: clearHistoryGroupMenuItem.enabled || deleteOrLeaveMenuItem.enabled
     }
 
     StatusAction {
-        id: clearHistoryMenuItem
-        objectName: "clearHistoryMenuItem"
+        id: clearHistoryGroupMenuItem
+        objectName: "clearHistoryGroupMenuItem"
+        enabled: (root.chatType !== Constants.chatType.oneToOne)
         text: qsTr("Clear History")
-        icon.name: "close-circle"
-        type: deleteOrLeaveMenuItem.enabled ? StatusAction.Type.Normal : StatusAction.Type.Danger
+        icon.name: "delete"
+        type: StatusAction.Type.Danger
         onTriggered: {
             Global.openPopup(clearChatConfirmationDialogComponent);
         }
@@ -193,7 +203,7 @@ StatusMenu {
                         qsTr("Close Chat") :
                         qsTr("Leave Chat")
         }
-        icon.name: root.chatType === Constants.chatType.oneToOne || root.isCommunityChat ? "delete" : "arrow-left"
+        icon.name: root.chatType === Constants.chatType.oneToOne || root.isCommunityChat ? "close-circle" : "arrow-left"
         icon.width: root.chatType === Constants.chatType.oneToOne || root.isCommunityChat ? 18 : 14
 
         type: StatusAction.Type.Danger
@@ -206,6 +216,18 @@ StatusMenu {
         }
 
         enabled: !root.isCommunityChat || root.amIChatAdmin
+    }
+
+    StatusAction {
+        id: clearHistoryMenuItem
+        objectName: "clearHistoryMenuItem"
+        enabled: (root.chatType === Constants.chatType.oneToOne)
+        text: qsTr("Clear History")
+        icon.name: "delete"
+        type: StatusAction.Type.Danger
+        onTriggered: {
+            Global.openPopup(clearChatConfirmationDialogComponent);
+        }
     }
 
     FileDialog {
@@ -226,8 +248,8 @@ StatusMenu {
         ConfirmationDialog {
             confirmButtonObjectName: "clearChatConfirmationDialogClearButton"
             headerSettings.title: qsTr("Clear chat history")
-            confirmationText: qsTr("Are you sure you want to clear chat history for <b>%1</b>?").arg(root.chatName)
-            confirmButtonLabel: qsTr("Clear")
+            confirmationText: qsTr("Are you sure you want to clear your chat history with <b>%1</b>? All messages will be deleted on your side and will be unrecoverable.").arg(root.chatName)
+            confirmButtonLabel: qsTr("Clear chat history")
             showCancelButton: true
             cancelBtnType: "normal"
 
@@ -278,7 +300,7 @@ StatusMenu {
             confirmButtonLabel: root.isCommunityChat ? qsTr("Delete") : headerSettings.title
             confirmationText: root.isCommunityChat ? qsTr("Are you sure you want to delete #%1 channel?").arg(root.chatName) :
                                                 root.chatType === Constants.chatType.oneToOne ?
-                                                qsTr("Are you sure you want to close this chat?"):
+                                                qsTr("Are you sure you want to close this chat? This will remove the chat from the list. Your chat history will be retained and shown the next time you message each other."):
                                                 qsTr("Are you sure you want to leave this chat?")
             showCancelButton: true
             cancelBtnType: "normal"

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1385,7 +1385,8 @@ QtObject {
         For1week = 4,
         TillUnmuted = 5,
         For1min = 6,
-        Unmuted = 7
+        Unmuted = 7,
+        For24hr = 8
     }
 
     enum LinkPreviewType {


### PR DESCRIPTION
The "Delete my messages for viola.stateofus.eth" option is not yet supported, TBD [here](https://github.com/status-im/status-desktop/issues/14169).
Fetching messages for specific timeframes TBD [here](https://github.com/status-im/status-desktop/issues/14312)
Leaving and deleting group when being the owner TBD [here](https://github.com/status-im/status-desktop/issues/14311)

Closes #13393 
Depends on https://github.com/status-im/status-go/pull/5813

### What does the PR do
StatusChatMenu: updated menu options as per designs

### Affected areas
StatusChatMenu

### Screenshot of functionality (including design for comparison)

1-1 chat:
![image](https://github.com/user-attachments/assets/79cedaff-5724-4958-8ee5-36a31cb96c76)

Group chat:
![image](https://github.com/user-attachments/assets/fdb61338-ca03-4aa1-a366-627f6cd018d1)

Community chat, admin:
![image](https://github.com/user-attachments/assets/13d9e23a-b32a-4c4e-abe3-37a5861166b6)

Community chat, non-admin:
![image](https://github.com/user-attachments/assets/074ef7c8-344c-4533-905a-cd604a3987e0)

