### PR TITLE
chore: fill holes in ChatType enum

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -55,7 +55,11 @@ switch("warning", "UnreachableElse:off")
 # Those are popular to miss in our app, and quickly make build log unreadable, so we want to prevent them
 switch("warningAsError", "UseBase:on")
 switch("warningAsError", "UnusedImport:on")
+switch("warningAsError", "Deprecated:on")
+switch("warningAsError", "HoleEnumConv:on")
 
 # Workaround for https://github.com/nim-lang/Nim/issues/23429
 switch("warning", "UseBase:on")
 switch("warning", "UnusedImport:on")
+switch("warning", "Deprecated:on")
+switch("warning", "HoleEnumConv:on")

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -650,7 +650,7 @@ proc terminateCurrentFlow*(self: Controller, lastStepInTheCurrentFlow: bool, nex
         exportedEncryptionPubKey = flowEvent.generatedWalletAccounts[0].publicKey # encryption key is at position 0
         if exportedEncryptionPubKey.len > 0:
           self.tmpFlowData.password = exportedEncryptionPubKey
-          for i in 0..< self.tmpRequestedPathsAlongWithAuthentication.len:
+          for i in 0..<self.tmpRequestedPathsAlongWithAuthentication.len:
             var path = self.tmpRequestedPathsAlongWithAuthentication[i]
             self.tmpFlowData.additinalPathsDetails[path] = KeyDetails(
               address: flowEvent.generatedWalletAccounts[i].address,

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -13,6 +13,7 @@ type ChatType* {.pure.}= enum
   Public = 2,
   PrivateGroupChat = 3,
   Profile = 4,
+  Timeline {.deprecated.} = 5,
   CommunityChat = 6
 
 type ChannelGroupType* {.pure.}= enum


### PR DESCRIPTION
## Fix `[HoleEnumConv]` enum warning

Fixed this warning:
```bash
/src/app_service/service/chat/dto/chat.nim(302, 33) Warning: conversion to enum with holes is unsafe: ChatType(chatTypeInt) [HoleEnumConv]
```

The simplest fix here is to fill the hole in the `ChatType` enum. Value `5` corresponds to `Timeline` chat type, which is deprecated:
https://github.com/status-im/status-go/blob/8bf03609fc0f76eb8488869db1a7c22c68408c01/protocol/chat.go#L43-L45

1. Added `Timeline` with `{.deprecated.}` pragma
2. Marked `[Deprecated]` warning as error. You'll get this if you try to use it:
```bash
/src/app_service/service/chat/dto/chat.nim(310, 19) Error: Timeline is deprecated [Deprecated]
```
3. Marked `[HoleEnumConv]` warning as error.

## Fix `[Spacing]` warning

Fixed this warning:
```bash
src/app/modules/shared_modules/keycard_popup/controller.nim(653, 21) Warning: Number of spaces around '..<' is not consistent [Spacing]
```

Just removed a redundant space. 