### PR TITLE
fix[Onboarding] Password screen is not correct

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
@@ -165,7 +165,6 @@ StatusDialog {
             StatusFlatButton {
                 text: qsTr("Cancel")
                 visible: !d.dbEncryptionInProgress && !d.passwordChanged
-                textColor: Style.current.darkGrey
                 onClicked: { root.close(); }
             }
         }
@@ -173,7 +172,7 @@ StatusDialog {
             StatusButton {
                 id: submitBtn
                 objectName: "changePasswordModalSubmitButton"
-                text: !d.dbEncryptionInProgress && !d.passwordChanged ? qsTr("Re-encrypt data using new password") : qsTr("Restart status")
+                text: !d.dbEncryptionInProgress && !d.passwordChanged ? qsTr("Re-encrypt data using new password") : qsTr("Restart Status")
                 enabled: !d.dbEncryptionInProgress
                 onClicked: {
                     if (d.passwordChanged) {

--- a/ui/imports/shared/popups/keycard/states/CreatePassword.qml
+++ b/ui/imports/shared/popups/keycard/states/CreatePassword.qml
@@ -17,12 +17,13 @@ Item {
         anchors.fill: parent
         anchors.topMargin: Style.current.xlPadding
         anchors.bottomMargin: Style.current.halfPadding
-        anchors.leftMargin: 2*(Style.current.xlPadding + Style.current.bigPadding)
-        anchors.rightMargin: 2*(Style.current.xlPadding + Style.current.bigPadding)
+        anchors.leftMargin: Style.current.xlPadding
+        anchors.rightMargin: Style.current.xlPadding
         spacing: Style.current.padding
 
         PasswordView {
             Layout.minimumWidth: 460
+            Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.fillHeight: true
             passwordStrengthScoreFunction: RootStore.getPasswordStrengthScore

--- a/ui/imports/shared/views/PasswordView.qml
+++ b/ui/imports/shared/views/PasswordView.qml
@@ -193,6 +193,8 @@ ColumnLayout {
     }
 
     ColumnLayout {
+        visible: !root.createNewPsw
+
         StatusBaseText {
             text: qsTr("Current password")
         }
@@ -204,7 +206,6 @@ ColumnLayout {
             property bool showPassword
 
             z: root.zFront
-            visible: !root.createNewPsw
             Layout.fillWidth: true
             Layout.alignment: root.contentAlignment
             placeholderText: qsTr("Enter current password")
@@ -229,12 +230,12 @@ ColumnLayout {
     }
 
     StatusModalDivider {
+        visible: !root.createNewPsw
         Layout.fillWidth: true
         Layout.alignment: root.contentAlignment
     }
 
     ColumnLayout {
-        spacing: 4
         z: root.zFront
         Layout.fillWidth: true
         Layout.alignment: root.contentAlignment
@@ -370,7 +371,6 @@ ColumnLayout {
     ColumnLayout {
         StatusBaseText {
             text: qsTr("Confirm new password")
-            color: Theme.palette.baseColor1
         }
 
         StatusPasswordInput {


### PR DESCRIPTION
### What does the PR do

- hide the "Current password" label when creating a new password
- fix margins inside the keycard popup
- some minor UI fixups according to Figma

Fixes: #14214
Fixes: #14177

### Affected areas

PasswordView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/e895c9c1-6ee0-4a90-ba02-fca13a700b83)

