### PR TITLE
fix: permissions with value>1000

### DIFF
--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -275,7 +275,7 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.assetsModel, key)
 
-                    addItem(Constants.TokenType.ERC20, modelItem, String(AmountsArithmetic.fromNumber(amount, modelItem.decimals)))
+                    addItem(Constants.TokenType.ERC20, modelItem, AmountsArithmetic.fromNumber(amount, modelItem.decimals).toFixed())
                     dropdown.close()
                 }
 
@@ -298,7 +298,7 @@ StatusScrollView {
                     const modelItem = PermissionsHelpers.getTokenByKey(root.assetsModel, key)
 
                     d.dirtyValues.selectedHoldingsModel.set(
-                                itemIndex, { type: Constants.TokenType.ERC20, key, amount: String(AmountsArithmetic.fromNumber(amount, modelItem.decimals)) })
+                                itemIndex, { type: Constants.TokenType.ERC20, key, amount: AmountsArithmetic.fromNumber(amount, modelItem.decimals).toFixed() })
                     dropdown.close()
                 }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14006

## What does the PR do

As documented in big.js, `toString()` might return exponential form, which is not expected by our status-go backend.
The fix is to use `toFixed()`, which always returns normal form.

https://github.com/status-im/status-desktop/assets/25482501/3a86c8d9-6d67-41ca-910b-9aa808d40c2c

