### PR TITLE
Refactor(getContactDetailsAsJson): Create the `ContactDetails` component

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -62,7 +62,19 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_REMOVED_TRUST_STATUS) do(e: Args):
     var args = TrustArgs(e)
     self.delegate.contactTrustStatusChanged(args.publicKey, args.isUntrustworthy)
+    
+  self.events.on(SIGNAL_CONTACT_VERIFIED) do (e: Args):
+    var args = ContactArgs(e)
+    self.delegate.updateContactVerificationStatus(args.contactId)
 
+  self.events.on(SIGNAL_CONTACT_VERIFICATION_SENT) do(e: Args):
+    var args = ContactArgs(e)
+    self.delegate.updateContactVerificationStatus(args.contactId)
+
+  self.events.on(SIGNAL_CONTACT_VERIFICATION_ACCEPTED) do(e: Args):
+    var args = VerificationRequestArgs(e)
+    self.delegate.onVerificationRequestUpdatedOrAdded(args.verificationRequest)
+    
   self.events.on(SIGNAL_CONTACT_UPDATED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
@@ -74,10 +86,12 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_CONTACT_VERIFICATION_DECLINED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.onVerificationRequestDeclined(args.contactId)
+    self.delegate.updateContactVerificationStatus(args.contactId)
 
   self.events.on(SIGNAL_CONTACT_VERIFICATION_CANCELLED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.onVerificationRequestCanceled(args.contactId)
+    self.delegate.updateContactVerificationStatus(args.contactId)
 
   self.events.on(SIGNAL_CONTACT_VERIFICATION_ADDED) do(e: Args):
     var args = VerificationRequestArgs(e)

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -79,6 +79,9 @@ method contactTrustStatusChanged*(self: AccessInterface, publicKey: string, isUn
 method contactUpdated*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method updateContactVerificationStatus*(self: AccessInterface, publicKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method contactsStatusUpdated*(self: AccessInterface, statusUpdates: seq[StatusUpdateDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -11,6 +11,8 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
+      contactsModel: Model
+      contactsModelVariant: QVariant
       myMutualContactsModel: Model
       myMutualContactsModelVariant: QVariant
       blockedContactsModel: Model
@@ -37,6 +39,8 @@ QtObject:
 
 
   proc delete*(self: View) =
+    self.contactsModel.delete
+    self.contactsModelVariant.delete
     self.myMutualContactsModel.delete
     self.myMutualContactsModelVariant.delete
     self.blockedContactsModel.delete
@@ -66,6 +70,8 @@ QtObject:
     new(result, delete)
     result.QObject.setup
     result.delegate = delegate
+    result.contactsModel = newModel()
+    result.contactsModelVariant = newQVariant(result.contactsModel)
     result.myMutualContactsModel = newModel()
     result.myMutualContactsModelVariant = newQVariant(result.myMutualContactsModel)
     result.blockedContactsModel = newModel()
@@ -92,6 +98,9 @@ QtObject:
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
+    
+  proc contactsModel*(self: View): Model =
+    return self.contactsModel
 
   proc myMutualContactsModel*(self: View): Model =
     return self.myMutualContactsModel
@@ -111,6 +120,13 @@ QtObject:
 
   # proc sentButRejectedContactRequestsModel*(self: View): Model =
   #   return self.sentButRejectedContactRequestsModel
+
+  proc contactsModelChanged(self: View) {.signal.}
+  proc getContactsModel(self: View): QVariant {.slot.} =
+    return self.contactsModelVariant
+  QtProperty[QVariant] contactsModel:
+    read = getContactsModel
+    notify = contactsModelChanged
 
   proc myMutualContactsModelChanged(self: View) {.signal.}
   proc getMyMutualContactsModel(self: View): QVariant {.slot.} =

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -22,6 +22,19 @@ type
     ContactRequest
     IncomingVerificationStatus
     OutgoingVerificationStatus
+    IsCurrentUser
+    DefaultDisplayName
+    OptionalName
+    LastUpdated
+    LastUpdatedLocally
+    Bio
+    ThumbnailImage
+    LargeImage
+    IsContactRequestReceived
+    IsContactRequestSent
+    IsSyncing
+    IsRemoved
+    TrustStatus
 
 QtObject:
   type
@@ -85,6 +98,19 @@ QtObject:
       ModelRole.ContactRequest.int: "contactRequest",
       ModelRole.IncomingVerificationStatus.int: "incomingVerificationStatus",
       ModelRole.OutgoingVerificationStatus.int: "outgoingVerificationStatus",
+      ModelRole.IsCurrentUser.int: "isCurrentUser",
+      ModelRole.DefaultDisplayName.int: "defaultDisplayName",
+      ModelRole.OptionalName.int: "optionalName",
+      ModelRole.LastUpdated.int: "lastUpdated",
+      ModelRole.LastUpdatedLocally.int: "lastUpdatedLocally",
+      ModelRole.Bio.int: "bio",
+      ModelRole.ThumbnailImage.int: "thumbnailImage",
+      ModelRole.LargeImage.int: "largeImage",
+      ModelRole.IsContactRequestReceived.int: "isContactRequestReceived",
+      ModelRole.IsContactRequestSent.int: "isContactRequestSent",
+      ModelRole.IsSyncing.int: "isSyncing",
+      ModelRole.IsRemoved.int: "isRemoved",
+      ModelRole.TrustStatus.int: "trustStatus",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -132,6 +158,34 @@ QtObject:
       result = newQVariant(item.incomingVerificationStatus.int)
     of ModelRole.OutgoingVerificationStatus:
       result = newQVariant(item.outgoingVerificationStatus.int)
+    of ModelRole.IsCurrentUser:
+      result = newQVariant(item.isCurrentUser)
+    of ModelRole.DefaultDisplayName:
+      result = newQVariant(item.defaultDisplayName)
+    of ModelRole.OptionalName:
+      result = newQVariant(item.optionalName)
+    of ModelRole.LastUpdated:
+      result = newQVariant(item.lastUpdated)
+    of ModelRole.LastUpdatedLocally:
+      result = newQVariant(item.lastUpdatedLocally)
+    of ModelRole.Bio:
+      result = newQVariant(item.bio)
+    of ModelRole.ThumbnailImage:
+      result = newQVariant(item.thumbnailImage)
+    of ModelRole.LargeImage:
+      result = newQVariant(item.largeImage)
+    of ModelRole.IsContactRequestReceived:
+      result = newQVariant(item.isContactRequestReceived)
+    of ModelRole.IsContactRequestSent:
+      result = newQVariant(item.isContactRequestSent)
+    of ModelRole.IsSyncing:
+      result = newQVariant(item.isSyncing)
+    of ModelRole.IsRemoved:
+      result = newQVariant(item.isRemoved)
+    of ModelRole.TrustStatus:
+      result = newQVariant(item.trustStatus.int)
+    else:
+      result = newQVariant()
 
   proc addItems*(self: Model, items: seq[UserItem]) =
     if(items.len == 0):

--- a/storybook/pages/ContactDetailsPage.qml
+++ b/storybook/pages/ContactDetailsPage.qml
@@ -1,0 +1,207 @@
+import QtQml 2.15
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import SortFilterProxyModel 0.2
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1
+import Storybook 1.0
+import utils 1.0
+import Models 1.0
+
+import AppLayouts.Profile.helpers 1.0
+import AppLayouts.Profile.stores 1.0
+
+import QtTest 1.15
+
+SplitView {
+    id: root
+
+    ColumnLayout {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        clip: true
+        spacing: 5
+        Label {
+            Layout.fillWidth: true
+            text: "publicKey: " + contactDetails.publicKey
+            font.bold: true
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "loading: " + contactDetails.loading
+            font.bold: true
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "displayName: " + contactDetails.displayName
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "ensName: " + contactDetails.ensName
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "ensVerified: " + contactDetails.ensVerified
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "localNickname: " + contactDetails.localNickname
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "alias: " + contactDetails.alias
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "icon: " + contactDetails.icon
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "colorId: " + contactDetails.colorId
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "colorHash: " + contactDetails.colorHash
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "onlineStatus: " + contactDetails.onlineStatus
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "isContact: " + contactDetails.isContact
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "isCurrentUser: " + contactDetails.isCurrentUser
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "isVerified: " + contactDetails.isVerified
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "isUntrustworthy: " + contactDetails.isUntrustworthy
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "isBlocked: " + contactDetails.isBlocked
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "contactRequestState: " + contactDetails.contactRequestState
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "incomingVerificationStatus: " + contactDetails.incomingVerificationStatus
+        }
+        Label {
+            Layout.fillWidth: true
+            text: "outgoingVerificationStatus: " + contactDetails.outgoingVerificationStatus
+        }
+
+        Pane {
+            contentItem: RowLayout {
+                ComboBox {
+                    id: pubKeySelector
+                    model: [...ModelUtils.modelToFlatArray(myContactsModel, "pubKey"), "myPubKey", "none"]
+                    ModelChangeTracker {
+                        id: modelChangeTracker
+                        model: myContactsModel
+                        onRevisionChanged: {
+                            pubKeySelector.model = [...ModelUtils.modelToFlatArray(myContactsModel, "pubKey"), "myPubKey", "none"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    UsersModelEditor {
+        id: myContactsModelEditor
+        SplitView.fillHeight: true
+        SplitView.preferredWidth: 500
+        model: myContactsModel
+
+        onRemoveClicked: (index) => {
+            myContactsModel.remove(index, 1)
+        }
+        onRemoveAllClicked: () => {
+            myContactsModel.clear()
+        }
+        onAddClicked: () => {
+            myContactsModel.append(getNewUser(myContactsModel.count))
+        }
+    }
+
+    UsersModel {
+        id: myContactsModel
+    }
+
+    ContactsStore {
+        id: contactsStoreMock
+        readonly property string myPublicKey: "0x123"
+        readonly property UsersModel contactsModel: myContactsModel
+        function requestContactInfo(pubKey) {
+            myContactsModel.append({
+                pubKey: pubKey,
+                displayName: "displayName",
+                ensName: "ensName",
+                ensVerified: true,
+                localNickname: "localNickname",
+                alias: "alias",
+                icon: "icon",
+                colorId: 1,
+                colorHash: [],
+                onlineStatus: 1,
+                isContact: true,
+                isCurrentUser: false,
+                isVerified: true,
+                isUntrustworthy: false,
+                isBlocked: false,
+                contactRequestState: 3,
+                incomingVerificationStatus: 3,
+                outgoingVerificationStatus: 2,
+                defaaaultDisplayName: "defaultDisplayName",
+                optionalName: "optionalName",
+                lastUpdated: 1234567890,
+                lastUpdatedLocally: 1234567890,
+                thumbnailImage: "thumbnailImage",
+                largeImage: "largeImage",
+                isContactRequestReceived: false,
+                isContactRequestSent: false,
+                isSyncing: false,
+                removed: false,
+                trustStatus: 1,
+                bio: "bio"
+            })
+        }
+    }
+
+    ProfileStore {
+        id: profileStoreMock
+        readonly property string displayName: "myDisplayName"
+        readonly property string name: "myEnsName"
+        readonly property string username: "myUsername"
+        readonly property string icon: "myIcon"
+        readonly property int colorId: 1
+        readonly property var colorHash: {}
+        readonly property int currentUserStatus: 1
+        readonly property string defaultDisplayName: "myDefaultDisplayName"
+        readonly property string thumbnailImage: "myThumbnailImage"
+        readonly property string largeImage: "myLargeImage"
+        readonly property string bio: "myBio"
+    }
+
+    ContactDetails {
+        id: contactDetails
+        contactsStore: contactsStoreMock
+        profileStore: profileStoreMock
+        publicKey: pubKeySelector.currentText === "myPubKey" ? "0x123" : pubKeySelector.currentText
+    }
+}
+// category: Contacts

--- a/storybook/pages/ContactDetailsPage.qml
+++ b/storybook/pages/ContactDetailsPage.qml
@@ -20,100 +20,102 @@ import QtTest 1.15
 SplitView {
     id: root
 
-    ColumnLayout {
+    Pane {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
-        clip: true
-        spacing: 5
-        Label {
-            Layout.fillWidth: true
-            text: "publicKey: " + contactDetails.publicKey
-            font.bold: true
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "loading: " + contactDetails.loading
-            font.bold: true
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "displayName: " + contactDetails.displayName
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "ensName: " + contactDetails.ensName
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "ensVerified: " + contactDetails.ensVerified
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "localNickname: " + contactDetails.localNickname
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "alias: " + contactDetails.alias
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "icon: " + contactDetails.icon
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "colorId: " + contactDetails.colorId
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "colorHash: " + contactDetails.colorHash
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "onlineStatus: " + contactDetails.onlineStatus
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "isContact: " + contactDetails.isContact
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "isCurrentUser: " + contactDetails.isCurrentUser
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "isVerified: " + contactDetails.isVerified
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "isUntrustworthy: " + contactDetails.isUntrustworthy
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "isBlocked: " + contactDetails.isBlocked
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "contactRequestState: " + contactDetails.contactRequestState
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "incomingVerificationStatus: " + contactDetails.incomingVerificationStatus
-        }
-        Label {
-            Layout.fillWidth: true
-            text: "outgoingVerificationStatus: " + contactDetails.outgoingVerificationStatus
-        }
+        contentItem: ColumnLayout {
+            clip: true
+            spacing: 5
+            Label {
+                Layout.fillWidth: true
+                text: "publicKey: " + contactDetails.publicKey
+                font.bold: true
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "loading: " + contactDetails.loading
+                font.bold: true
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "displayName: " + contactDetails.displayName
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "ensName: " + contactDetails.ensName
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "ensVerified: " + contactDetails.ensVerified
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "localNickname: " + contactDetails.localNickname
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "alias: " + contactDetails.alias
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "icon: " + contactDetails.icon
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "colorId: " + contactDetails.colorId
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "colorHash: " + contactDetails.colorHash
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "onlineStatus: " + contactDetails.onlineStatus
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "isContact: " + contactDetails.isContact
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "isCurrentUser: " + contactDetails.isCurrentUser
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "isVerified: " + contactDetails.isVerified
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "isUntrustworthy: " + contactDetails.isUntrustworthy
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "isBlocked: " + contactDetails.isBlocked
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "contactRequestState: " + contactDetails.contactRequestState
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "incomingVerificationStatus: " + contactDetails.incomingVerificationStatus
+            }
+            Label {
+                Layout.fillWidth: true
+                text: "outgoingVerificationStatus: " + contactDetails.outgoingVerificationStatus
+            }
 
-        Pane {
-            contentItem: RowLayout {
-                ComboBox {
-                    id: pubKeySelector
-                    model: [...ModelUtils.modelToFlatArray(myContactsModel, "pubKey"), "myPubKey", "none"]
-                    ModelChangeTracker {
-                        id: modelChangeTracker
-                        model: myContactsModel
-                        onRevisionChanged: {
-                            pubKeySelector.model = [...ModelUtils.modelToFlatArray(myContactsModel, "pubKey"), "myPubKey", "none"]
+            Pane {
+                contentItem: RowLayout {
+                    ComboBox {
+                        id: pubKeySelector
+                        model: [...ModelUtils.modelToFlatArray(myContactsModel, "pubKey"), "myPubKey", "none"]
+                        ModelChangeTracker {
+                            id: modelChangeTracker
+                            model: myContactsModel
+                            onRevisionChanged: {
+                                pubKeySelector.model = [...ModelUtils.modelToFlatArray(myContactsModel, "pubKey"), "myPubKey", "none"]
+                            }
                         }
                     }
                 }
@@ -121,20 +123,22 @@ SplitView {
         }
     }
 
-    UsersModelEditor {
-        id: myContactsModelEditor
+    Pane {
         SplitView.fillHeight: true
         SplitView.preferredWidth: 500
-        model: myContactsModel
+        contentItem: UsersModelEditor {
+            id: myContactsModelEditor
+            model: myContactsModel
 
-        onRemoveClicked: (index) => {
-            myContactsModel.remove(index, 1)
-        }
-        onRemoveAllClicked: () => {
-            myContactsModel.clear()
-        }
-        onAddClicked: () => {
-            myContactsModel.append(getNewUser(myContactsModel.count))
+            onRemoveClicked: (index) => {
+                myContactsModel.remove(index, 1)
+            }
+            onRemoveAllClicked: () => {
+                myContactsModel.clear()
+            }
+            onAddClicked: () => {
+                myContactsModel.append(getNewUser(myContactsModel.count))
+            }
         }
     }
 

--- a/storybook/qmlTests/tests/tst_ContactDetails.qml
+++ b/storybook/qmlTests/tests/tst_ContactDetails.qml
@@ -1,0 +1,336 @@
+import QtQuick 2.15
+import QtTest 1.15
+import QtQml 2.15
+
+import AppLayouts.Profile.helpers 1.0
+import AppLayouts.Profile.stores 1.0
+
+Item {
+    id: root
+
+    Component {
+        id: testComponent
+        ContactDetails {
+            id: contactDetails
+        }
+    }
+
+    Component {
+        id: failingTestComponent
+        ContactDetails {
+            id: contactDetails
+        }
+    }
+
+    Component {
+        id: contactsStore
+        ContactsStore {
+            readonly property string myPublicKey: "0x123"
+            readonly property ListModel contactsModel: ListModel { id: myContactsModel }
+            property var requestContactInfo: requestContactInfoCall
+            function requestContactInfoCall(pubKey) {
+                myContactsModel.append({
+                    pubKey: pubKey,
+                    displayName: "displayName",
+                    ensName: "ensName",
+                    isEnsVerified: true,
+                    localNickname: "localNickname",
+                    alias: "alias",
+                    icon: "icon",
+                    colorId: 1,
+                    colorHash: [],
+                    onlineStatus: 1,
+                    isContact: true,
+                    isCurrentUser: false,
+                    isVerified: true,
+                    isUntrustworthy: false,
+                    isBlocked: false,
+                    contactRequest: 3,
+                    incomingVerificationStatus: 3,
+                    outgoingVerificationStatus: 2,
+                    defaultDisplayName: "defaultDisplayName",
+                    optionalName: "optionalName",
+                    lastUpdated: 1234567890,
+                    lastUpdatedLocally: 1234567890,
+                    thumbnailImage: "thumbnailImage",
+                    largeImage: "largeImage",
+                    isContactRequestReceived: false,
+                    isContactRequestSent: false,
+                    isSyncing: false,
+                    isRemoved: false,
+                    trustStatus: 1,
+                    bio: "bio"
+                })
+            }
+        }
+    }
+
+    Component {
+        id: profileStore
+        ProfileStore {
+            id: profileStoreMock
+            readonly property string displayName: "myDisplayName"
+            readonly property string name: "myEnsName"
+            readonly property string username: "myUsername"
+            readonly property string icon: "myIcon"
+            readonly property int colorId: 1
+            readonly property var colorHash: {1}
+            readonly property int currentUserStatus: 1
+            readonly property string defaultDisplayName: "myDefaultDisplayName"
+            readonly property string thumbnailImage: "myThumbnailImage"
+            readonly property string largeImage: "myLargeImage"
+            readonly property string bio: "myBio"
+        }
+    }
+
+    TestCase {
+        name: "ContactDetailsTest"
+        function test_initialization() {
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: createTemporaryObject(contactsStore, root),
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: ""
+            })
+
+            verify(!!contactDetails, "Expected the contact details to initialize")
+        }
+
+        function test_initializationOwnProfile() {
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: createTemporaryObject(contactsStore, root),
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: "0x123"
+            })
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x123", "Expected the public key to be set")
+            compare(contactDetails.contactsStore.myPublicKey,"0x123", "Expected the contacts store to be set")
+            compare(contactDetails.profileStore.displayName,"myDisplayName", "Expected the profile store to be set")
+            compare(contactDetails.displayName, contactDetails.profileStore.displayName, "Expected the display name to be set")
+            compare(contactDetails.ensName, contactDetails.profileStore.name, "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+            compare(contactDetails.localNickname, "", "Expected the local nickname to be empty")
+            compare(contactDetails.alias, contactDetails.profileStore.username, "Expected the alias to be set")
+            compare(contactDetails.icon, contactDetails.profileStore.icon, "Expected the icon to be set")
+            compare(contactDetails.colorId, contactDetails.profileStore.colorId, "Expected the color id to be set")
+            compare(contactDetails.colorHash, contactDetails.profileStore.colorHash, "Expected the color hash to be empty")
+            compare(contactDetails.onlineStatus, contactDetails.profileStore.currentUserStatus, "Expected the online status to be set")
+            compare(contactDetails.thumbnailImage, contactDetails.profileStore.thumbnailImage, "Expected the is contact flag to be set")
+            compare(contactDetails.largeImage, contactDetails.profileStore.largeImage, "Expected the is contact flag to be set")
+            compare(contactDetails.bio, contactDetails.profileStore.bio, "Expected the is contact flag to be set")
+            compare(contactDetails.isContact, false, "Expected the is contact flag to be set")
+            compare(contactDetails.isCurrentUser, true, "Expected the is contact flag to be set")
+        }
+
+        function test_initializationWithContact() {
+            const contactsStoreMock = createTemporaryObject(contactsStore, root)
+            contactsStoreMock.requestContactInfo("0x321") //appending new contact to the model
+
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: contactsStoreMock,
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: "0x321"
+            })
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x321", "Expected the public key to be set")
+            compare(contactDetails.displayName, "displayName", "Expected the display name to be set")
+            compare(contactDetails.ensName, "ensName", "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+            compare(contactDetails.localNickname, "localNickname", "Expected the local nickname to be set")
+            compare(contactDetails.alias, "alias", "Expected the alias to be set")
+            compare(contactDetails.icon, "icon", "Expected the icon to be set")
+            compare(contactDetails.colorId, 1, "Expected the color id to be set")
+            compare(contactDetails.onlineStatus, 1, "Expected the online status to be set")
+            compare(contactDetails.thumbnailImage, "thumbnailImage", "Expected the thumbnailImage to be set")
+            compare(contactDetails.largeImage, "largeImage", "Expected the largeImage to be set")
+            compare(contactDetails.bio, "bio", "Expected the bio to be set")
+            compare(contactDetails.isContact, true, "Expected the is contact flag to be set")
+            compare(contactDetails.isCurrentUser, false, "Expected the isCurrentUser flag to be set")
+            compare(contactDetails.isVerified, true, "Expected the isVerified flag to be set")
+            compare(contactDetails.isUntrustworthy, false, "Expected the isUntrustworthy flag to be set")
+            compare(contactDetails.isBlocked, false, "Expected the isBlocked flag to be set")
+            compare(contactDetails.contactRequestState, 3, "Expected the contactRequestState flag to be set")
+            compare(contactDetails.incomingVerificationStatus, 3, "Expected the incomingVerificationStatus flag to be set")
+            compare(contactDetails.outgoingVerificationStatus, 2, "Expected the outgoingVerificationStatus flag to be set")
+            compare(contactDetails.defaultDisplayName, "defaultDisplayName", "Expected the defaultDisplayName to be set")
+            compare(contactDetails.optionalName, "optionalName", "Expected the optionalName to be set")
+            compare(contactDetails.lastUpdated, 1234567890, "Expected the lastUpdated to be set")
+            compare(contactDetails.lastUpdatedLocally, 1234567890, "Expected the lastUpdatedLocally to be set")
+            compare(contactDetails.isContactRequestReceived, false, "Expected the isContactRequestReceived flag to be set")
+            compare(contactDetails.isContactRequestSent, false, "Expected the isContactRequestSent flag to be set")
+            compare(contactDetails.isSyncing, false, "Expected the isSyncing to be set")
+            compare(contactDetails.removed, false, "Expected the removed flag to be set")
+            compare(contactDetails.trustStatus, 1, "Expected the trustStatus flag to be set")
+        }
+
+        function test_initFails() {
+            ignoreWarning(new RegExp("Required property publicKey was not initialized"))
+            ignoreWarning(new RegExp("Required property contactsStore was not initialized"))
+            ignoreWarning(new RegExp("Required property profileStore was not initialized"))
+
+            const contactDetails = createTemporaryObject(failingTestComponent, root)
+            verify(!contactDetails, "Expected the contact details to fail to initialize")
+        }
+
+        function test_initWithEmptyContacts() {
+            const contactsStoreMock = createTemporaryObject(contactsStore, root)
+            let requestContactInfoCallCount = 0
+            contactsStoreMock.requestContactInfo = function(pubKey) {
+                requestContactInfoCallCount++
+            }
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: contactsStoreMock,
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: "0x1234"
+            })
+
+            compare(requestContactInfoCallCount, 1, "Expected the requestContactInfo to be called")
+            compare(contactDetails.loading, true, "Expected the loading flag to be true")
+            compare(contactDetails.publicKey,"0x1234", "Expected the public key to be set")
+
+            //add the contact
+            contactsStoreMock.requestContactInfo = contactsStoreMock.requestContactInfoCall
+            contactsStoreMock.requestContactInfo("0x1234")
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x1234", "Expected the public key to be set")
+            compare(contactDetails.displayName, "displayName", "Expected the display name to be set")
+            compare(contactDetails.ensName, "ensName", "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+        }
+
+        function test_contactRemovedFromModel() {
+            const contactsStoreMock = createTemporaryObject(contactsStore, root)
+            contactsStoreMock.requestContactInfo("0x1234") //appending new contact to the model
+
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: contactsStoreMock,
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: "0x1234"
+            })
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x1234", "Expected the public key to be set")
+            compare(contactDetails.displayName, "displayName", "Expected the display name to be set")
+            compare(contactDetails.ensName, "ensName", "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+
+            // removing from model should not clear the contact details
+            contactsStoreMock.contactsModel.remove(0)
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be true")
+            compare(contactDetails.publicKey,"0x1234", "Expected the public key to be set")
+            compare(contactDetails.displayName, "displayName", "Expected the display name to be empty")
+            compare(contactDetails.ensName, "ensName", "Expected the ens name to be empty")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be false")
+        }
+
+        function test_liveUpdate() {
+            const contactsStoreMock = createTemporaryObject(contactsStore, root)
+            contactsStoreMock.requestContactInfo("0x1234") //appending new contact to the model
+
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: contactsStoreMock,
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: "0x1234"
+            })
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x1234", "Expected the public key to be set")
+            compare(contactDetails.displayName, "displayName", "Expected the display name to be set")
+            compare(contactDetails.ensName, "ensName", "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+
+            // updating the contact should update the contact details
+            contactsStoreMock.contactsModel.set(0, {
+                pubKey: "0x1234",
+                displayName: "newDisplayName",
+                ensName: "newEnsName",
+                isEnsVerified: false,
+                localNickname: "newLocalNickname",
+                alias: "newAlias",
+                icon: "newIcon",
+                colorId: 2,
+                colorHash: [],
+                onlineStatus: 2,
+                isContact: false,
+                isCurrentUser: true,
+                isVerified: false,
+                isUntrustworthy: true,
+                isBlocked: true,
+                contactRequest: 2,
+                incomingVerificationStatus: 2,
+                outgoingVerificationStatus: 1,
+                defaultDisplayName: "newDefaultDisplayName",
+                optionalName: "newOptionalName",
+                lastUpdated: 1234567891,
+                lastUpdatedLocally: 1234567891,
+                thumbnailImage: "newThumbnailImage",
+                largeImage: "newLargeImage",
+                isContactRequestReceived: true,
+                isContactRequestSent: true,
+                isSyncing: true,
+                isRemoved: true,
+                trustStatus: 2,
+                bio: "newBio"
+            })
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x1234", "Expected the public key to be set")
+            compare(contactDetails.displayName, "newDisplayName", "Expected the display name to be set")
+            compare(contactDetails.ensName, "newEnsName", "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, false, "Expected the ensVerified to be set")
+            compare(contactDetails.localNickname, "newLocalNickname", "Expected the local nickname to be set")
+            compare(contactDetails.alias, "newAlias", "Expected the alias to be set")
+            compare(contactDetails.icon, "newIcon", "Expected the icon to be set")
+            compare(contactDetails.colorId, 2, "Expected the color id to be set")
+            compare(contactDetails.onlineStatus, 2, "Expected the online status to be set")
+            compare(contactDetails.thumbnailImage, "newThumbnailImage", "Expected the thumbnailImage to be set")
+            compare(contactDetails.largeImage, "newLargeImage", "Expected the largeImage to be set")
+            compare(contactDetails.bio, "newBio", "Expected the bio to be set")
+            compare(contactDetails.isContact, false, "Expected the is contact flag to be set")
+            compare(contactDetails.isCurrentUser, true, "Expected the isCurrentUser flag to be set")
+            compare(contactDetails.isVerified, false, "Expected the isVerified flag to be set")
+            compare(contactDetails.isUntrustworthy, true, "Expected the isUntrustworthy flag to be set")
+            compare(contactDetails.isBlocked, true, "Expected the isBlocked flag to be set")
+            compare(contactDetails.contactRequestState, 2, "Expected the contactRequestState flag to be set")
+            compare(contactDetails.incomingVerificationStatus, 2, "Expected the incomingVerificationStatus flag to be set")
+            compare(contactDetails.outgoingVerificationStatus, 1, "Expected the outgoingVerificationStatus flag to be set")
+            compare(contactDetails.defaultDisplayName, "newDefaultDisplayName", "Expected the defaultDisplayName to be set")
+            compare(contactDetails.optionalName, "newOptionalName", "Expected the optionalName to be set")
+            compare(contactDetails.lastUpdated, 1234567891, "Expected the lastUpdated to be set")
+            compare(contactDetails.lastUpdatedLocally, 1234567891, "Expected the lastUpdatedLocally to be set")
+            compare(contactDetails.isContactRequestReceived, true, "Expected the isContactRequestReceived flag to be set")
+            compare(contactDetails.isContactRequestSent, true, "Expected the isContactRequestSent flag to be set")
+            compare(contactDetails.isSyncing, true, "Expected the isSyncing to be set")
+            compare(contactDetails.removed, true, "Expected the removed flag to be set")
+            compare(contactDetails.trustStatus, 2, "Expected the trustStatus flag to be set")
+        }
+
+        function test_changingPublicKeyFromOwnToContact() {
+            const contactsStoreMock = createTemporaryObject(contactsStore, root)
+            const contactDetails = createTemporaryObject(testComponent, root, {
+                contactsStore: contactsStoreMock,
+                profileStore: createTemporaryObject(profileStore, root),
+                publicKey: "0x123"
+            })
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x123", "Expected the public key to be set")
+            compare(contactDetails.contactsStore.myPublicKey,"0x123", "Expected the contacts store to be set")
+            compare(contactDetails.profileStore.displayName,"myDisplayName", "Expected the profile store to be set")
+            compare(contactDetails.displayName, contactDetails.profileStore.displayName, "Expected the display name to be set")
+            compare(contactDetails.ensName, contactDetails.profileStore.name, "Expected the ens name to be set")
+
+            contactDetails.publicKey = "0x321"
+
+            compare(contactDetails.loading, false, "Expected the loading flag to be false")
+            compare(contactDetails.publicKey,"0x321", "Expected the public key to be set")
+            compare(contactDetails.displayName, "displayName", "Expected the display name to be set")
+            compare(contactDetails.ensName, "ensName", "Expected the ens name to be set")
+            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+            compare(contactDetails.localNickname, "localNickname", "Expected the local nickname to be set")
+        }
+    }
+}

--- a/storybook/src/Storybook/StorybookUtils.qml
+++ b/storybook/src/Storybook/StorybookUtils.qml
@@ -20,4 +20,15 @@ QtObject {
         const regex = new RegExp(`^[ \\t]{${minIndent}}`, "gm")
         return code.replace(regex, "")
     }
+
+    function findChild(parent, name) {
+        if (!parent || !parent.children)
+            return null
+            
+        for (let i = 0; i < parent.children.length; i++) {
+            if (parent.children[i].objectName === name)
+                return parent.children[i]
+        }
+        return null
+    }
 }

--- a/storybook/stubs/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/storybook/stubs/AppLayouts/Profile/stores/ContactsStore.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.15
+
+QtObject {
+}

--- a/storybook/stubs/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/storybook/stubs/AppLayouts/Profile/stores/ProfileStore.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.15
+
+QtObject {
+}

--- a/storybook/stubs/AppLayouts/Profile/stores/qmldir
+++ b/storybook/stubs/AppLayouts/Profile/stores/qmldir
@@ -1,3 +1,5 @@
 LanguageStore 1.0 LanguageStore.qml
 ProfileSectionStore 1.0 ProfileSectionStore.qml
 WalletStore 1.0 WalletStore.qml
+ContactsStore 1.0 ContactsStore.qml
+ProfileStore 1.0 ProfileStore.qml

--- a/ui/StatusQ/include/StatusQ/concatmodel.h
+++ b/ui/StatusQ/include/StatusQ/concatmodel.h
@@ -67,7 +67,7 @@ public:
     // QAbstractItemModel interface
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     QHash<int, QByteArray> roleNames() const override;
 
     // QQmlParserStatus interface

--- a/ui/StatusQ/include/StatusQ/concatmodel.h
+++ b/ui/StatusQ/include/StatusQ/concatmodel.h
@@ -67,6 +67,7 @@ public:
     // QAbstractItemModel interface
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     QHash<int, QByteArray> roleNames() const override;
 
     // QQmlParserStatus interface

--- a/ui/StatusQ/src/concatmodel.cpp
+++ b/ui/StatusQ/src/concatmodel.cpp
@@ -305,6 +305,38 @@ QVariant ConcatModel::data(const QModelIndex &index, int role) const
     return {};
 }
 
+bool ConcatModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (!checkIndex(index, CheckIndexOption::IndexIsValid))
+        return false;
+
+    auto row = index.row();
+    
+    auto source = sourceForIndex(row);
+    if (source.first == nullptr)
+        return false;
+    
+    auto model = source.first->model();
+    if (model == nullptr)
+        return false;
+
+    auto sourcePosition = m_sources.indexOf(source.first);
+    if (sourcePosition == -1)
+        return false;
+        
+    auto& mapping = m_rolesMappingToSource[sourcePosition];
+    auto it = mapping.find(role);
+
+    if (it == mapping.end())
+        return false;
+
+    auto sourceIndex = model->index(source.second, 0);
+    if(!sourceIndex.isValid())
+        return false;
+
+    return model->setData(sourceIndex, value, it->second);
+}
+
 QHash<int, QByteArray> ConcatModel::roleNames() const
 {
     return m_roleNames;

--- a/ui/StatusQ/src/concatmodel.cpp
+++ b/ui/StatusQ/src/concatmodel.cpp
@@ -310,27 +310,27 @@ bool ConcatModel::setData(const QModelIndex &index, const QVariant &value, int r
     if (!checkIndex(index, CheckIndexOption::IndexIsValid))
         return false;
 
-    auto row = index.row();
+    const auto row = index.row();
     
-    auto source = sourceForIndex(row);
+    const auto source = sourceForIndex(row);
     if (source.first == nullptr)
         return false;
     
-    auto model = source.first->model();
+    const auto model = source.first->model();
     if (model == nullptr)
         return false;
 
-    auto sourcePosition = m_sources.indexOf(source.first);
+    const auto sourcePosition = m_sources.indexOf(source.first);
     if (sourcePosition == -1)
         return false;
         
-    auto& mapping = m_rolesMappingToSource[sourcePosition];
-    auto it = mapping.find(role);
+    const auto& mapping = m_rolesMappingToSource[sourcePosition];
+    const auto it = mapping.find(role);
 
     if (it == mapping.end())
         return false;
 
-    auto sourceIndex = model->index(source.second, 0);
+    const auto sourceIndex = model->index(source.second, 0);
     if(!sourceIndex.isValid())
         return false;
 

--- a/ui/StatusQ/src/modelentry.cpp
+++ b/ui/StatusQ/src/modelentry.cpp
@@ -319,7 +319,10 @@ void ModelEntry::cacheItem()
 
     for(const auto& role : qAsConst(m_roles))
     {
-        auto roleName = m_sourceModel->roleNames().key(role.toUtf8());
+        auto roleNames = m_sourceModel->roleNames().keys(role.toUtf8());
+        if (roleNames.isEmpty()) continue;
+
+        auto roleName = roleNames.first();
         auto roleValue = m_index.data(roleName);
 
         if(roleValue.canConvert<QAbstractItemModel*>())

--- a/ui/app/AppLayouts/Profile/helpers/ContactDetails.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ContactDetails.qml
@@ -67,7 +67,7 @@ QObject {
 
     QObject {
         id: d
-        property bool loading: !itemData.available && !isMe
+        readonly property bool loading: !itemData.available && !isMe
         onLoadingChanged: {
             if (loading) {
                 contactsStore.requestContactInfo(root.publicKey)

--- a/ui/app/AppLayouts/Profile/helpers/ContactDetails.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ContactDetails.qml
@@ -1,0 +1,113 @@
+import QtQuick 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import AppLayouts.Profile.stores 1.0
+
+import utils 1.0
+
+QObject {
+    id: root
+
+    required property ContactsStore contactsStore
+    required property ProfileStore profileStore
+    required property string publicKey
+
+    readonly property alias loading: d.loading
+
+    // model properties
+    readonly property string displayName: d.contactDetails.displayName ?? ""
+    readonly property string ensName: d.contactDetails.ensName ?? ""
+    readonly property bool ensVerified: d.contactDetails.isEnsVerified ?? false
+    readonly property string localNickname: d.contactDetails.localNickname ?? ""
+    readonly property string alias: d.contactDetails.alias ?? ""
+    readonly property string icon: d.contactDetails.icon ?? ""
+    readonly property int colorId: d.contactDetails.colorId ?? 0
+    readonly property var colorHash: d.contactDetails.colorHash ?? []
+    readonly property int onlineStatus: d.contactDetails.onlineStatus ?? Constants.onlineStatus.inactive
+    readonly property bool isContact: d.contactDetails.isContact ?? false
+    readonly property bool isCurrentUser: d.contactDetails.isCurrentUser ?? false
+    readonly property bool isVerified: d.contactDetails.isVerified ?? false
+    readonly property bool isUntrustworthy: d.contactDetails.isUntrustworthy ?? false
+    readonly property bool isBlocked: d.contactDetails.isBlocked ?? false
+    readonly property int contactRequestState: d.contactDetails.contactRequest ?? Constants.ContactRequestState.None
+    readonly property int incomingVerificationStatus: d.contactDetails.incomingVerificationStatus ?? Constants.verificationStatus.unverified
+    readonly property int outgoingVerificationStatus: d.contactDetails.outgoingVerificationStatus ?? Constants.verificationStatus.unverified
+    readonly property string defaultDisplayName: d.contactDetails.defaultDisplayName ?? ""
+    readonly property string optionalName: d.contactDetails.optionalName ?? ""
+    readonly property int lastUpdated: d.contactDetails.lastUpdated ?? 0
+    readonly property int lastUpdatedLocally: d.contactDetails.lastUpdatedLocally ?? 0
+    readonly property string thumbnailImage: d.contactDetails.thumbnailImage ?? ""
+    readonly property string largeImage: d.contactDetails.largeImage ?? ""
+    readonly property bool isContactRequestReceived: d.contactDetails.isContactRequestReceived ?? false
+    readonly property bool isContactRequestSent: d.contactDetails.isContactRequestSent ?? false
+    readonly property bool isSyncing: d.contactDetails.isSyncing ?? false
+    readonly property bool removed: d.contactDetails.isRemoved ?? false
+    readonly property int trustStatus: d.contactDetails.trustStatus ?? Constants.trustStatus.unknown
+    readonly property string bio: d.contactDetails.bio ?? ""
+
+    // Backwards compatibility properties - Don't use in new code
+    // TODO: #14965 - Try to remove these properties
+    readonly property string name: ensName
+    readonly property int verificationStatus: outgoingVerificationStatus
+
+    // Extra properties provided by getContactDetailsAsJson, not available in the model
+    // TODO: #14964 - Review all the model rolenames and fill the rest of the properties with data from the model
+    //readonly property int verificationStatus: d.contactDetails.verificationStatus ?? Constants.verificationStatus.unverified
+    //readonly property var socialLinks: d.contactDetails.socialLinks ?? []
+
+    ModelEntry {
+        id: itemData
+        sourceModel: root.publicKey !== "" && !d.isMe ? contactsStore.contactsModel : null
+        key: "pubKey"
+        value: root.publicKey
+        cacheOnRemoval: true
+    }
+
+    QObject {
+        id: d
+        property bool loading: !itemData.available && !isMe
+        onLoadingChanged: {
+            if (loading) {
+                contactsStore.requestContactInfo(root.publicKey)
+            }
+        }
+
+        readonly property bool isMe: root.contactsStore.myPublicKey === root.publicKey
+        readonly property var ownProfile: QObject {
+            readonly property string displayName: root.profileStore.displayName
+            readonly property string ensName: root.profileStore.name
+            readonly property bool isEnsVerified: root.profileStore.name !== ""
+            readonly property string localNickname: ""
+            readonly property string alias: root.profileStore.username
+            readonly property string icon: root.profileStore.icon
+            readonly property int colorId: root.profileStore.colorId
+            readonly property var colorHash: root.profileStore.colorHash
+            readonly property int onlineStatus: root.profileStore.currentUserStatus
+            readonly property bool isContact: false
+            readonly property bool isCurrentUser: true
+            readonly property bool isVerified: false
+            readonly property bool isUntrustworthy: false
+            readonly property bool isBlocked: false
+            readonly property int contactRequestState: Constants.ContactRequestState.None
+            readonly property int incomingVerificationStatus: Constants.verificationStatus.unverified
+            readonly property int outgoingVerificationStatus: Constants.verificationStatus.unverified
+            readonly property string defaultDisplayName: root.profileStore.defaultDisplayName
+            readonly property string optionalName: defaultDisplayName
+            readonly property string name: defaultDisplayName
+            readonly property int lastUpdated: 0
+            readonly property int lastUpdatedLocally: 0
+            readonly property string thumbnailImage: root.profileStore.thumbnailImage
+            readonly property string largeImage: root.profileStore.largeImage
+            readonly property bool isContactRequestReceived: Constants.ContactRequestState.None
+            readonly property bool isContactRequestSent: Constants.ContactRequestState.None
+            readonly property bool isSyncing: false
+            readonly property bool removed: false
+            readonly property int trustStatus: Constants.trustStatus.unknown
+            readonly property string bio: root.profileStore.bio
+        }
+
+        readonly property var contactDetails: !isMe ? itemData.item : ownProfile
+    }
+}

--- a/ui/app/AppLayouts/Profile/helpers/qmldir
+++ b/ui/app/AppLayouts/Profile/helpers/qmldir
@@ -3,3 +3,4 @@ ProfileShowcaseModelAdapter 1.0 ProfileShowcaseModelAdapter.qml
 ProfileShowcaseSettingsModelAdapter 1.0 ProfileShowcaseSettingsModelAdapter.qml
 ProfileShowcaseModels 1.0 ProfileShowcaseModels.qml
 VisibilityAndPositionDirtyStateModel 1.0 VisibilityAndPositionDirtyStateModel.qml
+ContactDetails 1.0 ContactDetails.qml

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.13
 import utils 1.0
 
+import StatusQ 0.1
+
 QtObject {
     id: root
 
@@ -11,6 +13,8 @@ QtObject {
 
     property string myPublicKey: !!Global.userProfile? Global.userProfile.pubKey : ""
 
+    // contactsModel holds all available contacts
+    property var contactsModel: contactsModule.contactsModel
     property var myContactsModel: contactsModule.myMutualContactsModel
     property var blockedContactsModel: contactsModule.blockedContactsModel
     property var receivedContactRequestsModel: contactsModule.receivedContactRequestsModel

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -8,23 +8,23 @@ QtObject {
 
     property var profileModule
 
-    property string pubkey: !!Global.userProfile? Global.userProfile.pubKey : ""
-    property string name: !!Global.userProfile? Global.userProfile.name : ""
-    property string username: !!Global.userProfile? Global.userProfile.username : ""
-    property string displayName: !!Global.userProfile? Global.userProfile.displayName : ""
-    property string preferredName: !!Global.userProfile? Global.userProfile.preferredName : ""
-    property string profileLargeImage: !!Global.userProfile? Global.userProfile.largeImage : ""
-    property string icon: !!Global.userProfile? Global.userProfile.icon : ""
+    property string pubkey: userProfile.pubKey
+    property string name: userProfile.name
+    property string username: userProfile.username
+    property string displayName: userProfile.displayName
+    property string preferredName: userProfile.preferredName
+    property string profileLargeImage: userProfile.largeImage
+    property string icon: userProfile.icon
     property bool userDeclinedBackupBanner: Global.appIsReady? localAccountSensitiveSettings.userDeclinedBackupBanner : false
     property var privacyStore: profileSectionModule.privacyModule
-    readonly property string keyUid: !!Global.userProfile ? Global.userProfile.keyUid : ""
-    readonly property bool isKeycardUser: !!Global.userProfile ? Global.userProfile.isKeycardUser : false
-    readonly property int currentUserStatus: !!Global.userProfile ? Global.userProfile.currentUserStatus : 0
-    readonly property var thumbnailImage: !!Global.userProfile ? Global.userProfile.thumbnailImage : ""
-    readonly property var largeImage: !!Global.userProfile ? Global.userProfile.largeImage : ""
+    readonly property string keyUid: userProfile.keyUid
+    readonly property bool isKeycardUser: userProfile.isKeycardUser
+    readonly property int currentUserStatus: userProfile.currentUserStatus
+    readonly property var thumbnailImage: userProfile.thumbnailImage
+    readonly property var largeImage: userProfile.largeImage
     readonly property int colorId: Utils.colorIdForPubkey(root.pubkey)
     readonly property var colorHash: Utils.getColorHashAsJson(root.pubkey, name != "")
-    readonly property string defaultDisplayName: Utils.getDefaultDisplayName("", name, displayName, username)
+    readonly property string defaultDisplayName: ProfileUtils.displayName("", name, displayName, username)
 
     readonly property string bio: profileModule.bio
     readonly property string socialLinksJson: profileModule.socialLinksJson

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -19,6 +19,12 @@ QtObject {
     property var privacyStore: profileSectionModule.privacyModule
     readonly property string keyUid: !!Global.userProfile ? Global.userProfile.keyUid : ""
     readonly property bool isKeycardUser: !!Global.userProfile ? Global.userProfile.isKeycardUser : false
+    readonly property int currentUserStatus: !!Global.userProfile ? Global.userProfile.currentUserStatus : 0
+    readonly property var thumbnailImage: !!Global.userProfile ? Global.userProfile.thumbnailImage : ""
+    readonly property var largeImage: !!Global.userProfile ? Global.userProfile.largeImage : ""
+    readonly property int colorId: Utils.colorIdForPubkey(root.pubkey)
+    readonly property var colorHash: Utils.getColorHashAsJson(root.pubkey, name != "")
+    readonly property string defaultDisplayName: Utils.getDefaultDisplayName("", name, displayName, username)
 
     readonly property string bio: profileModule.bio
     readonly property string socialLinksJson: profileModule.socialLinksJson

--- a/ui/app/AppLayouts/Profile/stores/qmldir
+++ b/ui/app/AppLayouts/Profile/stores/qmldir
@@ -5,3 +5,4 @@ NotificationsStore 1.0 NotificationsStore.qml
 DevicesStore 1.0 DevicesStore.qml
 ProfileSectionStore 1.0 ProfileSectionStore.qml
 WalletStore 1.0 WalletStore.qml
+ContactsStore 1.0 ContactsStore.qml


### PR DESCRIPTION
### What does the PR do

Closes #14963 
Depends on #14891

This PR creates the `ContactDetails` helper component to provide live data to the UI and implements all the logistics to have a functional implementation in the profile view.

#### Changes:
1. Expose a new model from nim `contactsModel`. This model holds all the available contacts. It's reusing the `user_model` that was extended to support all the extra data needed by the `ContactDetails`. https://github.com/status-im/status-desktop/commit/d9cc76a01757841af8d52ce4e8fe589790182775
2. Extend the `ProfileStore` to provide the extra info needed for own profile.
3. Create the `ContactDetails` component and add support for requesting new contact details through `contactsStore.requestContactInfo`
4. Adding the storybook page and qml tests
5. Adapt the profile view to the new `ContactDetails` component.


#### Extra (unrelated) - I can split it into a new PR if needed:
1. Forward the `setData` calls from the `ConcatModel` to the sourceModel. Nice to have whenever the source implements the `setData`. Found it's missing while implementing the storybook page.
2. Fix `ModelEntry` to avoid calling `data` for roles not found in the source.


#### Next steps

1. Fix: Mark as trusted dismissed if the trusted user changes the displayname needs to be fixed (TODO @alexjba : Add task)
2. Fix: Mark as untrusted, remove mark flow needs to be fixed (TODO @alexjba : Add task)
3. Continue the refactoring as planned here #11983 

### Affected areas

StatusQ models
Profile view

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/47811206/d534b035-97ae-45d9-88e1-66f159476bb4


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
