### PR TITLE
Fix(settings): crash when enabling history archive and disabling logs

### DIFF
--- a/src/backend/node_config.nim
+++ b/src/backend/node_config.nim
@@ -41,3 +41,13 @@ proc disableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
   except RpcException as e:
     error "error doing rpc request", methodName = "disableCommunityHistoryArchiveProtocol", exception=e.msg
     raise newException(RpcException, e.msg)
+
+proc  setLogLevel*(logLevel: LogLevel): RpcResponse[JsonNode] =
+  try:
+    let payload = %*[{
+      "logLevel": $logLevel
+    }]
+    result = core.callPrivateRPC("setLogLevel".prefix, payload)
+  except RpcException as e:
+    error "error doing rpc request", methodName = "setLogLevel", exception=e.msg
+    raise newException(RpcException, e.msg)


### PR DESCRIPTION
fixes #14643
(see more details in the ticket)

### What does the PR do

using a separate method to change log level

### Affected areas

settings, community archive protocol

### Screenshot of functionality (including design for comparison)

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://github.com/status-im/status-desktop/assets/1083341/864abc05-3b00-42c7-905e-fc1a5329fcaf



### Further improvements

* The `saveConfiguration` method overwrites NodeConfig fields it doesn't know about. It will lead to a crash if archive protocol is enabled. Replace all usages of this method and make the corresponding methods rewrite only updated fields (see `SetLogLevel, enableCommunityHistoryArchiveSupport`):
    * saveNewWakuNode
    * setV2LightMode
    * setNimbusProxyConfig
    * setMaxLogBackups
https://github.com/status-im/status-desktop/issues/12918

* Validate NodeConfig before writing to the database. Fix validation issues when APIModules and KeycardPairingDataFile are missing. Add KeycardPairingDataFile to node_config table.
https://github.com/status-im/status-desktop/issues/14813