### PR TITLE
fix(@desktop/wallet): properly handle collectible groups in send modal

### DIFF
--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -358,9 +358,11 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) 
   self.view.switchReceiveAccountByAddress(addresses[0])
 
 proc updateCollectiblesFilter*(self: Module) =
-  let addresses = @[self.view.getSenderAddressByIndex(self.senderCurrentAccountIndex)]
+  let senderAddress = self.view.getSenderAddressByIndex(self.senderCurrentAccountIndex)
+  let addresses = @[senderAddress]
   let chainIds = self.controller.getChainIds()
   self.collectiblesController.setFilterAddressesAndChains(addresses, chainIds)
+  self.nestedCollectiblesModel.setAddress(senderAddress)
 
 method setSelectedSenderAccountIndex*(self: Module, index: int) =
   self.senderCurrentAccountIndex = index

--- a/src/app/modules/shared_models/collectible_ownership_model.nim
+++ b/src/app/modules/shared_models/collectible_ownership_model.nim
@@ -71,3 +71,11 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+  
+  proc getBalance*(self: OwnershipModel, address: string): UInt256 =
+    var balance = stint.u256(0)
+    for item in self.items:
+      if item.address.toUpper == address.toUpper:
+        balance += item.balance
+        break
+    return balance

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -234,11 +234,13 @@ QtObject:
     notify = traitsChanged
 
   proc ownershipChanged*(self: CollectiblesEntry) {.signal.}
-  proc getOwnershipModel*(self: CollectiblesEntry): QVariant {.slot.} =
+  proc getOwnershipModel*(self: CollectiblesEntry): OwnershipModel =
+    return self.ownership
+  proc getOwnershipModelAsVariant*(self: CollectiblesEntry): QVariant {.slot.} =
     return newQVariant(self.ownership)
 
   QtProperty[QVariant] ownership:
-    read = getOwnershipModel
+    read = getOwnershipModelAsVariant
     notify = ownershipChanged
 
   proc communityIdChanged*(self: CollectiblesEntry) {.signal.}

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -188,7 +188,7 @@ QtObject:
       of CollectibleRole.IsLoading:
         result = newQVariant(false)
       of CollectibleRole.Ownership:
-        result = newQVariant(item.getOwnershipModel())
+        result = item.getOwnershipModelAsVariant()
       of CollectibleRole.CommunityId:
         result = newQVariant(item.getCommunityId())
       of CollectibleRole.CommunityName:

--- a/src/app/modules/shared_models/collectibles_nested_item.nim
+++ b/src/app/modules/shared_models/collectibles_nested_item.nim
@@ -1,37 +1,46 @@
 import stew/shims/strformat
 import app_service/common/types
+import stint
+
+type
+  ItemType* {.pure.} = enum
+    CommunityCollectible = 0,
+    NonCommunityCollectible = 1,
+    Collection = 2,
+    Community = 3
 
 type
   Item* = object
-    id: string  # Collectible ID if isCollection=false, Collection Slug otherwise
+    id: string  # CollectibleID if single collectible, GroupID (CollectionID/CommunityID) otherwise
     chainId: int
     name: string
     iconUrl: string
-    collectionId: string
-    collectionName: string
-    isCollection: bool
-    communityId: string
+    groupId: string
+    groupName: string
     tokenType: TokenType
+    itemType: ItemType
+    count: UInt256
 
 proc initItem*(
   id: string,
   chainId: int,
   name: string,
   iconUrl: string,
-  collectionId: string,
-  collectionName: string,
-  isCollection: bool,
-  communityId: string,
-  tokenType: TokenType
+  groupId: string,
+  groupName: string,
+  tokenType: TokenType,
+  itemType: ItemType,
+  count: UInt256,
 ): Item =
   result.id = id
   result.chainId = chainId
   result.name = name
   result.iconUrl = iconUrl
-  result.collectionId = collectionId
-  result.collectionName = collectionName
-  result.isCollection = isCollection
+  result.groupId = groupId
+  result.groupName = groupName
   result.tokenType = tokenType
+  result.itemType = itemType
+  result.count = count
 
 proc `$`*(self: Item): string =
   result = fmt"""CollectiblesNestedEntry(
@@ -39,11 +48,11 @@ proc `$`*(self: Item): string =
     chainId: {self.chainId},
     name: {self.name},
     iconUrl: {self.iconUrl},
-    collectionId: {self.collectionId},
-    collectionName: {self.collectionName},
-    isCollection: {self.isCollection},
-    communityId: {self.communityId},
+    groupId: {self.groupId},
+    groupName: {self.groupName},
     tokenType: {self.tokenType},
+    itemType: {self.itemType},
+    count: {self.count},
     ]"""
 
 proc getId*(self: Item): string =
@@ -58,17 +67,20 @@ proc getName*(self: Item): string =
 proc getIconUrl*(self: Item): string =
   return self.iconUrl
 
-proc getCollectionId*(self: Item): string =
-  return self.collectionId
+proc getGroupId*(self: Item): string =
+  return self.groupId
 
-proc getCollectionName*(self: Item): string =
-  return self.collectionName
-
-proc getIsCollection*(self: Item): bool =
-  return self.isCollection
-
-proc getCommunityId*(self: Item): string =
-  return self.communityId
+proc getGroupName*(self: Item): string =
+  return self.groupName
 
 proc getTokenType*(self: Item): int =
   return self.tokenType.int
+
+proc getItemType*(self: Item): int =
+  return self.itemType.int
+
+proc getCount*(self: Item): UInt256 =
+  return self.count
+
+proc getCountAsString*(self: Item): string =
+  return $self.count

--- a/src/app/modules/shared_models/collectibles_nested_utils.nim
+++ b/src/app/modules/shared_models/collectibles_nested_utils.nim
@@ -1,8 +1,36 @@
+import stint
+
 import ./collectibles_entry as flat_item
 import ./collectibles_nested_item as nested_item
 import app_service/common/types
 
-proc collectibleToCollectibleNestedItem*(flatItem: flat_item.CollectiblesEntry): nested_item.Item =
+proc collectibleToCommunityCollectibleNestedItem*(flatItem: flat_item.CollectiblesEntry, count: UInt256): nested_item.Item =
+  return nested_item.initItem(
+    flatItem.getIDAsString(),
+    flatItem.getChainID(),
+    flatItem.getName(),
+    flatItem.getImageURL(),
+    flatItem.getCommunityId(),
+    flatItem.getCommunityName(),
+    TokenType(flatItem.getTokenType()),
+    ItemType.CommunityCollectible,
+    count
+  )
+
+proc collectibleToCommunityNestedItem*(flatItem: flat_item.CollectiblesEntry, count: UInt256): nested_item.Item =
+  return nested_item.initItem(
+    flatItem.getCommunityId(),
+    flatItem.getChainID(),
+    flatItem.getCommunityName(),
+    flatItem.getCommunityImage(),
+    flatItem.getCommunityId(),
+    flatItem.getCommunityName(),
+    TokenType(flatItem.getTokenType()),
+    ItemType.Community,
+    count
+  )
+
+proc collectibleToNonCommunityCollectibleNestedItem*(flatItem: flat_item.CollectiblesEntry, count: UInt256): nested_item.Item =
   return nested_item.initItem(
     flatItem.getIDAsString(),
     flatItem.getChainID(),
@@ -10,12 +38,12 @@ proc collectibleToCollectibleNestedItem*(flatItem: flat_item.CollectiblesEntry):
     flatItem.getImageURL(),
     flatItem.getCollectionIDAsString(),
     flatItem.getCollectionName(),
-    false,
-    flatItem.getCommunityID(),
-    TokenType(flatItem.getTokenType())
+    TokenType(flatItem.getTokenType()),
+    ItemType.NonCommunityCollectible,
+    count
   )
 
-proc collectibleToCollectionNestedItem*(flatItem: flat_item.CollectiblesEntry): nested_item.Item =
+proc collectibleToCollectionNestedItem*(flatItem: flat_item.CollectiblesEntry, count: UInt256): nested_item.Item =
   return nested_item.initItem(
     flatItem.getCollectionIDAsString(),
     flatItem.getChainID(),
@@ -23,7 +51,7 @@ proc collectibleToCollectionNestedItem*(flatItem: flat_item.CollectiblesEntry): 
     flatItem.getCollectionImageURL(),
     flatItem.getCollectionIDAsString(),
     flatItem.getCollectionName(),
-    true,
-    flatItem.getCommunityID(),
-    TokenType(flatItem.getTokenType())
+    TokenType(flatItem.getTokenType()),
+    ItemType.Collection,
+    count
   )

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -328,7 +328,7 @@ StatusDialog {
                         maxInputBalance: d.maxInputBalance
                         currentCurrency: d.currencyStore.currentCurrency
 
-                        multiplierIndex: !!holdingSelector.selectedItem
+                        multiplierIndex: d.isSelectedHoldingValidAsset
                                          ? holdingSelector.selectedItem.decimals
                                          : 0
 

--- a/ui/imports/shared/popups/send/controls/CollectibleNestedDelegate.qml
+++ b/ui/imports/shared/popups/send/controls/CollectibleNestedDelegate.qml
@@ -29,7 +29,7 @@ StatusListItem {
 
     title: name
     statusListItemTitleAside.font.pixelSize: 15
-    asset.name: iconUrl ? iconUrl : ""
+    asset.name: iconUrl ?? ""
     asset.isImage: true
     asset.width: 32
     asset.height: 32
@@ -41,28 +41,26 @@ StatusListItem {
 
     onClicked: d.selectItem()
 
-    property int numItems
-
     components: [
         StatusRoundedImage {
             width: 20
             height: 20
-            image.source: Style.svg("tiny/%1".arg(networkIconUrl))
-            visible: !isCollection && root.sensor.containsMouse
+            image.source: Style.svg("tiny/%1".arg(networkIconUrl)) ?? ""
+            visible: !isGroup && root.sensor.containsMouse 
         },
         StatusBaseText {
             id: label
-            text: root.numItems
+            text: count
             font.pixelSize: 13
             color: Theme.palette.baseColor1
-            visible: isCollection
+            visible: isGroup || (!root.sensor.containsMouse && count > 1)
         },
         StatusIcon {
             icon: "tiny/chevron-right"
             color: Theme.palette.baseColor1
             width: 16
             height: 16
-            visible: isCollection
+            visible: isGroup
         }
     ]
 }

--- a/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
@@ -40,7 +40,7 @@ StatusListItem {
     }
 
     title: name
-    titleAsideText: symbol
+    titleAsideText: symbol ?? ""
     statusListItemTitleAside.font.pixelSize: 15
     statusListItemTitleAside.width: statusListItemTitleArea.width - statusListItemTitle.width
     statusListItemTitleAside.elide: Text.ElideRight

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -157,14 +157,24 @@ QtObject {
     }
 
     function collectibleToSelectorCollectible(collectible) {
+        var groupId = collectible.collectionUid
+        var groupName = collectible.collectionName
+        var itemType = Constants.CollectiblesNestedItemType.Collectible
+        if (collectible.communityId !== "") {
+            groupId = collectible.communityId
+            groupName = collectible.communityName
+            itemType = Constants.CollectiblesNestedItemType.CommunityCollectible
+        }
         return {
             uid: collectible.uid,
             chainId: collectible.chainId,
             name: collectible.name,
             iconUrl: collectible.imageUrl,
-            collectionUid: collectible.collectionUid,
-            collectionName: collectible.collectionName,
-            isCollection: false
+            groupId: groupId,
+            groupName: groupName,
+            tokenType: collectible.tokenType,
+            itemType: itemType,
+            count: 1 // TODO: Properly handle count
         }
     }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1292,4 +1292,12 @@ QtObject {
         UrlUnfurlingModeEnableAll = 2,
         UrlUnfurlingModeDisableAll = 3
     }
+
+    // these are in sync with src/app/modules/shared_models/collectibles_nested_item.nim ItemType
+    enum CollectiblesNestedItemType {
+        CommunityCollectible = 0,
+        NonCommunityCollectible = 1,
+        Collection = 2,
+        Community = 3
+    }
 }


### PR DESCRIPTION
Fixes #14080

### What does the PR do

Community collectibles were not properly handled in the Send modal, showing a group of 0 elements instead and not allowing to select them for sending. This PR fixes that. 

There was a small rework in preparation for future tasks. Some other minor issues are also fixed and support for ERC1155 balance display is introduced.


https://github.com/status-im/status-desktop/assets/11161531/98ae94a4-8336-4bf0-8454-2756ddaeefd4

