### PR TITLE
chore(global) add the DApps button under a feature flag

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -1,0 +1,28 @@
+import NimQml
+import os
+
+const DEFAULT_FLAG_DAPPS_ENABLED = false
+
+proc boolToEnv(defaultValue: bool): string =
+  return if defaultValue: "1" else: "0"
+
+QtObject:
+  type FeatureFlags* = ref object of QObject
+    dappsEnabled: bool
+
+  proc setup(self: FeatureFlags) =
+    self.QObject.setup()
+    self.dappsEnabled = getEnv("FLAG_DAPPS_ENABLED", boolToEnv(DEFAULT_FLAG_DAPPS_ENABLED)) != "0"
+
+  proc delete*(self: FeatureFlags) =
+    self.QObject.delete()
+
+  proc newFeatureFlags*(): FeatureFlags =
+    new(result, delete)
+    result.setup()
+
+  proc getDappsEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.dappsEnabled
+
+  QtProperty[bool] dappsEnabled:
+    read = getDappsEnabled

--- a/src/app/global/global_singleton.nim
+++ b/src/app/global/global_singleton.nim
@@ -7,6 +7,7 @@ import user_profile
 import utils
 import global_events
 import loader_deactivator
+import feature_flags
 
 export local_account_settings
 export local_account_sensitive_settings
@@ -71,6 +72,12 @@ proc loaderDeactivator*(self: GlobalSingleton): LoaderDeactivator =
     loaderDeactivator = newLoaderDeactivator()
   return loaderDeactivator
 
+proc featureFlags*(self: GlobalSingleton): FeatureFlags =
+  var featureFlags {.global.}: FeatureFlags
+  if (featureFlags.isNil):
+    featureFlags = newFeatureFlags()
+  return featureFlags
+
 proc delete*(self: GlobalSingleton) =
   self.engine.delete()
   self.localAccountSettings.delete()
@@ -78,3 +85,4 @@ proc delete*(self: GlobalSingleton) =
   self.localAppSettings.delete()
   self.userProfile.delete()
   self.loaderDeactivator.delete()
+  self.featureFlags.delete()

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -173,6 +173,9 @@ proc mainProc() =
   singletonInstance.engine.setRootContextProperty("signals", signalsManagerQVariant)
   singletonInstance.engine.setRootContextProperty("production", isProductionQVariant)
 
+  # Ensure we have the featureFlags instance available from the start
+  singletonInstance.engine.setRootContextProperty("featureFlagsRootContextProperty", newQVariant(singletonInstance.featureFlags()))
+
   app.installEventFilter(osThemeEvent)
   app.installEventFilter(urlSchemeEvent)
 

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -78,7 +78,7 @@ Item {
                 Layout.alignment: Qt.AlignTop
 
                 spacing: 8
-                visible: !root.walletStore.showSavedAddresses
+                visible: !root.walletStore.showSavedAddresses && Global.featureFlags.dappsEnabled
 
                 onConnectDapp: {
                     console.warn("TODO: run ConnectDappPopup...")

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -14,6 +14,9 @@ QtObject {
     property var userProfile
     property bool appIsReady: false
 
+    // avoid lookup of context property in QML
+    readonly property var featureFlags: featureFlagsRootContextProperty
+
     signal openPinnedMessagesPopupRequested(var store, var messageStore, var pinnedMessagesModel, string messageToPin, string chatId)
     signal openCommunityProfilePopupRequested(var store, var community, var chatCommunitySectionModule)
 


### PR DESCRIPTION
### Closes #14553

Also add basic feature flag support that work with `QML` and `nim`
The feature is disabled by default. To enable the feature for development: `FLAG_DAPPS_ENABLED=1 make run`