### PR TITLE
More object names added for link previews elements

### DIFF
--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -94,6 +94,7 @@ CalloutCard {
                 }
                 StatusBaseText {
                     id: title
+                    objectName: "linkPreviewTitle"
                     // One line centered next to the logo
                     // Two or more lines, or no logo, top aligned
                     readonly property bool centerText: lineCount == 1 && height === logo.height && logo.visible 
@@ -115,6 +116,7 @@ CalloutCard {
                 visible: root.type === Constants.LinkPreviewType.StatusContact
                 publicKey: root.userData.publicKey
                 oneRow: true
+                objectName: "linkPreviewEmojiHash"
             }
             StatusBaseText {
                 id: description

--- a/ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
@@ -185,6 +185,7 @@ CalloutCard {
                     spacing: 0
                     StatusBaseText {
                         id: titleText
+                        objectName: "linkPreviewTitleText"
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         font.pixelSize: Style.current.additionalTextSize
@@ -217,6 +218,7 @@ CalloutCard {
                 }
                 StatusBaseText {
                     id: subtitleText
+                    objectName: "linkPreviewSubtitleText"
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     font.pixelSize: Style.current.tertiaryTextFontSize

--- a/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
@@ -39,6 +39,7 @@ CalloutCard {
                 elide: Text.ElideRight
                 maximumLineCount: 1
                 text: qsTr("Show link previews?")
+                objectName: "titleText"
             }
             StatusBaseText {
                 Layout.fillWidth: true
@@ -49,6 +50,7 @@ CalloutCard {
                 elide: Text.ElideRight
                 maximumLineCount: 1
                 text: qsTr("A preview of your link will be shown here before you send it")
+                objectName: "subtitleText"
             }
         }
         ComboBox {
@@ -98,6 +100,7 @@ CalloutCard {
 
         StatusFlatRoundButton {
             id: closeButton
+            objectName: "closeLinkPreviewButton"
             Layout.preferredHeight: 38
             Layout.preferredWidth: 38
             type: StatusFlatRoundButton.Type.Secondary


### PR DESCRIPTION
### What does the PR do

Add object names for titles, subtitles of link preview bubbles, link preview area (also emojihash)

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

ui/imports/shared/controls/chat/LinkPreviewCard.qml
ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml