### PR TITLE
fix[Shared Addresses] Can't edit shared address while the join request is pending

### DIFF
--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -299,7 +299,7 @@ Item {
 
             chatListPopupMenu: ChatContextMenuView {
                 id: chatContextMenuView
-                showDebugOptions: root.store.isDebugEnabledfir
+                showDebugOptions: root.store.isDebugEnabled
 
                 // TODO pass the chatModel in its entirety instead of fetching the JSOn using just the id
                 openHandler: function (id) {

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -122,9 +122,7 @@ StatusListView {
                         text: qsTr("Edit Shared Addresses")
                         icon.name: "wallet"
                         enabled: {
-                            if (listItem.isOwner)
-                                return false
-                            if (listItem.isSpectator && !listItem.isInvitationPending)
+                            if (listItem.isOwner || listItem.isSpectator)
                                 return false
                             return true
                         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -606,7 +606,6 @@ Item {
                         StatusAction {
                             text: qsTr("Invite People")
                             icon.name: "share-ios"
-                            enabled: model.canManageUsers
                             objectName: "invitePeople"
                             onTriggered: {
                                 popups.openInviteFriendsToCommunityPopup(model,
@@ -645,9 +644,7 @@ Item {
                             text: qsTr("Edit Shared Addresses")
                             icon.name: "wallet"
                             enabled: {
-                                if (model.memberRole === Constants.memberRole.owner)
-                                    return false
-                                if (communityContextMenu.isSpectator && !appMain.rootStore.isMyCommunityRequestPending(model.id))
+                                if (model.memberRole === Constants.memberRole.owner || communityContextMenu.isSpectator)
                                     return false
                                 return true
                             }


### PR DESCRIPTION
### What does the PR do

- disallow changing the Shared addresses while our request to join community is still pending

Fixes https://github.com/status-im/status-desktop/issues/14292

### Affected areas

AppMain, Settings/Communities

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Main nav:
![Snímek obrazovky z 2024-04-08 13-18-36](https://github.com/status-im/status-desktop/assets/5377645/d8691d37-afe8-408b-b856-2d47a1bf8d51)

Settings/Communities:
![Snímek obrazovky z 2024-04-08 13-18-51](https://github.com/status-im/status-desktop/assets/5377645/23ce92a5-feab-4f21-8504-ed51aded8f79)
