### PR TITLE
fix(Community): community invitation is missing intro and logo

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -204,7 +204,8 @@ Control {
         }
     }
 
-    contentItem: ColumnLayout {
+    ColumnLayout {
+        anchors.fill: parent
         spacing: 0
 
         // warning panel

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -465,7 +465,7 @@ StatusStackModal {
                         Layout.fillWidth: true
                         text: root.introMessage || qsTr("Community <b>%1</b> has no intro message...").arg(root.communityName)
                         color: Theme.palette.directColor1
-                        wrapMode: Text.WordWrap
+                        wrapMode: Text.Wrap
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

- fix a binding loop warning for `implicitHeight` (can happen with no permissions at all)
- fix word wrap for long texts with no word breaks

Fixes #14536

### Affected areas

CommunityMembershipSetupDialog

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/2ae92093-d72e-4636-91ce-3f2b192b0298)

