### PR TITLE
feat(StatusQ/SubmodelProxyModel): Exposing roles computed per submodel to the top-level model

### DIFF
--- a/ui/StatusQ/include/StatusQ/submodelproxymodel.h
+++ b/ui/StatusQ/include/StatusQ/submodelproxymodel.h
@@ -3,6 +3,8 @@
 #include <QIdentityProxyModel>
 #include <QPointer>
 
+#include <limits>
+
 class QQmlComponent;
 
 class SubmodelProxyModel : public QIdentityProxyModel
@@ -20,6 +22,7 @@ public:
 
     QVariant data(const QModelIndex& index, int role) const override;
     void setSourceModel(QAbstractItemModel* sourceModel) override;
+    QHash<int, QByteArray> roleNames() const override;
 
     QQmlComponent* delegateModel() const;
     void setDelegateModel(QQmlComponent* delegateModel);
@@ -31,6 +34,10 @@ signals:
     void delegateModelChanged();
     void submodelRoleNameChanged();
 
+private slots:
+    void onCustomRoleChanged(QObject* source, int role);
+    void emitAllDataChanged();
+
 private:
     void initializeIfReady();
     void initialize();
@@ -39,9 +46,16 @@ private:
     void onDelegateChanged();
 
     QPointer<QQmlComponent> m_delegateModel;
+    QPointer<QQmlComponent> m_connector;
+
     QString m_submodelRoleName;
 
     bool m_initialized = false;
     bool m_sourceModelDeleted = false;
     int m_submodelRole = 0;
+    bool m_dataChangedQueued = false;
+
+    QHash<int, QByteArray> m_roleNames;
+    QHash<QString, int> m_additionalRolesMap;
+    int m_additionalRolesOffset = std::numeric_limits<int>::max();
 };

--- a/ui/StatusQ/src/movablemodel.cpp
+++ b/ui/StatusQ/src/movablemodel.cpp
@@ -131,8 +131,7 @@ void MovableModel::syncOrder()
 
 void MovableModel::syncOrderInternal()
 {
-    if (m_sourceModel)
-    {
+    if (m_sourceModel) {
         auto sourceModel = m_sourceModel;
 
         disconnect(m_sourceModel, nullptr, this, nullptr);
@@ -148,10 +147,9 @@ void MovableModel::syncOrderInternal()
         }
     }
 
-
     m_indexes.clear();
-    if (!m_synced)
-    {
+
+    if (!m_synced) {
         m_synced = true;
         emit syncedChanged();
     }

--- a/ui/StatusQ/src/sumaggregator.cpp
+++ b/ui/StatusQ/src/sumaggregator.cpp
@@ -14,7 +14,7 @@ QVariant SumAggregator::calculateAggregation() {
 
     // Check if m_roleName is part of the roles of the model
     QHash<int, QByteArray> roles = model()->roleNames();
-    if (!roleExists()) {
+    if (!roleExists() && model()->rowCount()) {
         qWarning() << "Provided role name does not exist in the current model";
         return 0.0;
     }

--- a/ui/StatusQ/tests/tst_MovableModel.cpp
+++ b/ui/StatusQ/tests/tst_MovableModel.cpp
@@ -756,6 +756,8 @@ private slots:
             { "name": "A", "subname": "a1" }
         ])");
 
+        QVERIFY(isSame(&sfpm, expectedSorted));
+
         QCOMPARE(model.synced(), true);
         QCOMPARE(signalsSpy.count(), signalsSpySfpm.count());
         QVERIFY(indexesTester.compare());
@@ -791,16 +793,6 @@ private slots:
         sfpm.sort(0, Qt::DescendingOrder);
 
         model.move(0, 1);
-
-        ListModelWrapper expectedSorted(engine, R"([
-            { "name": "C", "subname": "c3" },
-            { "name": "C", "subname": "c2" },
-            { "name": "C", "subname": "c1" },
-            { "name": "B", "subname": "b1" },
-            { "name": "A", "subname": "a2" },
-            { "name": "A", "subname": "a1" }
-        ])");
-
 
         auto source2 = R"([
             { "name": "E", "subname": "a1" },


### PR DESCRIPTION
### What does the PR do

- adds possibility to expose values computed per submodel as a role to top-level model in a dynamic, declarative way
- extends the existing Storybook page to present added functionality, adds intro describing the flow
- adds test (marked with SKIP(...)) pointing the problem with creating multiple proxies over the same source (to be fixed in a separate task: https://github.com/status-im/status-desktop/issues/14550)


[Screencast from 29.04.2024 16:07:21.webm](https://github.com/status-im/status-desktop/assets/20650004/3e0e841a-a758-4525-82f2-16e7f6af1abd)


Closes: #14390

### Affected areas
`SubmodelProxyModel`

