### PR TITLE
Fix/13630 collectible sort

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/SortOrderComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SortOrderComboBox.qml
@@ -14,7 +14,7 @@ import utils 1.0
 ComboBox {
     id: root
 
-    // expected model role names: text, value (enum TokenOrder), sortRoleName, icon (optional)
+    // expected model role names: text, value (enum TokenOrder), sortRoleName, icon (optional), isDisabled (optional) default is false
     // text === "---" denotes a separator
 
     property bool hasCustomOrderDefined
@@ -228,6 +228,9 @@ ComboBox {
             modelData["value"] === SortOrderComboBox.TokenOrderCustom
 
         visible: {
+            if (modelData["isDisabled"]) {
+                return false;
+            }
             if (custom) // hide "Custom order" menu entry if none defined
                 return root.hasCustomOrderDefined
             return true


### PR DESCRIPTION
### What does the PR do
fixes: #13630 
blocked by: [#5454](https://github.com/status-im/status-go/pull/5454)
disable the sort by date functionality if the timestamp is not available 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
<img width="1512" alt="image" src="https://github.com/status-im/status-desktop/assets/16547115/c20194a8-6d12-4906-a1c9-4eb79f20a240">

### Cool Spaceship Picture

<!-- optional but cool ->
