### PR TITLE
fix(CommunityPortal): don't show PermissionsRow for free communities

### DIFF
--- a/storybook/pages/CommunitiesPortalDummyModel.qml
+++ b/storybook/pages/CommunitiesPortalDummyModel.qml
@@ -3,6 +3,9 @@ import QtQuick 2.14
 import Models 1.0
 
 ListModel {
+
+    readonly property var emptyModel: ListModel {}
+
     Component.onCompleted: append([
         {
             featured: true,
@@ -97,8 +100,6 @@ ListModel {
             ]),
             permissionsModel: PermissionsModel.moreThanTwoInitialShortPermissionsModel,
             allTokenRequirementsMet: false
-
-
         },
         {
             featured: false,
@@ -136,7 +137,7 @@ ListModel {
             popularity: 4,
             available: true,
             tags: JSON.stringify([]),
-            permissionsModel: PermissionsModel.threeShortPermissionsModelData,
+            permissionsModel: PermissionsModel.channelsOnlyPermissionsModelNotMet,
             allTokenRequirementsMet: false
         },
         {
@@ -183,7 +184,7 @@ ListModel {
             popularity: 4,
             available: true,
             tags: JSON.stringify([]),
-            permissionsModel: PermissionsModel.threeShortPermissionsModel,
+            permissionsModel: PermissionsModel.channelsOnlyPermissionsModel,
             allTokenRequirementsMet: false
         },
         {
@@ -233,7 +234,8 @@ ListModel {
             activeMembers: 0,
             popularity: 4,
             available: true,
-            tags: JSON.stringify([])
+            tags: JSON.stringify([]),
+            permissionsModel: emptyModel
         }
         ])
 }

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -32,9 +32,10 @@ SplitView {
             SplitView.fillHeight: true
 
             assetsModel: AssetsModel {}
-            collectiblesModel:  CollectiblesModel {}
+            collectiblesModel: CollectiblesModel {}
             communitiesStore: CommunitiesStore {
                 readonly property int unreadNotificationsCount: 42
+                readonly property bool createCommunityEnabled: true
                 readonly property string communityTags: ModelsData.communityTags
                 readonly property var curatedCommunitiesModel: SortFilterProxyModel {
 

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -92,7 +92,8 @@ QtObject {
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         }
     ]
 
@@ -103,7 +104,8 @@ QtObject {
             channelsListModel: root.createChannelsModel(),
             permissionType: PermissionTypes.Type.Admin,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: true
         }
     ]
 
@@ -113,21 +115,24 @@ QtObject {
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         },
         {
             holdingsListModel: root.createHoldingsModel2(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: true
         },
         {
             holdingsListModel: root.createHoldingsModel1(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         }
     ]
 
@@ -137,14 +142,16 @@ QtObject {
             channelsListModel: root.createChannelsModel1(),
             permissionType: PermissionTypes.Type.Admin,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: true
+            isPrivate: true,
+            tokenCriteriaMet: false
         },
         {
             holdingsListModel: root.createHoldingsModel2(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: true
         }
     ]
 
@@ -154,14 +161,16 @@ QtObject {
             channelsListModel: root.createChannelsModel1(),
             permissionType: PermissionTypes.Type.Admin,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: true
+            isPrivate: true,
+            tokenCriteriaMet: true
         },
         {
             holdingsListModel: root.createHoldingsModel4(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         }
     ]
 
@@ -171,21 +180,24 @@ QtObject {
             channelsListModel: root.createChannelsModel1(),
             permissionType: PermissionTypes.Type.Admin,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: true
+            isPrivate: true,
+            tokenCriteriaMet: false
         },
         {
             holdingsListModel: root.createHoldingsModel1b(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         },
         {
             holdingsListModel: root.createHoldingsModel2(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         }
     ]
 
@@ -195,28 +207,32 @@ QtObject {
             channelsListModel: root.createChannelsModel1(),
             permissionType: PermissionTypes.Type.Admin,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: true
+            isPrivate: true,
+            tokenCriteriaMet: false
         },
         {
             holdingsListModel: root.createHoldingsModel2(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: false
         },
         {
             holdingsListModel: root.createHoldingsModel3(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: true
         },
         {
             holdingsListModel: root.createHoldingsModel5(),
             channelsListModel: root.createChannelsModel2(),
             permissionType: PermissionTypes.Type.Member,
             permissionState: PermissionTypes.State.Approved,
-            isPrivate: false
+            isPrivate: false,
+            tokenCriteriaMet: true
         }
     ]
 

--- a/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
@@ -3,6 +3,8 @@
 #include <QObject>
 #include <QJsonArray>
 
+#include <optional>
+
 class QAbstractItemModel;
 
 namespace PermissionTypes {
@@ -27,9 +29,15 @@ public:
 
     //!< Check whether the user can join the community and under which (highest possible) role
     //!< @return either:
-    //!          - `NoPermissions` if the permissionsModel is empty or malformed
-    //!          - `Member` if no such join permission(s) exist in the permissionsModel (e.g. when it has channel only permissions)
+    //!          - `NoPermissions` if the permissionsModel is empty or malformed, or has no join type permissions
     //!          - if satisfied: `TokenMaster`, `Admin`, or `Member`, in this order of relevance
+    //!          - `Member` if no such join permission(s) exist in the permissionsModel (e.g. when it has channel only permissions)
     //!          - `None` if no permission to join is satisfied (user can't join at all)
     Q_INVOKABLE int /*PermissionTypes::Type*/ isEligibleToJoinAs(QAbstractItemModel *permissionsModel) const;
+
+    //!< @return true when the @p permissionsModel contains some kind of "join" permission; false when the community is free to join
+    Q_INVOKABLE bool isTokenGatedCommunity(QAbstractItemModel *permissionsModel) const;
+
+private:
+    std::optional<PermissionTypes::Type> isEligibleToJoinAsInternal(QAbstractItemModel *permissionsModel) const;
 };

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -194,7 +194,6 @@ StatusSectionLayout {
                     visible: (d.searchMode && filteredCommunitiesModel.count === 0) || communitiesGrid.isEmpty
                     text: qsTr("No communities found")
                     color: Theme.palette.baseColor1
-                    font.pixelSize: 15
                 }
             }
         }

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -63,6 +63,10 @@ QtObject {
         return Internal.PermissionUtils.isEligibleToJoinAs(model)
     }
 
+    function isTokenGatedCommunity(model) {
+        return Internal.PermissionUtils.isTokenGatedCommunity(model)
+    }
+
     function setHoldingsTextFormat(type, name, amount, decimals) {
         if (typeof amount === "string") {
             amount = AmountsArithmetic.toNumber(AmountsArithmetic.fromString(amount), decimals)


### PR DESCRIPTION
### What does the PR do

- hide the permissions row and tokens when the community is free to join
- fix evaluating the `requirementsMet` property which affects the lock icon state (that role was never part of the model) -> the lock icon is now correctly opened/closed based on whether we are eligible to join or not
- add a helper C++ method `isTokenGatedCommunity`
- adjust the SB models, adding different variations of the permissionsModel for the CommunitiesPortalLayoutPage

Fixes #14671

### Affected areas

Community Portal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Community Portal with Status CC (free to join):
![image](https://github.com/status-im/status-desktop/assets/5377645/1d9a3920-efc9-4a43-836e-b302b4a13879)

CommunitiesPortalLayout in SB with different permissions models:
![image](https://github.com/status-im/status-desktop/assets/5377645/342ddc29-4977-4a94-b9b2-bc9f62fd4576)

