### PR TITLE
fix: ensure communityDetails are updated in PermissionsView

### DIFF
--- a/ui/app/AppLayouts/Communities/views/PermissionsView.qml
+++ b/ui/app/AppLayouts/Communities/views/PermissionsView.qml
@@ -31,7 +31,7 @@ ColumnLayout {
     required property var channelsModel
 
     // id, name, image, color, owner, admin properties expected
-    required property var communityDetails
+    required property QtObject communityDetails
 
     property int viewWidth: 560 // by design
     property bool viewOnlyCanAddReaction
@@ -44,16 +44,32 @@ ColumnLayout {
     signal userRestrictionsToggled(bool checked)
 
     readonly property alias count: repeater.count
+
+    Connections {
+        target: root.communityDetails
+        function onNameChanged(){
+            resetCommunityItemModel()
+        }
+        function onImageChanged(){
+            resetCommunityItemModel()
+        }
+        function onColorChanged(){
+            resetCommunityItemModel()
+        }
+    }
+
+    function resetCommunityItemModel(){
+        communityItemModel.clear()
+        communityItemModel.append({
+                   text: root.communityDetails.name,
+                   imageSource: root.communityDetails.image,
+                   color: root.communityDetails.color
+               })
+    }
+
     ListModel {
         id: communityItemModel
-
-        Component.onCompleted: {
-            append({
-                       text: root.communityDetails.name,
-                       imageSource: root.communityDetails.image,
-                       color: root.communityDetails.color
-                   })
-        }
+        Component.onCompleted: resetCommunityItemModel()
     }
 
     IntroPanel {


### PR DESCRIPTION
### What does the PR do

- ensure that `commuityDetails`  fields(`name`, `color`, `image`) are update in PermissionsView when they are changed

Fixes [#14800](https://github.com/status-im/status-desktop/issues/14800)

### Affected areas

Community Permissions

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/8908607/cc43f2b6-405c-4ff5-9a16-05d5af8b23ba

