### PR TITLE
fix(@desktop/communities): add hidden button to refresh (retrack tran…

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -24,6 +24,7 @@ const DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED = false
 const LAS_KEY_TRANSLATIONS_ENABLED = "global/translations_enabled"
 const DEFAULT_LAS_KEY_TRANSLATIONS_ENABLED = false
 const DEFAULT_LAS_KEY_CREATE_COMMUNITIES_ENABLED = false
+const LAS_KEY_REFRESH_TOKEN_ENABLED = "global/refresh_token_enabled"
 
 QtObject:
   type LocalAppSettings* = ref object of QObject
@@ -149,6 +150,18 @@ QtObject:
     read = getFakeLoadingScreenEnabled
     write = setFakeLoadingScreenEnabled
     notify = fakeLoadingScreenEnabledChanged
+
+  proc refreshTokenEnabledChanged*(self: LocalAppSettings) {.signal.}
+  proc getRefreshTokenEnabled*(self: LocalAppSettings): bool {.slot.} =
+    self.settings.value(LAS_KEY_REFRESH_TOKEN_ENABLED, newQVariant(false)).boolVal
+  proc setRefreshTokenEnabled*(self: LocalAppSettings, enabled: bool) {.slot.} =
+    self.settings.setValue(LAS_KEY_REFRESH_TOKEN_ENABLED, newQVariant(enabled))
+    self.refreshTokenEnabledChanged()
+
+  QtProperty[bool] refreshTokenEnabled:
+    read = getRefreshTokenEnabled
+    write = setRefreshTokenEnabled
+    notify = refreshTokenEnabledChanged
 
   proc createCommunityEnabledChanged*(self: LocalAppSettings) {.signal.}
   proc getCreateCommunityEnabled*(self: LocalAppSettings): bool {.slot.} =

--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -118,6 +118,9 @@ proc deployOwnerContracts*(self: Controller, communityId: string, addressFrom: s
 proc removeCommunityToken*(self: Controller, communityId: string, chainId: int, address: string) =
   self.communityTokensService.removeCommunityToken(communityId, chainId, address)
 
+proc refreshCommunityToken*(self: Controller, chainId: int, address: string) =
+  self.communityTokensService.refreshCommunityToken(chainId, address)
+
 proc airdropTokens*(self: Controller, communityId: string, password: string, tokensAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string], addressFrom: string) =
   self.communityTokensService.airdropTokens(communityId, password, tokensAndAmounts, walletAddresses, addressFrom)
 

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -93,6 +93,9 @@ method onAirdropStateChanged*(self: AccessInterface, communityId: string, tokenN
 method removeCommunityToken*(self: AccessInterface, communityId: string, chainId: int, address: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method refreshCommunityToken*(self: AccessInterface, chainId: int, address: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onOwnerTokenReceived*(self: AccessInterface, communityId: string, communityName: string, chainId: int, contractAddress: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -249,6 +249,9 @@ method deployAssets*(self: Module, communityId: string, fromAddress: string, nam
 method removeCommunityToken*(self: Module, communityId: string, chainId: int, address: string) =
   self.controller.removeCommunityToken(communityId, chainId, address)
 
+method refreshCommunityToken*(self: Module, chainId: int, address: string) =
+  self.controller.refreshCommunityToken(chainId, address)
+
 method onUserAuthenticated*(self: Module, password: string) =
   defer: self.resetTempValues()
   if password.len == 0:

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -34,6 +34,9 @@ QtObject:
   proc removeCommunityToken*(self: View, communityId: string, chainId: int, address: string) {.slot.} =
     self.communityTokensModule.removeCommunityToken(communityId, chainId, address)
 
+  proc refreshCommunityToken*(self: View, chainId: int, address: string) {.slot.} =
+    self.communityTokensModule.refreshCommunityToken(chainId, address)
+
   proc airdropTokens*(self: View, communityId: string, tokensJsonString: string, walletsJsonString: string, addressFrom: string) {.slot.} =
     self.communityTokensModule.airdropTokens(communityId, tokensJsonString, walletsJsonString, addressFrom)
 

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -1383,3 +1383,9 @@ QtObject:
     except Exception:
       error "can't get owner token owner address", message = getCurrentExceptionMsg()
     self.events.emit(SIGNAL_OWNER_TOKEN_OWNER_ADDRESS, ownerTokenArgs)
+
+  proc refreshCommunityToken*(self: Service, chainId: int, contractAddress: string) =
+    try:
+      discard tokens_backend.reTrackOwnerTokenDeploymentTransaction(chainId, contractAddress)
+    except Exception:
+      error "can't retrack token transaction", message = getCurrentExceptionMsg()

--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -144,6 +144,10 @@ proc getOwnerTokenOwnerAddress*(chainId: int, contractAddress: string): RpcRespo
   let payload = %*[chainId, contractAddress]
   return core.callPrivateRPC("communitytokens_ownerTokenOwnerAddress", payload)
 
+proc reTrackOwnerTokenDeploymentTransaction*(chainId: int, contractAddress: string): RpcResponse[JsonNode] =
+  let payload = %*[chainId, contractAddress]
+  return core.callPrivateRPC("communitytokens_reTrackOwnerTokenDeploymentTransaction", payload)
+
 rpc(registerReceivedCommunityTokenNotification, "wakuext"):
   communityId: string
   isFirst: bool

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -74,6 +74,7 @@ StackView {
     signal burnToken(string tokenKey, string amount, string accountAddress)
     signal airdropToken(string tokenKey, string amount, int type, var addresses)
     signal deleteToken(string tokenKey)
+    signal refreshToken(string tokenKey)
     signal registerDeployFeesSubscriber(var feeSubscriber)
     signal registerSelfDestructFeesSubscriber(var feeSubscriber)
     signal registerBurnTokenFeesSubscriber(var feeSubscriber)
@@ -519,6 +520,12 @@ StackView {
                         retryAssetOrCollectible()
                     }
                 }
+            },
+            StatusButton {
+                text: qsTr("Refresh")
+                visible: localAppSettings.refreshTokenEnabled && (tokenViewPage.token.deployState === Constants.ContractTransactionStatus.InProgress)
+                onClicked: root.refreshToken(tokenViewPage.token.key)
+                tooltip.text: qsTr("Restart token's transaction listening if the token got stuck in minting state")
             }
         ]
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -397,6 +397,9 @@ StatusSectionLayout {
             onDeleteToken:
                 communityTokensStore.deleteToken(root.community.id, tokenKey)
 
+            onRefreshToken:
+                communityTokensStore.refreshToken(tokenKey)
+
             onAirdropToken: {
                 root.goTo(Constants.CommunitySettingsSections.Airdrops)
 

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -41,6 +41,8 @@ QtObject {
     readonly property real scrollVelocity: localAppSettings.scrollVelocity
     readonly property real scrollDeceleration: localAppSettings.scrollDeceleration
 
+    readonly property bool refreshTokenEnabled: localAppSettings.refreshTokenEnabled ?? false
+
     readonly property bool isGoerliEnabled: networksModuleInst.isGoerliEnabled
 
     function logDir() {
@@ -171,6 +173,12 @@ QtObject {
             return
 
         localAppSettings.wakuV2ShardedCommunitiesEnabled = !localAppSettings.wakuV2ShardedCommunitiesEnabled
+    }
+
+    function toggleRefreshTokenEnabled() {
+        if(!localAppSettings)
+            return
+        localAppSettings.refreshTokenEnabled = !localAppSettings.refreshTokenEnabled
     }
 
     function setCustomScrollingEnabled(value) {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -488,6 +488,17 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
+                text: qsTr("Enable community tokens refreshing")
+                isSwitch: true
+                switchChecked: root.advancedStore.refreshTokenEnabled
+                onClicked: {
+                    root.advancedStore.toggleRefreshTokenEnabled()
+                }
+            }
+
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
                 text: qsTr("How many log files to keep archived")
                 currentValue: root.advancedStore.logMaxBackups
                 onClicked: {

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -80,6 +80,11 @@ QtObject {
         communityTokensModuleInst.removeCommunityToken(communityId, parts[0], parts[1])
     }
 
+    function refreshToken(contractUniqueKey) {
+        let parts = contractUniqueKey.split("_");
+        communityTokensModuleInst.refreshCommunityToken(parts[0], parts[1])
+    }
+
     function updateSmartContract(communityId, chainId, contractAddress, accountAddress) {
         communityTokensModuleInst.setSigner(communityId, chainId, contractAddress, accountAddress)
     }


### PR DESCRIPTION
Add hidden button to refresh (retrack transaction) community tokens

Issue #14699

How to use:

1. Enable community tokens refreshing in Advanced tab

![image](https://github.com/status-im/status-desktop/assets/61889657/db4e065b-0ae2-4676-a4d7-a4eb2e04669d)

2. Every token, when in minting state, will have visible "Refresh" button

![image](https://github.com/status-im/status-desktop/assets/61889657/6452e8a2-2810-48ff-9e01-f9709eb3e4b0)

3. Pressing that button will run transaction listening if the transaction hash is known (for older tokens, it will work only for owner/master tokens).

