### PR TITLE
fix: proper content for bridged messages in OS notifications

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1183,13 +1183,17 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
   elif(message.isGlobalMention()):
     notificationType = notification_details.NotificationType.NewMessageWithGlobalMention
 
-  let contactDetails = self.controller.getContactDetails(message.`from`)
+  var senderDisplayName = self.controller.getContactDetails(message.`from`).defaultDisplayName
   let communityChats = self.controller.getMyCommunity().chats
   let renderedMessageText = self.controller.getRenderedText(message.parsedText, communityChats)
   var plainText = singletonInstance.utils.plainText(renderedMessageText)
   if message.contentType == ContentType.Sticker or (message.contentType == ContentType.Image and len(plainText) == 0):
     plainText = "🖼️"
-  var notificationTitle = contactDetails.defaultDisplayName
+  if message.contentType == ContentType.BridgeMessage:
+    senderDisplayName = message.bridgeMessage.userName
+    plainText = message.bridgeMessage.content
+
+  var notificationTitle = senderDisplayName
 
   case chatDetails.chatType:
     of ChatType.PrivateGroupChat:


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14369

<img width="370" alt="Screenshot 2024-04-09 at 17 48 07" src="https://github.com/status-im/status-desktop/assets/25482501/eabba061-f3db-43a6-a3b1-f9dc3cccde5d">