### PR TITLE
fix(chat_section): fix parent badge not updating on chat close and open

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -836,6 +836,8 @@ method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
   let activeChatId = self.controller.getActiveChatId()
   if chatId == activeChatId:
     self.setFirstChannelAsActive()
+  
+  self.updateParentBadgeNotifications()
 
 proc refreshHiddenBecauseNotPermittedState(self: Module) =
   self.view.refreshAllChannelsAreHiddenBecauseNotPermittedChanged()
@@ -1393,11 +1395,7 @@ proc addOrUpdateChat(self: Module,
     not belongsToCommunity and sectionId != singletonInstance.userProfile.getPubKey()):
     return
 
-  let chatExists = self.doesCatOrChatExist(chat.id)
-
-  if not self.chatsLoaded or chatExists:
-    # Update badges
-    self.updateBadgeNotifications(chat, chat.unviewedMessagesCount > 0, chat.unviewedMentionsCount)
+  self.updateBadgeNotifications(chat, chat.unviewedMessagesCount > 0, chat.unviewedMentionsCount)
 
   if not self.chatsLoaded:
     return
@@ -1406,7 +1404,7 @@ proc addOrUpdateChat(self: Module,
   if chat.id == activeChatId:
     self.updateActiveChatMembership()
 
-  if chatExists:
+  if self.doesCatOrChatExist(chat.id):
     self.changeMutedOnChat(chat.id, chat.muted)
     self.changeCanPostValues(chat.id, chat.canPostReactions, chat.viewersCanPostReactions)
     self.updateChatRequiresPermissions(chat.id)


### PR DESCRIPTION
Fixes #14025

[unread-badge.webm](https://github.com/status-im/status-desktop/assets/11926403/2cfbd367-492e-4ad1-8c36-24ce8cd639e5)
