### PR TITLE
chore(Communities/InDropdown): Performance improved 

### DIFF
--- a/storybook/pages/InDropdownPage.qml
+++ b/storybook/pages/InDropdownPage.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import AppLayouts.Communities.popups 1.0
 

--- a/storybook/src/Models/ChannelsModel.qml
+++ b/storybook/src/Models/ChannelsModel.qml
@@ -82,6 +82,86 @@ ListModel {
         colorId: 4
     }
     ListElement {
+        itemId: "_report-scam2"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam2"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam3"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam3"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam4"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam4"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam5"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam5"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam6"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam6"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam7"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam7"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam8"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam8"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "_report-scam9"
+        isCategory: false
+        categoryId: "_support"
+        name: "report-scam9"
+        emoji: ""
+        color: ""
+        icon: ""
+        colorId: 4
+    }
+    ListElement {
         itemId: ""
         isCategory: true
         categoryId: "_faq"

--- a/ui/StatusQ/include/StatusQ/leftjoinmodel.h
+++ b/ui/StatusQ/include/StatusQ/leftjoinmodel.h
@@ -16,6 +16,9 @@ class LeftJoinModel : public QAbstractListModel
     Q_PROPERTY(QString joinRole READ joinRole
                WRITE setJoinRole NOTIFY joinRoleChanged)
 
+    Q_PROPERTY(QStringList rolesToJoin READ rolesToJoin
+               WRITE setRolesToJoin NOTIFY rolesToJoinChanged)
+
 public:
     explicit LeftJoinModel(QObject* parent = nullptr);
 
@@ -28,6 +31,9 @@ public:
     void setJoinRole(const QString& joinRole);
     const QString& joinRole() const;
 
+    void setRolesToJoin(const QStringList& roles);
+    const QStringList& rolesToJoin() const;
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
@@ -36,6 +42,7 @@ signals:
     void leftModelChanged();
     void rightModelChanged();
     void joinRoleChanged();
+    void rolesToJoinChanged();
 
 private:
     void initializeIfReady(bool reset);
@@ -51,6 +58,7 @@ private:
     QVector<int> m_joinedRoles;
 
     QString m_joinRole;
+    QStringList m_rolesToJoin;
     int m_leftModelJoinRole = 0;
     int m_rightModelJoinRole = 0;
 

--- a/ui/StatusQ/include/StatusQ/leftjoinmodel.h
+++ b/ui/StatusQ/include/StatusQ/leftjoinmodel.h
@@ -2,8 +2,9 @@
 
 #include <QAbstractListModel>
 #include <QPointer>
+#include <QQmlParserStatus>
 
-class LeftJoinModel : public QAbstractListModel
+class LeftJoinModel : public QAbstractListModel, public QQmlParserStatus
 {
     Q_OBJECT
 
@@ -37,6 +38,9 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex& index, int role) const override;
+
+    void classBegin() override;
+    void componentComplete() override;
 
 signals:
     void leftModelChanged();

--- a/ui/StatusQ/src/leftjoinmodel.cpp
+++ b/ui/StatusQ/src/leftjoinmodel.cpp
@@ -271,6 +271,16 @@ QVariant LeftJoinModel::data(const QModelIndex& index, int role) const
     return match.first().data(role - m_rightModelRolesOffset);
 }
 
+void LeftJoinModel::classBegin()
+{
+}
+
+void LeftJoinModel::componentComplete()
+{
+    if (!m_initialized)
+        initializeIfReady(false);
+}
+
 void LeftJoinModel::setLeftModel(QAbstractItemModel* model)
 {
     if (m_leftModel == model)

--- a/ui/StatusQ/tests/tst_LeftJoinModel.cpp
+++ b/ui/StatusQ/tests/tst_LeftJoinModel.cpp
@@ -942,6 +942,75 @@ private slots:
         QCOMPARE(modelResetSpy.count(), 1);
         QCOMPARE(dataChangedSpy.count(), 0);
     }
+
+    void invalidRolesToJoinTest()
+    {
+        TestModel leftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_1" }}
+        });
+
+        TestModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }},
+           { "other", { "other_1", "other_1" }}
+        });
+
+        LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
+        QTest::ignoreMessage(
+                    QtWarningMsg,
+                    "Role to join notExisting not found in the right model!");
+
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+
+        model.setRolesToJoin({ "name", "notExisting" });
+        model.setJoinRole("communityId");
+
+        QCOMPARE(model.roleNames(), {});
+        QCOMPARE(model.rowCount(), 0);
+    }
+
+    void rolesToJoinTest()
+    {
+        TestModel leftModel({
+           { "title", { "Token 1", "Token 2", "Token 3"}},
+           { "communityId", { "community_1", "community_2", "community_1" }}
+        });
+
+        TestModel rightModel({
+           { "name", { "Community 1", "Community 2" }},
+           { "communityId", { "community_1", "community_2" }},
+           { "other", { "other_1", "other_1" }}
+        });
+
+        LeftJoinModel model;
+        QAbstractItemModelTester tester(&model);
+
+        model.setLeftModel(&leftModel);
+        model.setRightModel(&rightModel);
+
+        model.setRolesToJoin({ "name" });
+        model.setJoinRole("communityId");
+
+        QHash<int, QByteArray> roles{{0, "title" }, {1, "communityId"}, {2, "name"}};
+
+        QCOMPARE(model.roleNames(), roles);
+        QCOMPARE(model.rowCount(), 3);
+
+        QCOMPARE(model.rowCount(), 3);
+        QCOMPARE(model.data(model.index(0, 0), 0), QString("Token 1"));
+        QCOMPARE(model.data(model.index(1, 0), 0), QString("Token 2"));
+        QCOMPARE(model.data(model.index(2, 0), 0), QString("Token 3"));
+        QCOMPARE(model.data(model.index(0, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(1, 0), 1), QString("community_2"));
+        QCOMPARE(model.data(model.index(2, 0), 1), QString("community_1"));
+        QCOMPARE(model.data(model.index(0, 0), 2), QString("Community 1"));
+        QCOMPARE(model.data(model.index(1, 0), 2), QString("Community 2"));
+        QCOMPARE(model.data(model.index(2, 0), 2), QString("Community 1"));
+    }
 };
 
 QTEST_MAIN(TestLeftJoinModel)


### PR DESCRIPTION
### What does the PR do

`LeftJoinModel`:
- Added possibility to explicitly define roles to be joined. That's especially needed when models is joined to itself as in the case of `InDropdown`.
- Added checks to componentComplete - early attempts to initialize proxy may fail bc left/right models may be not ready when they are set. It may lead to a situation where the model remains uninitialized and reporint 0 row count.

`InDropdown`:
- significant performance boost (from several seconds lag to milliseconds)
- removed multiple filtering separately for each category
- no instantiation of all delegates up front (regular ListView approach
  used)
- fixed category selection when filtering - selecting/deselecting only
  items fulfilling search criteria
- significant simplification of the code


### Affected areas
`LeftJoinModel`, `InDropdown`


### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00104.webm](https://github.com/status-im/status-desktop/assets/20650004/acadda95-595f-48ab-8842-338876b43ee3)

