### PR TITLE
fix: fix crashes on join and permission removed

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -679,7 +679,7 @@ proc addNewChat(
       memberRole = community.memberRole
 
   var categoryOpened = true
-  if chatDto.categoryId != "":
+  if chatDto.categoryId != "" and self.doesCatOrChatExist(chatDto.categoryId):
     let categoryItem = self.view.chatsModel.getItemById(chatDto.categoryId)
     categoryOpened = categoryItem.categoryOpened
     if channelGroup.id != "":


### PR DESCRIPTION
Fixes #14444 and #14447

The problem was that we accessed a categoryItem that might not have existed yet.
