### PR TITLE
fix: can't join an encrypted community

### DIFF
--- a/storybook/pages/CommunityMembershipSetupDialogPage.qml
+++ b/storybook/pages/CommunityMembershipSetupDialogPage.qml
@@ -55,6 +55,7 @@ SplitView {
 
                 isInvitationPending: ctrlIsInvitationPending.checked
                 requirementsCheckPending: ctrlRequirementsCheckPending.checked
+                joinPermissionsCheckSuccessful: ctrlJoinPermissionsCheckSuccessful.checked
 
                 walletAccountsModel: WalletAccountsModel {}
                 walletAssetsModel: root.walletAssetStore.groupedAccountAssetsModel
@@ -80,7 +81,7 @@ SplitView {
                             })
                 }
             }
-                }
+        }
 
         Item {
             SplitView.fillWidth: true
@@ -216,6 +217,14 @@ Nemo enim 😋 ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
                 id: ctrlRequirementsCheckPending
                 visible: !ctrlIsInvitationPending.checked
                 text: "Requirements check pending"
+            }
+
+            CheckBox {
+                Layout.leftMargin: 12
+                id: ctrlJoinPermissionsCheckSuccessful
+                visible: !ctrlIsInvitationPending.checked
+                text: "Join permission successful"
+                checked: true
             }
 
             Item {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
@@ -20,6 +20,7 @@ ToolTip {
 
     implicitWidth: Math.min(maxWidth, implicitContentWidth + 16)
     padding: 8
+    margins: 8
     delay: 200
     background: Item {
         id: statusToolTipBackground

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -21,10 +21,11 @@ Dialog {
        \qmlproperty color backgroundColor
         This property decides the modal background color
     */
-    property string backgroundColor: Theme.palette.statusModal.backgroundColor
+    property color backgroundColor: Theme.palette.statusModal.backgroundColor
     /*!
        \qmlproperty closeHandler
         This property decides the action to be performed when the close button is clicked. It allows to define
+        a custom function to be called when the popup is closed by the user.
     */
     property var closeHandler: root.close
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -621,6 +621,7 @@ QtObject {
                 readonly property string image: model.image
                 readonly property bool joined: model.joined
                 readonly property bool amIBanned: model.amIBanned
+                readonly property string introMessage: model.introMessage
                 // add others when needed..
             }
         }

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -32,6 +32,7 @@ Rectangle {
     property var collectiblesModel
 
     property bool requirementsCheckPending
+    property bool joinPermissionsCheckSuccessful
 
     readonly property bool lostPermissionToJoin: d.lostPermissionToJoin
     readonly property bool lostChannelPermissions: d.lostChannelPermissions
@@ -256,6 +257,7 @@ Rectangle {
 
     CommunityEligibilityTag {
         id: eligibilityHintBubble
+        visible: !root.requirementsCheckPending && root.joinPermissionsCheckSuccessful
         eligibleToJoinAs: root.eligibleToJoinAs
         isEditMode: root.isEditMode
         isDirty: root.isDirty

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -18,6 +18,8 @@ QtObject {
     property var communitiesModuleInst: communitiesModule
     property bool newVersionAvailable: false
     readonly property bool requirementsCheckPending: communitiesModuleInst.requirementsCheckPending
+    readonly property bool joinPermissionsCheckSuccessful: communitiesModuleInst.joinPermissionsCheckSuccessful
+    readonly property bool channelsPermissionsCheckSuccessful: communitiesModuleInst.channelsPermissionsCheckSuccessful
     property string latestVersion
     property string downloadURL
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -705,6 +705,7 @@ QtObject {
                 id: dialogRoot
 
                 requirementsCheckPending: root.rootStore.requirementsCheckPending
+                joinPermissionsCheckSuccessful: root.rootStore.joinPermissionsCheckSuccessful
 
                 walletAccountsModel: root.rootStore.walletAccountsModel
                 walletCollectiblesModel: WalletStore.RootStore.collectiblesStore.allCollectiblesModel
@@ -952,7 +953,9 @@ QtObject {
 
                 communityName: chatStore.sectionDetails.name
                 communityIcon: chatStore.sectionDetails.image
+
                 requirementsCheckPending: root.rootStore.requirementsCheckPending
+                joinPermissionsCheckSuccessful: root.rootStore.joinPermissionsCheckSuccessful
 
                 introMessage: chatStore.sectionDetails.introMessage
 


### PR DESCRIPTION
### What does the PR do

- fix the corner case and allow the user to join a community without an explicitly stated "Member" permission
- enable/disable the Share/Join/Save buttons when the permission to join check is ongoing, or when the permission check failed
- display tooltips over the disabled buttons explaining why it's disabled
- always display the eligibility button floating on top of the (scrollable) contents

Fixes #14473
Fixes #14299

### Affected areas

CommunityMembershipSetupDialog

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Main join dialog:
![Snímek obrazovky z 2024-04-25 12-24-03](https://github.com/status-im/status-desktop/assets/5377645/ea1d0532-291a-438a-9cdb-a7dd1a0a090e)

Check over:
![Snímek obrazovky z 2024-04-25 12-24-11](https://github.com/status-im/status-desktop/assets/5377645/1e61585c-d212-47ac-a399-f59cf048b5ca)

Editting addresses:
![Snímek obrazovky z 2024-04-25 12-22-14](https://github.com/status-im/status-desktop/assets/5377645/c827e6c5-3eca-48d3-a94d-ccc5371bfc05)

![Snímek obrazovky z 2024-04-25 12-24-20](https://github.com/status-im/status-desktop/assets/5377645/670fc314-4942-4306-981f-da1c639ef0b2)
