### PR TITLE
fix(Profile): Fix crashing when showcase collectible having disabled chainIds

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -204,5 +204,5 @@ proc requestProfileShowcaseForContact*(self: Controller, contactId: string, vali
 proc fetchProfileShowcaseAccountsByAddress*(self: Controller, address: string) =
   self.contactsService.fetchProfileShowcaseAccountsByAddress(address)
 
-proc getChainIds*(self: Controller): seq[int] =
-  self.networkService.getCurrentNetworks().map(n => n.chainId)
+proc getEnabledChainIds*(self: Controller): seq[int] =
+  return self.networkService.getCurrentNetworks().filter(n => n.isEnabled).map(n => n.chainId)

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -87,3 +87,10 @@ proc isPathOutOfTheDefaultStatusDerivationTree*(path: string): bool =
 
 proc contractUniqueKey*(chainId: int, contractAddress: string): string =
   return $chainId & "_" & contractAddress
+
+proc intersectSeqs*[T](seq1, seq2: seq[T]): seq[T] =
+  var result: seq[T] = @[]
+  for item in seq1:
+    if item in seq2:
+      result.add(item)
+  return result


### PR DESCRIPTION
Close #14243

### What does the PR do

Fix crash when a profile collectible had a chainId from disabled network e.g main net chain id when test net is enabled

### Affected areas

Profile

### Screenshot of functionality (including design for comparison)

<img width="679" alt="Screenshot 2024-04-02 at 16 36 56" src="https://github.com/status-im/status-desktop/assets/2522130/e4a54668-2102-48ac-a90f-411e6bffe3a0">
