### PR TITLE
fix(15015): cant save changes to the profile showcase

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
@@ -54,6 +54,7 @@ Item {
             minimumHeight: 108
             maximumHeight: 108
             input.verticalAlignment: TextEdit.AlignTop
+            validationMode: StatusInput.ValidationMode.Always
             validators: [
                 StatusValidator {
                     name: "maxLengthValidator"


### PR DESCRIPTION
Set bio's validationMode to StatusInput.ValidationMode.Always, as the default value (StatusInput.ValidationMode.OnlyWhenDirty) was preventing calculating up-to-date 'valid' state when the end-user does not change bio, but changes other data (e.g. Communities in Profile Showcase)

fixes #15015



https://github.com/status-im/status-desktop/assets/5157464/5570a49a-1540-4491-9a11-a8d95ef1d47c

