### PR TITLE
feat(@desktop/activityCenter): show notification about invite to group chat from non our mutual contact

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -165,7 +165,6 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
 
   # Services
   result.generalService = general_service.newService(statusFoundation.events, statusFoundation.threadpool)
-  result.activityCenterService = activity_center_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.keycardService = keycard_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.nodeConfigurationService = node_configuration_service.newService(statusFoundation.fleetConfiguration,
   result.settingsService, statusFoundation.events)
@@ -177,6 +176,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     statusFoundation.events, statusFoundation.threadpool, result.networkService, result.settingsService
   )
   result.chatService = chat_service.newService(statusFoundation.events, statusFoundation.threadpool, result.contactsService)
+  result.activityCenterService = activity_center_service.newService(statusFoundation.events, statusFoundation.threadpool, result.chatService)
   result.tokenService = token_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.networkService, result.settingsService
   )

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -76,6 +76,14 @@ proc init*(self: Controller) =
     if (evArgs.notificationIds.len > 0):
       self.delegate.removeActivityCenterNotifications(evArgs.notificationIds)
 
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_ACCEPTED) do(e: Args):
+    var evArgs = ActivityCenterNotificationIdArgs(e)
+    self.delegate.acceptActivityCenterNotificationDone(evArgs.notificationId)
+
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_DISMISSED) do(e: Args):
+    var evArgs = ActivityCenterNotificationIdArgs(e)
+    self.delegate.dismissActivityCenterNotificationDone(evArgs.notificationId)
+
 proc hasMoreToShow*(self: Controller): bool =
   return self.activityCenterService.hasMoreToShow()
 
@@ -108,6 +116,12 @@ proc markActivityCenterNotificationUnread*(self: Controller,notificationId: stri
 
 proc markAsSeenActivityCenterNotifications*(self: Controller) =
   self.activityCenterService.markAsSeenActivityCenterNotifications()
+
+proc acceptActivityCenterNotification*(self: Controller,notificationId: string) =
+  self.activityCenterService.acceptActivityCenterNotification(notificationId)
+
+proc dismissActivityCenterNotification*(self: Controller,notificationId: string) =
+  self.activityCenterService.dismissActivityCenterNotification(notificationId)
 
 proc replacePubKeysWithDisplayNames*(self: Controller, message: string): string =
   return self.messageService.replacePubKeysWithDisplayNames(message)

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -63,6 +63,18 @@ method markActivityCenterNotificationUnread*(self: AccessInterface, notification
 method markAsSeenActivityCenterNotifications*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method acceptActivityCenterNotification*(self: AccessInterface, notificationId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method dismissActivityCenterNotification*(self: AccessInterface, notificationId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method acceptActivityCenterNotificationDone*(self: AccessInterface, notificationId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method dismissActivityCenterNotificationDone*(self: AccessInterface, notificationId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method addActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -126,8 +126,14 @@ proc `read=`*(self: Item, value: bool) =
 proc dismissed*(self: Item): bool =
   return self.dismissed
 
+proc `dismissed=`*(self: Item, value: bool) =
+  self.dismissed = value
+
 proc accepted*(self: Item): bool =
   return self.accepted
+
+proc `accepted=`*(self: Item, value: bool) =
+  self.accepted = value
 
 proc messageItem*(self: Item): MessageItem =
   return self.messageItem

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -112,27 +112,55 @@ QtObject:
       NotifRoles.TokenData.int: "tokenData"
     }.toTable
 
+  proc findNotificationIndex(self: Model, notificationId: string): int =
+    if notificationId.len == 0:
+      return -1
+    for i in 0 ..< self.activityCenterNotifications.len:
+      if self.activityCenterNotifications[i].id == notificationId:
+        return i
+    return -1
+
   proc markActivityCenterNotificationUnread*(self: Model, notificationId: string) =
-    var i = 0
-    for acnViewItem in self.activityCenterNotifications:
-      if (acnViewItem.id == notificationId):
-        acnViewItem.read = false
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[NotifRoles.Read.int])
-        break
-      i.inc
+    let i = self.findNotificationIndex(notificationId)
+    if i == -1:
+      return
+
+    self.activityCenterNotifications[i].read = false
+    let index = self.createIndex(i, 0, nil)
+    defer: index.delete
+    self.dataChanged(index, index, @[NotifRoles.Read.int])
 
   proc markActivityCenterNotificationRead*(self: Model, notificationId: string) =
-    var i = 0
-    for acnViewItem in self.activityCenterNotifications:
-      if (acnViewItem.id == notificationId):
-        acnViewItem.read = true
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
-        self.dataChanged(index, index, @[NotifRoles.Read.int])
-        break
-      i.inc
+    let i = self.findNotificationIndex(notificationId)
+    if i == -1:
+      return
+
+    self.activityCenterNotifications[i].read = true
+    let index = self.createIndex(i, 0, nil)
+    defer: index.delete
+    self.dataChanged(index, index, @[NotifRoles.Read.int])
+
+  proc activityCenterNotificationAccepted*(self: Model, notificationId: string) =
+    let i = self.findNotificationIndex(notificationId)
+    if i == -1:
+      return
+
+    self.activityCenterNotifications[i].read = true
+    self.activityCenterNotifications[i].accepted = true
+    let index = self.createIndex(i, 0, nil)
+    defer: index.delete
+    self.dataChanged(index, index, @[NotifRoles.Accepted.int, NotifRoles.Read.int])
+
+  proc activityCenterNotificationDismissed*(self: Model, notificationId: string) =
+    let i = self.findNotificationIndex(notificationId)
+    if i == -1:
+      return
+
+    self.activityCenterNotifications[i].read = true
+    self.activityCenterNotifications[i].dismissed = true
+    let index = self.createIndex(i, 0, nil)
+    defer: index.delete
+    self.dataChanged(index, index, @[NotifRoles.Dismissed.int, NotifRoles.Read.int])
 
   proc removeNotifications*(self: Model, ids: seq[string]) =
     var i = 0

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -244,6 +244,18 @@ method resetActivityCenterNotifications*(self: Module, activityCenterNotificatio
 method markActivityCenterNotificationUnread*(self: Module, notificationId: string) =
   self.controller.markActivityCenterNotificationUnread(notificationId)
 
+method acceptActivityCenterNotification*(self: Module, notificationId: string) =
+  self.controller.acceptActivityCenterNotification(notificationId)
+
+method dismissActivityCenterNotification*(self: Module, notificationId: string) =
+  self.controller.dismissActivityCenterNotification(notificationId)
+
+method acceptActivityCenterNotificationDone*(self: Module, notificationId: string) =
+  self.view.acceptActivityCenterNotificationDone(notificationId)
+
+method dismissActivityCenterNotificationDone*(self: Module, notificationId: string) =
+  self.view.dismissActivityCenterNotificationDone(notificationId)
+
 method markActivityCenterNotificationUnreadDone*(self: Module, notificationIds: seq[string]) =
   for notificationId in notificationIds:
     self.view.markActivityCenterNotificationUnreadDone(notificationId)

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -90,6 +90,18 @@ QtObject:
     self.delegate.markAsSeenActivityCenterNotifications()
     self.hasUnseenActivityCenterNotificationsChanged()
 
+  proc acceptActivityCenterNotification(self: View, notificationId: string): void {.slot.} =
+    self.delegate.acceptActivityCenterNotification(notificationId)
+
+  proc dismissActivityCenterNotification(self: View, notificationId: string): void {.slot.} =
+    self.delegate.dismissActivityCenterNotification(notificationId)
+
+  proc acceptActivityCenterNotificationDone*(self: View, notificationId: string) =
+    self.model.activityCenterNotificationAccepted(notificationId)
+
+  proc dismissActivityCenterNotificationDone*(self: View, notificationId: string) =
+    self.model.activityCenterNotificationDismissed(notificationId)
+
   proc addActivityCenterNotifications*(self: View, activityCenterNotifications: seq[Item]) =
     self.model.upsertActivityCenterNotifications(activityCenterNotifications)
 

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -100,6 +100,7 @@ proc toActivityCenterNotificationDto*(jsonObj: JsonNode): ActivityCenterNotifica
   discard jsonObj.getProp("id", result.id)
   discard jsonObj.getProp("chatId", result.chatId)
   discard jsonObj.getProp("communityId", result.communityId)
+  discard jsonObj.getProp("name", result.name)
 
   result.membershipStatus = ActivityCenterMembershipStatus.Idle
   var membershipStatusInt: int

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -144,6 +144,8 @@ Popup {
                     return communityBannedNotificationComponent
                 case ActivityCenterStore.ActivityCenterNotificationType.CommunityUnbanned:
                     return communityUnbannedNotificationComponent
+                case ActivityCenterStore.ActivityCenterNotificationType.NewPrivateGroupChat:
+                    return groupChatInvitationNotificationComponent
                 default:
                     return null
                 }
@@ -350,6 +352,18 @@ Popup {
             onOpenShareAccountsClicked: {
                 Global.communityShareAddressesPopupRequested(notification.communityId, communityName, communityImage)
             }
+        }
+    }
+
+    Component {
+        id: groupChatInvitationNotificationComponent
+
+        ActivityNotificationUnknownGroupChatInvitation {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
         }
     }
 }

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -110,4 +110,12 @@ QtObject {
     function fetchActivityCenterNotifications() {
         root.activityCenterModuleInst.fetchActivityCenterNotifications()
     }
+
+    function acceptActivityCenterNotification(notification) {
+        root.activityCenterModuleInst.acceptActivityCenterNotification(notification.id)
+    }
+
+    function dismissActivityCenterNotification(notification) {
+        root.activityCenterModuleInst.dismissActivityCenterNotification(notification.id)
+    }
 }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationUnknownGroupChatInvitation.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationUnknownGroupChatInvitation.qml
@@ -1,0 +1,43 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+
+import shared 1.0
+import shared.panels 1.0
+import utils 1.0
+
+import "../controls"
+import "../panels"
+import "../stores"
+
+ActivityNotificationMessage {
+    id: root
+
+    messageDetails.messageText: qsTr("Invitation to an unknown group")
+
+    badgeComponent: ChannelBadge {
+        property var group: root.store.getChatDetails(notification.chatId)
+
+        chatType: notification.chatType
+        name: notification.name
+        asset.isImage: asset.name != ""
+        asset.name: group.icon
+        asset.emoji: group.emoji
+        asset.color: group.color
+    }
+
+    ctaComponent: MembershipCta {
+        membershipStatus: if (notification.accepted)
+                              return ActivityCenterStore.ActivityCenterMembershipStatus.Accepted
+                          else if (notification.dismissed)
+                              return ActivityCenterStore.ActivityCenterMembershipStatus.Declined
+                          else
+                              return ActivityCenterStore.ActivityCenterMembershipStatus.Pending
+
+        onAcceptRequestToJoinCommunity: activityCenterStore.acceptActivityCenterNotification(notification)
+        onDeclineRequestToJoinCommunity: activityCenterStore.dismissActivityCenterNotification(notification)
+    }
+}


### PR DESCRIPTION
### What does the PR do

When the client receives a group chat msg from the non our mutual contact and group chat is absent from our list (for example due to a backup issue) - show an invite to the group activity center notification

Closes: https://github.com/status-im/status-desktop/issues/8773

### Affected areas

New group chat activity center notification

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/117639195/89b37867-ee77-4d04-819b-33232ab5f98a)

![image](https://github.com/status-im/status-desktop/assets/117639195/038ad070-b5d9-4c8c-9209-58eb7ca6105b)

