### PR TITLE
fix: Fix content height for SharedAddressesPanel

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -204,7 +204,7 @@ Control {
         }
     }
 
-    ColumnLayout {
+    contentItem: ColumnLayout {
         anchors.fill: parent
         spacing: 0
 


### PR DESCRIPTION
### What does the PR do

Set contentItem explicitly, that's probably needed because root item is `Control`

### Affected areas

Communities

### Screenshot of functionality (including design for comparison)

Before:
<img width="763" alt="Screenshot 2024-05-01 at 15 16 20" src="https://github.com/status-im/status-desktop/assets/2522130/481314a6-1f43-42fb-b754-381dceb29d8d">

After:
<img width="763" alt="Screenshot 2024-05-01 at 15 15 42" src="https://github.com/status-im/status-desktop/assets/2522130/8f39006e-7177-4d1c-9b51-c6e840ca07be">

