### PR TITLE
fix(communities): Correct handling 'hide channel from certain members'

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -700,12 +700,19 @@ proc getChatItemFromChatDto(
   var viewersCanPostReactions = true
   if self.controller.isCommunity:
     let communityChat = community.getCommunityChat(chatDto.id)
-    # Some properties are only available on CommunityChat (they are useless for normal chats)
-    canPost = communityChat.canPost
-    canView = communityChat.canView
-    canPostReactions = communityChat.canPostReactions
-    hideIfPermissionsNotMet = communityChat.hideIfPermissionsNotMet
-    viewersCanPostReactions = communityChat.viewersCanPostReactions
+    # NOTE: workaround for new community chat, which is delivered in chatDto before the community will know about that
+    if community.hasCommunityChat(chatDto.id):
+      let communityChat = community.getCommunityChat(chatDto.id)
+      # Some properties are only available on CommunityChat (they are useless for normal chats)
+      canPost = communityChat.canPost
+      canView = communityChat.canView
+      canPostReactions = communityChat.canPostReactions
+      hideIfPermissionsNotMet = communityChat.hideIfPermissionsNotMet
+      viewersCanPostReactions = communityChat.viewersCanPostReactions
+    else:
+      canPostReactions = chatDto.canPostReactions
+      hideIfPermissionsNotMet = chatDto.hideIfPermissionsNotMet
+      viewersCanPostReactions = chatDto.viewersCanPostReactions
 
   result = chat_item.initItem(
     chatDto.id,

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -612,6 +612,12 @@ proc getCommunityChat*(self: CommunityDto, chatId: string): ChatDto =
   if chats.len > 0:
     return chats[0]
 
+proc hasCommunityChat*(self: CommunityDto, chatId: string): bool =
+  for communityChat in self.chats:
+    if chatId == communityChat.id:
+      return true
+  return false
+
 proc isOwner*(self: CommunityDto): bool =
   return self.memberRole == MemberRole.Owner
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1312,6 +1312,7 @@ QtObject:
         self.communities[communityId].chats.add(chatDto)
         let data = CommunityChatArgs(chat: chatDto)
         self.events.emit(SIGNAL_COMMUNITY_CHANNEL_CREATED, data)
+
     except Exception as e:
       error "Error creating community channel", msg = e.msg, communityId, name, description, procName="createCommunityChannel"
 

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -553,7 +553,7 @@ Item {
             property var deleteChatConfirmationDialog
 
             onCreateCommunityChannel: function (chName, chDescription, chEmoji, chColor,
-                                                chCategoryId, hideIfPermissionsNotMet) {
+                                                chCategoryId, viewOnlyCanAddReaction, hideIfPermissionsNotMet) {
                 root.store.createCommunityChannel(chName, chDescription, chEmoji, chColor,
                                                   chCategoryId, viewOnlyCanAddReaction, hideIfPermissionsNotMet)
                 chatId = root.store.currentChatContentModule().chatDetails.id


### PR DESCRIPTION
Close #14915

### What does the PR do

- [x] Fix saving `Hide channel from members who don’t have permissions to view the channel`
- [x] Fix editing for freshly created permitted chat
- [x] Fix handling on the receiver side

### Affected areas

Communities

### Screenshot of functionality (including design for comparison)

(with disabled send)
https://github.com/status-im/status-desktop/assets/2522130/bb3ab022-dbf1-4b24-a03d-d1fbfcc71d9d

https://github.com/status-im/status-desktop/assets/2522130/5e599036-c9e1-4324-9f52-65657a928ca2

P.S: expected result - https://github.com/status-im/status-desktop/issues/14978
