### PR TITLE
Chore/add object name rename keypair item

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/RenameKeypairPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/RenameKeypairPopup.qml
@@ -140,6 +140,7 @@ StatusModal {
         },
         StatusButton {
             text: qsTr("Save changes")
+            objectName: "saveRenameKeypairChangesButton"
             enabled: d.entryValid
             focus: true
             Keys.onReturnPressed: function(event) {

--- a/ui/app/AppLayouts/Profile/popups/WalletKeypairAccountMenu.qml
+++ b/ui/app/AppLayouts/Profile/popups/WalletKeypairAccountMenu.qml
@@ -80,6 +80,7 @@ StatusMenu {
 
     StatusAction {
         text: enabled? qsTr("Rename keypair") : ""
+        objectName: "renameKeypairMenuItem"
         enabled: !!root.keyPair &&
                  root.keyPair.pairType !== Constants.keypair.type.profile
         icon.name: "edit"


### PR DESCRIPTION
### What does the PR do

Add object names for save changes button and rename keypair menu item

### Affected areas

ui/app/AppLayouts/Profile/popups/RenameKeypairPopup.qml
ui/app/AppLayouts/Profile/popups/WalletKeypairAccountMenu.qml

