### PR TITLE
fix: Token Master permission missing token name

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
@@ -184,8 +184,20 @@ StackView {
 
                 viewWidth: root.viewWidth
 
+                SortFilterProxyModel {
+                    id: nonOwnerCollectibles
+                    sourceModel: root.collectiblesModel
+                    filters: [
+                        ValueFilter {
+                            roleName: "privilegesLevel"
+                            value: Constants.TokenPrivilegesLevel.Owner
+                            inverted: true
+                        }
+                    ]
+                }
+
                 assetsModel: root.assetsModel
-                collectiblesModel: root.collectiblesModel
+                collectiblesModel: nonOwnerCollectibles
                 channelsModel: allChannelsTransformed
                 communityDetails: root.communityDetails
                 showChannelSelector: root.showChannelSelector

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -304,18 +304,7 @@ StatusSectionLayout {
 
             assetsModel: rootStore.assetsModel
 
-            SortFilterProxyModel {
-                id: nonOwnerCollectibles
-                sourceModel: rootStore.collectiblesModel
-                filters: [
-                    ValueFilter {
-                        roleName: "privilegesLevel"
-                        value: Constants.TokenPrivilegesLevel.Owner
-                        inverted: true
-                    }
-                ]
-            }
-            collectiblesModel: nonOwnerCollectibles
+            collectiblesModel: rootStore.collectiblesModel
             channelsModel: rootStore.chatCommunitySectionModule.model
 
             communityDetails: d.communityDetails


### PR DESCRIPTION
Fixes #14449

### What does the PR do

To move fast on this ticket, I have a one liner change that produces expected result, meaning the token name is correctly displayed on the permission for the token master. However, I am aware that the model from which the data is coming from is a `SortFilterProxyModel` between the `assetsMOdel` and the `collectiblesModel` and that the `text` FastExpressionRole should provide the necessary data but, it seems that this is not enough, hence producing the missing token name bug. I would love to deepen my understanding or any feedbacks if I am missing something.

### Affected areas

- Permissions

### Screenshot of functionality (including design for comparison)

![Screenshot from 2024-05-06 21-54-11](https://github.com/status-im/status-desktop/assets/2589171/e1387dce-a135-41a4-8296-b1735c6e68fa)

![Screenshot from 2024-05-06 21-54-25](https://github.com/status-im/status-desktop/assets/2589171/9c234554-eaf5-44c7-b69a-814c7d373d2f)


