### PR TITLE
perf: use community members for unpermissioned channels

### DIFF
--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -415,11 +415,6 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
   discard jsonObj.getProp("encrypted", result.encrypted)
   discard jsonObj.getProp("isMember", result.isMember)
 
-  var chatsObj: JsonNode
-  if(jsonObj.getProp("chats", chatsObj)):
-    for _, chatObj in chatsObj:
-      result.chats.add(chatObj.toChatDto(result.id))
-
   var categoriesObj: JsonNode
   if(jsonObj.getProp("categories", categoriesObj)):
     for _, categoryObj in categoriesObj:
@@ -447,6 +442,11 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
   if(jsonObj.getProp("members", membersObj) and membersObj.kind == JObject):
     for memberId, memberObj in membersObj:
       result.members.add(toChannelMember(memberObj, memberId))
+
+  var chatsObj: JsonNode
+  if(jsonObj.getProp("chats", chatsObj)):
+    for _, chatObj in chatsObj:
+      result.chats.add(chatObj.toChatDto(result.id, result.members))
 
   var tagsObj: JsonNode
   if(jsonObj.getProp("tags", tagsObj)):
@@ -609,6 +609,14 @@ proc getCommunityChat*(self: CommunityDto, chatId: string): ChatDto =
   let chats = self.getCommunityChats(@[chatId])
   if chats.len > 0:
     return chats[0]
+
+proc getCommunityChatIndex*(self: CommunityDto, chatId: string): int =
+  var idx = 0
+  for communityChat in self.chats:
+    if chatId == communityChat.id:
+      return idx
+    idx.inc()
+  return -1
 
 proc hasCommunityChat*(self: CommunityDto, chatId: string): bool =
   for communityChat in self.chats:

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1306,7 +1306,8 @@ QtObject:
       let maxPosition = if chatsForCategory.len > 0: chatsForCategory[^1].position else: -1
 
       for chatObj in chatsJArr:
-        var chatDto = chatObj.toChatDto(communityId)
+        let community = self.communities[communityId]
+        var chatDto = chatObj.toChatDto(communityId, community.members)
         chatDto.position = maxPosition + 1
         self.chatService.updateOrAddChat(chatDto)
         self.communities[communityId].chats.add(chatDto)
@@ -1355,8 +1356,11 @@ QtObject:
         raise newException(RpcException, fmt"editCommunityChannel; there is no `chats` key in the response for community id: {communityId}")
 
       for chatObj in chatsJArr:
-        var chatDto = chatObj.toChatDto(communityId)
-
+        let community = self.communities[communityId]
+        var chatDto = chatObj.toChatDto(communityId, community.members)
+        let chatIndex = community.getCommunityChatIndex(chatDto.id)
+        if chatIndex > -1:
+          self.communities[communityId].chats[chatIndex] = chatDto
         self.chatService.updateOrAddChat(chatDto) # we have to update chats stored in the chat service.
 
         let data = CommunityChatArgs(chat: chatDto)


### PR DESCRIPTION
Fixes #15149

In [this status go PR](https://github.com/status-im/status-go/pull/5335), we are removing the members from channels that are not-permissioned to increase performance (we don't need to pass such a big JSON).

It doesn't change anything in the UI

[members.webm](https://github.com/status-im/status-desktop/assets/11926403/317ca55a-1596-433b-b604-7da586b68788)
