### PR TITLE
fix(build) fix python package error on make run with MacOS developer environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,10 +557,8 @@ ifeq ($(detected_OS),Darwin)
 		libkeycard.dylib \
 		@rpath/libkeycard.dylib \
 		bin/nim_status_client
-ifeq ("$(wildcard ./node_modules/.bin/fileicon)","")
-	echo -e "\033[92mInstalling:\033[39m fileicon"
-	yarn install
-endif
+	# Install or update package.json files
+	yarn install --check-files
 endif
 
 nim_status_client: force-rebuild-status-go $(NIM_STATUS_CLIENT)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "files": [],
   "devDependencies": {
     "create-dmg": "status-im/create-dmg#678fbd4",
-    "fileicon": "0.3.0"
+    "fileicon": "0.3.3"
   },
   "engines": {
     "node": ">=10",


### PR DESCRIPTION
The `fileicon` `v0.3.0` tool we used on MacOS to embed icons in our binary is failing. Upgrading to latest `v0.3.3` fixes this. It will require a `make update` though to fix local builds.

Also improved to update `yarn` packages all the time ensuring that a change in `package.json` will be reflected on `make update` without manual intervention.

The `make run` error

```bash
Building: StatusQ
Building: DOtherSide
Installing: StatusQ
Performing one-time user-level installation of required Python packages: pyobjc-core pyobjc-framework-Cocoa - this can take while...
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a Python library that isn't in Homebrew,
    use a virtual environment:
    
    python3 -m venv path/to/venv
    source path/to/venv/bin/activate
    python3 -m pip install xyz
    
    If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. You can install pipx with
    
    brew install pipx
    
    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip, or by adding
    'break-system-packages = true' to your pip.conf file. The latter
    will permanently disable this error.
    
    If you disable this error, we STRONGLY recommend that you additionally
    pass the '--user' flag to pip, or set 'user = true' in your pip.conf
    file. Failure to do this can result in a broken Homebrew installation.
    
    Read more about this behavior here: <https://peps.python.org/pep-0668/>

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
fileicon: ERROR: On-demand installation of Python packages failed unexpectedly.
make: *** [run-macos] Error 1
```