### PR TITLE
fix(chat_section): fix preview for pinned messages with images/stickers (#13684)

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -206,7 +206,9 @@ Loader {
 
 
     function startMessageFoundAnimation() {
-        root.item.startMessageFoundAnimation();
+        if (root.active && root.item.startMessageFoundAnimation) {
+            root.item.startMessageFoundAnimation()
+        }
     }
 
     signal openStickerPackPopup(string stickerPackId)


### PR DESCRIPTION
### What does the PR do

Fixes pinned messages preview.

Previously:
MessageByMessageId was returning a message from the persistence without preparation of its contents.

Now:
chat_content/module.nim `onPinMessage` calls `PreparedMessageById` to get a message with prepared links to images/stickers and passes it to `buildPinnedMessageItem`.

status-go PR: https://github.com/status-im/status-go/pull/5102

Fixes #13684

### Affected areas

chat_content, status-go messenger api

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/1083341/a4385f35-d449-411b-a038-ed733df016be

