### PR TITLE
fix(Profile flow): ID verification cannot be removed

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -75,6 +75,7 @@ method contactsStatusUpdated*(self: Module, statusUpdates: seq[StatusUpdateDto])
 
 method contactUpdated*(self: Module, publicKey: string) =
   let contactDetails = self.controller.getContactDetails(publicKey)
+  let isMe = publicKey == singletonInstance.userProfile.getPubKey()
   self.view.model().updateItem(
     pubKey = publicKey,
     displayName = contactDetails.dto.displayName,
@@ -84,7 +85,7 @@ method contactUpdated*(self: Module, publicKey: string) =
     alias = contactDetails.dto.alias,
     icon = contactDetails.icon,
     isContact = contactDetails.dto.isContact,
-    isVerified = contactDetails.dto.isContactVerified(),
+    isVerified = not isMe and contactDetails.dto.isContactVerified(),
     isUntrustworthy = contactDetails.dto.trustStatus == TrustStatus.Untrustworthy,
   )
 
@@ -129,7 +130,7 @@ proc addChatMember(self: Module,  member: ChatMember) =
     colorHash = contactDetails.colorHash,
     onlineStatus = status,
     isContact = contactDetails.dto.isContact,
-    isVerified = contactDetails.dto.isContactVerified(),
+    isVerified = not isMe and contactDetails.dto.isContactVerified(),
     memberRole = member.role,
     joined = member.joined,
     isUntrustworthy = contactDetails.dto.trustStatus == TrustStatus.Untrustworthy,
@@ -156,6 +157,7 @@ method onMembersChanged*(self: Module,  members: seq[ChatMember]) =
 
 method onChatMemberUpdated*(self: Module, publicKey: string, memberRole: MemberRole, joined: bool) =
   let contactDetails = self.controller.getContactDetails(publicKey)
+  let isMe = publicKey == singletonInstance.userProfile.getPubKey()
   self.view.model().updateItem(
     pubKey = publicKey,
     displayName = contactDetails.dto.displayName,
@@ -165,7 +167,7 @@ method onChatMemberUpdated*(self: Module, publicKey: string, memberRole: MemberR
     alias = contactDetails.dto.alias,
     icon = contactDetails.icon,
     isContact = contactDetails.dto.isContact,
-    isVerified = contactDetails.dto.isContactVerified(),
+    isVerified = not isMe and contactDetails.dto.isContactVerified(),
     memberRole = memberRole,
     joined = joined,
     isUntrustworthy = contactDetails.dto.trustStatus == TrustStatus.Untrustworthy,

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -168,6 +168,9 @@ proc sendVerificationRequest*(self: Controller, publicKey: string, challenge: st
 proc cancelVerificationRequest*(self: Controller, publicKey: string) =
   self.contactsService.cancelVerificationRequest(publicKey)
 
+proc removeTrustVerificationStatus*(self: Controller, publicKey: string) =
+  self.contactsService.removeTrustVerificationStatus(publicKey)
+
 proc verifiedTrusted*(self: Controller, publicKey: string) =
   self.contactsService.verifiedTrusted(publicKey)
 

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -91,6 +91,9 @@ method markUntrustworthy*(self: AccessInterface, publicKey: string): void {.base
 method removeTrustStatus*(self: AccessInterface, publicKey: string): void {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method removeTrustVerificationStatus*(self: AccessInterface, publicKey: string): void {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getSentVerificationDetailsAsJson*(self: AccessInterface, publicKey: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -245,6 +245,9 @@ method markUntrustworthy*(self: Module, publicKey: string): void =
 method removeTrustStatus*(self: Module, publicKey: string): void =
   self.controller.removeTrustStatus(publicKey)
 
+method removeTrustVerificationStatus*(self: Module, publicKey: string): void =
+  self.controller.removeTrustVerificationStatus(publicKey)
+
 method getSentVerificationDetailsAsJson*(self: Module, publicKey: string): string =
   let verificationRequest = self.controller.getVerificationRequestSentTo(publicKey)
   let (name, image, largeImage) = self.controller.getContactNameAndImage(publicKey)

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -202,6 +202,9 @@ QtObject:
   proc removeTrustStatus*(self: View, publicKey: string) {.slot.} =
     self.delegate.removeTrustStatus(publicKey)
 
+  proc removeTrustVerificationStatus*(self: View, publicKey: string) {.slot.} =
+    self.delegate.removeTrustVerificationStatus(publicKey)
+
   proc getSentVerificationDetailsAsJson(self: View, publicKey: string): string {.slot.} =
     return self.delegate.getSentVerificationDetailsAsJson(publicKey)
 

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -95,6 +95,10 @@ proc removeTrustStatus*(pubkey: string): RpcResponse[JsonNode] =
   let payload = %* [pubkey]
   result = callPrivateRPC("removeTrustStatus".prefix, payload)
 
+proc removeTrustVerificationStatus*(pubkey: string): RpcResponse[JsonNode] =
+  let payload = %* [pubkey]
+  result = callPrivateRPC("removeTrustVerificationStatus".prefix, payload)
+
 proc getTrustStatus*(pubkey: string): RpcResponse[JsonNode] =
   let payload = %* [pubkey]
   result = callPrivateRPC("getTrustStatus".prefix, payload)

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -264,6 +264,13 @@ SplitView {
                     ctrlIncomingVerificationStatus.currentIndex = ctrlIncomingVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
                 }
 
+                function removeTrustVerificationStatus(publicKey) {
+                    logs.logEvent("rootStore::contactStore::removeTrustVerificationStatus", ["publicKey"], arguments)
+                    ctrlTrustStatus.currentIndex = ctrlTrustStatus.indexOfValue(Constants.trustStatus.unknown)
+                    ctrlVerificationStatus.currentIndex = ctrlVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
+                    ctrlIncomingVerificationStatus.currentIndex = ctrlIncomingVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
+                }
+
                 function cancelVerificationRequest(pubKey) {
                     logs.logEvent("rootStore::contactStore::cancelVerificationRequest", ["pubKey"], arguments)
                     ctrlVerificationStatus.currentIndex = ctrlVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
@@ -397,6 +404,11 @@ SplitView {
 
                             function removeTrustStatus(publicKey) {
                                 logs.logEvent("contactsStore::removeTrustStatus", ["publicKey"], arguments)
+                                ctrlTrustStatus.currentIndex = ctrlTrustStatus.indexOfValue(Constants.trustStatus.unknown)
+                            }
+
+                            function removeTrustVerificationStatus(publicKey) {
+                                logs.logEvent("contactsStore::removeTrustVerificationStatus", ["publicKey"], arguments)
                                 ctrlTrustStatus.currentIndex = ctrlTrustStatus.indexOfValue(Constants.trustStatus.unknown)
                             }
 

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -127,6 +127,10 @@ QtObject {
         root.contactsModule.removeTrustStatus(pubKey)
     }
 
+    function removeTrustVerificationStatus(pubKey) {
+        root.contactsModule.removeTrustVerificationStatus(pubKey)
+    }
+
     function sendVerificationRequest(pubKey, challenge) {
         root.contactsModule.sendVerificationRequest(pubKey, challenge);
         Global.displaySuccessToastMessage(qsTr("ID verification request sent"))

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -386,7 +386,7 @@ QtObject {
                 onAccepted: {
                     rootStore.contactStore.removeContact(publicKey)
                     if (removeIDVerification)
-                        rootStore.contactStore.removeTrustStatus(publicKey)
+                        rootStore.contactStore.removeTrustVerificationStatus(publicKey)
                     if (markAsUntrusted) {
                         rootStore.contactStore.markUntrustworthy(publicKey)
                         Global.displaySuccessToastMessage(qsTr("%1 removed from contacts and marked as untrusted").arg(mainDisplayName))
@@ -457,7 +457,7 @@ QtObject {
             id: removeIDVerificationPopupComponent
             RemoveIDVerificationDialog {
                 onAccepted: {
-                    rootStore.contactStore.removeTrustStatus(publicKey)
+                    rootStore.contactStore.removeTrustVerificationStatus(publicKey)
 
                     if (markAsUntrusted && removeContact) {
                         rootStore.contactStore.markUntrustworthy(publicKey)
@@ -671,7 +671,7 @@ QtObject {
                 onAccepted: {
                     rootStore.contactStore.blockContact(publicKey)
                     if (removeIDVerification)
-                        rootStore.contactStore.removeTrustStatus(publicKey)
+                        rootStore.contactStore.removeTrustVerificationStatus(publicKey)
                     if (removeContact)
                         rootStore.contactStore.removeContact(publicKey)
                     Global.displaySuccessToastMessage(qsTr("%1 blocked").arg(mainDisplayName))


### PR DESCRIPTION
fixes #13619 
status-go PR: https://github.com/status-im/status-go/pull/5058
also hides the "trust" icon in the members list for myself

### What does the PR do

1. When "Remove ID verification" is clicked both Trusted and Verified verificationStatus will be reset to Unverified as well as trustStatus
2. The own account will not be marked as "trusted" in the groupchat member list

### Affected areas
contacts / members_list / verification

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/671a0a7e-ad39-42aa-ac85-1aa04e76361c

Added some general ideas on how to improve consistency:
https://github.com/status-im/status-desktop/issues/13619#issuecomment-2039823408