### PR TITLE
Hide Create Community button

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -17,11 +17,13 @@ const LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED = "global/custom_mouse_scroll_enabl
 const DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED = false
 const DEFAULT_VISIBILITY = 2 #windowed visibility, from qml
 const LAS_KEY_FAKE_LOADING_SCREEN_ENABLED = "global/fake_loading_screen"
+const LAS_KEY_CREATE_COMMUNITIES_ENABLED = "global/create_communities"
 let DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and not TEST_MODE_ENABLED #enabled in production, disabled in development and e2e tests
 const LAS_KEY_SHARDED_COMMUNITIES_ENABLED = "global/sharded_communities"
 const DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED = false
 const LAS_KEY_TRANSLATIONS_ENABLED = "global/translations_enabled"
 const DEFAULT_LAS_KEY_TRANSLATIONS_ENABLED = false
+const DEFAULT_LAS_KEY_CREATE_COMMUNITIES_ENABLED = false
 
 QtObject:
   type LocalAppSettings* = ref object of QObject
@@ -147,6 +149,19 @@ QtObject:
     read = getFakeLoadingScreenEnabled
     write = setFakeLoadingScreenEnabled
     notify = fakeLoadingScreenEnabledChanged
+
+  proc createCommunityEnabledChanged*(self: LocalAppSettings) {.signal.}
+  proc getCreateCommunityEnabled*(self: LocalAppSettings): bool {.slot.} =
+    self.settings.value(LAS_KEY_CREATE_COMMUNITIES_ENABLED, newQVariant(DEFAULT_LAS_KEY_CREATE_COMMUNITIES_ENABLED)).boolVal
+
+  proc setCreateCommunityEnabled*(self: LocalAppSettings, enabled: bool) {.slot.} =
+    self.settings.setValue(LAS_KEY_CREATE_COMMUNITIES_ENABLED, newQVariant(enabled))
+    self.createCommunityEnabledChanged()
+
+  QtProperty[bool] createCommunityEnabled:
+    read = getCreateCommunityEnabled
+    write = setCreateCommunityEnabled
+    notify = createCommunityEnabledChanged
 
   proc wakuV2ShardedCommunitiesEnabledChanged*(self: LocalAppSettings) {.signal.}
   proc getWakuV2ShardedCommunitiesEnabled*(self: LocalAppSettings): bool {.slot.} =

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -142,9 +142,9 @@ StatusSectionLayout {
                     objectName: "createCommunityButton"
                     Layout.preferredHeight: 38
                     verticalPadding: 0
-                    text: qsTr("Import existing community from Discord")
+                    text: qsTr("Create community")
                     onClicked: {
-                        Global.createCommunityPopupRequested(true /*isDiscordImport*/)
+                        Global.openPopup(chooseCommunityCreationTypePopupComponent)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -137,14 +137,18 @@ StatusSectionLayout {
                     onClicked: Global.importCommunityPopupRequested()
                 }
 
-                StatusButton {
-                    id: createBtn
-                    objectName: "createCommunityButton"
-                    Layout.preferredHeight: 38
-                    verticalPadding: 0
-                    text: qsTr("Create community")
-                    onClicked: {
-                        Global.openPopup(chooseCommunityCreationTypePopupComponent)
+                Loader {
+                    Layout.preferredHeight: active ? 38 : 0
+                    active: communitiesStore.createCommunityEnabled || communitiesStore.testEnvironment
+                    sourceComponent: StatusButton {
+                        id: createBtn
+                        objectName: "createCommunityButton"
+                        height: parent.height
+                        verticalPadding: 0
+                        text: qsTr("Create community")
+                        onClicked: {
+                            Global.openPopup(chooseCommunityCreationTypePopupComponent)
+                        }
                     }
                 }
             }

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -35,6 +35,9 @@ QtObject {
     property bool downloadingCommunityHistoryArchives: root.communitiesModuleInst.downloadingCommunityHistoryArchives
     property var advancedModule: profileSectionModule.advancedModule
 
+    readonly property bool createCommunityEnabled: localAppSettings.createCommunityEnabled ?? false
+    readonly property bool testEnvironment: localAppSettings.testEnvironment ?? false
+
     // TODO: Could the backend provide directly 2 filtered models??
     //property var featuredCommunitiesModel: root.communitiesModuleInst.curatedFeaturedCommunities
     //property var popularCommunitiesModel: root.communitiesModuleInst.curatedPopularCommunities

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -22,6 +22,7 @@ QtObject {
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
     readonly property bool isFakeLoadingScreenEnabled: localAppSettings.fakeLoadingScreenEnabled ?? false
+    readonly property bool createCommunityEnabled: localAppSettings.createCommunityEnabled ?? false
     property bool isManageCommunityOnTestModeEnabled: false
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string browser: "browser"
@@ -140,6 +141,13 @@ QtObject {
             return
 
         localAppSettings.fakeLoadingScreenEnabled = !localAppSettings.fakeLoadingScreenEnabled
+    }
+
+    function toggleCreateCommunityEnabled() {
+        if(!localAppSettings)
+            return
+
+        localAppSettings.createCommunityEnabled = !localAppSettings.createCommunityEnabled
     }
 
     function toggleManageCommunityOnTestnet() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -174,6 +174,17 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
+                text: qsTr("Enable Community Creation")
+                isSwitch: true
+                switchChecked: root.advancedStore.createCommunityEnabled
+                onClicked: {
+                    root.advancedStore.toggleCreateCommunityEnabled()
+                }
+            }
+
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
                 text: qsTr("Debug Wallet Connect")
                 visible: root.advancedStore.isDebugEnabled
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14530

(includes a revert of the previous hide that wasn't exactly what we wanted)

[community-creation.webm](https://github.com/status-im/status-desktop/assets/11926403/58504057-3718-4146-9c2b-3b638a430308)

Known issue: if you disable the setting, the Loader doesn't lose its width. It,s not a huge deal, as it's not a common use case, but if the UI team has an easy fix, might as well.