### PR TITLE
feat(ProfileShowcase): Sort and filter collectibles based on token ma…

### DIFF
--- a/ui/StatusQ/src/wallet/managetokenscontroller.cpp
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.cpp
@@ -227,6 +227,7 @@ void ManageTokensController::savingFinished()
     incRevision();
 
     setSettingsDirty(false);
+    requestLoadSettings();
 }
 
 void ManageTokensController::loadingStarted()

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -20,11 +20,14 @@ import "popups"
 import "views"
 import "views/profile"
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Layout 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups.Dialog 0.1
 import StatusQ.Core.Utils 0.1 as SQUtils
+
+import SortFilterProxyModel 0.2
 
 StatusSectionLayout {
     id: root
@@ -148,8 +151,28 @@ StatusSectionLayout {
 
                 communitiesShowcaseModel: root.store.ownShowcaseCommunitiesModel
                 accountsShowcaseModel: root.store.ownShowcaseAccountsModel
-                collectiblesShowcaseModel: root.store.ownShowcaseCollectiblesModel
                 socialLinksShowcaseModel: root.store.ownShowcaseSocialLinksModel
+                collectiblesShowcaseModel: SortFilterProxyModel {
+                    sourceModel: root.store.ownShowcaseCollectiblesModel
+                    sorters: [
+                        FastExpressionSorter {
+                            expression: {
+                                root.collectiblesStore.collectiblesController.revision
+                                return root.collectiblesStore.collectiblesController.compareTokens(modelLeft.uid, modelRight.uid)
+                            }
+                            expectedRoles: ["uid"]
+                        }
+                    ]
+                    filters: [
+                        FastExpressionFilter {
+                            expression: {
+                                root.collectiblesStore.collectiblesController.revision
+                                return root.collectiblesStore.collectiblesController.filterAcceptsSymbol(model.uid)
+                            }
+                            expectedRoles: ["uid"]
+                        }
+                    ]
+                }
 
                 assetsModel: root.globalStore.globalAssetsModel
                 collectiblesModel: root.globalStore.globalCollectiblesModel


### PR DESCRIPTION
…nagement settings

### What does the PR do

closes #13680
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Use `ManageTokensController` to sort and filter the collectibles model before loading it in the profile showcase view.

### Affected areas

Profile Showcase
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/11dbff68-2c9a-4c32-90bf-90758fc49759

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

