### PR TITLE
fix(token-order): global has settings check that introduced side effects

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -51,7 +51,7 @@ Loader {
                 id: statusRoundImage
                 width: parent.width
                 height: parent.height
-                image.source: root.asset.name
+                image.source: root.asset.isImage ? root.asset.name : ""
                 showLoadingIndicator: true
                 border.width: root.asset.imgIsIdenticon ? 1 : 0
                 border.color: Theme.palette.directColor7

--- a/ui/StatusQ/src/wallet/managetokenscontroller.cpp
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.cpp
@@ -276,9 +276,7 @@ QString ManageTokensController::settingsGroupName() const
 
 bool ManageTokensController::hasSettings() const
 {
-    Q_ASSERT(!m_settingsKey.isEmpty());
-    const auto groups = m_settings.childGroups();
-    return groups.contains(settingsGroupName());
+    return !m_settingsData.isEmpty();
 }
 
 int ManageTokensController::compareTokens(const QString& lhsSymbol, const QString& rhsSymbol) const

--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -160,7 +160,7 @@ private:
     void setSerializeAsCollectibles(const bool newSerializeAsCollectibles);
 
     QSettings m_settings;
-    SerializedTokenData m_settingsData; // symbol -> {sortOrder, visible, groupId, isCommunityGroup, isCollectionGroup}
+    SerializedTokenData m_settingsData;
     bool hasSettings() const;
     void loadSettingsData(bool withGroup = false);
 

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
@@ -54,8 +54,23 @@ Control {
             asset.width: 16
             asset.height: 16
             visible: root.useLongTextDescription && !!asset.source
-            asset.name: !!root.communityImage ? root.communityImage : "help"
-            asset.isImage: !!root.communityImage
+
+            Component.onCompleted: {
+                updateCommunityImage()
+            }
+            Connections {
+                target: root
+                function onCommunityImageChanged() {
+                    identicon.updateCommunityImage()
+                }
+            }
+
+            function updateCommunityImage() {
+                // Ensure we keep the flag in sync with the type of asset otherwise we generate warnings
+                identicon.asset.name = ""
+                identicon.asset.isImage = !!root.communityImage
+                identicon.asset.name = !!root.communityImage ? root.communityImage : "help"
+            }
         }
 
         RowLayout {


### PR DESCRIPTION
### Closes #14383
    
The "settings exist" done via `ManageTokensController::hasSettings()` was using the global store, hence not working user based. Therefore, after an onboarding the previous user's settings presence was taken into account.

The fix now uses the order data that is loaded externally per user.

`HEAD~1` also  fixes an annoying warning that was distracting from debugging