### PR TITLE
fix(wallet): update wallet assets and collectibles order on user action

### DIFF
--- a/storybook/pages/ManageAssetsPanelPage.qml
+++ b/storybook/pages/ManageAssetsPanelPage.qml
@@ -80,7 +80,7 @@ SplitView {
             Button {
                 enabled: showcasePanel.dirty
                 text: "Save"
-                onClicked: showcasePanel.saveSettings()
+                onClicked: showcasePanel.saveSettings(false /* update */)
             }
 
             Button {

--- a/storybook/pages/ManageCollectiblesPanelPage.qml
+++ b/storybook/pages/ManageCollectiblesPanelPage.qml
@@ -74,7 +74,7 @@ SplitView {
             Button {
                 enabled: showcasePanel.dirty
                 text: "Save"
-                onClicked: showcasePanel.saveSettings()
+                onClicked: showcasePanel.saveSettings(false /* update */)
             }
 
             Button {

--- a/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
+++ b/storybook/qmlTests/tests/tst_ManageCollectiblesPanel.qml
@@ -357,7 +357,7 @@ Item {
 
             // save
             verify(controlUnderTest.dirty)
-            controlUnderTest.saveSettings()
+            controlUnderTest.saveSettings(false /* update */)
             verify(!controlUnderTest.dirty)
 
             // load the settings and check BigKitty is still on top

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -68,10 +68,10 @@ SettingsContentBase {
     toast.changesDetectedText: manageTokensView.advancedTabVisible ? toast.defaultChangesDetectedText : qsTr("New custom sort order created")
 
     onSaveForLaterClicked: {
-        manageTokensView.saveChanges()
+        manageTokensView.saveChanges(false /* update */)
     }
     onSaveChangesClicked: {
-        manageTokensView.saveChanges()
+        manageTokensView.saveChanges(true /* update */)
 
         if (manageTokensView.advancedTabVisible) {
             // don't emit toasts when the Advanced tab is visible

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -42,8 +42,8 @@ Item {
     readonly property bool dirty: !!loader.item && loader.item.dirty
     readonly property bool advancedTabVisible: tabBar.currentIndex === d.advancedTabIndex
 
-    function saveChanges() {
-        loader.item.saveSettings()
+    function saveChanges(update) {
+        loader.item.saveSettings(update)
     }
 
     function resetChanges() {

--- a/ui/app/AppLayouts/Wallet/panels/ManageAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageAssetsPanel.qml
@@ -21,9 +21,12 @@ DoubleFlickableWithFolding {
     property var getCurrencyAmount: function (balance, symbol) {}
     property var getCurrentCurrencyAmount: function(balance) {}
 
-    function saveSettings() {
+    function saveSettings(update) {
         let jsonSettings = root.controller.serializeSettingsAsJson()
         root.controller.requestSaveSettings(jsonSettings);
+        if(update) {
+            root.controller.requestLoadSettings();
+        }
     }
 
     function revert() {

--- a/ui/app/AppLayouts/Wallet/panels/ManageCollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ManageCollectiblesPanel.qml
@@ -18,9 +18,12 @@ DoubleFlickableWithFolding {
     readonly property bool dirty: root.controller.dirty
     readonly property bool hasSettings: root.controller.hasSettings
 
-    function saveSettings() {
+    function saveSettings(update) {
         let jsonSettings = root.controller.serializeSettingsAsJson()
         root.controller.requestSaveSettings(jsonSettings)
+        if(update) {
+            root.controller.requestLoadSettings();
+        }
     }
 
     function revert() {


### PR DESCRIPTION
### Closes #14365

Add a specific state to the saveSettings action to update the model by reloading the data.

The previous implementation was using the same `saveChanges` API which doesn't refresh the model. There must have been a side effect that made it work.