### PR TITLE
fix: crash during closing the app if gif was sent/received

### DIFF
--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -111,6 +111,8 @@ Item {
                 root.clicked(imageMessage, mouse)
             }
         }
+
+        Component.onDestruction: imageMessage.source = ""
     }
 
     Loader {


### PR DESCRIPTION
### What does the PR do

Unload the gif source during the component destruction to avoid crashes on the application close

Closes # https://github.com/status-im/status-desktop/issues/13588

### Affected areas

Gifs
