### PR TITLE
fix(SubmodelProxyModel): model reset emitted properly when roles change

### DIFF
--- a/ui/StatusQ/include/StatusQ/submodelproxymodel.h
+++ b/ui/StatusQ/include/StatusQ/submodelproxymodel.h
@@ -4,8 +4,10 @@
 #include <QPointer>
 
 #include <limits>
+#include <optional>
 
 class QQmlComponent;
+class QQmlEngine;
 
 class SubmodelProxyModel : public QIdentityProxyModel
 {
@@ -34,27 +36,36 @@ signals:
     void delegateModelChanged();
     void submodelRoleNameChanged();
 
+protected slots:
+    void resetInternalData();
+
 private slots:
     void onCustomRoleChanged(QObject* source, int role);
     void emitAllDataChanged();
 
 private:
-    void initializeIfReady();
-    void initialize();
     void initRoles();
+    void updateRoleNames();
 
-    void onDelegateChanged();
+    QStringList fetchAdditionalRoles(QQmlComponent* delegateComponent);
+    QQmlComponent* buildConnectorComponent(
+            const QHash<QString, int>& additionalRoles,
+            QQmlEngine* engine, QObject* parent);
+
+    std::optional<int> findSubmodelRole(const QHash<int, QByteArray>& roleNames,
+                                        const QString& submodelRoleName);
 
     QPointer<QQmlComponent> m_delegateModel;
     QPointer<QQmlComponent> m_connector;
 
     QString m_submodelRoleName;
 
-    bool m_initialized = false;
     bool m_sourceModelDeleted = false;
-    int m_submodelRole = 0;
     bool m_dataChangedQueued = false;
 
+    std::optional<int> m_submodelRole = 0;
+
+    QStringList m_additionalRoles;
     QHash<int, QByteArray> m_roleNames;
     QHash<QString, int> m_additionalRolesMap;
     int m_additionalRolesOffset = std::numeric_limits<int>::max();


### PR DESCRIPTION
### What does the PR do

- fixes the problem observed in `SharedAddressesAccountSelector`
- add many new tests to cover fixed problem and other corner cases

Closes: #14650

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

`SubmodelProxyModel`

### Screenshot of functionality (including design for comparison)

![Screenshot from 2024-05-09 10-08-54](https://github.com/status-im/status-desktop/assets/20650004/9058503d-130f-4606-ab68-930969671bda)
