### PR TITLE
fix?: use libssl 1.1

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -32,8 +32,8 @@ elif defined(windows):
 else:
   --dynlibOverrideAll # don't use dlopen()
   # dynamically link these libs, since we're opting out of dlopen()
-  switch("passL", "-lcrypto")
-  switch("passL", "-lssl")
+  switch("passL", "-l:libcrypto.so.1.1")
+  switch("passL", "-l:libssl.so.1.1")
   # don't link libraries we're not actually using
   switch("passL", "-Wl,-as-needed")
 


### PR DESCRIPTION
In more recent versions of ubuntu, the version of ssl used is 3.0
Trying to compile desktop with -lcrypto and -lssl by default will end up causing the build process to fail with:
```
/usr/bin/ld: nimcache/release/nim_status_client/@m..@svendor@snimbus-build-system@svendor@sNim@slib@spure@snet.nim.c.o: in function `checkCertName__pureZnet_1309':
 /home/richard/status/status-desktop/vendor/nimbus-build-system/vendor/Nim/lib/pure/net.nim:831: undefined reference to `SSL_get_peer_certificate'
 collect2: error: ld returned 1 exit status
```
With this PR at least we are being explicit that we're using a version of libssl that has reached its end of life since 11th September 2023
https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/index.html

*le sigh*


newer versions should use the openssl v3, so do consider updating nimbus-build-system.


