### PR TITLE
fix: can't use the Tab button in the Mint Token form

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -89,7 +89,7 @@ StackView {
         pop(initialItem, StackView.Immediate)
     }
 
-    // This method will be called from the outsite from a different section like Airdrop or Permissions
+    // This method will be called from the outside from a different section like Airdrop or Permissions
     function openNewTokenForm(isAssetView) {
         resetNavigation()
 
@@ -342,7 +342,7 @@ StackView {
                     Layout.preferredWidth: root.viewWidth
                     Layout.fillHeight: true
 
-                    currentIndex: optionsTab.currentItem === collectiblesTab ? 0 : 1
+                    currentIndex: optionsTab.currentIndex
 
                     CustomEditCommunityTokenView {
                         id: newCollectibleView

--- a/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
@@ -95,6 +95,8 @@ StatusScrollView {
     contentWidth: mainLayout.width
     contentHeight: mainLayout.height
 
+    onVisibleChanged: if (visible) nameInput.forceActiveFocus()
+
     ColumnLayout {
         id: mainLayout
 
@@ -103,7 +105,6 @@ StatusScrollView {
 
         StatusBaseText {
             elide: Text.ElideRight
-            font.pixelSize: Theme.primaryTextFontSize
             text: root.isAssetView ? qsTr("Icon") : qsTr("Artwork")
         }
 
@@ -150,7 +151,7 @@ StatusScrollView {
             }
             extraValidator.errorMessage: d.containsAssetReferenceName ? qsTr("Asset name already exists") :
                                                                         qsTr("You have used this token name before")
-
+            input.tabNavItem: descriptionInput
             onTextChanged: root.token.name = text
         }
 
@@ -170,7 +171,7 @@ StatusScrollView {
             minLengthValidator.errorMessage: qsTr("Please enter a token description")
             regexValidator.regularExpression: Constants.regularExpressions.ascii
             regexValidator.errorMessage: qsTr("Only A-Z, 0-9 and standard punctuation allowed")
-
+            input.tabNavItem: symbolInput
             onTextChanged: root.token.description = text
         }
 
@@ -197,6 +198,7 @@ StatusScrollView {
                 return (!SQUtils.ModelUtils.contains(root.tokensModel, "symbol", symbolInput.text) && !d.containsAssetReferenceSymbol)
             }
             extraValidator.errorMessage: d.containsAssetReferenceSymbol ? qsTr("Symbol already exists") : qsTr("You have used this token symbol before")
+            input.tabNavItem: supplyInput.visible ? supplyInput : assetDecimalsInput
 
             onTextChanged: {
                 const cursorPos = input.edit.cursorPosition
@@ -210,7 +212,6 @@ StatusScrollView {
         StatusBaseText {
             text: qsTr("Network")
             color: Theme.palette.directColor1
-            font.pixelSize: Theme.primaryTextFontSize
         }
 
         Rectangle {
@@ -285,6 +286,7 @@ StatusScrollView {
             regexValidator.regularExpression: Constants.regularExpressions.numerical
             extraValidator.validate: function (value) { return parseInt(value) > 0 && parseInt(value) <= 999999999 }
             extraValidator.errorMessage: qsTr("Enter a number between 1 and 999,999,999")
+            input.tabNavItem: assetDecimalsInput.visible ? assetDecimalsInput : previewButton
 
             onTextChanged: {
                 const supplyNumber = parseInt(text)
@@ -333,6 +335,7 @@ StatusScrollView {
             regexValidator.regularExpression: Constants.regularExpressions.numerical
             extraValidator.validate: function (value) { return parseInt(value) > 0 && parseInt(value) <= 10 }
             extraValidator.errorMessage: qsTr("Enter a number between 1 and 10")
+            input.tabNavItem: previewButton
             onTextChanged: root.token.decimals = parseInt(text)
         }
 
@@ -382,6 +385,7 @@ StatusScrollView {
         }
 
         StatusButton {
+            id: previewButton
             Layout.preferredHeight: 44
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
@@ -389,6 +393,7 @@ StatusScrollView {
             Layout.bottomMargin: Style.current.padding
             text: qsTr("Preview")
             enabled: d.isFullyFilled
+            highlighted: visualFocus
 
             onClicked: root.previewClicked()
         }
@@ -435,7 +440,6 @@ StatusScrollView {
         StatusBaseText {
             text: labelDescComponent.label
             color: Theme.palette.directColor1
-            font.pixelSize: Theme.primaryTextFontSize
         }
 
         StatusBaseText {
@@ -443,7 +447,6 @@ StatusScrollView {
             Layout.fillHeight: true
             text: labelDescComponent.description
             color: Theme.palette.baseColor1
-            font.pixelSize: Theme.primaryTextFontSize
             lineHeight: 1.2
             wrapMode: Text.WordWrap
         }


### PR DESCRIPTION
### What does the PR do

- manually setup the TAB focus chain; in the future, this should be done properly on all new components using FocusScopes and similar

Fixes #13891

### Affected areas

EditCommunityTokenView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-25 11-08-18.webm](https://github.com/status-im/status-desktop/assets/5377645/8864cdd3-6799-47b1-a2ca-35eac0cd79f2)
