### PR TITLE
fix(StatusWindow): fix changing the window state(s)

### DIFF
--- a/ui/StatusQ/include/StatusQ/statuswindow.h
+++ b/ui/StatusQ/include/StatusQ/statuswindow.h
@@ -1,28 +1,19 @@
 #pragma once
 
 #include <QQuickWindow>
-#include <QScreen>
 
 class StatusWindow: public QQuickWindow
 {
     Q_OBJECT
 
-    Q_PROPERTY(bool isFullScreen READ isFullScreen NOTIFY isFullScreenChanged)
-
 public:
     explicit StatusWindow(QWindow *parent = nullptr);
 
     Q_INVOKABLE void toggleFullScreen();
-    Q_INVOKABLE void updatePosition();
-
-    bool isFullScreen() const;
-
-signals:
-    void isFullScreenChanged();
+    Q_INVOKABLE void toggleMinimize();
+    Q_INVOKABLE void restoreWindowState();
 
 private:
     void removeTitleBar();
     void showTitleBar();
-
-    bool m_isFullScreen;
 };

--- a/ui/StatusQ/src/statuswindow.cpp
+++ b/ui/StatusQ/src/statuswindow.cpp
@@ -1,43 +1,31 @@
 #include "StatusQ/statuswindow.h"
 
 StatusWindow::StatusWindow(QWindow *parent)
-: QQuickWindow(parent),
-  m_isFullScreen(false)
+    : QQuickWindow(parent)
 {
-    removeTitleBar();
+    if (!windowStates().testFlag(Qt::WindowFullScreen))
+        removeTitleBar();
 
     connect(this, &QQuickWindow::windowStateChanged, [&](Qt::WindowState windowState) {
-        if (windowState == Qt::WindowNoState) {
-            removeTitleBar();
-            m_isFullScreen = false;
-            emit isFullScreenChanged();
-        } else if (windowState == Qt::WindowFullScreen) {
-            m_isFullScreen = true;
-            emit isFullScreenChanged();
+        if (windowState == Qt::WindowFullScreen) {
             showTitleBar();
+        } else {
+            removeTitleBar();
         }
     });
 }
 
-void StatusWindow::updatePosition()
+void StatusWindow::restoreWindowState()
 {
-    auto point = QPoint(screen()->geometry().center().x() - geometry().width() / 2,
-                        screen()->geometry().center().y() - geometry().height() / 2);
-    if (point != this->position()) {
-        this->setPosition(point);
-    }
+    setWindowStates(windowStates() & ~Qt::WindowMinimized);
 }
 
 void StatusWindow::toggleFullScreen()
 {
-    if (m_isFullScreen) {
-        showNormal();
-    } else {
-        showFullScreen();
-    }
+    setWindowStates(windowStates() ^ Qt::WindowFullScreen);
 }
 
-bool StatusWindow::isFullScreen() const
+void StatusWindow::toggleMinimize()
 {
-	return m_isFullScreen;
+    setWindowStates(windowStates() ^ Qt::WindowMinimized);
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -122,28 +122,16 @@ StatusWindow {
 
     Action {
         shortcut: StandardKey.FullScreen
-        onTriggered: {
-            if (applicationWindow.visibility === Window.FullScreen) {
-                showNormal()
-            } else {
-                showFullScreen()
-            }
-        }
+        onTriggered: applicationWindow.toggleFullScreen()
     }
 
     Action {
         shortcut: "Ctrl+M"
-        onTriggered: {
-            if (applicationWindow.visibility === Window.Minimized) {
-                showNormal()
-            } else {
-                showMinimized()
-            }
-        }
+        onTriggered: applicationWindow.toggleMinimize()
     }
 
     Action {
-        shortcut: "Ctrl+W"
+        shortcut: StandardKey.Close
         enabled: loader.item && !!loader.item.appLayout && loader.item.appLayout.appView ? loader.item.appLayout.appView.currentIndex === Constants.appViewStackIndex.browser
                              : true
         onTriggered: {
@@ -152,7 +140,7 @@ StatusWindow {
     }
 
     Action {
-        shortcut: "Ctrl+Q"
+        shortcut: StandardKey.Quit
         onTriggered: {
             Qt.quit()
         }
@@ -259,23 +247,20 @@ StatusWindow {
         function onStateChanged() {
             if (Qt.application.state == d.previousApplicationState
                 && Qt.application.state == Qt.ApplicationActive) {
-                applicationWindow.visible = true
-                applicationWindow.showNormal()
+                makeStatusAppActive()
             }
             d.previousApplicationState = Qt.application.state
         }
     }
 
     //TODO remove direct backend access
-	Connections {
+    Connections {
         target: singleInstance
 
         function onSecondInstanceDetected() {
             console.log("User attempted to run the second instance of the application")
             // activating this instance to give user visual feedback
-            applicationWindow.show()
-            applicationWindow.raise()
-            applicationWindow.requestActivate()
+            makeStatusAppActive()
         }
     }
 
@@ -304,7 +289,8 @@ StatusWindow {
     signal navigateTo(string path)
 
     function makeStatusAppActive() {
-        applicationWindow.show()
+        applicationWindow.restoreWindowState()
+        applicationWindow.visible = true
         applicationWindow.raise()
         applicationWindow.requestActivate()
     }
@@ -402,7 +388,7 @@ StatusWindow {
         anchors.top: parent.top
         anchors.margins: 13
 
-        visible: Qt.platform.os === Constants.mac && !applicationWindow.isFullScreen
+        visible: Qt.platform.os === Constants.mac && applicationWindow.visibility !== Window.FullScreen
 
         onClose: {
             if (loader.sourceComponent != app) {
@@ -419,7 +405,7 @@ StatusWindow {
         }
 
         onMinimised: {
-            applicationWindow.showMinimized()
+            applicationWindow.toggleMinimize()
         }
 
         onMaximized: {


### PR DESCRIPTION
### What does the PR do

- since the window can be a combination of several states (e.g. maximized + fullscreen + minimized), use the newer `windowStates()` [flags](https://doc.qt.io/qt-5/qt.html#WindowState-enum) to track and toggle them
- call `makeStatusAppActive()` in all the identical codepaths (clicking tray icon, activating a mac or win instance, running a second instance, etc)
- fixes restoring the window to its previous state(s) when activating from the tray or dock icon
- use some more standard keyboard shortcuts

Fixes #14132

### Affected areas

main.qml, StatusWindow

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-05-10 03-31-33.webm](https://github.com/status-im/status-desktop/assets/5377645/b52a538c-a773-423a-9183-d4454d809d7f)

