### PR TITLE
feat(edit): enable editing the message in an image message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -303,6 +303,7 @@ Control {
                                 visible: active
                                 sourceComponent: StatusTextMessage {
                                     messageDetails: root.messageDetails
+                                    isEdited: root.isEdited
                                     allowShowMore: !root.isInPinnedPopup
                                     textField.anchors.rightMargin: root.isInPinnedPopup ? /*Style.current.xlPadding*/ 32 : 0 // margin for the "Unpin" floating button
                                     highlightedLink: root.highlightedLink

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -114,6 +114,7 @@ Loader {
     property double nextMessageTimestamp: nextMessageAsJsonObj ? nextMessageAsJsonObj.timestamp : 0
     property var nextMessageAsJsonObj
 
+    readonly property bool editRestricted: root.isSticker
     property bool editModeOn: false
     property bool isEdited: false
 
@@ -178,7 +179,7 @@ Loader {
             messageContentType: root.messageContentType,
             pinnedMessage: root.pinnedMessage,
             canPin: !!root.messageStore && root.messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins,
-            editRestricted: root.isSticker || root.isImage,
+            editRestricted: root.editRestricted,
         }
 
         Global.openMenu(messageContextMenuComponent, this, params)
@@ -946,7 +947,7 @@ Loader {
                         }
                     },
                     Loader {
-                        active: !root.isInPinnedPopup && root.isText && !root.editModeOn && root.amISender && delegate.hovered && !delegate.hideQuickActions
+                        active: !root.isInPinnedPopup && !root.editRestricted && !root.editModeOn && root.amISender && delegate.hovered && !delegate.hideQuickActions
                                 && !root.isViewMemberMessagesePopup && root.rootStore.permissionsStore.viewAndPostCriteriaMet
                         visible: active
                         sourceComponent: StatusFlatRoundButton {


### PR DESCRIPTION
Fixes #13255

It seems like all our code already supported it, we just blocked it in QML just in case 🤷

[edit-image.webm](https://github.com/status-im/status-desktop/assets/11926403/d897c2eb-4771-4c6f-8cbf-66d342037b6a)

Note that the second app (on the right) is on master, so it doesn't have the fix for `(edited)`

I think the only thing we could do to improve it is update the UI so that when we edit, the images are not "disappearing" while the edit input is active. I opened an issue here: https://github.com/status-im/status-desktop/issues/14480

Another note: I found a big bug that if you send a message then edit it while the other user is offline, the message will never appear for them. I opened it here: https://github.com/status-im/status-desktop/issues/14479
