### PR TITLE
StatusLetterIdenticon: Aligning avatar initials display with mobile

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -14,12 +14,15 @@ Rectangle {
     property int charactersLen: 1
     property color letterIdenticonColor: Theme.palette.miscColor5
     property bool useAcronymForLetterIdenticon: false
+    property bool strictBackgroundColor: !useAcronymForLetterIdenticon
 
     color: {
-        if (root.useAcronymForLetterIdenticon) {
-            return Qt.rgba(root.letterIdenticonColor.r, root.letterIdenticonColor.g, root.letterIdenticonColor.b, 0.2)
-        }
-        return root.letterIdenticonColor
+        if (root.strictBackgroundColor)
+            return root.letterIdenticonColor
+
+        return Qt.rgba(root.letterIdenticonColor.r,
+                       root.letterIdenticonColor.g,
+                       root.letterIdenticonColor.b, 0.2)
     }
 
     width: 40
@@ -33,7 +36,7 @@ Rectangle {
         height: Math.round(parent.height / 2)
         emojiId: Emoji.iconId(root.emoji, root.emojiSize) || Emoji.iconHex(root.emoji) || ""
     }
-    
+
     StatusBaseText {
         id: identiconText
 
@@ -47,9 +50,9 @@ Rectangle {
         font.weight: Font.Bold
         font.pixelSize: root.letterSize
         color: {
-            if (root.useAcronymForLetterIdenticon) {
+            if (!root.strictBackgroundColor)
                 return root.letterIdenticonColor
-            }
+
             return d.luminance(root.letterIdenticonColor) > 0.5 ? Qt.rgba(0, 0, 0, 0.5) : Qt.rgba(1, 1, 1, 0.7)
         }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -21,10 +21,10 @@ Rectangle {
     //
     // characterLen is ignored
     property bool useAcronymForLetterIdenticon: false
-    property bool strictBackgroundColor: !useAcronymForLetterIdenticon
+    property bool backgroundWithAlpha: useAcronymForLetterIdenticon
 
     color: {
-        if (root.strictBackgroundColor)
+        if (!root.backgroundWithAlpha)
             return root.letterIdenticonColor
 
         return Qt.rgba(root.letterIdenticonColor.r,
@@ -57,7 +57,7 @@ Rectangle {
         font.weight: Font.Bold
         font.pixelSize: root.letterSize
         color: {
-            if (!root.strictBackgroundColor)
+            if (root.backgroundWithAlpha)
                 return root.letterIdenticonColor
 
             return d.luminance(root.letterIdenticonColor) > 0.5 ? Qt.rgba(0, 0, 0, 0.5) : Qt.rgba(1, 1, 1, 0.7)

--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -13,6 +13,13 @@ Rectangle {
     property int letterSize: 21
     property int charactersLen: 1
     property color letterIdenticonColor: Theme.palette.miscColor5
+
+    // In this mode, one or two letters are used depending on words used:
+    // John -> J
+    // John Smith -> JS
+    // John Smith Junior -> JS
+    //
+    // characterLen is ignored
     property bool useAcronymForLetterIdenticon: false
     property bool strictBackgroundColor: !useAcronymForLetterIdenticon
 
@@ -57,19 +64,18 @@ Rectangle {
         }
 
         text: {
-            let parts = root.name.split(" ")
-            if (root.useAcronymForLetterIdenticon && parts.length > 1) {
-                let word = ""
-                for (let i=0; i<root.charactersLen; i++) {
-                    if (i >= parts.length) {
-                        return word
-                    }
+            const parts = root.name.split(" ")
 
+            if (root.useAcronymForLetterIdenticon) {
+                let word = ""
+
+                for (let i = 0; i < Math.min(parts.length, 2); i++) {
                     let shift = (parts[i].charAt(0) === "#") ||
                                 (parts[i].charAt(0) === "@")
 
                     word += parts[i].substring(shift, shift + 1).toUpperCase()
                 }
+
                 return word
             }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -120,6 +120,7 @@ Loader {
             letterSize: root.asset.letterSize
             charactersLen: root.asset.charactersLen
             useAcronymForLetterIdenticon: root.asset.useAcronymForLetterIdenticon
+            strictBackgroundColor: root.asset.useLetterIdenticonStrictBgColor
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -120,7 +120,7 @@ Loader {
             letterSize: root.asset.letterSize
             charactersLen: root.asset.charactersLen
             useAcronymForLetterIdenticon: root.asset.useAcronymForLetterIdenticon
-            strictBackgroundColor: root.asset.useLetterIdenticonStrictBgColor
+            backgroundWithAlpha: root.asset.letterIdenticonBgWithAlpha
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusIconTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusIconTabButton.qml
@@ -32,6 +32,8 @@ TabButton {
             asset.height: asset.isImage ? 28 : statusIconTabButton.icon.height
             asset.color: (statusIconTabButton.hovered || highlighted || statusIconTabButton.checked) ? Theme.palette.primaryColor1 : statusIconTabButton.icon.color
             asset.isLetterIdenticon: statusIconTabButton.name !== "" && !asset.isImage
+            asset.charactersLen: 1
+            asset.useAcronymForLetterIdenticon: false
             name: statusIconTabButton.name
         }
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusNavBarTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusNavBarTabButton.qml
@@ -12,7 +12,6 @@ StatusIconTabButton {
     property Component popupMenu
     property alias stateIcon: stateIcon
 
-
     StatusToolTip {
         id: statusTooltip
         visible: statusNavBarTabButton.hovered && !!statusTooltip.text

--- a/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
@@ -16,7 +16,7 @@ QtObject {
 
     property bool isLetterIdenticon
     property bool useAcronymForLetterIdenticon: true
-    property bool useLetterIdenticonStrictBgColor: true
+    property bool letterIdenticonBgWithAlpha: false
     property int letterSize: emoji ? 11 : (charactersLen == 1 ? _oneLetterSize : _twoLettersSize)
     property int charactersLen: 1
 

--- a/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
@@ -13,10 +13,13 @@ QtObject {
     property color hoverColor
     property color disabledColor
     property int rotation
+
     property bool isLetterIdenticon
     property bool useAcronymForLetterIdenticon
+    property bool useLetterIdenticonStrictBgColor: !useAcronymForLetterIdenticon
     property int letterSize: emoji ? 11 : (charactersLen == 1 ? _oneLetterSize : _twoLettersSize)
     property int charactersLen: 1
+
     property string emoji
     property string emojiSize: _emojiSize
 

--- a/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
@@ -15,8 +15,8 @@ QtObject {
     property int rotation
 
     property bool isLetterIdenticon
-    property bool useAcronymForLetterIdenticon
-    property bool useLetterIdenticonStrictBgColor: !useAcronymForLetterIdenticon
+    property bool useAcronymForLetterIdenticon: true
+    property bool useLetterIdenticonStrictBgColor: true
     property int letterSize: emoji ? 11 : (charactersLen == 1 ? _oneLetterSize : _twoLettersSize)
     property int charactersLen: 1
 

--- a/ui/app/AppLayouts/Onboarding/views/ProfileChatKeyView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ProfileChatKeyView.qml
@@ -84,7 +84,6 @@ Item {
                 asset.height: 86
                 asset.letterSize: 32
                 asset.color: Utils.colorForPubkey(d.publicKey)
-                asset.charactersLen: 2
                 asset.isImage: !!asset.name
                 asset.imgIsIdenticon: false
                 asset.name: d.image

--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -63,7 +63,7 @@ StatusListItem {
         height: 40
         color: Utils.getColorForId(root.colorId)
         isLetterIdenticon: true
-        useAcronymForLetterIdenticon: true
+        useLetterIdenticonStrictBgColor: false
     }
 
     statusListItemIcon.hoverEnabled: true

--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -63,7 +63,7 @@ StatusListItem {
         height: 40
         color: Utils.getColorForId(root.colorId)
         isLetterIdenticon: true
-        useLetterIdenticonStrictBgColor: false
+        letterIdenticonBgWithAlpha: true
     }
 
     statusListItemIcon.hoverEnabled: true

--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -62,13 +62,6 @@ StatusListItem {
         width: 40
         height: 40
         color: Utils.getColorForId(root.colorId)
-        charactersLen: {
-            let parts = root.name.split(" ")
-            if (parts.length > 1) {
-                return 2
-            }
-            return 1
-        }
         isLetterIdenticon: true
         useAcronymForLetterIdenticon: true
     }

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -562,7 +562,7 @@ StatusModal {
                             emoji: model.emoji
                             color: model.color
                             isLetterIdenticon: !model.icon
-                            useAcronymForLetterIdenticon: model.type === AddEditSavedAddressPopup.CardType.SavedAddress
+                            useLetterIdenticonStrictBgColor: model.type !== AddEditSavedAddressPopup.CardType.SavedAddress
                             charactersLen: 2
                         }
                     }

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -563,12 +563,7 @@ StatusModal {
                             color: model.color
                             isLetterIdenticon: !model.icon
                             useAcronymForLetterIdenticon: model.type === AddEditSavedAddressPopup.CardType.SavedAddress
-                            charactersLen: {
-                                if (model.type === AddEditSavedAddressPopup.CardType.SavedAddress && model.title.split(" ").length == 1) {
-                                    return 1
-                                }
-                                return 2
-                            }
+                            charactersLen: 2
                         }
                     }
                 }

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -562,7 +562,7 @@ StatusModal {
                             emoji: model.emoji
                             color: model.color
                             isLetterIdenticon: !model.icon
-                            useLetterIdenticonStrictBgColor: model.type !== AddEditSavedAddressPopup.CardType.SavedAddress
+                            letterIdenticonBgWithAlpha: model.type === AddEditSavedAddressPopup.CardType.SavedAddress
                             charactersLen: 2
                         }
                     }

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -231,13 +231,7 @@ StatusModal {
                         name: !root.selectedAccount.name && !root.selectedAccount.emoji? "status-logo-icon" : ""
                         color: !root.selectedAccount.name && !root.selectedAccount.emoji? "transparent" : Utils.getColorForId(root.selectedAccount.colorId)
                         emoji: root.selectedAccount.emoji
-                        charactersLen: {
-                            let parts = root.selectedAccount.name.split(" ")
-                            if (parts.length > 1) {
-                                return 2
-                            }
-                            return 1
-                        }
+                        charactersLen: 1
                         isLetterIdenticon: root.selectedAccount.name && !root.selectedAccount.emoji
                         useAcronymForLetterIdenticon: root.selectedAccount.name && !root.selectedAccount.emoji
                     }

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -233,12 +233,11 @@ StatusModal {
                         emoji: root.selectedAccount.emoji
                         charactersLen: 1
                         isLetterIdenticon: root.selectedAccount.name && !root.selectedAccount.emoji
-                        useAcronymForLetterIdenticon: root.selectedAccount.name && !root.selectedAccount.emoji
+                        useLetterIdenticonStrictBgColor: !root.selectedAccount.name || root.selectedAccount.emoji
                     }
                 }
             }
         }
-
 
         Item {
             width: parent.width

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -233,7 +233,7 @@ StatusModal {
                         emoji: root.selectedAccount.emoji
                         charactersLen: 1
                         isLetterIdenticon: root.selectedAccount.name && !root.selectedAccount.emoji
-                        useLetterIdenticonStrictBgColor: !root.selectedAccount.name || root.selectedAccount.emoji
+                        letterIdenticonBgWithAlpha: root.selectedAccount.name && !root.selectedAccount.emoji
                     }
                 }
             }

--- a/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
@@ -55,7 +55,7 @@ StatusDialog {
             asset {
                 color: Utils.getColorForId(root.colorId)
                 isLetterIdenticon: true
-                useLetterIdenticonStrictBgColor: false
+                letterIdenticonBgWithAlpha: true
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
@@ -55,7 +55,7 @@ StatusDialog {
             asset {
                 color: Utils.getColorForId(root.colorId)
                 isLetterIdenticon: true
-                useAcronymForLetterIdenticon: true
+                useLetterIdenticonStrictBgColor: false
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/RemoveSavedAddressPopup.qml
@@ -54,13 +54,6 @@ StatusDialog {
             name: root.name
             asset {
                 color: Utils.getColorForId(root.colorId)
-                charactersLen: {
-                    let parts = root.name.split(" ")
-                    if (parts.length > 1) {
-                        return 2
-                    }
-                    return 1
-                }
                 isLetterIdenticon: true
                 useAcronymForLetterIdenticon: true
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -715,7 +715,7 @@ Item {
                 implicitHeight: 32
                 identicon.asset.width: width
                 identicon.asset.height: height
-                identicon.asset.charactersLen: 2
+                identicon.asset.useAcronymForLetterIdenticon: true
                 identicon.asset.color: Utils.colorForPubkey(appMain.rootStore.userProfileInst.pubKey)
                 identicon.ringSettings.ringSpecModel: Utils.getColorHashAsJson(appMain.rootStore.userProfileInst.pubKey,
                                                                                appMain.rootStore.userProfileInst.preferredName)

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -36,7 +36,6 @@ Loader {
             height: root.imageHeight
             color: Utils.colorForColorId(root.colorId)
             name: root.image
-            charactersLen: 2
             isImage: true
         }
         ringSettings {


### PR DESCRIPTION
### What does the PR do

Changes in `StatusLetterIdenticon`:

- in `useAcronymForLetterIdenticon` the following letters generation rules are used, `charactersLength` property is ignored:
```
    John -> J
    John Smith -> JS
    John Smith Junior -> JS
```
- `useAcronymForLetterIdenticon` is no longer causing background semi-transparent. Semi-transparent background can be enabled by setting `backgroundWithAlpha` to `true` (`false` by default)
- `useAcronymForLetterIdenticon` is `true` by default
- adjust usages of `StatusSmartIdenticon`

### Affected areas
`StatusLetterIdenticon`, `StatusSmartIdenticon` and some components using `StatusSmartIdenticon`

### Screenshot of functionality (including design for comparison)

![Screenshot from 2024-05-17 19-40-02](https://github.com/status-im/status-desktop/assets/20650004/cde9e83d-4bb1-4701-b8f1-75c21cacc9c3)

![Screenshot from 2024-05-17 19-37-36](https://github.com/status-im/status-desktop/assets/20650004/9ff64558-2b75-42bf-a861-dd7abe7c95b0)

![Screenshot from 2024-05-17 19-41-02](https://github.com/status-im/status-desktop/assets/20650004/0dab6582-2581-4032-bab8-6775eadc658f)

![Screenshot from 2024-05-17 20-27-46](https://github.com/status-im/status-desktop/assets/20650004/142c53a0-354d-49ba-8a67-3dd2bf8f69e0)

![Screenshot from 2024-05-17 20-28-04](https://github.com/status-im/status-desktop/assets/20650004/31192b87-d6e5-4588-b404-966348719174)

![Screenshot from 2024-05-17 20-28-22](https://github.com/status-im/status-desktop/assets/20650004/86530820-6e40-4e9c-a653-e88563d62bb0)




