### PR TITLE
feat(@desktop/wallet): Integrate recurring onramp providers in Recurrent tab

### DIFF
--- a/src/app/modules/main/wallet_section/buy_sell_crypto/item.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/item.nim
@@ -7,15 +7,17 @@ type Item* = object
   logoUrl: string
   siteUrl: string  
   hostname: string
+  recurrentSiteUrl: string
 
 proc initItem*(name, description, fees, logoUrl, siteUrl,
-  hostname: string): Item =
+  hostname, recurrentSiteUrl,: string): Item =
   result.name = name
   result.description = description
   result.fees = fees
   result.logoUrl = logoUrl
   result.siteUrl = siteUrl
   result.hostname = hostname
+  result.recurrentSiteUrl = recurrentSiteUrl
 
 proc `$`*(self: Item): string =
   result = "Item("
@@ -25,6 +27,7 @@ proc `$`*(self: Item): string =
   result &= fmt"logoUrl:{self.logoUrl}, "
   result &= fmt"siteUrl:{self.siteUrl}"
   result &= fmt"hostname:{self.hostname}"
+  result &= fmt"recurrentSiteUrl:{self.recurrentSiteUrl}"
   result &= ")"
 
 method getName*(self: Item): string {.base.} =
@@ -44,3 +47,6 @@ method getSiteUrl*(self: Item): string {.base.} =
 
 method getHostname*(self: Item): string {.base.} =
   return self.hostname
+
+method getRecurrentSiteUrl*(self: Item): string {.base.} =
+  return self.recurrentSiteUrl

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/model.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/model.nim
@@ -10,6 +10,7 @@ type
     LogoUrl
     SiteUrl
     Hostname
+    RecurrentSiteUrl
 
 QtObject:
   type
@@ -36,7 +37,8 @@ QtObject:
       ModelRole.Fees.int:"fees",
       ModelRole.LogoUrl.int:"logoUrl",
       ModelRole.SiteUrl.int:"siteUrl",
-      ModelRole.Hostname.int:"hostname"
+      ModelRole.Hostname.int:"hostname",
+      ModelRole.RecurrentSiteUrl.int:"recurrentSiteUrl"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -62,6 +64,8 @@ QtObject:
       result = newQVariant(item.getSiteUrl)
     of ModelRole.Hostname:
       result = newQVariant(item.getHostname)
+    of ModelRole.RecurrentSiteUrl:
+      result = newQVariant(item.getRecurrentSiteUrl)
 
   proc setItems*(self: Model, items: seq[Item]) =
     self.beginResetModel()

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/module.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/module.nim
@@ -40,7 +40,8 @@ method updateCryptoServices*(self: Module, cryptoServices: seq[CryptoRampDto]) =
     w.fees,
     w.logoUrl,
     w.siteUrl,
-    w.hostname
+    w.hostname,
+    w.recurrentSiteUrl,
   ))
   self.view.setItems(items)
 

--- a/src/app_service/service/transaction/cryptoRampDto.nim
+++ b/src/app_service/service/transaction/cryptoRampDto.nim
@@ -10,6 +10,7 @@ type
     logoUrl*: string
     siteUrl*: string
     hostname*: string
+    recurrentSiteUrl*: string
 
 proc newDto*(
   name: string,
@@ -17,7 +18,8 @@ proc newDto*(
   fees: string,
   logoUrl: string,
   siteUrl: string,
-  hostname: string
+  hostname: string,
+  recurrentSiteUrl: string
 ): CryptoRampDto =
   return CryptoRampDto(
     name: name,
@@ -25,7 +27,8 @@ proc newDto*(
     fees: fees,
     logoUrl: logoUrl,
     siteUrl: siteUrl,
-    hostname: hostname
+    hostname: hostname,
+    recurrentSiteUrl: recurrentSiteUrl
   )
 
 proc `$`*(self: CryptoRampDto): string =
@@ -36,6 +39,7 @@ proc `$`*(self: CryptoRampDto): string =
   result &= fmt"logoUrl:{self.logoUrl}, "
   result &= fmt"siteUrl:{self.siteUrl}, "
   result &= fmt"hostname:{self.hostname}"
+  result &= fmt"recurrentSiteUrl:{self.recurrentSiteUrl}"
   result &= ")"
 
 proc toCryptoRampDto*(jsonObj: JsonNode): CryptoRampDto =
@@ -46,3 +50,4 @@ proc toCryptoRampDto*(jsonObj: JsonNode): CryptoRampDto =
   discard jsonObj.getProp("logoUrl", result.logoUrl)
   discard jsonObj.getProp("siteUrl", result.siteUrl)
   discard jsonObj.getProp("hostname", result.hostname)
+  discard jsonObj.getProp("recurrentSiteUrl", result.recurrentSiteUrl)

--- a/storybook/src/Models/OnRampProvidersModel.qml
+++ b/storybook/src/Models/OnRampProvidersModel.qml
@@ -9,7 +9,7 @@ ListModel {
             logoUrl:           ModelsData.onRampProviderImages.ramp,
             siteUrl:           "https://ramp.network/buy?hostApiKey=zrtf9u2uqebeyzcs37fu5857tktr3eg9w5tffove&swapAsset=DAI,ETH,USDC,USDT",
             hostname:          "ramp.network",
-            recurrentSiteURL:  ""
+            recurrentSiteUrl:  ""
         },
         {
             name:              "MoonPay",
@@ -18,7 +18,7 @@ ListModel {
             logoUrl:           ModelsData.onRampProviderImages.moonPay,
             siteUrl:           "https://buy.moonpay.com/?apiKey=pk_live_YQC6CQPA5qqDu0unEwHJyAYQyeIqFGR",
             hostname:          "moonpay.com",
-            recurrentSiteURL:  "https://buy.moonpay.com/?apiKey=pk_live_YQC6CQPA5qqDu0unEwHJyAYQyeIqFGR",
+            recurrentSiteUrl:  "https://buy.moonpay.com/?apiKey=pk_live_ABCCQPA5qqDu0unEwHJyAYQyeIqFGR",
         },
         {
             name:              "Latamex",
@@ -27,7 +27,7 @@ ListModel {
             logoUrl:           ModelsData.onRampProviderImages.latamex,
             siteUrl:           "https://latamex.com/",
             hostname:          "latamex.com",
-            recurrentSiteURL:  "",
+            recurrentSiteUrl:  "",
         }
     ]
 

--- a/ui/app/AppLayouts/Wallet/popups/BuyCryptoModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/BuyCryptoModal.qml
@@ -46,12 +46,11 @@ StatusDialog {
             Layout.fillHeight: true
             model: SortFilterProxyModel {
                 sourceModel: !!root.onRampProvidersModel ? root.onRampProvidersModel : null
-                // TODO: this temporary and changed under https://github.com/status-im/status-desktop/issues/14820
-                // when recurrentSiteURL is available
                 filters: ValueFilter {
                     enabled: tabBar.currentIndex
-                    roleName: "name"
+                    roleName: "recurrentSiteUrl"
                     value: ""
+                    inverted: true
                 }
             }
             delegate: StatusListItem {
@@ -78,7 +77,7 @@ StatusDialog {
                     }
                 ]
                 onClicked: {
-                    let url = tabBar.currentIndex ? recurrentSiteURL : siteUrl
+                    let url = tabBar.currentIndex ? recurrentSiteUrl : siteUrl
                     Global.openLinkWithConfirmation(url, hostname)
                     root.close()
                 }


### PR DESCRIPTION
fixes #14820

### What does the PR do

adds reccurentSiteUrl on the nim side and valid filter on qml model
Adding test cases for recurrent tab

### Affected areas

BuyCryptoModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/467d47fa-ac57-4e82-a408-a8f0af5a704b


https://github.com/status-im/status-desktop/assets/60327365/952ddd01-e218-4c8c-a54a-67653c9e49ec

