### PR TITLE
feat(CreateChannelPopup): inherit the channel color from community color

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/ColorPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/ColorPicker.qml
@@ -28,6 +28,7 @@ ColumnLayout {
 
     StatusPickerButton {
         Layout.fillWidth: true
+        Layout.preferredHeight: 44
 
         property string validationError: ""
 

--- a/ui/app/AppLayouts/Communities/models/ChannelPermissionsModelEditor.qml
+++ b/ui/app/AppLayouts/Communities/models/ChannelPermissionsModelEditor.qml
@@ -264,7 +264,7 @@ QtObject {
 
         // Channel permissions model containing the temporarely edited permissions
         property WritableProxyModel channelPermissionsModel: WritableProxyModel {
-            sourceModel: filteredPermissionsModel
+            sourceModel: d.filteredPermissionsModel
         }
 
         // Channels model containing the temporarely edited channel

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -41,7 +41,7 @@ StatusStackModal {
     property string channelName: ""
     property string channelDescription: ""
     property string channelEmoji: ""
-    property string channelColor: ""
+    property string channelColor: d.communityDetails.color !== "" ? d.communityDetails.color : ""
     property bool emojiPopupOpened: false
     property var emojiPopup: null
     readonly property int communityColorValidator: Utils.Validate.NoEmpty
@@ -103,7 +103,7 @@ StatusStackModal {
                                     d.hideIfPermissionsNotMet !== root.hideIfPermissionsNotMet ||
                                     nameInput.input.text !== root.channelName ||
                                     descriptionTextArea.text !== root.channelDescription ||
-                                    colorPanel.color.toString().toUpperCase() !== root.channelColor ||
+                                    !Qt.colorEqual(colorPanel.color, root.channelColor) ||
                                     nameInput.input.asset.emoji !== root.channelEmoji
 
         property int currentPage: CreateChannelPopup.CurrentPage.ChannelDetails
@@ -252,8 +252,6 @@ StatusStackModal {
 
     nextButton: StatusButton {
         objectName: "createOrEditCommunityChannelBtn"
-        font.weight: Font.Medium
-        height: 44
         visible: !d.colorPickerOpened
         enabled: typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext
         text: !!currentItem.nextButtonText ? currentItem.nextButtonText :
@@ -271,8 +269,6 @@ StatusStackModal {
 
     finishButton: StatusButton {
         objectName: "createChannelNextBtn"
-        font.weight: Font.Medium
-        height: 44
         text: (typeof currentItem.nextButtonText !== "undefined") ? currentItem.nextButtonText :
                                                                     qsTr("Import chat history")
         enabled: typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext
@@ -289,9 +285,7 @@ StatusStackModal {
     }
 
     readonly property StatusButton clearFilesButton: StatusButton {
-        font.weight: Font.Medium
         text: qsTr("Clear all")
-        height: 44
         type: StatusBaseButton.Type.Danger
         visible: typeof currentItem.isFileListView !== "undefined" && currentItem.isFileListView
         enabled: !fileListView.fileListModelEmpty && !root.communitiesStore.discordDataExtractionInProgress
@@ -348,7 +342,6 @@ StatusStackModal {
             if (root.channelEmoji) {
                 nameInput.input.asset.emoji = root.channelEmoji
             }
-            colorPanel.color = root.channelColor
         } else {
             nameInput.input.asset.isLetterIdenticon = true;
         }
@@ -452,7 +445,6 @@ StatusStackModal {
                             horizontalAlignment: Qt.AlignHCenter
                             text: qsTr("Refer to this <a href='https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Readme.md'>documentation</a> if you have any queries")
                             onLinkActivated: Global.openLink(link)
-                            onHoveredLinkChanged: print(hoveredLink)
                             MouseArea {
                                 anchors.fill: parent
                                 acceptedButtons: Qt.NoButton
@@ -705,7 +697,7 @@ StatusStackModal {
                             input.letterIconName = text
                         }
                     }
-                    input.asset.color: colorPanel.color.toString()
+                    input.asset.color: colorPanel.color
                     input.rightComponent: StatusRoundButton {
                         objectName: "StatusChannelPopup_emojiButton"
                         implicitWidth: 32
@@ -747,6 +739,7 @@ StatusStackModal {
 
                         property string validationError: ""
                         width: parent.width
+                        height: 44
                         anchors.bottom: parent.bottom
                         bgColor: colorPanel.colorSelected ? colorPanel.color : Theme.palette.baseColor2
                         contentColor: colorPanel.colorSelected ? Theme.palette.white : Theme.palette.baseColor1
@@ -909,8 +902,8 @@ StatusStackModal {
             leftPadding: 16
             rightPadding: 16
             height: Math.min(parent.height, 624)
-            property bool colorSelected: root.isEdit && root.channelColor
-            color: root.isEdit && root.channelColor ? root.channelColor : Theme.palette.primaryColor1
+            property bool colorSelected: !!root.channelColor && root.channelColor != Theme.palette.primaryColor1
+            color: root.channelColor || Theme.palette.primaryColor1
             onAccepted: {
                 colorSelected = true; d.colorPickerOpened = false; d.currentPage = CreateChannelPopup.CurrentPage.ChannelDetails;
             }


### PR DESCRIPTION
### What does the PR do

- if there's a valid community info and the color is non-empty, inherit it when creating a new channel
- also fix the color picker button height
- adjust the SB page with separate "create" and "edit" options

Fixes #14570

### Affected areas

CreateChannelPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-05-03 17-54-29.webm](https://github.com/status-im/status-desktop/assets/5377645/c60ae215-b725-4864-ab65-f83032e69ae3)

