### PR TITLE
fix: do not display the thousands separator when editing

### DIFF
--- a/storybook/pages/AmountToSendPage.qml
+++ b/storybook/pages/AmountToSendPage.qml
@@ -14,11 +14,12 @@ SplitView {
     readonly property var tokensBySymbolModel: TokensBySymbolModel {}
 
     readonly property double maxCryptoBalance: parseFloat(maxCryptoBalanceText.text)
-    readonly property double rate: parseFloat(rateText.text)
     readonly property int decimals: parseInt(decimalsText.text)
 
     Logs { id: logs }
-    
+
+    Component.onCompleted: amountToSendInput.input.forceActiveFocus()
+
     SplitView {
         orientation: Qt.Vertical
         SplitView.fillWidth: true
@@ -38,14 +39,14 @@ SplitView {
                 maxInputBalance: inputIsFiat ? root.maxCryptoBalance*amountToSendInput.selectedHolding.marketDetails.currencyPrice.amount
                                              : root.maxCryptoBalance
                 currentCurrency: "Fiat"
-                formatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
+                formatCurrencyAmount: function(amount, symbol, options, locale) {
                     const currencyAmount = {
-                      amount: amount,
-                      symbol: symbol,
-                      displayDecimals: root.decimals,
-                      stripTrailingZeroes: true
+                        amount: amount,
+                        symbol: symbol,
+                        displayDecimals: root.decimals,
+                        stripTrailingZeroes: true
                     }
-                    return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options)
+                    return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options, locale)
                 }
                 onReCalculateSuggestedRoute: function() {
                     logs.logEvent("onReCalculateSuggestedRoute")
@@ -78,19 +79,6 @@ SplitView {
                 background: Rectangle { border.color: 'lightgrey' }
                 Layout.preferredWidth: 200
                 text: "1000000"
-            }
-
-            Label {
-                Layout.topMargin: 10
-                Layout.fillWidth: true
-                text: "Fiat/Crypto rate"
-            }
-
-            TextField {
-                id: rateText
-                background: Rectangle { border.color: 'lightgrey' }
-                Layout.preferredWidth: 200
-                text: "10"
             }
 
             Label {

--- a/storybook/pages/StatusAmountInputPage.qml
+++ b/storybook/pages/StatusAmountInputPage.qml
@@ -20,6 +20,7 @@ SplitView {
         StatusAmountInput {
             id: input
             anchors.centerIn: parent
+            locale: Qt.locale(ctrlLocaleName.text)
         }
     }
 
@@ -34,12 +35,10 @@ SplitView {
             RowLayout {
                 Layout.fillWidth: true
                 Label {
-                    text: "Valid:"
+                    text: "Valid:\t"
                 }
                 Label {
                     Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignRight
-                    horizontalAlignment: Text.AlignRight
                     font.bold: true
                     text: input.valid ? "true" : "false"
                 }
@@ -47,14 +46,11 @@ SplitView {
             RowLayout {
                 Layout.fillWidth: true
                 Label {
-                    text: "Locale:"
+                    text: "Locale:\t"
                 }
-                Label {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignRight
-                    horizontalAlignment: Text.AlignRight
-                    font.bold: true
-                    text: input.locale.name
+                TextField {
+                    id: ctrlLocaleName
+                    placeholderText: "Default locale: %1".arg(input.locale.name)
                 }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusAmountInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusAmountInput.qml
@@ -9,6 +9,7 @@ StatusInput {
     id: root
 
     property var locale: LocaleUtils.userInputLocale
+    validationMode: StatusInput.ValidationMode.IgnoreInvalidInput
 
     input.edit.objectName: "amountInput"
 
@@ -16,7 +17,7 @@ StatusInput {
         StatusFloatValidator {
             bottom: 0
             errorMessage: ""
-            locale: LocaleUtils.userInputLocale
+            locale: root.locale
         }
     ]
 
@@ -27,7 +28,7 @@ StatusInput {
                           if(root.text.indexOf(root.locale.decimalPoint) === -1)
                             root.input.insert(root.input.cursorPosition, root.locale.decimalPoint)
                           event.accepted = true
-                      } else if ((event.key > Qt.Key_9 && event.key <= Qt.Key_BraceRight) || event.key === Qt.Key_Space) {
+                      } else if ((event.key > Qt.Key_9 && event.key <= Qt.Key_BraceRight) || event.key === Qt.Key_Space || event.key === Qt.Key_Tab) {
                           event.accepted = true
                       }
                   }

--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml
@@ -49,7 +49,10 @@ StatusValidator {
        \qmlproperty DoubleValidator StatusFloatValidator::qmlDoubleValidator
        This property holds a default qml double validator instance.
     */
-    readonly property DoubleValidator qmlDoubleValidator: DoubleValidator {}
+    readonly property DoubleValidator qmlDoubleValidator: DoubleValidator {
+        notation: DoubleValidator.StandardNotation
+        locale: root.locale.name
+    }
 
     name: "floatValidator"
     errorMessage: qsTr("Please enter a valid numeric value.")

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -1,12 +1,16 @@
 pragma Singleton
 
-import QtQml 2.14
-import Qt.labs.settings 1.0
+import QtQml 2.15
+import Qt.labs.settings 1.1
 
 QtObject {
     id: root
 
-    readonly property var userInputLocale: Qt.locale()
+    readonly property var userInputLocale: {
+        const loc = Qt.locale()
+        loc.numberOptions |= Locale.OmitGroupSeparator // no thousands separator in number-to-string functions
+        return loc
+    }
 
     function integralPartLength(num) {
         num = Math.abs(num)

--- a/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
@@ -116,8 +116,6 @@ ColumnLayout {
     AmountInput {
         id: amountInput
 
-        locale: LocaleUtils.userInputLocale
-
         Layout.fillWidth: true
         Layout.bottomMargin: (validationError !== "") ? root.spacing * 2 : 0
         customHeight: d.defaultHeight

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -11,7 +11,7 @@ Input {
     id: root
 
     property int maximumLength: 10
-    property var locale: Qt.locale()
+    property var locale: LocaleUtils.userInputLocale
 
     readonly property alias amount: d.amount
     property alias multiplierIndex: d.multiplierIndex
@@ -59,7 +59,7 @@ Input {
 
         function getEffectiveDigitsCount(str) {
             const digits = LocaleUtils.getLocalizedDigitsCount(text, root.locale)
-            return str.startsWith(locale.decimalPoint) ? digits + 1 : digits
+            return str.startsWith(root.locale.decimalPoint) ? digits + 1 : digits
         }
 
         function validate() {
@@ -119,8 +119,6 @@ Input {
     }
 
     validator: DoubleValidator {
-        id: doubleValidator
-
         decimals: root.allowDecimals ? 100 : 0
         bottom: 0
         notation: DoubleValidator.StandardNotation


### PR DESCRIPTION
### What does the PR do

- teach `userInputLocale` about `Locale.OmitGroupSeparator` option which discards the said thousands separator
- some more fixes to other inputs to do the same, and align what the validators do
- StatusAmountInput: discard illegal characters, and reuse the same locale for the validator
- StatusAmountInputPage: make it possible to select a different locale

Fixes #14165

### Affected areas

(Status)AmountInput, LocaleUtils

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2024-04-15 11-35-10](https://github.com/status-im/status-desktop/assets/5377645/32baf300-741d-41df-b64f-f6f51135f6de)

![image](https://github.com/status-im/status-desktop/assets/5377645/b7f57329-bb25-4052-af05-712de0473cd9)

