### PR TITLE
CHERRY-PICK-MASTER: fix: Hide ID verification buttons

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -336,6 +336,7 @@ SplitView {
                         implicitWidth: 640
 
                         readOnly: ctrlReadOnly.checked
+                        idVerificationFlowsEnabled: true // enabled in SB
                         publicKey: switchOwnProfile.checked ? "0xdeadbeef" : "0xrandomguy"
 
                         onCloseRequested: logs.logEvent("closeRequested()")

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -27,6 +27,7 @@ Pane {
     id: root
 
     property bool readOnly // inside settings/profile/preview
+    property bool idVerificationFlowsEnabled: false // disabled temporarily as per https://github.com/status-im/status-desktop/issues/14954
 
     property string publicKey: contactsStore.myPublicKey
     readonly property alias isCurrentUser: d.isCurrentUser
@@ -318,6 +319,7 @@ Pane {
             Loader {
                 Layout.alignment: Qt.AlignTop
                 Layout.preferredHeight: menuButton.visible ? menuButton.height : -1
+                active: root.idVerificationFlowsEnabled
                 sourceComponent: {
                     if (d.isCurrentUser && !root.readOnly)
                         return btnShareProfile
@@ -403,7 +405,7 @@ Pane {
                     StatusAction {
                         text: qsTr("Mark as ID verified")
                         icon.name: "checkmark-circle"
-                        enabled: d.isContact && !d.isBlocked && !(d.isTrusted || d.isLocallyTrusted)
+                        enabled: root.idVerificationFlowsEnabled && d.isContact && !d.isBlocked && !(d.isTrusted || d.isLocallyTrusted)
                         onTriggered: Global.openMarkAsIDVerifiedPopup(root.publicKey, d.contactDetails,
                                                                       popup => popup.accepted.connect(d.reload))
                     }
@@ -435,7 +437,7 @@ Pane {
                         text: qsTr("Remove ID verification")
                         icon.name: "delete"
                         type: StatusAction.Type.Danger
-                        enabled: d.isContact && (d.isTrusted || d.isLocallyTrusted)
+                        enabled: root.idVerificationFlowsEnabled && d.isContact && (d.isTrusted || d.isLocallyTrusted)
                         onTriggered: Global.openRemoveIDVerificationDialog(root.publicKey, d.contactDetails,
                                                                            popup => popup.accepted.connect(d.reload))
                     }
@@ -459,7 +461,7 @@ Pane {
                         text: qsTr("Cancel ID verification request")
                         icon.name: "delete"
                         type: StatusAction.Type.Danger
-                        enabled: d.isContact && !d.isBlocked && d.isVerificationRequestSent
+                        enabled: root.idVerificationFlowsEnabled && d.isContact && !d.isBlocked && d.isVerificationRequestSent
                         onTriggered: root.contactsStore.cancelVerificationRequest(root.publicKey)
                     }
                     StatusAction {

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -39,6 +39,8 @@ StatusMenu {
     }
     readonly property bool isBlockedContact: (!!contactDetails && contactDetails.isBlocked) || false
 
+    readonly property bool idVerificationFlowsEnabled: false // disabled temporarily as per https://github.com/status-im/status-desktop/issues/14954
+
     readonly property int outgoingVerificationStatus: {
         if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
             return 0
@@ -160,7 +162,8 @@ StatusMenu {
         text: qsTr("Request ID verification")
         objectName: "verifyIdentity_StatusItem"
         icon.name: "checkmark-circle"
-        enabled: !root.isMe && root.isContact
+        enabled: idVerificationFlowsEnabled
+                 && !root.isMe && root.isContact
                  && !root.isBlockedContact
                  && !root.userIsLocallyTrusted
                  && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
@@ -172,7 +175,7 @@ StatusMenu {
         text: qsTr("Mark as ID verified")
         objectName: "markAsVerified_StatusItem"
         icon.name: "checkmark-circle"
-        enabled: !root.isMe && root.isContact && !root.isBridgedAccount && !root.isBlockedContact && !(root.isTrusted || root.userIsLocallyTrusted)
+        enabled: idVerificationFlowsEnabled && !root.isMe && root.isContact && !root.isBridgedAccount && !root.isBlockedContact && !(root.isTrusted || root.userIsLocallyTrusted)
         onTriggered: Global.openMarkAsIDVerifiedPopup(root.selectedUserPublicKey, root.contactDetails, null)
     }
     StatusAction {
@@ -188,7 +191,7 @@ StatusMenu {
         }
         icon.name: root.isVerificationRequestSent && root.incomingVerificationStatus !== Constants.verificationStatus.verified ? "history"
                                                                                                                                : "checkmark-circle"
-        enabled: !root.isMe && root.isContact && !root.isBridgedAccount && !root.isBlockedContact && !(root.isTrusted || root.userIsLocallyTrusted) &&
+        enabled: idVerificationFlowsEnabled && !root.isMe && root.isContact && !root.isBridgedAccount && !root.isBlockedContact && !(root.isTrusted || root.userIsLocallyTrusted) &&
                  (root.hasActiveReceivedVerificationRequestFrom || root.isVerificationRequestSent)
 
         onTriggered: {
@@ -238,7 +241,7 @@ StatusMenu {
         text: qsTr("Remove ID verification")
         icon.name: "delete"
         type: StatusAction.Type.Danger
-        enabled: !root.isMe && root.isContact && !root.isBridgedAccount && (root.isTrusted || root.userIsLocallyTrusted)
+        enabled: idVerificationFlowsEnabled && !root.isMe && root.isContact && !root.isBridgedAccount && (root.isTrusted || root.userIsLocallyTrusted)
         onTriggered: Global.openRemoveIDVerificationDialog(root.selectedUserPublicKey, root.contactDetails, null)
     }
 
@@ -256,7 +259,7 @@ StatusMenu {
         text: qsTr("Cancel ID verification request")
         icon.name: "delete"
         type: StatusAction.Type.Danger
-        enabled: !root.isMe && root.isContact && !root.isBlockedContact && !root.isBridgedAccount && root.isVerificationRequestSent
+        enabled: idVerificationFlowsEnabled && !root.isMe && root.isContact && !root.isBlockedContact && !root.isBridgedAccount && root.isVerificationRequestSent
         onTriggered: root.store.contactsStore.cancelVerificationRequest(root.selectedUserPublicKey)
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/14968 to master

### What does the PR do

- temporarily disable all ID verification flows by default for 2.29
- enabled it in StoryBook for testing purposes

Fixes #14954

### Affected areas

ProfileDialogView, ProfileContextMenu