### PR TITLE
feat(wallet) connect assets ordering with saving to DB backend

### DIFF
--- a/src/app/modules/main/wallet_section/all_collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/view.nim
@@ -32,10 +32,6 @@ QtObject:
   proc updateCollectiblePreferences*(self: View, collectiblePreferencesJson: string) {.slot.} =
     self.delegate.updateCollectiblePreferences(collectiblePreferencesJson)
 
-  proc clearCollectiblePreferences*(self: View) {.slot.} =
-    # There is no requirements of clearing the preferences yet but controller is expected to expose it
-    discard
-
   proc getCollectiblePreferencesJson(self: View): QVariant {.slot.} =
     let preferences = self.delegate.getCollectiblePreferencesJson()
     return newQVariant(preferences)

--- a/src/app/modules/main/wallet_section/all_tokens/view.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/view.nim
@@ -146,11 +146,11 @@ QtObject:
   proc updateTokenPreferences*(self: View, tokenPreferencesJson: string) {.slot.} =
     self.delegate.updateTokenPreferences(tokenPreferencesJson)
 
-  proc getTokenPreferencesJson(self: View): QVariant {.slot.} =
+  proc getTokenPreferencesJson(self: View): string {.slot.} =
     let preferences = self.delegate.getTokenPreferencesJson()
-    return newQVariant(preferences)
+    return preferences
 
-  QtProperty[QVariant] tokenPreferencesJson:
+  QtProperty[string] tokenPreferencesJson:
     read = getTokenPreferencesJson
 
   proc tokenGroupByCommunityChanged*(self: View) {.signal.}

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -524,6 +524,7 @@ QtObject:
       if preferencesJson.kind == JArray:
         for preferences in preferencesJson:
           add(tokenPreferences, fromJson(preferences, TokenPreferences))
+
       let response = backend.updateTokenPreferences(tokenPreferences)
       if not response.error.isNil:
         raise newException(CatchableError, response.error.message)

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
@@ -26,6 +26,7 @@ StatusRoundedComponent {
 
     StatusImage {
         id: image
+
         anchors.fill: parent
         anchors.margins: parent.border.width
     }

--- a/ui/StatusQ/src/wallet/managetokensmodel.cpp
+++ b/ui/StatusQ/src/wallet/managetokensmodel.cpp
@@ -102,7 +102,7 @@ SerializedTokenData ManageTokensModel::save(bool isVisible, bool itemsAreGroups)
                                  token.communityId,
                                  isCollectionGroup,
                                  token.collectionUid,
-                                 tokenDataToCollectiblePreferencesItemType(token, isCommunityGroup, itemsAreGroups)});
+                                 tokenDataToCollectiblePreferencesItemType(isCommunityGroup, itemsAreGroups)});
     }
     setDirty(false);
     return result;

--- a/ui/StatusQ/src/wallet/tokendata.h
+++ b/ui/StatusQ/src/wallet/tokendata.h
@@ -19,7 +19,7 @@ struct TokenData {
 // mirrors CollectiblePreferencesItemType from src/backend/collectibles_types.nim
 enum class CollectiblePreferencesItemType { NonCommunityCollectible = 1, CommunityCollectible, Collection, Community };
 
-CollectiblePreferencesItemType tokenDataToCollectiblePreferencesItemType(const TokenData& tokenData, bool isCommunity, bool itemsAreGroups);
+CollectiblePreferencesItemType tokenDataToCollectiblePreferencesItemType(bool isCommunity, bool itemsAreGroups);
 
 struct TokenOrder {
     QString symbol;
@@ -47,7 +47,8 @@ struct TokenOrder {
     {
         return symbol == rhs.symbol && sortOrder == rhs.sortOrder && visible == rhs.visible &&
                isCommunityGroup == rhs.isCommunityGroup && (!isCommunityGroup || communityId == rhs.communityId) &&
-               isCollectionGroup == rhs.isCollectionGroup && (!isCollectionGroup || collectionUid == rhs.collectionUid) && type == rhs.type;
+               isCollectionGroup == rhs.isCollectionGroup &&
+               (!isCollectionGroup || collectionUid == rhs.collectionUid) && type == rhs.type;
     }
 
     QString getGroupId() const { return !communityId.isEmpty() ? communityId : collectionUid; }

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -319,7 +319,7 @@ SettingsContentBase {
             inShowcaseModel: priv.showcaseModels.accountsVisibleModel
             hiddenModel: priv.showcaseModels.accountsHiddenModel
             showcaseLimit: root.profileStore.getProfileShowcaseEntriesLimit()
-            currentWallet: root.walletStore.overview.mixedcaseAddress
+            currentWallet: RootStore.overview.mixedcaseAddress
 
             onChangePositionRequested: function (from, to) {
                 priv.showcaseModels.changeAccountPosition(from, to)

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -289,7 +289,7 @@ SettingsContentBase {
             userProfilePublicKey: walletStore.userProfilePublicKey
             onGoBack: stackContainer.currentIndex = mainViewIndex
             onVisibleChanged: {
-                if (!visible) {
+                if (!visible && !!root.walletStore) {
                     root.walletStore.selectedAccount = null
                     keyPair = null
                 }

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -41,11 +41,6 @@ QtObject {
             let jsonData = _allCollectiblesModule.getCollectiblePreferencesJson()
             loadingFinished(jsonData)
         }
-        onRequestClearSettings: {
-            savingStarted()
-            _allCollectiblesModule.clearCollectiblePreferences()
-            savingFinished()
-        }
 
         onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(
                                          qsTr("%1 community collectibles successfully hidden").arg(communityName), "", "checkmark-circle",

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -136,4 +136,12 @@ QtObject {
             root.displayAssetsBelowBalanceThresholdChanged()
         }
     }
+
+    function updateTokenPreferences(jsonData) {
+        root._allTokensModule.updateTokenPreferences(jsonData)
+    }
+
+    function getTokenPreferencesJson(jsonData) {
+        return root._allTokensModule.getTokenPreferencesJson(jsonData)
+    }
 }

--- a/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -20,21 +20,15 @@ QtObject {
         settingsKey: "WalletAssets"
         serializeAsCollectibles: false
 
-        // TODO #13312: call the assets controller for all events
         onRequestSaveSettings: (jsonData) => {
-            // savingStarted()
-            saveToQSettings(jsonData)
-            // savingFinished()
+            savingStarted()
+            walletTokensStore.updateTokenPreferences(jsonData)
+            savingFinished()
         }
         onRequestLoadSettings: {
-            // loadingStarted()
-            loadFromQSettings()
-            // loadingFinished()
-        }
-        onRequestClearSettings: {
-            // savingStarted()
-            clearQSettings()
-            // savingFinished()
+            loadingStarted()
+            let jsonData = walletTokensStore.getTokenPreferencesJson()
+            loadingFinished(jsonData)
         }
 
         onCommunityTokenGroupHidden: (communityName) => Global.displayToastMessage(


### PR DESCRIPTION
### Closes #13312

Use `updateTokenPreferences` and `getTokenPreferencesJson` to save assets instead of local `QSettings`
