### PR TITLE
feat: Enable WS and HTTP RPC servers for status desktop through config

### DIFF
--- a/src/app_service/common/net_utils.nim
+++ b/src/app_service/common/net_utils.nim
@@ -1,0 +1,13 @@
+import net
+
+# Util function to test if a port is busy
+proc isPortBusy*(port: Port): bool =
+  var sock: Socket
+  try:
+    sock = newSocket()
+    sock.setSockOpt(OptReuseAddr, true)
+    sock.bindAddr(port)
+    sock.close()
+    return false
+  except OSError:
+    return true

--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -271,3 +271,14 @@ var NODE_CONFIG* = %* {
   },
   "OutputMessageCSVEnabled": false
 }
+
+var STATUS_NODE_API_CONFIG* = %* {
+  "APIModules": "connector",
+  "ConnectorEnabled": true,
+  "HTTPEnabled": true,
+  "HTTPHost": "0.0.0.0",
+  "HTTPPort": 8545,
+  "WSEnabled": true,
+  "WSHost": "0.0.0.0",
+  "WSPort": 8586,
+}

--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -271,14 +271,3 @@ var NODE_CONFIG* = %* {
   },
   "OutputMessageCSVEnabled": false
 }
-
-var STATUS_NODE_API_CONFIG* = %* {
-  "APIModules": "connector",
-  "ConnectorEnabled": true,
-  "HTTPEnabled": true,
-  "HTTPHost": "0.0.0.0",
-  "HTTPPort": 8545,
-  "WSEnabled": true,
-  "WSHost": "0.0.0.0",
-  "WSPort": 8586,
-}

--- a/src/app_service/service/accounts/dto/api_config.nim
+++ b/src/app_service/service/accounts/dto/api_config.nim
@@ -1,0 +1,33 @@
+import json
+
+type APIConfig* = object
+  apiModules*: string
+  connectorEnabled*: bool
+  httpEnabled*: bool
+  httpHost*: string
+  httpPort*: int
+  wsEnabled*: bool
+  wsHost*: string
+  wsPort*: int
+
+proc defaultAPIConfig*(): APIConfig =
+  result.apiModules = "connector"
+  result.connectorEnabled = true
+  result.httpEnabled = true
+  result.httpHost = "0.0.0.0"
+  result.httpPort = 8545
+  result.wsEnabled = true
+  result.wsHost = "0.0.0.0"
+  result.wsPort = 8586
+
+proc toJson*(self: APIConfig): JsonNode =
+  return %* {
+    "apiModules": self.apiModules,
+    "connectorEnabled": self.connectorEnabled,
+    "httpEnabled": self.httpEnabled,
+    "httpHost": self.httpHost,
+    "httpPort": self.httpPort,
+    "wsEnabled": self.wsEnabled,
+    "wsHost": self.wsHost,
+    "wsPort": self.wsPort
+  }

--- a/src/app_service/service/accounts/dto/api_config.nim
+++ b/src/app_service/service/accounts/dto/api_config.nim
@@ -1,5 +1,7 @@
 import json
 
+include ../../../common/net_utils
+
 type APIConfig* = object
   apiModules*: string
   connectorEnabled*: bool
@@ -10,13 +12,21 @@ type APIConfig* = object
   wsHost*: string
   wsPort*: int
 
+proc checkAndSetPort(port: Port, isEnabled: var bool) =
+  if isPortBusy(port):
+    isEnabled = false
+
 proc defaultAPIConfig*(): APIConfig =
   result.apiModules = "connector"
   result.connectorEnabled = true
+
   result.httpEnabled = true
+  checkAndSetPort(Port(8545), result.httpEnabled)
   result.httpHost = "0.0.0.0"
   result.httpPort = 8545
+
   result.wsEnabled = true
+  checkAndSetPort(Port(8586), result.wsEnabled)
   result.wsHost = "0.0.0.0"
   result.wsPort = 8586
 

--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -40,6 +40,7 @@ type
 
     keycardInstanceUID*: string
     keycardPairingDataFile*: string
+    apiConfig*: Option[JsonNode]
 
 proc toJson*(self: CreateAccountRequest): JsonNode =
   result = %*{
@@ -91,3 +92,5 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
   for key, value in self.walletSecretsConfig.toJson().pairs():
     result[key] = value
 
+  if self.apiConfig.isSome():
+    result["apiConfig"] = %self.apiConfig.get()

--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -1,9 +1,11 @@
 import json, std/options
-import ./wallet_secretes_config
-import ./image_crop_rectangle
+import wallet_secretes_config
+import image_crop_rectangle
+import api_config
 
 export wallet_secretes_config
 export image_crop_rectangle
+export api_config
 
 type
   CreateAccountRequest* = object
@@ -40,7 +42,7 @@ type
 
     keycardInstanceUID*: string
     keycardPairingDataFile*: string
-    apiConfig*: Option[JsonNode]
+    apiConfig*: APIConfig
 
 proc toJson*(self: CreateAccountRequest): JsonNode =
   result = %*{
@@ -60,6 +62,7 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
     "upstreamConfig": self.upstreamConfig,
     "keycardInstanceUID": self.keycardInstanceUID,
     "keycardPairingDataFile": self.keycardPairingDataFile,
+    "apiConfig": self.apiConfig
   }
 
   if self.logLevel.isSome():
@@ -91,6 +94,3 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
 
   for key, value in self.walletSecretsConfig.toJson().pairs():
     result[key] = value
-
-  if self.apiConfig.isSome():
-    result["apiConfig"] = %self.apiConfig.get()

--- a/src/app_service/service/accounts/dto/login_request.nim
+++ b/src/app_service/service/accounts/dto/login_request.nim
@@ -1,7 +1,9 @@
 import json, std/options
 import wallet_secretes_config
+import api_config
 
 export wallet_secretes_config
+export api_config
 
 type
   LoginAccountRequest* = object
@@ -14,7 +16,7 @@ type
     keycardWhisperPrivateKey*: string
     mnemonic*: string
     walletSecretsConfig*: WalletSecretsConfig
-    apiConfig*: Option[JsonNode]
+    apiConfig*: APIConfig
 
 proc toJson*(self: LoginAccountRequest): JsonNode =
   result = %* {
@@ -26,9 +28,7 @@ proc toJson*(self: LoginAccountRequest): JsonNode =
     "bandwidthStatsEnabled": self.bandwidthStatsEnabled,
     "keycardWhisperPrivateKey": self.keycardWhisperPrivateKey,
     "mnemonic": self.mnemonic,
+    "apiConfig": self.apiConfig
   }
   for key, value in self.walletSecretsConfig.toJson().pairs():
     result[key] = value
-
-  if self.apiConfig.isSome():
-    result["apiConfig"] = %self.apiConfig.get()

--- a/src/app_service/service/accounts/dto/login_request.nim
+++ b/src/app_service/service/accounts/dto/login_request.nim
@@ -1,4 +1,4 @@
-import json
+import json, std/options
 import wallet_secretes_config
 
 export wallet_secretes_config
@@ -14,6 +14,7 @@ type
     keycardWhisperPrivateKey*: string
     mnemonic*: string
     walletSecretsConfig*: WalletSecretsConfig
+    apiConfig*: Option[JsonNode]
 
 proc toJson*(self: LoginAccountRequest): JsonNode =
   result = %* {
@@ -28,3 +29,6 @@ proc toJson*(self: LoginAccountRequest): JsonNode =
   }
   for key, value in self.walletSecretsConfig.toJson().pairs():
     result[key] = value
+
+  if self.apiConfig.isSome():
+    result["apiConfig"] = %self.apiConfig.get()

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -238,7 +238,7 @@ QtObject:
         torrentConfigPort: some(TORRENT_CONFIG_PORT),
         keycardPairingDataFile: main_constants.KEYCARDPAIRINGDATAFILE,
         walletSecretsConfig: self.buildWalletSecrets(),
-        apiConfig: some(STATUS_NODE_API_CONFIG)
+        apiConfig: defaultApiConfig()
       )
 
   proc createAccountAndLogin*(self: Service, password: string, displayName: string, imagePath: string, imageCropRectangle: ImageCropRectangle): string =
@@ -422,7 +422,7 @@ QtObject:
       mnemonic: mnemonic,
       walletSecretsConfig: self.buildWalletSecrets(),
       bandwidthStatsEnabled: true,
-      apiConfig: some(STATUS_NODE_API_CONFIG)
+      apiConfig: defaultApiConfig()
     )
 
     if main_constants.runtimeLogLevelSet():

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -238,6 +238,7 @@ QtObject:
         torrentConfigPort: some(TORRENT_CONFIG_PORT),
         keycardPairingDataFile: main_constants.KEYCARDPAIRINGDATAFILE,
         walletSecretsConfig: self.buildWalletSecrets(),
+        apiConfig: some(STATUS_NODE_API_CONFIG)
       )
 
   proc createAccountAndLogin*(self: Service, password: string, displayName: string, imagePath: string, imageCropRectangle: ImageCropRectangle): string =
@@ -421,6 +422,7 @@ QtObject:
       mnemonic: mnemonic,
       walletSecretsConfig: self.buildWalletSecrets(),
       bandwidthStatsEnabled: true,
+      apiConfig: some(STATUS_NODE_API_CONFIG)
     )
 
     if main_constants.runtimeLogLevelSet():


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/14795
Waits https://github.com/status-im/status-go/pull/5346

### Description

This PR enables rpc server over HTTP on port 8545 and over Websocket on port 8586.

### How to test

1. Start status desktop, create or login into account
2. After login rpc server should be available, test it with curl:
```
curl -X POST http://127.0.0.1:8545      -H 'Content-type: application/json'      -d '{
         "jsonrpc": "2.0",
         "id": 37,
         "method": "connector_callRPC",
         "params": ["{\"method\": \"eth_accounts\", \"params\": []}"]
     }' | jq
```
3. Websocket can be enabled in config, test with
```
wscat -c "ws://0.0.0.0:8586"
```