### PR TITLE
14220 check permissions light mode

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -92,14 +92,14 @@ proc getMySectionId*(self: Controller): string =
 proc asyncCheckPermissionsToJoin*(self: Controller) =
   if self.delegate.getPermissionsToJoinCheckOngoing():
     return
-  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId(), addresses = @[])
+  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId(), addresses = @[], fullCheck = false)
   self.delegate.setPermissionsToJoinCheckOngoing(true)
 
 proc asyncCheckAllChannelsPermissions*(self: Controller) =
   if self.allChannelsPermissionCheckOngoing:
     return
   self.allChannelsPermissionCheckOngoing = true
-  self.chatService.asyncCheckAllChannelsPermissions(self.getMySectionId(), addresses = @[])
+  self.chatService.asyncCheckAllChannelsPermissions(self.getMySectionId(), addresses = @[], fullCheck = false)
   self.delegate.setChannelsPermissionsCheckOngoing(true)
 
 proc asyncCheckChannelPermissions*(self: Controller, communityId: string, chatId: string) =

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -404,11 +404,11 @@ proc authenticate*(self: Controller) =
 proc getCommunityPublicKeyFromPrivateKey*(self: Controller, communityPrivateKey: string): string =
   result = self.communityService.getCommunityPublicKeyFromPrivateKey(communityPrivateKey)
 
-proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string]) =
-  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare)
+proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string], fullCheck: bool) =
+  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare, fullCheck)
 
-proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string]) =
-  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
+proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string], fullCheck: bool) =
+  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses, fullCheck)
 
 proc asyncGetRevealedAccountsForMember*(self: Controller, communityId, memberPubkey: string) =
   self.communityService.asyncGetRevealedAccountsForMember(communityId, memberPubkey)

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -857,11 +857,11 @@ method getCommunityPublicKeyFromPrivateKey*(self: Module, communityPrivateKey: s
 method checkPermissions*(self: Module, communityId: string, sharedAddresses: seq[string]) =
   self.joiningCommunityDetails.communityIdForPermissions = communityId
 
-  self.controller.asyncCheckPermissionsToJoin(communityId, sharedAddresses)
+  self.controller.asyncCheckPermissionsToJoin(communityId, sharedAddresses, fullCheck = true)
   self.view.setJoinPermissionsCheckSuccessful(false)
   self.checkingPermissionToJoinInProgress = true
 
-  self.controller.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
+  self.controller.asyncCheckAllChannelsPermissions(communityId, sharedAddresses, fullCheck = true)
   self.view.setChannelsPermissionsCheckSuccessful(false)
   self.checkingAllChannelPermissionsInProgress = true
 

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -209,11 +209,22 @@ type
   AsyncCheckPermissionsToJoinTaskArg = ref object of QObjectTaskArg
     communityId: string
     addresses: seq[string]
+    fullCheck: bool
 
 const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckPermissionsToJoinTaskArg](argEncoded)
   try:
-    let response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses)
+    var response = JsonNode()
+    if not arg.fullCheck:
+      let hasPermissionToJoin = status_go.checkPermissionsToJoinCommunityLight(arg.communityId, arg.addresses).result.getBool
+      if hasPermissionToJoin:
+        let permissionToJoin = CheckPermissionsToJoinResponseDto(satisfied: true)
+        response = %permissionToJoin
+      else:
+        response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses).result
+    else:
+      response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses).result
+
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -103,6 +103,12 @@ proc checkPermissionsToJoinCommunity*(communityId: string, addresses: seq[string
     "addresses": addresses
   }])
 
+proc checkPermissionsToJoinCommunityLight*(communityId: string, addresses: seq[string]): RpcResponse[JsonNode] =
+  result = callPrivateRPC("checkPermissionsToJoinCommunityLight".prefix, %*[{
+    "communityId": communityId,
+    "addresses": addresses
+  }])
+
 proc reevaluateCommunityMembersPermissions*(
     communityId: string,
   ): RpcResponse[JsonNode] =
@@ -120,6 +126,17 @@ proc checkAllCommunityChannelsPermissions*(communityId: string, addresses: seq[s
   result = callPrivateRPC("checkAllCommunityChannelsPermissions".prefix, %*[{
     "communityId": communityId,
     "addresses": addresses,
+  }])
+
+proc checkCommunityChannelPermissionsLight*(communityId: string, chatId: string): RpcResponse[JsonNode] =
+  result = callPrivateRPC("checkCommunityChannelPermissionsLight".prefix, %*[{
+    "communityId": communityId,
+    "chatId": chatId
+  }])
+
+proc checkAllCommunityChannelsPermissionsLight*(communityId: string): RpcResponse[JsonNode] =
+  result = callPrivateRPC("checkAllCommunityChannelsPermissionsLight".prefix, %*[{
+    "communityId": communityId
   }])
 
 proc allNonApprovedCommunitiesRequestsToJoin*(): RpcResponse[JsonNode] =


### PR DESCRIPTION
Light functions are used first in order to reduce the number of calls to blockchain.
If the permission is not met (user is not a member of community/channel member list), then normal permissions-check function is used.

status-go [pr](https://github.com/status-im/status-go/pull/5168)

Issue #14220

https://github.com/status-im/status-desktop/assets/61889657/c5d6e409-d331-4aba-9d9c-b4e44f896089

