### PR TITLE
fix(Profile Flow): Marking as ID verified is not reflected in community member

### DIFF
--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -221,7 +221,7 @@ proc trustStatus*(self: ContactsDto): TrustStatus =
   result = self.trustStatus
 
 proc isContactVerified*(self: ContactsDto): bool =
-  return self.verificationStatus == VerificationStatus.Verified
+  return self.verificationStatus == VerificationStatus.Verified or self.trustStatus == TrustStatus.Trusted
 
 proc isContactUntrustworthy*(self: ContactsDto): bool =
   return self.trustStatus == TrustStatus.Untrustworthy


### PR DESCRIPTION
fixes #13772

There are several approaches to displaying the "verified" icon for a contact:
- ProfileContexatMenu.qml, ProfileDialogView.qml - it checks whether the outgoingVerificationStatus, incomingVerificationStatus, or trustedStatus is "trusted"
- StatusMemberListItem.qml - only used the usersModule.model.isVerified field (which is the same as outgoingVerificationStatus)

### What does the PR do

1. Adds `trustStatus` to `ChatContentModule.usersModule.model`
2. Fixes `isVerified` value passed to `StatusMemberListItem` 

### Affected areas

usersModule.model

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/dc80f85e-c7db-4409-bf55-aae6870e015f

Further improvements:

- I think it makes sense to move this logic to users/module.nim and leave only the `isVerified` field to be calculated with trustedStatus (and maybe outgoingVerificationStatus, incomingVerificationStatus). But I'm not sure what should be in `isVerified` because there are several ways to verify
- Then other places like ContactListItemDelegate.qml will be fixed automatically 
