### PR TITLE
cherry-pick fix: Display name is not validated properly (UI part)

### DIFF
--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -540,7 +540,7 @@ QtObject {
                 errorMessage: qsTr("Display Names can’t start or end with a space")
             },
             StatusRegularExpressionValidator {
-                regularExpression: regularExpressions.alphanumericalExpanded
+                regularExpression: /^$|^[a-zA-Z0-9\-_\u0020]+$/
                 errorMessage: qsTr("Invalid characters (use A-Z and 0-9, hyphens and underscores only)")
             },
             StatusMinLengthValidator {


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/14142

### What does the PR do

- do not use the `alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_\.\u0020]+$/` regex which contains the dot (`.`) character too; be explicit here and do what the error message says
- the space character at start/end is validated above with the `startsWithSpaceValidator`

Fixes #14127