### PR TITLE
fix(ProfileDialogView): Share your own profile button is missing

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -319,10 +319,12 @@ Pane {
             Loader {
                 Layout.alignment: Qt.AlignTop
                 Layout.preferredHeight: menuButton.visible ? menuButton.height : -1
-                active: root.idVerificationFlowsEnabled
                 sourceComponent: {
                     if (d.isCurrentUser && !root.readOnly)
                         return btnShareProfile
+
+                    if (!root.idVerificationFlowsEnabled)
+                        return
 
                     if (d.isContact && !(d.isTrusted || d.isLocallyTrusted) && !d.isBlocked) {
                         if (d.isVerificationRequestSent)


### PR DESCRIPTION
### What does the PR do

- do not fully deactivate the secondary button slot/loader as it's also used by the Share button

Fixes #14995

### Affected areas

ProfileDialogView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/60438f39-9060-47cb-a31d-8f7dd3e218c1)


