### PR TITLE
fix(wallet): Update balance loading state on token fetched

### DIFF
--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -209,6 +209,10 @@ proc notifyModulesOnFilterChanged(self: Module) =
   self.allCollectiblesModule.refreshWalletAccounts()
   self.assetsModule.filterChanged(self.filter.addresses, self.filter.chainIds)
 
+proc notifyModulesBalanceIsLoaded(self: Module) =
+  self.overviewModule.filterChanged(self.filter.addresses, self.filter.chainIds)
+  self.accountsModule.filterChanged(self.filter.addresses, self.filter.chainIds)
+
 proc updateViewWithAddressFilterChanged(self: Module) =
   if self.overviewModule.getIsAllAccounts():
     self.view.filterChanged("")
@@ -271,7 +275,7 @@ method load*(self: Module) =
     self.notifyFilterChanged()
   self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
     self.setTotalCurrencyBalance()
-    # self.notifyFilterChanged()
+    self.notifyModulesBalanceIsLoaded()
   self.events.on(SIGNAL_TOKENS_PRICES_UPDATED) do(e:Args):
     self.setTotalCurrencyBalance()
     self.notifyFilterChanged()

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -66,8 +66,13 @@ proc getWalletAccoutColors(self: Module, walletAccounts: seq[WalletAccountDto]) 
 
 method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) =
   let walletAccounts = self.controller.getWalletAccountsByAddresses(addresses)
-  let walletAccount = walletAccounts[0]
-  let loading = walletAccounts[0].assetsLoading or self.controller.getTokensMarketValuesLoading()
+  if walletAccounts.len == 0:
+    return
+  var loading = self.controller.getTokensMarketValuesLoading()
+  for account in walletAccounts:
+    if account.assetsLoading:
+      loading = true
+      break 
   if self.isAllAccounts:
     let item = initItem(
       "",
@@ -82,6 +87,7 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) 
     )
     self.view.setData(item)
   else:
+    let walletAccount = walletAccounts[0]
     let isWatchOnlyAccount = walletAccount.walletType == "watch"
     let item = initItem(
       walletAccount.name,


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/14427
Closes #14514

### What does the PR do

* Update wałlet accounts model when balances are loaded
* Check all accounts for asset loading. It will properly show loading state in "All accounts" whenever any account is in loading state

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/0e572e7e-d86c-42c7-bfce-0f8828260ba3

