### PR TITLE
Fix 2 category issues (always collapsed and missing bold)

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -597,9 +597,13 @@ proc updateBadgeNotifications(self: Module, chat: ChatDto, hasUnreadMessages: bo
     if (self.chatContentModules.contains(chatId)):
       self.chatContentModules[chatId].onNotificationsUpdated(hasUnreadMessages, unviewedMentionsCount)
 
-    if chat.categoryId != "":
-      let hasUnreadMessages = self.controller.categoryHasUnreadMessages(chat.communityId, chat.categoryId)
-      self.view.chatsModel().setCategoryHasUnreadMessages(chat.categoryId, hasUnreadMessages)
+    if self.isCommunity:
+      let myCommunity = self.controller.getMyCommunity()
+      let communityChat = myCommunity.getCommunityChat(chatId)
+
+      if communityChat.categoryId != "":
+        let hasUnreadMessages = self.controller.categoryHasUnreadMessages(communityChat.communityId, communityChat.categoryId)
+        self.view.chatsModel().setCategoryHasUnreadMessages(communityChat.categoryId, hasUnreadMessages)
 
   self.updateParentBadgeNotifications()
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -695,12 +695,12 @@ proc addNewChat(
     if category.id == "":
       error "No category found for chat", chatName=chatDto.name, categoryId=chatDto.categoryId
     else:
-      categoryOpened = category.categoryOpened
+      categoryOpened = not category.collapsed
       categoryPosition = category.position
 
       # TODO: This call will update the model for each category in channels which is not
       # preferable. Please fix-me in https://github.com/status-im/status-desktop/issues/14431
-      self.view.chatsModel().changeCategoryOpened(category.id, category.categoryOpened)
+      self.view.chatsModel().changeCategoryOpened(category.id, categoryOpened)
 
   var canPostReactions = true
   var hideIfPermissionsNotMet = false
@@ -1394,7 +1394,7 @@ method toggleCollapsedCommunityCategory*(self: Module, categoryId: string, colla
   self.controller.toggleCollapsedCommunityCategory(categoryId, collapsed)
 
 method onToggleCollapsedCommunityCategory*(self: Module, categoryId: string, collapsed: bool) =
-  self.view.chatsModel().changeCategoryOpened(categoryId, collapsed)
+  self.view.chatsModel().changeCategoryOpened(categoryId, not collapsed)
 
 method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, toPosition: int) =
   self.controller.reorderCommunityChat(categoryId, chatId, toPosition + 1)

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -25,7 +25,7 @@ type Category* = object
   id*: string
   name*: string
   position*: int
-  categoryOpened*: bool
+  collapsed*: bool
 
 type
   Permission* = object
@@ -189,7 +189,7 @@ proc toCategory*(jsonObj: JsonNode): Category =
     discard jsonObj.getProp("id", result.id)
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("position", result.position)
-  discard jsonObj.getProp("categoryOpened", result.categoryOpened)
+  discard jsonObj.getProp("collapsed", result.collapsed)
 
 proc toChatMember*(jsonObj: JsonNode, memberId: string): ChatMember =
   # Parse status-go "Member" type

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -181,7 +181,7 @@ QtObject:
       var args = RpcResponseArgs(e)
       discard self.processMessengerResponse(args.response)
 
-  proc asyncGetActiveChat*(self: Service) =
+  proc asyncGetActiveChats*(self: Service) =
     let arg = AsyncGetActiveChatsTaskArg(
       tptr: cast[ByteAddress](asyncGetActiveChatsTask),
       vptr: cast[ByteAddress](self.vptr),
@@ -214,7 +214,7 @@ QtObject:
   proc init*(self: Service) =
     self.doConnect()
 
-    self.asyncGetActiveChat()
+    self.asyncGetActiveChats()
 
   proc hasChannel*(self: Service, chatId: string): bool =
     self.chats.hasKey(chatId)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -817,7 +817,7 @@ QtObject:
       let collapsedCommunityCategories = responseObj["collapsedCommunityCategories"]
       if collapsedCommunityCategories{"result"}.kind != JNull:
         for jsonCategory in collapsedCommunityCategories["result"]:
-          categories.add(jsonCategory.toCategoryDto())
+          categories.add(jsonCategory.toCollapsedCategoryDto())
 
       # All communities
       let communities = parseCommunities(responseObj["communities"], categories)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2424,6 +2424,7 @@ QtObject:
     for chat in self.communities[communityId].chats:
       if chat.categoryId != categoryId:
         continue
-      if (not chat.muted and chat.unviewedMessagesCount > 0) or chat.unviewedMentionsCount > 0:
+      let chatDto = self.chatService.getChatById(chat.id)
+      if (not chatDto.muted and chatDto.unviewedMessagesCount > 0) or chatDto.unviewedMentionsCount > 0:
         return true
     return false

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -147,11 +147,13 @@ Item {
                                 highlighted = true;
                                 categoryPopupMenuSlot.item.popup()
                             } else if (mouse.button === Qt.LeftButton) {
-                                root.toggleCollapsedCommunityCategory(model.categoryId, !statusChatListCategoryItem.opened)
+                                // We pass the value for collapsed that we want
+                                // So if opened == true, we want opened == false -> we pass collapsed = true
+                                root.toggleCollapsedCommunityCategory(model.categoryId, statusChatListCategoryItem.opened)
                             }
                         }
                         onToggleButtonClicked: {
-                            root.toggleCollapsedCommunityCategory(model.categoryId, !statusChatListCategoryItem.opened)
+                            root.toggleCollapsedCommunityCategory(model.categoryId, statusChatListCategoryItem.opened)
                         }
                         onMenuButtonClicked: {
                             statusChatListCategoryItem.setupPopup()


### PR DESCRIPTION
## Fixes categories being always closed on start

The problem was that we converted `collapsed` to `opened` way too early and with a logic error.

By using collapsed until the module, it's way easier to understand and also fixes the logic mistakes.

I also renamed a couple of functions and variables so that the mistake doesn't happen again.

## Fix category unread status

The problem was that the ChatDto doesn't have a categoryID, so we need to use the CommunityChat.

I think before, the channel groups had the full chat info, but not we can't rely on that.

The CommunityChat/Chat alignment refactor will simplify all of that https://github.com/status-im/status-desktop/issues/14219