### PR TITLE
feat(SharedAddressesAccountSelector): update wallet account sorting

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -170,6 +170,7 @@ StatusListView {
     spacing: Style.current.halfPadding
     delegate: StatusListItem {
         readonly property string address: model.address.toLowerCase()
+        readonly property int tokenCount: tagsCount
 
         id: listItem
         width: ListView.view.width - ListView.view.leftMargin - ListView.view.rightMargin
@@ -231,9 +232,11 @@ StatusListView {
                 inverted: true
             }
 
-            sorters: RoleSorter {
-                roleName: "symbol"
-            }
+            sorters: [
+                RoleSorter {
+                    roleName: "symbol"
+                }
+            ]
         }
 
         SortFilterProxyModel {

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -258,6 +258,7 @@ StatusListView {
 
                     // Singletons cannot be used directly in sfpm's expressions
                     expression: typeVal
+                    expectedRoles: []
                 },
                 FastExpressionRole {
                     name: "imageUrl"

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
@@ -73,34 +74,36 @@ Rectangle {
         readonly property var tokenMasterPermissionsModel: SortFilterProxyModel {
             id: tokenMasterPermissionsModel
             sourceModel: root.permissionsModel
-            function filterPredicate(modelData) {
-                return (modelData.permissionType === Constants.permissionType.becomeTokenMaster)
-                        && modelData.tokenCriteriaMet
+            function filterPredicate(permissionType, tokenCriteriaMet) {
+                return (permissionType === Constants.permissionType.becomeTokenMaster) && tokenCriteriaMet
             }
-            filters: ExpressionFilter {
-                expression: tokenMasterPermissionsModel.filterPredicate(model)
+            filters: FastExpressionFilter {
+                expression: tokenMasterPermissionsModel.filterPredicate(model.permissionType, model.tokenCriteriaMet)
+                expectedRoles: ["permissionType", "tokenCriteriaMet"]
             }
         }
         readonly property var adminPermissionsModel: SortFilterProxyModel {
             id: adminPermissionsModel
             sourceModel: root.permissionsModel
-            function filterPredicate(modelData) {
-                return (modelData.permissionType === Constants.permissionType.admin) &&
-                        (!modelData.isPrivate || (modelData.tokenCriteriaMet && modelData.isPrivate)) // visible or (hidden & met)
+            function filterPredicate(permissionType, tokenCriteriaMet, isPrivate) {
+                return (permissionType === Constants.permissionType.admin) &&
+                        (!isPrivate || (tokenCriteriaMet && isPrivate)) // visible or (hidden & met)
             }
-            filters: ExpressionFilter {
-                expression: adminPermissionsModel.filterPredicate(model)
+            filters: FastExpressionFilter {
+                expression: adminPermissionsModel.filterPredicate(model.permissionType, model.tokenCriteriaMet, model.isPrivate)
+                expectedRoles: ["permissionType", "tokenCriteriaMet", "isPrivate"]
             }
         }
         readonly property var joinPermissionsModel: SortFilterProxyModel {
             id: joinPermissionsModel
             sourceModel: root.permissionsModel
-            function filterPredicate(modelData) {
-                return (modelData.permissionType === Constants.permissionType.member) &&
-                        (!modelData.isPrivate || (modelData.tokenCriteriaMet && modelData.isPrivate)) // visible or (hidden & met)
+            function filterPredicate(permissionType, tokenCriteriaMet, isPrivate) {
+                return (permissionType === Constants.permissionType.member) &&
+                        (!isPrivate || (tokenCriteriaMet && isPrivate)) // visible or (hidden & met)
             }
-            filters: ExpressionFilter {
-                expression: joinPermissionsModel.filterPredicate(model)
+            filters: FastExpressionFilter {
+                expression: joinPermissionsModel.filterPredicate(model.permissionType, model.tokenCriteriaMet, model.isPrivate)
+                expectedRoles: ["permissionType", "tokenCriteriaMet", "isPrivate"]
             }
         }
 
@@ -108,12 +111,13 @@ Rectangle {
         readonly property var channelsPermissionsModel: SortFilterProxyModel {
             id: channelsPermissionsModel
             sourceModel: root.permissionsModel
-            function filterPredicate(modelData) {
-                return (modelData.permissionType === Constants.permissionType.read || modelData.permissionType === Constants.permissionType.viewAndPost) &&
-                        (!modelData.isPrivate || (modelData.tokenCriteriaMet && modelData.isPrivate)) // visible or (hidden & met)
+            function filterPredicate(permissionType, tokenCriteriaMet, isPrivate) {
+                return (permissionType === Constants.permissionType.read || permissionType === Constants.permissionType.viewAndPost) &&
+                        (!isPrivate || (tokenCriteriaMet && isPrivate)) // visible or (hidden & met)
             }
-            filters: ExpressionFilter {
-                expression: channelsPermissionsModel.filterPredicate(model)
+            filters: FastExpressionFilter {
+                expression: channelsPermissionsModel.filterPredicate(model.permissionType, model.tokenCriteriaMet, model.isPrivate)
+                expectedRoles: ["permissionType", "tokenCriteriaMet", "isPrivate"]
             }
         }
     }
@@ -485,13 +489,15 @@ Rectangle {
                                 model: SortFilterProxyModel {
                                     id: channelPermissionsModel
                                     sourceModel: root.permissionsModel
-                                    function filterPredicate(modelData) {
-                                        return modelData.permissionType === channelPermsSubPanel.permissionType &&
-                                                (!modelData.isPrivate || (modelData.tokenCriteriaMet && modelData.isPrivate)) &&
-                                                ModelUtils.contains(modelData.channelsListModel, "key", channelPermsPanel.channelKey) // filter and group by channel "key"
+                                    function filterPredicate(permissionType, tokenCriteriaMet, isPrivate, channelsListModel) {
+                                        return permissionType === channelPermsSubPanel.permissionType &&
+                                                (!isPrivate || (tokenCriteriaMet && isPrivate)) &&
+                                                ModelUtils.contains(channelsListModel, "key", channelPermsPanel.channelKey) // filter and group by channel "key"
                                     }
-                                    filters: ExpressionFilter {
-                                        expression: channelPermissionsModel.filterPredicate(model)
+                                    filters: FastExpressionFilter {
+                                        expression: channelPermissionsModel.filterPredicate(model.permissionType, model.tokenCriteriaMet,
+                                                                                            model.isPrivate, model.channelsListModel)
+                                        expectedRoles: ["permissionType", "tokenCriteriaMet", "isPrivate", "channelsListModel"]
                                     }
                                 }
                                 delegate: ColumnLayout {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -2,6 +2,8 @@ import QtQuick 2.13
 
 import utils 1.0
 
+import StatusQ 0.1
+
 import SortFilterProxyModel 0.2
 import AppLayouts.Wallet.stores 1.0 as WalletStore
 
@@ -62,24 +64,26 @@ QtObject {
     readonly property var globalAssetsModel: SortFilterProxyModel {
         sourceModel: communitiesModuleInst.tokenList
 
-        proxyRoles: ExpressionRole {
+        proxyRoles: FastExpressionRole {
             function tokenIcon(symbol) {
                 return Constants.tokenIcon(symbol)
             }
             name: "iconSource"
             expression: !!model.icon ? model.icon : tokenIcon(model.symbol)
+            expectedRoles: ["icon", "symbol"]
         }
     }
 
     readonly property var globalCollectiblesModel: SortFilterProxyModel {
         sourceModel: communitiesModuleInst.collectiblesModel
 
-        proxyRoles: ExpressionRole {
-            function icon(icon) {
+        proxyRoles: FastExpressionRole {
+            function collectibleIcon(icon) {
                 return !!icon ? icon : Style.png("tokens/DEFAULT-TOKEN")
             }
             name: "iconSource"
-            expression: icon(model.icon)
+            expression: collectibleIcon(model.icon)
+            expectedRoles: ["icon"]
         }
     }
 

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -183,27 +183,8 @@ StatusStackModal {
             }
         }
 
-        property var initialAddressesModel: SortFilterProxyModel {
+        readonly property var initialAddressesModel: SortFilterProxyModel {
             sourceModel: root.walletAccountsModel
-            sorters: [
-                FastExpressionSorter {
-                    function sortPredicate(lhs, rhs) {
-                        if (lhs.walletType === rhs.walletType) return 0
-                        return lhs.walletType === Constants.generatedWalletType ? -1 : 1
-                    }
-
-                    expression: {
-                        return sortPredicate(modelLeft, modelRight)
-                    }
-                    expectedRoles: ["walletType"]
-                },
-                RoleSorter {
-                    roleName: "position"
-                },
-                RoleSorter {
-                    roleName: "name"
-                }
-            ]
         }
 
         function proceedToSigningOrSubmitRequest(uidOfComponentThisFunctionIsCalledFrom) {


### PR DESCRIPTION
### What does the PR do

- implement sorting of the wallet accounts by the number of tokens (aka tags) and then by alphabet
- due to the delegate complexity here and usage of nested models, keep track of the tags count separately and outside of the model
- this will be improved later on as part of the complete sort/order design described in https://github.com/status-im/status-desktop/issues/14192

Fixes https://github.com/status-im/status-desktop/issues/14101

### Affected areas

SharedAddressesAccountSelector, SharedAddressesPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/3c0124e7-7752-4fae-bb16-97be7d93a003)

