### PR TITLE
fix(Token Management): update wording for Save/Apply buttons

### DIFF
--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -64,7 +64,8 @@ SettingsContentBase {
     toast.type: SettingsDirtyToastMessage.Type.Info
     toast.cancelButtonVisible: manageTokensView.advancedTabVisible
     toast.saveForLaterButtonVisible: !manageTokensView.advancedTabVisible
-    toast.saveChangesText: manageTokensView.advancedTabVisible ? toast.defaultSaveChangesText : qsTr("Apply to my Wallet")
+    toast.saveForLaterText: qsTr("Save")
+    toast.saveChangesText: manageTokensView.advancedTabVisible ? toast.defaultSaveChangesText : qsTr("Save and apply")
     toast.changesDetectedText: manageTokensView.advancedTabVisible ? toast.defaultChangesDetectedText : qsTr("New custom sort order created")
 
     onSaveForLaterClicked: {


### PR DESCRIPTION
### What does the PR do

- "Save for later" -> "Save"
- "Apply to my Wallet" -> "Save and apply"

Fixes #14519

### Affected areas

Settings/Wallet/Manage tokens

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2024-04-26 11-13-53](https://github.com/status-im/status-desktop/assets/5377645/56a7198a-3350-457e-8560-ab82f5dffdd7)

