### PR TITLE
fix: The emoji color selector animation is out of bounds

### DIFF
--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -225,6 +225,7 @@ Popup {
             Row {
                 id: skinToneEmoji
                 property bool expandSkinColorOptions: false
+                clip: true
                 width: expandSkinColorOptions ? (22 * skinColorEmojiRepeater.count) : 22
                 height: 22
                 opacity: expandSkinColorOptions ? 1.0 : 0.0


### PR DESCRIPTION
Issue #14744

### What does the PR do

fix the emoji color selector animation is out of bounds

### Affected areas

StatusEmojiPopup

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
[Mdias 2024-05-17.16-20.webm](https://github.com/status-im/status-desktop/assets/8908607/208be58b-6188-4f09-876a-01a21b4fb13b)
