### PR TITLE
fix: Inclusion of Watched addresses in Balances: Wording change

### DIFF
--- a/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
@@ -108,12 +108,28 @@ Rectangle {
             spacing: 1
             model: d.relatedAccounts
             delegate: WalletAccountDelegate {
+                id: walletAccountDelegate
                 width: ListView.view.width
-                label: keyPair.pairType !== Constants.keypair.type.watchOnly ? "" : model.account.hideFromTotalBalance ? qsTr("Excl. from total balance"): qsTr("Incl. in total balance")
                 account: model.account
                 totalCount: ListView.view.count
                 getNetworkShortNames: root.getNetworkShortNames
                 onGoToAccountView: root.goToAccountView(model.account)
+
+                RowLayout {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.right: parent.right
+                    anchors.rightMargin: Style.current.padding + walletAccountDelegate.statusListItemComponentsSlot.width
+                    visible: keyPair.pairType === Constants.keypair.type.watchOnly
+
+                    StatusIcon {
+                        icon: "wallet"
+                        color: Theme.palette.baseColor1
+                    }
+                    StatusBaseText {
+                        text: model.account.hideFromTotalBalance ? qsTr("Excluded") : qsTr("Included")
+                        color: Theme.palette.baseColor1
+                    }
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -229,7 +229,7 @@ ColumnLayout {
 
     StatusListItem {
         Layout.fillWidth: true
-        title: qsTr("Include in total balance")
+        title: qsTr("Include in total balances and activity")
         objectName: "includeTotalBalanceListItem"
         visible: d.watchOnlyAccount
         color: Theme.palette.transparent

--- a/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
+++ b/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
@@ -47,7 +47,8 @@ StatusMenu {
     StatusAction {
         objectName: "AccountMenu-HideFromTotalBalance-%1".arg(root.uniqueIdentifier)
         enabled: !!root.account && root.account.walletType === Constants.watchWalletType
-        text: !!root.account ? root.account.hideFromTotalBalance ? qsTr("Include in total balance"): qsTr("Exclude from total balance"): ""
+        text: !!root.account ? root.account.hideFromTotalBalance ? qsTr("Include in balances and activity")
+                                                                 : qsTr("Exclude from balances and activity") : ""
         icon.name: !!root.account ? root.account.hideFromTotalBalance ? "show" : "hide": ""
         onTriggered: root.hideFromTotalBalanceClicked(root.account.address, !root.account.hideFromTotalBalance)
     }


### PR DESCRIPTION
### What does the PR do

- "Include in total balance" -> "Include in balances and activity"

Fixes #14517

### Affected areas

(Settings/)Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2024-04-26 11-54-55](https://github.com/status-im/status-desktop/assets/5377645/320db920-de0f-4550-b7f8-2d064fc24af2)

![Snímek obrazovky z 2024-04-26 11-54-25](https://github.com/status-im/status-desktop/assets/5377645/3b9b44ad-74d9-408b-9342-564817f8b6b5)

![Snímek obrazovky z 2024-04-26 17-16-17](https://github.com/status-im/status-desktop/assets/5377645/b2758c73-2352-41d0-834e-6f2de6ef9fe8)



