### PR TITLE
feat(SharedAddresses): display the eligibility bubble in edit mode too

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/CommunityEligibilityTag.qml
+++ b/ui/app/AppLayouts/Communities/controls/CommunityEligibilityTag.qml
@@ -12,6 +12,8 @@ Rectangle {
     id: root
 
     required property int /*PermissionTypes.Type*/ eligibleToJoinAs
+    property bool isEditMode
+    property bool isDirty
 
     implicitWidth: hintRow.implicitWidth + 2*Style.current.padding
     implicitHeight: 40
@@ -22,7 +24,7 @@ Rectangle {
 
     QtObject {
         id: d
-        readonly property var joinHint: PermissionTypes.getJoinEligibilityHint(root.eligibleToJoinAs)
+        readonly property var joinHint: PermissionTypes.getJoinEligibilityHint(root.eligibleToJoinAs, root.isEditMode, root.isDirty)
     }
 
     RowLayout {

--- a/ui/app/AppLayouts/Communities/controls/PermissionTypes.qml
+++ b/ui/app/AppLayouts/Communities/controls/PermissionTypes.qml
@@ -32,8 +32,12 @@ QtObject {
         return ""
     }
 
-    function getJoinEligibilityHint(type) {
-        const template = qsTr("You are eligible to join as")
+    function getJoinEligibilityHint(type, isEditMode = false, isDirty = false) {
+        var template = qsTr("You are eligible to join as")
+        if (isEditMode) {
+            template = isDirty ? qsTr("You'll be a") : qsTr("You're a")
+        }
+
         switch (type) {
         case PermissionTypes.Type.TokenMaster:
             return [template, qsTr("TokenMaster"), "tiny/token-master"]
@@ -42,6 +46,8 @@ QtObject {
         case PermissionTypes.Type.Member:
             return [template, qsTr("Member"), "tiny/group"]
         case PermissionTypes.Type.None:
+            if (isEditMode)
+                return [qsTr("You'll no longer be a"), qsTr("Member"), "tiny/group"]
             return [qsTr("Not eligible to join with current address selections"), "", ""]
         }
         return ["", "", ""]

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -177,6 +177,8 @@ StatusListView {
         title: model.name
         tertiaryTitle: root.hasPermissions && !tagsCount ? qsTr("No relevant tokens") : ""
 
+        onClicked: shareAddressCheckbox.toggle()
+
         SubmodelProxyModel {
             id: filteredBalances
             sourceModel: root.walletAssetsModel

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -20,7 +20,6 @@ import AppLayouts.Communities.views 1.0
 import AppLayouts.Communities.helpers 1.0
 
 import utils 1.0
-import shared.panels 1.0
 
 Control {
     id: root
@@ -185,15 +184,24 @@ Control {
         spacing: 0
 
         // warning panel
-        ModuleWarning {
+        Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: 32
-            text: d.lostCommunityPermission ? qsTr("Selected addresses have insufficient tokens to maintain %1 membership").arg(root.communityName) :
-                                              d.lostChannelPermissions ? qsTr("By deselecting these addresses, you will lose channel permissions") :
-                                                                         ""
-            active: d.lostCommunityPermission || d.lostChannelPermissions
-            visible: active
-            closeBtnVisible: false
+            color: Theme.palette.dangerColor1
+            visible: d.lostCommunityPermission || d.lostChannelPermissions
+
+            StatusBaseText {
+                width: parent.width
+                anchors.verticalCenter: parent.verticalCenter
+                horizontalAlignment: Qt.AlignHCenter
+                elide: Text.ElideRight
+                text: d.lostCommunityPermission ? qsTr("Selected addresses have insufficient tokens to maintain %1 membership").arg(root.communityName) :
+                                                  d.lostChannelPermissions ? qsTr("By deselecting these addresses, you will lose channel permissions") :
+                                                                             ""
+                font.pixelSize: Style.current.additionalTextSize
+                font.weight: Font.Medium
+                color: Theme.palette.indirectColor1
+            }
         }
 
         // addresses
@@ -293,6 +301,7 @@ Control {
         SharedAddressesPermissionsPanel {
             id: permissionsView
             isEditMode: root.isEditMode
+            isDirty: d.dirty
             permissionsModel: root.permissionsModel
             assetsModel: root.assetsModel
             collectiblesModel: root.collectiblesModel

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -22,6 +22,7 @@ Rectangle {
     required property int /*PermissionTypes.Type*/ eligibleToJoinAs
 
     property bool isEditMode
+    property bool isDirty
 
     property string communityName
     property string communityIcon
@@ -256,7 +257,8 @@ Rectangle {
     CommunityEligibilityTag {
         id: eligibilityHintBubble
         eligibleToJoinAs: root.eligibleToJoinAs
-        visible: !root.isEditMode
+        isEditMode: root.isEditMode
+        isDirty: root.isDirty
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 24
         anchors.horizontalCenter: parent.horizontalCenter
@@ -327,7 +329,7 @@ Rectangle {
                 StatusBaseText {
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: Theme.tertiaryTextFontSize
-                    text: model.text
+                    text: !!model.text ? model.text : ""
                     color: model.available ? Theme.palette.successColor1 : Theme.palette.baseColor1
                 }
             }

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -173,8 +173,8 @@ StatusStackModal {
 
         readonly property int selectedSharedAddressesCount: d.selectedSharedAddressesMap.size
 
-        readonly property int accessType: d.eligibleToJoinAs !== - 1 ? Constants.communityChatOnRequestAccess
-                                                                     : Constants.communityChatPublicAccess
+        readonly property int accessType: d.eligibleToJoinAs !== -1 ? Constants.communityChatOnRequestAccess
+                                                                    : Constants.communityChatPublicAccess
         property int eligibleToJoinAs: PermissionsHelpers.isEligibleToJoinAs(root.permissionsModel)
         readonly property var _con: Connections {
             target: root.permissionsModel
@@ -444,7 +444,7 @@ StatusStackModal {
                 CommunityEligibilityTag {
                     Layout.alignment: Qt.AlignHCenter
                     eligibleToJoinAs: d.eligibleToJoinAs
-                    visible: !root.isEditMode && !root.isInvitationPending && d.accessType === Constants.communityChatOnRequestAccess
+                    visible: !root.isInvitationPending && d.accessType === Constants.communityChatOnRequestAccess
                 }
             }
         }


### PR DESCRIPTION
### What does the PR do

- previously, we'd display the bubble only when joining the community
- now we display it also when editing the shared addresses, with a slightly different wording (eg. "You're an admin" -> "You'll be a member"), hinting the user about the future change
- remove the usage of `ModuleWarning` as we don't want its delay or transitions here, replace it with a regular red `Rectangle` + text

Fixes #13397

### Affected areas

Edit Shared Addresses

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Initial state with default accounts:
![Snímek obrazovky z 2024-04-12 12-05-51](https://github.com/status-im/status-desktop/assets/5377645/711de27c-24e2-49d5-88da-6c9d6ed70ad0)

The "crucial" account unchecked:
![Snímek obrazovky z 2024-04-12 12-06-30](https://github.com/status-im/status-desktop/assets/5377645/0f1e9aa1-57d1-4b2b-b61d-2a88061e0225)




