### PR TITLE
fix(Communities): Introduce request id for checking community permissions

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -92,14 +92,14 @@ proc getMySectionId*(self: Controller): string =
 proc asyncCheckPermissionsToJoin*(self: Controller) =
   if self.delegate.getPermissionsToJoinCheckOngoing():
     return
-  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId(), addresses = @[])
+  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId(), addresses = @[], CommunityPermissionsCheckRequestID.GeneralCommunity)
   self.delegate.setPermissionsToJoinCheckOngoing(true)
 
 proc asyncCheckAllChannelsPermissions*(self: Controller) =
   if self.allChannelsPermissionCheckOngoing:
     return
   self.allChannelsPermissionCheckOngoing = true
-  self.chatService.asyncCheckAllChannelsPermissions(self.getMySectionId(), addresses = @[])
+  self.chatService.asyncCheckAllChannelsPermissions(self.getMySectionId(), addresses = @[], CommunityPermissionsCheckRequestID.GeneralCommunity)
   self.delegate.setChannelsPermissionsCheckOngoing(true)
 
 proc asyncCheckChannelPermissions*(self: Controller, communityId: string, chatId: string) =

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -303,12 +303,12 @@ proc init*(self: Controller) =
 
     self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_RESPONSE) do(e: Args):
       let args = CheckPermissionsToJoinResponseArgs(e)
-      if (args.communityId == self.sectionId):
+      if (args.communityId == self.sectionId and args.requestId == CommunityPermissionsCheckRequestID.GeneralCommunity):
         self.delegate.onCommunityCheckPermissionsToJoinResponse(args.checkPermissionsToJoinResponse)
 
     self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_FAILED) do(e: Args):
       let args = CheckPermissionsToJoinFailedArgs(e)
-      if (args.communityId == self.sectionId):
+      if (args.communityId == self.sectionId and args.requestId == CommunityPermissionsCheckRequestID.GeneralCommunity):
         self.delegate.setPermissionsToJoinCheckOngoing(false)
 
     self.events.on(SIGNAL_CHECK_CHANNEL_PERMISSIONS_RESPONSE) do(e: Args):
@@ -318,13 +318,13 @@ proc init*(self: Controller) =
 
     self.events.on(SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_RESPONSE) do(e: Args):
       let args = CheckAllChannelsPermissionsResponseArgs(e)
-      if args.communityId == self.sectionId:
+      if args.communityId == self.sectionId and args.requestId == CommunityPermissionsCheckRequestID.GeneralCommunity:
         self.allChannelsPermissionCheckOngoing = false
         self.delegate.onCommunityCheckAllChannelsPermissionsResponse(args.checkAllChannelsPermissionsResponse)
 
     self.events.on(SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_FAILED) do(e: Args):
       let args = CheckChannelsPermissionsErrorArgs(e)
-      if args.communityId == self.sectionId:
+      if args.communityId == self.sectionId and args.requestId == CommunityPermissionsCheckRequestID.GeneralCommunity:
         self.allChannelsPermissionCheckOngoing = false
         self.delegate.setPermissionsToJoinCheckOngoing(false)
 

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -407,11 +407,11 @@ proc authenticate*(self: Controller) =
 proc getCommunityPublicKeyFromPrivateKey*(self: Controller, communityPrivateKey: string): string =
   result = self.communityService.getCommunityPublicKeyFromPrivateKey(communityPrivateKey)
 
-proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string]) =
-  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare)
+proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string], requestId: CommunityPermissionsCheckRequestID) =
+  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare, requestId)
 
-proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string]) =
-  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
+proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string], requestId: CommunityPermissionsCheckRequestID) =
+  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses, requestId)
 
 proc asyncGetRevealedAccountsForMember*(self: Controller, communityId, memberPubkey: string) =
   self.communityService.asyncGetRevealedAccountsForMember(communityId, memberPubkey)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -170,13 +170,18 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_RESPONSE) do(e: Args):
     let args = CheckPermissionsToJoinResponseArgs(e)
-    self.delegate.onCommunityCheckPermissionsToJoinResponse(args.communityId, args.checkPermissionsToJoinResponse)
+    self.delegate.onCommunityCheckPermissionsToJoinResponse(
+      args.communityId,
+      args.checkPermissionsToJoinResponse,
+      args.requestId == CommunityPermissionsCheckRequestID.SharedAddressesCheck
+    )
 
   self.events.on(SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_RESPONSE) do(e: Args):
     let args = CheckAllChannelsPermissionsResponseArgs(e)
     self.delegate.onCommunityCheckAllChannelsPermissionsResponse(
       args.communityId,
       args.checkAllChannelsPermissionsResponse,
+      args.requestId == CommunityPermissionsCheckRequestID.SharedAddressesCheck
     )
 
   self.events.on(SIGNAL_COMMUNITY_MEMBER_REVEALED_ACCOUNTS_LOADED) do(e: Args):

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -239,20 +239,21 @@ method signSharedAddressesForKeypair*(self: AccessInterface, keyUid: string, pin
 method joinCommunityOrEditSharedAddresses*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string) {.base.} =
+method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string, dedicated: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getCommunityPublicKeyFromPrivateKey*(self: AccessInterface, communityPrivateKey: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method checkPermissions*(self: AccessInterface, communityId: string, sharedAddresses: seq[string], temporary: bool) {.base.} =
+method checkPermissions*(self: AccessInterface, communityId: string, sharedAddresses: seq[string], dedicated: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, communityId: string, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =
+method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, communityId: string,
+    checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto, dedicated: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCheckAllChannelsPermissionsResponse*(self: AccessInterface, communityId: string,
-    checkChannelPermissionsResponse: CheckAllChannelsPermissionsResponseDto) {.base.} =
+    checkChannelPermissionsResponse: CheckAllChannelsPermissionsResponseDto, dedicated: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCheckPermissionsToJoinFailed*(self: AccessInterface, communityId: string, ValueErrorerror: string) {.base.} =

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -245,7 +245,7 @@ method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string
 method getCommunityPublicKeyFromPrivateKey*(self: AccessInterface, communityPrivateKey: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method checkPermissions*(self: AccessInterface, communityId: string, sharedAddresses: seq[string]) {.base.} =
+method checkPermissions*(self: AccessInterface, communityId: string, sharedAddresses: seq[string], temporary: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, communityId: string, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -356,10 +356,10 @@ QtObject:
   proc joinCommunityOrEditSharedAddresses*(self: View) {.slot.} =
     self.delegate.joinCommunityOrEditSharedAddresses()
 
-  proc checkPermissions*(self: View, communityId: string, addressesToShare: string) {.slot.} =
+  proc checkPermissions*(self: View, communityId: string, addressesToShare: string, temporary: bool) {.slot.} =
     try:
       let sharedAddresses = map(parseJson(addressesToShare).getElems(), proc(x:JsonNode):string = x.getStr())
-      self.delegate.checkPermissions(communityId, sharedAddresses)
+      self.delegate.checkPermissions(communityId, sharedAddresses, temporary)
     except Exception as e:
       echo "Error updating token model with addresses: ", e.msg
 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -20,6 +20,8 @@ QtObject:
       modelVariant: QVariant
       spectatedCommunityPermissionModel: TokenPermissionsModel
       spectatedCommunityPermissionModelVariant: QVariant
+      dedicatedCommunityPermissionModel: TokenPermissionsModel
+      dedicatedCommunityPermissionModelVariant: QVariant
       curatedCommunitiesModel: CuratedCommunityModel
       curatedCommunitiesModelVariant: QVariant
       curatedCommunitiesLoading: bool
@@ -67,6 +69,8 @@ QtObject:
     self.modelVariant.delete
     self.spectatedCommunityPermissionModel.delete
     self.spectatedCommunityPermissionModelVariant.delete
+    self.dedicatedCommunityPermissionModel.delete
+    self.dedicatedCommunityPermissionModelVariant.delete
     self.curatedCommunitiesModel.delete
     self.curatedCommunitiesModelVariant.delete
     self.discordFileListModel.delete
@@ -97,6 +101,8 @@ QtObject:
     result.modelVariant = newQVariant(result.model)
     result.spectatedCommunityPermissionModel = newTokenPermissionsModel()
     result.spectatedCommunityPermissionModelVariant = newQVariant(result.spectatedCommunityPermissionModel)
+    result.dedicatedCommunityPermissionModel = newTokenPermissionsModel()
+    result.dedicatedCommunityPermissionModelVariant = newQVariant(result.dedicatedCommunityPermissionModel)
     result.curatedCommunitiesModel = newCuratedCommunityModel()
     result.curatedCommunitiesModelVariant = newQVariant(result.curatedCommunitiesModel)
     result.curatedCommunitiesLoading = false
@@ -344,8 +350,11 @@ QtObject:
   proc spectatedCommunityPermissionModel*(self: View): TokenPermissionsModel =
     result = self.spectatedCommunityPermissionModel
 
-  proc prepareTokenModelForCommunity(self: View, communityId: string) {.slot.} =
-    self.delegate.prepareTokenModelForCommunity(communityId)
+  proc dedicatedCommunityPermissionModel*(self: View): TokenPermissionsModel =
+    result = self.dedicatedCommunityPermissionModel
+
+  proc prepareTokenModelForCommunity(self: View, communityId: string, dedicated: bool) {.slot.} =
+    self.delegate.prepareTokenModelForCommunity(communityId, dedicated)
 
   proc signProfileKeypairAndAllNonKeycardKeypairs*(self: View) {.slot.} =
     self.delegate.signProfileKeypairAndAllNonKeycardKeypairs()
@@ -356,10 +365,10 @@ QtObject:
   proc joinCommunityOrEditSharedAddresses*(self: View) {.slot.} =
     self.delegate.joinCommunityOrEditSharedAddresses()
 
-  proc checkPermissions*(self: View, communityId: string, addressesToShare: string, temporary: bool) {.slot.} =
+  proc checkPermissions*(self: View, communityId: string, addressesToShare: string, dedicated: bool) {.slot.} =
     try:
       let sharedAddresses = map(parseJson(addressesToShare).getElems(), proc(x:JsonNode):string = x.getStr())
-      self.delegate.checkPermissions(communityId, sharedAddresses, temporary)
+      self.delegate.checkPermissions(communityId, sharedAddresses, dedicated)
     except Exception as e:
       echo "Error updating token model with addresses: ", e.msg
 
@@ -368,6 +377,12 @@ QtObject:
 
   QtProperty[QVariant] spectatedCommunityPermissionModel:
     read = getSpectatedCommunityPermissionModel
+
+  proc getDedicatedCommunityPermissionModel(self: View): QVariant {.slot.} =
+    return self.dedicatedCommunityPermissionModelVariant
+
+  QtProperty[QVariant] dedicatedCommunityPermissionModel:
+    read = getDedicatedCommunityPermissionModel
 
   proc curatedCommunitiesModel*(self: View): CuratedCommunityModel =
     result = self.curatedCommunitiesModel

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -45,6 +45,7 @@ type
   AsyncCheckAllChannelsPermissionsTaskArg = ref object of QObjectTaskArg
     communityId: string
     addresses: seq[string]
+    requestId: CommunityPermissionsCheckRequestID
 
 const asyncCheckAllChannelsPermissionsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckAllChannelsPermissionsTaskArg](argEncoded)
@@ -53,10 +54,12 @@ const asyncCheckAllChannelsPermissionsTask: Task = proc(argEncoded: string) {.gc
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,
+      "requestId": arg.requestId,
       "error": "",
     })
   except Exception as e:
     arg.finish(%* {
       "communityId": arg.communityId,
+      "requestId": arg.requestId,
       "error": e.msg,
     })

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -54,12 +54,12 @@ const asyncCheckAllChannelsPermissionsTask: Task = proc(argEncoded: string) {.gc
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,
-      "requestId": arg.requestId,
+      "requestId": arg.requestId.int,
       "error": "",
     })
   except Exception as e:
     arg.finish(%* {
       "communityId": arg.communityId,
-      "requestId": arg.requestId,
+      "requestId": arg.requestId.int,
       "error": e.msg,
     })

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -99,6 +99,7 @@ type
     checkAllChannelsPermissionsResponse*: CheckAllChannelsPermissionsResponseDto
 
   CheckChannelsPermissionsErrorArgs* = ref object of Args
+    requestId*: CommunityPermissionsCheckRequestID
     communityId*: string
     error*: string
 
@@ -892,4 +893,5 @@ QtObject:
       self.events.emit(SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_FAILED, CheckChannelsPermissionsErrorArgs(
         communityId: communityId,
         error: errMsg,
+        requestId: requestId
       ))

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -218,13 +218,13 @@ const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe,
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,
-      "requestId": arg.requestId,
+      "requestId": arg.requestId.int,
       "error": "",
     })
   except Exception as e:
     arg.finish(%* {
       "communityId": arg.communityId,
-      "requestId": arg.requestId,
+      "requestId": arg.requestId.int,
       "error": e.msg,
     })
 

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -209,6 +209,7 @@ type
   AsyncCheckPermissionsToJoinTaskArg = ref object of QObjectTaskArg
     communityId: string
     addresses: seq[string]
+    requestId: CommunityPermissionsCheckRequestID
 
 const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckPermissionsToJoinTaskArg](argEncoded)
@@ -217,11 +218,13 @@ const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe,
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,
+      "requestId": arg.requestId,
       "error": "",
     })
   except Exception as e:
     arg.finish(%* {
       "communityId": arg.communityId,
+      "requestId": arg.requestId,
       "error": e.msg,
     })
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -43,6 +43,11 @@ type
     KickPending,
     BannedWithAllMessagesDelete
 
+type
+  CommunityPermissionsCheckRequestID* = enum
+    GeneralCommunity = 0,
+    SharedAddressesCheck
+
 proc isBanned*(state: CommunityMemberPendingBanOrKick): bool =
   return state == CommunityMemberPendingBanOrKick.Banned or state == CommunityMemberPendingBanOrKick.BannedWithAllMessagesDelete
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -144,6 +144,7 @@ type
     checkPermissionsToJoinResponse*: CheckPermissionsToJoinResponseDto
 
   CheckPermissionsToJoinFailedArgs* = ref object of Args
+    requestId*: CommunityPermissionsCheckRequestID
     communityId*: string
     error*: string
 
@@ -1661,6 +1662,7 @@ QtObject:
       self.events.emit(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_FAILED, CheckPermissionsToJoinFailedArgs(
         communityId: communityId,
         error: errMsg,
+        requestId: requestId
       ))
 
   proc generateJoiningCommunityRequestsForSigning*(self: Service, memberPubKey: string, communityId: string,

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -701,6 +701,6 @@ QtObject {
     }
 
     function updatePermissionsModel(communityId, sharedAddresses) {
-        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
+        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses), false)
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -57,8 +57,8 @@ QtObject {
         }
     }
 
-    function prepareTokenModelForCommunity(publicKey) {
-        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
+    function prepareTokenModelForCommunity(publicKey, dedicated) {
+        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey, dedicated)
     }
 
     readonly property bool allChannelsAreHiddenBecauseNotPermitted: root.chatCommunitySectionModule.allChannelsAreHiddenBecauseNotPermitted &&
@@ -68,6 +68,8 @@ QtObject {
 
     readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?
                                      root.communitiesModuleInst.spectatedCommunityPermissionModel : null
+
+    readonly property var dedicatedPermissionsModel: root.communitiesModuleInst.dedicatedPermissionsModel
 
     readonly property string overviewChartData: chatCommunitySectionModule.overviewChartData
 
@@ -700,7 +702,7 @@ QtObject {
         }
     }
 
-    function updatePermissionsModel(communityId, sharedAddresses) {
-        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses), false)
+    function updatePermissionsModel(communityId, sharedAddresses, dedicated) {
+        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses), dedicated)
     }
 }

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -116,8 +116,8 @@ QtObject {
         root.communitiesModuleInst.spectateCommunity(publicKey, "");
     }
 
-    function prepareTokenModelForCommunity(publicKey) {
-        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey);
+    function prepareTokenModelForCommunity(publicKey, dedicated) {
+        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey, dedicated);
     }
 
     function getCommunityDetails(communityId) {

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -542,7 +542,7 @@ Item {
             assetsModel: root.store.assetsModel
             collectiblesModel: root.store.collectiblesModel
             permissionsModel: {
-                root.store.prepareTokenModelForCommunity(communityData.id)
+                root.store.prepareTokenModelForCommunity(communityData.id, false)
                 return root.store.permissionsModel
             }
             channelsModel: root.store.chatCommunitySectionModule.model

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -271,7 +271,7 @@ QtObject {
     }
 
     function updatePermissionsModel(communityId, sharedAddresses) {
-        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
+        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses), false)
     }
 
     function promoteSelfToControlNode(communityId) {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -35,8 +35,8 @@ QtObject {
         return Constants.LoginType.Password
     }
 
-    function prepareTokenModelForCommunity(publicKey) {
-        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
+    function prepareTokenModelForCommunity(publicKey, dedicated) {
+        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey, dedicated)
     }
 
     property string communityKeyToImport
@@ -270,8 +270,8 @@ QtObject {
         communitiesModuleInst.cleanJoinEditCommunityData()
     }
 
-    function updatePermissionsModel(communityId, sharedAddresses) {
-        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses), false)
+    function updatePermissionsModel(communityId, sharedAddresses, dedicated) {
+        communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses), dedicated)
     }
 
     function promoteSelfToControlNode(communityId) {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -714,8 +714,8 @@ QtObject {
 
                 walletAssetsModel: walletAssetsStore.groupedAccountAssetsModel
                 permissionsModel: {
-                    root.rootStore.prepareTokenModelForCommunity(dialogRoot.communityId)
-                    return root.rootStore.permissionsModel
+                    root.rootStore.prepareTokenModelForCommunity(dialogRoot.communityId, true)
+                    return root.rootStore.dedicatedPermissionsModel
                 }
                 assetsModel: root.rootStore.assetsModel
                 collectiblesModel: root.rootStore.collectiblesModel
@@ -762,7 +762,7 @@ QtObject {
                 }
 
                 onSharedAddressesUpdated: {
-                    root.rootStore.updatePermissionsModel(dialogRoot.communityId, sharedAddresses)
+                    root.rootStore.updatePermissionsModel(dialogRoot.communityId, sharedAddresses, true)
                 }
 
                 onAboutToShow: { root.rootStore.communityKeyToImport = dialogRoot.communityId; }
@@ -978,7 +978,7 @@ QtObject {
                 }
 
                 onSharedAddressesUpdated: {
-                    root.rootStore.updatePermissionsModel(editSharedAddressesPopup.communityId, sharedAddresses)
+                    root.rootStore.updatePermissionsModel(editSharedAddressesPopup.communityId, sharedAddresses, false)
                 }
 
                 onPrepareForSigning: {


### PR DESCRIPTION
Close #14376

### What does the PR do

https://github.com/status-im/status-desktop/assets/2522130/e4d42e95-8d87-4221-822a-75fb8d39590d

- [x] Add enum request id to track permissions check role
- [x] Add dedicated permissions model for addresses check popup

### Affected areas

Communities

