### PR TITLE
feat(@desktop/wallet): Add Select Input and  output params to swap modal

### DIFF
--- a/storybook/pages/SwapInputPanelPage.qml
+++ b/storybook/pages/SwapInputPanelPage.qml
@@ -35,6 +35,7 @@ SplitView {
             fromTokenAmount: ctrlFromTokenAmount.text
             toTokenKey: ctrlToTokenKey.text
             toTokenAmount: ctrlToTokenAmount.text
+            selectedAccountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         }
 
         readonly property SwapModalAdaptor adaptor: SwapModalAdaptor {

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtTest 1.15
 
 import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
 
 import AppLayouts.Wallet.stores 1.0
 import AppLayouts.Wallet.panels 1.0
@@ -37,7 +38,9 @@ Item {
                 assetsWithFilteredBalances: thisWalletAssetStore.groupedAccountsAssetsModel
             }
             currencyStore: CurrenciesStore {}
-            swapFormData: SwapInputParamsForm {}
+            swapFormData: SwapInputParamsForm {
+                selectedAccountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            }
             swapOutputData: SwapOutputData {}
         }
     }
@@ -135,7 +138,7 @@ Item {
 
             const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
             verify(!!amountToSendInput)
-            tryCompare(amountToSendInput.input, "text", Number(tokenAmount).toLocaleString(Qt.locale(), 'f', -128))
+            tryCompare(amountToSendInput.input, "text", AmountsArithmetic.fromString(tokenAmount).toLocaleString(Qt.locale(), 'f', -128))
         }
 
         function test_enterTokenAmountLocalizedNumber() {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -136,7 +136,7 @@ Item {
         }
 
         property SwapInputParamsForm swapFormData: SwapInputParamsForm {
-            selectedAccountIndex: d.selectedAccountIndex
+            selectedAccountAddress: StatusQUtils.ModelUtils.get(RootStore.nonWatchAccounts, d.selectedAccountIndex, "address")
             selectedNetworkChainId: {
                 // Without this when we switch testnet mode, the correct network is not evaluated
                 RootStore.areTestNetworksEnabled
@@ -216,7 +216,7 @@ Item {
                                                                   hasFloatingButtons: true
                                                               })
             onLaunchSwapModal: {
-                d.swapFormData.selectedAccountIndex = d.selectedAccountIndex
+                d.swapFormData.selectedAccountAddress = StatusQUtils.ModelUtils.get(RootStore.nonWatchAccounts, d.selectedAccountIndex, "address")
                 d.swapFormData.selectedNetworkChainId = StatusQUtils.ModelUtils.getByKey(RootStore.filteredFlatModel, "layer", 1, "chainId")
                 d.swapFormData.fromTokensKey = tokensKey
                 d.swapFormData.toTokenKey = RootStore.areTestNetworksEnabled ? Constants.swap.testStatusTokenKey : Constants.swap.mainnetStatusTokenKey
@@ -335,7 +335,7 @@ Item {
             }
             onLaunchSwapModal: {
                 d.swapFormData.fromTokensKey =  ""
-                d.swapFormData.selectedAccountIndex = d.selectedAccountIndex
+                d.swapFormData.selectedAccountAddress = StatusQUtils.ModelUtils.get(RootStore.nonWatchAccounts, d.selectedAccountIndex, "address")
                 d.swapFormData.selectedNetworkChainId = StatusQUtils.ModelUtils.getByKey(RootStore.filteredFlatModel, "layer", 1, "chainId")
                 if(!!walletStore.currentViewedHoldingTokensKey && walletStore.currentViewedHoldingType === Constants.TokenType.ERC20) {
                     d.swapFormData.fromTokensKey =  walletStore.currentViewedHoldingTokensKey

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -67,7 +67,7 @@ QtObject {
       rationale: https://github.com/status-im/status-desktop/pull/14959#discussion_r1627110880
       */
     function calculateMaxSafeSendAmount(value, symbol) {
-        if (symbol !== Constants.ethToken) {
+        if (symbol !== Constants.ethToken || value === 0) {
             return value
         }
 

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -29,25 +29,31 @@ Control {
     required property var processedAssetsModel
 
     property string tokenKey
-    onTokenKeyChanged: {
-        if (!!tokenKey)
-            Qt.callLater(d.setSelectedHoldingId, tokenKey, Constants.TokenType.ERC20)
-    }
+    onTokenKeyChanged: reevaluateSelectedId()
     property string tokenAmount
     onTokenAmountChanged: {
         if (!!tokenAmount)
-            Qt.callLater(() => amountToSendInput.input.text = Number(tokenAmount).toLocaleString(Qt.locale(), 'f', -128))
+            Qt.callLater(() => amountToSendInput.input.text = SQUtils.AmountsArithmetic.fromString(tokenAmount).toLocaleString(locale, 'f', -128))
     }
 
     property int swapSide: SwapInputPanel.SwapSide.Pay
     property bool fiatInputInteractive
     property bool loading
+    property bool interactive: true
 
     // output API
     readonly property string selectedHoldingId: d.selectedHoldingId
     readonly property double cryptoValue: amountToSendInput.cryptoValueToSendFloat
     readonly property string cryptoValueRaw: amountToSendInput.cryptoValueToSend
     readonly property bool cryptoValueValid: amountToSendInput.inputNumberValid
+    /* TODO: this does not work as expected because of bug -
+       https://github.com/status-im/status-desktop/issues/15162 */
+    readonly property bool amountEnteredGreaterThanBalance: cryptoValue > maxSendButton.maxSafeValue
+    function reevaluateSelectedId() {
+        if (!!tokenKey) {
+            Qt.callLater(d.setSelectedHoldingId, tokenKey, Constants.TokenType.ERC20)
+        }
+    }
 
     // visual properties
     property int swapExchangeButtonWidth: 44
@@ -185,7 +191,7 @@ Control {
                 id: amountToSendInput
                 objectName: "amountToSendInput"
                 caption: root.caption
-                interactive: true
+                interactive: root.interactive
                 selectedHolding: d.selectedHolding
                 fiatInputInteractive: root.fiatInputInteractive
                 input.input.edit.color: !input.valid ? Theme.palette.dangerColor1 : maxSendButton.hovered ? Theme.palette.baseColor1

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapInputParamsForm.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapInputParamsForm.qml
@@ -9,15 +9,15 @@ QtObject {
 
     signal formValuesChanged()
 
-    property int selectedAccountIndex: 0
+    property string selectedAccountAddress: ""
     property int selectedNetworkChainId: -1
     property string fromTokensKey: ""
-    property string fromTokenAmount: "0"
+    property string fromTokenAmount: ""
     property string toTokenKey: ""
-    property string toTokenAmount: "0"
+    property string toTokenAmount: ""
     property double selectedSlippage: 0.5
 
-    onSelectedAccountIndexChanged: root.formValuesChanged()
+    onSelectedAccountAddressChanged: root.formValuesChanged()
     onSelectedNetworkChainIdChanged: root.formValuesChanged()
     onFromTokensKeyChanged: root.formValuesChanged()
     onFromTokenAmountChanged: root.formValuesChanged()
@@ -25,17 +25,17 @@ QtObject {
     onToTokenAmountChanged: root.formValuesChanged()
 
     function resetFormData() {
-        selectedAccountIndex = 0
+        selectedAccountAddress = ""
         selectedNetworkChainId = -1
         fromTokensKey = ""
-        fromTokenAmount = "0"
+        fromTokenAmount = ""
         toTokenKey = ""
-        toTokenAmount = "0"
+        toTokenAmount = ""
         selectedSlippage = 0.5
     }
 
     function isFormFilledCorrectly() {
-        return root.selectedAccountIndex >= 0 &&
+        return !!root.selectedAccountAddress &&
                 root.selectedNetworkChainId !== -1 &&
                 !!root.fromTokensKey && !!root.toTokenKey &&
                 ((!!root.fromTokenAmount &&

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapOutputData.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapOutputData.qml
@@ -5,8 +5,8 @@ to the swap request can be placed here at one place. */
 QtObject {
     id: root
 
-    property string fromTokenAmount: "0"
-    property string toTokenAmount: "0"
+    property string fromTokenAmount: ""
+    property string toTokenAmount: ""
     property real totalFees: 0
     property var bestRoutes: []
     property bool approvalNeeded
@@ -14,8 +14,8 @@ QtObject {
     property var rawPaths: []
 
     function reset() {
-        root.fromTokenAmount = "0"
-        root.toTokenAmount = "0"
+        root.fromTokenAmount = ""
+        root.toTokenAmount = ""
         root.totalFees = 0
         root.bestRoutes = []
         root.approvalNeeded = false

--- a/ui/imports/shared/popups/send/panels/HoldingItemSelector.qml
+++ b/ui/imports/shared/popups/send/panels/HoldingItemSelector.qml
@@ -91,6 +91,7 @@ Item {
         contentItem: RowLayout {
             StatusRoundedImage {
                 id: tokenIcon
+                objectName: "holdingSelectorsTokenIcon"
                 Layout.preferredWidth: root.contentIconSize
                 Layout.preferredHeight: root.contentIconSize
                 visible: !!d.iconSource
@@ -102,6 +103,7 @@ Item {
                 }
             }
             StatusBaseText {
+                objectName: "holdingSelectorsContentItemText"
                 Layout.fillWidth: true
                 font.pixelSize: root.contentTextSize
                 elide: Text.ElideRight

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -95,8 +95,11 @@ ColumnLayout {
                         d.cryptoValueToSend, root.multiplierIndex).toString()
         }
 
-        readonly property string zeroString:
-            LocaleUtils.numberToLocaleString(0, 2, topAmountToSendInput.locale)
+        // Crypto value should be represented by 0 and fiat with 0.00
+        readonly property string zeroString: {
+            let decimals = root.inputIsFiat ? 2 : 0
+            LocaleUtils.numberToLocaleString(0, decimals, topAmountToSendInput.locale)
+        }
 
         readonly property double parsedInput:
             LocaleUtils.numberFromLocaleString(topAmountToSendInput.text,


### PR DESCRIPTION
fixes #14826, #14825

### What does the PR do

This PR uses the SwapInputPanel and connects it to the backend. it tried to cover all the flows of Swap M1 designs related to input and output fields that can be supported and added TODO is places there are bugs such as the ones listed here https://github.com/status-im/status-desktop/issues/15162

Have written UTS for all possible scenarios but may need more as we find more corner cases. some tests are comented because of the issue mentioned above. 

US's covered
https://www.notion.so/Select-input-parameters-56c5f81573d145f6b079678cdaaa362c?pvs=4 and 
https://www.notion.so/Select-output-parameters-ce74bb4ee5fe43f9923476a26e8ff130?pvs=4

### Affected areas

SwapModal, SwapInputPanel

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/217f1a27-5b10-4077-be7d-9b2209c9030d

https://github.com/status-im/status-desktop/assets/60327365/dbc95326-e842-4491-808a-f8969fa111e3


