### PR TITLE
fix(community): update hidden channels visibility when joining the community

### DIFF
--- a/monitoring/MonitorEntryPoint.qml
+++ b/monitoring/MonitorEntryPoint.qml
@@ -298,7 +298,15 @@ Component {
                         text: "Note: 'applicationWindow' is good root object in"
                               + " most cases. 'WalletStores.RootStore' and"
                               + " `SharedStores.RootStore` are also exposed for"
-                              + " convenience for models created within those singletons."
+                              + " convenience for models created within those singletons. \n\n"
+                              + " Hack (see #15181): If you want to inspect a model that is not"
+                              + " from the root object (under a repeater), add objectName to a dummy object in AppMain.qml: \n"
+                              + " property var modelIWantToInspect: SortFilterProxyModel { \n"
+                              + "   objectName: \"YYY\" \n"
+                              + " } \n"
+                              + " and inside your item add something like this: \n"
+                              + " Component.onCompleted: appMain.modelIWantToInspect.sourceModel = this.model \n"
+                              + " Then you can use 'YYY' as the object name in this search."
                     }
 
                     RowLayout {

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -428,6 +428,8 @@ QtObject:
     
     let modelIndex = self.createIndex(index, 0, nil)
     defer: modelIndex.delete
+    changedRoles.add(ModelRole.HideIfPermissionsNotMet.int) # depends on canPost, canView
+    changedRoles.add(ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int) # depends on hideIfPermissionsNotMet
     self.dataChanged(modelIndex, modelIndex, changedRoles)
 
   proc changeMutedOnItemByCategoryId*(self: Model, categoryId: string, muted: bool) =


### PR DESCRIPTION
fixes #14719

### What does the PR do

Trigger role updates when dependency roles are updated

```mermaid
graph TD
    A[itemShouldBeHiddenBecauseNotPermitted]
    B[memberRole]
    C[isCategory]
    D[categoryId]
    E[hideBecausePermissionsAreNotMet\n*of all items in category]
    F[hideIfPermissionsNotMet]
    G[canPost]
    H[canView]

    A --> B
    A --> C
    A --> D
    A --> E
    E --> F
    E --> G
    E --> H

```


### Affected areas

Communities, show hidden channels to admin when joining a community

### StatusQ checklist

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/ed654334-5f2b-464c-a3b8-d32d6ab2ce09

### Further improvements
There should be another potential problem: when I change the visibility of a channel in the category, the `ShouldBeHiddenBecausePermissionsAreNotMet` for the category item should not be updated with the current code. But for some reason this doesn't happen, and the category gets hidden when all the channels in it are hidden

### Cool Spaceship Picture
<details>

![image](https://github.com/status-im/status-desktop/assets/1083341/8147ffc0-4ab3-47ae-896e-a7a86e141c26)

</details>