### PR TITLE
fix(Syncing): cancelling syncing flow should not result in error dialog

### DIFF
--- a/src/app/modules/main/profile_section/devices/module.nim
+++ b/src/app/modules/main/profile_section/devices/module.nim
@@ -113,6 +113,8 @@ method onLoggedInUserAuthenticated*(self: Module, pin: string, password: string,
       if chatKey.startsWith("0x"):
         chatKey = chatKey[2..^1]
   let connectionString = self.controller.getConnectionStringForBootstrappingAnotherDevice(password, chatKey)
+  if password.len == 0 and pin.len == 0:
+    return
   self.view.openPopupWithConnectionString(connectionString)
 
 proc validateConnectionString*(self: Module, connectionString: string): string =


### PR DESCRIPTION
Closes #11908

### What does the PR do

When user cancels or closes KeycardPopup.qml, it will be 'Rejected'. Appropriate state will be signaled up to the interested objects.
ProfileLayout.qml reacts to the 'Rejected' / 'Accepted' state by discarding any error messages from the nim layer.

### Affected areas

ProfileLayout.qml, KeycardPopup.qml, SyncingView.qml

### Screenshot of functionality (including design for comparison)

- [x ] I've checked the design and this PR matches it (No designs for cancel/discard/X of Sync Device flow)


