### PR TITLE
fix(StatusCommunityCard): fix some visual glitches

### DIFF
--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -19,8 +19,7 @@ ColumnLayout {
     property url banner: ctrlCommunityBanner.checked ? Style.png("settings/communities@2x") : ""
     readonly property bool shardingEnabled: ctrlShardingEnabled.checked
     property alias shardIndex: ctrlShardIndex.value
-
-    spacing: 12
+    property bool adminControlsEnabled: true
 
     ColumnLayout {
         Label {
@@ -59,7 +58,7 @@ ColumnLayout {
         Slider {
             value: root.membersCount
             from: 0
-            to: 1000
+            to: 3000
             onValueChanged: root.membersCount = value
         }
     }
@@ -108,6 +107,7 @@ ColumnLayout {
     }
 
     RowLayout {
+        visible: root.adminControlsEnabled
         Label {
             text: "Is community admin:"
         }
@@ -118,6 +118,7 @@ ColumnLayout {
         }
     }
     RowLayout {
+        visible: root.adminControlsEnabled
         Label {
             text: "Is community editable:"
         }
@@ -142,6 +143,7 @@ ColumnLayout {
         }
     }
     RowLayout {
+        visible: root.adminControlsEnabled
         Layout.fillWidth: true
         CheckBox {
             id: ctrlShardingEnabled

--- a/storybook/pages/StatusCommunityCardPage.qml
+++ b/storybook/pages/StatusCommunityCardPage.qml
@@ -1,23 +1,16 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
 
 import Storybook 1.0
 
 SplitView {
     id: root
 
-    orientation: Qt.Vertical
-
-    readonly property string source: `
-        import QtQml 2.14
-        import StatusQ.Components 0.1
-        Component {
-            StatusCommunityCard {
-               name: nameTextField.text
-            }
-        }
-    `
+    orientation: Qt.Horizontal
 
     Logs { id: logs }
 
@@ -25,72 +18,60 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        HotLoader {
-            id: loader
-
+        StatusCommunityCard {
             anchors.centerIn: parent
-            source: sourceCodeBox.sourceCode
+            cardSize: ctrlSize.checked ? StatusCommunityCard.Size.Big : StatusCommunityCard.Size.Small
+            communityId: "community_id"
+            name: infoEditor.name
+            description: infoEditor.description
+            members: infoEditor.membersCount
+            activeUsers: members/2
+            //popularity: 4 // not visualized?
+            banner: infoEditor.banner
+            asset.source: infoEditor.image
+            asset.isImage: true
+            communityColor: infoEditor.color
+            loaded: !ctrlLoading.checked
 
-            Connections {
-                target: loader.item
-
-                function onClicked() {
-                    logs.logEvent("StatusCommunityCard::clicked",
-                                  ["communityId"], arguments)
-                }
+            categories: ListModel {
+                ListElement { name: "gaming"; emoji: "🎮"; selected: false }
+                ListElement { name: "art"; emoji: "🖼️️"; selected: false }
+                ListElement { name: "crypto"; emoji: "💸"; selected: true }
+                ListElement { name: "nsfw"; emoji: "🍆"; selected: false }
+                ListElement { name: "markets"; emoji: "💎"; selected: false }
             }
-        }
 
-        Pane {
-            anchors.fill: parent
-            visible: !!loader.errors
-
-            CompilationErrorsBox {
-                anchors.fill: parent
-                errors: loader.errors
-            }
+            onClicked: logs.logEvent("StatusCommunityCard::onClicked", ["communityId"], arguments)
+            onRightClicked: logs.logEvent("StatusCommunityCard::onRightClicked", ["communityId"], arguments)
         }
     }
 
     LogsAndControlsPanel {
-        id: logsAndControlsPanel
-
-        SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 200
+        SplitView.preferredWidth: 250
 
         logsView.logText: logs.logText
 
-        RowLayout {
-            anchors.fill: parent
+        CommunityInfoEditor {
+            id: infoEditor
+            colorVisible: true
+            adminControlsEnabled: false
 
-            Item {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                ColumnLayout {
-                    anchors.fill: parent
-
-                    TextField {
-                        id: nameTextField
-                        text: "Card name!"
-                    }
-                }
+            Switch {
+                id: ctrlSize
+                text: "Big card"
+                checked: true
             }
 
-            SourceCodeBox {
-                id: sourceCodeBox
-
-                Layout.preferredWidth: root.width / 2
-                Layout.fillHeight: true
-
-                sourceCode: root.source
-                hasErrors: !!loader.errors
+            Switch {
+                id: ctrlLoading
+                text: "Loading"
+                checked: false
             }
         }
     }
 }
 
-// category: Panels
+// category: Components
 
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=8159%3A416159
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=8159%3A416160

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityTags.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityTags.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.14
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 
@@ -53,19 +54,21 @@ Item {
                 }
 
                 filters: [
-                    ExpressionFilter {
+                    FastExpressionFilter {
                         enabled: root.filterString !== ""
                         expression: {
                             root.filterString
                             return model.name.toUpperCase().indexOf(root.filterString.toUpperCase()) !== -1
                         }
+                        expectedRoles: ["name"]
                     },
-                    ExpressionFilter {
+                    FastExpressionFilter {
                         enabled: root.mode !== StatusCommunityTags.Highlight
                         expression: {
                             root.mode
                             return filterModel.selectionPredicate(model.selected)
                         }
+                        expectedRoles: ["selected"]
                     }
                 ]
             }

--- a/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
@@ -93,6 +93,7 @@ StatusScrollView {
                 collectiblesModel: root.collectiblesModel
                 model: card.permissionsList
                 requirementsMet: card.requirementsMet
+                overlappingBorder: 0
             }
 
             onClicked: root.cardClicked(communityId)

--- a/ui/imports/shared/views/profile/ProfileShowcaseCommunitiesView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseCommunitiesView.qml
@@ -132,12 +132,13 @@ Item {
             onClicked: {
                 if (root.readOnly)
                     return
-                if (mouse.button === Qt.LeftButton) {
-                    Global.switchToCommunity(model.id);
-                    root.closeRequested();
-                } else {
-                    Global.openMenu(delegatesActionsMenu, this, { communityId: model.id, url: Utils.getCommunityShareLink(model.id) });
-                }
+                Global.switchToCommunity(model.id)
+                root.closeRequested()
+            }
+            onRightClicked: {
+                if (root.readOnly)
+                    return
+                Global.openMenu(delegatesActionsMenu, this, { communityId: model.id, url: Utils.getCommunityShareLink(model.id) })
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

- correct propagation of hover events, fixes card flicker
- improve the ugly thick border
- token icons are now correctly rounded
- fix text descent lines are cut of ("y" and "p" truncated at the bottom) due to excessive clipping, set correct max line count
- fix tag outline not being visible in dark mode
- add/update the corresponding SB page, with more controls to play around with the different params

Fixes #14555

### Affected areas

StatusCommunityCard

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-05-01 15-31-30.webm](https://github.com/status-im/status-desktop/assets/5377645/d50a586a-6c11-443d-9db0-6033eb21d2cb)

Correctly rounded token icons:
![image](https://github.com/status-im/status-desktop/assets/5377645/603f80dc-f3e1-42d0-8569-0fe73c228df8)


