### PR TITLE
chore: do not show permissions change notifications if permission is private or we are not a community member

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -285,9 +285,9 @@ proc init*(self: Controller) =
         self.delegate.onCommunityTokenPermissionUpdateFailed(args.communityId)
 
     self.events.on(SIGNAL_COMMUNITY_TOKEN_PERMISSION_DELETED) do(e: Args):
-      let args = CommunityTokenPermissionRemovedArgs(e)
+      let args = CommunityTokenPermissionArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.onCommunityTokenPermissionDeleted(args.communityId, args.permissionId)
+        self.delegate.onCommunityTokenPermissionDeleted(args.communityId, args.tokenPermission)
         self.asyncCheckPermissions()
 
     self.events.on(SIGNAL_COMMUNITY_TOKEN_PERMISSION_DELETION_FAILED) do(e: Args):

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -354,7 +354,7 @@ method onCommunityTokenPermissionUpdated*(self: AccessInterface, communityId: st
 method onCommunityTokenPermissionUpdateFailed*(self: AccessInterface, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityTokenPermissionDeleted*(self: AccessInterface, communityId: string, permissionId: string) {.base.} =
+method onCommunityTokenPermissionDeleted*(self: AccessInterface, communityId: string, tokenPermission: CommunityTokenPermissionDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityTokenPermissionDeletionFailed*(self: AccessInterface, communityId: string) {.base.} =

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -103,10 +103,6 @@ type
     communityId*: string
     tokenMetadata*: CommunityTokensMetadataDto
 
-  CommunityTokenPermissionRemovedArgs* = ref object of Args
-    communityId*: string
-    permissionId*: string
-
   DiscordCategoriesAndChannelsArgs* = ref object of Args
     categories*: seq[DiscordCategoryDto]
     channels*: seq[DiscordChannelDto]
@@ -687,8 +683,7 @@ QtObject:
           if not community.tokenPermissions.hasKey(id):
             self.communities[community.id].tokenPermissions.del(id)
             self.events.emit(SIGNAL_COMMUNITY_TOKEN_PERMISSION_DELETED,
-            CommunityTokenPermissionRemovedArgs(communityId: community.id, permissionId: id))
-
+            CommunityTokenPermissionArgs(communityId: community.id, tokenPermission: prvTokenPermission))
       else:
         for id, tokenPermission in community.tokenPermissions:
           if not prevCommunity.tokenPermissions.hasKey(id):


### PR DESCRIPTION
### What does the PR do

Hide community permission notifications if:
- the client is not a community member
- permission is private

Closes: https://github.com/status-im/status-desktop/issues/14331

### Affected areas

permissions notifications (create/edit/delete)

