### PR TITLE
chore: add object names for links preview and add button

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/AddSocialLinkModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/AddSocialLinkModal.qml
@@ -29,6 +29,7 @@ StatusStackModal {
     rightButtons: [finishButton]
     finishButton: StatusButton {
         text: qsTr("Add")
+        objectName: "addButton"
         enabled: linkTarget.valid && (!customTitle.visible || customTitle.valid)
         onClicked: {
             root.addLinkRequested(d.selectedLinkTypeText || customTitle.text, // text for custom link, otherwise the link typeId

--- a/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
@@ -122,12 +122,14 @@ CalloutCard {
 
         StatusAction {
             text: qsTr("Show for this message")
+            objectName: "showForThisMessagePreviewMenuItem"
             icon.name: "show"
             onTriggered: contextMenu.enableLinkPreviewForThisMessage()
         }
 
         StatusAction {
             text: qsTr("Always show previews")
+            objectName: "alwaysShowPreviewMenuItem"
             icon.name: "show"
             onTriggered: contextMenu.enableLinkPreview()
         }
@@ -136,6 +138,7 @@ CalloutCard {
 
         StatusAction {
             text: qsTr("Never show previews")
+            objectName: "neverShowPreviewsMenuItem"
             icon.name: "hide"
             type: StatusAction.Type.Danger
             onTriggered: contextMenu.disableLinkPreview()


### PR DESCRIPTION
### What does the PR do

Add object names for links preview popup elements and add button (social links popup)
### Affected areas

ui/app/AppLayouts/Profile/popups/AddSocialLinkModal.qml
ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml

