### PR TITLE
StatusQ(ConcatModel): Proper handling of source models' layout changes

### DIFF
--- a/ui/StatusQ/include/StatusQ/concatmodel.h
+++ b/ui/StatusQ/include/StatusQ/concatmodel.h
@@ -113,4 +113,8 @@ private:
     std::vector<std::unordered_map<int, int>> m_rolesMappingToSource;
     std::vector<bool> m_rolesMappingInitializationFlags;
     std::vector<int> m_rowCounts;
+
+    // helpers for handling layoutChanged from source
+    QList<QPersistentModelIndex> m_layoutChangePersistentIndexes;
+    QModelIndexList m_proxyIndexes;
 };

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -83,7 +83,7 @@ target_link_libraries(SumAggregatorTest PRIVATE StatusQ StatusQTestLib)
 add_test(NAME SumAggregatorTest COMMAND SumAggregatorTest)
 
 add_executable(ConcatModelTest tst_ConcatModel.cpp)
-target_link_libraries(ConcatModelTest PRIVATE StatusQ StatusQTestLib)
+target_link_libraries(ConcatModelTest PRIVATE StatusQ StatusQTestLib SortFilterProxyModel)
 add_test(NAME ConcatModelTest COMMAND ConcatModelTest)
 
 add_executable(WritableProxyModelTest tst_WritableProxyModel.cpp)

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
@@ -85,6 +85,9 @@ void TestModel::remove(int index)
 
 void TestModel::invert()
 {
+    if (m_data.size() < 2)
+        return;
+
     emit layoutAboutToBeChanged();
 
     for (auto& entry : m_data)
@@ -95,6 +98,32 @@ void TestModel::invert()
 
     for (const QModelIndex& index: persistentIndexes)
         changePersistentIndex(index, createIndex(count - index.row() - 1, 0));
+
+    emit layoutChanged();
+}
+
+void TestModel::removeEverySecond()
+{
+    if (m_data.empty())
+        return;
+
+    emit layoutAboutToBeChanged();
+
+    for (auto& entry : m_data) {
+        QVariantList& data = entry.second;
+
+        for (auto i = 0; i < data.size(); i++)
+            data.removeAt(i);
+    }
+
+    const auto persistentIndexes = persistentIndexList();
+
+    for (const QModelIndex& index : persistentIndexes) {
+        if (index.row() % 2 == 0)
+            changePersistentIndex(index, {});
+        else
+            changePersistentIndex(index, createIndex(index.row() / 2, 0));
+    }
 
     emit layoutChanged();
 }

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.h
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.h
@@ -19,6 +19,13 @@ public:
     // inverts order of items, emits layoutAboutToBeChanged / layoutChanged
     void invert();
 
+    // removes every second item from the model but doesn't emit
+    // rowsAboutToBeRemoved/rowsRemoved. The update is notified via
+    // layoutAboutToBeChanged/layoutChanged. It's useful for testing proxy
+    // models against that scenario, which may occur in some circumstances, e.g.
+    // during SFPM initialization where initial filtering is notified this way.
+    void removeEverySecond();
+
 private:
     void initRoles();
 

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -153,7 +153,6 @@ StatusListView {
                     symbol: d.collectiblesNamesToSymbols[firstEntry.name] || "",
                     enabledNetworkBalance: e.length,
                     account: firstEntry.ownership[0].accountAddress,
-                    type: Constants.TokenType.ERC721,
                     imageUrl: d.collectiblesNamesToImages[firstEntry.name] || ""
                 }
             })
@@ -210,15 +209,16 @@ StatusListView {
         ConcatModel {
             id: concatModel
 
+            markerRoleName: "type"
+
             sources: [
                 SourceModel {
-                    // During initialization sfpm provides rowCount not taking
-                    // filtering into account, deferring model assignment as
-                    // a workaround
-                    Component.onCompleted: model = walletAccountAssetsModel
+                    model: walletAccountAssetsModel
+                    markerRoleValue: Constants.TokenType.ERC20
                 },
                 SourceModel {
-                    Component.onCompleted: model = accountCollectiblesModel
+                    model: accountCollectiblesModel
+                    markerRoleValue: Constants.TokenType.ERC721
                 }
             ]
         }
@@ -255,15 +255,6 @@ StatusListView {
                     expectedRoles: ["balances", "decimals"]
                 },
                 FastExpressionRole {
-                    name: "type"
-
-                    readonly property int typeVal: Constants.TokenType.ERC20
-
-                    // Singletons cannot be used directly in sfpm's expressions
-                    expression: typeVal
-                    expectedRoles: []
-                },
-                FastExpressionRole {
                     name: "imageUrl"
 
                     function getIcon(symbol) {
@@ -295,8 +286,11 @@ StatusListView {
             StatusBaseText {
                 anchors.verticalCenter: parent.verticalCenter
                 font.pixelSize: Theme.tertiaryTextFontSize
+
+                readonly property int type: model.type
+
                 text: {
-                    if (model.type === Constants.TokenType.ERC20)
+                    if (type === Constants.TokenType.ERC20)
                         return LocaleUtils.currencyAmountToLocaleString(
                                     root.getCurrencyAmount(model.enabledNetworkBalance,
                                                            model.symbol))


### PR DESCRIPTION
### What does the PR do

- Add method to `TestModel` removing items an emiting `layoutChanged`
- Proper handling of source models layout change
Whenever source model emits `layoutAboutToBeChanged`/`layoutChanged`,
persisten model are updated appropriately, also scenario when items are
removed is covered.
- Extensive tests, including case with SFPM removing items in between `layoutAboutToBeChanged`/`layoutChanged` signals
- `SharedAddressesAccountSelector` - workaround removed, now source models are set directly to `ConcatModel`
- `SharedAddressesAccountSelector` - flow simplified by setting `type` role via `ConcatModel`

Closes: https://github.com/status-im/status-desktop/issues/14244
Closes: https://github.com/status-im/status-desktop/issues/14245

### Affected areas
`TestModel`, `ConcatModel`, `SharedAddressesAccountSelector`
