### PR TITLE
fix(wallet): activity details missing - 2.28.x

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -299,7 +299,7 @@ Item {
                         width: parent.width
                         title: d.transactionType === Constants.TransactionType.Swap || d.transactionType === Constants.TransactionType.Bridge ?
                                    qsTr("In") : qsTr("From")
-                        addresses: d.isTransactionValid && d.reEvaluateSender? [d.transaction.from] : []
+                        addresses: d.isTransactionValid && d.reEvaluateSender? [d.transaction.sender] : []
                         contactsStore: root.contactsStore
                         rootStore: WalletStores.RootStore
                         onButtonClicked: {
@@ -342,7 +342,7 @@ Item {
                     TransactionAddressTile {
                         width: parent.width
                         title: qsTr("To")
-                        addresses: d.isTransactionValid && visible && d.reEvaluateRecipient? [d.transaction.to] : []
+                        addresses: d.isTransactionValid && visible && d.reEvaluateRecipient? [d.transaction.recipient] : []
                         contactsStore: root.contactsStore
                         rootStore: WalletStores.RootStore
                         onButtonClicked: addressMenu.openReceiverMenu(this, addresses[0], [d.networkShortName])


### PR DESCRIPTION
Cherry picked from https://github.com/status-im/status-desktop/pull/14069

Fixes wrong properties referenced in `TransactionDetailView`
