### PR TITLE
fix(@wallet): prevent collectibles error due to irrelevant chain state

### DIFF
--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -70,7 +70,11 @@ QtObject:
     # Otherwise, if any address+chainID is updating, then the whole model is updating
     # Otherwise, the model is idle
     for address, statusPerChainID in self.ownershipStatus.pairs:
+      if not self.addresses.contains(address):
+        continue
       for chainID, status in statusPerChainID:
+        if not self.chainIds.contains(chainID):
+          continue
         if status.state == OwnershipStateError:
           overallState = OwnershipStateError
           break


### PR DESCRIPTION
### What does the PR do

Only use relevant (i.e. contained in the current filter) chains and addresses to determine the Collectible Model's state.
