### PR TITLE
(Chat): Display system messages about adding/removing members immediately after an update is performed

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2085,7 +2085,7 @@ QtObject:
       # We no longer send invites, but merely share the community so
       # users can request access (with automatic acception)
       let response = status_go.shareCommunityToUsers(communityId, pubKeys, inviteMessage)
-      discard self.chatService.processMessageUpdateAfterSend(response)
+      discard self.chatService.processMessengerResponse(response)
     except Exception as e:
       error "Error sharing community", msg = e.msg
       result = "Error sharing community: " & e.msg

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -644,7 +644,7 @@ QtObject:
             if(not pinned and not pin):
               self.numOfPinnedMessagesPerChat[chatId] = self.getNumOfPinnedMessages(chatId) - 1
               self.events.emit(SIGNAL_MESSAGE_UNPINNED, data)
-          discard self.chatService.processMessageUpdateAfterSend(response)
+          discard self.chatService.processMessengerResponse(response)
 
     except Exception as e:
       error "error: ", procName="pinUnpinMessage", errName = e.name, errDesription = e.msg

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -369,7 +369,7 @@ QtObject:
         communityId = "", # communityId is not necessary when sending a sticker
         sticker.hash,
         sticker.packId)
-    discard self.chatService.processMessageUpdateAfterSend(response)
+    discard self.chatService.processMessengerResponse(response)
     self.addStickerToRecent(sticker)
 
   proc removeRecentStickers*(self: Service, packId: string) =


### PR DESCRIPTION
fixes #9876, #10702

### What does the PR do
chats/service.nim

1. `addGroupMembers`/`removeMemberFromGroupChat` now analyzes and processes the `GroupChatResponse`
2. Similarly to the `processMessageUpdateAfterSend`, the procedure `processGroupChatUpdateAfterSend` has been added. Now they both use the `signalChatsAndMessagesUpdates` proc, which emits signals to notify UI of new chats/messages
3. Added a separate `parseGroupChatResponse` method to parse GroupChatResponse, since this structure has 'chat' and ChatResponse has 'chats'

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/67bf41f1-da24-4665-a01b-dabc2c2d06fb

