### PR TITLE
Fix asset value in HoldingsDropdown when adding an asset to permissions

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -313,7 +313,10 @@ StatusDropdown {
                 d.collectibleAmountText = ""
 
                 if (checkedKeys.includes(key)) {
-                    const amount = root.usedTokens.find(entry => entry.key === key).amount
+
+                    const amountBasicUnit = root.usedTokens.find(entry => entry.key === key).amount
+                    const decimals = PermissionsHelpers.getTokenByKey(root.assetsModel, key).decimals
+                    const amount = AmountsArithmetic.toNumber(amountBasicUnit, decimals)
 
                     if(d.extendedDropdownType === ExtendedDropdownContent.Type.Assets)
                         root.assetAmount = amount


### PR DESCRIPTION
### What does the PR do

When creating or editing a community permission, if you add a holding token that has already been added, the amount value displayed is in basic units (long value) of that token instead of primary units.

This PR fixes that

Fixes [#14919](https://github.com/status-im/status-desktop/issues/14919)

### Affected areas

Community | Permissions | Assets Holding

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/8908607/c6276c45-b5cd-49eb-a022-af8c63391166


