### PR TITLE
fix(wallet): Show community name in tag

### DIFF
--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -22,10 +22,7 @@ type
     Ownership
     # Community-related roles
     CommunityId
-    CommunityName
-    CommunityColor
     CommunityPrivilegesLevel
-    CommunityImage
     TokenType
     Soulbound
 
@@ -145,10 +142,7 @@ QtObject:
       CollectibleRole.IsLoading.int:"isLoading",
       CollectibleRole.Ownership.int:"ownership",
       CollectibleRole.CommunityId.int:"communityId",
-      CollectibleRole.CommunityName.int:"communityName",
-      CollectibleRole.CommunityColor.int:"communityColor",
       CollectibleRole.CommunityPrivilegesLevel.int:"communityPrivilegesLevel",
-      CollectibleRole.CommunityImage.int:"communityImage",
       CollectibleRole.TokenType.int:"tokenType",
       CollectibleRole.Soulbound.int:"soulbound"
     }.toTable
@@ -195,14 +189,8 @@ QtObject:
         result = item.getOwnershipModelAsVariant()
       of CollectibleRole.CommunityId:
         result = newQVariant(item.getCommunityId())
-      of CollectibleRole.CommunityName:
-        result = newQVariant(item.getCommunityName())
-      of CollectibleRole.CommunityColor:
-        result = newQVariant(item.getCommunityColor())
       of CollectibleRole.CommunityPrivilegesLevel:
         result = newQVariant(item.getCommunityPrivilegesLevel())
-      of CollectibleRole.CommunityImage:
-        result = newQVariant(item.getCommunityImage())
       of CollectibleRole.TokenType:
         result = newQVariant(item.getTokenType())
       of CollectibleRole.Soulbound:
@@ -227,10 +215,7 @@ QtObject:
       of "collectionSlug": result = item.getCollectionSlug()
       of "isLoading": result = $false
       of "communityId": result = item.getCommunityID()
-      of "communityName": result = item.getCommunityName()
-      of "communityColor": result = item.getCommunityColor()
       of "communityPrivilegesLevel": result = $item.getCommunityPrivilegesLevel()
-      of "communityImage": result = item.getCommunityImage()
 
   proc resetCollectibleItems(self: Model, newItems: seq[CollectiblesEntry] = @[]) =
     self.beginResetModel()

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -3,6 +3,7 @@ import QtQuick 2.13
 import utils 1.0
 
 import StatusQ 0.1
+import StatusQ.Models 0.1
 import StatusQ.Core.Utils 0.1
 
 import SortFilterProxyModel 0.2
@@ -13,7 +14,7 @@ QtObject {
     property var walletModule
     property var accountsModule: root.walletModule.accountsModule
     property var networksModuleInst: networksModule
-    property var collectibles: root.walletModule.collectiblesModel
+    property var collectibles: _jointCollectiblesBySymbolModel
 
     property var accountSensitiveSettings: Global.appIsReady? localAccountSensitiveSettings : null
     property var dappList: Global.appIsReady? dappPermissionsModule.dapps : null
@@ -54,6 +55,42 @@ QtObject {
             value: Constants.watchWalletType
             inverted: true
         }
+    }
+
+    /* PRIVATE: This model renames the roles
+        1. "id" to "communityId"
+        2. "name" to "communityName"
+        3. "image" to "communityImage"
+        4. "description" to "communityDescription"
+        in communitiesModule.model so that it can be easily
+        joined with the Collectibles model */
+    readonly property var _renamedCommunitiesModel: RolesRenamingModel {
+        sourceModel: communitiesModule.model
+        mapping: [
+            RoleRename {
+                from: "id"
+                to: "communityId"
+            },
+            RoleRename {
+                from: "name"
+                to: "communityName"
+            },
+            RoleRename {
+                from: "image"
+                to: "communityImage"
+            },
+            RoleRename {
+                from: "description"
+                to: "communityDescription"
+            }
+        ]
+    }
+
+    /* PRIVATE: This model joins the "Tokens By Symbol Model" and "Communities Model" by communityId */
+    property LeftJoinModel _jointCollectiblesBySymbolModel: LeftJoinModel {
+        leftModel: root.walletModule.collectiblesModel
+        rightModel: _renamedCommunitiesModel
+        joinRole: "communityId"
     }
 
     property string userProfilePublicKey: userProfile.pubKey

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
@@ -19,7 +19,6 @@ Control {
     property string communityId
     property var communityImage
     property bool loading
-    property bool useLongTextDescription: true
 
     property Component customBackground: Component {
         Rectangle {
@@ -53,7 +52,7 @@ Control {
             Layout.preferredHeight: visible ? asset.width : 0
             asset.width: 16
             asset.height: 16
-            visible: root.useLongTextDescription && !!asset.source
+            visible: !d.unknownCommunityName && !!asset.source
 
             Component.onCompleted: {
                 updateCommunityImage()

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -5,6 +5,8 @@ import StatusQ.Models 0.1
 
 import utils 1.0
 
+import SortFilterProxyModel 0.2
+
 QtObject {
     id: root
 
@@ -27,7 +29,7 @@ QtObject {
     }
 
     readonly property var collectiblesController: ManageTokensController {
-        sourceModel: allCollectiblesModel
+        sourceModel: _jointCollectiblesBySymbolModel
         settingsKey: "WalletCollectibles"
         serializeAsCollectibles: true
 
@@ -51,6 +53,43 @@ QtObject {
                                         qsTr("%1 community collectibles are now visible").arg(communityName), "", "checkmark-circle",
                                         false, Constants.ephemeralNotificationType.success, "")
     }
+
+    /* PRIVATE: This model renames the roles
+        1. "id" to "communityId"
+        2. "name" to "communityName"
+        3. "image" to "communityImage"
+        4. "description" to "communityDescription"
+        in communitiesModule.model so that it can be easily
+        joined with the Collectibles model */
+    readonly property var _renamedCommunitiesModel: RolesRenamingModel {
+        sourceModel: communitiesModule.model
+        mapping: [
+            RoleRename {
+                from: "id"
+                to: "communityId"
+            },
+            RoleRename {
+                from: "name"
+                to: "communityName"
+            },
+            RoleRename {
+                from: "image"
+                to: "communityImage"
+            },
+            RoleRename {
+                from: "description"
+                to: "communityDescription"
+            }
+        ]
+    }
+
+    /* PRIVATE: This model joins the "Tokens By Symbol Model" and "Communities Model" by communityId */
+    property LeftJoinModel _jointCollectiblesBySymbolModel: LeftJoinModel {
+        leftModel: allCollectiblesModel
+        rightModel: _renamedCommunitiesModel
+        joinRole: "communityId"
+    }
+
     readonly property bool areCollectiblesFetching: !!root._allCollectiblesModel ? root._allCollectiblesModel.isFetching : true
     readonly property bool areCollectiblesUpdating: !!root._allCollectiblesModel ? root._allCollectiblesModel.isUpdating : false
     readonly property bool areCollectiblesError: !!root._allCollectiblesModel ? root._allCollectiblesModel.isError : false

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
@@ -189,7 +189,6 @@ Control {
             communityImage: root.communityImage
             visible: root.isCommunityCollectible
             enabled: !root.isLoading
-            useLongTextDescription: false
             
             TapHandler {
                 enabled: !d.unknownCommunityName


### PR DESCRIPTION
Closes #14597

### What does the PR do

This change is step to streamline the way we show community info 
* Removed community roles from collectibles model
* Left joined the collectibles model with communities model in Profile and Wallet stores

### Affected areas

Profile showcase and wallet collectibles view

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/11396062/ff4decce-a3a7-417e-a6d8-a27da9f85e7f)

![image](https://github.com/status-im/status-desktop/assets/11396062/0bbbaf5b-e26d-41b4-ba75-cd317e5855d3)
