### PR TITLE
chore(ci): allow overriding PRODUCTION_PARAMETERS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ $(FCITX5_QT): | check-qt-dir deps
 			.. $(HANDLE_OUTPUT) && \
 		$(FCITX5_QT_BUILD_CMD)
 
-PRODUCTION_PARAMETERS := -d:production
+PRODUCTION_PARAMETERS ?= -d:production
 
 $(STATUS_CLIENT_APPIMAGE): override RESOURCES_LAYOUT := $(PRODUCTION_PARAMETERS)
 $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop $(FCITX5_QT)


### PR DESCRIPTION
This would allow us to create non-prod builds in CI.