### PR TITLE
fix(HistoryNodes): Fix mailserver management UI controllers

### DIFF
--- a/src/app/core/signals/remote_signals/mailserver.nim
+++ b/src/app/core/signals/remote_signals/mailserver.nim
@@ -33,6 +33,7 @@ type MailserverAvailableSignal* = ref object of Signal
 
 type MailserverChangedSignal* = ref object of Signal
   address*: string
+  id*: string
 
 type MailserverNotWorkingSignal* = ref object of Signal
 
@@ -84,6 +85,7 @@ proc fromEvent*(T: type MailserverChangedSignal, jsonSignal: JsonNode): Mailserv
   result = MailserverChangedSignal()
   result.signalType = SignalType.MailserverChanged
   result.address = jsonSignal["event"]{"address"}.getStr()
+  result.id = jsonSignal["event"]{"id"}.getStr()
 
 proc fromEvent*(T: type MailserverNotWorkingSignal, jsonSignal: JsonNode): MailserverNotWorkingSignal =
   result = MailserverNotWorkingSignal()

--- a/src/app/modules/main/profile_section/sync/controller.nim
+++ b/src/app/modules/main/profile_section/sync/controller.nim
@@ -34,19 +34,24 @@ proc delete*(self: Controller) =
 
 proc init*(self: Controller) =
   self.events.on(SIGNAL_ACTIVE_MAILSERVER_CHANGED) do(e: Args):
-    var args = ActiveMailserverChangedArgs(e)
-    self.delegate.onActiveMailserverChanged(args.nodeAddress)
+    self.delegate.onActiveMailserverChanged()
+
+  self.events.on(SIGNAL_PINNED_MAILSERVER_CHANGED) do(e: Args):
+    self.delegate.onPinnedMailserverChanged()
 
 proc getAllMailservers*(self: Controller): seq[tuple[name: string, nodeAddress: string]] =
   return self.mailserversService.getAllMailservers()
 
-proc getPinnedMailserver*(self: Controller): string =
+proc getPinnedMailserverId*(self: Controller): string =
   let fleet = self.nodeConfigurationService.getFleet()
-  self.settingsService.getPinnedMailserver(fleet)
+  self.settingsService.getPinnedMailserverId(fleet)
 
-proc pinMailserver*(self: Controller, mailserverID: string) =
+proc setPinnedMailserverId*(self: Controller, mailserverID: string) =
   let fleet = self.nodeConfigurationService.getFleet()
-  discard self.settingsService.pinMailserver(mailserverID, fleet)
+  discard self.settingsService.setPinnedMailserverId(mailserverID, fleet)
+
+proc getActiveMailserverId*(self: Controller): string =
+  return self.mailserversService.getActiveMailserverId()
 
 proc saveNewMailserver*(self: Controller, name: string, nodeAddress: string) =
   discard self.mailserversService.saveMailserver(name, nodeAddress)
@@ -58,4 +63,4 @@ proc getUseMailservers*(self: Controller): bool =
   return self.settingsService.getUseMailservers()
 
 proc setUseMailservers*(self: Controller, value: bool): bool =
-  return self.settingsService.saveUseMailservers(value)
+  return self.settingsService.toggleUseMailservers(value)

--- a/src/app/modules/main/profile_section/sync/io_interface.nim
+++ b/src/app/modules/main/profile_section/sync/io_interface.nim
@@ -15,7 +15,10 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onActiveMailserverChanged*(self: AccessInterface, nodeAddress: string) {.base.} =
+method onActiveMailserverChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onPinnedMailserverChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method viewDidLoad*(self: AccessInterface) {.base.} =
@@ -24,10 +27,13 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method isAutomaticSelection*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getMailserverNameForNodeAddress*(self: AccessInterface, nodeAddress: string): string {.base.} =
+method getActiveMailserverId*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setActiveMailserver*(self: AccessInterface, mailserverID: string) {.base.} =
+method getPinnedMailserverId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setPinnedMailserverId*(self: AccessInterface, mailserverID: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method saveNewMailserver*(self: AccessInterface, name: string, nodeAddress: string) {.base.} =

--- a/src/app/modules/main/profile_section/sync/module.nim
+++ b/src/app/modules/main/profile_section/sync/module.nim
@@ -63,19 +63,23 @@ method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
 method isAutomaticSelection*(self: Module): bool =
-  return self.controller.getPinnedMailserver().len == 0
+  return self.controller.getPinnedMailserverId().len == 0
 
-method onActiveMailserverChanged*(self: Module, nodeAddress: string) =
-  self.view.onActiveMailserverSet(nodeAddress)
+method onActiveMailserverChanged*(self: Module) =
+  self.view.onActiveMailserverSet()
 
-method getMailserverNameForNodeAddress*(self: Module, nodeAddress: string): string =
-  let name = self.view.model().getNameForNodeAddress(nodeAddress)
-  if(name.len > 0):
-    return name
-  return "---"
+method onPinnedMailserverChanged*(self: Module) =
+  self.view.onPinnedMailserverSet()
 
-method setActiveMailserver*(self: Module, mailserverID: string) =
-  self.controller.pinMailserver(mailserverID)
+method setPinnedMailserverId*(self: Module, mailserverID: string) =
+  self.controller.setPinnedMailserverId(mailserverID)
+
+method getPinnedMailserverId*(self: Module): string =
+  return self.controller.getPinnedMailserverId()
+
+method getActiveMailserverId*(self: Module): string =
+  let res = self.controller.getActiveMailserverId()
+  return res
 
 method saveNewMailserver*(self: Module, name: string, nodeAddress: string) =
   self.controller.saveNewMailserver(name, nodeAddress)
@@ -90,5 +94,5 @@ method getUseMailservers*(self: Module): bool =
   return self.controller.getUseMailservers()
 
 method setUseMailservers*(self: Module, value: bool) =
-  if (self.controller.setUseMailservers(value)):
+  if self.controller.setUseMailservers(value):
     self.view.useMailserversChanged()

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -255,6 +255,6 @@ proc pinnedMailserverToJsonNode*(mailserver: PinnedMailserver): JsonNode =
     "waku.test": mailserver.wakuTest,
     "status.test": mailserver.statusTest,
     "status.prod": mailserver.statusProd,
-    "shard.test": mailserver.shardsTest,
+    "shards.test": mailserver.shardsTest,
     "sharding.staging": mailserver.shardsStaging,
   }

--- a/src/backend/mailservers.nim
+++ b/src/backend/mailservers.nim
@@ -20,6 +20,12 @@ proc saveMailserver*(id: string, name: string, enode: string, fleet: string):
 proc getMailservers*(): RpcResponse[JsonNode] =
   result = core.callPrivateRPC("mailservers_getMailservers")
 
+proc setPinnedMailservers*(mailservers: JsonNode): RpcResponse[JsonNode] =
+  result = core.callPrivateRPC("setPinnedMailservers".prefix, %*[ mailservers ])
+
+proc toggleUseMailservers*(value: bool): RpcResponse[JsonNode] =
+  result = core.callPrivateRPC("toggleUseMailservers".prefix, %*[ value ])
+
 proc syncChatFromSyncedFrom*(chatId: string): RpcResponse[JsonNode] =
   let payload = %*[chatId]
   result = core.callPrivateRPC("syncChatFromSyncedFrom".prefix, payload)

--- a/ui/app/AppLayouts/Profile/popups/WakuStoreModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/WakuStoreModal.qml
@@ -100,10 +100,10 @@ StatusModal {
                             StatusRadioButton {
                                 id: nodeRadioBtn
                                 ButtonGroup.group: nodesButtonGroup
-                                checked: model.nodeAddress === root.messagingStore.activeMailserver
+                                checked: model.name === root.messagingStore.pinnedMailserverId
                                 onCheckedChanged: {
                                      if (checked) {
-                                        root.messagingStore.setActiveMailserver(model.name)
+                                         root.messagingStore.setPinnedMailserverId(model.name)
                                     }
                                 }
                             }

--- a/ui/app/AppLayouts/Profile/stores/MessagingStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/MessagingStore.qml
@@ -19,14 +19,12 @@ QtObject {
 
     // Module Properties
     property bool automaticMailserverSelection: syncModule.automaticSelection
-    property string activeMailserver: syncModule.activeMailserver
+    property string activeMailserverId: syncModule.activeMailserverId
+    property string pinnedMailserverId: syncModule.pinnedMailserverId
 
-    function getMailserverNameForNodeAddress(nodeAddress) {
-        return root.syncModule.getMailserverNameForNodeAddress(nodeAddress)
-    }
 
-    function setActiveMailserver(mailserverID) {
-        root.syncModule.setActiveMailserver(mailserverID)
+    function setPinnedMailserverId(mailserverID) {
+        root.syncModule.setPinnedMailserverId(mailserverID)
     }
 
     function saveNewMailserver(name, nodeAddress) {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -314,7 +314,7 @@ SettingsContentBase {
                 anchors.leftMargin: Style.current.padding
                 anchors.rightMargin: Style.current.padding
                 title: qsTr("History nodes")
-                label: root.messagingStore.getMailserverNameForNodeAddress(root.messagingStore.activeMailserver)
+                label: root.messagingStore.activeMailserverId || "---"
                 components: [
                     StatusIcon {
                         icon: "next"


### PR DESCRIPTION
Fixes #14982

### What does the PR do

1. Fix the distinction between pinned and active servers
2. Use id instead of address. Previously mailserver could store id or address. Change method names to be more explicit.
3. Fix typo in fleet name "shard.test"
4. Prefer go API methods to set/get mail servers that fire a "mailserver.changed" signal. Instead of SaveSettings API
    1. toggleUseMailservers
    2. setPinnedMailservers
5. The sync module doesn't store pinned/active mail servers to avoid inconsistencies. This is done in my settings/mail server services

### Affected areas

mailservers, settings

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/f7652680-25fd-4c11-a2e6-185d78fd6104

### Further improvements

#15030 
#15032
