### PR TITLE
(desktop/bug) Fix view&post token permitted channel input

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -97,7 +97,9 @@ proc asyncCheckPermissionsToJoin*(self: Controller) =
 proc asyncCheckAllChannelsPermissions*(self: Controller) =
   if self.delegate.getPermissionsToJoinCheckOngoing():
     return
-  self.chatService.asyncCheckAllChannelsPermissions(self.getMySectionId(), addresses = @[])
+
+  let addresses = self.communityService.getSharedAddresses()
+  self.chatService.asyncCheckAllChannelsPermissions(self.getMySectionId(), addresses)
   self.delegate.setChannelsPermissionsCheckOngoing(true)
 
 proc asyncCheckChannelPermissions*(self: Controller, communityId: string, chatId: string) =
@@ -466,6 +468,7 @@ proc setActiveItem*(self: Controller, itemId: string) =
   let isSectionActive = self.getIsCurrentSectionActive()
   if not isSectionActive:
     return
+
   if self.activeItemId != "":
     self.messageService.asyncLoadInitialMessagesForChat(self.activeItemId)
 


### PR DESCRIPTION
### Description

Currently the PR is WIP. 
I need feedbacks on that approach, and if there's better way to solve the problems at hands. The code seems much more tricky than I had anticipated.
This PR fixes #14117 and will fix the use cases mentioned in `What does the PR do`

### What does the PR do

This PR attempts to fix

- Restore write when channel is unlocked
- Set the channel permissions at boot
- Detect changes when user
   - edit permissions
   - create permissions
   - delete permissions

### Affected areas

- Channel
- Permissions

### Screenshot of functionality (including design for comparison)

Updated screencast

[Screencast from 2024-04-06 12:04:05 AM.webm](https://github.com/status-im/status-desktop/assets/2589171/d9ef0049-3caa-4bae-9389-d68c8a1fc642)
