### PR TITLE
fix(wallet): Hide loading when selected account is loaded

### DIFF
--- a/src/app/modules/main/wallet_section/all_collectibles/io_interface.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/io_interface.nim
@@ -45,3 +45,6 @@ method getCollectibleGroupByCollection*(self: AccessInterface): bool {.base.} =
 
 method toggleCollectibleGroupByCollection*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method setSelectedAccount*(self: AccessInterface, address: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/all_collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/module.nim
@@ -78,6 +78,9 @@ method viewDidLoad*(self: Module) =
   self.moduleLoaded = true
   self.delegate.allCollectiblesModuleDidLoad()
 
+method setSelectedAccount*(self: Module, address: string) =
+  self.collectiblesController.setSelectedAccount(address)
+
 method getAllCollectiblesModel*(self: Module): collectibles_model.Model =
   return self.collectiblesController.getModel()
 

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -236,6 +236,7 @@ proc setKeypairOperabilityForObservedAccount(self: Module, address: string) =
 method setFilterAddress*(self: Module, address: string) =
   self.setKeypairOperabilityForObservedAccount(address)
   self.filter.setAddress(address)
+  self.allCollectiblesModule.setSelectedAccount(address)
   self.overviewModule.setIsAllAccounts(false)
   self.view.setAddressFilters(address)
   self.notifyFilterChanged()
@@ -243,6 +244,7 @@ method setFilterAddress*(self: Module, address: string) =
 method setFilterAllAddresses*(self: Module) =
   self.view.setKeypairOperabilityForObservedAccount("")
   self.filter.setAddresses(self.getWalletAddressesNotHidden())
+  self.allCollectiblesModule.setSelectedAccount("")
   self.view.setAddressFilters(self.filter.addresses.join(":"))
   self.overviewModule.setIsAllAccounts(true)
   self.notifyFilterChanged()

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -38,6 +38,7 @@ QtObject:
 
       addresses: seq[string]
       chainIds: seq[int]
+      selectedAddress: string
       filter: backend_collectibles.CollectibleFilter
 
       ownershipStatus: Table[string, Table[int, OwnershipStatus]] # Table[address][chainID] -> OwnershipStatus
@@ -70,7 +71,7 @@ QtObject:
     # Otherwise, if any address+chainID is updating, then the whole model is updating
     # Otherwise, the model is idle
     for address, statusPerChainID in self.ownershipStatus.pairs:
-      if not self.addresses.contains(address):
+      if not self.addresses.contains(address) or (self.selectedAddress != "" and self.selectedAddress != address):
         continue
       for chainID, status in statusPerChainID:
         if not self.chainIds.contains(chainID):
@@ -283,6 +284,10 @@ QtObject:
     result.setupEventHandlers()
 
     signalConnect(result.model, "loadMoreItems()", result, "onModelLoadMoreItems()")
+
+  proc setSelectedAccount*(self: Controller, address: string) =
+    self.selectedAddress = address
+    self.checkModelState()
 
   proc setFilterAddressesAndChains*(self: Controller, addresses: seq[string], chainIds: seq[int]) = 
     if chainIds == self.chainIds and addresses == self.addresses:


### PR DESCRIPTION
Task https://github.com/status-im/status-desktop/issues/13776

### What does the PR do

* Pass currently selected account in the UI to collectible to update `isUpdating` and `isLoading` properties accordingly

### Affected areas

Wallet / collectibles view

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/11396062/3ace9f51-92a5-4372-8b25-10a1a3b671e3

