### PR TITLE
fix(Permissions): tokenOwner is present in the list of collectibles when adding a permission

### DIFF
--- a/src/app/modules/shared_models/token_list_item.nim
+++ b/src/app/modules/shared_models/token_list_item.nim
@@ -17,6 +17,7 @@ type
     supply*: string
     infiniteSupply*: bool
     decimals*: int
+    privilegesLevel*: int
 
 proc initTokenListItem*(
   key: string,
@@ -28,7 +29,8 @@ proc initTokenListItem*(
   communityId: string = "",
   supply: string = "1",
   infiniteSupply: bool = true,
-  decimals: int
+  decimals: int,
+  privilegesLevel: int
 ): TokenListItem =
   result.key = key
   result.symbol = symbol
@@ -40,6 +42,7 @@ proc initTokenListItem*(
   result.supply = supply
   result.infiniteSupply = infiniteSupply
   result.decimals = decimals
+  result.privilegesLevel = privilegesLevel
 
 proc `$`*(self: TokenListItem): string =
   result = fmt"""TokenListItem(
@@ -52,6 +55,7 @@ proc `$`*(self: TokenListItem): string =
     supply: {self.supply},
     infiniteSupply: {self.infiniteSupply},
     decimals: {self.decimals},
+    privilegesLevel: {self.privilegesLevel}
     ]"""
 
 proc getKey*(self: TokenListItem): string =
@@ -83,3 +87,6 @@ proc getInfiniteSupply*(self: TokenListItem): bool =
 
 proc getDecimals*(self: TokenListItem): int =
   return self.decimals
+
+proc getPrivilegesLevel*(self: TokenListItem): int =
+  return self.privilegesLevel

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -14,6 +14,7 @@ type
     Supply
     InfiniteSupply
     Decimals
+    PrivilegesLevel
 
 QtObject:
   type TokenListModel* = ref object of QAbstractListModel
@@ -93,6 +94,7 @@ QtObject:
       ModelRole.Supply.int:"supply",
       ModelRole.InfiniteSupply.int:"infiniteSupply",
       ModelRole.Decimals.int:"decimals",
+      ModelRole.PrivilegesLevel.int:"privilegesLevel",
     }.toTable
 
   method rowCount(self: TokenlistModel, index: QModelIndex = nil): int =
@@ -128,3 +130,5 @@ QtObject:
         result = newQVariant(item.getInfiniteSupply())
       of ModelRole.Decimals:
         result = newQVariant(item.getDecimals())
+      of ModelRole.PrivilegesLevel:
+        result = newQVariant(item.getPrivilegesLevel())

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -300,7 +300,19 @@ StatusSectionLayout {
             // solution soon.
 
             assetsModel: rootStore.assetsModel
-            collectiblesModel: rootStore.collectiblesModel
+
+            SortFilterProxyModel {
+                id: nonOwnerCollectibles
+                sourceModel: rootStore.collectiblesModel
+                filters: [
+                    ValueFilter {
+                        roleName: "privilegesLevel"
+                        value: Constants.TokenPrivilegesLevel.Owner
+                        inverted: true
+                    }
+                ]
+            }
+            collectiblesModel: nonOwnerCollectibles
             channelsModel: rootStore.chatCommunitySectionModule.model
 
             communityDetails: d.communityDetails


### PR DESCRIPTION
fixes #13561

### What does the PR do
1. Add `privilegesLevel` role to token_list_model.nim
2. Communities/module.nim - moved duplicate code to buildCommunityTokenItemFallback
3. CommunitySettingsView.qml - filter out collectibles with TokenPrivilegesLevel.Owner

### Affected areas
Community - Permissions - HoldingsDropdown

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/82129351-d2f7-4052-8bce-4ee135cf5804


### Alternative solution

If we always show community-minted tokens, it may be sufficient to filter the `communityTokens` model (a similar approach is used for `AirdropsSettingsPanel)

```

            Loader {
                id: collectiblesModelLoader
                active: airdropPanel.communityTokens

                sourceComponent: SortFilterProxyModel {

                    sourceModel: airdropPanel.communityTokens
                    filters: [
                        ValueFilter {
                            roleName: "tokenType"
                            value: Constants.TokenType.ERC721
                        },
                        ExpressionFilter {
                            function getPrivileges(privilegesLevel) {
                                return privilegesLevel === Constants.TokenPrivilegesLevel.Community ||
                                        (root.isOwner && privilegesLevel === Constants.TokenPrivilegesLevel.TMaster)
                            }

                            expression: { return getPrivileges(model.privilegesLevel) }
                        }
                    ]
```