### PR TITLE
fix(@desktop/wallet): prevent collectibles controller crash if networ…

### DIFF
--- a/src/app/modules/shared_modules/collectible_details/controller.nim
+++ b/src/app/modules/shared_modules/collectible_details/controller.nim
@@ -55,7 +55,8 @@ QtObject:
 
   proc getExtraData(self: Controller, chainID: int): ExtraData =
     let network = self.networkService.getNetworkByChainId(chainID)
-    return getExtraData(network)
+    if not network.isNil:
+      return getExtraData(network)
 
   proc processGetCollectiblesDetailsResponse(self: Controller, response: JsonNode) =
     defer: self.setIsDetailedEntryLoading(false)

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -152,7 +152,8 @@ QtObject:
 
   proc getExtraData(self: Controller, chainID: int): ExtraData =
     let network = self.networkService.getNetworkByChainId(chainID)
-    return getExtraData(network)
+    if not network.isNil:
+      return getExtraData(network)
 
   proc setTempItems(self: Controller, newItems: seq[CollectiblesEntry], offset: int) =
     if offset == 0:


### PR DESCRIPTION
…k unknown

### What does the PR do

We didn't check for nil when requesting networks in the collectibles controller. This caused a crash if a collectible from some unknown network (or one from the opposite chains to whatever the testnet mode is set to) was processed. This PR adds a nil check. 
