### PR TITLE
feat(@desktop/wallet): Add Swap Feature Flag

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -2,6 +2,7 @@ import NimQml
 import os
 
 const DEFAULT_FLAG_DAPPS_ENABLED = false
+const DEFAULT_FLAG_SWAP_ENABLED = false
 
 proc boolToEnv(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"
@@ -9,10 +10,12 @@ proc boolToEnv(defaultValue: bool): string =
 QtObject:
   type FeatureFlags* = ref object of QObject
     dappsEnabled: bool
+    swapEnabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
     self.dappsEnabled = getEnv("FLAG_DAPPS_ENABLED", boolToEnv(DEFAULT_FLAG_DAPPS_ENABLED)) != "0"
+    self.swapEnabled = getEnv("FLAG_SWAP_ENABLED", boolToEnv(DEFAULT_FLAG_SWAP_ENABLED)) != "0"
 
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
@@ -26,3 +29,9 @@ QtObject:
 
   QtProperty[bool] dappsEnabled:
     read = getDappsEnabled
+
+  proc getSwapEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.swapEnabled
+
+  QtProperty[bool] swapEnabled:
+    read = getSwapEnabled

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -80,6 +80,17 @@ Rectangle {
             onClicked: function () {
                 Global.openPopup(buySellModal);
             }
+        }        
+
+        StatusFlatButton {
+            id: swap
+
+            visible: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled && Global.featureFlags.swapEnabled
+            icon.name: "swap"
+            text: qsTr("Swap")
+            onClicked: function () {
+                console.warn("TODO: launch swap modal...")
+            }
         }
     }
 


### PR DESCRIPTION
fixes #14627

### What does the PR do

Added a feature flag behind which we will hide all swap related code on desktop client

simply export FLAG_SWAP_ENABLED=1 in order to see the swap functionality on desktop

### Affected areas
 NA


### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

