### PR TITLE
fix: Permission created before making device a control node is not getting active

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
@@ -13,6 +13,7 @@ import utils 1.0
 Control {
     id: root
 
+    property bool isPromoteSelfToControlNodeEnabled: false
     property bool isControlNode: true
     property string communityName: ""
     property string communityColor: ""
@@ -45,6 +46,7 @@ Control {
         id: mainGrid
         columnSpacing: 16
         rowSpacing: 16
+        visible: root.isPromoteSelfToControlNodeEnabled
 
         StatusRoundIcon {
             id: icon

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -58,6 +58,8 @@ StackLayout {
     property string pubsubTopic
     property string pubsubTopicKey
 
+    property bool isTokenDeployed: !!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed
+
     // Community transfer ownership related props:
     required property bool isPendingOwnershipRequest
     signal finaliseOwnershipClicked
@@ -198,9 +200,10 @@ StackLayout {
             communityColor: root.color
             isControlNode: root.isControlNode
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
+            isPromoteSelfToControlNodeEnabled: root.isControlNode || root.isTokenDeployed
 
             onExportControlNodeClicked:{
-                if(!!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed) {
+                if(root.isTokenDeployed) {
                     root.exportControlNodeClicked()
                 } else {
                     Global.openPopup(transferOwnershipAlertPopup, { mode: TransferOwnershipAlertPopup.Mode.MoveControlNode })
@@ -208,8 +211,7 @@ StackLayout {
             }
             onImportControlNodeClicked: root.importControlNodeClicked()
             onFinaliseOwnershipTransferClicked: root.finaliseOwnershipClicked()
-            //TODO update once the domain changes
-            onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "status-communities/about-the-control-node-in-status-communities")
+            onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "communities/about-the-control-node-in-status-communities")
         }
     }
 


### PR DESCRIPTION
### What does the PR do

This PR mitigates permission stuck in pending state upon making device a control node. It fixes
[#14023](https://github.com/status-im/status-desktop/issues/14023) by applying events and publishing community events once the device is promoted to control node.
Related to https://github.com/status-im/status-go/pull/5070

### Affected areas

- NA

### Screenshot of functionality (including design for comparison)

Performing tests to gather evidence for resolution.