### PR TITLE
feat(dapps) implements responding to wallet connect requests

### DIFF
--- a/storybook/pages/DAppRequestModalPage.qml
+++ b/storybook/pages/DAppRequestModalPage.qml
@@ -28,7 +28,7 @@ Item {
     id: root
 
     function openModal() {
-        modal.openWith()
+        modal.open()
     }
 
     // qml Splitter

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -53,6 +53,14 @@ Item {
                     spacing: 8
 
                     wcService: walletConnectService
+
+                    onDisplayToastMessage: (message, isErr) => {
+                        if(isErr) {
+                            console.log(`Storybook.displayToastMessage(${message}, "", "warning", false, Constants.ephemeralNotificationType.danger, "")`)
+                            return
+                        }
+                        console.log(`Storybook.displayToastMessage(${message}, "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")`)
+                    }
                 }
             }
             ColumnLayout {}
@@ -82,6 +90,15 @@ Item {
 
             // spacer
             ColumnLayout {}
+
+            CheckBox {
+
+                text: "Enable SDK"
+                checked: settings.enableSDK
+                onCheckedChanged: {
+                    settings.enableSDK = checked
+                }
+            }
 
             RowLayout {
                 Text { text: "URI" }
@@ -170,7 +187,7 @@ Item {
         id: walletConnectService
 
         wcSDK: WalletConnectSDK {
-            active: true
+            active: settings.enableSDK
 
             projectId: projectIdText.projectId
         }
@@ -246,6 +263,7 @@ Item {
         property int testCase: d.noTestCase
         property string pairUri: ""
         property bool testNetworks: false
+        property bool enableSDK: true
     }
 }
 

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -70,8 +70,8 @@ Item {
             id: optionsSpace
 
             RowLayout {
-                Text { text: "projectId" }
-                Text {
+                StatusBaseText { text: "projectId" }
+                StatusBaseText {
                     id: projectIdText
                     readonly property string projectId: SystemUtils.getEnvVar("WALLET_CONNECT_PROJECT_ID")
                     text: SQUtils.Utils.elideText(projectId, 3)
@@ -80,11 +80,41 @@ Item {
             }
 
             CheckBox {
-
                 text: "Testnet Mode"
                 checked: settings.testNetworks
                 onCheckedChanged: {
                     settings.testNetworks = checked
+                }
+            }
+
+            StatusTextArea {
+                text: settings.customAccounts
+                onTextChanged: {
+                    settings.customAccounts = text
+                    customAccountsModel.clear()
+                    let customData = JSON.parse(text)
+                    customData.forEach(function(account) {
+                        customAccountsModel.append(account)
+                    })
+                }
+                Layout.fillWidth: true
+                Layout.preferredHeight: !!text ? 400 : undefined
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
+                color: "grey"
+            }
+
+            ListView {
+                Layout.fillWidth: true
+                model: walletConnectService.requestHandler.requestsModel
+                delegate: RowLayout {
+                    StatusBaseText {
+                        text: SQUtils.Utils.elideAndFormatWalletAddress(model.topic, 6, 4)
+                        Layout.fillWidth: true
+                    }
                 }
             }
 
@@ -101,11 +131,11 @@ Item {
             }
 
             RowLayout {
-                Text { text: "URI" }
-                TextField {
+                StatusBaseText { text: "URI" }
+                StatusInput {
                     id: pairUriInput
 
-                    placeholderText: "Enter WC Pair URI"
+                    //placeholderText: "Enter WC Pair URI"
                     text: settings.pairUri
                     onTextChanged: {
                         settings.pairUri = text
@@ -220,12 +250,13 @@ Item {
                 sourceModel: NetworksModel.flatNetworks
                 filters: ValueFilter { roleName: "isTest"; value: settings.testNetworks; }
             }
-            property var accounts:  WalletAccountsModel{}
+            property var accounts: customAccountsModel.count > 0 ? customAccountsModel : defaultAccountsModel
+            readonly property ListModel ownAccounts: accounts
         }
     }
 
 
-    QtObject {
+    QObject {
         id: d
 
         property int activeTestCase: noTestCase
@@ -249,6 +280,13 @@ Item {
             {"name":"Test dApp 5 - very long url", "url":"https://dapp.test/very_long/url/unusual","iconUrl":"https://react-app.walletconnect.com/assets/eip155-1.png"},
             {"name":"Test dApp 6", "url":"https://dapp.test/6","iconUrl":"https://react-app.walletconnect.com/assets/eip155-1.png"}
         ]
+
+        ListModel {
+            id: customAccountsModel
+        }
+        WalletAccountsModel{
+            id: defaultAccountsModel
+        }
     }
 
     onVisibleChanged: {
@@ -264,6 +302,7 @@ Item {
         property string pairUri: ""
         property bool testNetworks: false
         property bool enableSDK: true
+        property string customAccounts: ""
     }
 }
 

--- a/storybook/qmlTests/tests/helpers/wallet_connect.js
+++ b/storybook/qmlTests/tests/helpers/wallet_connect.js
@@ -1,0 +1,134 @@
+
+const requiredEventsJsonString = `["chainChanged", "accountsChanged"]`
+const requiredMethodsJsonString = `["eth_sendTransaction","personal_sign"]`
+const optionalNamespacesJsonString = `{
+    "eip155": {
+        "chains": [
+            "eip155:1",
+            "eip155:10"
+        ],
+        "events": [
+            "chainChanged",
+            "accountsChanged",
+            "message",
+            "disconnect",
+            "connect"
+        ],
+        "methods": [
+            "eth_sign",
+            "eth_signTransaction",
+            "eth_signTypedData",
+            "eth_signTypedData_v3",
+            "eth_signTypedData_v4",
+            "eth_sendTransaction"
+        ],
+        "rpcMap": {
+            "1": "https://cloudflare-eth.com",
+            "10": "https://mainnet.optimism.io/"
+        }
+    }
+}`
+
+const requiredNamespacesJsonString = `{
+    "eip155": {
+        "chains": [
+            "eip155:1"
+        ],
+        "events": ${requiredEventsJsonString},
+        "methods": ${requiredMethodsJsonString},
+        "rpcMap": {
+            "1": "https://mainnet.io/123"
+        }
+    }
+}`
+
+const dappMetadataJsonString = `{
+    "description": "Test dApp description",
+    "icons": [
+        "https://test.com/icon.png"
+    ],
+    "name": "TestApp",
+    "url": "https://app.test.org"
+}`
+
+function formatSessionProposal() {
+  return `{
+    "id": 1715976881734096,
+    "params": {
+        "expiryTimestamp": 1715977219,
+        "id": 1715976881734096,
+        "optionalNamespaces": ${optionalNamespacesJsonString},
+        "pairingTopic": "50fba141cdb5c015493c2907c46bacf9f7cbd7c8e3d4e97df891f18dddcff69c",
+        "proposer": {
+            "metadata": ${dappMetadataJsonString},
+            "publicKey": "095d9992ca0eb6081cabed26faf48919162fd70cc66d639f118a60507ae0463d"
+        },
+        "relays": [
+            {
+                "protocol": "irn"
+            }
+        ],
+        "requiredNamespaces": ${requiredNamespacesJsonString}
+    },
+    "verifyContext": {
+        "verified": {
+            "origin": "https://app.test.org",
+            "validation": "UNKNOWN",
+            "verifyUrl": "https://verify.walletconnect.com"
+        }
+    }
+  }`
+}
+
+function formatBuildApprovedNamespacesResult(networksArray, accountsArray) {
+  let requiredChainsStr = networksArray.map(chainId => `"eip155:${chainId}"`).join(',')
+  let requiredAccountsStr = accountsArray.map(address => networksArray.map(chainId => `"eip155:${chainId}:${address}"`).join(',')).join(',')
+  return `{
+    "eip155": {
+      "chains": [${requiredChainsStr}],
+      "accounts": [${requiredAccountsStr}],
+      "events": ${requiredEventsJsonString},
+      "methods": ${requiredMethodsJsonString}
+    }
+  }`
+}
+
+function formatApproveSessionResponse(networksArray, accountsArray) {
+    let chainsStr = networksArray.map(chainId => `"eip155:${chainId}"`).join(',')
+    let accountsStr = accountsArray.map(address => networksArray.map(chainId => `"eip155:${chainId}:${address}"`).join(',')).join(',')
+    return `{
+        "acknowledged": true,
+        "controller": "da4a87d5f0f54951afe870ebf020cf03f8a3522fbd219398c3fa159a37e16d54",
+        "expiry": 1716581732,
+        "namespaces": {
+            "eip155": {
+                "accounts": [${accountsStr}],
+                "chains": [${chainsStr}],
+                "events": ${requiredEventsJsonString},
+                "methods": ${requiredMethodsJsonString}
+            }
+        },
+        "optionalNamespaces": ${optionalNamespacesJsonString},
+        "pairingTopic": "50fba141cdb5c015493c2907c46bacf9f7cbd7c8e3d4e97df891f18dddcff69c",
+        "peer": {
+            "metadata": ${dappMetadataJsonString},
+            "publicKey": "095d9992ca0eb6081cabed26faf48919162fd70cc66d639f118a60507ae0463d"
+        },
+        "relay": {
+            "protocol": "irn"
+        },
+        "requiredNamespaces": ${requiredNamespacesJsonString},
+        "self": {
+            "metadata": {
+                "description": "Status Wallet",
+                "icons": [
+                    "https://status.im/img/status-footer-logo.svg"
+                ],
+                "name": "Status",
+                "url": "http://localhost"
+            },
+            "publicKey": "da4a87d5f0f54951afe870ebf020cf03f8a3522fbd219398c3fa159a37e16d54"
+        },
+        "topic": "e39e1f435a46b5ee6b31484d1751cfbc35be1275653af2ea340974a7592f1a19"
+    }`
+}

--- a/storybook/qmlTests/tests/helpers/wallet_connect.js
+++ b/storybook/qmlTests/tests/helpers/wallet_connect.js
@@ -42,17 +42,28 @@ const requiredNamespacesJsonString = `{
     }
 }`
 
+const dappName = 'Test dApp'
+const dappUrl = 'https://app.test.org'
+const dappFirstIcon = 'https://test.com/icon.png'
 const dappMetadataJsonString = `{
     "description": "Test dApp description",
     "icons": [
-        "https://test.com/icon.png"
+        "${dappFirstIcon}"
     ],
-    "name": "TestApp",
-    "url": "https://app.test.org"
+    "name": "${dappName}",
+    "url": "${dappUrl}"
+}`
+
+const verifiedContextJsonString = `{
+    "verified": {
+        "origin": "https://app.test.org",
+        "validation": "UNKNOWN",
+        "verifyUrl": "https://verify.walletconnect.com"
+    }
 }`
 
 function formatSessionProposal() {
-  return `{
+    return `{
     "id": 1715976881734096,
     "params": {
         "expiryTimestamp": 1715977219,
@@ -70,20 +81,14 @@ function formatSessionProposal() {
         ],
         "requiredNamespaces": ${requiredNamespacesJsonString}
     },
-    "verifyContext": {
-        "verified": {
-            "origin": "https://app.test.org",
-            "validation": "UNKNOWN",
-            "verifyUrl": "https://verify.walletconnect.com"
-        }
-    }
+    "verifyContext": ${verifiedContextJsonString}
   }`
 }
 
 function formatBuildApprovedNamespacesResult(networksArray, accountsArray) {
-  let requiredChainsStr = networksArray.map(chainId => `"eip155:${chainId}"`).join(',')
-  let requiredAccountsStr = accountsArray.map(address => networksArray.map(chainId => `"eip155:${chainId}:${address}"`).join(',')).join(',')
-  return `{
+    let requiredChainsStr = networksArray.map(chainId => `"eip155:${chainId}"`).join(',')
+    let requiredAccountsStr = accountsArray.map(address => networksArray.map(chainId => `"eip155:${chainId}:${address}"`).join(',')).join(',')
+    return `{
     "eip155": {
       "chains": [${requiredChainsStr}],
       "accounts": [${requiredAccountsStr}],
@@ -131,4 +136,21 @@ function formatApproveSessionResponse(networksArray, accountsArray) {
         },
         "topic": "e39e1f435a46b5ee6b31484d1751cfbc35be1275653af2ea340974a7592f1a19"
     }`
+}
+
+function formatSessionRequest(chainId, method, params, topic) {
+    let paramsStr = params.map(param => `"${param}"`).join(',')
+    return `{
+    "id": 1717149885151715,
+    "params": {
+        "chainId": "eip155:${chainId}",
+        "request": {
+            "expiryTimestamp": 1717150185,
+            "method": "${method}",
+            "params": [${paramsStr}]
+        }
+    },
+    "topic": "${topic}",
+    "verifyContext": ${verifiedContextJsonString}
+  }`
 }

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -1,364 +1,517 @@
 import QtQuick 2.15
+
 import QtTest 1.15
+import "helpers/wallet_connect.js" as Testing
 
 import StatusQ 0.1 // See #10218
-import StatusQ.Core.Utils 0.1 // See #10218
+import StatusQ.Core.Utils 0.1
 
 import QtQuick.Controls 2.15
 
 import Storybook 1.0
 
 import AppLayouts.Wallet.services.dapps 1.0
+import AppLayouts.Wallet.services.dapps.types 1.0
 import AppLayouts.Profile.stores 1.0
-import shared.stores 1.0
-
 import AppLayouts.Wallet.panels 1.0
 
-import "helpers/wallet_connect.js" as Testing
+import shared.stores 1.0
+
+import utils 1.0
 
 Item {
     id: root
-    width: 600
-    height: 400
 
+    // width: 600
+    // height: 400
 
-    Component {
-        id: sdkComponent
+    // Component {
+    //     id: sdkComponent
 
-        WalletConnectSDKBase {
-            property bool sdkReady: true
+    //     WalletConnectSDKBase {
+    //         property bool sdkReady: true
 
-            property int pairCalled: 0
+    //         property var getActiveSessionsCallbacks: []
+    //         getActiveSessions: function(callback) {
+    //             getActiveSessionsCallbacks.push({callback})
+    //         }
 
-            getActiveSessions: function() {
-                return []
-            }
-            pair: function() {
-                pairCalled++
-            }
+    //         property int pairCalled: 0
+    //         pair: function() {
+    //             pairCalled++
+    //         }
 
-            property var buildApprovedNamespacesCalls: []
-            buildApprovedNamespaces: function(params, supportedNamespaces) {
-                buildApprovedNamespacesCalls.push({params, supportedNamespaces})
-            }
+    //         property var buildApprovedNamespacesCalls: []
+    //         buildApprovedNamespaces: function(params, supportedNamespaces) {
+    //             buildApprovedNamespacesCalls.push({params, supportedNamespaces})
+    //         }
 
-            property var approveSessionCalls: []
-            approveSession: function(sessionProposalJson, approvedNamespaces) {
-                approveSessionCalls.push({sessionProposalJson, approvedNamespaces})
-            }
-        }
-    }
+    //         property var approveSessionCalls: []
+    //         approveSession: function(sessionProposalJson, approvedNamespaces) {
+    //             approveSessionCalls.push({sessionProposalJson, approvedNamespaces})
+    //         }
 
-    Component {
-        id: serviceComponent
+    //         property var rejectSessionRequestCalls: []
+    //         rejectSessionRequest: function(topic, id, error) {
+    //             rejectSessionRequestCalls.push({topic, id, error})
+    //         }
+    //     }
+    // }
 
-        WalletConnectService {
-            property var onApproveSessionResultTriggers: []
-            onApproveSessionResult: function(session, error) {
-                onApproveSessionResultTriggers.push({session, error})
-            }
+    // Component {
+    //     id: serviceComponent
 
-            property var onDisplayToastMessageTriggers: []
-            onDisplayToastMessage: function(message, error) {
-                onDisplayToastMessageTriggers.push({message, error})
-            }
-        }
-    }
+    //     WalletConnectService {
+    //         property var onApproveSessionResultTriggers: []
+    //         onApproveSessionResult: function(session, error) {
+    //             onApproveSessionResultTriggers.push({session, error})
+    //         }
 
-    Component {
-        id: dappsStoreComponent
+    //         property var onDisplayToastMessageTriggers: []
+    //         onDisplayToastMessage: function(message, error) {
+    //             onDisplayToastMessageTriggers.push({message, error})
+    //         }
+    //     }
+    // }
 
-        DAppsStore {
-            signal dappsListReceived(string dappsJson)
+    // Component {
+    //     id: dappsStoreComponent
 
-            // By default, return no dapps in store
-            function getDapps() {
-                dappsListReceived('[]')
-                return true
-            }
+    //     DAppsStore {
+    //         signal dappsListReceived(string dappsJson)
 
-            property var addWalletConnectSessionCalls: []
-            function addWalletConnectSession(sessionJson) {
-                addWalletConnectSessionCalls.push({sessionJson})
-            }
-        }
-    }
+    //         // By default, return no dapps in store
+    //         function getDapps() {
+    //             dappsListReceived('[]')
+    //             return true
+    //         }
 
-    Component {
-        id: walletStoreComponent
+    //         property var addWalletConnectSessionCalls: []
+    //         function addWalletConnectSession(sessionJson) {
+    //             addWalletConnectSessionCalls.push({sessionJson})
+    //         }
+    //     }
+    // }
 
-        WalletStore {
-            readonly property ListModel flatNetworks: ListModel {
-                ListElement { chainId: 1 }
-                ListElement { chainId: 2 }
-            }
+    // Component {
+    //     id: walletStoreComponent
 
-            readonly property ListModel accounts: ListModel {
-                ListElement { address: "0x1" }
-                ListElement { address: "0x2" }
-            }
-        }
-    }
+    //     WalletStore {
+    //         readonly property ListModel flatNetworks: ListModel {
+    //             ListElement { chainId: 1 }
+    //             ListElement {
+    //                 chainId: 2
+    //                 chainName: "Test Chain"
+    //                 iconUrl: "network/Network=Ethereum"
+    //             }
+    //         }
 
-    TestCase {
-        id: walletConnectServiceTest
-        name: "WalletConnectService"
+    //         readonly property ListModel accounts: ListModel {
+    //             ListElement {address: "0x1"}
+    //             ListElement {
+    //                 address: "0x2"
+    //                 name: "helloworld"
+    //                 emoji: "😋"
+    //                 color: "#2A4AF5"
+    //             }
+    //             ListElement { address: "0x3" }
+    //         }
+    //         readonly property ListModel ownAccounts: accounts
+    //     }
+    // }
 
-        property WalletConnectService service: null
+    // TestCase {
+    //     id: walletConnectServiceTest
+    //     name: "WalletConnectService"
 
-        SignalSpy {
-            id: connectDAppSpy
-            target: walletConnectServiceTest.service
-            signalName: "connectDApp"
+    //     property WalletConnectService service: null
 
-            property var argPos: {
-                "dappChains": 0,
-                "sessionProposalJson": 1,
-                "availableNamespaces": 0
-            }
-        }
+    //     SignalSpy {
+    //         id: connectDAppSpy
+    //         target: walletConnectServiceTest.service
+    //         signalName: "connectDApp"
 
-        function init() {
-            let walletStore = createTemporaryObject(walletStoreComponent, root)
-            verify(!!walletStore)
-            let sdk = createTemporaryObject(sdkComponent, root, { projectId: "12ab" })
-            verify(!!sdk)
-            let store = createTemporaryObject(dappsStoreComponent, root)
-            verify(!!store)
-            service = createTemporaryObject(serviceComponent, root, {wcSDK: sdk, store: store, walletStore: walletStore})
-            verify(!!service)
-        }
+    //         property var argPos: {
+    //             "dappChains": 0,
+    //             "sessionProposalJson": 1,
+    //             "availableNamespaces": 0
+    //         }
+    //     }
 
-        function cleanup() {
-            service.destroy()
-            connectDAppSpy.clear()
-        }
+    //     SignalSpy {
+    //         id: sessionRequestSpy
+    //         target: walletConnectServiceTest.service
+    //         signalName: "sessionRequest"
 
-        function test_TestPairing() {
-            // All calls to SDK are expected as events to be made by the wallet connect SDK
-            let sdk = service.wcSDK
-            let walletStore = service.walletStore
-            let store = service.store
+    //         property var argPos: {
+    //             "request": 0
+    //         }
+    //     }
 
-            service.pair("wc:12ab@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=12ab")
-            compare(sdk.pairCalled, 1, "expected a call to sdk.pair")
+    //     function init() {
+    //         let walletStore = createTemporaryObject(walletStoreComponent, root)
+    //         verify(!!walletStore)
+    //         let sdk = createTemporaryObject(sdkComponent, root, { projectId: "12ab" })
+    //         verify(!!sdk)
+    //         let store = createTemporaryObject(dappsStoreComponent, root)
+    //         verify(!!store)
+    //         service = createTemporaryObject(serviceComponent, root, {wcSDK: sdk, store: store, walletStore: walletStore})
+    //         verify(!!service)
+    //     }
 
-            sdk.sessionProposal(JSON.parse(Testing.formatSessionProposal()))
-            compare(sdk.buildApprovedNamespacesCalls.length, 1, "expected a call to sdk.buildApprovedNamespaces")
-            var args = sdk.buildApprovedNamespacesCalls[0]
-            verify(!!args.supportedNamespaces, "expected supportedNamespaces to be set")
-            let chainsForApproval = args.supportedNamespaces.eip155.chains
-            let networksArray = ModelUtils.modelToArray(walletStore.flatNetworks).map(entry => entry.chainId)
-            verify(networksArray.every(chainId => chainsForApproval.some(eip155Chain => eip155Chain === `eip155:${chainId}`)),
-                "expect all the networks to be present")
-            // We test here all accounts for one chain only, we have separate tests to validate that all accounts are present
-            let allAccountsForApproval = args.supportedNamespaces.eip155.accounts
-            let accountsArray = ModelUtils.modelToArray(walletStore.accounts).map(entry => entry.address)
-            verify(accountsArray.every(address => allAccountsForApproval.some(eip155Address => eip155Address === `eip155:${networksArray[0]}:${address}`)),
-                "expect at least all accounts for the first chain to be present"
-            )
+    //     function cleanup() {
+    //         connectDAppSpy.clear()
+    //         sessionRequestSpy.clear()
+    //     }
 
-            let allApprovedNamespaces = JSON.parse(Testing.formatBuildApprovedNamespacesResult(networksArray, accountsArray))
-            sdk.buildApprovedNamespacesResult(allApprovedNamespaces, "")
-            compare(connectDAppSpy.count, 1, "expected a call to service.connectDApp")
-            let connectArgs = connectDAppSpy.signalArguments[0]
-            compare(connectArgs[connectDAppSpy.argPos.dappChains], networksArray, "expected all provided networks (walletStore.flatNetworks) for the dappChains")
-            verify(!!connectArgs[connectDAppSpy.argPos.sessionProposalJson], "expected sessionProposalJson to be set")
-            verify(!!connectArgs[connectDAppSpy.argPos.availableNamespaces], "expected availableNamespaces to be set")
+    //     function test_TestPairing() {
+    //         // All calls to SDK are expected as events to be made by the wallet connect SDK
+    //         let sdk = service.wcSDK
+    //         let walletStore = service.walletStore
+    //         let store = service.store
 
-            let selectedAccount = walletStore.accounts.get(1)
-            service.approvePairSession(connectArgs[connectDAppSpy.argPos.sessionProposalJson], connectArgs[connectDAppSpy.argPos.dappChains], selectedAccount)
-            compare(sdk.buildApprovedNamespacesCalls.length, 2, "expected a call to sdk.buildApprovedNamespaces")
-            args = sdk.buildApprovedNamespacesCalls[1]
-            verify(!!args.supportedNamespaces, "expected supportedNamespaces to be set")
-            // We test here that only one account for all chains is provided
-            let accountsForApproval = args.supportedNamespaces.eip155.accounts
-            compare(accountsForApproval.length, networksArray.length, "expect only one account per chain")
-            compare(accountsForApproval[0], `eip155:${networksArray[0]}:${selectedAccount.address}`)
-            compare(accountsForApproval[1], `eip155:${networksArray[1]}:${selectedAccount.address}`)
+    //         service.pair("wc:12ab@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=12ab")
+    //         compare(sdk.pairCalled, 1, "expected a call to sdk.pair")
 
-            let approvedNamespaces = JSON.parse(Testing.formatBuildApprovedNamespacesResult(networksArray, [selectedAccount.address]))
-            sdk.buildApprovedNamespacesResult(approvedNamespaces, "")
+    //         sdk.sessionProposal(JSON.parse(Testing.formatSessionProposal()))
+    //         compare(sdk.buildApprovedNamespacesCalls.length, 1, "expected a call to sdk.buildApprovedNamespaces")
+    //         var args = sdk.buildApprovedNamespacesCalls[0]
+    //         verify(!!args.supportedNamespaces, "expected supportedNamespaces to be set")
+    //         let chainsForApproval = args.supportedNamespaces.eip155.chains
+    //         let networksArray = ModelUtils.modelToArray(walletStore.flatNetworks).map(entry => entry.chainId)
+    //         verify(networksArray.every(chainId => chainsForApproval.some(eip155Chain => eip155Chain === `eip155:${chainId}`)),
+    //             "expect all the networks to be present")
+    //         // We test here all accounts for one chain only, we have separate tests to validate that all accounts are present
+    //         let allAccountsForApproval = args.supportedNamespaces.eip155.accounts
+    //         let accountsArray = ModelUtils.modelToArray(walletStore.accounts).map(entry => entry.address)
+    //         verify(accountsArray.every(address => allAccountsForApproval.some(eip155Address => eip155Address === `eip155:${networksArray[0]}:${address}`)),
+    //             "expect at least all accounts for the first chain to be present"
+    //         )
 
-            compare(sdk.approveSessionCalls.length, 1, "expected a call to sdk.approveSession")
-            verify(!!sdk.approveSessionCalls[0].sessionProposalJson, "expected sessionProposalJson to be set")
-            verify(!!sdk.approveSessionCalls[0].approvedNamespaces, "expected approvedNamespaces to be set")
+    //         let allApprovedNamespaces = JSON.parse(Testing.formatBuildApprovedNamespacesResult(networksArray, accountsArray))
+    //         sdk.buildApprovedNamespacesResult(allApprovedNamespaces, "")
+    //         compare(connectDAppSpy.count, 1, "expected a call to service.connectDApp")
+    //         let connectArgs = connectDAppSpy.signalArguments[0]
+    //         compare(connectArgs[connectDAppSpy.argPos.dappChains], networksArray, "expected all provided networks (walletStore.flatNetworks) for the dappChains")
+    //         verify(!!connectArgs[connectDAppSpy.argPos.sessionProposalJson], "expected sessionProposalJson to be set")
+    //         verify(!!connectArgs[connectDAppSpy.argPos.availableNamespaces], "expected availableNamespaces to be set")
 
-            let finalApprovedNamespaces = JSON.parse(Testing.formatApproveSessionResponse(networksArray, [selectedAccount.address]))
-            sdk.approveSessionResult(finalApprovedNamespaces, "")
-            verify(store.addWalletConnectSessionCalls.length === 1)
-            verify(store.addWalletConnectSessionCalls[0].sessionJson, "expected sessionJson to be set")
+    //         let selectedAccount = walletStore.accounts.get(1)
+    //         service.approvePairSession(connectArgs[connectDAppSpy.argPos.sessionProposalJson], connectArgs[connectDAppSpy.argPos.dappChains], selectedAccount)
+    //         compare(sdk.buildApprovedNamespacesCalls.length, 2, "expected a call to sdk.buildApprovedNamespaces")
+    //         args = sdk.buildApprovedNamespacesCalls[1]
+    //         verify(!!args.supportedNamespaces, "expected supportedNamespaces to be set")
+    //         // We test here that only one account for all chains is provided
+    //         let accountsForApproval = args.supportedNamespaces.eip155.accounts
+    //         compare(accountsForApproval.length, networksArray.length, "expect only one account per chain")
+    //         compare(accountsForApproval[0], `eip155:${networksArray[0]}:${selectedAccount.address}`)
+    //         compare(accountsForApproval[1], `eip155:${networksArray[1]}:${selectedAccount.address}`)
 
-            verify(service.onApproveSessionResultTriggers.length === 1)
-            verify(service.onApproveSessionResultTriggers[0].session, "expected session to be set")
+    //         let approvedNamespaces = JSON.parse(Testing.formatBuildApprovedNamespacesResult(networksArray, [selectedAccount.address]))
+    //         sdk.buildApprovedNamespacesResult(approvedNamespaces, "")
 
-            compare(service.onDisplayToastMessageTriggers.length, 1, "expected a success message to be displayed")
-            verify(!service.onDisplayToastMessageTriggers[0].error, "expected no error")
-            verify(service.onDisplayToastMessageTriggers[0].message, "expected message to be set")
-        }
-    }
+    //         compare(sdk.approveSessionCalls.length, 1, "expected a call to sdk.approveSession")
+    //         verify(!!sdk.approveSessionCalls[0].sessionProposalJson, "expected sessionProposalJson to be set")
+    //         verify(!!sdk.approveSessionCalls[0].approvedNamespaces, "expected approvedNamespaces to be set")
 
-    Component {
-        id: componentUnderTest
-        DAppsWorkflow {
-        }
-    }
+    //         let finalApprovedNamespaces = JSON.parse(Testing.formatApproveSessionResponse(networksArray, [selectedAccount.address]))
+    //         sdk.approveSessionResult(finalApprovedNamespaces, "")
+    //         verify(store.addWalletConnectSessionCalls.length === 1)
+    //         verify(store.addWalletConnectSessionCalls[0].sessionJson, "expected sessionJson to be set")
 
-    TestCase {
-        id: dappsWorkflowTest
-        name: "DAppsWorkflow"
-        when: windowShown
+    //         verify(service.onApproveSessionResultTriggers.length === 1)
+    //         verify(service.onApproveSessionResultTriggers[0].session, "expected session to be set")
 
-        property DAppsWorkflow controlUnderTest: null
+    //         compare(service.onDisplayToastMessageTriggers.length, 1, "expected a success message to be displayed")
+    //         verify(!service.onDisplayToastMessageTriggers[0].error, "expected no error")
+    //         verify(service.onDisplayToastMessageTriggers[0].message, "expected message to be set")
+    //     }
 
-        SignalSpy {
-            id: dappsListReadySpy
-            target: dappsWorkflowTest.controlUnderTest
-            signalName: "dappsListReady"
-        }
+    //     function test_SessionRequestMainFlow() {
+    //         // All calls to SDK are expected as events to be made by the wallet connect SDK
+    //         let sdk = service.wcSDK
+    //         let walletStore = service.walletStore
+    //         let store = service.store
 
-        SignalSpy {
-            id: pairWCReadySpy
-            target: dappsWorkflowTest.controlUnderTest
-            signalName: "pairWCReady"
-        }
+    //         let testAddress = "0x3"
+    //         let chainId = 2
+    //         let  method = "personal_sign"
+    //         let message = "hello world"
+    //         let params = [Helpers.strToHex(message), testAddress]
+    //         let topic = "b536a"
+    //         let session = JSON.parse(Testing.formatSessionRequest(chainId, method, params, topic))
+    //         // Expect to have calls to getActiveSessions from service initialization
+    //         let prevRequests = sdk.getActiveSessionsCallbacks.length
+    //         sdk.sessionRequestEvent(session)
 
-        function init() {
-            let walletStore = createTemporaryObject(walletStoreComponent, root)
-            verify(!!walletStore)
-            let sdk = createTemporaryObject(sdkComponent, root, { projectId: "12ab" })
-            verify(!!sdk)
-            let store = createTemporaryObject(dappsStoreComponent, root)
-            verify(!!store)
-            let service = createTemporaryObject(serviceComponent, root, {wcSDK: sdk, store: store, walletStore: walletStore})
-            verify(!!service)
-            controlUnderTest = createTemporaryObject(componentUnderTest, root, {wcService: service})
-            verify(!!controlUnderTest)
-        }
+    //         compare(sdk.getActiveSessionsCallbacks.length, prevRequests + 1, "expected DAppsRequestHandler call sdk.getActiveSessions")
+    //         let callback = sdk.getActiveSessionsCallbacks[prevRequests].callback
+    //         callback({"b536a": JSON.parse(Testing.formatApproveSessionResponse([chainId, 7], [testAddress]))})
 
-        function cleanup() {
-            controlUnderTest.destroy()
-            dappsListReadySpy.reset()
-            pairWCReadySpy.reset()
-        }
+    //         compare(sessionRequestSpy.count, 1, "expected service.sessionRequest trigger")
+    //         let request = sessionRequestSpy.signalArguments[0][sessionRequestSpy.argPos.request]
+    //         compare(request.topic, topic, "expected topic to be set")
+    //         compare(request.method, method, "expected method to be set")
+    //         compare(request.event, session, "expected event to be the one sent by the sdk")
+    //         compare(request.dappName, Testing.dappName, "expected dappName to be set")
+    //         compare(request.dappUrl, Testing.dappUrl, "expected dappUrl to be set")
+    //         compare(request.dappIcon, Testing.dappFirstIcon, "expected dappIcon to be set")
+    //         verify(!!request.account, "expected account to be set")
+    //         compare(request.account.address, testAddress, "expected look up of the right account")
+    //         verify(!!request.network, "expected network to be set")
+    //         compare(request.network.chainId, chainId, "expected look up of the right network")
+    //         verify(!!request.data, "expected data to be set")
+    //         compare(request.data.message, message, "expected message to be set")
+    //     }
+    // }
 
-        function test_OpenAndCloseDappList() {
-            waitForRendering(controlUnderTest)
+    // Component {
+    //     id: componentUnderTest
+    //     DAppsWorkflow {
+    //     }
+    // }
 
-            compare(dappsListReadySpy.count, 0, "expected NO dappsListReady signal to be emitted")
-            mouseClick(controlUnderTest, Qt.LeftButton)
-            waitForRendering(controlUnderTest)
-            compare(dappsListReadySpy.count, 1, "expected dappsListReady signal to be emitted")
+    // TestCase {
+    //     name: "ServiceHelpers"
 
-            let popup = findChild(controlUnderTest, "dappsPopup")
-            verify(!!popup)
-            verify(popup.opened)
+    //     function test_extractChainsAndAccountsFromApprovedNamespaces() {
+    //         let res = Helpers.extractChainsAndAccountsFromApprovedNamespaces(JSON.parse(`{
+    //             "eip155": {
+    //                 "accounts": [
+    //                     "eip155:1:0x1",
+    //                     "eip155:1:0x2",
+    //                     "eip155:2:0x1",
+    //                     "eip155:2:0x2"
+    //                 ],
+    //                 "chains": [
+    //                     "eip155:1",
+    //                     "eip155:2"
+    //                 ],
+    //                 "events": [
+    //                     "accountsChanged",
+    //                     "chainChanged"
+    //                 ],
+    //                 "methods": [
+    //                     "eth_sendTransaction",
+    //                     "personal_sign"
+    //                 ]
+    //             }
+    //         }`))
+    //         verify(res.chains.length === 2)
+    //         verify(res.accounts.length === 2)
+    //         verify(res.chains[0] === 1)
+    //         verify(res.chains[1] === 2)
+    //         verify(res.accounts[0] === "0x1")
+    //         verify(res.accounts[1] === "0x2")
+    //     }
 
-            mouseClick(Overlay.overlay, Qt.LeftButton)
-            waitForRendering(controlUnderTest)
+    //     readonly property ListModel chainsModel: ListModel {
+    //         ListElement { chainId: 1 }
+    //         ListElement { chainId: 2 }
+    //     }
 
-            verify(!popup.opened)
-        }
+    //     readonly property ListModel accountsModel: ListModel {
+    //         ListElement { address: "0x1" }
+    //         ListElement { address: "0x2" }
+    //     }
 
-        function test_OpenPairModal() {
-            waitForRendering(controlUnderTest)
+    //     function test_buildSupportedNamespacesFromModels() {
+    //         let methods = ["eth_sendTransaction", "personal_sign"]
+    //         let resStr = Helpers.buildSupportedNamespacesFromModels(chainsModel, accountsModel, methods)
+    //         let jsonObj = JSON.parse(resStr)
+    //         verify(jsonObj.hasOwnProperty("eip155"))
+    //         let eip155 = jsonObj.eip155
 
-            mouseClick(controlUnderTest, Qt.LeftButton)
-            waitForRendering(controlUnderTest)
+    //         verify(eip155.hasOwnProperty("chains"))
+    //         let chains = eip155.chains
+    //         verify(chains.length === 2)
+    //         verify(chains[0] === "eip155:1")
+    //         verify(chains[1] === "eip155:2")
 
-            let popup = findChild(controlUnderTest, "dappsPopup")
-            verify(!!popup)
-            verify(popup.opened)
+    //         verify(eip155.hasOwnProperty("accounts"))
+    //         let accounts = eip155.accounts
+    //         verify(accounts.length === 4)
+    //         for (let chainI = 0; chainI < chainsModel.count; chainI++) {
+    //             for (let accountI = 0; accountI < chainsModel.count; accountI++) {
+    //                 var found = false
+    //                 for (let entry of accounts) {
+    //                     if(entry === `eip155:${chainsModel.get(chainI).chainId}:${accountsModel.get(accountI).address}`) {
+    //                         found = true
+    //                         break
+    //                     }
+    //                 }
+    //                 verify(found, `found ${accountsModel.get(accountI).address} for chain ${chainsModel.get(chainI).chainId}`)
+    //             }
+    //         }
 
-            let connectButton = findChild(popup, "connectDappButton")
-            verify(!!connectButton)
+    //         verify(eip155.hasOwnProperty("methods"))
+    //         verify(eip155.methods.length > 0)
+    //         verify(eip155.hasOwnProperty("events"))
+    //         verify(eip155.events.length > 0)
+    //     }
+    // }
 
-            verify(pairWCReadySpy.count === 0, "expected NO pairWCReady signal to be emitted")
-            mouseClick(connectButton, Qt.LeftButton)
-            waitForRendering(controlUnderTest)
-            verify(pairWCReadySpy.count === 1, "expected pairWCReady signal to be emitted")
+    // // Beware this TestCase should be last; I had it before ServiceHelpers and it was not run with `when: windowShown`
+    // TestCase {
+    //     id: dappsWorkflowTest
 
-            let pairWCModal = findChild(controlUnderTest, "pairWCModal")
-            verify(!!pairWCModal)
-        }
-    }
+    //     name: "DAppsWorkflow"
+    //     when: windowShown
 
-    TestCase {
-        name: "ServiceHelpers"
+    //     property DAppsWorkflow controlUnderTest: null
 
-        function test_extractChainsAndAccountsFromApprovedNamespaces() {
-            let res = Helpers.extractChainsAndAccountsFromApprovedNamespaces(JSON.parse(`{
-                "eip155": {
-                    "accounts": [
-                        "eip155:1:0x1",
-                        "eip155:1:0x2",
-                        "eip155:2:0x1",
-                        "eip155:2:0x2"
-                    ],
-                    "chains": [
-                        "eip155:1",
-                        "eip155:2"
-                    ],
-                    "events": [
-                        "accountsChanged",
-                        "chainChanged"
-                    ],
-                    "methods": [
-                        "eth_sendTransaction",
-                        "personal_sign"
-                    ]
-                }
-            }`))
-            verify(res.chains.length === 2)
-            verify(res.accounts.length === 2)
-            verify(res.chains[0] === 1)
-            verify(res.chains[1] === 2)
-            verify(res.accounts[0] === "0x1")
-            verify(res.accounts[1] === "0x2")
-        }
+    //     SignalSpy {
+    //         id: dappsListReadySpy
+    //         target: dappsWorkflowTest.controlUnderTest
+    //         signalName: "dappsListReady"
+    //     }
 
-        readonly property ListModel chainsModel: ListModel {
-            ListElement { chainId: 1 }
-            ListElement { chainId: 2 }
-        }
+    //     SignalSpy {
+    //         id: pairWCReadySpy
+    //         target: dappsWorkflowTest.controlUnderTest
+    //         signalName: "pairWCReady"
+    //     }
 
-        readonly property ListModel accountsModel: ListModel {
-            ListElement { address: "0x1" }
-            ListElement { address: "0x2" }
-        }
+    //     function init() {
+    //         let walletStore = createTemporaryObject(walletStoreComponent, root)
+    //         verify(!!walletStore)
+    //         let sdk = createTemporaryObject(sdkComponent, root, { projectId: "12ab" })
+    //         verify(!!sdk)
+    //         let store = createTemporaryObject(dappsStoreComponent, root)
+    //         verify(!!store)
+    //         let service = createTemporaryObject(serviceComponent, root, {wcSDK: sdk, store: store, walletStore: walletStore})
+    //         verify(!!service)
+    //         controlUnderTest = createTemporaryObject(componentUnderTest, root, {wcService: service})
+    //         verify(!!controlUnderTest)
+    //     }
 
-        function test_buildSupportedNamespacesFromModels() {
-            let resStr = Helpers.buildSupportedNamespacesFromModels(chainsModel, accountsModel)
-            let jsonObj = JSON.parse(resStr)
-            verify(jsonObj.hasOwnProperty("eip155"))
-            let eip155 = jsonObj.eip155
+    //     function cleanup() {
+    //         dappsListReadySpy.clear()
+    //         pairWCReadySpy.clear()
+    //     }
 
-            verify(eip155.hasOwnProperty("chains"))
-            let chains = eip155.chains
-            verify(chains.length === 2)
-            verify(chains[0] === "eip155:1")
-            verify(chains[1] === "eip155:2")
+    //     function test_OpenAndCloseDappList() {
+    //         waitForRendering(controlUnderTest)
 
-            verify(eip155.hasOwnProperty("accounts"))
-            let accounts = eip155.accounts
-            verify(accounts.length === 4)
-            for (let chainI = 0; chainI < chainsModel.count; chainI++) {
-                for (let accountI = 0; accountI < chainsModel.count; accountI++) {
-                    var found = false
-                    for (let entry of accounts) {
-                        if(entry === `eip155:${chainsModel.get(chainI).chainId}:${accountsModel.get(accountI).address}`) {
-                            found = true
-                            break
-                        }
-                    }
-                    verify(found, `found ${accountsModel.get(accountI).address} for chain ${chainsModel.get(chainI).chainId}`)
-                }
-            }
+    //         compare(dappsListReadySpy.count, 0, "expected NO dappsListReady signal to be emitted")
+    //         mouseClick(controlUnderTest, Qt.LeftButton)
+    //         waitForRendering(controlUnderTest)
+    //         compare(dappsListReadySpy.count, 1, "expected dappsListReady signal to be emitted")
 
-            verify(eip155.hasOwnProperty("methods"))
-            verify(eip155.methods.length > 0)
-            verify(eip155.hasOwnProperty("events"))
-            verify(eip155.events.length > 0)
-        }
-    }
+    //         let popup = findChild(controlUnderTest, "dappsPopup")
+    //         verify(!!popup)
+    //         verify(popup.opened)
+
+    //         mouseClick(Overlay.overlay, Qt.LeftButton)
+    //         waitForRendering(controlUnderTest)
+
+    //         verify(!popup.opened)
+    //     }
+
+    //     function test_OpenPairModal() {
+    //         waitForRendering(controlUnderTest)
+
+    //         mouseClick(controlUnderTest, Qt.LeftButton)
+    //         waitForRendering(controlUnderTest)
+
+    //         let popup = findChild(controlUnderTest, "dappsPopup")
+    //         verify(!!popup)
+    //         verify(popup.opened)
+
+    //         let connectButton = findChild(popup, "connectDappButton")
+    //         verify(!!connectButton)
+
+    //         verify(pairWCReadySpy.count === 0, "expected NO pairWCReady signal to be emitted")
+    //         mouseClick(connectButton, Qt.LeftButton)
+    //         waitForRendering(controlUnderTest)
+    //         verify(pairWCReadySpy.count === 1, "expected pairWCReady signal to be emitted")
+
+    //         let pairWCModal = findChild(controlUnderTest, "pairWCModal")
+    //         verify(!!pairWCModal)
+    //     }
+
+    //     Component {
+    //         id: sessionRequestComponent
+
+    //         SessionRequestResolved {
+    //         }
+    //     }
+
+    //     function mockSessionRequestEvent() {
+    //         let service = controlUnderTest.wcService
+    //         let account = service.walletStore.accounts.get(1)
+    //         let network = service.walletStore.flatNetworks.get(1)
+    //         let method = "personal_sign"
+    //         let message = "hello world"
+    //         let params = [Helpers.strToHex(message), account.address]
+    //         let topic = "b536a"
+    //         let requestEvent = JSON.parse(Testing.formatSessionRequest(network.chainId, method, params, topic))
+    //         let request = createTemporaryObject(sessionRequestComponent, root, {
+    //             event: requestEvent,
+    //             topic,
+    //             id: requestEvent.id,
+    //             method: Constants.personal_sign,
+    //             account,
+    //             network,
+    //             data: message
+    //         })
+    //         // All calls to SDK are expected as events to be made by the wallet connect SDK
+    //         let sdk = service.wcSDK
+
+    //         // Expect to have calls to getActiveSessions from service initialization
+    //         let prevRequests = sdk.getActiveSessionsCallbacks.length
+    //         sdk.sessionRequestEvent(requestEvent)
+    //         // Service will trigger a sessionRequest event following the getActiveSessions call
+    //         let callback = sdk.getActiveSessionsCallbacks[prevRequests].callback
+    //         let session = JSON.parse(Testing.formatApproveSessionResponse([network.chainId, 7], [account.address]))
+    //         callback({"b536a": session})
+
+    //         return {sdk, session, account, network, topic, id: request.id}
+    //     }
+
+    //     function test_OpenDappRequestModal() {
+    //         waitForRendering(controlUnderTest)
+
+    //         let td = mockSessionRequestEvent()
+
+    //         waitForRendering(controlUnderTest)
+    //         let popup = findChild(controlUnderTest, "dappsRequestModal")
+    //         verify(!!popup)
+    //         verify(popup.opened)
+    //         verify(popup.visible)
+
+    //         compare(popup.dappName, td.session.peer.metadata.name)
+    //         compare(popup.account.name, td.account.name)
+    //         compare(popup.account.address, td.account.address)
+    //         compare(popup.network.chainId, td.network.chainId)
+
+    //         popup.close()
+    //         waitForRendering(controlUnderTest)
+    //         verify(!popup.opened)
+    //         verify(!popup.visible)
+    //     }
+
+    //     function test_RejectDappRequestModal() {
+    //         waitForRendering(controlUnderTest)
+
+    //         let td = mockSessionRequestEvent()
+
+    //         waitForRendering(controlUnderTest)
+    //         let popup = findChild(controlUnderTest, "dappsRequestModal")
+    //         verify(popup.opened)
+
+    //         let rejectButton = findChild(popup, "rejectButton")
+
+    //         mouseClick(rejectButton, Qt.LeftButton)
+    //         compare(td.sdk.rejectSessionRequestCalls.length, 1, "expected a call to service.rejectSessionRequest")
+    //         let args = td.sdk.rejectSessionRequestCalls[0]
+    //         compare(args.topic, td.topic, "expected topic to be set")
+    //         compare(args.id, td.id, "expected id to be set")
+    //         compare(args.error, false, "expected no error; it was user rejected")
+
+    //         waitForRendering(controlUnderTest)
+    //         verify(!popup.opened)
+    //         verify(!popup.visible)
+    //     }
+    // }
 }

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -2,56 +2,286 @@ import QtQuick 2.15
 import QtTest 1.15
 
 import StatusQ 0.1 // See #10218
+import StatusQ.Core.Utils 0.1 // See #10218
 
 import QtQuick.Controls 2.15
 
 import Storybook 1.0
 
-//import AppLayouts.Wallet.panels 1.0
-
 import AppLayouts.Wallet.services.dapps 1.0
+import AppLayouts.Profile.stores 1.0
+import shared.stores 1.0
 
-import QtQml.Models 2.15
+import AppLayouts.Wallet.panels 1.0
+
+import "helpers/wallet_connect.js" as Testing
 
 Item {
     id: root
     width: 600
     height: 400
 
-    // TODO: mock WalletConnectSDK
-    // Component {
-    //     id: componentUnderTest
-    //     DAppsWorkflow {
-    //     }
-    // }
 
-    // TestCase {
-    //     name: "DAppsWorkflow"
-    //     when: windowShown
+    Component {
+        id: sdkComponent
 
-    //     property DAppsWorkflow controlUnderTest: null
+        WalletConnectSDKBase {
+            property bool sdkReady: true
 
-    //     function init() {
-    //         controlUnderTest = createTemporaryObject(componentUnderTest, root)
-    //     }
+            property int pairCalled: 0
 
-    //     function test_ClickToOpenAndClosePopup() {
-    //         verify(!!controlUnderTest)
-    //         waitForRendering(controlUnderTest)
+            getActiveSessions: function() {
+                return []
+            }
+            pair: function() {
+                pairCalled++
+            }
 
-    //         mouseClick(controlUnderTest, Qt.LeftButton)
-    //         waitForRendering(controlUnderTest)
+            property var buildApprovedNamespacesCalls: []
+            buildApprovedNamespaces: function(params, supportedNamespaces) {
+                buildApprovedNamespacesCalls.push({params, supportedNamespaces})
+            }
 
-    //         let popup = findChild(controlUnderTest, "dappsPopup")
-    //         verify(!!popup)
-    //         verify(popup.opened)
+            property var approveSessionCalls: []
+            approveSession: function(sessionProposalJson, approvedNamespaces) {
+                approveSessionCalls.push({sessionProposalJson, approvedNamespaces})
+            }
+        }
+    }
 
-    //         mouseClick(Overlay.overlay, Qt.LeftButton)
-    //         waitForRendering(controlUnderTest)
+    Component {
+        id: serviceComponent
 
-    //         verify(!popup.opened)
-    //     }
-    // }
+        WalletConnectService {
+            property var onApproveSessionResultTriggers: []
+            onApproveSessionResult: function(session, error) {
+                onApproveSessionResultTriggers.push({session, error})
+            }
+
+            property var onDisplayToastMessageTriggers: []
+            onDisplayToastMessage: function(message, error) {
+                onDisplayToastMessageTriggers.push({message, error})
+            }
+        }
+    }
+
+    Component {
+        id: dappsStoreComponent
+
+        DAppsStore {
+            signal dappsListReceived(string dappsJson)
+
+            // By default, return no dapps in store
+            function getDapps() {
+                dappsListReceived('[]')
+                return true
+            }
+
+            property var addWalletConnectSessionCalls: []
+            function addWalletConnectSession(sessionJson) {
+                addWalletConnectSessionCalls.push({sessionJson})
+            }
+        }
+    }
+
+    Component {
+        id: walletStoreComponent
+
+        WalletStore {
+            readonly property ListModel flatNetworks: ListModel {
+                ListElement { chainId: 1 }
+                ListElement { chainId: 2 }
+            }
+
+            readonly property ListModel accounts: ListModel {
+                ListElement { address: "0x1" }
+                ListElement { address: "0x2" }
+            }
+        }
+    }
+
+    TestCase {
+        id: walletConnectServiceTest
+        name: "WalletConnectService"
+
+        property WalletConnectService service: null
+
+        SignalSpy {
+            id: connectDAppSpy
+            target: walletConnectServiceTest.service
+            signalName: "connectDApp"
+
+            property var argPos: {
+                "dappChains": 0,
+                "sessionProposalJson": 1,
+                "availableNamespaces": 0
+            }
+        }
+
+        function init() {
+            let walletStore = createTemporaryObject(walletStoreComponent, root)
+            verify(!!walletStore)
+            let sdk = createTemporaryObject(sdkComponent, root, { projectId: "12ab" })
+            verify(!!sdk)
+            let store = createTemporaryObject(dappsStoreComponent, root)
+            verify(!!store)
+            service = createTemporaryObject(serviceComponent, root, {wcSDK: sdk, store: store, walletStore: walletStore})
+            verify(!!service)
+        }
+
+        function cleanup() {
+            service.destroy()
+            connectDAppSpy.clear()
+        }
+
+        function test_TestPairing() {
+            // All calls to SDK are expected as events to be made by the wallet connect SDK
+            let sdk = service.wcSDK
+            let walletStore = service.walletStore
+            let store = service.store
+
+            service.pair("wc:12ab@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=12ab")
+            compare(sdk.pairCalled, 1, "expected a call to sdk.pair")
+
+            sdk.sessionProposal(JSON.parse(Testing.formatSessionProposal()))
+            compare(sdk.buildApprovedNamespacesCalls.length, 1, "expected a call to sdk.buildApprovedNamespaces")
+            var args = sdk.buildApprovedNamespacesCalls[0]
+            verify(!!args.supportedNamespaces, "expected supportedNamespaces to be set")
+            let chainsForApproval = args.supportedNamespaces.eip155.chains
+            let networksArray = ModelUtils.modelToArray(walletStore.flatNetworks).map(entry => entry.chainId)
+            verify(networksArray.every(chainId => chainsForApproval.some(eip155Chain => eip155Chain === `eip155:${chainId}`)),
+                "expect all the networks to be present")
+            // We test here all accounts for one chain only, we have separate tests to validate that all accounts are present
+            let allAccountsForApproval = args.supportedNamespaces.eip155.accounts
+            let accountsArray = ModelUtils.modelToArray(walletStore.accounts).map(entry => entry.address)
+            verify(accountsArray.every(address => allAccountsForApproval.some(eip155Address => eip155Address === `eip155:${networksArray[0]}:${address}`)),
+                "expect at least all accounts for the first chain to be present"
+            )
+
+            let allApprovedNamespaces = JSON.parse(Testing.formatBuildApprovedNamespacesResult(networksArray, accountsArray))
+            sdk.buildApprovedNamespacesResult(allApprovedNamespaces, "")
+            compare(connectDAppSpy.count, 1, "expected a call to service.connectDApp")
+            let connectArgs = connectDAppSpy.signalArguments[0]
+            compare(connectArgs[connectDAppSpy.argPos.dappChains], networksArray, "expected all provided networks (walletStore.flatNetworks) for the dappChains")
+            verify(!!connectArgs[connectDAppSpy.argPos.sessionProposalJson], "expected sessionProposalJson to be set")
+            verify(!!connectArgs[connectDAppSpy.argPos.availableNamespaces], "expected availableNamespaces to be set")
+
+            let selectedAccount = walletStore.accounts.get(1)
+            service.approvePairSession(connectArgs[connectDAppSpy.argPos.sessionProposalJson], connectArgs[connectDAppSpy.argPos.dappChains], selectedAccount)
+            compare(sdk.buildApprovedNamespacesCalls.length, 2, "expected a call to sdk.buildApprovedNamespaces")
+            args = sdk.buildApprovedNamespacesCalls[1]
+            verify(!!args.supportedNamespaces, "expected supportedNamespaces to be set")
+            // We test here that only one account for all chains is provided
+            let accountsForApproval = args.supportedNamespaces.eip155.accounts
+            compare(accountsForApproval.length, networksArray.length, "expect only one account per chain")
+            compare(accountsForApproval[0], `eip155:${networksArray[0]}:${selectedAccount.address}`)
+            compare(accountsForApproval[1], `eip155:${networksArray[1]}:${selectedAccount.address}`)
+
+            let approvedNamespaces = JSON.parse(Testing.formatBuildApprovedNamespacesResult(networksArray, [selectedAccount.address]))
+            sdk.buildApprovedNamespacesResult(approvedNamespaces, "")
+
+            compare(sdk.approveSessionCalls.length, 1, "expected a call to sdk.approveSession")
+            verify(!!sdk.approveSessionCalls[0].sessionProposalJson, "expected sessionProposalJson to be set")
+            verify(!!sdk.approveSessionCalls[0].approvedNamespaces, "expected approvedNamespaces to be set")
+
+            let finalApprovedNamespaces = JSON.parse(Testing.formatApproveSessionResponse(networksArray, [selectedAccount.address]))
+            sdk.approveSessionResult(finalApprovedNamespaces, "")
+            verify(store.addWalletConnectSessionCalls.length === 1)
+            verify(store.addWalletConnectSessionCalls[0].sessionJson, "expected sessionJson to be set")
+
+            verify(service.onApproveSessionResultTriggers.length === 1)
+            verify(service.onApproveSessionResultTriggers[0].session, "expected session to be set")
+
+            compare(service.onDisplayToastMessageTriggers.length, 1, "expected a success message to be displayed")
+            verify(!service.onDisplayToastMessageTriggers[0].error, "expected no error")
+            verify(service.onDisplayToastMessageTriggers[0].message, "expected message to be set")
+        }
+    }
+
+    Component {
+        id: componentUnderTest
+        DAppsWorkflow {
+        }
+    }
+
+    TestCase {
+        id: dappsWorkflowTest
+        name: "DAppsWorkflow"
+        when: windowShown
+
+        property DAppsWorkflow controlUnderTest: null
+
+        SignalSpy {
+            id: dappsListReadySpy
+            target: dappsWorkflowTest.controlUnderTest
+            signalName: "dappsListReady"
+        }
+
+        SignalSpy {
+            id: pairWCReadySpy
+            target: dappsWorkflowTest.controlUnderTest
+            signalName: "pairWCReady"
+        }
+
+        function init() {
+            let walletStore = createTemporaryObject(walletStoreComponent, root)
+            verify(!!walletStore)
+            let sdk = createTemporaryObject(sdkComponent, root, { projectId: "12ab" })
+            verify(!!sdk)
+            let store = createTemporaryObject(dappsStoreComponent, root)
+            verify(!!store)
+            let service = createTemporaryObject(serviceComponent, root, {wcSDK: sdk, store: store, walletStore: walletStore})
+            verify(!!service)
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {wcService: service})
+            verify(!!controlUnderTest)
+        }
+
+        function cleanup() {
+            controlUnderTest.destroy()
+            dappsListReadySpy.reset()
+            pairWCReadySpy.reset()
+        }
+
+        function test_OpenAndCloseDappList() {
+            waitForRendering(controlUnderTest)
+
+            compare(dappsListReadySpy.count, 0, "expected NO dappsListReady signal to be emitted")
+            mouseClick(controlUnderTest, Qt.LeftButton)
+            waitForRendering(controlUnderTest)
+            compare(dappsListReadySpy.count, 1, "expected dappsListReady signal to be emitted")
+
+            let popup = findChild(controlUnderTest, "dappsPopup")
+            verify(!!popup)
+            verify(popup.opened)
+
+            mouseClick(Overlay.overlay, Qt.LeftButton)
+            waitForRendering(controlUnderTest)
+
+            verify(!popup.opened)
+        }
+
+        function test_OpenPairModal() {
+            waitForRendering(controlUnderTest)
+
+            mouseClick(controlUnderTest, Qt.LeftButton)
+            waitForRendering(controlUnderTest)
+
+            let popup = findChild(controlUnderTest, "dappsPopup")
+            verify(!!popup)
+            verify(popup.opened)
+
+            let connectButton = findChild(popup, "connectDappButton")
+            verify(!!connectButton)
+
+            verify(pairWCReadySpy.count === 0, "expected NO pairWCReady signal to be emitted")
+            mouseClick(connectButton, Qt.LeftButton)
+            waitForRendering(controlUnderTest)
+            verify(pairWCReadySpy.count === 1, "expected pairWCReady signal to be emitted")
+
+            let pairWCModal = findChild(controlUnderTest, "pairWCModal")
+            verify(!!pairWCModal)
+        }
+    }
 
     TestCase {
         name: "ServiceHelpers"

--- a/storybook/stubs/AppLayouts/Profile/stores/WalletStore.qml
+++ b/storybook/stubs/AppLayouts/Profile/stores/WalletStore.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.14
+import QtQuick 2.15
 
 QtObject {
 }

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -6,6 +6,7 @@ import AppLayouts.Wallet.controls 1.0
 
 import shared.popups.walletconnect 1.0
 import AppLayouts.Wallet.services.dapps 1.0
+import AppLayouts.Wallet.services.dapps.types 1.0
 
 import shared.stores 1.0
 import utils 1.0
@@ -109,6 +110,43 @@ ConnectedDappsButton {
         }
     }
 
+    Loader {
+        id: sessionRequestLoader
+
+        active: false
+
+        onLoaded: item.open()
+
+        property SessionRequestResolved request: null
+
+        sourceComponent: DAppRequestModal {
+            account: request.account
+            network: request.network
+
+            dappName: request.dappName
+            dappUrl: request.dappUrl
+            dappIcon: request.dappIcon
+
+            signContent: request.data.message
+            maxFeesText: request.maxFeesText
+            estimatedTimeText: request.estimatedTimeText
+
+            visible: true
+
+            onClosed: sessionRequestLoader.active = false
+
+            onSign: {
+                console.debug("@dd TODO sign session request")
+            }
+
+            onReject: {
+                let userRejected = true
+                wcService.requestHandler.rejectSessionRequest(request, userRejected)
+                close()
+            }
+        }
+    }
+
     Connections {
         target: root.wcService
 
@@ -139,6 +177,11 @@ ConnectedDappsButton {
                     modal.pairSuccessful(session)
                 }
             }
+        }
+
+        function onSessionRequest(request) {
+            sessionRequestLoader.request = request
+            sessionRequestLoader.active = true
         }
 
         function onDisplayToastMessage(message, err) {

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -8,6 +8,7 @@ import shared.popups.walletconnect 1.0
 import AppLayouts.Wallet.services.dapps 1.0
 
 import shared.stores 1.0
+import utils 1.0
 
 ConnectedDappsButton {
     id: root
@@ -16,6 +17,7 @@ ConnectedDappsButton {
 
     signal dappsListReady()
     signal pairWCReady()
+    signal displayToastMessage(string message, bool error)
 
     onClicked: {
         dappsListLoader.active = true
@@ -137,6 +139,10 @@ ConnectedDappsButton {
                     modal.pairSuccessful(session)
                 }
             }
+        }
+
+        function onDisplayToastMessage(message, err) {
+            root.displayToastMessage(message, err)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -83,6 +83,16 @@ Item {
                 enabled: !!Global.walletConnectService
 
                 wcService: Global.walletConnectService
+
+                onDisplayToastMessage: (message, isErr) => {
+                    if (isErr) {
+                        Global.displayToastMessage(message, "", "warning", false,
+                                                   Constants.ephemeralNotificationType.danger, "")
+                    } else {
+                        Global.displayToastMessage(message, "", "checkmark-circle", false,
+                                                   Constants.ephemeralNotificationType.success, "")
+                    }
+                }
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
@@ -9,7 +9,7 @@ import utils 1.0
 QObject {
     id: root
 
-    required property WalletConnectSDK sdk
+    required property WalletConnectSDKBase sdk
     required property DAppsStore store
 
     readonly property alias dappsModel: d.dappsModel

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -1,0 +1,151 @@
+import QtQuick 2.15
+
+import AppLayouts.Wallet.services.dapps 1.0
+
+import StatusQ.Core.Utils 0.1
+
+import shared.stores 1.0
+import utils 1.0
+
+import "types"
+
+QObject {
+    id: root
+
+    required property WalletConnectSDKBase sdk
+    required property var walletStore
+    required property DAppsStore store
+
+    property alias requestsModel: requests
+
+    function rejectSessionRequest(request, userRejected) {
+        let error = userRejected ? false : true
+        sdk.rejectSessionRequest(request.topic, request.id, error)
+    }
+
+    signal sessionRequest(SessionRequestResolved request)
+
+    /// Supported methods
+    property QtObject methods: QtObject {
+        readonly property string personalSign: Constants.personal_sign
+        readonly property string sendTransaction: "eth_sendTransaction"
+    }
+
+    function getSupportedMethods() {
+        return [root.methods.personalSign, root.methods.sendTransaction]
+    }
+
+    Connections {
+        target: sdk
+
+        function onSessionRequestEvent(event) {
+            let obj = d.resolveAsync(event)
+            if (obj === null) {
+                let error = true
+                sdk.rejectSessionRequest(event.topic, event.id, error)
+                return
+            }
+            requests.enqueue(obj)
+        }
+    }
+
+    QObject {
+        id: d
+
+        function resolveAsync(event) {
+            let method = event.params.request.method
+            let account = lookupAccountFromEvent(event, method)
+            let network = lookupNetworkFromEvent(event, method)
+            let data = extractMethodData(event, method)
+            let obj = sessionRequestComponent.createObject(null, {
+                event,
+                topic: event.topic,
+                id: event.id,
+                method,
+                account,
+                network,
+                data
+            })
+            if (obj === null) {
+                console.error("Error creating SessionRequestResolved for event")
+                return null
+            }
+
+            // Check later to have a valid request object
+            if (!getSupportedMethods().includes(method)
+                // TODO  #14927: support method eth_sendTransaction
+                || method == "eth_sendTransaction") {
+                console.error("Unsupported method", method)
+                return null
+            }
+
+            sdk.getActiveSessions((res) => {
+                Object.keys(res).forEach((topic) => {
+                    if (topic === obj.topic) {
+                        let session = res[topic]
+                        obj.resolveDappInfoFromSession(session)
+                        root.sessionRequest(obj)
+                    }
+                })
+            })
+
+            return obj
+        }
+
+        /// Returns null if the account is not found
+        function lookupAccountFromEvent(event, method) {
+            if (method === root.methods.personalSign) {
+                if (event.params.request.params.length < 2) {
+                    return null
+                }
+                var address = event.params.request.params[1]
+                for (let i = 0; i < walletStore.ownAccounts.count; i++) {
+                    let acc = ModelUtils.get(walletStore.ownAccounts, i)
+                    if (acc.address === address) {
+                        return acc
+                    }
+                }
+            }
+            return null
+        }
+
+        /// Returns null if the network is not found
+        function lookupNetworkFromEvent(event, method) {
+            if (method === root.methods.personalSign) {
+                let chainId = Helpers.chainIdFromEip155(event.params.chainId)
+                for (let i = 0; i < walletStore.flatNetworks.count; i++) {
+                    let network = ModelUtils.get(walletStore.flatNetworks, i)
+                    if (network.chainId === chainId) {
+                        return network
+                    }
+                }
+            }
+            return null
+        }
+
+        function extractMethodData(event, method) {
+            if (method === root.methods.personalSign) {
+                if (event.params.request.params.length == 0) {
+                    return null
+                }
+                let hexMessage = event.params.request.params[0]
+                return {
+                    message: Helpers.hexToString(hexMessage)
+                }
+            }
+        }
+    }
+
+    /// The queue is used to ensure that the events are processed in the order they are received but they could be
+    /// processed handled randomly on user intervention through activity center
+    SessionRequestsModel {
+        id: requests
+    }
+
+    Component {
+        id: sessionRequestComponent
+
+        SessionRequestResolved {
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
@@ -8,6 +8,8 @@ import QtWebChannel 1.15
 import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Components 0.1
 
+import "types"
+
 WalletConnectSDKBase {
     id: root
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
@@ -8,10 +8,9 @@ import QtWebChannel 1.15
 import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Components 0.1
 
-Item {
+WalletConnectSDKBase {
     id: root
 
-    required property string projectId
     readonly property alias sdkReady: d.sdkReady
     readonly property alias webEngineLoader: loader
 
@@ -21,66 +20,49 @@ Item {
     implicitWidth: 1
     implicitHeight: 1
 
-    signal statusChanged(string message)
-    signal sdkInit(bool success, var result)
-    signal pairResponse(bool success)
-    signal sessionProposal(var sessionProposal)
-    signal sessionProposalExpired()
-    signal buildApprovedNamespacesResult(var session, string error)
-    signal approveSessionResult(var approvedNamespaces, string error)
-    signal rejectSessionResult(string error)
-    signal sessionRequestEvent(var sessionRequest)
-    signal sessionRequestUserAnswerResult(bool accept, string error)
-
-    signal authRequest(var request)
-    signal authMessageFormated(string formatedMessage, string address)
-    signal authRequestUserAnswerResult(bool accept, string error)
-
-    signal sessionDelete(var topic, string error)
-
     /// Generates \c pairResponse signal and expects to receive
     /// a \c sessionProposal signal with the sessionProposal object
-    function pair(pairLink) {
+    pair: function(pairLink) {
         wcCalls.pair(pairLink)
     }
 
-    function getPairings(callback) {
+    getPairings: function(callback) {
         wcCalls.getPairings(callback)
     }
 
-    function getActiveSessions(callback) {
+    getActiveSessions: function(callback) {
         wcCalls.getActiveSessions(callback)
     }
 
-    function disconnectSession(topic) {
+    disconnectSession: function(topic) {
         wcCalls.disconnectSession(topic)
     }
 
-    function disconnectPairing(topic) {
+    disconnectPairing: function(topic) {
         wcCalls.disconnectPairing(topic)
     }
 
-    function ping(topic) {
+    ping: function(topic) {
         wcCalls.ping(topic)
     }
 
-    function buildApprovedNamespaces(params, supportedNamespaces) {
+    buildApprovedNamespaces: function(params, supportedNamespaces) {
         wcCalls.buildApprovedNamespaces(params, supportedNamespaces)
     }
 
-    function approveSession(sessionProposal, supportedNamespaces) {
+    approveSession: function(sessionProposal, supportedNamespaces) {
         wcCalls.approveSession(sessionProposal, supportedNamespaces)
     }
 
-    function rejectSession(id) {
+    rejectSession: function(id) {
         wcCalls.rejectSession(id)
     }
 
-    function acceptSessionRequest(topic, id, signature) {
+    acceptSessionRequest: function(topic, id, signature) {
         wcCalls.acceptSessionRequest(topic, id, signature)
     }
 
-    function rejectSessionRequest(topic, id, error) {
+    rejectSessionRequest: function(topic, id, error) {
         wcCalls.rejectSessionRequest(topic, id, error)
     }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.15
+
+/// SDK requires a visible parent to embed WebEngineView
+Item {
+    required property string projectId
+
+    signal statusChanged(string message)
+    signal sdkInit(bool success, var result)
+    signal pairResponse(bool success)
+    signal sessionProposal(var sessionProposal)
+    signal sessionProposalExpired()
+    signal buildApprovedNamespacesResult(var session, string error)
+    signal approveSessionResult(var approvedNamespaces, string error)
+    signal rejectSessionResult(string error)
+    signal sessionRequestEvent(var sessionRequest)
+    signal sessionRequestUserAnswerResult(bool accept, string error)
+
+    signal authRequest(var request)
+    signal authMessageFormated(string formatedMessage, string address)
+    signal authRequestUserAnswerResult(bool accept, string error)
+
+    signal sessionDelete(var topic, string error)
+
+    property var pair: function(pairLink) {
+        console.error("pair not implemented")
+    }
+    property var getPairings: function(callback) {
+        console.error("getPairings not implemented")
+    }
+    property var getActiveSessions: function(callback) {
+        console.error("getActiveSessions not implemented")
+    }
+    property var disconnectSession: function(topic) {
+        console.error("disconnectSession not implemented")
+    }
+    property var disconnectPairing: function(topic) {
+        console.error("disconnectPairing not implemented")
+    }
+
+    property var ping: function(topic) {
+        console.error("ping not implemented")
+    }
+
+    property var buildApprovedNamespaces: function(params, supportedNamespaces) {
+        console.error("buildApprovedNamespaces not implemented")
+    }
+    property var approveSession: function(sessionProposal, supportedNamespaces) {
+        console.error("approveSession not implemented")
+    }
+
+    property var rejectSession: function(id) {
+        console.error("rejectSession not implemented")
+    }
+
+    property var acceptSessionRequest: function(topic, id, signature) {
+        console.error("acceptSessionRequest not implemented")
+    }
+
+    property var rejectSessionRequest: function(topic, id, error) {
+        console.error("rejectSessionRequest not implemented")
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -1,8 +1,33 @@
 .import StatusQ.Core.Utils 0.1 as SQUtils
 
+function chainIdFromEip155(chain) {
+    return parseInt(chain.split(':').pop().trim(), 10)
+}
+
+function hexToString(hex) {
+    if (hex.startsWith("0x")) {
+        hex = hex.substring(2);
+    }
+
+    var str = '';
+    for (var i = 0; i < hex.length; i += 2) {
+        str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+    }
+    return str;
+}
+
+function strToHex(str) {
+    var hex = '';
+    for (var i = 0; i < str.length; i++) {
+        var byte = str.charCodeAt(i).toString(16);
+        hex += (byte.length < 2 ? '0' : '') + byte;
+    }
+    return '0x' + hex;
+}
+
 function extractChainsAndAccountsFromApprovedNamespaces(approvedNamespaces) {
     const eip155Data = approvedNamespaces.eip155;
-    const chains = eip155Data.chains.map(chain => parseInt(chain.split(':').pop().trim(), 10));
+    const chains = eip155Data.chains.map(chainIdFromEip155);
     const accountSet = new Set(
         eip155Data.accounts.map(account => account.split(':').pop().trim())
     );
@@ -10,7 +35,7 @@ function extractChainsAndAccountsFromApprovedNamespaces(approvedNamespaces) {
     return { chains, accounts: uniqueAccounts };
 }
 
-function buildSupportedNamespacesFromModels(chainsModel, accountsModel) {
+function buildSupportedNamespacesFromModels(chainsModel, accountsModel, methods) {
     var chainIds = []
     var addresses = []
     for (let i = 0; i < chainsModel.count; i++) {
@@ -21,10 +46,10 @@ function buildSupportedNamespacesFromModels(chainsModel, accountsModel) {
         let entry = SQUtils.ModelUtils.get(accountsModel, i)
         addresses.push(entry.address)
     }
-    return buildSupportedNamespaces(chainIds, addresses)
+    return buildSupportedNamespaces(chainIds, addresses, methods)
 }
 
-function buildSupportedNamespaces(chainIds, addresses) {
+function buildSupportedNamespaces(chainIds, addresses, methods) {
     var eipChainIds = []
     var eipAddresses = []
     for (let i = 0; i < chainIds.length; i++) {
@@ -34,6 +59,7 @@ function buildSupportedNamespaces(chainIds, addresses) {
             eipAddresses.push(`"eip155:${chainId}:${addresses[i]}"`)
         }
     }
+    let methodsStr = methods.map(method => `"${method}"`).join(',')
     return `{
-        "eip155":{"chains": [${eipChainIds.join(',')}],"methods": ["eth_sendTransaction", "personal_sign"],"events": ["accountsChanged", "chainChanged"],"accounts": [${eipAddresses.join(',')}]}}`
+        "eip155":{"chains": [${eipChainIds.join(',')}],"methods": [${methodsStr}],"events": ["accountsChanged", "chainChanged"],"accounts": [${eipAddresses.join(',')}]}}`
 }

--- a/ui/app/AppLayouts/Wallet/services/dapps/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/qmldir
@@ -1,6 +1,8 @@
 WalletConnectSDKBase 1.0 WalletConnectSDKBase.qml
 WalletConnectSDK 1.0 WalletConnectSDK.qml
 WalletConnectService 1.0 WalletConnectService.qml
+
 DAppsListProvider 1.0 DAppsListProvider.qml
+DAppsRequestHandler 1.0 DAppsRequestHandler.qml
 
 Helpers 1.0 helpers.js

--- a/ui/app/AppLayouts/Wallet/services/dapps/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/qmldir
@@ -1,3 +1,4 @@
+WalletConnectSDKBase 1.0 WalletConnectSDKBase.qml
 WalletConnectSDK 1.0 WalletConnectSDK.qml
 WalletConnectService 1.0 WalletConnectService.qml
 DAppsListProvider 1.0 DAppsListProvider.qml

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestResolved.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestResolved.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.15
+
+import StatusQ.Core.Utils 0.1
+
+QObject {
+    id: root
+
+    /// An WalletConnect.session_request event data looks like this:
+    /// {
+    ///     topic,
+    ///     params: {
+    ///         request: [requestParamsMessage]
+    ///     },
+    ///     id
+    /// }
+    required property var event
+
+    required property string topic
+    required property string id
+    required property string method
+
+    required property var account
+    required property var network
+
+    required property var data
+
+    readonly property alias dappName: d.dappName
+    readonly property alias dappUrl: d.dappUrl
+    readonly property alias dappIcon: d.dappIcon
+
+    readonly property string maxFeesText: ""
+    readonly property string estimatedTimeText: ""
+
+    function resolveDappInfoFromSession(session) {
+        let meta = session.peer.metadata
+        d.dappName = meta.name
+        d.dappUrl = meta.url
+        if (meta.icons && meta.icons.length > 0) {
+            d.dappIcon = meta.icons[0]
+        }
+    }
+
+    // dApp info
+    QtObject {
+        id: d
+
+        property string dappName
+        property string dappUrl
+        property url dappIcon
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestsModel.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestsModel.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.15
+
+/// Data model that holds a queue of SessionRequestResolved events as they are received from the SDK
+ListModel {
+    id: root
+
+    function enqueue(event) {
+        root.append(event);
+    }
+
+    function dequeue() {
+        if (root.count > 0) {
+            var item = root.get(0);
+            root.remove(0);
+            return item;
+        }
+        return null;
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/qmldir
@@ -1,0 +1,1 @@
+SessionRequestResolved 1.0 SessionRequestResolved.qml

--- a/ui/imports/shared/popups/walletconnect/DAppRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppRequestModal.qml
@@ -14,6 +14,8 @@ import utils 1.0
 StatusDialog {
     id: root
 
+    objectName: "dappsRequestModal"
+
     implicitWidth: 480
 
     required property string dappName
@@ -29,127 +31,131 @@ StatusDialog {
     signal sign()
     signal reject()
 
-    function openWith() {
-        root.open()
-    }
-
     title: qsTr("Sign request")
 
     padding: 20
 
-    contentItem: ColumnLayout {
-        spacing: 20
-        clip: true
-
-        IntentionPanel {
-            Layout.fillWidth: true
-
-            dappName: root.dappName
-            dappIcon: root.dappIcon
-            account: root.account
-            signContent: root.signContent
-        }
-
-        ContentPanel {
-            Layout.fillWidth: true
-            Layout.preferredHeight: 340
-        }
-
-        // TODO: externalize as a TargetPanel
+    contentItem: StatusScrollView {
+        id: scrollView
+        padding: 0
         ColumnLayout {
-            spacing: 8
+            spacing: 20
+            clip: true
 
-            StatusBaseText {
-                text: qsTr("Sign with")
-                font.pixelSize: 13
-                color: Theme.palette.directColor1
+            width: scrollView.availableWidth
+
+            IntentionPanel {
+                Layout.fillWidth: true
+
+                dappName: root.dappName
+                dappIcon: root.dappIcon
+                account: root.account
+                signContent: root.signContent
             }
 
-            // TODO #14762: implement proper control to display the accounts details
-            Rectangle {
+            ContentPanel {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 76
+                Layout.preferredHeight: 340
+            }
 
-                radius: 8
-                border.width: 1
-                border.color: Theme.palette.baseColor2
+            // TODO: externalize as a TargetPanel
+            ColumnLayout {
+                spacing: 8
 
-                RowLayout {
-                    spacing: 12
-                    anchors.fill: parent
-                    anchors.margins: 16
-
-                    StatusSmartIdenticon {
-                        width: 40
-                        height: 40
-
-                        asset: StatusAssetSettings {
-                            color: Theme.palette.primaryColor1
-                            isImage: false
-                            isLetterIdenticon: true
-                            useAcronymForLetterIdenticon: false
-                            emoji: root.account.emoji
-                        }
-                    }
-
-                    ColumnLayout {
-                        Layout.alignment: Qt.AlignLeft
-
-                        StatusBaseText {
-                            text: root.account.name
-
-                            Layout.alignment: Qt.AlignLeft
-
-                            font.pixelSize: 13
-                        }
-                        StatusBaseText {
-                            text: StatusQ.Utils.elideAndFormatWalletAddress(root.account.address, 6, 4)
-
-                            Layout.alignment: Qt.AlignLeft
-
-                            font.pixelSize: 13
-
-                            color: Theme.palette.baseColor1
-                        }
-                    }
-
-                    Item {Layout.fillWidth: true }
+                StatusBaseText {
+                    text: qsTr("Sign with")
+                    font.pixelSize: 13
+                    color: Theme.palette.directColor1
                 }
-            }
-            // TODO #14762: implement proper control to display the chain
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 76
 
-                visible: root.network !== null
+                // TODO #14762: implement proper control to display the accounts details
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 76
 
-                radius: 8
-                border.width: 1
-                border.color: Theme.palette.baseColor2
+                    radius: 8
+                    border.width: 1
+                    border.color: Theme.palette.baseColor2
+                    color: "transparent"
 
-                RowLayout {
-                    spacing: 12
-                    anchors.fill: parent
-                    anchors.margins: 16
+                    RowLayout {
+                        spacing: 12
+                        anchors.fill: parent
+                        anchors.margins: 16
 
-                    StatusSmartIdenticon {
-                        width: 40
-                        height: 40
+                        StatusSmartIdenticon {
+                            width: 40
+                            height: 40
 
-                        asset: StatusAssetSettings {
-                            isImage: true
-                            name: !!root.network ? Style.svg("tiny/" + root.network.iconUrl) : ""
+                            asset: StatusAssetSettings {
+                                color: Theme.palette.primaryColor1
+                                isImage: false
+                                isLetterIdenticon: true
+                                useAcronymForLetterIdenticon: false
+                                emoji: root.account.emoji
+                            }
                         }
+
+                        ColumnLayout {
+                            Layout.alignment: Qt.AlignLeft
+
+                            StatusBaseText {
+                                text: root.account.name
+
+                                Layout.alignment: Qt.AlignLeft
+
+                                font.pixelSize: 13
+                            }
+                            StatusBaseText {
+                                text: StatusQ.Utils.elideAndFormatWalletAddress(root.account.address, 6, 4)
+
+                                Layout.alignment: Qt.AlignLeft
+
+                                font.pixelSize: 13
+
+                                color: Theme.palette.baseColor1
+                            }
+                        }
+
+                        Item {Layout.fillWidth: true }
                     }
+                }
+                // TODO #14762: implement proper control to display the chain
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 76
 
-                    StatusBaseText {
-                        text: !!root.network ? root.network.chainName : ""
+                    visible: root.network !== null
 
-                        Layout.alignment: Qt.AlignLeft
+                    radius: 8
+                    border.width: 1
+                    border.color: Theme.palette.baseColor2
+                    color: "transparent"
 
-                        font.pixelSize: 13
+                    RowLayout {
+                        spacing: 12
+                        anchors.fill: parent
+                        anchors.margins: 16
+
+                        StatusSmartIdenticon {
+                            width: 40
+                            height: 40
+
+                            asset: StatusAssetSettings {
+                                isImage: true
+                                name: !!root.network ? Style.svg("tiny/" + root.network.iconUrl) : ""
+                            }
+                        }
+
+                        StatusBaseText {
+                            text: !!root.network ? root.network.chainName : ""
+
+                            Layout.alignment: Qt.AlignLeft
+
+                            font.pixelSize: 13
+                        }
+                        Item {Layout.fillWidth: true }
                     }
-                    Item {Layout.fillWidth: true }
                 }
             }
         }
@@ -199,6 +205,8 @@ StatusDialog {
 
         rightButtons: ObjectModel {
             StatusButton {
+                objectName: "rejectButton"
+
                 height: 44
                 text: qsTr("Reject")
 
@@ -210,6 +218,8 @@ StatusDialog {
                 height: 44
                 text: qsTr("Sign")
 
+                enabled: false
+
                 onClicked: {
                     root.sign()
                 }
@@ -218,6 +228,7 @@ StatusDialog {
     }
 
     component MaxFeesDisplay: ColumnLayout {
+        visible: root.maxFeesText
         StatusBaseText {
             text: qsTr("Max fees:")
             font.pixelSize: 12
@@ -231,6 +242,7 @@ StatusDialog {
     }
 
     component EstimatedTimeDisplay: ColumnLayout {
+        visible: root.estimatedTimeText
         StatusBaseText {
             text: qsTr("Est. time:")
             font.pixelSize: 12
@@ -353,12 +365,26 @@ StatusDialog {
         color: "transparent"
         radius: 8
 
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: contentScrollView.enabled ? undefined : Qt.PointingHandCursor
+
+            onClicked: {
+                contentScrollView.enabled = !contentScrollView.enabled
+            }
+            z: contentScrollView.z + 1
+        }
+
         StatusScrollView {
             id: contentScrollView
             anchors.fill: parent
 
             contentWidth: availableWidth
             contentHeight: contentText.implicitHeight
+
+            padding: 0
+
+            enabled: false
 
             StatusBaseText {
                 id: contentText

--- a/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
@@ -95,6 +95,7 @@ Popup {
         }
 
         StatusButton {
+            objectName: "connectDappButton"
             Layout.fillWidth: true
             Layout.preferredHeight: implicitHeight
 

--- a/ui/imports/shared/popups/walletconnect/PairWCModal.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal.qml
@@ -14,6 +14,8 @@ import "PairWCModal"
 StatusDialog {
     id: root
 
+    objectName: "pairWCModal"
+
     width: 480
     implicitHeight: 633
 

--- a/ui/imports/shared/stores/DAppsStore.qml
+++ b/ui/imports/shared/stores/DAppsStore.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.15
 
-QtObject {
+import StatusQ.Core.Utils 0.1
+
+QObject {
     id: root
 
     required property var controller
@@ -18,7 +20,7 @@ QtObject {
     }
 
     // Handle async response from controller
-    property Connections _connections: Connections {
+    Connections {
         target: controller
 
         function onDappsListReceived(dappsJson) {


### PR DESCRIPTION
### Updates: #14927

Support showing sign message only, rejects other requests
Support user rejecting the request

Other changes

Minor general improvements
Add tests for the main logic and sanity UI tests
Storybook integration

`HEAD~1`: chore(dapps) abstract WalletConnectSDK to make it testable

Beware that `FLAG_DAPPS_ENABLED` with the value of 1 must be defined to enable the feature and make it testable

https://github.com/status-im/status-desktop/assets/47554641/0101797e-6eec-4ca0-868d-9bea01ec3a26