### PR TITLE
fix: Reload contact info whenever the profile dirty flag is dropped

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -129,6 +129,11 @@ Pane {
         d.reload()
     }
 
+    onDirtyChanged: {
+        if (!dirty)
+            d.reload()
+    }
+
     Component {
         id: btnEditProfileComponent
         StatusButton {
@@ -504,8 +509,7 @@ Pane {
                     font.bold: true
                     font.pixelSize: 22
                     elide: Text.ElideRight
-                    text: root.dirty ? root.dirtyValues.displayName
-                                     : StatusQUtils.Emoji.parse(d.mainDisplayName, StatusQUtils.Emoji.size.middle)
+                    text: StatusQUtils.Emoji.parse(root.dirty ? root.dirtyValues.displayName : d.mainDisplayName, StatusQUtils.Emoji.size.middle)
                 }
                 StatusContactVerificationIcons {
                     id: verificationIcons
@@ -633,7 +637,8 @@ Pane {
                     Layout.preferredHeight: 300
 
                     currentTabIndex: showcaseTabBar.currentIndex
-                    mainDisplayName: d.mainDisplayName
+                    mainDisplayName: root.dirty ? root.dirtyValues.displayName
+                                     : d.mainDisplayName
                     readOnly: root.readOnly
                     
                     communitiesModel: root.showcaseCommunitiesModel

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -50,6 +50,8 @@ Control {
         property int delegateHeightS: 152
         property int delegateWidthM: 202
         property int delegateHeightM: 160
+
+        readonly property string displayNameVerySmallEmoji: StatusQUtils.Emoji.parse(root.mainDisplayName, StatusQUtils.Emoji.size.verySmall)
     }
 
     component PositionSFPM: SortFilterProxyModel {
@@ -127,7 +129,7 @@ Control {
             cellWidth: d.delegateWidthM
             cellHeight: d.delegateHeightM
 
-            mainDisplayName: root.mainDisplayName
+            mainDisplayName: d.displayNameVerySmallEmoji
             readOnly: root.readOnly
             globalAssetsModel: root.globalAssetsModel
             globalCollectiblesModel: root.globalCollectiblesModel
@@ -142,7 +144,7 @@ Control {
             width: parent.width
             height: parent.height
 
-            mainDisplayName: root.mainDisplayName
+            mainDisplayName: d.displayNameVerySmallEmoji
             sendToAccountEnabled: root.sendToAccountEnabled
             accountsModel: accountsProxyModel
             walletStore: root.walletStore
@@ -160,7 +162,7 @@ Control {
             cellWidth: d.delegateWidthS
             cellHeight: d.delegateHeightS
 
-            mainDisplayName: root.mainDisplayName
+            mainDisplayName: d.displayNameVerySmallEmoji
             collectiblesModel: collectiblesProxyModel
             walletStore: root.walletStore
 
@@ -199,7 +201,7 @@ Control {
             cellWidth: d.delegateWidthS
             cellHeight: d.delegateHeightS
 
-            mainDisplayName: root.mainDisplayName
+            mainDisplayName: d.displayNameVerySmallEmoji
             socialLinksModel: socialLinksProxyModel
 
             onCopyToClipboard: root.copyToClipboard(text)


### PR DESCRIPTION

### What does the PR do

closes #14573 

We need to manually request the contact information again because the contact object is not live

Other:
Propagate live values to showcase view
Parse display name emojis in the showcase view as well
Parse display name emojis for dirty values as well

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Profile dialog
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/36e22aa6-db9d-454a-a05b-9653ef44db32



https://github.com/status-im/status-desktop/assets/47811206/2144d75e-ad62-45f9-8384-4e07faf9a4d5


