### PR TITLE
chore: use sigkill to kill the process

### DIFF
--- a/test/e2e/scripts/utils/local_system.py
+++ b/test/e2e/scripts/utils/local_system.py
@@ -43,7 +43,7 @@ def kill_process(pid, sig: signal.Signals = signal.SIGKILL):
 
 
 @allure.step('Kill process with retries')
-def kill_process_with_retries(pid, sig: signal.Signals = signal.SIGTERM, attempts: int = 3):
+def kill_process_with_retries(pid, sig: signal.Signals = signal.SIGKILL, attempts: int = 3):
     LOG.debug('Killing process: %d', pid)
     try:
         p = psutil.Process(pid)
@@ -51,7 +51,7 @@ def kill_process_with_retries(pid, sig: signal.Signals = signal.SIGTERM, attempt
         LOG.warning('Process %d already gone.', pid)
         return
 
-    p.terminate()
+    p.send_signal(sig)
 
     while attempts > 0:
         attempts -= 1


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-desktop/issues/15131

I realised it is not enough to comment the steps in 1 test. The problem was also at the place when we stop the test, so i just changed the signal type we use

I ran this in the pr where tests are stuck and it passes now https://ci.status.im/job/status-desktop/job/e2e/job/manual/2054/console

NOTE: the code is a point to simplify, i will review it later, we need to unblock PRs now

### Affected areas

tests
