### PR TITLE
fix(keycard): unable to import account from keycard

### DIFF
--- a/src/app/modules/startup/internal/biometrics_state.nim
+++ b/src/app/modules/startup/internal/biometrics_state.nim
@@ -13,7 +13,7 @@ proc delete*(self: BiometricsState) =
 method getNextPrimaryState*(self: BiometricsState, controller: Controller): State =
   if self.flowType == FlowType.FirstRunOldUserImportSeedPhrase or
     self.flowType == FlowType.FirstRunOldUserKeycardImport:
-    return createState(StateType.ProfileFetching, self.flowType, self)
+    return createState(StateType.ProfileFetching, self.flowType, nil)
   return nil
 
 method getNextSecondaryState*(self: BiometricsState, controller: Controller): State =

--- a/src/app/modules/startup/internal/keycard_enter_pin_state.nim
+++ b/src/app/modules/startup/internal/keycard_enter_pin_state.nim
@@ -56,7 +56,7 @@ method resolveKeycardNextState*(self: KeycardEnterPinState, keycardFlowType: str
     if keycardFlowType == ResponseTypeValueKeycardFlowResult:
       controller.setKeycardEvent(keycardEvent)
       if not main_constants.IS_MACOS:
-        controller.setupKeycardAccount(storeToKeychain = false)
-        return nil
+        controller.setupKeycardAccount(storeToKeychain = false, recoverAccount = true)
+        return createState(StateType.ProfileFetching, self.flowType, nil)
       let backState = findBackStateWithTargetedStateType(self, StateType.RecoverOldUser)
       return createState(StateType.Biometrics, self.flowType, backState)

--- a/src/app/modules/startup/internal/keycard_wrong_puk_state.nim
+++ b/src/app/modules/startup/internal/keycard_wrong_puk_state.nim
@@ -39,8 +39,8 @@ method resolveKeycardNextState*(self: KeycardWrongPukState, keycardFlowType: str
       controller.setKeycardEvent(keycardEvent)
       controller.setPukValid(true)
       if not main_constants.IS_MACOS:
-        controller.setupKeycardAccount(storeToKeychain = false)
-        return nil
+        controller.setupKeycardAccount(storeToKeychain = false, recoverAccount = true)
+        return createState(StateType.ProfileFetching, self.flowType, nil)
       let backState = findBackStateWithTargetedStateType(self, StateType.RecoverOldUser)
       return createState(StateType.Biometrics, self.flowType, backState)
   if self.flowType == FlowType.AppLogin:


### PR DESCRIPTION
Handling for recovering Status profile for Linux updated since we don't use biometrics for Linux and that requires slightly different flow.

Closes: #14673