### PR TITLE
fix(wallet): Load activity details

### DIFF
--- a/src/app/modules/main/wallet_section/activity/details_controller.nim
+++ b/src/app/modules/main/wallet_section/activity/details_controller.nim
@@ -49,12 +49,12 @@ QtObject:
     notify = activityDetailsChanged
 
   proc setActivityEntry*(self: Controller, entry: ActivityEntry) =
-    self.activityEntry = entry
-    self.activityEntryChanged()
-
     if self.activityDetails != nil:
       self.activityDetails = nil
-      self.activityDetailsChanged()    
+      self.activityDetailsChanged()
+      
+    self.activityEntry = entry
+    self.activityEntryChanged()
 
   proc resetActivityEntry*(self: Controller) {.slot.} =
     self.setActivityEntry(nil)

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -863,14 +863,14 @@ StatusListItem {
                 width: 17
                 height: 17
             }
-            PropertyChanges {
-                target: d
-                titlePixelSize: 17
-                datePixelSize: 13
-                subtitlePixelSize: 15
-                loadingPixelSize: 14
-                showRetryButton: (!root.loading && root.transactionStatus === Constants.TransactionStatus.Failed && walletRootStore.isOwnedAccount(modelData.sender))
-            }
+            // PropertyChanges { // TODO uncomment when retry failed tx is implemented
+            //     target: d
+            //     titlePixelSize: 17
+            //     datePixelSize: 13
+            //     subtitlePixelSize: 15
+            //     loadingPixelSize: 14
+            //     showRetryButton: (!root.loading && root.transactionStatus === Constants.TransactionStatus.Failed && walletRootStore.isOwnedAccount(modelData.sender))
+            // }
         }
     ]
 


### PR DESCRIPTION
Cherrypick of https://github.com/status-im/status-desktop/pull/14505

### What does the PR do

* Hide retry button as retry functionality wasn't implemented
* Fix loading activity details when opening details view

### Affected areas

Wallet activity details view
