### PR TITLE
fix(SendModal): Unblock sending collectibles flow

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -58,7 +58,7 @@ StatusDialog {
 
     property var recalculateRoutesAndFees: Backpressure.debounce(popup, 600, function() {
         if(!!popup.preSelectedAccount && !!holdingSelector.selectedItem
-                && recipientLoader.ready && amountToSendInput.inputNumberValid) {
+                && recipientLoader.ready && (amountToSendInput.inputNumberValid || d.isCollectiblesTransfer)) {
             popup.isLoading = true
             popup.store.suggestedRoutes(d.isCollectiblesTransfer ? "1" : amountToSendInput.cryptoValueToSend)
         }
@@ -81,7 +81,8 @@ StatusDialog {
         readonly property double maxCryptoBalance: isSelectedHoldingValidAsset ? selectedHolding.currentBalance : 0
         readonly property double maxInputBalance: amountToSendInput.inputIsFiat ? maxFiatBalance : maxCryptoBalance
         readonly property string inputSymbol: amountToSendInput.inputIsFiat ? currencyStore.currentCurrency : !!d.selectedHolding && !!d.selectedHolding.symbol ? d.selectedHolding.symbol: ""
-        readonly property bool errorMode: popup.isLoading || !recipientLoader.ready ? false : errorType !== Constants.NoError || networkSelector.errorMode || !amountToSendInput.inputNumberValid
+        readonly property bool errorMode: popup.isLoading || !recipientLoader.ready ? false : errorType !== Constants.NoError || networkSelector.errorMode
+                                                                                      || !(amountToSendInput.inputNumberValid || d.isCollectiblesTransfer)
         readonly property string uuid: Utils.uuid()
         property bool isPendingTx: false
         property string totalTimeEstimate
@@ -451,7 +452,7 @@ StatusDialog {
 
             contentWidth: availableWidth
 
-            visible: recipientLoader.ready && !!d.selectedHolding && amountToSendInput.inputNumberValid
+            visible: recipientLoader.ready && !!d.selectedHolding && (amountToSendInput.inputNumberValid || d.isCollectiblesTransfer)
 
             objectName: "sendModalScroll"
 
@@ -489,7 +490,7 @@ StatusDialog {
         maxFiatFees: popup.isLoading ? "..." : d.currencyStore.formatCurrencyAmount(d.totalFeesInFiat, d.currencyStore.currentCurrency)
         totalTimeEstimate: popup.isLoading? "..." : d.totalTimeEstimate
         pending: d.isPendingTx || popup.isLoading
-        visible: recipientLoader.ready && amountToSendInput.inputNumberValid && !d.errorMode
+        visible: recipientLoader.ready && (amountToSendInput.inputNumberValid || d.isCollectiblesTransfer) && !d.errorMode
         onNextButtonClicked: popup.sendTransaction()
     }
 


### PR DESCRIPTION
### What does the PR do

This PR unblocks send modal flow related to collectibles. Because of invalid state of hidden amount input the flow was broken (routes/fees part was never visible).

Closes: #15039

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`SendModal`

### Screenshot of functionality (including design for comparison)

[Screencast from 05.06.2024 14:47:47.webm](https://github.com/status-im/status-desktop/assets/20650004/3c4379c5-5c67-48be-8d6f-ffe56d1ad70d)

