### PR TITLE
14879 error message is misleading when pasting bio longer than 240 chars

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
@@ -48,15 +48,24 @@ Item {
 
             label: qsTr("Bio")
             placeholderText: qsTr("Tell us about yourself")
+            input.maximumLength : 32767
             charLimit: 240
             multiline: true
             minimumHeight: 108
             maximumHeight: 108
             input.verticalAlignment: TextEdit.AlignTop
             validators: [
+                StatusValidator {
+                    name: "maxLengthValidator"
+                    validate: function (t) { return t.length <= bioInput.charLimit}
+                    errorMessage: qsTr("Bio can’t be longer than %n character(s)", "", bioInput.charLimit)
+                },
                 StatusRegularExpressionValidator {
                     regularExpression: Constants.regularExpressions.asciiWithEmoji
                     errorMessage: qsTr("Invalid characters. Standard keyboard characters and emojis only.")
+                    validate: function (value) {
+                        return (regularExpression.test(value) || (value.length === 0));
+                    }
                 }
             ]
             input.tabNavItem: displayNameInput.input.edit


### PR DESCRIPTION
### What does the PR do

In ProfileDescriptionPanel.qml in bioInput component separated charLimit and input.maximumLength, so StatusInput was left intact. This made bio input to behave on desktop similarly to mobile clients

### Affected areas

ProfileDescriptionPanel.qml 

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/5157464/8d7b8939-0955-4a73-8620-d13cd060737e


