### PR TITLE
fix(ProfileContextMenu): don't overflow the title

### DIFF
--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -200,7 +200,8 @@ Item {
 
             StyledText {
                 objectName: "ProfileHeader_displayName"
-                Layout.maximumWidth: root.width - Style.current.xlPadding
+                Layout.maximumWidth: root.width - verificationIcons.width - contentContainer.anchors.leftMargin - contentContainer.anchors.rightMargin -
+                                     (editButtonLoader.active ? editButtonLoader.item.width : 0)
                 text: root.displayName
                 elide: Text.ElideRight
                 font {
@@ -210,7 +211,7 @@ Item {
             }
 
             StatusContactVerificationIcons {
-                Layout.alignment: Qt.AlignVCenter
+                id: verificationIcons
                 visible: !root.isCurrentUser && !root.isBridgedAccount
                 isContact: root.isContact
                 trustIndicator: root.trustStatus
@@ -218,6 +219,7 @@ Item {
             }
 
             Loader {
+                id: editButtonLoader
                 sourceComponent: SVGImage {
                     objectName: "ProfileHeader_displayNameEditIcon"
                     height: compact ? 10 : 16

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -148,8 +148,9 @@ StatusMenu {
     SendContactRequestMenuItem {
         id: sendContactRequestMenuItem
         objectName: "sendContactRequest_StatusItem"
-        enabled: !root.isMe && !root.isContact
-                                && !root.isBlockedContact && !root.hasPendingContactRequest && !root.isBridgedAccount
+        enabled: !root.isMe && !root.isContact && !root.isBlockedContact
+                 && (contactDetails.contactRequestState === Constants.ContactRequestState.None || contactDetails.contactRequestState === Constants.ContactRequestState.Dismissed)
+                 && !root.isBridgedAccount
         onTriggered: Global.openContactRequestPopup(root.selectedUserPublicKey, root.contactDetails, null)
     }
 


### PR DESCRIPTION
### What does the PR do

- calculate the text width correctly, taking into account all the contents (verification icons, edit button) and also the margins
- extra commit to fix the erroneous "Send CR" menu entry

Fixes #14462

### Affected areas

ProfileContextMenu

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

No clipped icons:
![image](https://github.com/status-im/status-desktop/assets/5377645/7f1197e1-a0b6-408e-9bf0-193deeb27dfb)

Pending CR + context menu:
![image](https://github.com/status-im/status-desktop/assets/5377645/91fa810b-f824-462a-bad7-7dfe8885a0ea)

![image](https://github.com/status-im/status-desktop/assets/5377645/2dd5f9ef-4f81-4a12-bdb4-34c4b4fdd9cd)

