### PR TITLE
Chore/cherry pick join fix

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -865,9 +865,11 @@ method checkPermissions*(self: Module, communityId: string, sharedAddresses: seq
   self.joiningCommunityDetails.communityIdForPermissions = communityId
 
   self.controller.asyncCheckPermissionsToJoin(communityId, sharedAddresses)
+  self.view.setJoinPermissionsCheckSuccessful(false)
   self.checkingPermissionToJoinInProgress = true
 
   self.controller.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
+  self.view.setChannelsPermissionsCheckSuccessful(false)
   self.checkingAllChannelPermissionsInProgress = true
 
   self.view.setCheckingPermissionsInProgress(inProgress = true)
@@ -944,12 +946,12 @@ proc updateCheckingPermissionsInProgressIfNeeded(self: Module, inProgress = fals
   self.view.setCheckingPermissionsInProgress(inProgress)
 
 method onCommunityCheckPermissionsToJoinFailed*(self: Module, communityId: string, error: string) =
-  # TODO show error
+  self.view.setJoinPermissionsCheckSuccessful(false)
   self.checkingPermissionToJoinInProgress = false
   self.updateCheckingPermissionsInProgressIfNeeded(inProgress = false)
 
 method onCommunityCheckAllChannelPermissionsFailed*(self: Module, communityId: string, error: string) =
-  # TODO show error
+  self.view.setChannelsPermissionsCheckSuccessful(false)
   self.checkingAllChannelPermissionsInProgress = false
   self.updateCheckingPermissionsInProgressIfNeeded(inProgress = false)
 
@@ -960,6 +962,7 @@ method onCommunityCheckPermissionsToJoinResponse*(self: Module, communityId: str
     return
   self.applyPermissionResponse(communityId, checkPermissionsToJoinResponse.permissions)
   self.checkingPermissionToJoinInProgress = false
+  self.view.setJoinPermissionsCheckSuccessful(true)
   self.updateCheckingPermissionsInProgressIfNeeded(inProgress = false)
 
 method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, communityId: string,
@@ -968,6 +971,7 @@ method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, communityId
       self.joiningCommunityDetails.communityIdForPermissions != communityId:
     return
   self.checkingAllChannelPermissionsInProgress = false
+  self.view.setChannelsPermissionsCheckSuccessful(true)
   self.updateCheckingPermissionsInProgressIfNeeded(inProgress = false)
   for _, channelPermissionResponse in checkChannelPermissionsResponse.channels:
     self.applyPermissionResponse(

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -55,6 +55,8 @@ QtObject:
       discordImportHasCommunityImage: bool
       downloadingCommunityHistoryArchives: bool
       checkingPermissionsInProgress: bool
+      joinPermissionsCheckSuccessful: bool
+      channelsPermissionsCheckSuccessful: bool
       myRevealedAddressesStringForCurrentCommunity: string
       myRevealedAirdropAddressForCurrentCommunity: string
       keypairsSigningModel: KeyPairModel
@@ -120,6 +122,9 @@ QtObject:
     result.tokenListModelVariant = newQVariant(result.tokenListModel)
     result.collectiblesListModel = newTokenListModel()
     result.collectiblesListModelVariant = newQVariant(result.collectiblesListModel)
+    result.checkingPermissionsInProgress = false
+    result.joinPermissionsCheckSuccessful = false
+    result.channelsPermissionsCheckSuccessful = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -799,6 +804,34 @@ QtObject:
   QtProperty[bool] requirementsCheckPending:
     read = getCheckingPermissionsInProgress
     notify = checkingPermissionsInProgressChanged
+
+  proc joinPermissionsCheckSuccessfulChanged*(self: View) {.signal.}
+
+  proc setJoinPermissionsCheckSuccessful*(self: View, successful: bool) =
+    if (self.joinPermissionsCheckSuccessful == successful): return
+    self.joinPermissionsCheckSuccessful = successful
+    self.joinPermissionsCheckSuccessfulChanged()
+
+  proc getJoinPermissionsCheckSuccessful*(self: View): bool {.slot.} =
+    return self.joinPermissionsCheckSuccessful
+
+  QtProperty[bool] joinPermissionsCheckSuccessful:
+    read = getJoinPermissionsCheckSuccessful
+    notify = joinPermissionsCheckSuccessfulChanged
+
+  proc channelsPermissionsCheckSuccessfulChanged*(self: View) {.signal.}
+
+  proc setChannelsPermissionsCheckSuccessful*(self: View, successful: bool) =
+    if (self.channelsPermissionsCheckSuccessful == successful): return
+    self.channelsPermissionsCheckSuccessful = successful
+    self.channelsPermissionsCheckSuccessfulChanged()
+
+  proc getChannelsPermissionsCheckSuccessful*(self: View): bool {.slot.} =
+    return self.channelsPermissionsCheckSuccessful
+
+  QtProperty[bool] channelsPermissionsCheckSuccessful:
+    read = getChannelsPermissionsCheckSuccessful
+    notify = channelsPermissionsCheckSuccessfulChanged
 
   proc keypairsSigningModel*(self: View): KeyPairModel =
     return self.keypairsSigningModel

--- a/storybook/pages/CommunityMembershipSetupDialogPage.qml
+++ b/storybook/pages/CommunityMembershipSetupDialogPage.qml
@@ -55,6 +55,7 @@ SplitView {
 
                 isInvitationPending: ctrlIsInvitationPending.checked
                 requirementsCheckPending: ctrlRequirementsCheckPending.checked
+                joinPermissionsCheckSuccessful: ctrlJoinPermissionsCheckSuccessful.checked
 
                 walletAccountsModel: WalletAccountsModel {}
                 walletAssetsModel: root.walletAssetStore.groupedAccountAssetsModel
@@ -80,7 +81,7 @@ SplitView {
                             })
                 }
             }
-                }
+        }
 
         Item {
             SplitView.fillWidth: true
@@ -216,6 +217,14 @@ Nemo enim 😋 ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
                 id: ctrlRequirementsCheckPending
                 visible: !ctrlIsInvitationPending.checked
                 text: "Requirements check pending"
+            }
+
+            CheckBox {
+                Layout.leftMargin: 12
+                id: ctrlJoinPermissionsCheckSuccessful
+                visible: !ctrlIsInvitationPending.checked
+                text: "Join permission successful"
+                checked: true
             }
 
             Item {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
@@ -20,6 +20,7 @@ ToolTip {
 
     implicitWidth: Math.min(maxWidth, implicitContentWidth + 16)
     padding: 8
+    margins: 8
     delay: 200
     background: Item {
         id: statusToolTipBackground

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -21,10 +21,11 @@ Dialog {
        \qmlproperty color backgroundColor
         This property decides the modal background color
     */
-    property string backgroundColor: Theme.palette.statusModal.backgroundColor
+    property color backgroundColor: Theme.palette.statusModal.backgroundColor
     /*!
        \qmlproperty closeHandler
         This property decides the action to be performed when the close button is clicked. It allows to define
+        a custom function to be called when the popup is closed by the user.
     */
     property var closeHandler: root.close
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -618,6 +618,7 @@ QtObject {
                 readonly property string image: model.image
                 readonly property bool joined: model.joined
                 readonly property bool amIBanned: model.amIBanned
+                readonly property string introMessage: model.introMessage
                 // add others when needed..
             }
         }

--- a/ui/app/AppLayouts/Communities/controls/CommunityEligibilityTag.qml
+++ b/ui/app/AppLayouts/Communities/controls/CommunityEligibilityTag.qml
@@ -12,6 +12,8 @@ Rectangle {
     id: root
 
     required property int /*PermissionTypes.Type*/ eligibleToJoinAs
+    property bool isEditMode
+    property bool isDirty
 
     implicitWidth: hintRow.implicitWidth + 2*Style.current.padding
     implicitHeight: 40
@@ -22,7 +24,7 @@ Rectangle {
 
     QtObject {
         id: d
-        readonly property var joinHint: PermissionTypes.getJoinEligibilityHint(root.eligibleToJoinAs)
+        readonly property var joinHint: PermissionTypes.getJoinEligibilityHint(root.eligibleToJoinAs, root.isEditMode, root.isDirty)
     }
 
     RowLayout {

--- a/ui/app/AppLayouts/Communities/controls/PermissionTypes.qml
+++ b/ui/app/AppLayouts/Communities/controls/PermissionTypes.qml
@@ -32,8 +32,12 @@ QtObject {
         return ""
     }
 
-    function getJoinEligibilityHint(type) {
-        const template = qsTr("You are eligible to join as")
+    function getJoinEligibilityHint(type, isEditMode = false, isDirty = false) {
+        var template = qsTr("You are eligible to join as")
+        if (isEditMode) {
+            template = isDirty ? qsTr("You'll be a") : qsTr("You're a")
+        }
+
         switch (type) {
         case PermissionTypes.Type.TokenMaster:
             return [template, qsTr("TokenMaster"), "tiny/token-master"]
@@ -42,6 +46,8 @@ QtObject {
         case PermissionTypes.Type.Member:
             return [template, qsTr("Member"), "tiny/group"]
         case PermissionTypes.Type.None:
+            if (isEditMode)
+                return [qsTr("You'll no longer be a"), qsTr("Member"), "tiny/group"]
             return [qsTr("Not eligible to join with current address selections"), "", ""]
         }
         return ["", "", ""]

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -178,6 +178,8 @@ StatusListView {
         title: model.name
         tertiaryTitle: root.hasPermissions && !tagsCount ? qsTr("No relevant tokens") : ""
 
+        onClicked: shareAddressCheckbox.toggle()
+
         SubmodelProxyModel {
             id: filteredBalances
             sourceModel: root.walletAssetsModel

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -20,7 +20,6 @@ import AppLayouts.Communities.views 1.0
 import AppLayouts.Communities.helpers 1.0
 
 import utils 1.0
-import shared.panels 1.0
 
 Control {
     id: root
@@ -185,15 +184,24 @@ Control {
         spacing: 0
 
         // warning panel
-        ModuleWarning {
+        Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: 32
-            text: d.lostCommunityPermission ? qsTr("Selected addresses have insufficient tokens to maintain %1 membership").arg(root.communityName) :
-                                              d.lostChannelPermissions ? qsTr("By deselecting these addresses, you will lose channel permissions") :
-                                                                         ""
-            active: d.lostCommunityPermission || d.lostChannelPermissions
-            visible: active
-            closeBtnVisible: false
+            color: Theme.palette.dangerColor1
+            visible: d.lostCommunityPermission || d.lostChannelPermissions
+
+            StatusBaseText {
+                width: parent.width
+                anchors.verticalCenter: parent.verticalCenter
+                horizontalAlignment: Qt.AlignHCenter
+                elide: Text.ElideRight
+                text: d.lostCommunityPermission ? qsTr("Selected addresses have insufficient tokens to maintain %1 membership").arg(root.communityName) :
+                                                  d.lostChannelPermissions ? qsTr("By deselecting these addresses, you will lose channel permissions") :
+                                                                             ""
+                font.pixelSize: Style.current.additionalTextSize
+                font.weight: Font.Medium
+                color: Theme.palette.indirectColor1
+            }
         }
 
         // addresses
@@ -293,6 +301,7 @@ Control {
         SharedAddressesPermissionsPanel {
             id: permissionsView
             isEditMode: root.isEditMode
+            isDirty: d.dirty
             permissionsModel: root.permissionsModel
             assetsModel: root.assetsModel
             collectiblesModel: root.collectiblesModel

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -22,6 +22,7 @@ Rectangle {
     required property int /*PermissionTypes.Type*/ eligibleToJoinAs
 
     property bool isEditMode
+    property bool isDirty
 
     property string communityName
     property string communityIcon
@@ -256,7 +257,8 @@ Rectangle {
     CommunityEligibilityTag {
         id: eligibilityHintBubble
         eligibleToJoinAs: root.eligibleToJoinAs
-        visible: !root.isEditMode
+        isEditMode: root.isEditMode
+        isDirty: root.isDirty
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 24
         anchors.horizontalCenter: parent.horizontalCenter
@@ -327,7 +329,7 @@ Rectangle {
                 StatusBaseText {
                     anchors.verticalCenter: parent.verticalCenter
                     font.pixelSize: Theme.tertiaryTextFontSize
-                    text: model.text
+                    text: !!model.text ? model.text : ""
                     color: model.available ? Theme.palette.successColor1 : Theme.palette.baseColor1
                 }
             }

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -32,6 +32,7 @@ Rectangle {
     property var collectiblesModel
 
     property bool requirementsCheckPending
+    property bool joinPermissionsCheckSuccessful
 
     readonly property bool lostPermissionToJoin: d.lostPermissionToJoin
     readonly property bool lostChannelPermissions: d.lostChannelPermissions
@@ -256,6 +257,7 @@ Rectangle {
 
     CommunityEligibilityTag {
         id: eligibilityHintBubble
+        visible: !root.requirementsCheckPending && root.joinPermissionsCheckSuccessful
         eligibleToJoinAs: root.eligibleToJoinAs
         isEditMode: root.isEditMode
         isDirty: root.isDirty

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -18,6 +18,8 @@ QtObject {
     property var communitiesModuleInst: communitiesModule
     property bool newVersionAvailable: false
     readonly property bool requirementsCheckPending: communitiesModuleInst.requirementsCheckPending
+    readonly property bool joinPermissionsCheckSuccessful: communitiesModuleInst.joinPermissionsCheckSuccessful
+    readonly property bool channelsPermissionsCheckSuccessful: communitiesModuleInst.channelsPermissionsCheckSuccessful
     property string latestVersion
     property string downloadURL
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -705,6 +705,7 @@ QtObject {
                 id: dialogRoot
 
                 requirementsCheckPending: root.rootStore.requirementsCheckPending
+                joinPermissionsCheckSuccessful: root.rootStore.joinPermissionsCheckSuccessful
 
                 walletAccountsModel: root.rootStore.walletAccountsModel
                 walletCollectiblesModel: WalletStore.RootStore.collectiblesStore.allCollectiblesModel
@@ -952,7 +953,9 @@ QtObject {
 
                 communityName: chatStore.sectionDetails.name
                 communityIcon: chatStore.sectionDetails.image
+
                 requirementsCheckPending: root.rootStore.requirementsCheckPending
+                joinPermissionsCheckSuccessful: root.rootStore.joinPermissionsCheckSuccessful
 
                 introMessage: chatStore.sectionDetails.introMessage
 

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -173,8 +173,8 @@ StatusStackModal {
 
         readonly property int selectedSharedAddressesCount: d.selectedSharedAddressesMap.size
 
-        readonly property int accessType: d.eligibleToJoinAs !== - 1 ? Constants.communityChatOnRequestAccess
-                                                                     : Constants.communityChatPublicAccess
+        readonly property int accessType: d.eligibleToJoinAs !== -1 ? Constants.communityChatOnRequestAccess
+                                                                    : Constants.communityChatPublicAccess
         property int eligibleToJoinAs: PermissionsHelpers.isEligibleToJoinAs(root.permissionsModel)
         readonly property var _con: Connections {
             target: root.permissionsModel
@@ -444,7 +444,7 @@ StatusStackModal {
                 CommunityEligibilityTag {
                     Layout.alignment: Qt.AlignHCenter
                     eligibleToJoinAs: d.eligibleToJoinAs
-                    visible: !root.isEditMode && !root.isInvitationPending && d.accessType === Constants.communityChatOnRequestAccess
+                    visible: !root.isInvitationPending && d.accessType === Constants.communityChatOnRequestAccess
                 }
             }
         }

--- a/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
+++ b/ui/imports/shared/popups/CommunityMembershipSetupDialog.qml
@@ -90,20 +90,20 @@ StatusStackModal {
             if (root.isInvitationPending)
                 return true
 
-            if (root.requirementsCheckPending || !root.joinPermissionsCheckSuccessful)
+            if (root.requirementsCheckPending && !root.joinPermissionsCheckSuccessful)
                 return false
 
-            if (d.accessType !== Constants.communityChatOnRequestAccess)
+            if (root.joinPermissionsCheckSuccessful || d.accessType !== Constants.communityChatOnRequestAccess)
                 return true
 
             return d.eligibleToJoinAs !== PermissionTypes.Type.None
         }
-        loading: root.requirementsCheckPending && !root.isInvitationPending
+        loading: root.requirementsCheckPending && !root.joinPermissionsCheckSuccessful && !root.isInvitationPending
         tooltip.text: {
             if (interactive)
                 return ""
 
-            if (root.requirementsCheckPending)
+            if (root.requirementsCheckPending && !root.joinPermissionsCheckSuccessful)
                 return qsTr("Requirements check pending")
 
             if (!root.joinPermissionsCheckSuccessful)


### PR DESCRIPTION
Cherry-picks:
https://github.com/status-im/status-desktop/pull/14374
and
https://github.com/status-im/status-desktop/pull/14518

This is to get the fix when you couldn't join an encrypted community even without a permission to join

EDIT: I did add a new commit myself. See https://github.com/status-im/status-desktop/pull/14648/commits/6b01af86c87aef5a5ab193f4543b904449fdd101
What it does is it speeds up the join flow A LOT. Before, we waited for all permisisons to be checked before activating the button to join, but now, it enables the button as soon as we get the response from the `joinPermissionsCheckSuccessful`.
Do check it out @caybro in case I did something wrong, but it's pretty simple.