### PR TITLE
Fixes and changes for tests stability

### DIFF
--- a/test/e2e/gui/components/emoji_popup.py
+++ b/test/e2e/gui/components/emoji_popup.py
@@ -18,7 +18,14 @@ class EmojiPopup(QObject):
         return self
 
     @allure.step('Select emoji')
-    def select(self, name: str):
+    def select(self, name: str, attempts: int = 2):
         self._search_text_edit.text = name
         self._emoji_item.real_name['objectName'] = 'statusEmoji_' + name
-        self._emoji_item.click()
+        try:
+            self._emoji_item.click()
+        except LookupError as err:
+            if attempts:
+                return self.select(name, attempts - 1)
+            else:
+                raise err
+        EmojiPopup().wait_until_hidden()

--- a/test/e2e/gui/components/wallet/wallet_account_popups.py
+++ b/test/e2e/gui/components/wallet/wallet_account_popups.py
@@ -1,5 +1,6 @@
 import random
 
+import configs.timeouts
 from constants.wallet import *
 from gui.screens.settings_wallet import *
 from gui.components.base_popup import BasePopup
@@ -78,7 +79,7 @@ class AccountPopup(BasePopup):
     @allure.step('Set emoji for account')
     def set_emoji(self, value: str):
         self._emoji_button.click()
-        EmojiPopup().select(value)
+        EmojiPopup().wait_until_appears(timeout_msec=10000).select(value)
         return self
 
     @allure.step('Get emoji id from account header')
@@ -159,8 +160,15 @@ class AccountPopup(BasePopup):
 
     @allure.step('Click confirmation (add account / save changes) button')
     def save_changes(self):
+        assert driver.waitFor(lambda: self.is_save_changes_button_enabled(),
+                              configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         self._add_save_account_confirmation_button.click()
         return self
+
+    @allure.step('Get enabled state of (add account / save changes) button')
+    def is_save_changes_button_enabled(self):
+        return driver.waitForObjectExists(self._add_save_account_confirmation_button.real_name,
+                                          configs.timeouts.UI_LOAD_TIMEOUT_MSEC).enabled
 
 
 class EditAccountFromSettingsPopup(BasePopup):

--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -7,7 +7,7 @@ mainWindow_communitiesPortalLayout_CommunitiesPortalLayout = {"container": statu
 mainWindow_Create_New_Community_StatusButton = {"checkable": False, "container": mainWindow_communitiesPortalLayout_CommunitiesPortalLayout, "objectName": "createCommunityButton", "type": "StatusButton", "visible": True}
 
 # Community View
-mainWindow_communityLoader_Loader = {"container": statusDesktop_mainWindow, "id": "communityLoader", "type": "Loader", "unnamed": 1, "visible": True}
+mainWindow_communityLoader_Loader = {"container": statusDesktop_mainWindow, "objectName": "StatusSectionLayout", "type": "ContentItem", "visible": True}
 # Left Panel
 mainWindow_communityColumnView_CommunityColumnView = {"container": mainWindow_communityLoader_Loader, "objectName": "communityColumnView", "type": "CommunityColumnView", "visible": True}
 mainWindow_communityHeaderButton_StatusChatInfoButton = {"checkable": False, "container": mainWindow_communityColumnView_CommunityColumnView, "objectName": "communityHeaderButton", "type": "StatusChatInfoButton", "visible": True}

--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -4,6 +4,7 @@ from allure_commons._allure import step
 
 import configs
 import constants
+import driver
 from gui.components.context_menu import ContextMenu
 from gui.main_window import MainWindow
 from . import marks
@@ -20,8 +21,10 @@ pytestmark = marks
     'new_channel_description, new_channel_emoji',
     [('Channel', 'Description', 'sunglasses', None, '#4360df', 'New-channel', 'New channel description', 'thumbsup')])
 # @pytest.mark.critical TODO: https://github.com/status-im/desktop-qa-automation/issues/658
-def test_create_edit_remove_community_channel(main_screen, channel_name, channel_description, channel_emoji, channel_emoji_image,
-                                channel_color, new_channel_name, new_channel_description, new_channel_emoji):
+def test_create_edit_remove_community_channel(main_screen, channel_name, channel_description, channel_emoji,
+                                              channel_emoji_image,
+                                              channel_color, new_channel_name, new_channel_description,
+                                              new_channel_emoji):
     with step('Enable creation of community option'):
         settings = main_screen.left_panel.open_settings()
         settings.left_panel.open_advanced_settings().enable_creation_of_communities()
@@ -58,7 +61,8 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
         assert channel.name == new_channel_name
 
     with step('Verify edited channel details are correct in community toolbar'):
-        assert community_screen.tool_bar.channel_name == new_channel_name
+        assert driver.waitFor(lambda: community_screen.tool_bar.channel_name == new_channel_name,
+                              configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         assert community_screen.tool_bar.channel_description == new_channel_description
         assert community_screen.tool_bar.channel_emoji == '👍 '
         assert community_screen.tool_bar.channel_color == channel_color

--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -92,16 +92,14 @@ def test_join_community_and_pin_unpin_message(multiple_instances):
                                   configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Join community button not hidden'
 
         with step(f'User {user_one.name}, see two members in community members list'):
-            assert driver.waitFor(lambda: user_two.name in community_screen.right_panel.members,
-                                  10000)
+            assert driver.waitFor(lambda: user_two.name in community_screen.right_panel.members, 10000)
             assert driver.waitFor(lambda: '2' in community_screen.left_panel.members)
             main_screen.hide()
 
         with step(f'User {user_two.name}, see two members in community members list'):
             aut_two.attach()
             main_screen.prepare()
-            assert driver.waitFor(lambda: user_one.name in community_screen.right_panel.members,
-                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            assert driver.waitFor(lambda: user_one.name in community_screen.right_panel.members, 10000)
             assert '2' in community_screen.left_panel.members
 
         with step(f'Go to edit community for {user_two.name} and check that pin message checkbox is not checked'):

--- a/test/e2e/tests/wallet_main_screen/wallet - assets tab/test_wallet_assets_sorting.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - assets tab/test_wallet_assets_sorting.py
@@ -148,6 +148,8 @@ def test_wallet_sort_assets(main_screen: MainWindow, address, name, dai, weenus,
     pytest.param('0xFf58d746A67C2E42bCC07d6B3F58406E8837E883', 'AssetsCollectibles', 'Dai Stablecoin', 'WEENUS Token',
                  'Status Test Token', 'Ether')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_custom_ordering(main_screen: MainWindow, address, name, dai, weenus, stt, eth):
     with step('Turn on Testnet mode'):
         networks = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_networks()

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
@@ -107,7 +107,7 @@ def test_plus_button_re_importing_seed_phrase(main_screen: MainWindow, user_acco
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_seed_phrase(
-            seed_phrase.split()).save()
+            seed_phrase.split()).save_changes()
         AuthenticatePopup().wait_until_appears().authenticate(user_account.password)
         account_popup.wait_until_hidden()
 


### PR DESCRIPTION
- Changes for wallet tests stabilisation - added waiting, attempts
- Skipped assets ordering tests (forgot to do this before - it fails because of known issue)
- Edited name of method save to save_changes in one test because of recent changes
- Increased timeout in pin unpin test
- Added waitFor channel name after editing

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2019/allure/