### PR TITLE
fix(StatusQ/Aggregator): Proper recalculation on layout change removing rows

### DIFF
--- a/ui/StatusQ/include/StatusQ/aggregator.h
+++ b/ui/StatusQ/include/StatusQ/aggregator.h
@@ -35,5 +35,7 @@ private:
     QAbstractItemModel* m_model = nullptr;
     QVariant m_value;
 
+    int m_onLayoutToBeChangedCount = 0;
+
     void connectToModel();
 };

--- a/ui/StatusQ/src/aggregator.cpp
+++ b/ui/StatusQ/src/aggregator.cpp
@@ -1,16 +1,19 @@
 #include "StatusQ/aggregator.h"
 #include <QAbstractItemModel>
 
-Aggregator::Aggregator(QObject *parent)
-    : QObject(parent){
+Aggregator::Aggregator(QObject* parent)
+    : QObject(parent)
+{
     connect(this, &Aggregator::modelChanged, this, &Aggregator::recalculate);
 }
 
-QAbstractItemModel* Aggregator::model() const {
+QAbstractItemModel* Aggregator::model() const
+{
     return m_model;
 }
 
-void Aggregator::setModel(QAbstractItemModel* model) {
+void Aggregator::setModel(QAbstractItemModel* model)
+{
     if(m_model == model)
         return;
 
@@ -22,7 +25,8 @@ void Aggregator::setModel(QAbstractItemModel* model) {
     emit modelChanged();
 }
 
-QVariant Aggregator::value() const {
+QVariant Aggregator::value() const
+{
     return m_value;
 }
 
@@ -37,15 +41,38 @@ void Aggregator::recalculate()
     emit valueChanged();
 }
 
-void Aggregator:: connectToModel() {
-    if(m_model) {
-        connect(m_model, &QAbstractItemModel::rowsInserted, this, &Aggregator::recalculate);
-        connect(m_model, &QAbstractItemModel::rowsRemoved, this, &Aggregator::recalculate);
-        connect(m_model, &QAbstractItemModel::modelReset, this, &Aggregator::recalculate);
-        connect(m_model, &QAbstractItemModel::dataChanged, this,
-              [this](auto&, auto&, const QVector<int>& roles) {
-          if (this->acceptRoles(roles))
-              this->recalculate();
-        });
-    }
+void Aggregator:: connectToModel()
+{
+    if(m_model == nullptr)
+        return;
+
+    connect(m_model, &QAbstractItemModel::rowsInserted, this, &Aggregator::recalculate);
+    connect(m_model, &QAbstractItemModel::rowsRemoved, this, &Aggregator::recalculate);
+    connect(m_model, &QAbstractItemModel::modelReset, this, &Aggregator::recalculate);
+
+    // Some models (like SFPM) emit layoutAboutToBeChanged/layoutChanged while
+    // removing some rows in the meantime. If the row count is changed, then
+    // aggregation must be recalculated. In most cases, for regular layout
+    // change events it's not necessary to recalculate.
+    connect(m_model, &QAbstractItemModel::layoutAboutToBeChanged, this, [this] {
+        auto model = this->model();
+
+        if (model == nullptr)
+            return;
+
+        m_onLayoutToBeChangedCount = model->rowCount();
+    });
+
+    connect(m_model, &QAbstractItemModel::layoutChanged, this, [this] {
+        auto model = this->model();
+
+        if (model != nullptr && m_onLayoutToBeChangedCount != model->rowCount())
+            this->recalculate();
+    });
+
+    connect(m_model, &QAbstractItemModel::dataChanged, this,
+          [this](auto&, auto&, const QVector<int>& roles) {
+      if (this->acceptRoles(roles))
+          this->recalculate();
+    });
 }

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
@@ -128,6 +128,12 @@ void TestModel::removeEverySecond()
     emit layoutChanged();
 }
 
+void TestModel::reset()
+{
+    beginResetModel();
+    endResetModel();
+}
+
 void TestModel::initRoles()
 {
     m_roles.reserve(m_data.size());

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.h
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.h
@@ -26,6 +26,9 @@ public:
     // during SFPM initialization where initial filtering is notified this way.
     void removeEverySecond();
 
+    // emits modelAboutToBeReset/modelReset, content remains the same
+    void reset();
+
 private:
     void initRoles();
 


### PR DESCRIPTION
### What does the PR do

- adds handling for special case where there are rows removed between `layoutAboutToBeChanged`/`layoutChanged` signals
- proper unit test added, existing unit tests extended
- minor code style alignments

Similar special handling had to be applied to `ConcatModel`: https://github.com/status-im/status-desktop/pull/14368

Closes: #14554

### Affected areas
`StatusQ/Aggregator`

### Screenshot of functionality (including design for comparison)

[Screencast from 06.05.2024 12:53:51.webm](https://github.com/status-im/status-desktop/assets/20650004/4e9c2d6c-640a-4ab2-acac-f145052bf5b5)
