### PR TITLE
fix: Display name is not validated properly (UI part)

### DIFF
--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -540,7 +540,7 @@ QtObject {
                 errorMessage: qsTr("Display Names can’t start or end with a space")
             },
             StatusRegularExpressionValidator {
-                regularExpression: regularExpressions.alphanumericalExpanded
+                regularExpression: /^$|^[a-zA-Z0-9\-_\u0020]+$/
                 errorMessage: qsTr("Invalid characters (use A-Z and 0-9, hyphens and underscores only)")
             },
             StatusMinLengthValidator {


### PR DESCRIPTION
### What does the PR do

- do not use the `alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_\.\u0020]+$/` regex which contains the dot (`.`) character too; be explicit here and do what the error message says
- the space character at start/end is validated above with the `startsWithSpaceValidator`

CHERRY-PICK-TO: 2.28

Fixes #14127

### Affected areas

Display name validation

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-03-25 14-08-04.webm](https://github.com/status-im/status-desktop/assets/5377645/d103ba4d-4d69-4fa6-892f-4f8e8248732a)

