### PR TITLE
Fix/fix missing community info in collectibles view

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
@@ -187,7 +187,6 @@ Control {
             communityImage: root.communityImage
             visible: root.isCommunityCollectible
             enabled: !root.isLoading
-            useLongTextDescription: false
             
             TapHandler {
                 enabled: !d.unknownCommunityName


### PR DESCRIPTION
### What does the PR do

Closes #14437
status-go part: https://github.com/status-im/status-go/pull/5109

status-go bump fixes missing wallet community data cache updates
Local change fixes missing icon in the Community Tag in the Collectibles view.

![Screenshot 2024-05-02 at 13 42 33](https://github.com/status-im/status-desktop/assets/11161531/310d59f1-61d7-4387-af30-3cb3b098ff15)
