### PR TITLE
fix(links): open status links in the browser when not shared urls

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint
+import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, browsers
 
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model
@@ -1628,6 +1628,10 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
     self.statusDeepLinkToActivate = statusDeepLink
     return
   let urlData = self.sharedUrlsModule.parseSharedUrl(statusDeepLink)
+  if urlData.notASupportedStatusLink:
+    # Just open it in the browser
+    openDefaultBrowser(statusDeepLink)
+    return
   if urlData.channel.uuid != "":
     self.onStatusUrlRequested(StatusUrlAction.OpenCommunityChannel, urlData.community.communityId, urlData.channel.uuid,
       url="", userId="", urlData.community.shard)

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -282,6 +282,13 @@ QtObject:
     defer: indexEnd.delete
     self.dataChanged(indexStart, indexEnd)
       
+  proc getLinkPreviewType*(self: Model, url: string): int {.slot.} =
+    let index = self.findUrlIndex(url)
+    if index == -1:
+      return PreviewType.NoPreview.int
+
+    return self.items[index].linkPreview.previewType.int
+
   proc getUnfuledLinkPreviews*(self: Model): seq[LinkPreview] =
     result = @[]
     for item in self.items:

--- a/src/app_service/service/shared_urls/dto/url_data.nim
+++ b/src/app_service/service/shared_urls/dto/url_data.nim
@@ -29,6 +29,7 @@ type UrlDataDto* = object
   community*: CommunityUrlDataDto
   channel*: CommunityChannelUrlDataDto
   contact*: ContactUrlDataDto
+  notASupportedStatusLink*: bool # If this is true, it was not a supported status link, so we should open it in a browser
 
 proc getShard*(jsonObj: JsonNode): Shard =
   var shardObj: JsonNode

--- a/src/app_service/service/shared_urls/service.nim
+++ b/src/app_service/service/shared_urls/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles
+import NimQml, json, chronicles, strutils
 
 import ../../../backend/general as status_general
 import ../../../app/core/eventemitter
@@ -24,9 +24,12 @@ QtObject:
   proc parseSharedUrl*(self: Service, url: string): UrlDataDto =
     try:
       let response = status_general.parseSharedUrl(url)
-      if not response.result.contains("error"):
-        return response.result.toUrlDataDto()
-      let errMsg = response.result["error"].getStr()
-      error "failed to parse shared url: ", url, errDesription = errMsg
+      if  response.result.contains("error"):
+        let errMsg = response.result["error"].getStr()
+        raise newException(Exception, errMsg)
+      # not a status shared url
+      return response.result.toUrlDataDto()
     except Exception as e:
-      error "failed to parse shared url: ", url, errDesription = e.msg
+      if not e.msg.contains("not a status shared url"):
+        error "failed to parse shared url: ", url, errDesription = e.msg
+      result.notASupportedStatusLink = true

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -682,15 +682,20 @@ Loader {
                         const pubkey = link.replace("//", "");
                         Global.openProfilePopup(pubkey)
                         return
-                    } else if (link.startsWith('#')) {
+                    }
+                    if (link.startsWith('#')) {
                         rootStore.chatCommunitySectionModule.switchToChannel(link.replace("#", ""))
-                        return
-                    } else if (Utils.isStatusDeepLink(link)) {
-                        Global.activateDeepLink(link)
                         return
                     }
 
-                    Global.openLink(link)
+                    const linkPreviewType = root.linkPreviewModel.getLinkPreviewType(link)
+
+                    if (linkPreviewType === Constants.LinkPreviewType.Standard || !Utils.isStatusDeepLink(link)) {
+                        Global.openLink(link)
+                        return
+                    }
+
+                    Global.activateDeepLink(link)
                 }
 
                 onProfilePictureClicked: {


### PR DESCRIPTION
Fixes #14844

The problem was that links to status.app that are not shared links were still considered shared urls, because our util function can only check if it contains `status.app`.

The solution is two fold:
1. If there are Link Previews, I ask the link preview for the type of Link. If it's a normal link, I just open it.
2. If there are no Link Preview for that link, we call `parseSharedUrl` as before, but now we handle the failure by opening in the browser because we can assume that it's a normal link.