### PR TITLE
fix(StatusLoadingIndicator): make StatusLoadingIndicator use Animator

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
@@ -255,7 +255,6 @@ Rectangle {
                 Layout.alignment: Qt.AlignTop | Qt.AlignRight
                 Layout.preferredHeight: 16
                 Layout.preferredWidth: 16
-                mipmap: true
             }
         }
         RowLayout {

--- a/ui/StatusQ/src/StatusQ/Components/StatusGroupBox.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusGroupBox.qml
@@ -44,11 +44,10 @@ GroupBox {
             StatusIcon {
                 sourceSize.width: width || undefined
                 sourceSize.height: height || undefined
-                mipmap: true
                 antialiasing: true
                 width: root.iconSize
                 height: width
-                source: root.icon
+                icon: root.icon
                 color: enabled ? "transparent" : Theme.palette.baseColor1
             }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusLoadingIndicator.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLoadingIndicator.qml
@@ -1,18 +1,20 @@
-import QtQuick 2.13
+import QtQuick 2.15
+
 import StatusQ.Core 0.1
 
 StatusIcon {
-    id: statusIcon
+    id: root
+
     icon: "loading"
-    height: 17
-    width: 17
-    RotationAnimation {
-        target: statusIcon;
-        from: 0;
-        to: 360;
+    height: 20
+    width: 20
+
+    RotationAnimator {
+        target: root
+        from: 0
+        to: 360
         duration: 1200
         running: visible
         loops: Animation.Infinite
     }
 }
-

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusSticker.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusSticker.qml
@@ -78,7 +78,6 @@ Loader {
             StatusIcon {
                 icon: "refresh"
                 color: Theme.palette.directColor1
-                mipmap: false
                 MouseArea {
                     anchors.fill: parent
                     cursorShape: Qt.PointingHandCursor

--- a/ui/StatusQ/src/StatusQ/Core/StatusIcon.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusIcon.qml
@@ -1,11 +1,10 @@
-import QtQuick 2.13
-import QtGraphicalEffects 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Controls.impl 2.15 // for ColorImage
 
-Image {
+ColorImage {
     property string icon: ""
-    property color color: "transparent"
 
-    id: statusIcon
     width: 24
     height: 24
     // SVGs must have sourceSize, PNGs not; otherwise blurry
@@ -21,12 +20,5 @@ Image {
             source = "../../assets/img/icons/" + icon+ ".svg";
             objectName = icon + "-icon"
         }
-    }
-
-    layer.smooth: true
-    layer.format: ShaderEffectSource.RGBA
-    layer.enabled: !Qt.colorEqual(statusIcon.color, "transparent")
-    layer.effect: ColorOverlay {
-        color: statusIcon.color
     }
 }

--- a/ui/app/AppLayouts/Communities/controls/InlineNetworksComboBox.qml
+++ b/ui/app/AppLayouts/Communities/controls/InlineNetworksComboBox.qml
@@ -79,8 +79,6 @@ StatusComboBox {
 
                 Layout.preferredWidth: d.iconSize
                 Layout.preferredHeight: d.iconSize
-
-                mipmap: true
             }
 
             CustomText {

--- a/ui/app/AppLayouts/Communities/models/ChannelPermissionsModelEditor.qml
+++ b/ui/app/AppLayouts/Communities/models/ChannelPermissionsModelEditor.qml
@@ -246,26 +246,25 @@ QtObject {
             }
         }
         
+        readonly property var filteredPermissionsModel: SortFilterProxyModel {
+            sourceModel: root.permissionsModel
+
+            filters: [
+                FastExpressionFilter {
+                    function filterPredicate(id, permissionType) {
+                        return !PermissionTypes.isCommunityPermission(permissionType) && root.permissionsModel.belongsToChat(id, root.channelId)
+                    }
+                    expression: {
+                        return filterPredicate(model.id, model.permissionType)
+                    }
+                    expectedRoles: [ "id", "permissionType" ]
+                }
+            ]
+        }
 
         // Channel permissions model containing the temporarely edited permissions
         property WritableProxyModel channelPermissionsModel: WritableProxyModel {
-            sourceModel: SortFilterProxyModel {
-                id: filteredPermissionsModel
-
-                sourceModel: root.permissionsModel
-
-                filters: [
-                    FastExpressionFilter {
-                        function filterPredicate(id, permissionType) {
-                            return !PermissionTypes.isCommunityPermission(permissionType) && root.permissionsModel.belongsToChat(id, root.channelId)
-                        }
-                        expression: {
-                            return filterPredicate(model.id, model.permissionType)
-                        }
-                        expectedRoles: [ "id", "permissionType" ]
-                    }
-                ]
-            }
+            sourceModel: filteredPermissionsModel
         }
 
         // Channels model containing the temporarely edited channel

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -315,9 +315,7 @@ StatusListView {
                 ButtonGroup.group: d.airdropGroup
                 anchors.verticalCenter: parent.verticalCenter
                 icon.name: "airdrop"
-                icon.color: hovered ? Theme.palette.primaryColor3 :
-                                      checked ? Theme.palette.primaryColor1
-                                              : disabledTextColor
+                icon.color: checked ? Theme.palette.primaryColor1 : disabledTextColor
                 checkable: true
                 checked: {
                     const obj = root.selectedSharedAddressesMap.get(listItem.address)


### PR DESCRIPTION
### What does the PR do

TLDR: the `StatusLoadingIndicator` will be able to continue the (rotating) animation eventhough the app might be stuck as `RotationAnimator` runs on the render thread
(separate commit to fix the failing ui-tests)

- make `StatusIcon` use internally `ColorImage` component which makes it possible to recolor `Image` on the fly w/o the need to use `QtGraphicalEffects` module and a separate color layer
- which in turn enables us to use `StatusIcon` with the `RotationAnimator`
- one minor drawback though, we can no longer use the versioned properties like `mipmap` with `StatusIcon`; not a big deal as we use this with SVGs only

Fixes #10014

### Affected areas

StatusIcon, StatusLoadingIndicator

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-05-02 20-56-49.webm](https://github.com/status-im/status-desktop/assets/5377645/a153a4fb-c7ff-40e3-91a9-cd9543004834)

