### PR TITLE
fix(CommunitySettingsView): hide control node functionality for admins and token masters

### DIFF
--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -20,7 +20,7 @@ ColumnLayout {
     readonly property bool shardingEnabled: ctrlShardingEnabled.checked
     property alias shardIndex: ctrlShardIndex.value
 
-    spacing: 24
+    spacing: 12
 
     ColumnLayout {
         Label {

--- a/storybook/pages/FinaliseOwnershipPopupPage.qml
+++ b/storybook/pages/FinaliseOwnershipPopupPage.qml
@@ -93,11 +93,9 @@ SplitView {
                 font.bold: true
             }
 
-            TextInput {
+            TextField {
                 id: communityNameText
-
                 text: "Doodles"
-
             }
 
             Label {
@@ -105,7 +103,7 @@ SplitView {
                 font.bold: true
             }
 
-            TextInput {
+            TextField {
                 id: communitySymbolText
 
                 text: "OWNDOO"
@@ -116,7 +114,7 @@ SplitView {
                 font.bold: true
             }
 
-            TextInput {
+            TextField {
                 id: tokenChainText
 
                 text: "Optimism"

--- a/storybook/pages/OverviewSettingsFooterPage.qml
+++ b/storybook/pages/OverviewSettingsFooterPage.qml
@@ -44,24 +44,19 @@ SplitView {
             SplitView.preferredHeight: 150
 
             logsView.logText: logs.logText
-        }
-    }
-    
-    Pane {
-        SplitView.preferredWidth: 300
-        SplitView.fillHeight: true
 
-        ColumnLayout {
-            Switch {
-                id: controlNodeSwitch
-                text: "Control node on/off"
-                checked: true
-            }
+            ColumnLayout {
+                Switch {
+                    id: controlNodeSwitch
+                    text: "Control node on/off"
+                    checked: true
+                }
 
-            Switch {
-                id: pendingOwnershipSwitch
-                text: "Is there a pending transfer ownership request?"
-                checked: true
+                Switch {
+                    id: pendingOwnershipSwitch
+                    text: "Is there a pending transfer ownership request?"
+                    checked: true
+                }
             }
         }
     }

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -2,11 +2,18 @@ import QtQuick 2.14
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import mainui 1.0
 import AppLayouts.Communities.panels 1.0
 
 SplitView {
     id: root
     SplitView.fillWidth: true
+
+    Popups {
+        popupParent: root
+        rootStore: QtObject {}
+        communityTokensStore: QtObject {}
+    }
 
     OverviewSettingsPanel {
         SplitView.fillWidth: true
@@ -18,8 +25,11 @@ SplitView {
         color: communityEditor.color
         bannerImageData: communityEditor.banner
 
-        editable: communityEditor.isCommunityEditable
         isOwner: communityEditor.amISectionAdmin
+        isAdmin: ctrlIsAdmin.checked
+        isTokenMaster: ctrlIsTM.checked
+
+        editable: communityEditor.isCommunityEditable
         communitySettingsDisabled: !editable
 
         shardingEnabled: communityEditor.shardingEnabled
@@ -32,16 +42,27 @@ SplitView {
         SplitView.minimumWidth: 300
         SplitView.preferredWidth: 300
 
-        ColumnLayout {
-            CommunityInfoEditor{
-                id: communityEditor
-                anchors.fill: parent
-            }
+        ScrollView {
+            anchors.fill: parent
+            contentWidth: availableWidth
 
-            Switch {
-                id: pendingOwnershipSwitch
-                text: "Is there a pending transfer ownership request?"
-                checked: true
+            CommunityInfoEditor {
+                id: communityEditor
+
+                Switch {
+                    id: pendingOwnershipSwitch
+                    text: "Pending transfer ownership request?"
+                }
+
+                Switch {
+                    id: ctrlIsAdmin
+                    text: "Is admin?"
+                }
+
+                Switch {
+                    id: ctrlIsTM
+                    text: "Is token master?"
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsChart.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsChart.qml
@@ -8,7 +8,6 @@ import StatusQ.Components 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
-import StatusQ.Components 0.1
 
 import utils 1.0
 
@@ -49,7 +48,7 @@ StatusChartPanel {
         readonly property var hoveredModelMetadata: modelMetadata[root.timeRangeTabBarIndex].modelItems[hoveredBarIndex]
         readonly property var tooltipConfig: modelMetadata[root.timeRangeTabBarIndex].tooltipConfig
         readonly property var graphTabsModel: [{text: messagesLabel, enabled: true}]
-        property var now: Date.now()
+        property double now: Date.now()
         property var lastRequestModelMetadata: null
 
         readonly property var chartData: selectedTabInfo.modelItems.map(x => d.itemsCountInRange(root.model, x.start, x.end))
@@ -210,9 +209,8 @@ StatusChartPanel {
         }
 
         function monthStr(before = 0, timeReference = now, roundCurrentTime = true, shortFormat = true) {
-            const format = shortFormat ? "MMM" : "MMMM"
             const timeStamp = LocaleUtils.months(before, timeReference, roundCurrentTime)
-            return LocaleUtils.formatDate(timeStamp, format)
+            return Qt.locale().standaloneMonthName(new Date(timeStamp).getMonth(), shortFormat ? Locale.ShortFormat : Locale.LongFormat)
         }
 
         function yearsStr(before = 0, timeReference = now, roundCurrentTime = true) {
@@ -254,7 +252,7 @@ StatusChartPanel {
         }
 
         function getAdjustedTooltipPosition(event) {
-            // By defaullt the popup is displayed on the right of the cursor
+            // By default the popup is displayed on the right of the cursor
             // If there is not enough space on the right, display it on the left
             const relativeMousePoint = event.target.mapToItem(toolTip.parent, event.x, event.y) // relative to tooltip parent
             const leftPositon = (toolTip.parent.width - (toolTip.width + toolTip.rightPadding + relativeMousePoint.x + 15)) < 0
@@ -375,7 +373,6 @@ StatusChartPanel {
                 Layout.fillWidth: true
                 StatusBaseText {
                     elide: Qt.ElideRight
-                    font.pixelSize: Style.current.primaryTextFontSize
                     color: Theme.palette.baseColor1
                     text: d.tooltipConfig.timeRangeString
                 }
@@ -385,8 +382,6 @@ StatusChartPanel {
                 StatusBaseText {
                     Layout.alignment: Qt.AlignRight
                     elide: Qt.ElideRight
-                    font.pixelSize: Style.current.primaryTextFontSize
-                    color: Theme.palette.directColor1
                     text: d.hoveredModelMetadata ? d.tooltipConfig.timeRangeFormatter(d.hoveredModelMetadata.start, d.hoveredModelMetadata.end)
                                                  : ""
                 }

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
@@ -13,7 +13,7 @@ import utils 1.0
 Control {
     id: root
 
-    property bool isControlNode: true   
+    property bool isControlNode: true
     property string communityName: ""
     property string communityColor: ""
 

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -22,6 +22,9 @@ StackLayout {
     id: root
 
     required property bool isOwner
+    required property bool isAdmin
+    required property bool isTokenMaster
+
     property string communityId
     property string name
     property string description
@@ -176,7 +179,7 @@ StackLayout {
 
             Rectangle {
                 Layout.fillWidth: true
-
+                visible: mainSettingsPage.footer.active
                 implicitHeight: 1
                 color: Theme.palette.statusMenu.separatorColor
             }
@@ -223,6 +226,7 @@ StackLayout {
     }
 
     SettingsPage {
+        id: mainSettingsPage
         Layout.fillWidth: !root.communitySettingsDisabled
         Layout.preferredWidth: root.communitySettingsDisabled ? 560 + leftPadding + rightPadding : -1
         Layout.fillHeight: !root.communitySettingsDisabled
@@ -236,7 +240,13 @@ StackLayout {
 
         footer: Loader {
             sourceComponent: overviewSettingsFooterComp
-            active: !root.communitySettingsDisabled
+            active: {
+                if (root.communitySettingsDisabled)
+                    return false
+                if (root.isAdmin || root.isTokenMaster)
+                    return root.isPendingOwnershipRequest // not allowed for admin or TM unless there's the pending request
+                return true
+            }
         }
     }
 
@@ -329,6 +339,7 @@ StackLayout {
 
             active: !!editSettingsPanelLoader.item &&
                     editSettingsPanelLoader.item.dirty
+            visible: active
 
             saveChangesButtonEnabled:
                 !!editSettingsPanelLoader.item &&

--- a/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
@@ -236,14 +236,11 @@ StatusDialog {
                 components: [
                     RowLayout {
                         StatusIcon {
-                            Layout.alignment: Qt.AlignVCenter
-
                             icon: "arrow-right"
                             color: Theme.palette.primaryColor1
                         }
 
                         StatusBaseText {
-                            Layout.alignment: Qt.AlignVCenter
                             Layout.rightMargin: Style.current.padding
 
                             text: qsTr("Visit Community")

--- a/ui/app/AppLayouts/Communities/popups/ManageShardingPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/ManageShardingPopup.qml
@@ -82,6 +82,7 @@ StatusDialog {
 
     ConfirmationDialog {
         id: confirmationPopup
+        width: root.width - root.margins
         anchors.centerIn: parent
         headerSettings.title: qsTr("Are you sure you want to disable sharding?")
         showCancelButton: true

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipAlertPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipAlertPopup.qml
@@ -68,7 +68,6 @@ StatusDialog {
 
             StatusButton {
                 text: qsTr("Mint %1 Owner token").arg(root.communityName)
-                type: StatusBaseButton.Type.Normal
 
                 onClicked: {
                     root.mintClicked()

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -168,6 +168,8 @@ StatusSectionLayout {
             readonly property bool sectionEnabled: true
 
             isOwner: root.isOwner
+            isAdmin: root.isAdmin
+            isTokenMaster: root.isTokenMasterOwner
             communityId: root.community.id
             name: root.community.name
             description: root.community.description
@@ -187,7 +189,7 @@ StatusSectionLayout {
             isControlNode: root.isControlNode
             communitySettingsDisabled: root.communitySettingsDisabled
             overviewChartData: rootStore.overviewChartData
-            shardingEnabled: localAppSettings.wakuV2ShardedCommunitiesEnabled ?? false
+            shardingEnabled: !isAdmin && !isTokenMaster && localAppSettings.wakuV2ShardedCommunitiesEnabled
             shardIndex: root.community.shardIndex
             shardingInProgress: root.chatCommunitySectionModule.shardingInProgress
             pubsubTopic: root.community.pubsubTopic

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -41,7 +41,7 @@ QtObject {
 
     signal openExternalLink(string link)
     signal saveDomainToUnfurledWhitelist(string domain)
-    signal ownershipDeclined
+    signal ownershipDeclined(string communityId, string communityName)
 
     property var activePopupComponents: []
 
@@ -1109,9 +1109,9 @@ QtObject {
 
                 Connections {
                     target: root
-                    onOwnershipDeclined: {
+                    function onOwnershipDeclined(communityId: string, communityName: string) {
                         finalisePopup.close()
-                        root.rootStore.communityTokensStore.ownershipDeclined(communityId, communityName)
+                        root.communityTokensStore.ownershipDeclined(communityId, communityName)
                     }
                 }
             }
@@ -1122,7 +1122,7 @@ QtObject {
             FinaliseOwnershipDeclinePopup {
                 destroyOnClose: true
 
-                onDeclineClicked: root.ownershipDeclined()
+                onDeclineClicked: root.ownershipDeclined(communityId, communityName)
             }
         },
         // End of components related to transfer community ownership flow.


### PR DESCRIPTION
### What does the PR do

- hide the footer when the user is an admin or token master, unless there is a pending ownership request (`isPendingOwnershipRequest`)
- similarly, hide the sharding section in `CommunityInfoEditor`
- do not cover the shard button with the `SettingsDirtyToastMessage`
- some SB page cleanups and additions
- separate 2 commits to fix issues in the `OverviewSettingsChart` and `FinaliseOwnershipPopup`

Fixes #14105

### Affected areas

Community settings

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

Admin:
![image](https://github.com/status-im/status-desktop/assets/5377645/b40a50f5-5829-4ecc-bf4c-ce664a8f54bb)

TM:
![image](https://github.com/status-im/status-desktop/assets/5377645/7c2dc9e2-d5ab-43f9-ad30-75480e6318f4)

Pending request:
![image](https://github.com/status-im/status-desktop/assets/5377645/6d579284-0c6c-4a29-905e-f40789a2adb1)

Owner + (admin or TM):
![image](https://github.com/status-im/status-desktop/assets/5377645/0a6d5188-db1a-4c8d-bae2-e4562ecf593c)


Sharding not enabled:
![image](https://github.com/status-im/status-desktop/assets/5377645/89d466b3-3133-413d-a437-30be38720875)

