### PR TITLE
fix: set joined to all members of the comm since they are in the list

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -387,7 +387,6 @@ proc createCommunitySectionItem[T](self: Module[T], communityDetails: CommunityD
     communityDetails.muted,
     # members
     members.map(proc(member: ChatMember): MemberItem =
-      let contactDetails = self.controller.getContactDetails(member.id)
       var state = MembershipRequestState.Accepted
       if member.id in communityDetails.pendingAndBannedMembers:
         let memberState = communityDetails.pendingAndBannedMembers[member.id].toMembershipRequestState()

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -209,7 +209,7 @@ proc toGroupChatMember*(jsonObj: JsonNode): ChatMember =
   result.role = if admin: MemberRole.Owner else: MemberRole.None
   result.joined = true
 
-proc toChannelMember*(jsonObj: JsonNode, memberId: string, joined: bool): ChatMember =
+proc toChannelMember*(jsonObj: JsonNode, memberId: string): ChatMember =
   # Parse status-go "CommunityMember" type
   # Mapping this DTO is not straightforward since only keys are used for id. We
   # handle it a bit different.
@@ -220,6 +220,9 @@ proc toChannelMember*(jsonObj: JsonNode, memberId: string, joined: bool): ChatMe
   if(jsonObj.getProp("roles", rolesObj)):
     for roleObj in rolesObj:
       roles.add(roleObj.getInt)
+
+  # People in the community members' list are joined by default
+  result.joined = true
 
   result.role = MemberRole.None
   if roles.contains(MemberRole.Owner.int):

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -445,10 +445,8 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
 
   var membersObj: JsonNode
   if(jsonObj.getProp("members", membersObj) and membersObj.kind == JObject):
-    # Do not show members list in closed communities
-    let joined = result.isMember or result.tokenPermissions.len == 0
     for memberId, memberObj in membersObj:
-      result.members.add(toChannelMember(memberObj, memberId, joined))
+      result.members.add(toChannelMember(memberObj, memberId))
 
   var tagsObj: JsonNode
   if(jsonObj.getProp("tags", tagsObj)):


### PR DESCRIPTION
Fixes #14994

If you are part of the community member list, it means you are joined. It made no sense to add conditions to it.

The original bug was caused by my own code. I removed `result.joined = joined` in my refactor. TBH, I don't remmeber why I did it.

However, just re-adding that line felt wrong. That old code made no sense. First of all the line in `dto/community.nim` 
```nim
let joined = result.isMember or result.tokenPermissions.len == 0
```
made no sense, because `isMember` is for ourselves. So if we were part of the community, everyone else was also joined. Which in the end still worked, because indeed we want everyone to have `joined: true` from the member list, but it used a bad way to do it.

![image](https://github.com/status-im/status-desktop/assets/11926403/af01af09-bd92-4207-83c6-1af6e553cbe0)
