### PR TITLE
fix: Messages: Change unfurl image crop aspect ratio to align with Open Graph

### DIFF
--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -28,7 +28,7 @@ CalloutCard {
 
     borderWidth: 1
     implicitHeight: 290
-    implicitWidth: 305
+    implicitWidth: 324+2*borderWidth
     hoverEnabled: true
     dropShadow: d.highlight
     borderColor: d.highlight ? Style.current.background : Style.current.border
@@ -45,6 +45,7 @@ CalloutCard {
             Layout.rightMargin: d.bannerImageMargins
             Layout.topMargin: d.bannerImageMargins
             Layout.preferredHeight: 170
+            Layout.preferredWidth: 324
             active: !!d.bannerImageSource
             sourceComponent: StatusImage {
                 id: bannerImage


### PR DESCRIPTION

Fixes: [13379](https://github.com/status-im/status-desktop/issues/13379)

### What does the PR do

According to the descripbtion in [13379](https://github.com/status-im/status-desktop/issues/13379) and [Figma: Exploring the application of OG aspect ratio image crops for unfurls ](https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/%F0%9F%92%AC-Chat%E2%8E%9CDesktop?type=design&mode=design&t=43aRj8DnMnKLb37q-0) aspect ratios of unfurled images should be 1.91:1 (324px x 170px)

### Affected areas

Chat: LinkPreviewCard.qml

### Screenshot of functionality (including design for comparison)
Using GammaRay to check the actual size of the Image control containing unfurled image indeed shows that the new width is 324px:
![image](https://github.com/status-im/status-desktop/assets/5157464/894b4e83-0f88-449f-be6e-ffee595c5984)

figma design:

![image](https://github.com/status-im/status-desktop/assets/5157464/4e51a044-502f-442b-9ca8-d697b82383ed)



- [x] I've checked the design and this PR matches it