### PR TITLE
fix(SendModal) missing icons for assets in Send Modal

### DIFF
--- a/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
@@ -48,7 +48,10 @@ StatusListItem {
         let balance = !!model && !!model.currentCurrencyBalance ? model.currentCurrencyBalance : 0
         return root.formatCurrentCurrencyAmount(balance)
     }
-    asset.name: symbol ? Style.png("tokens/" + symbol) : ""
+    // Community assets have a dedicated image streamed from status-go
+    asset.name: !!model.image
+                ? model.image
+                : Constants.tokenIcon(symbol)
     asset.isImage: true
     asset.width: 32
     asset.height: 32

--- a/ui/imports/shared/popups/send/panels/HoldingSelector.qml
+++ b/ui/imports/shared/popups/send/panels/HoldingSelector.qml
@@ -98,7 +98,15 @@ Item {
         }
 
         property var assetIconSourceFn: function (asset) {
-            return !!asset && asset.symbol ? Style.png("tokens/%1".arg(asset.symbol)) : ""
+            if (!asset) {
+                return ""
+            } else if (asset.image) {
+                // Community assets have a dedicated image streamed from status-go
+                return asset.image
+            } else {
+                return Constants.tokenIcon(asset.symbol)
+            }
+            return ""
         }
 
         property var collectibleTextFn: function (item) {


### PR DESCRIPTION
### Closes: #14218

In case of assets the symbol doesn't have an icon representation in resources, hence we use the image of the asset itself. Same fix was applied for header and delegates