### PR TITLE
fix(@desktop/group chat): fix empty member list in group chat

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -130,7 +130,7 @@ proc getChatMembers*(self: Controller): seq[ChatMember] =
     let members = myCommunity.getCommunityChat(self.chatId).members
     if members.len > 0:
       return members
-    return self.chatService.getChatById(self.chatId).members
+  return self.chatService.getChatById(self.chatId).members
 
 proc getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, largeImage: string] =


### PR DESCRIPTION
### Description

fixes #14907 due to a regression from [pr](https://github.com/status-im/status-desktop/pull/14873)

### What does the PR do

The PR adds a fallback logic to retrieve the list of members from `self.chatService.getChatById(self.chatId).members`

### Affected areas

- Chat list

### Screenshot of functionality (including design for comparison)

