### PR TITLE
refactor: rely on canPost and canView instead of checking permissions

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -134,12 +134,6 @@ method onMadeActive*(self: AccessInterface) {.base.} =
 method onMadeInactive*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onUpdateViewOnlyPermissionsSatisfied*(self: AccessInterface, value: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onUpdateViewAndPostPermissionsSatisfied*(self: AccessInterface, value: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method setPermissionsCheckOngoing*(self: AccessInterface, value: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -444,12 +444,6 @@ method amIChatAdmin*(self: Module): bool =
     return communityDto.memberRole == MemberRole.Owner or
       communityDto.memberRole == MemberRole.Admin or communityDto.memberRole == MemberRole.TokenMaster
 
-method onUpdateViewOnlyPermissionsSatisfied*(self: Module, value: bool) =
-  self.view.setViewOnlyPermissionsSatisfied(value)
-
-method onUpdateViewAndPostPermissionsSatisfied*(self: Module, value: bool) =
-  self.view.setViewAndPostPermissionsSatisfied(value)
-
 method setPermissionsCheckOngoing*(self: Module, value: bool) =
   self.view.setPermissionsCheckOngoing(value)
 

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -13,8 +13,6 @@ QtObject:
       pinnedMessagesModelVariant: QVariant
       chatDetails: ChatDetails
       chatDetailsVariant: QVariant
-      viewOnlyPermissionsSatisfied: bool
-      viewAndPostPermissionsSatisfied: bool
       permissionsCheckOngoing: bool
 
   proc chatDetailsChanged*(self:View) {.signal.}
@@ -34,8 +32,6 @@ QtObject:
     result.pinnedMessagesModelVariant = newQVariant(result.pinnedMessagesModel)
     result.chatDetails = newChatDetails()
     result.chatDetailsVariant = newQVariant(result.chatDetails)
-    result.viewOnlyPermissionsSatisfied = false
-    result.viewAndPostPermissionsSatisfied = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -148,30 +144,6 @@ QtObject:
 
   proc updateChatBlocked*(self: View, blocked: bool) =
     self.chatDetails.setBlocked(blocked)
-
-  proc viewOnlyPermissionsSatisfiedChanged(self: View) {.signal.}
-
-  proc setViewOnlyPermissionsSatisfied*(self: View, value: bool) =
-    self.viewOnlyPermissionsSatisfied = value
-    self.viewOnlyPermissionsSatisfiedChanged()
-
-  proc getViewOnlyPermissionsSatisfied*(self: View): bool {.slot.} =
-    return self.viewOnlyPermissionsSatisfied or self.amIChatAdmin()
-  QtProperty[bool] viewOnlyPermissionsSatisfied:
-    read = getViewOnlyPermissionsSatisfied
-    notify = viewOnlyPermissionsSatisfiedChanged
-
-  proc viewAndPostPermissionsSatisfiedChanged(self: View) {.signal.}
-
-  proc setViewAndPostPermissionsSatisfied*(self: View, value: bool) =
-    self.viewAndPostPermissionsSatisfied = value
-    self.viewAndPostPermissionsSatisfiedChanged()
-
-  proc getViewAndPostPermissionsSatisfied*(self: View): bool {.slot.} =
-    return self.viewAndPostPermissionsSatisfied or self.amIChatAdmin()
-  QtProperty[bool] viewAndPostPermissionsSatisfied:
-    read = getViewAndPostPermissionsSatisfied
-    notify = viewAndPostPermissionsSatisfiedChanged
 
   proc getPermissionsCheckOngoing*(self: View): bool {.slot.} =
     return self.permissionsCheckOngoing

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -91,7 +91,7 @@ proc getMySectionId*(self: Controller): string =
 proc asyncCheckPermissionsToJoin*(self: Controller) =
   if self.delegate.getPermissionsToJoinCheckOngoing():
     return
-  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId(), addresses = @[], fullCheck = false)
+  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId(), addresses = @[])
   self.delegate.setPermissionsToJoinCheckOngoing(true)
 
 proc asyncCheckChannelPermissions*(self: Controller, communityId: string, chatId: string) =

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -40,8 +40,6 @@ type
     canView: bool
     viewersCanPostReactions: bool
     hideIfPermissionsNotMet: bool
-    viewOnlyPermissionsSatisfied: bool
-    viewAndPostPermissionsSatisfied: bool
 
 proc initItem*(
     id,
@@ -75,8 +73,6 @@ proc initItem*(
     canPostReactions = true,
     viewersCanPostReactions = true,
     hideIfPermissionsNotMet: bool,
-    viewOnlyPermissionsSatisfied: bool,
-    viewAndPostPermissionsSatisfied: bool,
     ): Item =
   result = Item()
   result.id = id
@@ -111,8 +107,6 @@ proc initItem*(
   result.canPostReactions = canPostReactions
   result.viewersCanPostReactions = viewersCanPostReactions
   result.hideIfPermissionsNotMet = hideIfPermissionsNotMet
-  result.viewOnlyPermissionsSatisfied = viewOnlyPermissionsSatisfied
-  result.viewAndPostPermissionsSatisfied = viewAndPostPermissionsSatisfied
 
 proc `$`*(self: Item): string =
   result = fmt"""chat_section/Item(
@@ -146,8 +140,6 @@ proc `$`*(self: Item): string =
     canPostReactions: {$self.canPostReactions},
     viewersCanPostReactions: {$self.viewersCanPostReactions},
     hideIfPermissionsNotMet: {$self.hideIfPermissionsNotMet},
-    viewOnlyPermissionsSatisfied: {$self.viewOnlyPermissionsSatisfied},
-    viewAndPostPermissionsSatisfied: {$self.viewAndPostPermissionsSatisfied},
     ]"""
 
 proc toJsonNode*(self: Item): JsonNode =
@@ -182,8 +174,6 @@ proc toJsonNode*(self: Item): JsonNode =
     "canPostReactions": self.canPostReactions,
     "viewersCanPostReactions": self.viewersCanPostReactions,
     "hideIfPermissionsNotMet": self.hideIfPermissionsNotMet,
-    "viewOnlyPermissionsSatisfied": self.viewOnlyPermissionsSatisfied,
-    "viewAndPostPermissionsSatisfied": self.viewAndPostPermissionsSatisfied
   }
 
 proc delete*(self: Item) =
@@ -288,18 +278,6 @@ proc hideIfPermissionsNotMet*(self: Item): bool =
 proc `hideIfPermissionsNotMet=`*(self: var Item, value: bool) =
   self.hideIfPermissionsNotMet = value
 
-proc viewAndPostPermissionsSatisfied*(self: Item): bool =
-  self.viewAndPostPermissionsSatisfied
-
-proc `viewAndPostPermissionsSatisfied=`*(self: var Item, value: bool) =
-  self.viewAndPostPermissionsSatisfied = value
-
-proc viewOnlyPermissionsSatisfied*(self: Item): bool =
-  self.viewOnlyPermissionsSatisfied
-
-proc `viewOnlyPermissionsSatisfied=`*(self: var Item, value: bool) =
-  self.viewOnlyPermissionsSatisfied = value
-
 proc categoryPosition*(self: Item): int =
   self.categoryPosition
 
@@ -379,4 +357,4 @@ proc `viewersCanPostReactions=`*(self: Item, value: bool) =
   self.viewersCanPostReactions = value
 
 proc hideBecausePermissionsAreNotMet*(self: Item): bool =
-  self.hideIfPermissionsNotMet and not self.viewOnlyPermissionsSatisfied and not self.viewAndPostPermissionsSatisfied
+  self.hideIfPermissionsNotMet and not self.canPost and not self.canView

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -405,24 +405,30 @@ QtObject:
     let index = self.getItemIdxById(id)
     if index == -1:
       return
-    if(self.items[index].canView == canView and
-        self.items[index].canPost == canPost and
-        self.items[index].canPostReactions == canPostReactions and
-        self.items[index].viewersCanPostReactions == viewersCanPostReactions
-      ):
+    var changedRoles: seq[int] = @[]
+
+    if self.items[index].canView != canView:
+      self.items[index].canView = canView
+      changedRoles.add(ModelRole.CanView.int)
+
+    if self.items[index].canPost != canPost:
+      self.items[index].canPost = canPost
+      changedRoles.add(ModelRole.CanPost.int)
+
+    if self.items[index].canPostReactions != canPostReactions:
+      self.items[index].canPostReactions = canPostReactions
+      changedRoles.add(ModelRole.CanPostReactions.int)
+
+    if self.items[index].viewersCanPostReactions != viewersCanPostReactions:
+      self.items[index].viewersCanPostReactions = viewersCanPostReactions
+      changedRoles.add(ModelRole.ViewersCanPostReactions.int)
+
+    if changedRoles.len == 0:
       return
-    self.items[index].canPost = canPost
-    self.items[index].canView = canView
-    self.items[index].canPostReactions = canPostReactions
-    self.items[index].viewersCanPostReactions = viewersCanPostReactions
+    
     let modelIndex = self.createIndex(index, 0, nil)
     defer: modelIndex.delete
-    self.dataChanged(modelIndex, modelIndex, @[
-      ModelRole.CanPost.int,
-      ModelRole.CanView.int,
-      ModelRole.CanPostReactions.int,
-      ModelRole.ViewersCanPostReactions.int
-    ])
+    self.dataChanged(modelIndex, modelIndex, changedRoles)
 
   proc changeMutedOnItemByCategoryId*(self: Model, categoryId: string, muted: bool) =
     for i in 0 ..< self.items.len:

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -35,13 +35,13 @@ type
     LoaderActive
     Locked
     RequiresPermissions
+    CanPost
+    CanView
     CanPostReactions
     ViewersCanPostReactions
     HideIfPermissionsNotMet
-    ViewOnlyPermissionsSatisfied
-    ViewAndPostPermissionsSatisfied
     ShouldBeHiddenBecausePermissionsAreNotMet #this is a complex role which depends on other roles
-                                              #(MemberRole , HideIfPermissionsNotMet, ViewOnlyPermissionsSatisfied, ViewAndPostPermissionsSatisfied)
+                                              #(MemberRole , HideIfPermissionsNotMet, canPost and canView)
 
 QtObject:
   type
@@ -130,8 +130,6 @@ QtObject:
       ModelRole.Position.int:"position",
       ModelRole.CategoryId.int:"categoryId",
       ModelRole.HideIfPermissionsNotMet.int:"hideIfPermissionsNotMet",
-      ModelRole.ViewOnlyPermissionsSatisfied.int:"viewOnlyPermissionsSatisfied",
-      ModelRole.ViewAndPostPermissionsSatisfied.int:"viewAndPostPermissionsSatisfied",
       ModelRole.CategoryPosition.int:"categoryPosition",
       ModelRole.Highlight.int:"highlight",
       ModelRole.CategoryOpened.int:"categoryOpened",
@@ -141,6 +139,8 @@ QtObject:
       ModelRole.LoaderActive.int:"loaderActive",
       ModelRole.Locked.int:"locked",
       ModelRole.RequiresPermissions.int:"requiresPermissions",
+      ModelRole.CanPost.int:"canPost",
+      ModelRole.CanView.int:"canView",
       ModelRole.CanPostReactions.int:"canPostReactions",
       ModelRole.ViewersCanPostReactions.int:"viewersCanPostReactions",
       ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int:"shouldBeHiddenBecausePermissionsAreNotMet"
@@ -211,16 +211,16 @@ QtObject:
       result = newQVariant(item.isLocked)
     of ModelRole.RequiresPermissions:
       result = newQVariant(item.requiresPermissions)
+    of ModelRole.CanPost:
+      result = newQVariant(item.canPost)
+    of ModelRole.CanView:
+      result = newQVariant(item.canView)
     of ModelRole.CanPostReactions:
       result = newQVariant(item.canPostReactions)
     of ModelRole.ViewersCanPostReactions:
       result = newQVariant(item.viewersCanPostReactions)
     of ModelRole.HideIfPermissionsNotMet:
       result = newQVariant(item.hideIfPermissionsNotMet)
-    of ModelRole.ViewAndPostPermissionsSatisfied:
-      result = newQVariant(item.viewAndPostPermissionsSatisfied)
-    of ModelRole.ViewOnlyPermissionsSatisfied:
-      result = newQVariant(item.viewOnlyPermissionsSatisfied)
     of ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet:
       return newQVariant(self.itemShouldBeHiddenBecauseNotPermitted(item))
 
@@ -370,36 +370,6 @@ QtObject:
     defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Locked.int])
 
-  proc setViewOnlyPermissionsSatisfied*(self: Model, id: string, satisfied: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-
-    if (self.items[index].viewOnlyPermissionsSatisfied == satisfied):
-      return
-
-    self.items[index].viewOnlyPermissionsSatisfied = satisfied
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    # refresh also ShouldBeHiddenBecausePermissionsAreNotMet because it depends on ViewOnlyPermissionsSatisfied
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.ViewOnlyPermissionsSatisfied.int, ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int])
-    self.updateHiddenFlagForCategory(self.items[index].categoryId)
-
-  proc setViewAndPostPermissionsSatisfied*(self: Model, id: string, satisfied: bool) =
-    let index = self.getItemIdxById(id)
-    if index == -1:
-      return
-
-    if (self.items[index].viewAndPostPermissionsSatisfied == satisfied):
-      return
-
-    self.items[index].viewAndPostPermissionsSatisfied = satisfied
-    let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
-    # refresh also ShouldBeHiddenBecausePermissionsAreNotMet because it depends on ViewAndPostPermissionsSatisfied
-    self.dataChanged(modelIndex, modelIndex, @[ModelRole.ViewAndPostPermissionsSatisfied.int, ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int])
-    self.updateHiddenFlagForCategory(self.items[index].categoryId)
-
   proc setItemPermissionsRequired*(self: Model, id: string, value: bool) =
     let index = self.getItemIdxById(id)
     if index == -1:
@@ -431,19 +401,25 @@ QtObject:
     defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Muted.int])
 
-  proc changeCanPostValues*(self: Model, id: string, canPostReactions, viewersCanPostReactions: bool) =
+  proc changeCanPostValues*(self: Model, id: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool) =
     let index = self.getItemIdxById(id)
     if index == -1:
       return
-    if(self.items[index].canPostReactions == canPostReactions and
+    if(self.items[index].canView == canView and
+        self.items[index].canPost == canPost and
+        self.items[index].canPostReactions == canPostReactions and
         self.items[index].viewersCanPostReactions == viewersCanPostReactions
       ):
       return
+    self.items[index].canPost = canPost
+    self.items[index].canView = canView
     self.items[index].canPostReactions = canPostReactions
     self.items[index].viewersCanPostReactions = viewersCanPostReactions
     let modelIndex = self.createIndex(index, 0, nil)
     defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
+      ModelRole.CanPost.int,
+      ModelRole.CanView.int,
       ModelRole.CanPostReactions.int,
       ModelRole.ViewersCanPostReactions.int
     ])

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -949,7 +949,6 @@ method onCategoryUnmuted*(self: Module, categoryId: string) =
 method changeMutedOnChat*(self: Module, chatId: string, muted: bool) =
   self.view.chatsModel().changeMutedOnItemById(chatId, muted)
 
-# TODO update this
 proc changeCanPostValues*(self: Module, chatId: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool) =
   self.view.chatsModel().changeCanPostValues(chatId, canPost, canView, canPostReactions, viewersCanPostReactions)
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -69,11 +69,11 @@ proc buildChatSectionUI(
   mailserversService: mailservers_service.Service,
   sharedUrlsService: shared_urls_service.Service,
 )
-
 proc reevaluateRequiresTokenPermissionToJoin(self: Module)
-
-proc changeCanPostValues*(self: Module, chatId: string, canPostReactions, viewersCanPostReactions: bool)
-
+proc changeCanPostValues*(self: Module, chatId: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool)
+method onCommunityCheckPermissionsToJoinResponse*(self: Module, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto)
+method onCommunityCheckChannelPermissionsResponse*(self: Module, chatId: string, checkChannelPermissionsResponse: CheckChannelPermissionsResponseDto)
+method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, checkAllChannelsPermissionsResponse: CheckAllChannelsPermissionsResponseDto)
 method addOrUpdateChat(self: Module,
     chat: ChatDto,
     belongsToCommunity: bool,
@@ -275,8 +275,6 @@ proc addCategoryItem(self: Module, category: Category, memberRole: MemberRole, c
         category.id,
         category.position,
         hideIfPermissionsNotMet = false,
-        viewOnlyPermissionsSatisfied = true,
-        viewAndPostPermissionsSatisfied = true,
       )
 
   if insertIntoModel:
@@ -448,8 +446,6 @@ method onChatsLoaded*(
 
     self.view.setRequestToJoinState(requestToJoinState)
     self.initCommunityTokenPermissionsModel()
-    self.onCommunityCheckAllChannelsPermissionsResponse(community.channelPermissions)
-    self.controller.asyncCheckPermissionsToJoin()
 
   let activeChatId = self.controller.getActiveChatId()
   let isCurrentSectionActive = self.controller.getIsCurrentSectionActive()
@@ -534,7 +530,18 @@ method activeItemSet*(self: Module, itemId: string) =
   if self.controller.isCommunity():
     let community = self.controller.getMyCommunity()
     if not community.isPrivilegedUser:
-      self.controller.asyncCheckChannelPermissions(mySectionId, activeChatId)
+      if not chat_item.canView or not chat_item.canPost:
+        # User doesn't have full access to this channel. Check permissions to know what is missing
+        self.controller.asyncCheckChannelPermissions(mySectionId, activeChatId)
+
+      self.onCommunityCheckChannelPermissionsResponse(activeChatId, CheckChannelPermissionsResponseDto(
+        viewOnlyPermissions: ViewOnlyOrViewAndPostPermissionsResponseDto(
+          satisfied: chat_item.canView
+        ),
+        viewAndPostPermissions: ViewOnlyOrViewAndPostPermissionsResponseDto(
+          satisfied: chat_item.canPost
+        ),
+      ))
 
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
@@ -568,16 +575,6 @@ proc updateChatLocked(self: Module, chatId: string) =
   let communityId = self.controller.getMySectionId()
   let locked = self.controller.checkChatIsLocked(communityId, chatId)
   self.view.chatsModel().setItemLocked(chatId, locked)
-
-proc updateViewOnlyPermissionsSatisfied(self: Module, chatId: string, satisifed: bool) =
-  if not self.controller.isCommunity():
-    return
-  self.view.chatsModel().setViewOnlyPermissionsSatisfied(chatId, satisifed)
-
-proc updateViewAndPostPermissionsSatisfied(self: Module, chatId: string, satisifed: bool) =
-  if not self.controller.isCommunity():
-    return
-  self.view.chatsModel().setViewAndPostPermissionsSatisfied(chatId, satisifed)
 
 proc updateChatRequiresPermissions(self: Module, chatId: string) =
   if not self.controller.isCommunity():
@@ -628,9 +625,13 @@ method onActiveSectionChange*(self: Module, sectionId: string) =
   if self.isCommunity():
     let community = self.controller.getMyCommunity()
     if not community.isPrivilegedUser:
-      self.controller.asyncCheckPermissionsToJoin()
-      if firstLoad:
-        self.controller.asyncCheckAllChannelsPermissions()
+      if not community.joined:
+        self.controller.asyncCheckPermissionsToJoin()
+      else:
+        # We do not care about the combinations when we do satisfy
+        self.onCommunityCheckPermissionsToJoinResponse(CheckPermissionsToJoinResponseDto(
+          satisfied: true
+        ))
 
   self.delegate.onActiveChatChange(self.controller.getMySectionId(), self.controller.getActiveChatId())
 
@@ -753,8 +754,6 @@ proc getChatItemFromChatDto(
     canPostReactions = canPostReactions,
     viewersCanPostReactions = viewersCanPostReactions,
     hideIfPermissionsNotMet = hideIfPermissionsNotMet,
-    viewOnlyPermissionsSatisfied = true, # will be updated in async call
-    viewAndPostPermissionsSatisfied = true, # will be updated in async call
   )
 
 proc addNewChat(
@@ -898,7 +897,7 @@ proc refreshHiddenBecauseNotPermittedState(self: Module) =
 method onCommunityChannelEdited*(self: Module, chat: ChatDto) =
   if(not self.chatContentModules.contains(chat.id)):
     return
-  self.changeCanPostValues(chat.id, chat.canPostReactions, chat.viewersCanPostReactions)
+  self.changeCanPostValues(chat.id, chat.canPost, chat.canView, chat.canPostReactions, chat.viewersCanPostReactions)
   self.view.chatsModel().updateItemDetailsById(chat.id, chat.name, chat.description, chat.emoji, chat.color, chat.hideIfPermissionsNotMet)
   self.refreshHiddenBecauseNotPermittedState()
 
@@ -950,8 +949,9 @@ method onCategoryUnmuted*(self: Module, categoryId: string) =
 method changeMutedOnChat*(self: Module, chatId: string, muted: bool) =
   self.view.chatsModel().changeMutedOnItemById(chatId, muted)
 
-proc changeCanPostValues*(self: Module, chatId: string, canPostReactions, viewersCanPostReactions: bool) =
-  self.view.chatsModel().changeCanPostValues(chatId, canPostReactions, viewersCanPostReactions)
+# TODO update this
+proc changeCanPostValues*(self: Module, chatId: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool) =
+  self.view.chatsModel().changeCanPostValues(chatId, canPost, canView, canPostReactions, viewersCanPostReactions)
 
 method onCommunityTokenPermissionDeleted*(self: Module, communityId: string, tokenPermission: CommunityTokenPermissionDto) =
   self.rebuildCommunityTokenPermissionsModel()
@@ -1067,11 +1067,7 @@ proc updateChannelPermissionViewData*(
     self.updateChatLocked(chatId)
 
   if self.chatContentModules.hasKey(chatId):
-    self.chatContentModules[chatId].onUpdateViewOnlyPermissionsSatisfied(viewOnlyPermissions.satisfied)
-    self.chatContentModules[chatId].onUpdateViewAndPostPermissionsSatisfied(viewAndPostPermissions.satisfied)
     self.chatContentModules[chatId].setPermissionsCheckOngoing(false)
-  self.updateViewOnlyPermissionsSatisfied(chatId, viewOnlyPermissions.satisfied)
-  self.updateViewAndPostPermissionsSatisfied(chatId, viewAndPostPermissions.satisfied)
   self.refreshHiddenBecauseNotPermittedState()
 
 method onCommunityCheckPermissionsToJoinResponse*(self: Module, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) =
@@ -1379,8 +1375,6 @@ method prepareEditCategoryModel*(self: Module, categoryId: string) =
       c.position,
       categoryId="",
       hideIfPermissionsNotMet=false,
-      viewOnlyPermissionsSatisfied = true,
-      viewAndPostPermissionsSatisfied = true,
     )
     self.view.editCategoryChannelsModel().appendItem(chatItem)
   let catChats = self.controller.getChats(communityId, categoryId)
@@ -1404,8 +1398,6 @@ method prepareEditCategoryModel*(self: Module, categoryId: string) =
       c.position,
       categoryId,
       hideIfPermissionsNotMet=false,
-      viewOnlyPermissionsSatisfied = true,
-      viewAndPostPermissionsSatisfied = true,
     )
     self.view.editCategoryChannelsModel().appendItem(chatItem, ignoreCategory = true)
 
@@ -1467,7 +1459,7 @@ method addOrUpdateChat(self: Module,
       self.chatContentModules[chat.id].onChatUpdated(result)
 
     self.changeMutedOnChat(chat.id, chat.muted)
-    self.changeCanPostValues(chat.id, chat.canPostReactions, chat.viewersCanPostReactions)
+    self.changeCanPostValues(chat.id, result.canPost, result.canView, result.canPostReactions, result.viewersCanPostReactions)
     self.updateChatRequiresPermissions(chat.id)
     self.updateChatLocked(chat.id)
     if (chat.chatType == ChatType.PrivateGroupChat):

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -404,11 +404,11 @@ proc authenticate*(self: Controller) =
 proc getCommunityPublicKeyFromPrivateKey*(self: Controller, communityPrivateKey: string): string =
   result = self.communityService.getCommunityPublicKeyFromPrivateKey(communityPrivateKey)
 
-proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string], fullCheck: bool) =
-  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare, fullCheck)
+proc asyncCheckPermissionsToJoin*(self: Controller, communityId: string, addressesToShare: seq[string]) =
+  self.communityService.asyncCheckPermissionsToJoin(communityId, addressesToShare)
 
-proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string], fullCheck: bool) =
-  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses, fullCheck)
+proc asyncCheckAllChannelsPermissions*(self: Controller, communityId: string, sharedAddresses: seq[string]) =
+  self.chatService.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
 
 proc asyncGetRevealedAccountsForMember*(self: Controller, communityId, memberPubkey: string) =
   self.communityService.asyncGetRevealedAccountsForMember(communityId, memberPubkey)

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -858,11 +858,11 @@ method getCommunityPublicKeyFromPrivateKey*(self: Module, communityPrivateKey: s
 method checkPermissions*(self: Module, communityId: string, sharedAddresses: seq[string]) =
   self.joiningCommunityDetails.communityIdForPermissions = communityId
 
-  self.controller.asyncCheckPermissionsToJoin(communityId, sharedAddresses, fullCheck = true)
+  self.controller.asyncCheckPermissionsToJoin(communityId, sharedAddresses)
   self.view.setJoinPermissionsCheckSuccessful(false)
   self.setCheckingPermissionToJoinInProgress(true)
 
-  self.controller.asyncCheckAllChannelsPermissions(communityId, sharedAddresses, fullCheck = true)
+  self.controller.asyncCheckAllChannelsPermissions(communityId, sharedAddresses)
   self.view.setChannelsPermissionsCheckSuccessful(false)
   self.checkingAllChannelPermissionsInProgress = true
 

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -27,10 +27,7 @@ type
 const asyncCheckChannelPermissionsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckChannelPermissionsTaskArg](argEncoded)
   try:
-    var response = status_communities.checkCommunityChannelPermissionsLight(arg.communityId, arg.chatId).result
-    let channelPermissions = response.toCheckChannelPermissionsResponseDto()
-    if  not channelPermissions.viewOnlyPermissions.satisfied and not channelPermissions.viewAndPostPermissions.satisfied:
-      response = status_communities.checkCommunityChannelPermissions(arg.communityId, arg.chatId).result
+    let response = status_communities.checkCommunityChannelPermissions(arg.communityId, arg.chatId).result
 
     arg.finish(%* {
       "response": response,
@@ -49,16 +46,11 @@ type
   AsyncCheckAllChannelsPermissionsTaskArg = ref object of QObjectTaskArg
     communityId: string
     addresses: seq[string]
-    fullCheck: bool
 
 const asyncCheckAllChannelsPermissionsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckAllChannelsPermissionsTaskArg](argEncoded)
   try:
-    var result = JsonNode()
-    if arg.fullCheck:
-      result = status_communities.checkAllCommunityChannelsPermissions(arg.communityId, arg.addresses).result
-    else:
-      result = status_communities.checkAllCommunityChannelsPermissionsLight(arg.communityId).result
+    let result = status_communities.checkAllCommunityChannelsPermissions(arg.communityId, arg.addresses).result
     let allChannelsPermissions = result.toCheckAllChannelsPermissionsResponseDto()
     arg.finish(%* {
       "response": allChannelsPermissions,

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -702,14 +702,13 @@ QtObject:
       let errMsg = e.msg
       error "error checking all channel permissions: ", errMsg
 
-  proc asyncCheckAllChannelsPermissions*(self: Service, communityId: string, addresses: seq[string], fullCheck: bool) =
+  proc asyncCheckAllChannelsPermissions*(self: Service, communityId: string, addresses: seq[string]) =
     let arg = AsyncCheckAllChannelsPermissionsTaskArg(
       tptr: cast[ByteAddress](asyncCheckAllChannelsPermissionsTask),
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCheckAllChannelsPermissionsDone",
       communityId: communityId,
       addresses: addresses,
-      fullCheck: fullCheck
     )
 
     self.threadpool.start(arg)

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -209,21 +209,11 @@ type
   AsyncCheckPermissionsToJoinTaskArg = ref object of QObjectTaskArg
     communityId: string
     addresses: seq[string]
-    fullCheck: bool
 
 const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncCheckPermissionsToJoinTaskArg](argEncoded)
   try:
-    var response = JsonNode()
-    if not arg.fullCheck:
-      let hasPermissionToJoin = status_go.checkPermissionsToJoinCommunityLight(arg.communityId, arg.addresses).result.getBool
-      if hasPermissionToJoin:
-        let permissionToJoin = CheckPermissionsToJoinResponseDto(satisfied: true)
-        response = %permissionToJoin
-      else:
-        response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses).result
-    else:
-      response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses).result
+    let response = status_go.checkPermissionsToJoinCommunity(arg.communityId, arg.addresses).result
 
     arg.finish(%* {
       "response": response,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1619,14 +1619,13 @@ QtObject:
     self.events.emit(SIGNAL_COMMUNITY_DATA_IMPORTED, CommunityArgs(community: community))
     self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: @[community]))
 
-  proc asyncCheckPermissionsToJoin*(self: Service, communityId: string, addresses: seq[string], fullCheck: bool) =
+  proc asyncCheckPermissionsToJoin*(self: Service, communityId: string, addresses: seq[string]) =
     let arg = AsyncCheckPermissionsToJoinTaskArg(
       tptr: cast[ByteAddress](asyncCheckPermissionsToJoinTask),
       vptr: cast[ByteAddress](self.vptr),
       slot: "onAsyncCheckPermissionsToJoinDone",
       communityId: communityId,
       addresses: addresses,
-      fullCheck: fullCheck
     )
     self.threadpool.start(arg)
 

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -103,12 +103,6 @@ proc checkPermissionsToJoinCommunity*(communityId: string, addresses: seq[string
     "addresses": addresses
   }])
 
-proc checkPermissionsToJoinCommunityLight*(communityId: string, addresses: seq[string]): RpcResponse[JsonNode] =
-  result = callPrivateRPC("checkPermissionsToJoinCommunityLight".prefix, %*[{
-    "communityId": communityId,
-    "addresses": addresses
-  }])
-
 proc reevaluateCommunityMembersPermissions*(
     communityId: string,
   ): RpcResponse[JsonNode] =
@@ -126,17 +120,6 @@ proc checkAllCommunityChannelsPermissions*(communityId: string, addresses: seq[s
   result = callPrivateRPC("checkAllCommunityChannelsPermissions".prefix, %*[{
     "communityId": communityId,
     "addresses": addresses,
-  }])
-
-proc checkCommunityChannelPermissionsLight*(communityId: string, chatId: string): RpcResponse[JsonNode] =
-  result = callPrivateRPC("checkCommunityChannelPermissionsLight".prefix, %*[{
-    "communityId": communityId,
-    "chatId": chatId
-  }])
-
-proc checkAllCommunityChannelsPermissionsLight*(communityId: string): RpcResponse[JsonNode] =
-  result = callPrivateRPC("checkAllCommunityChannelsPermissionsLight".prefix, %*[{
-    "communityId": communityId
   }])
 
 proc allNonApprovedCommunitiesRequestsToJoin*(): RpcResponse[JsonNode] =

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -674,7 +674,7 @@ QtObject {
             } else if (_d.activeChatType === Constants.chatType.privateGroupChat) {
                 return _d.amIMember
             } else if (_d.activeChatType === Constants.chatType.communityChat) {
-                return currentChatContentModule().viewAndPostPermissionsSatisfied
+                return currentChatContentModule().chatDetails.canPost
             }
 
             return true

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -46,7 +46,7 @@ Item {
     property int activeChatType: parentModule && parentModule.activeItem.type
     property bool stickersLoaded: false
     property bool permissionUpdatePending: false
-    property bool viewAndPostPermissionsSatisfied: true
+    property bool canPost: true
     property var viewAndPostHoldingsModel
 
     readonly property var contactDetails: rootStore ? rootStore.oneToOneChatContact : null
@@ -300,7 +300,7 @@ Item {
                             if (root.permissionUpdatePending) {
                                 return qsTr("Some permissions are being updated. You will be able to send messages once the control node is back online.")
                             }
-                            if (!root.viewAndPostPermissionsSatisfied) {
+                            if (!root.canPost) {
                                 return qsTr("Sorry, you don't have permissions to post in this channel.")
                             }
                             return root.rootStore.chatInputPlaceHolderText
@@ -389,7 +389,7 @@ Item {
                     anchors.left: parent.left
                     anchors.leftMargin: (2*Style.current.bigPadding)
                     visible: (!!root.viewAndPostHoldingsModel && (root.viewAndPostHoldingsModel.count > 0)
-                              && !root.amISectionAdmin && !root.viewAndPostPermissionsSatisfied)
+                              && !root.amISectionAdmin && !root.canPost)
                     assetsModel: root.rootStore.assetsModel
                     collectiblesModel: root.rootStore.collectiblesModel
                     holdingsModel: root.viewAndPostHoldingsModel

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -49,8 +49,8 @@ StatusSectionLayout {
     property bool stickersLoaded: false
 
     readonly property var chatContentModule: rootStore.currentChatContentModule() || null
-    readonly property bool viewOnlyPermissionsSatisfied: chatContentModule.viewOnlyPermissionsSatisfied
-    readonly property bool viewAndPostPermissionsSatisfied: chatContentModule.viewAndPostPermissionsSatisfied
+    readonly property bool canView: chatContentModule.chatDetails.canView
+    readonly property bool canPost: chatContentModule.chatDetails.canPost
 
     property bool hasViewOnlyPermissions: false
     property bool hasUnrestrictedViewOnlyPermission: false
@@ -104,13 +104,13 @@ StatusSectionLayout {
             return false
         }
         if (!hasViewAndPostPermissions && hasViewOnlyPermissions) {
-            return !viewOnlyPermissionsSatisfied
+            return !canView
         }
         if (hasViewAndPostPermissions && !hasViewOnlyPermissions) {
-            return !viewAndPostPermissionsSatisfied
+            return !canPost
         }
         if (hasViewOnlyPermissions && hasViewAndPostPermissions) {
-            return !viewOnlyPermissionsSatisfied && !viewAndPostPermissionsSatisfied
+            return !canView && !canPost
         }
         return false
     }
@@ -245,7 +245,7 @@ StatusSectionLayout {
             stickersPopup: root.stickersPopup
             permissionUpdatePending: root.permissionUpdatePending
             viewAndPostHoldingsModel: root.viewAndPostPermissionsModel
-            viewAndPostPermissionsSatisfied: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.viewAndPostPermissionsSatisfied
+            canPost: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.canPost
             amISectionAdmin: root.amISectionAdmin
             onOpenStickerPackPopup: {
                 Global.openPopup(statusStickerPackClickPopup, {packId: stickerPackId, store: root.stickersPopup.store} )
@@ -267,8 +267,8 @@ StatusSectionLayout {
             collectiblesModel: root.collectiblesModel
             requestToJoinState: root.requestToJoinState
             requiresRequest: !root.amIMember
-            requirementsMet: (viewOnlyPermissionsSatisfied && viewOnlyPermissionsModel.count > 0) ||
-                             (viewAndPostPermissionsSatisfied && viewAndPostPermissionsModel.count > 0)
+            requirementsMet: (canView && viewOnlyPermissionsModel.count > 0) ||
+                             (canPost && viewAndPostPermissionsModel.count > 0)
             requirementsCheckPending: root.chatContentModule.permissionsCheckOngoing
             onRequestToJoinClicked: root.requestToJoinClicked()
             onInvitationPendingClicked: root.invitationPendingClicked()


### PR DESCRIPTION
Fixes #14983

status-go PR: https://github.com/status-im/status-go/pull/5267

We had the issue of checking actual permissions for a lot of things. That is a problem because it can be untrue information if the control node hadn't run the re-evaluation yet, plus it was slower.

The solution here is to rely on communityChat's `canPost` and `canView` as well as Community's `joined`. Those properties are computed by the control node itself, so they will always be accurate to the real state.
 
[refactor-perms.webm](https://github.com/status-im/status-desktop/assets/11926403/eb8f1d78-15a3-465b-9d76-aed86779928e)


**Known issue:** As seen in the video, when the owner adds a permission that would grant us access to a channel, the UI will still show that we do not meet the requirements, with the token we do have as blue, which is very confusing. The reason is that the re-evaluation hasn't been done yet. In the video, I force it with a restart. Once the re-eval is done, the channel is granted access correctly. This should be fixed in https://github.com/status-im/status-desktop/issues/14931