### PR TITLE
fix(UX Improvement): Clicking on the community logo when in the admin panel should take back to the community (#14271)

### DIFF
--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -105,7 +105,8 @@ StatusSectionLayout {
                 Layout.leftMargin: Style.current.halfPadding
                 Layout.rightMargin: Style.current.halfPadding
                 type: StatusChatInfoButton.Type.OneToOneChat
-                hoverEnabled: false
+                hoverEnabled: true
+                onClicked: root.backToCommunityClicked()
             }
 
             StatusListView {


### PR DESCRIPTION
### What does the PR do
 
Fixes [#14271](https://github.com/status-im/status-desktop/issues/14271)

Set StatusChatInfoButton in CommunitySettingsView.qml to be hoverable. Clicking on StatusChatInfoButton will have the same behavior as "Back to community" link. 

Now StatusChatInfoButton in CommunitySettingsView behaves similarly to StatusChatInfoButton in StatusAppChatView:
![image](https://github.com/status-im/status-desktop/assets/5157464/21106435-8d35-4334-803f-d1fccafcaeac)

### Affected areas

Communities: CommunitySettingsView.qml

### StatusQ checklist

- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
![image](https://github.com/status-im/status-desktop/assets/5157464/fd46ef48-07f9-443c-a6fa-36c8143fe42d)


### Cool Spaceship Picture

<!-- optional but cool ->
