### PR TITLE
13371 propagate token actions

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -62,6 +62,7 @@ type SignalType* {.pure.} = enum
   DBReEncryptionStarted = "db.reEncryption.started"
   DBReEncryptionFinished = "db.reEncryption.finished"
   CommunityTokenTransactionStatusChanged = "communityToken.communityTokenTransactionStatusChanged"
+  CommunityTokenAction = "communityToken.communityTokenAction"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -131,6 +131,7 @@ QtObject:
       # pairing
       of SignalType.LocalPairing: LocalPairingSignal.fromEvent(jsonSignal)
       of SignalType.CommunityTokenTransactionStatusChanged: CommunityTokenTransactionStatusChangedSignal.fromEvent(jsonSignal)
+      of SignalType.CommunityTokenAction: CommunityTokenActionSignal.fromEvent(jsonSignal)
       else: Signal()
 
     result.signalType = signalType

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -355,6 +355,14 @@ proc init*(self: Controller) =
       self.getRemoteDestructedAmount(communityToken.chainId, communityToken.address))
     self.delegate.onBurnStateChanged(communityToken.communityId, communityToken.chainId, communityToken.address, args.status)
 
+  self.events.on(SIGNAL_BURN_ACTION_RECEIVED) do(e: Args):
+    let args = RemoteDestructArgs(e)
+    let communityToken = args.communityToken
+    self.delegate.onCommunityTokenSupplyChanged(communityToken.communityId, communityToken.chainId,
+      communityToken.address, communityToken.supply,
+      self.getRemainingSupply(communityToken.chainId, communityToken.address),
+      self.getRemoteDestructedAmount(communityToken.chainId, communityToken.address))
+
   self.events.on(SIGNAL_FINALISE_OWNERSHIP_STATUS) do(e: Args):
     let args = FinaliseOwnershipStatusArgs(e)
     self.delegate.onFinaliseOwnershipStatusChanged(args.isPending, args.communityId)

--- a/src/app_service/common/conversion.nim
+++ b/src/app_service/common/conversion.nim
@@ -87,3 +87,5 @@ proc wei2Gwei*(input: string): string =
 proc intToEnum*[T](intVal: int, defaultVal: T): T =
   result = if (intVal >= ord(low(T)) and intVal <= ord(high(T))): T(intVal) else: defaultVal
 
+proc intToEnum*[T](intVal: int): T =
+  result = if (intVal >= ord(low(T)) and intVal <= ord(high(T))): T(intVal) else: raise newException(ValueError, "Can't convert int to enum")


### PR DESCRIPTION
### What does the PR do

Handle signal with information about token actions made by other owner/tokenmaster and update UI accordingly.

status-go [pr](https://github.com/status-im/status-go/pull/5243)

Issue #13371 

All 3 operations were tested: airdrop, burn and remote destruct.
Airdrop/remote destruct - the list of holders is refreshed.
Burn - token supply is changed.