### PR TITLE
chore: use checkbox indicator to locate checkboxes on login, click objects in the middle

### DIFF
--- a/test/e2e/configs/testpath.py
+++ b/test/e2e/configs/testpath.py
@@ -12,7 +12,7 @@ TEST_VP: typing.Optional[SystemPath] = None
 TEST_ARTIFACTS: typing.Optional[SystemPath] = None
 
 # Test Directories
-RUN_ID = os.getenv('RUN_DIR', f'run_{datetime.today().strftime("%Y-%m-%d %H:%M:%S")}')
+RUN_ID = os.getenv('RUN_DIR', f'run_{datetime.today().strftime("%Y-%m-%d %H-%M-%S")}')
 RESULTS: SystemPath = ROOT / 'local_run_results'
 RUN: SystemPath = RESULTS / RUN_ID
 VP: SystemPath = ROOT / 'ext' / 'vp'

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -61,7 +61,7 @@ def pytest_exception_interact(node):
     test_path, test_name, test_params = generate_test_info(node)
     node_dir: SystemPath = configs.testpath.RUN / test_path / test_name / test_params
     node_dir.mkdir(parents=True, exist_ok=True)
-    screenshot = node_dir / f'screenshot_{datetime.today().strftime("%Y-%m-%d %H:%M:%S")}.png'
+    screenshot = node_dir / f'screenshot_{datetime.today().strftime("%Y-%m-%d %H-%M-%S")}.png'
     ImageGrab.grab(xdisplay=configs.system.DISPLAY if IS_LIN else None).save(screenshot)
     allure.attach(
         name='Screenshot on fail',

--- a/test/e2e/gui/components/onboarding/before_started_popup.py
+++ b/test/e2e/gui/components/onboarding/before_started_popup.py
@@ -12,7 +12,9 @@ class BeforeStartedPopUp(BasePopup):
     def __init__(self):
         super(BeforeStartedPopUp, self).__init__()
         self._acknowledge_checkbox = CheckBox(names.acknowledge_checkbox)
+        self._acknowledgeIndicator = QObject(names.acknowledgeIndicator)
         self._terms_of_use_checkBox = CheckBox(names.termsOfUseCheckBox_StatusCheckBox)
+        self._termsOfUseIndicator = QObject(names.termsOfUseIndicator)
         self._get_started_button = Button(names.getStartedStatusButton_StatusButton)
         self._terms_of_use_link = QObject(names.termsOfUseLink_StatusBaseText)
         self._privacy_policy_link = QObject(names.privacyPolicyLink_StatusBaseText)
@@ -24,8 +26,8 @@ class BeforeStartedPopUp(BasePopup):
 
     @allure.step('Allow all and get started')
     def get_started(self):
-        self._acknowledge_checkbox.set(True)
-        self._terms_of_use_checkBox.set(True)
+        self._acknowledgeIndicator.click()
+        self._termsOfUseIndicator.click()
         assert self._terms_of_use_link.is_visible, f"Terms of use link is missing"
         assert self._privacy_policy_link.is_visible, f"Privacy Policy link is missing"
         self._get_started_button.click()

--- a/test/e2e/gui/elements/check_box.py
+++ b/test/e2e/gui/elements/check_box.py
@@ -14,7 +14,7 @@ class CheckBox(QObject):
     @allure.step("Set {0} value: {1}")
     def set(self, value: bool):
         if self.is_checked is not value:
-            self.click()
+            self.click(x=5, y=5)
             assert driver.waitFor(
                 lambda: self.is_checked is value, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Value not changed'
         LOG.info('%s: value changed to "%s"', self, value)

--- a/test/e2e/gui/elements/check_box.py
+++ b/test/e2e/gui/elements/check_box.py
@@ -14,7 +14,7 @@ class CheckBox(QObject):
     @allure.step("Set {0} value: {1}")
     def set(self, value: bool):
         if self.is_checked is not value:
-            self.click(x=5, y=5)
+            self.click()
             assert driver.waitFor(
                 lambda: self.is_checked is value, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), 'Value not changed'
         LOG.info('%s: value changed to "%s"', self, value)

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -96,8 +96,8 @@ class QObject:
     ):
         driver.mouseClick(
             self.object,
-            x or int(self.object.width * 0.1),
-            y or int(self.object.height * 0.1),
+            x or int(self.object.width * 0.5),
+            y or int(self.object.height * 0.5),
             button or driver.Qt.LeftButton
         )
         LOG.info('%s: is clicked with Qt.LeftButton', self)

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -177,8 +177,8 @@ class MainWindow(Window):
     @allure.step('Sign Up user')
     def sign_up(self, user_account: UserAccount = constants.user.user_account_one):
         BeforeStartedPopUp().get_started()
-        wellcome_screen = WelcomeToStatusView().wait_until_appears()
-        profile_view = wellcome_screen.get_keys().generate_new_keys()
+        welcome_screen = WelcomeToStatusView().wait_until_appears()
+        profile_view = welcome_screen.get_keys().generate_new_keys()
         profile_view.set_display_name(user_account.name)
         create_password_view = profile_view.next()
         confirm_password_view = create_password_view.create_password(user_account.password)

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -43,7 +43,9 @@ o_StatusListView = {"container": statusDesktop_mainWindow_overlay, "type": "Stat
 """ Onboarding """
 # Before you get started Popup
 acknowledge_checkbox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "acknowledgeCheckBox", "type": "StatusCheckBox", "visible": True}
+acknowledgeIndicator = {"container": acknowledge_checkbox, "objectName": "indicator", "type": "Item", "visible": True}
 termsOfUseCheckBox_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName":"termsOfUseCheckBox", "type": "StatusCheckBox", "visible": True}
+termsOfUseIndicator = {"container": termsOfUseCheckBox_StatusCheckBox, "objectName": "indicator", "type": "Item", "visible": True}
 getStartedStatusButton_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "getStartedStatusButton", "type": "StatusButton", "visible": True}
 termsOfUseLink_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "termsOfUseLink", "type": "StatusBaseText", "visible": True}
 privacyPolicyLink_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "objectName": "privacyPolicyLink", "type": "StatusBaseText", "visible": True}

--- a/test/e2e/tests/communities/test_communities_mint_owner_token.py
+++ b/test/e2e/tests/communities/test_communities_mint_owner_token.py
@@ -126,7 +126,7 @@ def test_mint_owner_token(keys_screen, main_window, user_account):
                               configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     with step('Start minting'):
-        start_minting = select_network.click_mint()
+        start_minting = edit_owner_token_view.click_mint()
 
     with step('Verify fee text and sign transaction'):
         assert start_minting.get_fee_title == 'Mint ' + community_params[

--- a/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
@@ -43,6 +43,7 @@ CheckBox {
     font.pixelSize: size === StatusCheckBox.Size.Regular ? 15 : 13
 
     indicator: Rectangle {
+        objectName: "indicator"
         anchors.left: root.leftSide? parent.left : undefined
         anchors.right: !root.leftSide? parent.right : undefined
         implicitWidth: size === StatusCheckBox.Size.Regular


### PR DESCRIPTION
### What does the PR do

- click checkboxes' indicators on `Before get started` modal instead of checkbox item (which has text as well)
- click other elements in the middle by default
- remove `:` to make windows happy

### Affected areas

ui tests
