### PR TITLE
chore: Cherry pick - Fix token criteria updates in the permissons model

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -935,12 +935,13 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
 
       var updatedTokenCriteriaItems: seq[TokenCriteriaItem] = @[]
       var permissionSatisfied = true
+      var aCriteriaChanged = false
 
       for index, tokenCriteriaItem in tokenPermissionItem.getTokenCriteria().getItems():
         let criteriaMet = criteriaResult.criteria[index]
 
-        if tokenCriteriaItem.criteriaMet == criteriaMet:
-          continue
+        if tokenCriteriaItem.criteriaMet != criteriaMet:
+          aCriteriaChanged = true
 
         let updatedTokenCriteriaItem = initTokenCriteriaItem(
           tokenCriteriaItem.symbol,
@@ -956,7 +957,7 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
 
         updatedTokenCriteriaItems.add(updatedTokenCriteriaItem)
 
-      if updatedTokenCriteriaItems.len == 0:
+      if not aCriteriaChanged:
         continue
 
       thereWasAnUpdate = true

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -903,13 +903,13 @@ proc applyPermissionResponse*(self: Module, communityId: string, permissions: Ta
 
     var updatedTokenCriteriaItems: seq[TokenCriteriaItem] = @[]
     var permissionSatisfied = true
+    var aCriteriaChanged = false
 
     for index, tokenCriteriaItem in tokenPermissionItem.getTokenCriteria().getItems():
       let criteriaMet = criteriaResult.criteria[index]
 
-      if tokenCriteriaItem.criteriaMet == criteriaMet:
-        continue
-
+      if tokenCriteriaItem.criteriaMet != criteriaMet:
+          aCriteriaChanged = true
 
       let updatedTokenCriteriaItem = initTokenCriteriaItem(
         tokenCriteriaItem.symbol,
@@ -925,8 +925,9 @@ proc applyPermissionResponse*(self: Module, communityId: string, permissions: Ta
 
       updatedTokenCriteriaItems.add(updatedTokenCriteriaItem)
 
-    if updatedTokenCriteriaItems.len == 0:
+    if not aCriteriaChanged:
       continue
+      
     let updatedTokenPermissionItem = initTokenPermissionItem(
         tokenPermissionItem.id,
         tokenPermissionItem.`type`,


### PR DESCRIPTION
### What does the PR do

closes #14446

Re-create the token criteria and include all items whenever the model changes.

The previous perf optimisation fix filtered the items where the criteriaMet doesn't change.

(cherry picked from commit a9a83df301f2b2b6b20e255b699dd56dcb0c4a73)


