### PR TITLE
fix(wallet): hidden groups are still loading from user local settings

### DIFF
--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
+import Qt.labs.settings 1.0
+
 import SortFilterProxyModel 0.2
 
 import StatusQ 0.1
@@ -99,9 +101,19 @@ SplitView {
                 settingsKey: "WalletAssets"
                 serializeAsCollectibles: false
 
-                onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
-                onRequestLoadSettings: loadFromQSettings()
-                onRequestClearSettings: clearQSettings()
+                onRequestSaveSettings: (jsonData) => {
+                    savingStarted()
+                    settingsStore.setValue(settingsKey, jsonData)
+                    savingFinished()
+                }
+                onRequestLoadSettings: {
+                    loadingStarted()
+                    const jsonData = settingsStore.value(settingsKey, null)
+                    loadingFinished(jsonData)
+                }
+                onRequestClearSettings: {
+                    settingsStore.setValue(settingsKey, null)
+                }
 
                 onTokenHidden: (symbol, name) => Global.displayToastMessage(
                                    qsTr("%1 (%2) was successfully hidden").arg(name).arg(symbol), "", "checkmark-circle",
@@ -132,6 +144,11 @@ SplitView {
             onReceiveRequested: logs.logEvent("onReceiveRequested", ["symbol"], arguments)
             onSwitchToCommunityRequested: logs.logEvent("onSwitchToCommunityRequested", ["communityId"], arguments)
             onManageTokensRequested: logs.logEvent("onManageTokensRequested")
+
+            Settings {
+                id: settingsStore
+                category: "ManageTokens-" + assetsView.controller.settingsKey
+            }
         }
 
         ColumnLayout {

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
+import Qt.labs.settings 1.0
+
 import StatusQ 0.1
 import StatusQ.Models 0.1
 import StatusQ.Core 0.1
@@ -84,9 +86,19 @@ SplitView {
             settingsKey: "WalletCollectibles"
             serializeAsCollectibles: true
 
-            onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
-            onRequestLoadSettings: loadFromQSettings()
-            onRequestClearSettings: clearQSettings()
+            onRequestSaveSettings: (jsonData) => {
+                savingStarted()
+                settingsStore.setValue(settingsKey, jsonData)
+                savingFinished()
+            }
+            onRequestLoadSettings: {
+                loadingStarted()
+                const jsonData = settingsStore.value(settingsKey, null)
+                loadingFinished(jsonData)
+            }
+            onRequestClearSettings: {
+                settingsStore.setValue(settingsKey, null)
+            }
 
             onTokenHidden: (symbol, name) => Global.displayToastMessage(
                                qsTr("%1 was successfully hidden").arg(name), "", "checkmark-circle",
@@ -111,6 +123,11 @@ SplitView {
         isUpdating: ctrlUpdatingCheckbox.checked
         isFetching: ctrlFetchingCheckbox.checked
         isError: ctrlErrorCheckbox.checked
+
+        Settings {
+            id: settingsStore
+            category: "ManageTokens-" + collectiblesView.controller.settingsKey
+        }
     }
 
     LogsAndControlsPanel {

--- a/storybook/pages/ManageAssetsPanelPage.qml
+++ b/storybook/pages/ManageAssetsPanelPage.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
+import Qt.labs.settings 1.0
+
 import StatusQ.Core 0.1
 import StatusQ.Models 0.1
 
@@ -52,9 +54,24 @@ SplitView {
             settingsKey: "WalletAssets"
             serializeAsCollectibles: false
 
-            onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
-            onRequestLoadSettings: loadFromQSettings()
-            onRequestClearSettings: clearQSettings()
+            onRequestSaveSettings: (jsonData) => {
+                savingStarted()
+                settingsStore.setValue(settingsKey, jsonData)
+                savingFinished()
+            }
+            onRequestLoadSettings: {
+                loadingStarted()
+                const jsonData = settingsStore.value(settingsKey, null)
+                loadingFinished(jsonData)
+            }
+            onRequestClearSettings: {
+                settingsStore.setValue(settingsKey, null)
+            }
+        }
+
+        Settings {
+            id: settingsStore
+            category: "ManageTokens-" + showcasePanel.controller.settingsKey
         }
     }
 

--- a/storybook/pages/ManageCollectiblesPanelPage.qml
+++ b/storybook/pages/ManageCollectiblesPanelPage.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
+import Qt.labs.settings 1.0
+
 import StatusQ 0.1
 import StatusQ.Models 0.1
 import StatusQ.Core 0.1
@@ -46,9 +48,24 @@ SplitView {
             settingsKey: "WalletCollectibles"
             serializeAsCollectibles: true
 
-            onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
-            onRequestLoadSettings: loadFromQSettings()
-            onRequestClearSettings: clearQSettings()
+            onRequestSaveSettings: (jsonData) => {
+                savingStarted()
+                settingsStore.setValue(settingsKey, jsonData)
+                savingFinished()
+            }
+            onRequestLoadSettings: {
+                loadingStarted()
+                const jsonData = settingsStore.value(settingsKey, null)
+                loadingFinished(jsonData)
+            }
+            onRequestClearSettings: {
+                settingsStore.setValue(settingsKey, null)
+            }
+        }
+
+        Settings {
+            id: settingsStore
+            category: "ManageTokens-" + showcasePanel.controller.settingsKey
         }
     }
 

--- a/storybook/pages/ManageHiddenPanelPage.qml
+++ b/storybook/pages/ManageHiddenPanelPage.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
+import Qt.labs.settings 1.0
+
 import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Models 0.1
@@ -46,9 +48,24 @@ SplitView {
         settingsKey: "WalletAssets"
         serializeAsCollectibles: false
 
-        onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
-        onRequestLoadSettings: loadFromQSettings()
-        onRequestClearSettings: clearQSettings()
+        onRequestSaveSettings: (jsonData) => {
+            savingStarted()
+            assetsSettingsStore.setValue(settingsKey, jsonData)
+            savingFinished()
+        }
+        onRequestLoadSettings: {
+            loadingStarted()
+            const jsonData = assetsSettingsStore.value(settingsKey, null)
+            loadingFinished(jsonData)
+        }
+        onRequestClearSettings: {
+            assetsSettingsStore.setValue(settingsKey, null)
+        }
+    }
+
+    Settings {
+        id: assetsSettingsStore
+        category: "ManageTokens-" + assetsController.settingsKey
     }
 
     ManageTokensController {
@@ -57,9 +74,24 @@ SplitView {
         settingsKey: "WalletCollectibles"
         serializeAsCollectibles: true
 
-        onRequestSaveSettings: (jsonData) => saveToQSettings(jsonData)
-        onRequestLoadSettings: loadFromQSettings()
-        onRequestClearSettings: clearQSettings()
+        onRequestSaveSettings: (jsonData) => {
+            savingStarted()
+            collectiblesSettingsStore.setValue(settingsKey, jsonData)
+            savingFinished()
+        }
+        onRequestLoadSettings: {
+            loadingStarted()
+            const jsonData = collectiblesSettingsStore.value(settingsKey, null)
+            loadingFinished(jsonData)
+        }
+        onRequestClearSettings: {
+            collectiblesSettingsStore.setValue(settingsKey, null)
+        }
+    }
+
+    Settings {
+        id: collectiblesSettingsStore
+        category: "ManageTokens-" + collectiblesController.settingsKey
     }
 
     ManageHiddenPanel {

--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -52,14 +52,13 @@ public:
     Q_INVOKABLE void showHideGroup(const QString& groupId, bool flag);
     Q_INVOKABLE void showHideCollectionGroup(const QString& groupId, bool flag);
 
-    Q_INVOKABLE void loadFromQSettings();
-    Q_INVOKABLE void saveToQSettings(const QString& json);
     Q_INVOKABLE void clearQSettings();
     Q_INVOKABLE void revert();
 
-    /// required to be called before the saving is started
+    /// required to call and guard the saving process
     Q_INVOKABLE void savingStarted();
     Q_INVOKABLE void savingFinished();
+    /// required to call and guard the loading process
     Q_INVOKABLE void loadingStarted();
     Q_INVOKABLE void loadingFinished(const QString& jsonData);
 


### PR DESCRIPTION
### Updates #14365

Removed loading hidden groups from local settings and instead reload them from the externally loaded settings.
Also move the local saving code from the controller to external, therefore now it is implemented in storybook