### PR TITLE
14044 handle edit messages in bridge

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -609,9 +609,16 @@ method onMessageEdited*(self: Module, message: MessageDto) =
   let mentionedUsersPks = itemBeforeChange.mentionedUsersPks
   let communityChats = self.controller.getCommunityDetails().chats
 
+  var updatedText = ""
+  if message.contentType == ContentType.BridgeMessage:
+    # message from bridge does not have any tags, we need to add them here to show correctly edited message
+    updatedText = "<p>" & message.bridgeMessage.content & "</p>"
+  else:
+    updatedText = self.controller.getRenderedText(message.parsedText, communityChats)
+
   self.view.model().updateEditedMsg(
     message.id,
-    self.controller.getRenderedText(message.parsedText, communityChats),
+    updatedText,
     message.text,
     message.parsedText,
     message.contentType,


### PR DESCRIPTION
Displaying edited bridge messages correctly.

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/61889657/daec4e84-e82a-4231-bba6-0a986068bc38

