### PR TITLE
fix(communities): keycard authentication marked automatically as authenticated

### DIFF
--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -16,6 +16,9 @@ method load*(self: AccessInterface) {.base.} =
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method cleanJoinEditCommunityData*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onActivated*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -140,7 +140,7 @@ method delete*(self: Module) =
   self.controller.delete
   self.communityTokensModule.delete
 
-proc clean(self: Module) =
+method cleanJoinEditCommunityData*(self: Module) =
   self.joiningCommunityDetails.clear()
 
 method load*(self: Module) =
@@ -351,20 +351,20 @@ method communityMuted*(self: Module, communityId: string, muted: bool) =
   self.view.model().setMuted(communityId, muted)
 
 method communityAccessRequested*(self: Module, communityId: string) =
-  self.clean()
+  self.cleanJoinEditCommunityData()
   self.view.communityAccessRequested(communityId)
 
 method communityAccessFailed*(self: Module, communityId, err: string) =
   error "communities: ", err
-  self.clean()
+  self.cleanJoinEditCommunityData()
   self.view.communityAccessFailed(communityId, err)
 
 method communityEditSharedAddressesSucceeded*(self: Module, communityId: string) =
-  self.clean()
+  self.cleanJoinEditCommunityData()
   self.view.communityEditSharedAddressesSucceeded(communityId)
 
 method communityEditSharedAddressesFailed*(self: Module, communityId, error: string) =
-  self.clean()
+  self.cleanJoinEditCommunityData()
   self.view.communityEditSharedAddressesFailed(communityId, error)
 
 method communityHistoryArchivesDownloadStarted*(self: Module, communityId: string) =
@@ -723,7 +723,6 @@ proc anyProfileKeyPairAddressSelectedToBeRevealed(self: Module): bool =
 method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid: string) =
   if password == "" and pin == "":
     info "unsuccesful authentication"
-    self.clean()
     return
 
   self.joiningCommunityDetails.profilePassword = password

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -124,6 +124,9 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
+  proc cleanJoinEditCommunityData*(self: View) {.slot.} =
+    self.delegate.cleanJoinEditCommunityData()
+
   proc communityAdded*(self: View, communityId: string) {.signal.}
   proc communityChanged*(self: View, communityId: string) {.signal.}
   proc discordOldestMessageTimestampChanged*(self: View) {.signal.}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -135,7 +135,8 @@ Dialog {
     }
 
     onClosed: {
-        if (root.destroyOnClose)
+        if (root.destroyOnClose) {
             root.destroy();
+        }
     }
 }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -317,7 +317,7 @@ StackLayout {
             }
 
             onClosed: {
-                destroy()
+                root.rootStore.cleanJoinEditCommunityData()
             }
 
             Connections {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -415,6 +415,10 @@ QtObject {
         communitiesModuleInst.joinCommunityOrEditSharedAddresses()
     }
 
+    function cleanJoinEditCommunityData() {
+        communitiesModuleInst.cleanJoinEditCommunityData()
+    }
+
     function getLatestBlockNumber(chainId) {
         return walletSection.getChainIdForSend(chainId)
     }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -586,7 +586,7 @@ Item {
                     }
 
                     onClosed: {
-                        destroy()
+                        root.store.cleanJoinEditCommunityData()
                     }
 
                     Connections {

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -277,7 +277,9 @@ SettingsContentBase {
                 root.rootStore.updatePermissionsModel(dialogRoot.communityId, sharedAddresses)
             }
 
-            onClosed: destroy()
+            onClosed: {
+                chatStore.cleanJoinEditCommunityData()
+            }
 
             Connections {
                 target: chatStore.communitiesModuleInst

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -253,6 +253,10 @@ QtObject {
         communitiesModuleInst.joinCommunityOrEditSharedAddresses()
     }
 
+    function cleanJoinEditCommunityData() {
+        communitiesModuleInst.cleanJoinEditCommunityData()
+    }
+
     function updatePermissionsModel(communityId, sharedAddresses) {
         communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
     }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -735,11 +735,17 @@ QtObject {
                         dialogRoot.close();
                     }
                 }
+
                 onSharedAddressesUpdated: {
                     root.rootStore.updatePermissionsModel(dialogRoot.communityId, sharedAddresses)
                 }
+
                 onAboutToShow: { root.rootStore.communityKeyToImport = dialogRoot.communityId; }
-                onClosed: { root.rootStore.communityKeyToImport = ""; destroy(); }
+
+                onClosed: {
+                    root.rootStore.communityKeyToImport = "";
+                    root.rootStore.cleanJoinEditCommunityData()
+                }
 
                 Connections {
                     target: root.rootStore.communitiesModuleInst
@@ -963,7 +969,9 @@ QtObject {
                     root.rootStore.joinCommunityOrEditSharedAddresses()
                 }
 
-                onClosed: destroy()
+                onClosed: {
+                    root.rootStore.cleanJoinEditCommunityData()
+                }
 
                 Connections {
                     target: root.rootStore.communitiesModuleInst

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -18,6 +18,7 @@ import SortFilterProxyModel 0.2
 StatusStackModal {
     id: root
 
+    destroyOnClose: true
     property bool isEditMode: false
 
     required property string communityName


### PR DESCRIPTION
A fix for this issue was in the line `726` in `module.nim`, but I also made a change to make sure that all sensitive data kept in the memory while the popup is active gets cleared on the popup close.

Closes #14174