### PR TITLE
fix: correct member list for new community channels

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -124,8 +124,12 @@ proc getChat*(self: Controller): ChatDto =
 proc getChatMembers*(self: Controller): seq[ChatMember] =
   if self.belongsToCommunity:
     let myCommunity = self.getMyCommunity()
-    return myCommunity.getCommunityChat(self.chatId).members
-  else:
+    # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
+    # see log here: https://github.com/status-im/status-desktop/issues/14442#issuecomment-2120756598
+    # should be resolved in https://github.com/status-im/status-desktop/issues/14219
+    let members = myCommunity.getCommunityChat(self.chatId).members
+    if members.len > 0:
+      return members
     return self.chatService.getChatById(self.chatId).members
 
 proc getContactNameAndImage*(self: Controller, contactId: string):


### PR DESCRIPTION
Close #14442
Waits https://github.com/status-im/status-go/pull/5190

### What does the PR do

Temporary workaround for showing members for a new channels (and in a few more rare cases)
Should be refactored in https://github.com/status-im/status-desktop/issues/14219

### Affected areas

Chats, Communities

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/2522130/dfac425a-afed-49ca-b5a5-bbe2ceff12bb

