### PR TITLE
Use one kill_process method in autotests instead of multiple

### DIFF
--- a/test/e2e/constants/wallet.py
+++ b/test/e2e/constants/wallet.py
@@ -79,5 +79,5 @@ class WalletSeedPhrase(Enum):
 
 class WalletAccountPopup(Enum):
     WALLET_ACCOUNT_NAME_MIN = 'Account name must be at least 5 characters'
-    WALLET_KEYPAIR_NAME_MIN = 'Key pair name must be at least 5 characters'
-    WALLET_KEYPAIR_MIN = 'Key pair must be at least 5 characters'
+    WALLET_KEYPAIR_NAME_MIN = 'Key pair name must be at least 5 character(s)'
+    WALLET_KEYPAIR_MIN = 'Key pair must be at least 5 character(s)'

--- a/test/e2e/driver/aut.py
+++ b/test/e2e/driver/aut.py
@@ -73,13 +73,6 @@ class AUT:
         squish.currentApplicationContext().detach()
         self.ctx = None
 
-    def kill_process(self):
-        if self.pid is None:
-            LOG.warning('No PID available for AUT.')
-            return
-        local_system.kill_process_with_retries(self.pid)
-        self.pid = None
-
     @allure.step('Attach Squish to Test Application')
     def attach(self, timeout_sec: int = configs.timeouts.PROCESS_TIMEOUT_SEC):
         LOG.info('Attaching to AUT: localhost:%d', self.port)
@@ -123,7 +116,7 @@ class AUT:
     def stop(self):
         LOG.info('Stopping AUT: %s', self.path)
         self.detach_context()
-        self.kill_process()
+        local_system.kill_process(self.pid)
 
     @allure.step("Start and attach AUT")
     def launch(self) -> 'AUT':

--- a/test/e2e/driver/server.py
+++ b/test/e2e/driver/server.py
@@ -42,7 +42,7 @@ class SquishServer:
         if cls.pid is None:
             return
         LOG.info('Stopping Squish Server with PID: %d', cls.pid)
-        local_system.kill_process_with_retries(cls.pid)
+        local_system.kill_process(cls.pid)
         cls.pid = None
         cls.port = None
 

--- a/test/e2e/tests/onboarding/test_onboarding_generate_new_keys.py
+++ b/test/e2e/tests/onboarding/test_onboarding_generate_new_keys.py
@@ -133,6 +133,3 @@ def test_generate_new_keys_sign_out_from_settings(aut, main_window, keys_screen,
     with step('Click sign out and quit in settings'):
         sign_out_screen = settings.left_panel.open_sign_out_and_quit()
         sign_out_screen.sign_out_and_quit()
-
-    with step('Check the application process is not running'):
-        psutil.Process(aut.pid).wait(timeout=30)

--- a/test/e2e/tests/onboarding/test_onboarding_import_seed.py
+++ b/test/e2e/tests/onboarding/test_onboarding_import_seed.py
@@ -69,14 +69,12 @@ def test_import_seed_phrase(keys_screen, main_window, aut: AUT, user_account, de
         profile_popup = user_canvas.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
 
-    # TODO: https://github.com/status-im/status-desktop/issues/15124
-    # TODO: https://github.com/status-im/status-desktop/issues/15131
-    # with step('Restart application and try re-importing seed phrase again'):
-    #    aut.restart()
-    #    enter_seed_view = LoginView().add_existing_status_user().open_keys_view().open_enter_seed_phrase_view()
-    #    enter_seed_view.input_seed_phrase(user_account.seed_phrase, autocomplete)
-    #    confirm_import = enter_seed_view.click_import_seed_phrase_button()
+    with step('Restart application and try re-importing seed phrase again'):
+        aut.restart()
+        enter_seed_view = LoginView().add_existing_status_user().open_keys_view().open_enter_seed_phrase_view()
+        enter_seed_view.input_seed_phrase(user_account.seed_phrase, autocomplete)
+        confirm_import = enter_seed_view.click_import_seed_phrase_button()
 
-    #with step('Verify that keys already exist popup appears and text is correct'):
-    #    assert confirm_import.get_key_exist_title() == KeysExistText.KEYS_EXIST_TITLE.value
-    #    assert KeysExistText.KEYS_EXIST_TEXT.value in confirm_import.get_text_labels()
+    with step('Verify that keys already exist popup appears and text is correct'):
+        assert confirm_import.get_key_exist_title() == KeysExistText.KEYS_EXIST_TITLE.value
+        assert KeysExistText.KEYS_EXIST_TEXT.value in confirm_import.get_text_labels()

--- a/test/e2e/tests/settings/settings_password/test_settings_password_change_password.py
+++ b/test/e2e/tests/settings/settings_password/test_settings_password_change_password.py
@@ -35,9 +35,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
     with step('Click re-encrypt data button and then restart'):
         ChangePasswordPopup().click_re_encrypt_data_restart_button()
 
-    with step('Verify the application process is not running'):
-        psutil.Process(aut.pid).wait(timeout=30)
-
     with step('Restart application'):
         aut.restart()
 


### PR DESCRIPTION
### What does the PR do

- removed unnecessary steps to check the process is closed from tests as it was never working, because even i log out from the app by a button (the very last step of the test), i am killing the app process as next thing immediately by a fixture
https://github.com/status-im/status-desktop/blob/75d755ea0f54c6ac514e0063fcb4627bc37854c7/test/e2e/fixtures/aut.py#L63
- brought back the steps i commented earlier (with app restart). It should work normally now
- decided to go with 1 method of `kill process` instead of multiple ones

Full tests run is here https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/386/console,  same as nightly of the other day

### Affected areas

Autotests