### PR TITLE
chore(SharedAddressesPermissionsPanel): optimize the speed

### DIFF
--- a/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
@@ -16,6 +16,8 @@ class PermissionUtilsInternal : public QObject
 public:
     explicit PermissionUtilsInternal(QObject* parent = nullptr);
 
+    Q_INVOKABLE QVariantMap getTokenByKey(QAbstractItemModel *model, const QVariant& keyValue) const;
+
     //!< traverse the permissions @p model, and look for unique token keys recursively under holdingsListModel->key
     Q_INVOKABLE QStringList getUniquePermissionTokenKeys(QAbstractItemModel *model, int type) const;
 

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -12,26 +12,7 @@ import utils 1.0
 
 QtObject {
     function getTokenByKey(model, key) {
-        if (!model)
-            return null
-
-        const count = model.rowCount()
-
-        for (let i = 0; i < count; i++) {
-            const item = ModelUtils.get(model, i)
-
-            if (item.key === key)
-                return item
-
-            if (item.subItems) {
-                const subitem = getTokenByKey(item.subItems, key)
-
-                if (subitem !== null)
-                    return subitem
-            }
-        }
-
-        return null
+        return Internal.PermissionUtils.getTokenByKey(model, key)
     }
 
     function getTokenNameByKey(model, key) {

--- a/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
+++ b/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
@@ -25,29 +25,26 @@ SortFilterProxyModel {
         FastExpressionRole {
             name: "text"
 
-            function getName(type, key) {
+            function getName(type, item, key) {
                 if (type === Constants.TokenType.ENS)
                     return key
+                return item ? item.symbol || item.shortName || item.name : ""
+            }
 
+            function getDecimals(type, item) {
+                if (type !== Constants.TokenType.ERC20)
+                    return 0
+                return item.decimals
+            }
+
+            function getText(type, key, amount) {
                 const model = type === Constants.TokenType.ERC20
                             ? assetsModel
                             : collectiblesModel
                 const item = PermissionsHelpers.getTokenByKey(model, key)
 
-                return item ? item.symbol || item.shortName || item.name : ""
-            }
-
-            function getDecimals(type, key) {
-                if (type !== Constants.TokenType.ERC20) {
-                    return 0
-                }
-                const item = PermissionsHelpers.getTokenByKey(assetsModel, key)
-                return item.decimals
-            }
-
-            function getText(type, key, amount) {
-                const name = getName(type, key)
-                const decimals = getDecimals(type, key)
+                const name = getName(type, item, key)
+                const decimals = getDecimals(type, item)
 
                 return PermissionsHelpers.setHoldingsTextFormat(
                             type, name, amount, decimals)
@@ -89,7 +86,6 @@ SortFilterProxyModel {
             readonly property int none: OperatorsUtils.Operators.None
 
             expression: none
-            expectedRoles: []
         }
     ]
 }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -38,10 +38,6 @@ QtObject {
     }
 
     property string communityKeyToImport
-    onCommunityKeyToImportChanged: {
-        if (!!communityKeyToImport)
-            root.prepareTokenModelForCommunity(communityKeyToImport);
-    }
 
     readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?
                                      root.communitiesModuleInst.spectatedCommunityPermissionModel : null


### PR DESCRIPTION
### What does the PR do

- don't use the expensive `ExpressionFoo` in SFPM, just use `AnyOf/AllOf` combinations where possible
- in HoldingsSelectionModel, don't call the `getTokenByKey` twice to construct the `text`, once is enough
- lastly, rewrite the JS helper `PermissionsHelpers.getTokenByKey` to C++; this method gets called recursively way too often from many places
- separate commit to fix the double `permissionsModel` construction from the RootStore

In the longterm, we should provide a specific C++ transformation model
for SharedAddressesPermissionsPanel to follow the UI requirements more
closely; that way we'd be able to fix the issues here for good

Fixes #14276

### Affected areas

SharedAddressesPermissionsPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

All good still:

![image](https://github.com/status-im/status-desktop/assets/5377645/b8d2b0a1-5c9e-4029-b87f-4a9c31efb1f6)

