### PR TITLE
feat(community): show a message when the member reevaluation is ongoing

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -52,6 +52,7 @@ type SignalType* {.pure.} = enum
   DiscordChannelImportFinished = "community.discordChannelImportFinished"
   DiscordChannelImportProgress = "community.discordChannelImportProgress"
   DiscordChannelImportCancelled = "community.discordChannelImportCancelled"
+  MemberReevaluationStatus = "community.memberReevaluationStatus"
   WakuFetchingBackupProgress = "waku.fetching.backup.progress"
   WakuBackedUpProfile = "waku.backedup.profile"
   WakuBackedUpSettings = "waku.backedup.settings"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -121,6 +121,7 @@ QtObject:
       of SignalType.DiscordChannelImportFinished: DiscordChannelImportFinishedSignal.fromEvent(jsonSignal)
       of SignalType.DiscordChannelImportProgress: DiscordChannelImportProgressSignal.fromEvent(jsonSignal)
       of SignalType.DiscordChannelImportCancelled: DiscordChannelImportCancelledSignal.fromEvent(jsonSignal)
+      of SignalType.MemberReevaluationStatus: CommunityMemberReevaluationStatusSignal.fromEvent(jsonSignal)
       # sync from waku part
       of SignalType.WakuFetchingBackupProgress: WakuFetchingBackupProgressSignal.fromEvent(jsonSignal)
       of SignalType.WakuBackedUpProfile: WakuBackedUpProfileSignal.fromEvent(jsonSignal)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -367,6 +367,11 @@ proc init*(self: Controller) =
       if args.communityId == self.sectionId:
        self.delegate.setShardingInProgress(false)
 
+    self.events.on(SIGNAL_MEMBER_REEVALUATION_STATUS) do(e: Args):
+      let args = CommunityMemberReevaluationStatusArg(e)
+      if args.communityId == self.sectionId:
+        self.delegate.communityMemberReevaluationStatusUpdated(args.status)
+
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.onContactDetailsUpdated(args.contactId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -9,6 +9,7 @@ import ../../../../app_service/service/message/service as message_service
 import ../../../../app_service/service/mailservers/service as mailservers_service
 import ../../../../app_service/service/shared_urls/service as shared_urls_service
 import ../../../../app_service/common/types
+import ../../../../app/core/signals/types
 
 import model as chats_model
 import item as chat_item
@@ -427,4 +428,7 @@ method openCommunityChatAndScrollToMessage*(self: AccessInterface, chatId: strin
   raise newException(ValueError, "No implementation available")
 
 method updateRequestToJoinState*(self: AccessInterface, state: RequestToJoinState) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method communityMemberReevaluationStatusUpdated*(self: AccessInterface, status: CommunityMemberReevaluationStatus) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -37,6 +37,7 @@ import ../../../../app_service/service/community_tokens/service as community_tok
 import ../../../../app_service/service/shared_urls/service as shared_urls_service
 import ../../../../app_service/service/visual_identity/service as visual_identity
 import ../../../../app_service/service/contacts/dto/contacts as contacts_dto
+import ../../../../app/core/signals/types
 
 export io_interface
 
@@ -1588,3 +1589,6 @@ method openCommunityChatAndScrollToMessage*(self: Module, chatId: string, messag
 
 method updateRequestToJoinState*(self: Module, state: RequestToJoinState) =
   self.view.setRequestToJoinState(state)
+
+method communityMemberReevaluationStatusUpdated*(self: Module, status: CommunityMemberReevaluationStatus) =
+  self.view.setCommunityMemberReevaluationStatus(status.int)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -37,6 +37,7 @@ QtObject:
       memberMessagesModel: member_msg_model.Model
       memberMessagesModelVariant: QVariant
       requestToJoinState: RequestToJoinState
+      communityMemberReevaluationStatus: int
 
 
   proc delete*(self: View) =
@@ -82,6 +83,7 @@ QtObject:
     result.memberMessagesModel = member_msg_model.newModel()
     result.memberMessagesModelVariant = newQVariant(result.memberMessagesModel)
     result.requestToJoinState = RequestToJoinState.None
+    result.communityMemberReevaluationStatus = 0
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -555,3 +557,18 @@ QtObject:
       return
     self.requestToJoinState = requestToJoinState
     self.requestToJoinStateChanged()
+
+  proc communityMemberReevaluationStatusChanged*(self: View) {.signal.}
+
+  proc getCommunityMemberReevaluationStatus*(self: View): int {.slot.} =
+    return self.communityMemberReevaluationStatus
+
+  QtProperty[int] communityMemberReevaluationStatus:
+    read = getCommunityMemberReevaluationStatus
+    notify = communityMemberReevaluationStatusChanged
+
+  proc setCommunityMemberReevaluationStatus*(self: View, value: int) =
+    if self.communityMemberReevaluationStatus == value:
+      return
+    self.communityMemberReevaluationStatus = value
+    self.communityMemberReevaluationStatusChanged()

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -167,6 +167,10 @@ type
   CommunityShardSetArgs* = ref object of Args
     communityId*: string
 
+  CommunityMemberReevaluationStatusArg* = ref object of Args
+    communityId*: string
+    status*: CommunityMemberReevaluationStatus  
+
 # Signals which may be emitted by this service:
 const SIGNAL_COMMUNITY_DATA_LOADED* = "communityDataLoaded"
 const SIGNAL_COMMUNITY_JOINED* = "communityJoined"
@@ -219,6 +223,8 @@ const SIGNAL_DISCORD_COMMUNITY_IMPORT_CANCELED* = "discordCommunityImportCancele
 const SIGNAL_DISCORD_CHANNEL_IMPORT_FINISHED* = "discordChannelImportFinished"
 const SIGNAL_DISCORD_CHANNEL_IMPORT_PROGRESS* = "discordChannelImportProgress"
 const SIGNAL_DISCORD_CHANNEL_IMPORT_CANCELED* = "discordChannelImportCanceled"
+
+const SIGNAL_MEMBER_REEVALUATION_STATUS* = "communityMemberReevaluationStatus"
 
 const SIGNAL_COMMUNITY_TOKEN_PERMISSION_CREATED* = "communityTokenPermissionCreated"
 const SIGNAL_COMMUNITY_TOKEN_PERMISSION_CREATION_FAILED* = "communityTokenPermissionCreationFailed"
@@ -422,6 +428,13 @@ QtObject:
           # Don't just emit this signal when all communities are done downloading history data,
           # but implement a solution for individual updates
           self.events.emit(SIGNAL_COMMUNITY_HISTORY_ARCHIVES_DOWNLOAD_FINISHED, CommunityIdArgs(communityId: receivedData.communityId))
+    
+    self.events.on(SignalType.MemberReevaluationStatus.event) do(e: Args):
+      var receivedData = CommunityMemberReevaluationStatusSignal(e)
+      self.events.emit(SIGNAL_MEMBER_REEVALUATION_STATUS, CommunityMemberReevaluationStatusArg(
+        communityId: receivedData.communityId,
+        status: receivedData.status,
+      ))
 
   proc findIndexById(id: string, chats: seq[ChatDto]): int =
     var idx = -1

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -5,6 +5,7 @@ import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
 
 import shared 1.0
 import shared.panels 1.0
@@ -20,6 +21,7 @@ Item {
     property var store
     property var usersModel
     property string label
+    property int communityMemberReevaluationStatus: Constants.CommunityMemberReevaluationStatus.None
 
     StatusBaseText {
         id: titleText
@@ -35,9 +37,34 @@ Item {
         text: root.label
     }
 
+    StatusBaseText {
+        id: communityMemberReevaluationInProgressText
+        visible: root.communityMemberReevaluationStatus === Constants.CommunityMemberReevaluationStatus.InProgress
+        height: visible ? implicitHeight : 0 
+        anchors.top: titleText.bottom
+        anchors.topMargin: visible ? Style.current.padding : 0
+        anchors.left: parent.left
+        anchors.leftMargin: Style.current.padding
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        font.pixelSize: Style.current.secondaryTextFontSize
+        color: Theme.palette.directColor1
+        text: qsTr("Member re-evaluation in progress...")
+        wrapMode: Text.WordWrap
+
+        StatusToolTip {
+            text: qsTr("Saving community edits might take longer than usual")
+            visible: hoverHandler.hovered
+        }
+        HoverHandler {
+            id: hoverHandler
+            enabled: communityMemberReevaluationInProgressText.visible
+        }
+    }
+
     Item {
         anchors {
-            top: titleText.bottom
+            top: communityMemberReevaluationInProgressText.bottom
             topMargin: Style.current.padding
             left: parent.left
             leftMargin: Style.current.halfPadding

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -64,6 +64,8 @@ QtObject {
     readonly property bool allChannelsAreHiddenBecauseNotPermitted: root.chatCommunitySectionModule.allChannelsAreHiddenBecauseNotPermitted &&
                                                                     !root.chatCommunitySectionModule.requiresTokenPermissionToJoin
 
+    readonly property int communityMemberReevaluationStatus: root.chatCommunitySectionModule && root.chatCommunitySectionModule.communityMemberReevaluationStatus
+
     readonly property bool requirementsCheckPending: root.communitiesModuleInst.requirementsCheckPending
 
     readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -186,6 +186,7 @@ StatusSectionLayout {
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")
+            communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
             usersModel: root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
         }
     }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1312,4 +1312,10 @@ QtObject {
         InProgress = 1,
         Requested = 2
     }
+
+    enum CommunityMemberReevaluationStatus {
+        None = 0,
+        InProgress = 1,
+        Done = 2
+    }
 }


### PR DESCRIPTION
Fixes #14378

This is only for the control node. We can improve the UI later

status-go PR: https://github.com/status-im/status-go/pull/5120

[reevaluation-message.webm](https://github.com/status-im/status-desktop/assets/11926403/c6d2d88e-56b2-42cc-8f8c-c35eff4e8832)
