### PR TITLE
fix: Hide members count from community cards when the community is en…

### DIFF
--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -16,6 +16,8 @@ type
     featured: bool
     permissionModel: TokenPermissionsModel
     amIBanned: bool
+    joined: bool
+    encrypted: bool
 
 proc initCuratedCommunityItem*(
   id: string,
@@ -30,7 +32,9 @@ proc initCuratedCommunityItem*(
   activeMembers: int,
   featured: bool,
   tokenPermissionsItems: seq[TokenPermissionItem],
-  amIBanned: bool
+  amIBanned: bool,
+  joined: bool,
+  encrypted: bool
 ): CuratedCommunityItem =
   result.id = id
   result.name = name
@@ -47,6 +51,8 @@ proc initCuratedCommunityItem*(
   if tokenPermissionsItems.len > 0:
     result.permissionModel.setItems(tokenPermissionsItems)
   result.amIBanned = amIBanned
+  result.joined = joined
+  result.encrypted = encrypted
 
 proc `$`*(self: CuratedCommunityItem): string =
   result = fmt"""CuratedCommunityItem(
@@ -60,6 +66,8 @@ proc `$`*(self: CuratedCommunityItem): string =
     activeMembers: {self.activeMembers}
     featured: {self.featured}
     amIBanned: {self.amIBanned}
+    joined: {self.joined}
+    encrypted: {self.encrypted}
     ]"""
 
 proc getId*(self: CuratedCommunityItem): string =
@@ -103,3 +111,9 @@ proc setPermissionModelItems*(self: CuratedCommunityItem, items: seq[TokenPermis
 
 proc getAmIBanned*(self: CuratedCommunityItem): bool =
   return self.amIBanned
+
+proc getJoined*(self: CuratedCommunityItem): bool =
+  return self.joined
+
+proc getEncrypted*(self: CuratedCommunityItem): bool =
+  return self.encrypted

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -18,6 +18,8 @@ type
     Tags
     Permissions
     AmIBanned
+    Joined
+    Encrypted
 
 QtObject:
   type CuratedCommunityModel* = ref object of QAbstractListModel
@@ -67,6 +69,8 @@ QtObject:
       ModelRole.Tags.int:"tags",
       ModelRole.Permissions.int:"permissionsModel",
       ModelRole.AmIBanned.int:"amIBanned",
+      ModelRole.Joined.int:"joined",
+      ModelRole.Encrypted.int:"encrypted"
     }.toTable
 
   method data(self: CuratedCommunityModel, index: QModelIndex, role: int): QVariant =
@@ -106,6 +110,10 @@ QtObject:
         result = newQVariant(item.getFeatured())
       of ModelRole.AmIBanned:
         result = newQVariant(item.getAmIBanned())
+      of ModelRole.Joined:
+        result = newQVariant(item.getJoined())
+      of ModelRole.Encrypted:
+        result = newQVariant(item.getEncrypted())
 
   proc findIndexById(self: CuratedCommunityModel, id: string): int =
     for i in 0 ..< self.items.len:

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -274,7 +274,9 @@ proc getCuratedCommunityItem(self: Module, community: CommunityDto): CuratedComm
     int(community.activeMembersCount),
     community.featuredInDirectory,
     tokenPermissionsItems,
-    amIbanned
+    amIbanned,
+    community.joined,
+    community.encrypted,
   )
 
 proc getDiscordCategoryItem(self: Module, c: DiscordCategoryDto): DiscordCategoryItem =

--- a/src/app_service/service/message/dto/status_community_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_link_preview.nim
@@ -14,6 +14,8 @@ QtObject:
     color: string
     icon: LinkPreviewThumbnail
     banner: LinkPreviewThumbnail
+    encrypted: bool
+    joined: bool
 
   proc setup*(self: StatusCommunityLinkPreview) =
     self.QObject.setup()
@@ -74,6 +76,22 @@ QtObject:
   proc getBanner*(self: StatusCommunityLinkPreview): LinkPreviewThumbnail =
     result = self.banner
 
+  proc getEncrypted*(self: StatusCommunityLinkPreview): bool {.slot.} =
+    result = self.encrypted
+  proc encryptedChanged*(self: StatusCommunityLinkPreview) {.signal.}
+
+  QtProperty[bool] encrypted:
+    read = getEncrypted
+    notify = encryptedChanged
+
+  proc getJoined*(self: StatusCommunityLinkPreview): bool {.slot.} =
+    result = self.joined
+  proc joinedChanged*(self: StatusCommunityLinkPreview) {.signal.}
+
+  QtProperty[bool] joined:
+    read = getJoined
+    notify = joinedChanged
+
   proc toStatusCommunityLinkPreview*(jsonObj: JsonNode): StatusCommunityLinkPreview =
     new(result, delete)
     result.setup()
@@ -108,7 +126,9 @@ QtObject:
       activeMembersCount: {self.activeMembersCount},
       color: {self.color},
       icon: {self.icon},
-      banner: {self.banner}
+      banner: {self.banner},
+      encrypted: {self.encrypted},
+      joined: {self.joined}
     )"""
 
   proc `%`*(self: StatusCommunityLinkPreview): JsonNode =
@@ -120,7 +140,9 @@ QtObject:
       "activeMembersCount": self.activeMembersCount,
       "color": self.color,
       "icon": self.icon,
-      "banner": self.banner
+      "banner": self.banner,
+      "encrypted": self.encrypted,
+      "joined": self.joined
     }
 
   proc empty*(self: StatusCommunityLinkPreview): bool =
@@ -154,5 +176,13 @@ QtObject:
 
     self.icon.update(0, 0, "", community.images.thumbnail)
     self.banner.update(0, 0, "", community.images.banner)
+
+    if self.encrypted != community.encrypted:
+      self.encrypted = community.encrypted
+      self.encryptedChanged()
+
+    if self.joined != community.joined:
+      self.joined = community.joined
+      self.joinedChanged()
 
     return true

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -391,7 +391,7 @@ Rectangle {
             // Bottom Row extra info component
             Loader {
                 id: bottomRowLoader
-                Layout.fillWidth: (!!item && item.width===0)
+                Layout.fillWidth: true
                 Layout.preferredHeight: 24
                 active: ((root.categories.count > 0) || !!root.bottomRowComponent)
                 sourceComponent: tagsListComponent

--- a/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
@@ -83,6 +83,7 @@ StatusScrollView {
             activeUsers: model.activeMembers
             popularity: model.popularity
             categories: tagsJson.model
+            memberCountVisible: model.joined || !model.encrypted
 
 
             // Community restrictions

--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -253,7 +253,7 @@ CalloutCard {
             PropertyChanges { target: title; text: root.communityData.name }
             PropertyChanges { target: description; text: root.communityData.description }
             PropertyChanges { target: d; bannerImageSource: root.communityData.banner }
-            PropertyChanges { target: footerLoader; active: true; visible: true; sourceComponent: communityFooterComponent }
+            PropertyChanges { target: footerLoader; active: true; visible: !root.communityData.encrypted || root.communityData.joined; sourceComponent: communityFooterComponent }
         },
         State {
             name: "channel"

--- a/ui/imports/shared/controls/chat/private/CommunityData.qml
+++ b/ui/imports/shared/controls/chat/private/CommunityData.qml
@@ -8,5 +8,7 @@ QtObject {
     property string color
     property int    membersCount
     property int    activeMembersCount // -1 when not available. >= 0 otherwise.
+    property bool   encrypted
+    property bool   joined
     readonly property bool activeMembersCountAvailable: activeMembersCount >= 0
 }

--- a/ui/imports/shared/controls/delegates/LinkPreviewCardDelegate.qml
+++ b/ui/imports/shared/controls/delegates/LinkPreviewCardDelegate.qml
@@ -73,6 +73,8 @@ LinkPreviewCard {
         membersCount: statusCommunityPreview ? statusCommunityPreview.membersCount : 0
         activeMembersCount: statusCommunityPreview && isLocalData ? statusCommunityPreview.activeMembersCount : -1
         color: statusCommunityPreview ? statusCommunityPreview.color : ""
+        encrypted: statusCommunityPreview ? statusCommunityPreview.encrypted : false
+        joined: statusCommunityPreview ? statusCommunityPreview.joined : false
     }
     channelData {
         name: statusCommunityChannelPreview ? statusCommunityChannelPreview.displayName : ""


### PR DESCRIPTION
…crypted and the community info is not available

### What does the PR do

closes #13192 

Changes:
1. Adding `encrypted` and `joined` flags in the link preview model and curated communities model
2. Hide the members count in community cards for encrypted communities when the user is not a member
3. Fixing a bug on community cards where sometimes the card had artefacts due to improper width

### Affected areas

Link previews
Communities portal

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/d89e337d-58ef-47fa-bb91-10ed5ef814e8


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
