### PR TITLE
fix(wallet): Fetch preferences only when changed

### DIFF
--- a/ui/StatusQ/src/wallet/managetokenscontroller.h
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.h
@@ -108,6 +108,7 @@ private:
     QAbstractItemModel* sourceModel() const { return m_sourceModel; }
     void setSourceModel(QAbstractItemModel* newSourceModel);
     void parseSourceModel();
+    void rebuildModels();
 
     void addItem(int index);
 


### PR DESCRIPTION
Fixes #14515 

### What does the PR do

Decrease number of fetches of preferences. Further improvements can be made to only update specific rows, but at this moment to not introduce breaking changes it will be postponed.
Preferences only change when they are changed in settings so fetching them on every change is unnecessary.

### Affected areas

Wallet asset and collectible lists.

### Video

https://github.com/status-im/status-desktop/assets/11396062/a94619b3-59d4-4a7c-af75-c7dcf600932b



