### PR TITLE
fix(CommunityPermissions): Fix token criteria updates in the permissions model

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -933,12 +933,13 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
 
       var updatedTokenCriteriaItems: seq[TokenCriteriaItem] = @[]
       var permissionSatisfied = true
+      var aCriteriaChanged = false
 
       for index, tokenCriteriaItem in tokenPermissionItem.getTokenCriteria().getItems():
         let criteriaMet = criteriaResult.criteria[index]
 
-        if tokenCriteriaItem.criteriaMet == criteriaMet:
-          continue
+        if tokenCriteriaItem.criteriaMet != criteriaMet:
+          aCriteriaChanged = true
 
         let updatedTokenCriteriaItem = initTokenCriteriaItem(
           tokenCriteriaItem.symbol,
@@ -954,7 +955,7 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
 
         updatedTokenCriteriaItems.add(updatedTokenCriteriaItem)
 
-      if updatedTokenCriteriaItems.len == 0:
+      if not aCriteriaChanged:
         continue
 
       thereWasAnUpdate = true

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -899,13 +899,13 @@ proc applyPermissionResponse*(self: Module, communityId: string, permissions: Ta
 
     var updatedTokenCriteriaItems: seq[TokenCriteriaItem] = @[]
     var permissionSatisfied = true
+    var aCriteriaChanged = false
 
     for index, tokenCriteriaItem in tokenPermissionItem.getTokenCriteria().getItems():
       let criteriaMet = criteriaResult.criteria[index]
 
-      if tokenCriteriaItem.criteriaMet == criteriaMet:
-        continue
-
+      if tokenCriteriaItem.criteriaMet != criteriaMet:
+          aCriteriaChanged = true
 
       let updatedTokenCriteriaItem = initTokenCriteriaItem(
         tokenCriteriaItem.symbol,
@@ -921,8 +921,9 @@ proc applyPermissionResponse*(self: Module, communityId: string, permissions: Ta
 
       updatedTokenCriteriaItems.add(updatedTokenCriteriaItem)
 
-    if updatedTokenCriteriaItems.len == 0:
+    if not aCriteriaChanged:
       continue
+      
     let updatedTokenPermissionItem = initTokenPermissionItem(
         tokenPermissionItem.id,
         tokenPermissionItem.`type`,


### PR DESCRIPTION
### What does the PR do

The tokens criteria items were filtered out if the `criteriaMet` flag doesn't change after a model update.

This filtering was done due to perf reasons, but we need all the token criteria items in the model.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Community permissions

### Screenshot of functionality (including design for comparison)

This shows that both token criteria items are shown in the UI even though one is met and one is not.

https://github.com/status-im/status-desktop/assets/47811206/67318258-bfc5-42b3-bb17-ad88cc751c6e



