### PR TITLE
fix(status-go): skip Nix shell use to avoid Glibc errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,8 +429,9 @@ export STATUSGO_LIBDIR
 
 $(STATUSGO): | deps
 	echo -e $(BUILD_MSG) "status-go"
-	+ cd vendor/status-go && \
-	  $(MAKE) statusgo-shared-library $(STATUSGO_MAKE_PARAMS) $(HANDLE_OUTPUT)
+	# FIXME: Nix shell usage breaks builds due to Glibc mismatch.
+	$(MAKE) -C vendor/status-go statusgo-shared-library SHELL=/bin/sh \
+		$(STATUSGO_MAKE_PARAMS) $(HANDLE_OUTPUT)
 
 status-go: $(STATUSGO)
 


### PR DESCRIPTION
Linux builds on desktop are stuck with:
```
/usr/bin/ld: .../libstatus.so: undefined reference to `pthread_mutexattr_init@GLIBC_2.34'
/usr/bin/ld: .../libstatus.so: undefined reference to `dlclose@GLIBC_2.34'
/usr/bin/ld: .../libstatus.so: undefined reference to `pthread_detach@GLIBC_2.34'
/usr/bin/ld: .../libstatus.so: undefined reference to `__isoc23_strtol@GLIBC_2.38'
```
Due to using old Glibc 2.34 from Ubuntu 22.04 while Nix uses 2.38.