### PR TITLE
fix(Communities): Show channel for non-members when read-only, tokenless permission is set

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -155,6 +155,44 @@ StackLayout {
                              root.sectionItemModel.memberRole === Constants.memberRole.admin ||
                              root.sectionItemModel.memberRole === Constants.memberRole.tokenMaster
             hasViewOnlyPermissions: root.permissionsStore.viewOnlyPermissionsModel.count > 0
+
+            hasUnrestrictedViewOnlyPermission: {
+                viewOnlyUnrestrictedPermissionHelper.revision
+
+                const model = root.permissionsStore.viewOnlyPermissionsModel
+                const count = model.rowCount()
+
+                for (let i = 0; i < count; i++) {
+                    const holdings = ModelUtils.get(model, i, "holdingsListModel")
+
+                    if (holdings.rowCount() === 0)
+                        return true
+                }
+
+                return false
+            }
+
+            Instantiator {
+                id: viewOnlyUnrestrictedPermissionHelper
+
+                model: root.permissionsStore.viewOnlyPermissionsModel
+
+                property int revision: 0
+
+                delegate: QObject {
+                    ModelChangeTracker {
+                        model: model.holdingsListModel
+
+                        onRevisionChanged: viewOnlyUnrestrictedPermissionHelper.revision++
+                    }
+                }
+            }
+
+            ModelChangeTracker {
+                model: root.permissionsStore.viewOnlyPermissionsModel
+                onRevisionChanged: viewOnlyUnrestrictedPermissionHelper.revision++
+            }
+
             hasViewAndPostPermissions: root.permissionsStore.viewAndPostPermissionsModel.count > 0
             viewOnlyPermissionsModel: root.permissionsStore.viewOnlyPermissionsModel
             viewAndPostPermissionsModel: root.permissionsStore.viewAndPostPermissionsModel

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -51,7 +51,10 @@ StatusSectionLayout {
     readonly property var chatContentModule: rootStore.currentChatContentModule() || null
     readonly property bool viewOnlyPermissionsSatisfied: chatContentModule.viewOnlyPermissionsSatisfied
     readonly property bool viewAndPostPermissionsSatisfied: chatContentModule.viewAndPostPermissionsSatisfied
+
     property bool hasViewOnlyPermissions: false
+    property bool hasUnrestrictedViewOnlyPermission: false
+
     property bool hasViewAndPostPermissions: false
     property bool amIMember: false
     property bool amISectionAdmin: false
@@ -92,6 +95,9 @@ StatusSectionLayout {
             return false
         }
         if (!amIMember) {
+            if (hasUnrestrictedViewOnlyPermission)
+                return false
+
             return hasViewAndPostPermissions || hasViewOnlyPermissions
         }
         if (amISectionAdmin) {


### PR DESCRIPTION
### What does the PR do

When channel has view-only permission not requiring any holdings, the channel is not encrypted and should be presented to non-members in read-only mode.

There is additional flag introduced `hasUnrestrictedViewOnlyPermission` reflecting described condition. If `true`, the channel overlay is not presented.

Closes: #14439

### Affected areas
`ChatLayout`

### Screenshot of functionality (including design for comparison)

[Screencast from 17.05.2024 11:53:34.webm](https://github.com/status-im/status-desktop/assets/20650004/cd60375f-c947-413f-9501-8e8193f72a92)

