### PR TITLE
chore: change order of rpc text input

### DIFF
--- a/ui/app/AppLayouts/Node/NodeLayout.qml
+++ b/ui/app/AppLayouts/Node/NodeLayout.qml
@@ -159,19 +159,6 @@ StatusSectionLayout {
         }
 
         RowLayout {
-            id: resultContainer
-            Layout.fillHeight: true
-            Layout.rightMargin: Style.current.padding
-            Layout.leftMargin: Style.current.padding
-            StatusTextArea { 
-                id: callResult
-                Layout.fillWidth: true
-                text: root.store.nodeModelInst.callResult
-                readOnly: true
-            }
-        }
-
-        RowLayout {
             id: rpcInputContainer
             height: 70
             Layout.fillWidth: true
@@ -241,6 +228,19 @@ StatusSectionLayout {
                         }
                     }
                 }
+            }
+        }
+
+        RowLayout {
+            id: resultContainer
+            Layout.fillHeight: true
+            Layout.rightMargin: Style.current.padding
+            Layout.leftMargin: Style.current.padding
+            StatusTextArea { 
+                id: callResult
+                Layout.fillWidth: true
+                text: root.store.nodeModelInst.callResult
+                readOnly: true
             }
         }
     }


### PR DESCRIPTION
Changes the order of the fields in the node management tab, so the text field to enter the RPC call is always available, because otherwise, once you use a method that returns a large amount of data, the field will no longer be visible.

