### PR TITLE
fix(identicon): fix Ethereum icon not appearing in community tags

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -31,7 +31,7 @@ Rectangle {
         anchors.centerIn: parent
         width: Math.round(parent.width / 2)
         height: Math.round(parent.height / 2)
-        emojiId: Emoji.iconId(root.emoji, root.emojiSize) || ""
+        emojiId: Emoji.iconHex(root.emoji) || ""
     }
     
     StatusBaseText {


### PR DESCRIPTION
Fixes #14599

The problem was that the Twemoji `emojiId` function blocked on the replace whereas `iconHex` works.
It's the same that is used in `StatusCommunityTag.qml`.

Maybe it's worth modifying all the `emojiId` calls to `iconHex`?

![image](https://github.com/status-im/status-desktop/assets/11926403/d1d9d4af-720f-46e7-8287-d7c7b7c94965)
