### PR TITLE
fix(general): when biometric is setup the authentication flow is not correct showing the password one instead

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -180,7 +180,6 @@ proc checkKeycardAvailability*(self: Controller) =
 
 proc init*(self: Controller, fullConnect = true) =
   self.connectKeycardReponseSignal()
-  self.connectKeychainSignals()
 
   var handlerId = self.events.onWithUUID(SIGNAL_SHARED_KEYCARD_MODULE_USER_AUTHENTICATED) do(e: Args):
     let args = SharedKeycarModuleArgs(e)

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -551,8 +551,13 @@ proc proceedWithRunFlow[T](self: Module[T], flowToRun: FlowType, keyUid: string,
           self.controller.tryToObtainDataFromKeychain()
         return
       self.view.setCurrentState(newEnterPasswordState(flowToRun, nil))
-      self.authenticationPopupIsAlreadyRunning = true
-      self.controller.readyToDisplayPopup()
+      if singletonInstance.userProfile.getUsingBiometricLogin():
+        self.tmpLocalState = newReadingKeycardState(flowToRun, nil)
+        self.controller.connectKeychainSignals()
+        self.controller.tryToObtainDataFromKeychain()
+      else:
+        self.authenticationPopupIsAlreadyRunning = true
+        self.controller.readyToDisplayPopup()
       return
     else:
       self.prepareKeyPairItemForAuthentication(keyUid)

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -10,6 +10,8 @@ import shared.stores 1.0 as SharedStores
 import shared.popups.keycard 1.0
 import shared.stores.send 1.0
 
+import StatusQ.Core.Theme 0.1
+
 import AppLayouts.Wallet.controls 1.0
 import AppLayouts.Wallet.stores 1.0
 


### PR DESCRIPTION
Don't know why that line was added, but seems it was a main culprit for this issue, the point is to have biometrics signals connected when needed only:
https://github.com/status-im/status-desktop/pull/13793/files

Closes #14173