### PR TITLE
fix(mute): fix muted community still sending notifs and having a badge

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -372,6 +372,11 @@ proc init*(self: Controller) =
       if args.communityId == self.sectionId:
         self.delegate.communityMemberReevaluationStatusUpdated(args.status)
 
+    self.events.on(SIGNAL_COMMUNITY_MUTED) do(e: Args):
+      let args = CommunityMutedArgs(e)
+      if args.communityId == self.sectionId:
+        self.delegate.onSectionMutedChanged()
+
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.onContactDetailsUpdated(args.contactId)
@@ -490,9 +495,9 @@ proc getChatsAndBuildUI*(self: Controller) =
         self.sharedUrlsService,
       )
 
-proc sectionUnreadMessagesAndMentionsCount*(self: Controller, communityId: string):
+proc sectionUnreadMessagesAndMentionsCount*(self: Controller, communityId: string, sectionIsMuted: bool):
     tuple[unviewedMessagesCount: int, unviewedMentionsCount: int] =
-  return self.chatService.sectionUnreadMessagesAndMentionsCount(communityId)
+  return self.chatService.sectionUnreadMessagesAndMentionsCount(communityId, sectionIsMuted)
 
 proc getChatDetails*(self: Controller, chatId: string): ChatDto =
   return self.chatService.getChatById(chatId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -97,6 +97,9 @@ method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto) {.base.} =
 method onMarkMessageAsUnread*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onSectionMutedChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onCommunityMuted*(self: AccessInterface, chatId: string, muted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -496,9 +496,9 @@ proc setActiveSectionId*(self: Controller, sectionId: string) =
 proc getAllChats*(self: Controller): seq[ChatDto] =
   result = self.chatService.getAllChats()
 
-proc sectionUnreadMessagesAndMentionsCount*(self: Controller, communityId: string):
+proc sectionUnreadMessagesAndMentionsCount*(self: Controller, communityId: string, sectionIsMuted: bool):
     tuple[unviewedMessagesCount: int, unviewedMentionsCount: int] =
-  return self.chatService.sectionUnreadMessagesAndMentionsCount(communityId)
+  return self.chatService.sectionUnreadMessagesAndMentionsCount(communityId, sectionIsMuted)
 
 proc setCurrentUserStatus*(self: Controller, status: StatusType) =
   if(self.settingsService.saveSendStatusUpdates(status)):

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -331,7 +331,10 @@ proc createCommunitySectionItem[T](self: Module[T], communityDetails: CommunityD
     # We will update the model later when we finish loading the accounts
     self.controller.asyncGetRevealedAccountsForAllMembers(communityDetails.id)
 
-  let (unviewedCount, notificationsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(communityDetails.id)
+  let (unviewedCount, notificationsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
+    communityDetails.id,
+    communityDetails.muted,
+  )
 
   let hasNotification = unviewedCount > 0 or notificationsCount > 0
   let active = self.getActiveSectionId() == communityDetails.id # We must pass on if the current item section is currently active to keep that property as it is
@@ -665,7 +668,10 @@ method onChatsLoaded*[T](
     sharedUrlsService,
     networkService
   )
-  let (unviewedMessagesCount, unviewedMentionsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(myPubKey)
+  let (unviewedMessagesCount, unviewedMentionsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
+    myPubKey,
+    sectionIsMuted = false
+  )
   let personalChatSectionItem = initItem(
     myPubKey,
     sectionType = SectionType.Chat,
@@ -1091,7 +1097,8 @@ method communityEdited*[T](
   var communitySectionItem = self.createCommunitySectionItem(community)
   # We need to calculate the unread counts because the community update doesn't come with it
   let (unviewedMessagesCount, unviewedMentionsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
-    communitySectionItem.id
+    communitySectionItem.id,
+    communitySectionItem.muted,
   )
   communitySectionItem.setHasNotification(unviewedMessagesCount > 0)
   communitySectionItem.setNotificationsCount(unviewedMentionsCount)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -219,24 +219,24 @@ QtObject:
   proc hasChannel*(self: Service, chatId: string): bool =
     self.chats.hasKey(chatId)
 
-  proc sectionUnreadMessagesAndMentionsCount*(self: Service, sectionId: string):
+  proc sectionUnreadMessagesAndMentionsCount*(self: Service, sectionId: string, sectionIsMuted: bool):
       tuple[unviewedMessagesCount: int, unviewedMentionsCount: int] =
 
     result.unviewedMentionsCount = 0
     result.unviewedMessagesCount = 0
 
     let myPubKey = singletonInstance.userProfile.getPubKey()
-    var seactionIdToFind = sectionId
+    var sectionIdToFind = sectionId
     if sectionId == myPubKey:
-      # If the section is the personal one (ID == pubKey), then we set the seactionIdToFind to ""
+      # If the section is the personal one (ID == pubKey), then we set the sectionIdToFind to ""
       # because personal chats have communityId == ""
-      seactionIdToFind = ""
+      sectionIdToFind = ""
     for _, chat in self.chats:
-      if chat.communityId != seactionIdToFind:
+      if chat.communityId != sectionIdToFind:
         continue
       result.unviewedMentionsCount += chat.unviewedMentionsCount
       # We count the unread messages if we are unmuted and it's not a mention, we want to show a badge on mentions
-      if chat.unviewedMentionsCount == 0 and chat.muted:
+      if chat.unviewedMentionsCount == 0 and (chat.muted or sectionIsMuted):
         continue
       if chat.unviewedMessagesCount > 0:
         result.unviewedMessagesCount = result.unviewedMessagesCount + chat.unviewedMessagesCount

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2213,6 +2213,9 @@ QtObject:
         return
 
       let muted = if (MutedType(mutedType) == MutedType.Unmuted): false else: true
+
+      self.communities[communityId].muted = muted
+
       self.events.emit(SIGNAL_COMMUNITY_MUTED,
         CommunityMutedArgs(communityId: communityId, muted: muted))
     except Exception as e:


### PR DESCRIPTION
Fixes #14816

The muted property on the community was never checked anywhere. I don't know how it ever worked, but oh well.

I also made it so that when the mute property on the community changes, the badge gets re-evaluated.

[muted-community.webm](https://github.com/status-im/status-desktop/assets/11926403/c9231d98-f2f1-472a-ad2a-29cf2695cd9a)
