### PR TITLE
fix(ChangePasswordView): Clear and cancel button is not blue

### DIFF
--- a/storybook/pages/ChangePasswordViewPage.qml
+++ b/storybook/pages/ChangePasswordViewPage.qml
@@ -83,3 +83,5 @@ SplitView {
 }
 
 // category: Views
+
+// https://www.figma.com/file/d0G7m8X6ELjQlFOEKQpn1g/Profile-WIP?type=design&node-id=11-115317&mode=design&t=mBpxe2bJKzpseHGN-0

--- a/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
+++ b/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
@@ -160,11 +160,9 @@ SettingsContentBase {
 
         RowLayout {
             Layout.fillWidth: true
-            StatusLinkText {
+            StatusFlatButton {
                 text: qsTr("Clear & cancel")
-                onClicked: {
-                    choosePasswordForm.reset();
-                }
+                onClicked: choosePasswordForm.reset()
             }
             Item { Layout.fillWidth: true }
             StatusButton {


### PR DESCRIPTION
### What does the PR do

- use the proper `StatusFlatButton` as it was meant in the Figma design

Fixes #13763

### Affected areas

Settings/Password

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-05-02 12-46-41.webm](https://github.com/status-im/status-desktop/assets/5377645/6233b521-c295-43cf-a68b-7196f8c191a5)

