### PR TITLE
feat(wallet): Disable send for soulbound collectibles

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -262,7 +262,15 @@ Item {
             walletStore: RootStore
             networkConnectionStore: root.networkConnectionStore
             isCommunityOwnershipTransfer: footer.isHoldingSelected && footer.isOwnerCommunityCollectible
-            communityName: !!walletStore.currentViewedCollectible ? walletStore.currentViewedCollectible.communityName : ""
+            communityName: {
+                if (!walletStore.currentViewedCollectible)
+                    return ""
+                const name = walletStore.currentViewedCollectible.communityName
+                const id = walletStore.currentViewedCollectible.communityId
+                if (name === id)
+                    return Utils.compactAddress(id, 4)
+                return name
+            }
             onLaunchShareAddressModal: Global.openShowQRPopup({
                                                                   switchingAccounsEnabled: true,
                                                                   changingPreferredChainsEnabled: true,

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -28,6 +28,11 @@ Rectangle {
 
     color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
 
+    QtObject {
+        id: d
+        readonly property int collectibleTransferableTrait: !!walletStore.currentViewedCollectible && sendButton.visible ? walletStore.findCollectibleTrait(walletStore.currentViewedCollectible, Constants.collectibleTrait.transferable, Constants.collectibleTrait.transferableNoValue) : -1
+    }
+
     StatusModalDivider {
         anchors.top: parent.top
         width: parent.width
@@ -39,12 +44,13 @@ Rectangle {
         spacing:  Style.current.padding
 
         StatusFlatButton {
+            id: sendButton
             objectName: "walletFooterSendButton"
             icon.name: "send"
             text: root.isCommunityOwnershipTransfer ? qsTr("Send Owner token to transfer %1 Community ownership").arg(root.communityName) : qsTr("Send")
-            interactive: networkConnectionStore.sendBuyBridgeEnabled
+            interactive: d.collectibleTransferableTrait != 1 && networkConnectionStore.sendBuyBridgeEnabled
             onClicked: root.launchSendModal()
-            tooltip.text: networkConnectionStore.sendBuyBridgeToolTipText
+            tooltip.text: d.collectibleTransferableTrait == 1 ? qsTr("Soulbound collectibles cannot be sent to another wallet") : networkConnectionStore.sendBuyBridgeToolTipText
             visible: !walletStore.overview.isWatchOnlyAccount && walletStore.overview.canSend
         }
 

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -601,4 +601,19 @@ QtObject {
         let baseLink = root.areTestNetworksEnabled ? Constants.openseaExplorerLinks.testnetLink : Constants.openseaExplorerLinks.mainnetLink
         return "%1/assets/%2/%3/%4".arg(baseLink).arg(networkName).arg(contractAddress).arg(tokenId)
     }
+
+    function findCollectibleTrait(collectible, trait, value) {
+        // Return values:
+        // -1: Trait does not exist
+        // 0: Trait found but value is different
+        // 1: Trait found and Value is the the same
+        if (!collectible || !value || !trait) {
+            return -1
+        }
+        const index = SQUtils.ModelUtils.indexOf(collectible.traits, "traitType", trait)
+        if (index < 0)
+            return -1
+
+        return SQUtils.ModelUtils.get(collectible.traits, index, "value") === value ? 1 : 0
+    }
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -758,6 +758,11 @@ QtObject {
         }
     }
 
+    readonly property QtObject collectibleTrait: QtObject {
+        readonly property string transferable: "Transferable"
+        readonly property string transferableNoValue: "No"
+    }
+
     readonly property QtObject keypairImportPopup: QtObject {
         readonly property int popupWidth: 480
         readonly property int contentHeight: 626


### PR DESCRIPTION
Task #13810 

### What does the PR do

* Disabled send button and showed tooltip on hover for soulbound collectibles
* Elided community id for unknown communities

### Affected areas

Wallet / collectibles details

### Screenshot of functionality (including design for comparison)

![soulbound](https://github.com/status-im/status-desktop/assets/11396062/7004e8c2-124d-4284-bb96-fe3e617de800)
