### PR TITLE
feat(Settings): remove UI scaling option panel

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -38,22 +38,6 @@ SettingsContentBase {
         appearanceView.updateFontSize(localAccountSensitiveSettings.fontSize)
     }
 
-    readonly property var priv: QtObject {
-        id: priv
-
-        readonly property real savedDpr: {
-            const scaleFactorStr = appearanceView.appearanceStore.readTextFile(uiScaleFilePath)
-            if (scaleFactorStr === "") {
-                return 1
-            }
-            const scaleFactor = parseFloat(scaleFactorStr)
-            if (isNaN(scaleFactor)) {
-                return 1
-            }
-            return scaleFactor
-        }
-    }
-
     Item {
         id: appearanceContainer
         anchors.left: !!parent ? parent.left : undefined
@@ -127,51 +111,9 @@ SettingsContentBase {
             }
         }
 
-        StatusSectionHeadline {
-            id: labelZoom
-            anchors.top: fontSizeSlider.bottom
-            anchors.topMargin: Style.current.bigPadding*2
-            anchors.left: parent.left
-            anchors.right: parent.right
-            text: qsTr("Zoom (requires restart)")
-        }
-
-        StatusQ.StatusLabeledSlider {
-            id: zoomSlider
-
-            readonly property int initialValue: priv.savedDpr * 100
-            readonly property bool dirty: value !== initialValue
-
-            anchors.top: labelZoom.bottom
-            anchors.topMargin: Style.current.padding
-            width: parent.width
-            from: 50
-            to: 300
-            stepSize: 25
-            model: [ qsTr("50%"), qsTr("75%"), qsTr("100%"), qsTr("125%"), qsTr("150%"), qsTr("175%"), qsTr("200%"),
-                qsTr("225%"), qsTr("250%"), qsTr("275%"), qsTr("300%")]
-            value: initialValue
-            onMoved: {
-                const uiScale = zoomSlider.value === 100 ? "" // reset to native highdpi
-                                                         : zoomSlider.value / 100.0
-                appearanceView.appearanceStore.writeTextFile(uiScaleFilePath, uiScale)
-            }
-            onPressedChanged: {
-                if (!pressed && dirty) {
-                    confirmAppRestartModal.open()
-                }
-            }
-
-            ConfirmAppRestartModal {
-                id: confirmAppRestartModal
-                onAccepted: Utils.restartApplication();
-                onClosed: zoomSlider.value = zoomSlider.initialValue
-            }
-        }
-
         Rectangle {
             id: modeSeparator
-            anchors.top: zoomSlider.bottom
+            anchors.top: fontSizeSlider.bottom
             anchors.topMargin: Style.current.padding*3
             anchors.left: parent.left
             anchors.right: parent.right

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -25,8 +25,8 @@ StatusWindow {
 
     id: applicationWindow
     objectName: "mainWindow"
-    minimumWidth: 1200 / Screen.devicePixelRatio
-    minimumHeight: 680 / Screen.devicePixelRatio
+    minimumWidth: 1200
+    minimumHeight: 680
     color: Style.current.background
     title: {
         // Set application settings

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -161,24 +161,10 @@ char *dos_qguiapplication_application_dir_path()
 
 void dos_qguiapplication_enable_hdpi(const char *uiScaleFilePath)
 {
+    Q_UNUSED(uiScaleFilePath)
+
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-
-    QFile scaleFile(QString::fromUtf8(uiScaleFilePath));
-    if (scaleFile.open(QIODevice::ReadOnly)) {
-        const auto scaleStr = scaleFile.readAll();
-        bool ok = false;
-        const auto scale = scaleStr.toDouble(&ok);
-        if (ok) {
-            // we want to scale the app on our own
-            qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "0");
-            // workaround for bug/feature when Qt would bail out if the scale is "1" and revert to DPI based scaling
-            constexpr auto unaryScale = 1.1;
-            qputenv("QT_SCREEN_SCALE_FACTORS", QByteArray::number(unaryScale));
-            // compensate for the workaround above so that we get the desired scale factor
-            qputenv("QT_SCALE_FACTOR", QByteArray::number(scale/unaryScale, 'f', 2));
-        }
-    }
 }
 
 void dos_qguiapplication_initialize_opengl()
@@ -193,12 +179,12 @@ void dos_qtwebview_initialize()
 
 void dos_qguiapplication_try_enable_threaded_renderer()
 {
-    if(QSysInfo::kernelType() == "darwin" && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    if(QSysInfo::kernelType() == QLatin1String("darwin") && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     {
         //Threaded renderer is crashing on M1 Macs
         return;
     }
-    qputenv("QSG_RENDER_LOOP", "threaded");
+    qputenv("QSG_RENDER_LOOP", QByteArrayLiteral("threaded"));
 }
 
 // This catches the QT and QML logs and outputs them.


### PR DESCRIPTION
### What does the PR do

- as discussed with Design, do not allow the user to select the UI scale option from Settings as it causes many problems; instead rely on the OS/Qt HighDPI support to handle the scaling for us
- note however, for advanced users, it's still possible to specify the UI scale manually by exporting the standard `QT_SCALE_FACTOR` prior to starting the app
- in the longterm, we will come with our own scaling solution at the QML level, independent from the OS

Fixes #14137

### Affected areas

Settings/Appearance

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/82551a28-a5e9-4dbf-b8be-3af325aa635a)

