### PR TITLE
fix(wallet): properly marshall multiTxCommand type

### DIFF
--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -54,6 +54,15 @@ proc `$`*(self: MultiTransactionDto): string =
     multiTxType:{self.multiTxType}
   )"""
 
+proc `%`*(self: MultiTransactionCommandDto): JsonNode {.inline.} =
+  result = newJObject()
+  result["fromAddress"] = %(self.fromAddress)
+  result["toAddress"] = %(self.toAddress)
+  result["fromAsset"] = %(self.fromAsset)
+  result["toAsset"] = %(self.toAsset)
+  result["fromAmount"] = %(self.fromAmount)
+  result["type"] = %int(self.multiTxType)
+
 proc getTransactionByHash*(chainId: int, hash: string): RpcResponse[JsonNode] =
   core.callPrivateRPCWithChainId("eth_getTransactionByHash", chainId, %* [hash])
 


### PR DESCRIPTION
Part of #15098

### What does the PR do

Implement custom marshaller for `MultiTransactionCommandDto`, properly handling the `MultiTransactionType` field so it gets serialized as a number instead of the enum label.
```
  MultiTransactionCommandDto* = ref object of RootObj
    fromAddress* {.serializedFieldName("fromAddress").}: string
    toAddress* {.serializedFieldName("toAddress").}: string
    fromAsset* {.serializedFieldName("fromAsset").}: string
    toAsset* {.serializedFieldName("toAsset").}: string
    fromAmount* {.serializedFieldName("fromAmount").}: string
    multiTxType* {.serializedFieldName("type").}: MultiTransactionType
```