### PR TITLE
fix(permissions): Communities: HoldingsDropdown doesn't allow decimal input

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/TokenItem.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenItem.qml
@@ -13,6 +13,7 @@ Control {
     property string shortName
     property string amount
     property url iconSource
+    property string decimals
     property bool selected: false
     property bool showSubItemsIcon: false
 

--- a/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
@@ -19,6 +19,7 @@ ColumnLayout {
     property alias tokenShortName: item.shortName
     property alias tokenAmount: item.amount
     property alias tokenImage: item.iconSource
+    property alias tokenDecimals: item.decimals
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
     property alias decimals: amountInput.tokenDecimals
@@ -131,7 +132,7 @@ ColumnLayout {
         maximumAmount: !!networksComboBoxLoader.item
                        ? networksComboBoxLoader.item.currentAmount : "0"
         tokenDecimals: !!networksComboBoxLoader.item
-                       ? networksComboBoxLoader.item.decimals : 0
+                       ? networksComboBoxLoader.item.decimals : root.tokenDecimals
         multiplierIndex: !!networksComboBoxLoader.item
                          ? networksComboBoxLoader.item.currentMultiplierIndex : 0
 

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -36,6 +36,13 @@ QtObject {
         return ""
     }
 
+    function getTokenDecimalsByKey(model, key) {
+        const item = getTokenByKey(model, key)
+        if (item)
+            return item.decimals ?? 0
+        return 0
+    }
+
     function getTokenRemainingSupplyByKey(model, key) {
         const item = getTokenByKey(model, key)
 

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -306,7 +306,7 @@ StatusDropdown {
                       && ModelUtils.get(root.collectiblesModel, 0, "category") === TokenCategories.Category.General
             }
 
-            onTypeChanged: forceActiveFocus()            
+            onTypeChanged: forceActiveFocus()
 
             onItemClicked: {
                 d.assetAmountText = ""
@@ -402,6 +402,7 @@ StatusDropdown {
             tokenName: PermissionsHelpers.getTokenNameByKey(root.assetsModel, root.assetKey)
             tokenShortName: PermissionsHelpers.getTokenShortNameByKey(root.assetsModel, root.assetKey)
             tokenImage: PermissionsHelpers.getTokenIconByKey(root.assetsModel, root.assetKey)
+            tokenDecimals: PermissionsHelpers.getTokenDecimalsByKey(root.assetsModel, root.assetKey)
             tokenAmount: PermissionsHelpers.getTokenRemainingSupplyByKey(root.assetsModel, root.assetKey)
             amountText: d.assetAmountText
             tokenCategoryText: qsTr("Asset")
@@ -477,6 +478,7 @@ StatusDropdown {
             tokenShortName: ""
             tokenImage: PermissionsHelpers.getTokenIconByKey(root.collectiblesModel, root.collectibleKey)
             tokenAmount: PermissionsHelpers.getTokenRemainingSupplyByKey(root.collectiblesModel, root.collectibleKey)
+            tokenDecimals: PermissionsHelpers.getTokenDecimalsByKey(root.collectiblesModel, root.assetKey)
             amountText: d.collectibleAmountText
             tokenCategoryText: qsTr("Collectible")
             addOrUpdateButtonEnabled: d.collectiblesReady


### PR DESCRIPTION
 (Edit Permissions)

If `asset.chainName` is empty, HoldingsDropdown doesn't initialize "decimals" for AmountInput

Fixes #14942

### What does the PR do

Use `assetsModel.decimals` when `TokenPanel.networksModel` is not intialized

### Affected areas

Communities

### StatusQ checklist
(!) testing in progress

### Screenshot of functionality (including design for comparison)
<img width="712" alt="image" src="https://github.com/status-im/status-desktop/assets/1083341/df4a5ac4-68ae-4bad-b130-149cee01ac9e">

### Cool Spaceship Picture

```mermaid
%% Flowchart
graph LR

	subgraph AmountInput 
		AmountTokenDecimals[tokenDecimals]
	end
	
	subgraph TokenPanel
	  TokentokenDecimals[tokenDecimals]
	  TokenDecimals[decimals]
	  TokenNetworksModel[networksModel]
	  TokenItem[item]
	  networksComboBoxLoader
	  TokentokenDecimals --> TokenItem
	  networksComboBoxLoader --> TokenNetworksModel
	end
	
	subgraph HoldingsDropdown
		assetsModel[(assetsModel)]
		AssetsTokenPanel[TokenPanel]
	end 
	
	AmountTokenDecimals -->|init| networksComboBoxLoader
	AmountTokenDecimals --> TokentokenDecimals
	TokenNetworksModel -->|chainName?| assetsModel
	TokenItem -->|init| assetsModel

```
