### PR TITLE
fix(Wallet): "All accounts" title casing typo

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -56,7 +56,7 @@ Item {
                     if (root.walletStore.showSavedAddresses)
                         return qsTr("Saved addresses")
 
-                    return overview.isAllAccounts ? qsTr("All Accounts") : overview.name
+                    return overview.isAllAccounts ? qsTr("All accounts") : overview.name
                 }
             }
             StatusEmoji {


### PR DESCRIPTION
### What does the PR do

"All Accounts" -> "All accounts" in main wallet view

Fixes #14669

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
![image](https://github.com/status-im/status-desktop/assets/5377645/e1fdb4dd-4cce-4106-91ee-71684b573e1b)



