### PR TITLE
fix(chat): Display mention tag even if there is no mention

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -807,7 +807,7 @@ QtObject:
       if (responseObj.kind != JObject):
         raise newException(CatchableError, "mark all messages read response is not an json object")
 
-      if responseObj.contains("error"):
+      if responseObj.contains("error") and responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
         raise newException(CatchableError, responseObj{"error"}.getStr)
 
       var chatId: string


### PR DESCRIPTION
fixes #14928

### What does the PR do
fixes error handling when error is null

### Affected areas

MarkAllRead


### further improvements

I think the same change should be applied to onAsyncSearchMessages, onAsyncLoadMoreMessagesForChat, onAsyncLoadPinnedMessagesForChat. But we need to check the status-go first
Optional: I would also put all this error parsing into a separate method, because it looks the same