### PR TITLE
Save only the settings that are changed

### DIFF
--- a/src/app/modules/main/node_section/controller.nim
+++ b/src/app/modules/main/node_section/controller.nim
@@ -61,14 +61,14 @@ proc init*(self: Controller) =
 proc sendRPCMessageRaw*(self: Controller, inputJSON: string): string =
    return self.nodeService.sendRPCMessageRaw(inputJSON);
 
-proc isV2LightMode*(self: Controller): bool =
-   return self.nodeConfigurationService.isV2LightMode()
+proc isLightClient*(self: Controller): bool =
+   return self.nodeConfigurationService.isLightClient()
 
 proc isFullNode*(self: Controller): bool =
    return self.nodeConfigurationService.isFullNode()
 
-proc setV2LightMode*(self: Controller, enabled: bool): bool =
-   return self.nodeConfigurationService.setV2LightMode(enabled)
+proc setLightClient*(self: Controller, enabled: bool): bool =
+   return self.nodeConfigurationService.setLightClient(enabled)
 
 proc getWakuVersion*(self: Controller): int =
     return 2

--- a/src/app/modules/main/node_section/io_interface.nim
+++ b/src/app/modules/main/node_section/io_interface.nim
@@ -30,10 +30,10 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method sendRPCMessageRaw*(self: AccessInterface, inputJSON: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setV2LightMode*(self: AccessInterface, enabled: bool) {.base.} =
+method setLightClient*(self: AccessInterface, enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method isV2LightMode*(self: AccessInterface): bool {.base.} =
+method isLightClient*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method isFullNode*(self: AccessInterface): bool {.base.} =

--- a/src/app/modules/main/node_section/module.nim
+++ b/src/app/modules/main/node_section/module.nim
@@ -54,12 +54,12 @@ method viewDidLoad*(self: Module) =
 method sendRPCMessageRaw*(self: Module, inputJSON: string): string =
   return self.controller.sendRPCMessageRaw(inputJSON)
 
-method setV2LightMode*(self: Module, enabled: bool) =
-  if(self.controller.setV2LightMode(enabled)):
+method setLightClient*(self: Module, enabled: bool) =
+  if(self.controller.setLightClient(enabled)):
     quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
 
-method isV2LightMode*(self: Module): bool =
-  return self.controller.isV2LightMode()
+method isLightClient*(self: Module): bool =
+  return self.controller.isLightClient()
 
 method isFullNode*(self: Module): bool =
    return self.controller.isFullNode()

--- a/src/app/modules/main/node_section/view.nim
+++ b/src/app/modules/main/node_section/view.nim
@@ -97,11 +97,11 @@ QtObject:
 
   proc log*(self: View, logContent: string) {.signal.}
 
-  proc getWakuV2LightClient(self: View): bool {.slot.} = self.delegate.isV2LightMode()
+  proc getWakuV2LightClient(self: View): bool {.slot.} = self.delegate.isLightClient()
 
   QtProperty[bool] WakuV2LightClient:
     read = getWakuV2LightClient
     notify = initialized
 
   proc setWakuV2LightClient*(self: View, enabled: bool) {.slot.} =
-    self.delegate.setV2LightMode(enabled)
+    self.delegate.setLightClient(enabled)

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -57,10 +57,10 @@ proc setMaxLogBackups*(self: Controller, value: int) =
   self.delegate.onLogMaxBackupsChanged()
 
 proc getWakuV2LightClientEnabled*(self: Controller): bool =
-  return self.nodeConfigurationService.getV2LightMode()
+  return self.nodeConfigurationService.isLightClient()
 
 proc setWakuV2LightClientEnabled*(self: Controller, enabled: bool) =
-  if (not self.nodeConfigurationService.setV2LightMode(enabled)):
+  if (not self.nodeConfigurationService.setLightClient(enabled)):
     # in the future we may do a call from here to show a popup about this error
     error "an error occurred, we couldn't set WakuV2 light client"
     return
@@ -122,7 +122,7 @@ proc isNimbusProxyEnabled*(self: Controller): bool =
 proc toggleNimbusProxy*(self: Controller) =
   let enabled = self.nodeConfigurationService.isNimbusProxyEnabled()
 
-  if(not self.nodeConfigurationService.setNimbusProxyConfig(not enabled)):
+  if not self.nodeConfigurationService.setNimbusProxyConfigEnabled(not enabled):
     error "an error occurred, we couldn't toggle nimbus proxy"
     return
 

--- a/src/app/modules/main/profile_section/waku/controller.nim
+++ b/src/app/modules/main/profile_section/waku/controller.nim
@@ -34,5 +34,5 @@ proc init*(self: Controller) =
 proc getAllWakuNodes*(self: Controller): seq[string] =
   return self.nodeConfigurationService.getAllWakuNodes()
 
-proc saveNewWakuNode*(self: Controller, nodeAddress: string) =
-  self.nodeConfigurationService.saveNewWakuNode(nodeAddress)
+proc saveNewWakuNode*(self: Controller, nodeAddress: string): bool =
+  return self.nodeConfigurationService.saveNewWakuNode(nodeAddress)

--- a/src/app/modules/main/profile_section/waku/module.nim
+++ b/src/app/modules/main/profile_section/waku/module.nim
@@ -61,6 +61,6 @@ method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
 method saveNewWakuNode*(self: Module, nodeAddress: string) =
-  self.controller.saveNewWakuNode(nodeAddress)
-  let item = initItem(nodeAddress)
-  self.view.model().addItem(item)
+  if self.controller.saveNewWakuNode(nodeAddress):
+    let item = initItem(nodeAddress)
+    self.view.model().addItem(item)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -446,12 +446,6 @@ QtObject:
   proc unpinMailserver*(self: Service, fleet: Fleet): bool =
     return self.setPinnedMailserverId("", fleet)
 
-  proc saveNodeConfiguration*(self: Service, value: JsonNode): bool =
-    if(self.saveSetting(KEY_NODE_CONFIG, value)):
-      self.settings.nodeConfig = value
-      return true
-    return false
-
   proc saveAutoMessageEnabled*(self: Service, value: bool): bool =
     if(self.saveSetting(KEY_AUTO_MESSAGE_ENABLED, value)):
       self.settings.autoMessageEnabled = value

--- a/src/backend/node_config.nim
+++ b/src/backend/node_config.nim
@@ -29,25 +29,31 @@ proc switchFleet*(fleet: string, nodeConfig: JsonNode): RpcResponse[JsonNode] =
     raise newException(RpcException, e.msg)
 
 proc enableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
-  try:
-    result = core.callPrivateRPC("enableCommunityHistoryArchiveProtocol".prefix)
-  except RpcException as e:
-    error "error doing rpc request", methodName = "enableCommunityHistoryArchiveProtocol", exception=e.msg
-    raise newException(RpcException, e.msg)
+  return core.callPrivateRPC("enableCommunityHistoryArchiveProtocol".prefix, %* [])
 
 proc disableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] =
-  try:
-    result = core.callPrivateRPC("disableCommunityHistoryArchiveProtocol".prefix)
-  except RpcException as e:
-    error "error doing rpc request", methodName = "disableCommunityHistoryArchiveProtocol", exception=e.msg
-    raise newException(RpcException, e.msg)
+  return core.callPrivateRPC("disableCommunityHistoryArchiveProtocol".prefix, %* [])
 
-proc  setLogLevel*(logLevel: LogLevel): RpcResponse[JsonNode] =
-  try:
-    let payload = %*[{
-      "logLevel": $logLevel
-    }]
-    result = core.callPrivateRPC("setLogLevel".prefix, payload)
-  except RpcException as e:
-    error "error doing rpc request", methodName = "setLogLevel", exception=e.msg
-    raise newException(RpcException, e.msg)
+proc setLogLevel*(logLevel: LogLevel): RpcResponse[JsonNode] =
+  let payload = %*[{
+    "logLevel": $logLevel
+  }]
+  result = core.callPrivateRPC("setLogLevel".prefix, payload)
+
+proc setMaxLogBackups*(maxLogBackups: int): RpcResponse[JsonNode] =
+  let payload = %*[{
+    "maxLogBackups": maxLogBackups
+  }]
+  return core.callPrivateRPC("setMaxLogBackups".prefix, payload)
+
+proc setLightClient*(enabled: bool): RpcResponse[JsonNode] =
+  let payload = %*[{
+    "enabled": enabled
+  }]
+  return core.callPrivateRPC("setLightClient".prefix, payload)
+
+proc saveNewWakuNode*(nodeAddress: string): RpcResponse[JsonNode] =
+  let payload = %*[{
+    "nodeAddress": nodeAddress
+  }]
+  return core.callPrivateRPC("saveNewWakuNode".prefix, payload)


### PR DESCRIPTION
### What does the PR do
status-go PR https://github.com/status-im/status-go/pull/5237
fixes #12918 #14889

1. The main goal - remove all uses of `saveNodeConfiguration`. Because it can overwrite the values it doesn't know about. 
(for example https://github.com/status-im/status-desktop/pull/14812)

2. Use instead: setLightClient, saveNewWakuNode, setMaxLogBackups (https://github.com/status-im/status-desktop/issues/14889)

### Affected areas
Settings, NodeConfig

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/3c87fddf-e356-4ffe-9005-fe67adc17c62


### additional info

`setNimbusProxyConfigEnabled` currently is not used anywhere. Should be fixed after merging https://github.com/status-im/status-go/pull/4254

### further improvements:
https://github.com/status-im/status-desktop/issues/14929