### PR TITLE
fix(@desktop/communities): Lazy loading token holders

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -178,3 +178,9 @@ proc declineOwnership*(self: Controller, communityId: string) =
 
 proc asyncGetOwnerTokenOwnerAddress*(self: Controller, chainId: int, contractAddress: string) =
   self.communityTokensService.asyncGetOwnerTokenOwnerAddress(chainId, contractAddress)
+
+proc startTokenHoldersManagement*(self: Controller, chainId: int, contractAddress: string) =
+  self.communityTokensService.startTokenHoldersManagement(chainId, contractAddress)
+
+proc stopTokenHoldersManagement*(self: Controller) =
+  self.communityTokensService.stopTokenHoldersManagement()

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -119,3 +119,9 @@ method onOwnerTokenOwnerAddress*(self: AccessInterface, chainId: int, contractAd
 
 method asyncGetOwnerTokenDetails*(self: AccessInterface, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method startTokenHoldersManagement*(self: AccessInterface, chainId: int, contractAddress: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method stopTokenHoldersManagement*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -385,3 +385,9 @@ method onOwnerTokenOwnerAddress*(self: Module, chainId: int, contractAddress: st
     "contractAddress": contractAddress
   }
   self.view.setOwnerTokenDetails($jsonObj)
+
+method startTokenHoldersManagement*(self: Module, chainId: int, contractAddress: string) =
+  self.controller.startTokenHoldersManagement(chainId, contractAddress)
+
+method stopTokenHoldersManagement*(self: Module) =
+  self.controller.stopTokenHoldersManagement()

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -145,3 +145,9 @@ QtObject:
   QtProperty[string] ownerTokenDetails:
     read = getOwnerTokenDetails
     notify = ownerTokenDetailsChanged
+
+  proc startTokenHoldersManagement*(self: View, chainId: int, contractAddress: string) {.slot.} =
+    self.communityTokensModule.startTokenHoldersManagement(chainId, contractAddress)
+
+  proc stopTokenHoldersManagement*(self: View) {.slot.} =
+    self.communityTokensModule.stopTokenHoldersManagement()

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -79,6 +79,9 @@ StackView {
     signal registerSelfDestructFeesSubscriber(var feeSubscriber)
     signal registerBurnTokenFeesSubscriber(var feeSubscriber)
 
+    signal startTokenHoldersManagement(int chainId, string address)
+    signal stopTokenHoldersManagement()
+
     function navigateBack() {
         pop(StackView.Immediate)
     }
@@ -540,6 +543,9 @@ StackView {
             membersModel: tokenViewPage.membersModel
             tokenOwnersModel: tokenViewPage.tokenOwnersModel
             isOwnerTokenItem: tokenViewPage.isOwnerTokenItem
+
+            onStartTokenHoldersManagement: root.startTokenHoldersManagement(chainId, address)
+            onStopTokenHoldersManagement: root.stopTokenHoldersManagement()
 
             onGeneralAirdropRequested: {
                 root.airdropToken(view.airdropKey,

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -368,6 +368,10 @@ StatusSectionLayout {
 
             onRegisterBurnTokenFeesSubscriber: d.feesBroker.registerBurnFeesSubscriber(feeSubscriber)
 
+            onStartTokenHoldersManagement: communityTokensStore.startTokenHoldersManagement(chainId, address)
+
+            onStopTokenHoldersManagement: communityTokensStore.stopTokenHoldersManagement()
+
             onMintCollectible:
                 communityTokensStore.deployCollectible(
                     root.community.id, collectibleItem)

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -78,6 +78,20 @@ StatusScrollView {
     signal kickRequested(string name, string contactId, string address)
     signal banRequested(string name, string contactId, string address)
 
+    signal startTokenHoldersManagement(int chainId, string address)
+    signal stopTokenHoldersManagement()
+
+    onVisibleChanged: {
+        if (visible) {
+            root.startTokenHoldersManagement(root.chainId, root.token.tokenAddress)
+        } else {
+            root.stopTokenHoldersManagement()
+        }
+    }
+
+    Component.onCompleted: root.startTokenHoldersManagement(root.chainId, root.token.tokenAddress)
+    Component.onDestruction: root.stopTokenHoldersManagement()
+
     QtObject {
         id: d
 

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -220,4 +220,12 @@ QtObject {
     function asyncGetOwnerTokenDetails(communityId) {
         communityTokensModuleInst.asyncGetOwnerTokenDetails(communityId)
     }
+
+    function startTokenHoldersManagement(chainId, contractAddress) {
+        communityTokensModuleInst.startTokenHoldersManagement(chainId, contractAddress)
+    }
+
+    function stopTokenHoldersManagement() {
+        communityTokensModuleInst.stopTokenHoldersManagement()
+    }
 }


### PR DESCRIPTION
Token holders are not fetched when application starts. 
Tokens holders are fetched only for a concrete token for which CommunityTokenView is opened.
The time of last fetch operation for every token is kept in cache. 

Possible cases:
1. Open token screen and there are no holders yet - fetch holders instantly and run timer to refresh in 5 minutes
2. Open token screen and holders were fetched <5minutes ago - run timer to fetch holders
3. Open token screen and holders were fetched >5minutes ago - do the same as 1.
4. Close token screen - stop timer and do nothing

Fix #14974
