### PR TITLE
fix(joinCommunity): Fixing permissions checks in join community flows

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -421,3 +421,35 @@ method communityContainsChat*(self: AccessInterface, chatId: string): bool {.bas
 
 method openCommunityChatAndScrollToMessage*(self: AccessInterface, chatId: string, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method requestRevealedAddresses*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCommunityMemberRevealedAccountsLoaded*(self: AccessInterface, memberPubkey: string,
+    revealedAccounts: seq[RevealedAccount]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method checkPermissions*(self: AccessInterface, sharedAddresses: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCommunityCheckPermissionsToJoinFailed*(self: AccessInterface, ValueErrorerror: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCommunityCheckAllChannelPermissionsFailed*(self: AccessInterface, ValueErrorerror: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getSelectedAddressesForPermissionsCheck*(self: AccessInterface): seq[string] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setSelectedAddressesForPermissionsCheck*(self: AccessInterface, addresses: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCommunityCheckPermissionsWithSelectedAddressesResponse*(self: AccessInterface, 
+    addresses: seq[string],
+    communityPermissions: CheckPermissionsToJoinResponseDto,
+    channelPermissions: CheckAllChannelsPermissionsResponseDto,
+    error: string ) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCommunityCheckPermissionsWithSelectedAddressesFailed*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -168,25 +168,6 @@ proc init*(self: Controller) =
     let args = CommunityTokenMetadataArgs(e)
     self.delegate.onCommunityTokenMetadataAdded(args.communityId, args.tokenMetadata)
 
-  self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_RESPONSE) do(e: Args):
-    let args = CheckPermissionsToJoinResponseArgs(e)
-    self.delegate.onCommunityCheckPermissionsToJoinResponse(args.communityId, args.checkPermissionsToJoinResponse)
-
-  self.events.on(SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_RESPONSE) do(e: Args):
-    let args = CheckAllChannelsPermissionsResponseArgs(e)
-    self.delegate.onCommunityCheckAllChannelsPermissionsResponse(
-      args.communityId,
-      args.checkAllChannelsPermissionsResponse,
-    )
-
-  self.events.on(SIGNAL_COMMUNITY_MEMBER_REVEALED_ACCOUNTS_LOADED) do(e: Args):
-    let args = CommunityMemberRevealedAccountsArgs(e)
-    self.delegate.onCommunityMemberRevealedAccountsLoaded(
-      args.communityId,
-      args.memberPubkey,
-      args.memberRevealedAccounts,
-    )
-
   self.events.on(SIGNAL_TOKENS_LIST_UPDATED) do(e: Args):
     self.delegate.onWalletAccountTokensRebuilt()
 
@@ -198,14 +179,6 @@ proc init*(self: Controller) =
     if args.uniqueIdentifier != UNIQUE_COMMUNITIES_MODULE_AUTH_IDENTIFIER:
       return
     self.delegate.onUserAuthenticated(args.pin, args.password, args.keyUid)
-
-    self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_FAILED) do(e: Args):
-      let args = CheckPermissionsToJoinFailedArgs(e)
-      self.delegate.onCommunityCheckPermissionsToJoinFailed(args.communityId, args.error)
-
-    self.events.on(SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_FAILED) do(e: Args):
-      let args = CheckChannelsPermissionsErrorArgs(e)
-      self.delegate.onCommunityCheckAllChannelPermissionsFailed(args.communityId, args.error)
 
   self.events.on(SIGNAL_SHARED_KEYCARD_MODULE_DATA_SIGNED) do(e: Args):
     let args = SharedKeycarModuleArgs(e)
@@ -406,15 +379,6 @@ proc authenticate*(self: Controller) =
 
 proc getCommunityPublicKeyFromPrivateKey*(self: Controller, communityPrivateKey: string): string =
   result = self.communityService.getCommunityPublicKeyFromPrivateKey(communityPrivateKey)
-
-proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string]) =
-  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare)
-
-proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string]) =
-  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
-
-proc asyncGetRevealedAccountsForMember*(self: Controller, communityId, memberPubkey: string) =
-  self.communityService.asyncGetRevealedAccountsForMember(communityId, memberPubkey)
 
 proc generateJoiningCommunityRequestsForSigning*(self: Controller, memberPubKey: string, communityId: string,
   addressesToReveal: seq[string]): seq[SignParamsDto] =

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -1,6 +1,5 @@
 import tables
 import ../../../../app_service/service/community/service as community_service
-import ../../../../app_service/service/chat/service as chat_service
 import app_service/common/types
 import ../../shared_models/section_item
 
@@ -236,30 +235,7 @@ method signSharedAddressesForKeypair*(self: AccessInterface, keyUid: string, pin
 method joinCommunityOrEditSharedAddresses*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method getCommunityPublicKeyFromPrivateKey*(self: AccessInterface, communityPrivateKey: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method checkPermissions*(self: AccessInterface, communityId: string, sharedAddresses: seq[string]) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, communityId: string, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onCommunityCheckAllChannelsPermissionsResponse*(self: AccessInterface, communityId: string,
-    checkChannelPermissionsResponse: CheckAllChannelsPermissionsResponseDto) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onCommunityCheckPermissionsToJoinFailed*(self: AccessInterface, communityId: string, ValueErrorerror: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onCommunityCheckAllChannelPermissionsFailed*(self: AccessInterface, communityId: string, ValueErrorerror: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onCommunityMemberRevealedAccountsLoaded*(self: AccessInterface, communityId: string, memberPubkey: string,
-    revealedAccounts: seq[RevealedAccount]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method removeCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -60,3 +60,28 @@ const asyncCheckAllChannelsPermissionsTask: Task = proc(argEncoded: string) {.gc
       "communityId": arg.communityId,
       "error": e.msg,
     })
+
+type
+  AsyncCheckPermissionsWithSelectedAddresesTaskArg = ref object of QObjectTaskArg
+    communityId: string
+    addresses: seq[string]
+
+const asyncCheckPermissionsWithSelectedAddresesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncCheckPermissionsWithSelectedAddresesTaskArg](argEncoded)
+  try:
+    let channelsPermissionsResponse = status_communities.checkAllCommunityChannelsPermissions(arg.communityId, arg.addresses)
+    let communityPermissionsResponse = status_communities.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses)
+
+    arg.finish(%* {
+      "channelsResponse": channelsPermissionsResponse.result,
+      "communityResponse": communityPermissionsResponse.result,
+      "communityId": arg.communityId,
+      "addresses": arg.addresses,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "communityId": arg.communityId,
+      "addresses": arg.addresses,
+      "error": e.msg,
+    })

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1614,6 +1614,8 @@ QtObject:
   proc onAsyncCheckPermissionsToJoinDone*(self: Service, rpcResponse: string) {.slot.} =
     let rpcResponseObj = rpcResponse.parseJson
     let communityId = rpcResponseObj{"communityId"}.getStr()
+
+    echo "Check permissions to join rpcResponseObj: ", $rpcResponseObj
     try:
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
         raise newException(CatchableError, rpcResponseObj["error"].getStr)

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -106,7 +106,7 @@ StackLayout {
                              communityData.memberRole === Constants.memberRole.tokenMaster
             communityItemsModel: root.rootStore.communityItemsModel
             requirementsMet: root.permissionsStore.allTokenRequirementsMet
-            requirementsCheckPending: root.rootStore.permissionsCheckOngoing
+            requirementsCheckPending: sectionItem.requirementsCheckPending
             requiresRequest: !communityData.amIMember
             communityHoldingsModel: root.permissionsStore.becomeMemberPermissionsModel
             viewOnlyHoldingsModel: root.permissionsStore.viewOnlyPermissionsModel

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -33,6 +33,25 @@ QtObject {
 
     property var communityItemsModel: chatCommunitySectionModule.model
 
+    readonly property var myRevealedAddressesForCurrentCommunity: {
+        try {
+            let revealedAddresses = root.chatCommunitySectionModule.myRevealedAddressesStringForCurrentCommunity
+            let revealedAddressArray = JSON.parse(revealedAddresses)
+            return revealedAddressArray.map(addr => addr.toLowerCase())
+        } catch (e) {
+            console.error("Error parsing my revealed addresses", e)
+        }
+        return []
+    }
+    readonly property string myRevealedAirdropAddressForCurrentCommunity:
+        root.chatCommunitySectionModule.myRevealedAirdropAddressForCurrentCommunity.toLowerCase()
+    
+    property var selectedAddressesForPermissionsModel
+    onSelectedAddressesForPermissionsModelChanged: {
+        root.chatCommunitySectionModule.selectedAddressesForPermissionsModel = selectedAddressesForPermissionsModel
+    }
+    readonly property var permissionsModelWithSelectedAddresses: root.chatCommunitySectionModule.permissionsModelWithSelectedAddresses
+    
     property var assetsModel: SortFilterProxyModel {
         sourceModel: communitiesModuleInst.tokenList
 
@@ -57,17 +76,8 @@ QtObject {
         }
     }
 
-    function prepareTokenModelForCommunity(publicKey) {
-        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
-    }
-
     readonly property bool allChannelsAreHiddenBecauseNotPermitted: root.chatCommunitySectionModule.allChannelsAreHiddenBecauseNotPermitted &&
                                                                     !root.chatCommunitySectionModule.requiresTokenPermissionToJoin
-
-    readonly property bool requirementsCheckPending: root.communitiesModuleInst.requirementsCheckPending
-
-    readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?
-                                     root.communitiesModuleInst.spectatedCommunityPermissionModel : null
 
     readonly property string overviewChartData: chatCommunitySectionModule.overviewChartData
 
@@ -695,7 +705,13 @@ QtObject {
         }
     }
 
-    function updatePermissionsModel(communityId, sharedAddresses) {
-        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
+    function requestRevealedAddresses() {
+        print ("requestRevealedAddresses")
+        console.trace()
+        root.chatCommunitySectionModule.requestRevealedAddresses()
+    }
+
+    function updatePermissionsModel(sharedAddresses) {
+        root.chatCommunitySectionModule.checkPermissions(JSON.stringify(sharedAddresses))
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -262,7 +262,7 @@ StatusSectionLayout {
             requiresRequest: !root.amIMember
             requirementsMet: (viewOnlyPermissionsSatisfied && viewOnlyPermissionsModel.count > 0) ||
                              (viewAndPostPermissionsSatisfied && viewAndPostPermissionsModel.count > 0)
-            requirementsCheckPending: root.chatContentModule.permissionsCheckOngoing
+            requirementsCheckPending: root.rootStore.permissionsCheckOngoing
             onRequestToJoinClicked: root.requestToJoinClicked()
             onInvitationPendingClicked: root.invitationPendingClicked()
         }

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -110,14 +110,9 @@ QtObject {
     }
 
     property var communitiesList: communitiesModuleInst.model
-    readonly property bool requirementsCheckPending: communitiesModuleInst.requirementsCheckPending
 
     function spectateCommunity(publicKey) {
         root.communitiesModuleInst.spectateCommunity(publicKey, "");
-    }
-
-    function prepareTokenModelForCommunity(publicKey) {
-        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey);
     }
 
     function getCommunityDetails(communityId) {

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -53,10 +53,7 @@ Item {
         communityData.memberRole === Constants.memberRole.admin ||
         communityData.memberRole === Constants.memberRole.tokenMaster
 
-    readonly property var permissionsModel: {
-        root.store.prepareTokenModelForCommunity(communityData.id)
-        return root.store.permissionsModel
-    }
+    readonly property var permissionsModel: root.communitySectionModule.permissionsModel
 
     signal infoButtonClicked
     signal manageButtonClicked

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -17,7 +17,6 @@ QtObject {
     property var aboutModuleInst: aboutModule
     property var communitiesModuleInst: communitiesModule
     property bool newVersionAvailable: false
-    readonly property bool requirementsCheckPending: communitiesModuleInst.requirementsCheckPending
     property string latestVersion
     property string downloadURL
 
@@ -32,32 +31,6 @@ QtObject {
             return Constants.LoginType.Keycard
         return Constants.LoginType.Password
     }
-
-    function prepareTokenModelForCommunity(publicKey) {
-        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
-    }
-
-    property string communityKeyToImport
-    onCommunityKeyToImportChanged: {
-        if (!!communityKeyToImport)
-            root.prepareTokenModelForCommunity(communityKeyToImport);
-    }
-
-    readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?
-                                     root.communitiesModuleInst.spectatedCommunityPermissionModel : null
-
-    readonly property var myRevealedAddressesForCurrentCommunity: {
-        try {
-            let revealedAddresses = root.communitiesModuleInst.myRevealedAddressesStringForCurrentCommunity
-            let revealedAddressArray = JSON.parse(revealedAddresses)
-            return revealedAddressArray.map(addr => addr.toLowerCase())
-        } catch (e) {
-            console.error("Error parsing my revealed addresses", e)
-        }
-        return []
-    }
-    readonly property string myRevealedAirdropAddressForCurrentCommunity:
-        root.communitiesModuleInst.myRevealedAirdropAddressForCurrentCommunity.toLowerCase()
 
     property var walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
     
@@ -270,10 +243,6 @@ QtObject {
 
     function cleanJoinEditCommunityData() {
         communitiesModuleInst.cleanJoinEditCommunityData()
-    }
-
-    function updatePermissionsModel(communityId, sharedAddresses) {
-        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
     }
 
     function promoteSelfToControlNode(communityId) {

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -49,6 +49,8 @@ StatusStackModal {
     property string currentAirdropAddress: ""
     onCurrentAirdropAddressChanged: d.reEvaluateModels()
 
+    property var selectedAddresses: d.getSelectedAddresses().addresses
+
     property var getCurrencyAmount: function (balance, symbol){}
 
     property var canProfileProveOwnershipOfProvidedAddressesFn: function(addresses) { return false }
@@ -183,8 +185,27 @@ StatusStackModal {
             }
         }
 
-        readonly property var initialAddressesModel: SortFilterProxyModel {
+        property var initialAddressesModel: SortFilterProxyModel {
             sourceModel: root.walletAccountsModel
+            sorters: [
+                FastExpressionSorter {
+                    function sortPredicate(lhs, rhs) {
+                        if (lhs.walletType === rhs.walletType) return 0
+                        return lhs.walletType === Constants.generatedWalletType ? -1 : 1
+                    }
+
+                    expression: {
+                        return sortPredicate(modelLeft, modelRight)
+                    }
+                    expectedRoles: ["walletType"]
+                },
+                RoleSorter {
+                    roleName: "position"
+                },
+                RoleSorter {
+                    roleName: "name"
+                }
+            ]
         }
 
         function proceedToSigningOrSubmitRequest(uidOfComponentThisFunctionIsCalledFrom) {


### PR DESCRIPTION
### What does the PR do

Closing: #14095 
Closing: #14200
Closing: #12326


Moving the permissions model from communities module to chat section module (at least that's the main intention). But we'll need to also move or adapt other dependencies like check permissions on selected addresses, revealed addresses.

Motivation: The current implementation in communities module is built based on the assumption that we'll need the permissions for only one community at a time. But it's not the case. We have lots of qml bindings on the permission model, each one requesting the model for a new community because the permissionsModel access is done something like:

```
    readonly property var permissionsModel: {
        root.store.prepareTokenModelForCommunity(communityData.id)
        return root.store.permissionsModel
    }
```

O top of this, there are issues with permission update events handling and we're not always seeing the permission updates in qml.

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->