### PR TITLE
feat(settings): Fixed changing network urls

### DIFF
--- a/src/app/modules/main/wallet_section/networks/controller.nim
+++ b/src/app/modules/main/wallet_section/networks/controller.nim
@@ -64,8 +64,8 @@ proc isGoerliEnabled*(self: Controller): bool =
 proc toggleIsGoerliEnabled*(self: Controller) =
   self.walletAccountService.toggleIsGoerliEnabled()
 
-proc updateNetworkEndPointValues*(self: Controller, chainId: int, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) =
-  self.networkService.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+proc updateNetworkEndPointValues*(self: Controller, chainId: int, testNetwork: bool, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) =
+  self.networkService.updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
 
 proc fetchChainIdForUrl*(self: Controller, url: string, isMainUrl: bool) =
   self.walletAccountService.fetchChainIdForUrl(url, isMainUrl)

--- a/src/app/modules/main/wallet_section/networks/io_interface.nim
+++ b/src/app/modules/main/wallet_section/networks/io_interface.nim
@@ -38,7 +38,7 @@ method setNetworksState*(self: AccessInterface, chainIds: seq[int], enable: bool
 method refreshNetworks*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method updateNetworkEndPointValues*(self: AccessInterface, chainId: int, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) {.base.} =
+method updateNetworkEndPointValues*(self: AccessInterface, chainId: int, testNetwork: bool, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method fetchChainIdForUrl*(self: AccessInterface, url: string, isMainUrl: bool) {.base.} =

--- a/src/app/modules/main/wallet_section/networks/module.nim
+++ b/src/app/modules/main/wallet_section/networks/module.nim
@@ -73,8 +73,8 @@ method toggleIsGoerliEnabled*(self: Module) =
 method setNetworksState*(self: Module, chainIds: seq[int], enabled: bool) =
   self.controller.setNetworksState(chainIds, enabled)
 
-method updateNetworkEndPointValues*(self: Module, chainId: int, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) =
-  self.controller.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+method updateNetworkEndPointValues*(self: Module, chainId: int, testNetwork: bool, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) =
+  self.controller.updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
 
 method fetchChainIdForUrl*(self: Module, url: string, isMainUrl: bool) =
   self.controller.fetchChainIdForUrl(url, isMainUrl)

--- a/src/app/modules/main/wallet_section/networks/view.nim
+++ b/src/app/modules/main/wallet_section/networks/view.nim
@@ -100,8 +100,8 @@ QtObject:
   proc getBlockExplorerURL*(self: View, chainId: int): string {.slot.} =
     return self.flatNetworks.getBlockExplorerURL(chainId)
 
-  proc updateNetworkEndPointValues*(self: View, chainId: int, newMainRpcInput: string, newFailoverRpcUrl: string, revertToDefault: bool) {.slot.} =
-    self.delegate.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+  proc updateNetworkEndPointValues*(self: View, chainId: int, testNetwork: bool, newMainRpcInput: string, newFailoverRpcUrl: string, revertToDefault: bool) {.slot.} =
+    self.delegate.updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
 
   proc fetchChainIdForUrl*(self: View, url: string, isMainUrl: bool) {.slot.} =
     self.delegate.fetchChainIdForUrl(url, isMainUrl)

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -108,8 +108,8 @@ QtObject {
         return networksModuleInst.fetchChainIdForUrl(url, isMainUrl)
     }
 
-    function updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault) {
-        networksModuleInst.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+    function updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault) {
+        networksModuleInst.updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
     }
 
     function updateWalletAccountPreferredChains(address, preferredChainIds) {

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -264,9 +264,10 @@ SettingsContentBase {
             Layout.fillWidth: true
             networksModule: root.walletStore.networksModuleInst
             networkRPCChanged: root.walletStore.networkRPCChanged
+            areTestNetworksEnabled: root.walletStore.areTestNetworksEnabled
             onEvaluateRpcEndPoint: root.walletStore.evaluateRpcEndPoint(url, isMainUrl)
             onUpdateNetworkValues: {
-                root.walletStore.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+                root.walletStore.updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
                 stackContainer.currentIndex = networksViewIndex
             }
         }

--- a/ui/app/AppLayouts/Profile/views/wallet/EditNetworkView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/EditNetworkView.qml
@@ -13,9 +13,15 @@ ColumnLayout {
     property var networksModule
     property var combinedNetwork
     property var networkRPCChanged
+    property bool areTestNetworksEnabled: false
 
     signal evaluateRpcEndPoint(string url, bool isMainUrl)
-    signal updateNetworkValues(int chainId, string newMainRpcInput, string newFailoverRpcUrl, bool revertToDefault)
+    signal updateNetworkValues(int chainId, bool testNetwork, string newMainRpcInput, string newFailoverRpcUrl, bool revertToDefault)
+
+    onVisibleChanged: {
+        if (visible)
+            editPreviwTabBar.currentIndex = root.areTestNetworksEnabled ? 1 : 0
+    }
 
     StatusTabBar {
         id: editPreviwTabBar
@@ -47,7 +53,7 @@ ColumnLayout {
             networksModule: root.networksModule
             networkRPCChanged: root.networkRPCChanged
             onEvaluateRpcEndPoint: root.evaluateRpcEndPoint(url, isMainUrl)
-            onUpdateNetworkValues: root.updateNetworkValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+            onUpdateNetworkValues: root.updateNetworkValues(chainId, false, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
         }
     }
 
@@ -58,7 +64,7 @@ ColumnLayout {
             networksModule: root.networksModule
             networkRPCChanged: root.networkRPCChanged
             onEvaluateRpcEndPoint: root.evaluateRpcEndPoint(url, isMainUrl)
-            onUpdateNetworkValues: root.updateNetworkValues(chainId, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
+            onUpdateNetworkValues: root.updateNetworkValues(chainId, true, newMainRpcInput, newFailoverRpcUrl, revertToDefault)
         }
     }
 }


### PR DESCRIPTION
Task #14228

### What does the PR do

* Passed additional parameter to use proper networks depending on active tab (prod or test)
* Added binding to open tab (prod or test) depending whether currently test network is enabled|
  NOTE this is executed in onVisibleChanged because normal binding would be broken when tabs are manually changed.

### Affected areas

Settings / networks


### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/11396062/3454125a-542a-49ff-abfa-722eb2a4c655

