### PR TITLE
fix: Hovering community in the profile showcase leads to crash

### DIFF
--- a/ui/imports/shared/views/profile/ProfileShowcaseCommunitiesView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseCommunitiesView.qml
@@ -61,9 +61,6 @@ Item {
             asset.height: 32
             name: model.name ?? ""
             memberCountVisible: false
-            layer.enabled: hovered
-            border.width: hovered ? 0 : 1
-            border.color: Theme.palette.baseColor2
             banner: model.bannerImageData ?? ""
             descriptionFontSize: 12
             descriptionFontColor: Theme.palette.baseColor1


### PR DESCRIPTION
### What does the PR do

- messing around with the DropShadow layer lead to a nasty crash somewhere deep inside Qt mouse event handlers

Fixes #14596

### Affected areas

Profile/Profile Showcase/Communities

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-05-03 17-20-44.webm](https://github.com/status-im/status-desktop/assets/5377645/55923de2-0b0f-4069-9e1c-a8908e6c49d5)

