### PR TITLE
hotfix: use canPost and canView from chat in case of a new channel

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -710,6 +710,8 @@ proc getChatItemFromChatDto(
       hideIfPermissionsNotMet = communityChat.hideIfPermissionsNotMet
       viewersCanPostReactions = communityChat.viewersCanPostReactions
     else:
+      canPost = chatDto.canPost
+      canView = chatDto.canView
       canPostReactions = chatDto.canPostReactions
       hideIfPermissionsNotMet = chatDto.hideIfPermissionsNotMet
       viewersCanPostReactions = chatDto.viewersCanPostReactions


### PR DESCRIPTION
Leftover after https://github.com/status-im/status-desktop/pull/14977

### What does the PR do

Fresh created channel will have valid canView and canPost before handling the community description

### Affected areas

Communities

