### PR TITLE
fix: Fixing the share addresses popup height when only owner and TM permissions are available

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -69,7 +69,7 @@ Control {
         id: d
 
         // internal logic
-        readonly property bool hasPermissions: root.permissionsModel && root.permissionsModel.count
+        readonly property bool hasPermissions: root.permissionsModel && root.permissionsModel.count && permissionsView.hasAnyVisiblePermission
         readonly property int selectedSharedAddressesCount: root.selectedSharedAddressesMap.size
 
         readonly property bool dirty: {

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -69,7 +69,7 @@ Control {
         id: d
 
         // internal logic
-        readonly property bool hasPermissions: root.permissionsModel && root.permissionsModel.count && permissionsView.hasAnyVisiblePermission
+        readonly property bool hasPermissions: permissionsView.hasAnyVisiblePermission
         readonly property int selectedSharedAddressesCount: root.selectedSharedAddressesMap.size
 
         readonly property bool dirty: {


### PR DESCRIPTION
### What does the PR do

closes #14195

The `hasPermissions` flag has an impact in how the popup height is calculated. When the permissionsModel has only hidden permissions, the `hasPermissions` flag is true, but UI wise there's no permission to display.

Fix: Account for hidden permissions when computing `hasPermissions` flag

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Join community flow
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/47811206/1490ab8c-248f-4c40-a56b-ab10b6eaa677


