### PR TITLE
fix: community tag icon is missing

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -31,7 +31,7 @@ Rectangle {
         anchors.centerIn: parent
         width: Math.round(parent.width / 2)
         height: Math.round(parent.height / 2)
-        emojiId: Emoji.iconId(root.emoji, root.emojiSize) || ""
+        emojiId: Emoji.iconId(root.emoji, root.emojiSize) || Emoji.iconHex(root.emoji) || ""
     }
     
     StatusBaseText {
@@ -86,4 +86,3 @@ Rectangle {
         }
     }
 }
-


### PR DESCRIPTION
### What does the PR do

- check for emoji using either `iconId` or `iconHex` as a fallback if the former fails (can happen with some emojis)

Fixes #14599

### Affected areas

Community portal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2024-05-09 13-47-05](https://github.com/status-im/status-desktop/assets/5377645/8914f631-6119-4f50-8122-85d37f9dcdc7)

