### PR TITLE
chore: rename holders string to match the general in app approach

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -71,7 +71,7 @@ Control {
             font.pixelSize: Style.current.primaryTextFontSize
             color: Theme.palette.baseColor1
 
-            text: qsTr("%1 token holders").arg(root.tokenName)
+            text: qsTr("%1 token hodlers").arg(root.tokenName)
         }
 
         SearchBox {

--- a/ui/app/AppLayouts/Communities/panels/TokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TokenHoldersPanel.qml
@@ -43,7 +43,7 @@ Control {
             font.pixelSize: Style.current.primaryTextFontSize
             color: Theme.palette.baseColor1
 
-            text: qsTr("%1 token holders").arg(root.tokenName)
+            text: qsTr("%1 token hodlers").arg(root.tokenName)
         }
 
         SearchBox {

--- a/ui/i18n/qml_base.ts
+++ b/ui/i18n/qml_base.ts
@@ -21553,8 +21553,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     <message>
         <location filename="../app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml" line="74" />
         <location filename="../app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml" line="74" />
-        <source>%1 token holders</source>
-        <translation>%1 token holders</translation>
+        <source>%1 token hodlers</source>
+        <translation>%1 token hodlers</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml" line="90" />
@@ -23472,8 +23472,8 @@ access to your webcam</translation>
     <message>
         <location filename="../app/AppLayouts/Communities/panels/TokenHoldersPanel.qml" line="46" />
         <location filename="../app/AppLayouts/Communities/panels/TokenHoldersPanel.qml" line="46" />
-        <source>%1 token holders</source>
-        <translation type="unfinished">%1 token holders</translation>
+        <source>%1 token hodlers</source>
+        <translation type="unfinished">%1 token hodlers</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Communities/panels/TokenHoldersPanel.qml" line="60" />


### PR DESCRIPTION
### What does the PR do

Rename a string to match the general pattern across the application

<img width="811" alt="Screenshot 2024-05-28 at 17 18 11" src="https://github.com/status-im/status-desktop/assets/82375995/aae3b9dc-b0c4-46ee-91e0-24ca96700676">
