### PR TITLE
fix(ProfileShowcase): Filter out communities the user hasn't joined from

### DIFF
--- a/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseSettingsModelAdapter.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ProfileShowcaseSettingsModelAdapter.qml
@@ -59,6 +59,10 @@ QObject {
                 expectedRoles: ["members"]
             }
         ]
+        filters: ValueFilter {
+            roleName: "joined"
+            value: true
+        }
     }
 
     JoinModel {


### PR DESCRIPTION
### What does the PR do

Closes #14231 

Filter the communities the user hasn't joined.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Profile showcase

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/79d0397a-f111-463f-8d01-295d17c71614
