### PR TITLE
fix(TokenUI): Hide explicitly ManageTokensCommunityTag in community settings page

### DIFF
--- a/ui/app/AppLayouts/Communities/views/MintedTokensView.qml
+++ b/ui/app/AppLayouts/Communities/views/MintedTokensView.qml
@@ -254,7 +254,7 @@ StatusScrollView {
                     navigationIconVisible: false
                     privilegesLevel: model.privilegesLevel
                     ornamentColor: model.color
-                    communityId: root.communityId
+                    communityId: ""
                     onClicked: root.itemClicked(model.contractUniqueKey,
                                                 model.chainId, model.chainName,
                                                 model.accountName, model.address)


### PR DESCRIPTION
### What does the PR do

PR hide the ManageTokensCommunityTag item in "Community"->Tokens page. Previous changes introduced ManageTokensCommunityTag [12519](https://github.com/status-im/status-desktop/issues/12519) ManageTokensCommunityTag for displaying community icon and name when showing Collectibles in User's Wallet->Collectibles page. However when going to particular Community and checking its "Tokens" there is no need to display that tag, according to the [MintedTokensSettingsPanel](https://github.com/status-im/status-desktop/commit/8a83aba05a6aafa94822ee5225f878fabc5b8fbb#diff-0488295b2d9e9eb20093f3f473b5d483c1f9d33499a47c6e72637f05e06a6db1R182) PR: [11347](https://github.com/status-im/status-desktop/pull/11347)

### Affected areas

Wallet
Communities

### StatusQ checklist

- [x ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5157464/133c535e-3ff1-491f-95d7-7264fcd86932)

In Wallet -> Collectibles, ManageTokensCommunityTag is displayed:

![image](https://github.com/status-im/status-desktop/assets/5157464/8910bba0-b66a-4ffe-9e0c-3a23cfa1f227)

