### PR TITLE
Upgrade go to 1.21

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -81,8 +81,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1
 ENV PATH="/opt/cmake/bin:${PATH}"
 
 # Installing Golang
-RUN GOLANG_SHA256="698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd" \
- && GOLANG_TARBALL="go1.20.4.linux-amd64.tar.gz" \
+RUN GOLANG_SHA256="e330e5d977bf4f3bdc157bc46cf41afa5b13d66c914e12fd6b694ccda65fcf92" \
+ && GOLANG_TARBALL="go1.21.10.linux-amd64.tar.gz" \
  && wget -q "https://dl.google.com/go/${GOLANG_TARBALL}" \
  && echo "${GOLANG_SHA256} ${GOLANG_TARBALL}" | sha256sum -c \
  && sudo tar -C /usr/local -xzf "${GOLANG_TARBALL}" \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -9,7 +9,7 @@ pipeline {
     /* Necessary image with Ubuntu 20.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.4.0-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.4.1-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -7,7 +7,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.20"
+    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.21"
   }
 
   parameters {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.8.13'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'windows && x86_64 && qt-5.15.2 && go-1.20' }
+  agent { label 'windows && x86_64 && qt-5.15.2 && go-1.21' }
 
   parameters {
     booleanParam(

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -18,7 +18,7 @@ function Install-Dependencies {
     if (!(scoop bucket list | Where { $_.Name -eq "extras" })) {
         scoop bucket add extras
     }
-    scoop install --global go@1.20.4
+    scoop install --global go@1.21.10
     scoop install --global vcredist2022
     scoop install --global `
         7zip git dos2unix findutils `

--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ in pkgs.mkShell {
     qt5Full
     bash curl wget git file unzip jq lsb-release
     cmake gnumake pkg-config gnugrep qtCustom
-    go_1_19
+    go_1_21
     pcre nss pcsclite extra-cmake-modules
     xorg.libxcb xorg.libX11 libxkbcommon
   ] ++ (with gst_all_1; [


### PR DESCRIPTION
## What does the PR do

- updates status-go reference to build from the branch where we bump go to 1.21 
- https://github.com/status-im/status-go/pull/5216

## Affected areas

Could be many areas since go upgrades impact every feature that communicates with status-go
