### PR TITLE
fix(CommunitiesModule): Qt props fixed to not crash MonitoringTool

### DIFF
--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -212,7 +212,7 @@ QtObject:
     return self.discordImportedChannelId
 
   QtProperty[int] discordImportedChannelId:
-    read = getDiscordImportedChannelIdCount
+    read = getDiscordImportedChannelId
     notify = discordImportedChannelIdChanged
 
   proc setDiscordImportErrorsCount*(self: View, count: int) =
@@ -838,7 +838,8 @@ QtObject:
 
   proc keypairsSigningModelChanged*(self: View) {.signal.}
   proc getKeypairsSigningModel(self: View): QVariant {.slot.} =
-    return newQVariant(self.keypairsSigningModel)
+    return (if self.keypairsSigningModel.isNil: newQVariant() else: newQVariant(self.keypairsSigningModel))
+
   QtProperty[QVariant] keypairsSigningModel:
     read = getKeypairsSigningModel
     notify = keypairsSigningModelChanged


### PR DESCRIPTION
### What does the PR do

There were 2 properties broken, but they weren't crashing the app because they weren't used. However it was a problem for Monitoring Tool reading all the exposed properties.

Closes: #14493

### Affected areas
`src/app/modules/main/communities/view.nim`

![Screenshot from 2024-04-23 09-47-03](https://github.com/status-im/status-desktop/assets/20650004/c16442d9-e2e0-4aa6-a02d-ebbb74f97835)
