### PR TITLE
(desktop) Implement collapsed categories

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -184,6 +184,12 @@ proc init*(self: Controller) =
       self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
   if (self.isCommunitySection):
+    self.events.on(SIGNAL_COMMUNITY_CATEGORY_COLLAPSED_TOGGLED) do(e: Args):
+      let args = CommunityCategoryCollapsedArgs(e)
+
+      if (args.communityId == self.sectionId):
+        self.delegate.onToggleCollapsedCommunityCategory(args.categoryId, args.collapsed)
+
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
       let belongsToCommunity = args.chat.communityId.len > 0
@@ -690,6 +696,9 @@ proc shareCommunityToUsers*(self: Controller, pubKeys: string, inviteMessage: st
 
 proc reorderCommunityCategories*(self: Controller, categoryId: string, position: int) =
   self.communityService.reorderCommunityCategories(self.sectionId, categoryId, position)
+
+proc toggleCollapsedCommunityCategory*(self: Controller, categoryId: string, collapsed: bool) =
+  self.communityService.toggleCollapsedCommunityCategory(self.sectionId, categoryId, collapsed)
 
 proc reorderCommunityChat*(self: Controller, categoryId: string, chatId: string, position: int) =
   self.communityService.reorderCommunityChat(self.sectionId, categoryId, chatId, position)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -312,6 +312,12 @@ method prepareEditCategoryModel*(self: AccessInterface, categoryId: string) {.ba
 method reorderCommunityCategories*(self: AccessInterface, categoryId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method toggleCollapsedCommunityCategory*(self: AccessInterface, categoryId: string, collapsed: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onToggleCollapsedCommunityCategory*(self: AccessInterface, categoryId: string, collapsed: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method reorderCommunityChat*(self: AccessInterface, categoryId: string, chatId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -277,6 +277,7 @@ proc addCategoryItem(self: Module, category: Category, memberRole: MemberRole, c
         viewOnlyPermissionsSatisfied = true,
         viewAndPostPermissionsSatisfied = true
       )
+
   if insertIntoModel:
     self.view.chatsModel().appendItem(result)
 
@@ -679,20 +680,18 @@ proc addNewChat(
       memberRole = community.memberRole
 
   var categoryOpened = true
+
   if chatDto.categoryId != "":
-    let categoryItem = self.view.chatsModel.getItemById(chatDto.categoryId)
-    categoryOpened = categoryItem.categoryOpened
-    if channelGroup.id != "":
-      for category in channelGroup.categories:
-        if category.id == chatDto.categoryId:
-          categoryPosition = category.position
-          break
+    let category = self.controller.getCommunityCategoryDetails(self.controller.getMySectionId(), chatDto.categoryId)
+    if category.id == "":
+      error "No category found for chat", chatName=chatDto.name, categoryId=chatDto.categoryId
     else:
-      let category = self.controller.getCommunityCategoryDetails(self.controller.getMySectionId(), chatDto.categoryId)
-      if category.id == "":
-        error "No category found for chat", chatName=chatDto.name, categoryId=chatDto.categoryId
-      else:
-        categoryPosition = category.position
+      categoryOpened = category.categoryOpened
+      categoryPosition = category.position
+
+      # TODO: This call will update the model for each category in channels which is not
+      # preferable. Please fix-me in https://github.com/status-im/status-desktop/issues/14431
+      self.view.chatsModel().changeCategoryOpened(category.id, category.categoryOpened)
 
   result = chat_item.initItem(
     chatDto.id,
@@ -1364,6 +1363,12 @@ method reorderCommunityCategories*(self: Module, categoryId: string, categoryPos
     finalPosition = 0
 
   self.controller.reorderCommunityCategories(categoryId, finalPosition)
+
+method toggleCollapsedCommunityCategory*(self: Module, categoryId: string, collapsed: bool) =
+  self.controller.toggleCollapsedCommunityCategory(categoryId, collapsed)
+
+method onToggleCollapsedCommunityCategory*(self: Module, categoryId: string, collapsed: bool) =
+  self.view.chatsModel().changeCategoryOpened(categoryId, collapsed)
 
 method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, toPosition: int) =
   self.controller.reorderCommunityChat(categoryId, chatId, toPosition + 1)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -354,6 +354,9 @@ QtObject:
   proc reorderCommunityCategories*(self: View, categoryId: string, categoryPosition: int) {.slot} =
     self.delegate.reorderCommunityCategories(categoryId, categoryPosition)
 
+  proc toggleCollapsedCommunityCategory*(self: View, categoryId: string, collapsed: bool) {.slot} =
+    self.delegate.toggleCollapsedCommunityCategory(categoryId, collapsed)
+
   proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int) {.slot} =
     self.delegate.reorderCommunityChat(categoryId, chatId, position)
 

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -122,6 +122,9 @@ method communityImported*(self: AccessInterface, community: CommunityDto) {.base
 method communityDataImported*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method toggleCollapsedCommunityCategory*(self: AccessInterface, communityId:string, categoryId: string, collapsed: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method communityInfoRequestFailed*(self: AccessInterface, communityId: string, errorMsg: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -25,6 +25,7 @@ type Category* = object
   id*: string
   name*: string
   position*: int
+  categoryOpened*: bool
 
 type
   Permission* = object
@@ -217,6 +218,7 @@ proc toCategory*(jsonObj: JsonNode): Category =
     discard jsonObj.getProp("id", result.id)
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("position", result.position)
+  discard jsonObj.getProp("categoryOpened", result.categoryOpened)
 
 proc toChatMember*(jsonObj: JsonNode, memberId: string): ChatMember =
   # Parse status-go "Member" type

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -11,12 +11,14 @@ const asyncLoadCommunitiesDataTask: Task = proc(argEncoded: string) {.gcsafe, ni
     let responseCommunities = status_go.getAllCommunities()
     let responseSettings = status_go.getCommunitiesSettings()
     let responseNonApprovedRequestsToJoin = status_go.allNonApprovedCommunitiesRequestsToJoin()
+    let responseCollapsedCommunityCategories = status_go.collapsedCommunityCategories()
 
     arg.finish(%* {
       "tags": responseTags,
       "communities": responseCommunities,
       "settings": responseSettings,
       "nonAprrovedRequestsToJoin": responseNonApprovedRequestsToJoin,
+      "collapsedCommunityCategories": responseCollapsedCommunityCategories,
       "error": "",
     })
   except Exception as e:

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -408,6 +408,17 @@ proc editCommunityCategory*(
       "chatIds": channels
     }])
 
+proc toggleCollapsedCommunityCategory*(communityId: string, categoryId: string, collapsed: bool): RpcResponse[JsonNode] =
+  result = callPrivateRPC("toggleCollapsedCommunityCategory".prefix, %*[
+    {
+      "communityId": communityId,
+      "categoryId": categoryId,
+      "collapsed": collapsed
+    }])
+
+proc collapsedCommunityCategories*(): RpcResponse[JsonNode] =
+  result = callPrivateRPC("collapsedCommunityCategories".prefix, %*[])
+
 proc deleteCommunityCategory*(
     communityId: string,
     categoryId: string

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -32,6 +32,7 @@ Item {
     signal categoryReordered(string categoryId, int to)
     signal chatItemReordered(string categoryId, string chatId, int to)
     signal categoryAddButtonClicked(string id)
+    signal toggleCollapsedCommunityCategory(string categoryId, bool collapsed)
 
     StatusListView {
         id: statusChatListItems
@@ -146,10 +147,12 @@ Item {
                                 highlighted = true;
                                 categoryPopupMenuSlot.item.popup()
                             } else if (mouse.button === Qt.LeftButton) {
-                                root.model.sourceModel.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
+                                root.toggleCollapsedCommunityCategory(model.categoryId, !statusChatListCategoryItem.opened)
                             }
                         }
-                        onToggleButtonClicked: root.model.sourceModel.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
+                        onToggleButtonClicked: {
+                            root.toggleCollapsedCommunityCategory(model.categoryId, !statusChatListCategoryItem.opened)
+                        }
                         onMenuButtonClicked: {
                             statusChatListCategoryItem.setupPopup()
                             highlighted = true

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -29,6 +29,7 @@ Item {
     signal chatItemReordered(string categoryId, string chatId, int to)
     signal chatListCategoryReordered(string categoryId, int to)
     signal categoryAddButtonClicked(string id)
+    signal toggleCollapsedCommunityCategory(string categoryId, bool collapsed)
 
     MouseArea {
         id: sensor
@@ -53,6 +54,7 @@ Item {
             draggableItems: root.draggableItems
             showCategoryActionButtons: root.showCategoryActionButtons
             onCategoryAddButtonClicked: root.categoryAddButtonClicked(id)
+            onToggleCollapsedCommunityCategory: root.toggleCollapsedCommunityCategory(categoryId, collapsed)
 
             model: SortFilterProxyModel {
                 sourceModel: root.model

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -392,6 +392,10 @@ QtObject {
         chatCommunitySectionModule.reorderCommunityCategories(categoryId, to)
     }
 
+    function toggleCollapsedCommunityCategory(categoryId, collapsed) {
+        chatCommunitySectionModule.toggleCollapsedCommunityCategory(categoryId, collapsed)
+    }
+
     function reorderCommunityChat(categoryId, chatId, to) {
         chatCommunitySectionModule.reorderCommunityChat(categoryId, chatId, to)
     }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -200,6 +200,8 @@ Item {
                                                              categoryId: id
                                                          })
 
+            onToggleCollapsedCommunityCategory: root.store.toggleCollapsedCommunityCategory(categoryId, collapsed)
+
             popupMenu: StatusMenu {
                 hideDisabledItems: false
                 StatusAction {


### PR DESCRIPTION
### Context

This previous PR https://github.com/status-im/status-go/pull/3269 the status-go part was already implement for enabling the persisting of collapsed or expanded categories.

### What does the PR do

This PR implements the `nim` part for enabling having collapsed categories that persist into the database. This fixes #13944

### Affected areas

- communities collapsed categories

### Screenshot of functionality (including design for comparison)

[Screencast from 2024-03-24 03:41:58 AM.webm](https://github.com/status-im/status-desktop/assets/2589171/55deee29-e7e8-4c8e-af82-1a49ccab4166)

