### PR TITLE
[CHERRY-PICK] fix(main): set personnal chat as active if last active was profile

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -641,7 +641,7 @@ method onChannelGroupsLoaded*[T](
     return
   var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
-  if activeSectionId == "":
+  if activeSectionId == "" or activeSectionId == conf.SETTINGS_SECTION_ID:
     activeSectionId = singletonInstance.userProfile.getPubKey()
 
   for channelGroup in channelGroups:


### PR DESCRIPTION
Fixes #14111

Cherry-pick of https://github.com/status-im/status-desktop/pull/14155