### PR TITLE
fix(ProfileDialogView): wrap bio in a scroll view

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -93,17 +93,6 @@ SplitView {
                                       incomingVerificationStatus: ctrlIncomingVerificationStatus.currentValue,
                                       contactRequestState: ctrlContactRequestState.currentValue,
                                       bio: bio.text,
-                                      socialLinks: JSON.stringify
-                                                   ([{
-                                                         text: "__twitter",
-                                                         url: "https://twitter.com/ethstatus",
-                                                         icon: "twitter"
-                                                     },
-                                                     {
-                                                         text: "__github",
-                                                         url: "https://github.com/status-im",
-                                                         icon: "github"
-                                                     }]),
                                       onlineStatus: ctrlOnlineStatus.currentValue
                                   })
         }
@@ -639,11 +628,20 @@ SplitView {
                         Layout.fillWidth: true
                         id: bio
                         selectByMouse: true
-                        text: "Hi, I am Alex. I'm an indie developer who mainly works on web products.
+                        text: "
+
+
+Hi, I am Alex. I'm an indie developer who mainly works on web products.
+
+
 
 I worked for several different companies and created a couple of my own products from scratch. Currently building Telescope and Prepacked.
 
-Say hi, or find me on Twitter, GitHub, or Mastodon."
+Say hi, or find me on Twitter, GitHub, or Mastodon.
+
+
+
+"
                     }
                 }
             }

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -464,6 +464,7 @@ Pane {
                         enabled: d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy && !d.isBlocked
                         onTriggered: {
                             root.contactsStore.removeTrustStatus(root.publicKey)
+                            d.reload()
                         }
                     }
                     StatusAction {
@@ -556,12 +557,21 @@ Pane {
                     }
                 }
             }
-            StatusBaseText {
+            StatusScrollView {
+                id: bioScrollView
                 Layout.fillWidth: true
+                Layout.preferredHeight: 116
+                contentWidth: availableWidth
                 Layout.topMargin: Style.current.halfPadding
-                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-                text: root.dirty ? root.dirtyValues.bio : d.contactDetails.bio
-                visible: !!text
+                padding: 0
+                rightPadding: Style.current.padding
+                visible: !!bioText.text
+                StatusBaseText {
+                    id: bioText
+                    width: bioScrollView.availableWidth
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                    text: root.dirty ? root.dirtyValues.bio.trim() : d.contactDetails.bio.trim()
+                }
             }
             EmojiHash {
                 Layout.topMargin: Style.current.halfPadding


### PR DESCRIPTION
### What does the PR do

- also trim the leading/trailing whitespace
- fixes long bio (mainly due to linebreaks) pushing down everything below and also overflowing the preview
- adjust SB page to include such example bio and remove the obsolete socialLinks (they are now part of the showcase models)

Fixes #14463
Fixes #14465

### Affected areas

ProfileDialogView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-04-19 00-05-53.webm](https://github.com/status-im/status-desktop/assets/5377645/18bdb19b-07b6-4e08-accf-ec3ec1e5629d)

