### PR TITLE
fix: set correct permision required UI during joining the community

### DIFF
--- a/storybook/pages/JoinCommunityPermissionsEditor.qml
+++ b/storybook/pages/JoinCommunityPermissionsEditor.qml
@@ -125,6 +125,16 @@ ColumnLayout {
             text: "Long model"
             onCheckedChanged: if(checked) root.communityHoldingsModel = PermissionsModel.longPermissionsModel
         }
+
+        RadioButton {
+            text: "Private met model"
+            onCheckedChanged: if(checked) root.communityHoldingsModel = PermissionsModel.privatePermissionsModel
+        }
+
+        RadioButton {
+            text: "Private not met model"
+            onCheckedChanged: if(checked) root.communityHoldingsModel = PermissionsModel.privatePermissionsNotMetModel
+        }
     }
 
     ColumnLayout {

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -47,13 +47,52 @@ QtObject {
         }
     ]
 
-    readonly property var shortPermissionsModelData: [
+    readonly property var privatePermissionsModelData: [
         {
-            holdingsListModel: root.createHoldingsModel4(),
+            holdingsListModel: root.createHoldingsModel1(),
             channelsListModel: root.createChannelsModel1(),
             permissionType: PermissionTypes.Type.Admin,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: true
+            isPrivate: true,
+            tokenCriteriaMet: false
+        },
+        {
+            holdingsListModel: root.createHoldingsModel2(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Admin,
+            permissionState: PermissionTypes.State.Approved,
+            isPrivate: true,
+            tokenCriteriaMet: true
+        }
+    ]
+
+    readonly property var privatePermissionsModelNotMetData: [
+        {
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Admin,
+            permissionState: PermissionTypes.State.Approved,
+            isPrivate: true,
+            tokenCriteriaMet: false
+        },
+        {
+            holdingsListModel: root.createHoldingsModel2(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Admin,
+            permissionState: PermissionTypes.State.Approved,
+            isPrivate: true,
+            tokenCriteriaMet: false
+        }
+    ]
+
+
+    readonly property var shortPermissionsModelData: [
+        {
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            permissionState: PermissionTypes.State.Approved,
+            isPrivate: false
         }
     ]
 
@@ -69,13 +108,6 @@ QtObject {
     ]
 
     readonly property var longPermissionsModelData: [
-        {
-            holdingsListModel: root.createHoldingsModel4(),
-            channelsListModel: root.createChannelsModel1(),
-            permissionType: PermissionTypes.Type.Admin,
-            permissionState: PermissionTypes.State.Approved,
-            isPrivate: true
-        },
         {
             holdingsListModel: root.createHoldingsModel3(),
             channelsListModel: root.createChannelsModel2(),
@@ -460,6 +492,28 @@ QtObject {
         }
     }
 
+    readonly property ListModel privatePermissionsModel: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.privatePermissionsModel
+        }
+
+        Component.onCompleted: {
+            append(privatePermissionsModelData)
+            guard.enabled = true
+        }
+    }
+
+    readonly property ListModel privatePermissionsNotMetModel: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.privatePermissionsNotMetModel
+        }
+
+        Component.onCompleted: {
+            append(privatePermissionsModelNotMetData)
+            guard.enabled = true
+        }
+    }
+
     readonly property var shortPermissionsModel: ListModel {
         readonly property ModelChangeGuard guard: ModelChangeGuard {
             model: root.shortPermissionsModel
@@ -663,12 +717,6 @@ QtObject {
 
     function createHoldingsModel3() {
         return [
-                    {
-                        type: Constants.TokenType.ERC20,
-                        key: "eth",
-                        amount: 15,
-                        available: true
-                    },
                     {
                         type: Constants.TokenType.ERC721,
                         key: "Kitty4",

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -61,7 +61,8 @@ QtObject {
         root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
     }
 
-    readonly property bool allChannelsAreHiddenBecauseNotPermitted: root.chatCommunitySectionModule.allChannelsAreHiddenBecauseNotPermitted
+    readonly property bool allChannelsAreHiddenBecauseNotPermitted: root.chatCommunitySectionModule.allChannelsAreHiddenBecauseNotPermitted &&
+                                                                    !root.chatCommunitySectionModule.requiresTokenPermissionToJoin
 
     readonly property bool requirementsCheckPending: root.communitiesModuleInst.requirementsCheckPending
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -157,8 +157,8 @@ StatusSectionLayout {
 
     centerPanel: Loader {
         anchors.fill: parent
-        sourceComponent: root.allChannelsAreHiddenBecauseNotPermitted ? allChatsAreHiddenComponent :
-                                      (root.contentLocked ? joinCommunityCenterPanelComponent : chatColumnViewComponent)
+        sourceComponent: (root.allChannelsAreHiddenBecauseNotPermitted || root.contentLocked) ?
+                             joinCommunityCenterPanelComponent : chatColumnViewComponent
     }
 
     showRightPanel: {
@@ -251,6 +251,7 @@ StatusSectionLayout {
 
         JoinCommunityCenterPanel {
             joinCommunity: false
+            allChannelsAreHiddenBecauseNotPermitted: root.allChannelsAreHiddenBecauseNotPermitted
             name: sectionItemModel.name
             channelName: root.chatContentModule.chatDetails.name
             viewOnlyHoldingsModel: root.viewOnlyPermissionsModel
@@ -264,18 +265,6 @@ StatusSectionLayout {
             requirementsCheckPending: root.chatContentModule.permissionsCheckOngoing
             onRequestToJoinClicked: root.requestToJoinClicked()
             onInvitationPendingClicked: root.invitationPendingClicked()
-        }
-    }
-
-    Component {
-        id: allChatsAreHiddenComponent
-
-        StatusBaseText {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            visible: root.allChannelsAreHiddenBecauseNotPermitted
-            text: qsTr("Sorry, you don't hodl the necessary tokens to view or post in any of <b>%1</b> channels").arg(sectionItemModel.name)
-            color: Theme.palette.dangerColor1
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -13,6 +13,7 @@ import shared.stores.send 1.0
 import SortFilterProxyModel 0.2
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Layout 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Controls 0.1

--- a/ui/app/AppLayouts/Communities/panels/JoinCommunityCenterPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinCommunityCenterPanel.qml
@@ -12,6 +12,7 @@ ColumnLayout {
     id: root
 
     property bool joinCommunity: true // Otherwise it means join channel action
+    property bool allChannelsAreHiddenBecauseNotPermitted: false
 
     property string name
     property string channelName
@@ -139,6 +140,7 @@ ColumnLayout {
 
                     topPadding: 2 * bottomPadding
                     joinCommunity: root.joinCommunity
+                    allChannelsAreHiddenBecauseNotPermitted: root.allChannelsAreHiddenBecauseNotPermitted
                     requirementsMet: root.requirementsMet
                     requirementsCheckPending: root.requirementsCheckPending
                     isInvitationPending: root.isInvitationPending

--- a/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
@@ -58,7 +58,7 @@ Control {
             filters: [
                 // The only permissions to be discarded are if they are private and NOT met
                 FastExpressionFilter {
-                    expression: { return !!model && !(!model.tokenCriteriaMet && model.isPrivate) }
+                    expression: d.filterPermissions(model)
                     expectedRoles: ["tokenCriteriaMet", "isPrivate"]
                 }
             ]
@@ -90,6 +90,10 @@ Control {
                 }
             ]
         }
+
+        function filterPermissions(model) {
+            return !!model && (model.tokenCriteriaMet || !model.isPrivate)
+        }
     }
 
     padding: 35 // default by design
@@ -118,8 +122,18 @@ Control {
             model: d.visiblePermissionsModel
         }
 
+        StatusBaseText {
+            Layout.fillWidth: true
+
+            visible: root.allChannelsAreHiddenBecauseNotPermitted
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            text: d.allChannelsAreHiddenBecauseNotPermittedText
+            textFormat: Text.StyledText
+        }
+
         CustomHoldingsListPanel {
-            visible: !root.joinCommunity && d.viewOnlyPermissionsModel.count > 0
+            visible: (!root.joinCommunity && d.viewOnlyPermissionsModel.count > 0) && !root.allChannelsAreHiddenBecauseNotPermitted
             introText: root.requiresRequest ? 
                 qsTr("To view the <b>#%1</b> channel you need to join <b>%2</b> and prove that you hold").arg(root.channelName).arg(root.communityName) :
                 qsTr("To view the <b>#%1</b> channel you need to hold").arg(root.channelName)
@@ -127,10 +141,9 @@ Control {
         }
 
         CustomHoldingsListPanel {
-             visible: (!root.joinCommunity && d.viewAndPostPermissionsModel.count > 0) || root.allChannelsAreHiddenBecauseNotPermitted
-            introText: root.allChannelsAreHiddenBecauseNotPermitted ? d.allChannelsAreHiddenBecauseNotPermittedText :
-                           root.requiresRequest ? qsTr("To view and post in the <b>#%1</b> channel you need to join <b>%2</b> and prove that you hold").arg(root.channelName).arg(root.communityName) :
-                                                  qsTr("To view and post in the <b>#%1</b> channel you need to hold").arg(root.channelName)
+            visible: (!root.joinCommunity && d.viewAndPostPermissionsModel.count > 0) && !root.allChannelsAreHiddenBecauseNotPermitted
+            introText: root.requiresRequest ? qsTr("To view and post in the <b>#%1</b> channel you need to join <b>%2</b> and prove that you hold").arg(root.channelName).arg(root.communityName) :
+                                              qsTr("To view and post in the <b>#%1</b> channel you need to hold").arg(root.channelName)
             model: d.viewAndPostPermissionsModel
         }
 

--- a/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinPermissionsOverlayPanel.qml
@@ -142,7 +142,7 @@ Control {
             text: root.isInvitationPending ? (root.joinCommunity ? d.communityMembershipRequestPendingText : d.channelMembershipRequestPendingText)
                                            : d.communityRequestToJoinText
             font.pixelSize: 13
-            enabled: root.requirementsMet || d.communityPermissionsModel.count === 0
+            enabled: root.requirementsMet || (joinCommunity && d.communityPermissionsModel.count === 0)
             onClicked: root.isInvitationPending ? root.invitationPendingClicked() : root.requestToJoinClicked()
         }
 

--- a/ui/imports/shared/stores/PermissionsStore.qml
+++ b/ui/imports/shared/stores/PermissionsStore.qml
@@ -97,7 +97,9 @@ QtObject {
         id: becomeMemberPermissionsModel
         sourceModel: root.permissionsModel
         function filterPredicate(modelData) {
-            return (modelData.permissionType == Constants.permissionType.member) &&
+            return (modelData.permissionType === Constants.permissionType.member ||
+                    modelData.permissionType === Constants.permissionType.admin ||
+                    modelData.permissionType === Constants.permissionType.becomeTokenMaster) &&
                 (modelData.tokenCriteriaMet || !modelData.isPrivate)
         }
         filters: [

--- a/ui/imports/shared/stores/PermissionsStore.qml
+++ b/ui/imports/shared/stores/PermissionsStore.qml
@@ -96,16 +96,15 @@ QtObject {
     readonly property var becomeMemberPermissionsModel: SortFilterProxyModel {
         id: becomeMemberPermissionsModel
         sourceModel: root.permissionsModel
-        function filterPredicate(modelData) {
-            return (modelData.permissionType === Constants.permissionType.member ||
-                    modelData.permissionType === Constants.permissionType.admin ||
-                    modelData.permissionType === Constants.permissionType.becomeTokenMaster) &&
-                (modelData.tokenCriteriaMet || !modelData.isPrivate)
+        function filterPredicate(permissionType) {
+            return (permissionType === Constants.permissionType.member ||
+                    permissionType === Constants.permissionType.admin ||
+                    permissionType === Constants.permissionType.becomeTokenMaster)
         }
         filters: [
             FastExpressionFilter {
-                expression: becomeMemberPermissionsModel.filterPredicate(model)
-                expectedRoles: ["permissionType", "tokenCriteriaMet", "isPrivate"]
+                expression: { return becomeMemberPermissionsModel.filterPredicate(model.permissionType) }
+                expectedRoles: ["permissionType"]
             }
         ]
     }


### PR DESCRIPTION
### What does the PR do

Fixes
- crash fix
- set correct permission required UI during joining the closed community
- if community permission is closed and the user owns TM or admin token - show this token in the join community permission view
- if all channels are hidden, show the "You don't hold the necessary tokens" UI only if the community is not closed and we fit the permissions to join the community
- do not show join community permission view if it is open community

Closes: 
- https://github.com/status-im/status-desktop/issues/14091
- https://github.com/status-im/status-desktop/issues/14085
- https://github.com/status-im/status-desktop/issues/14104

IMPACT:
- join community permission view for a member, who wants to join
- showing community channels permission
