### PR TITLE
[CHERRY-PICK] fix(edit): fix edits received before the message did not appear

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -604,6 +604,8 @@ method editMessage*(self: Module, messageId: string, contentType: int, updatedMs
 method onMessageEdited*(self: Module, message: MessageDto) =
   let itemBeforeChange = self.view.model().getItemWithMessageId(message.id)
   if(itemBeforeChange.isNil):
+    # We received the edited message before we received the real message. Just show the final message as is
+    self.messagesAdded(@[message])
     return
 
   let mentionedUsersPks = itemBeforeChange.mentionedUsersPks


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/14482

Fixes #14479

The problem is our code assumed that we'd have the original message first, but in the case where messages are sent and edited before we open our app, when we fetch, we can't guarantee the order, so we might get the fully edited message directly from status-go.

The solution is simply to treat those messages as new messages.
