### PR TITLE
fix(ci): prefix PATH with correct Go compiler path

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -67,7 +67,8 @@ pipeline {
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* WARNING: Qt 5.15.8 installed via Brew. */
     QTDIR = '/opt/homebrew/opt/qt@5'
-    PATH = "${env.QTDIR}/bin:${env.PATH}"
+    /* Enforce Go version installed infra-role-golang. */
+    PATH = "${env.QTDIR}/bin:/usr/local/go/bin:${env.PATH}"
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */


### PR DESCRIPTION
Otherwise we end up with weird errors like:
```
status-go/go.mod:5: unknown directive: toolchain
```