### PR TITLE
fix(communities): when only keycard accounts selected (and 1 keycard) authentication is not triggered

### DIFF
--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -192,7 +192,7 @@ StatusStackModal {
                     console.error("selected shared addresses must not be empty")
                     return
                 }
-                const keyUid = d.selectedSharedAddressesMap.values()[0].keyUid
+                const keyUid = d.selectedSharedAddressesMap.values().next().value.keyUid
                 root.signSharedAddressesForKeypair(keyUid)
                 return
             }


### PR DESCRIPTION
It's a single line change since `values()` on the map returns an iterator, and since I changed that line based on review comments in my previous PR it got broken. Fixed now.

Closes #14175