### PR TITLE
feat(ci): add Nix 2.19.3 for status-go builds

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -29,7 +29,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     QT_PATH=/opt/qt \
     QT_PLATFORM=gcc_64 \
     QT_VERSION=$QT_VERSION
-    
+
 ENV PATH=${QT_PATH}/${QT_VERSION}/${QT_PLATFORM}/bin:$PATH \
     QTDIR=${QT_PATH}/${QT_VERSION}/${QT_PLATFORM}
 
@@ -77,7 +77,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1
  && chmod +x cmake-3.22.1-linux-x86_64.sh \
  && sudo mkdir /opt/cmake \
  && sudo sh cmake-3.22.1-linux-x86_64.sh --prefix=/opt/cmake --exclude-subdir --skip-license \
- && rm -f cmake-3.22.1-linux-x86_64.sh 
+ && rm -f cmake-3.22.1-linux-x86_64.sh
 ENV PATH="/opt/cmake/bin:${PATH}"
 
 # Installing Golang
@@ -89,11 +89,17 @@ RUN GOLANG_SHA256="698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a38
  && rm "${GOLANG_TARBALL}" \
  && sudo ln -s /usr/local/go/bin/go /usr/local/bin
 
+# Create Nix directory as root.
+RUN mkdir /nix && chown 1001:1001 /nix
+
 # Jenkins user needs a specific UID/GID to work
 RUN sudo groupadd -g 1001 jenkins \
  && sudo useradd --create-home -u 1001 -g 1001 jenkins
 USER jenkins
 ENV HOME="/home/jenkins"
+
+# Nix for jenkins user to build status-go.
+RUN curl -s https://nixos.org/releases/nix/nix-2.19.3/install | sh -s -- --no-daemon
 
 LABEL maintainer="jakub@status.im"
 LABEL source="https://github.com/status-im/status-desktop"

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -9,7 +9,7 @@ pipeline {
     /* Necessary image with Ubuntu 20.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.3.0-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.4.0-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.linux
+++ b/ci/cpp/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.macos
+++ b/ci/cpp/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.windows
+++ b/ci/cpp/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.11'
+library 'status-jenkins-lib@v1.8.13'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
Otherwise it fails with:
```
performing a single-user installation of Nix...
directory /nix does not exist; creating it by running 'mkdir -m 0755 /nix && chown jenkins /nix' using sudo
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
/tmp/nix-binary-tarball-unpack.roliyEDk9X/unpack/nix-2.19.3-x86_64-linux/install: please manually run 'mkdir -m 0755 /nix && chown jenkins /nix' as root to create /nix
```
Related to:
* https://github.com/status-im/status-go/pull/4388