### PR TITLE
feat(dApps) implement sign transaction for wallet connect

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -249,12 +249,10 @@ QtObject:
 
     # setup other event handlers
     self.eventsHandler.onFilteringDone(proc (jsonObj: JsonNode) =
-      echo "@dd eventsHandler.onFilteringDone: ", $jsonObj
       self.processResponse(jsonObj)
     )
 
     self.eventsHandler.onFilteringUpdateDone(proc (jn: JsonNode) =
-      echo "@dd eventsHandler.onFilteringUpdateDone: ", $jn
       if jn.kind != JArray:
         error "expected an array"
 

--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -249,10 +249,12 @@ QtObject:
 
     # setup other event handlers
     self.eventsHandler.onFilteringDone(proc (jsonObj: JsonNode) =
+      echo "@dd eventsHandler.onFilteringDone: ", $jsonObj
       self.processResponse(jsonObj)
     )
 
     self.eventsHandler.onFilteringUpdateDone(proc (jn: JsonNode) =
+      echo "@dd eventsHandler.onFilteringUpdateDone: ", $jn
       if jn.kind != JArray:
         error "expected an array"
 

--- a/src/app/modules/shared_modules/wallet_connect/controller.nim
+++ b/src/app/modules/shared_modules/wallet_connect/controller.nim
@@ -55,3 +55,6 @@ QtObject:
 
   proc signTypedDataV4*(self: Controller, address: string, password: string, typedDataJson: string): string {.slot.} =
     return self.service.signTypedDataV4(address, password, typedDataJson)
+
+  proc signTransaction*(self: Controller, address: string, chainId: int, password: string, txJson: string): string {.slot.} =
+    return self.service.signTransaction(address, chainId, password, txJson)

--- a/src/app_service/service/wallet_connect/service.nim
+++ b/src/app_service/service/wallet_connect/service.nim
@@ -103,7 +103,7 @@ QtObject:
       return ""
     if buildTxResponse.isNil or buildTxResponse.kind != JsonNodeKind.JObject or
       not buildTxResponse.hasKey("txArgs") or not buildTxResponse.hasKey("messageToSign"):
-        error "unexpected buildTransaction response"
+        error "unexpected wallet_buildTransaction response"
         return ""
     var txToBeSigned = buildTxResponse["messageToSign"].getStr
     if txToBeSigned.len != wallet_constants.TX_HASH_LEN_WITH_PREFIX:

--- a/storybook/pages/DAppRequestModalPage.qml
+++ b/storybook/pages/DAppRequestModalPage.qml
@@ -50,10 +50,10 @@ Item {
                 dappName: settings.dappName
                 dappUrl: settings.dappUrl
                 dappIcon: settings.dappIcon
-                signContent: d.signTestContent
-                method: "eth_signTypedData_v4"
-                maxFeesText: "1.82 EUR"
-                estimatedTimeText: "3-5 mins"
+                payloadData: d.currentPayload ? d.currentPayload.payloadData : null
+                method: d.currentPayload ? d.currentPayload.method : ""
+                maxFeesText: d.currentPayload ? d.currentPayload.maxFeesText : ""
+                estimatedTimeText: d.currentPayload ? d.currentPayload.estimatedTimeText : ""
 
                 account: d.selectedAccount
                 network: d.selectedNetwork
@@ -107,6 +107,18 @@ Item {
                 text: settings.accountDisplay
                 onTextChanged: settings.accountDisplay = text
             }
+            StatusComboBox {
+                id: methodsComboBox
+
+                model: d.methodsModel
+                control.textRole: "method"
+                currentIndex: settings.payloadMethod
+                onCurrentIndexChanged: {
+                    d.currentPayload = null
+                    settings.payloadMethod = currentIndex
+                    d.currentPayload = d.payloadOptions[currentIndex]
+                }
+            }
 
             Item { Layout.fillHeight: true }
         }
@@ -119,17 +131,44 @@ Item {
         property string dappUrl: "opensea.io"
         property string dappIcon: "https://opensea.io/static/images/logos/opensea-logo.svg"
         property string accountDisplay: "helloworld"
+        property int payloadMethod: 0
     }
 
     QtObject {
         id: d
+
+        Component.onCompleted: methodsModel.append(payloadOptions)
 
         readonly property var accountsModel: WalletAccountsModel{}
         readonly property var selectedAccount: accountsModel.data[0]
 
         readonly property var selectedNetwork: NetworksModel.flatNetworks.get(0)
 
-        readonly property var signTestContent: "{\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Person\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"wallet\",\"type\":\"address\"}],\"Mail\":[{\"name\":\"from\",\"type\":\"Person\"},{\"name\":\"to\",\"type\":\"Person\"},{\"name\":\"contents\",\"type\":\"string\"}]},\"primaryType\":\"Mail\",\"domain\":{\"name\":\"Ether Mail\",\"version\":\"1\",\"chainId\":1,\"verifyingContract\":\"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC\"},\"message\":{\"from\":{\"name\":\"Cow\",\"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"},\"to\":{\"name\":\"Bob\",\"wallet\":\"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB\"},\"contents\":\"Hello, Bob!\"}}"
+        readonly property ListModel methodsModel: ListModel {}
+        property var currentPayload: payloadOptions[settings.payloadMethod]
+        property string maxFeesText: ""
+        property string estimatedTimeText: ""
+
+        readonly property var payloadOptions: [
+            {
+                payloadData: {"message":"This is a message to sign.\nSigning this will prove ownership of the account."},
+                method: "personal_sign",
+                maxFeesText: "",
+                estimatedTimeText: ""
+            },
+            {
+                payloadData: {"message": "{\"types\":{\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}],\"Person\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"wallet\",\"type\":\"address\"}],\"Mail\":[{\"name\":\"from\",\"type\":\"Person\"},{\"name\":\"to\",\"type\":\"Person\"},{\"name\":\"contents\",\"type\":\"string\"}]},\"primaryType\":\"Mail\",\"domain\":{\"name\":\"Ether Mail\",\"version\":\"1\",\"chainId\":1,\"verifyingContract\":\"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC\"},\"message\":{\"from\":{\"name\":\"Cow\",\"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"},\"to\":{\"name\":\"Bob\",\"wallet\":\"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB\"},\"contents\":\"Hello, Bob!\"}}"},
+                method: "eth_signTypedData_v4",
+                maxFeesText: "",
+                estimatedTimeText: ""
+            },
+            {
+                payloadData: {"tx":{"data":"0x","from":"0xE2d622C817878dA5143bBE06866ca8E35273Ba8a","gasLimit":"0x5208","gasPrice":"0x048ddbc5","nonce":"0x2a","to":"0xE2d622C817878dA5143bBE06866ca8E35273Ba8a","value":"0x00"}},
+                method: "eth_signTransaction",
+                maxFeesText: "1.82 EUR",
+                estimatedTimeText: "3-5 mins"
+            }
+        ]
     }
 }
 

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -284,16 +284,20 @@ Item {
 
             // hardcoded for https://react-app.walletconnect.com/
             function signMessage(topic, id, address, password, message) {
+                console.info(`calling mocked DAppsStore.signMessage(${topic}, ${id}, ${address}, ${password}, ${message})`)
                 return "0x0b083acc1b3b612dd38e8e725b28ce9b2dd4936b4cf7922da4e4a3c6f44f7f4f6d3050ccb41455a2b85093f1bfadb10fc6a75d83bb590b2eb70e3447653459701c"
             }
 
             // hardcoded for https://react-app.walletconnect.com/
             function signTypedDataV4(topic, id, address, password, typedDataJson) {
+                console.info(`calling mocked DAppsStore.signTypedDataV4(${topic}, ${id}, ${address}, ${password}, ${typedDataJson})`)
                 return "0xf8ceb3468319cc215523b67c24c4504b3addd9bf8de31c278038d7478c9b6de554f7d8a516cd5d6a066b7d48b81f03d9d6bb7d5d754513c08325674ebcc7efbc1b"
             }
 
-            function signTransaction(topic, id, address, password, tx) {
-                return "0xf8ceb3468319cc215523b67c24c4504b3addd9bf8de31c278038d7478c9b6de554f7d8a516cd5d6a066b7d48b81f03d9d6bb7d5d754513c08325674ebcc7efbc1b"
+            // hardcoded for https://react-app.walletconnect.com/
+            function signTransaction(topic, id, address, chainId, password, tx) {
+                console.info(`calling mocked DAppsStore.signTransaction(${topic}, ${id}, ${address}, ${chainId}, ${password}, ${tx})`)
+                return "0xf8672a8402fb7acf82520894e2d622c817878da5143bbe06866ca8e35273ba8a80808401546d71a04fc89c2f007c3b27d0fcff07d3e69c29f940967fab4caf525f9af72dadb48befa00c5312a3cb6f50328889ad361a0c88bb9d1b1a4fc510f6783b287930b4e187b5"
             }
         }
 

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -53,14 +53,6 @@ Item {
                     spacing: 8
 
                     wcService: walletConnectService
-
-                    onDisplayToastMessage: (message, isErr) => {
-                        if(isErr) {
-                            console.log(`Storybook.displayToastMessage(${message}, "", "warning", false, Constants.ephemeralNotificationType.danger, "")`)
-                            return
-                        }
-                        console.log(`Storybook.displayToastMessage(${message}, "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")`)
-                    }
                 }
             }
             ColumnLayout {}
@@ -299,6 +291,10 @@ Item {
             function signTypedDataV4(topic, id, address, password, typedDataJson) {
                 return "0xf8ceb3468319cc215523b67c24c4504b3addd9bf8de31c278038d7478c9b6de554f7d8a516cd5d6a066b7d48b81f03d9d6bb7d5d754513c08325674ebcc7efbc1b"
             }
+
+            function signTransaction(topic, id, address, password, tx) {
+                return "0xf8ceb3468319cc215523b67c24c4504b3addd9bf8de31c278038d7478c9b6de554f7d8a516cd5d6a066b7d48b81f03d9d6bb7d5d754513c08325674ebcc7efbc1b"
+            }
         }
 
         walletStore: WalletStore {
@@ -310,7 +306,13 @@ Item {
             readonly property ListModel ownAccounts: accounts
         }
 
-        onDisplayToastMessage: (message, error) => console.info("Storybook - toast message: ", message, !!error ? "; error: " + error: "")
+        onDisplayToastMessage: (message, isErr) => {
+            if(isErr) {
+                console.log(`Storybook.displayToastMessage(${message}, "", "warning", false, Constants.ephemeralNotificationType.danger, "")`)
+                return
+            }
+            console.log(`Storybook.displayToastMessage(${message}, "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")`)
+        }
     }
 
 

--- a/storybook/qmlTests/tests/helpers/wallet_connect.js
+++ b/storybook/qmlTests/tests/helpers/wallet_connect.js
@@ -54,6 +54,13 @@ const dappMetadataJsonString = `{
     "url": "${dappUrl}"
 }`
 
+// https://metamask.github.io/test-dapp/ use case that doesn't have icons
+const noIconsDappMetadataJsonString = `{
+    "description": "This is the E2e Test Dapp",
+    "name": "${dappName}",
+    "url": "${dappUrl}"
+}`
+
 const verifiedContextJsonString = `{
     "verified": {
         "origin": "https://app.test.org",
@@ -62,7 +69,12 @@ const verifiedContextJsonString = `{
     }
 }`
 
-function formatSessionProposal() {
+function formatSessionProposal(custom) {
+    var dappMetadataJsonStringOverride = dappMetadataJsonString
+    if (custom && custom.dappMetadataJsonString) {
+        dappMetadataJsonStringOverride = custom.dappMetadataJsonString
+    }
+
     return `{
     "id": 1715976881734096,
     "params": {
@@ -71,7 +83,7 @@ function formatSessionProposal() {
         "optionalNamespaces": ${optionalNamespacesJsonString},
         "pairingTopic": "50fba141cdb5c015493c2907c46bacf9f7cbd7c8e3d4e97df891f18dddcff69c",
         "proposer": {
-            "metadata": ${dappMetadataJsonString},
+            "metadata": ${dappMetadataJsonStringOverride},
             "publicKey": "095d9992ca0eb6081cabed26faf48919162fd70cc66d639f118a60507ae0463d"
         },
         "relays": [
@@ -98,7 +110,11 @@ function formatBuildApprovedNamespacesResult(networksArray, accountsArray) {
   }`
 }
 
-function formatApproveSessionResponse(networksArray, accountsArray) {
+function formatApproveSessionResponse(networksArray, accountsArray, custom) {
+    var dappMetadataJsonStringOverride = dappMetadataJsonString
+    if (custom && custom.dappMetadataJsonString) {
+        dappMetadataJsonStringOverride = custom.dappMetadataJsonString
+    }
     let chainsStr = networksArray.map(chainId => `"eip155:${chainId}"`).join(',')
     let accountsStr = accountsArray.map(address => networksArray.map(chainId => `"eip155:${chainId}:${address}"`).join(',')).join(',')
     return `{
@@ -116,7 +132,7 @@ function formatApproveSessionResponse(networksArray, accountsArray) {
         "optionalNamespaces": ${optionalNamespacesJsonString},
         "pairingTopic": "50fba141cdb5c015493c2907c46bacf9f7cbd7c8e3d4e97df891f18dddcff69c",
         "peer": {
-            "metadata": ${dappMetadataJsonString},
+            "metadata": ${dappMetadataJsonStringOverride},
             "publicKey": "095d9992ca0eb6081cabed26faf48919162fd70cc66d639f118a60507ae0463d"
         },
         "relay": {

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -78,6 +78,7 @@ Item {
     // Component {
     //     id: dappsStoreComponent
 
+
     //     DAppsStore {
     //         property string dappsListReceivedJsonStr: '[]'
 
@@ -133,7 +134,7 @@ Item {
     //                 emoji: "😋"
     //                 color: "#2A4AF5"
     //             }
-    //             ListElement { address: "0x3" }
+    //             ListElement { address: "0x3a" }
     //         }
     //         readonly property ListModel ownAccounts: accounts
     //     }
@@ -182,6 +183,23 @@ Item {
     //         store.userAuthenticated(td.topic, td.request.id, "password", "")
     //         compare(store.signMessageCalls.length, 1, "expected a call to store.signMessage")
     //         compare(store.signMessageCalls[0].message, td.request.data)
+    //     }
+
+    //     function test_onSessionRequestEventDifferentCaseForAddress() {
+    //         let sdk = handler.sdk
+
+    //         let testAddressUpper = "0x3A"
+    //         let chainId = 2
+    //         let  method = "personal_sign"
+    //         let message = "hello world"
+    //         let params = [Helpers.strToHex(message), testAddressUpper]
+    //         let topic = "b536a"
+    //         let session = JSON.parse(Testing.formatSessionRequest(chainId, method, params, topic))
+    //         // Expect to have calls to getActiveSessions from service initialization
+    //         let prevRequests = sdk.getActiveSessionsCallbacks.length
+    //         sdk.sessionRequestEvent(session)
+
+    //         compare(sdk.getActiveSessionsCallbacks.length, 1, "expected DAppsRequestHandler call sdk.getActiveSessions")
     //     }
     // }
 
@@ -298,7 +316,7 @@ Item {
     //         let walletStore = service.walletStore
     //         let store = service.store
 
-    //         let testAddress = "0x3"
+    //         let testAddress = "0x3a"
     //         let chainId = 2
     //         let  method = "personal_sign"
     //         let message = "hello world"

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -25,7 +25,7 @@ Item {
     width: 600
     height: 400
 
-    // TODO #15151 fix CI crash and re-enable tests
+    // // TODO #15151 fix CI crash and re-enable tests
     // Component {
     //     id: sdkComponent
 
@@ -79,13 +79,15 @@ Item {
     //     id: dappsStoreComponent
 
     //     DAppsStore {
+    //         property string dappsListReceivedJsonStr: '[]'
+
     //         signal dappsListReceived(string dappsJson)
     //         signal userAuthenticated(string topic, string id, string password, string pin)
     //         signal userAuthenticationFailed(string topic, string id)
 
     //         // By default, return no dapps in store
     //         function getDapps() {
-    //             dappsListReceived('[]')
+    //             dappsListReceived(dappsListReceivedJsonStr)
     //             return true
     //         }
 
@@ -333,8 +335,54 @@ Item {
     // }
 
     // Component {
-    //     id: componentUnderTest
-    //     DAppsWorkflow {
+    //     id: dappsListProviderComponent
+    //     DAppsListProvider {
+    //     }
+    // }
+
+    // TestCase {
+    //     name: "DAppsListProvider"
+
+    //     property DAppsListProvider provider: null
+
+    //     readonly property var dappsListReceivedJsonStr: '[{"url":"https://tst1.com","name":"name1","iconUrl":"https://tst1.com/u/1"},{"url":"https://tst2.com","name":"name2","iconUrl":"https://tst2.com/u/2"}]'
+
+    //     function init() {
+    //         // Simulate the SDK not being ready
+    //         let sdk = createTemporaryObject(sdkComponent, root, {projectId: "12ab", sdkReady: false})
+    //         verify(!!sdk)
+    //         let store = createTemporaryObject(dappsStoreComponent, root, {
+    //             dappsListReceivedJsonStr: dappsListReceivedJsonStr
+    //         })
+    //         verify(!!store)
+    //         provider = createTemporaryObject(dappsListProviderComponent, root, {sdk: sdk, store: store})
+    //         verify(!!provider)
+    //     }
+
+    //     function cleanup() {
+    //     }
+
+    //     // Implemented as a regression to metamask not having icons which failed dapps list
+    //     function test_TestUpdateDapps() {
+    //         provider.updateDapps()
+
+    //         // Validate that persistance fallback is working
+    //         compare(provider.dappsModel.count, 2, "expected dappsModel have the right number of elements")
+    //         let persistanceList = JSON.parse(dappsListReceivedJsonStr)
+    //         compare(provider.dappsModel.get(0).url, persistanceList[0].url, "expected url to be set")
+    //         compare(provider.dappsModel.get(0).iconUrl, persistanceList[0].iconUrl, "expected iconUrl to be set")
+    //         compare(provider.dappsModel.get(1).name, persistanceList[1].name, "expected name to be set")
+
+    //         // Validate that SDK's `getActiveSessions` is not called if not ready
+    //         let sdk = provider.sdk
+    //         compare(sdk.getActiveSessionsCallbacks.length, 0, "expected no calls to sdk.getActiveSessions yet")
+    //         sdk.sdkReady = true
+    //         compare(sdk.getActiveSessionsCallbacks.length, 1, "expected a call to sdk.getActiveSessions when SDK becomes ready")
+    //         let callback = sdk.getActiveSessionsCallbacks[0].callback
+    //         let session = JSON.parse(Testing.formatApproveSessionResponse([1, 2], ["0x1"], {dappMetadataJsonString: Testing.noIconsDappMetadataJsonString}))
+    //         callback({"b536a": session, "b537b": session})
+    //         compare(provider.dappsModel.count, 1, "expected dappsModel have the SDK's reported dapps")
+    //         compare(provider.dappsModel.get(0).iconUrl, "", "expected iconUrl to be missing")
     //     }
     // }
 
@@ -418,7 +466,13 @@ Item {
     //     }
     // }
 
-    // TODO #15151: this TestCase if placed before ServiceHelpers was not run with `when: windowShown`. Check if related to the CI crash
+    // Component {
+    //     id: componentUnderTest
+    //     DAppsWorkflow {
+    //     }
+    // }
+
+    // // TODO #15151: this TestCase if placed before ServiceHelpers was not run with `when: windowShown`. Check if related to the CI crash
     // TestCase {
     //     id: dappsWorkflowTest
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -138,4 +138,22 @@ QtObject {
     function roleNames(model) {
         return Internal.ModelUtils.roleNames(model)
     }
+
+    /// Returns the first model entry that satisfies the condition function or null if none is found.
+    function getFirstModelEntryIf(model, conditionFn) {
+        if (!model)
+            return null
+
+        const count = model.rowCount()
+
+        for (let i = 0; i < count; i++) {
+            const modelItem = Internal.ModelUtils.get(model, i)
+
+            if (conditionFn(modelItem)) {
+                return modelItem
+            }
+        }
+
+        return null
+    }
 }

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -149,6 +149,17 @@ ConnectedDappsButton {
                 root.wcService.requestHandler.rejectSessionRequest(request, userRejected)
                 close()
             }
+
+            Connections {
+                target: root.wcService.requestHandler
+
+                function onMaxFeesUpdated(maxFees, symbol) {
+                    maxFeesText = `${maxFees.toFixed(2)} ${symbol}`
+                }
+                function onEstimatedTimeUpdated(minMinutes, maxMinutes) {
+                    estimatedTimeText = qsTr("%1-%2mins").arg(minMinutes).arg(maxMinutes)
+                }
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -18,7 +18,6 @@ ConnectedDappsButton {
 
     signal dappsListReady()
     signal pairWCReady()
-    signal displayToastMessage(string message, bool error)
 
     onClicked: {
         dappsListLoader.active = true
@@ -128,7 +127,7 @@ ConnectedDappsButton {
             dappUrl: request.dappUrl
             dappIcon: request.dappIcon
 
-            signContent: request.data.message
+            payloadData: request.data
             method: request.method
             maxFeesText: request.maxFeesText
             estimatedTimeText: request.estimatedTimeText
@@ -156,7 +155,7 @@ ConnectedDappsButton {
     Connections {
         target: root.wcService ? root.wcService.requestHandler : null
 
-        function onSessionRequestResult(request, payload, isSuccess) {
+        function onSessionRequestResult(request, isSuccess) {
             if (isSuccess) {
                 sessionRequestLoader.active = false
             } else {
@@ -200,10 +199,6 @@ ConnectedDappsButton {
         function onSessionRequest(request) {
             sessionRequestLoader.request = request
             sessionRequestLoader.active = true
-        }
-
-        function onDisplayToastMessage(message, err) {
-            root.displayToastMessage(message, err)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -83,16 +83,6 @@ Item {
                 enabled: !!Global.walletConnectService
 
                 wcService: Global.walletConnectService
-
-                onDisplayToastMessage: (message, isErr) => {
-                    if (isErr) {
-                        Global.displayToastMessage(message, "", "warning", false,
-                                                   Constants.ephemeralNotificationType.danger, "")
-                    } else {
-                        Global.displayToastMessage(message, "", "checkmark-circle", false,
-                                                   Constants.ephemeralNotificationType.success, "")
-                    }
-                }
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
@@ -54,17 +54,18 @@ QObject {
                 sdk.getActiveSessions((sessions) => {
                     root.store.dappsListReceived.disconnect(dappsListReceivedFn);
 
-                    // TODO #14755: on SDK dApps refresh update the model that has data source from persistence instead of using reset
-                    dapps.clear();
-
                     let tmpMap = {}
                     for (let key in sessions) {
                         let dapp = sessions[key].peer.metadata
-                        if (dapp.icons.length > 0) {
+                        if (!!dapp.icons && dapp.icons.length > 0) {
                             dapp.iconUrl = dapp.icons[0]
+                        } else {
+                            dapp.iconUrl = ""
                         }
                         tmpMap[dapp.url] = dapp;
                     }
+                    // TODO #14755: on SDK dApps refresh update the model that has data source from persistence instead of using reset
+                    dapps.clear();
                     // Iterate tmpMap and fill dapps
                     for (let key in tmpMap) {
                         dapps.append(tmpMap[key]);

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -112,8 +112,20 @@ QObject {
         function resolveAsync(event) {
             let method = event.params.request.method
             let account = lookupAccountFromEvent(event, method)
+            if(!account) {
+                console.error("Error finding account for event", JSON.stringify(event))
+                return null
+            }
             let network = lookupNetworkFromEvent(event, method)
+            if(!network) {
+                console.error("Error finding network for event", JSON.stringify(event))
+                return null
+            }
             let data = extractMethodData(event, method)
+            if(!data) {
+                console.error("Error in event data lookup", JSON.stringify(event))
+                return null
+            }
             let obj = sessionRequestComponent.createObject(null, {
                 event,
                 topic: event.topic,
@@ -175,7 +187,9 @@ QObject {
                 }
                 address = event.params.request.params[0].from
             }
-            return ModelUtils.getByKey(walletStore.ownAccounts, "address", address)
+            return ModelUtils.getFirstModelEntryIf(walletStore.ownAccounts, (account) => {
+                return account.address.toLowerCase() === address.toLowerCase()
+            })
         }
 
         /// Returns null if the network is not found

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -6,6 +6,7 @@ import StatusQ.Core.Utils 0.1
 
 import AppLayouts.Wallet 1.0
 import AppLayouts.Wallet.services.dapps 1.0
+import AppLayouts.Wallet.services.dapps.types 1.0
 import AppLayouts.Profile.stores 1.0
 import shared.stores 1.0
 import shared.popups.walletconnect 1.0
@@ -56,7 +57,7 @@ QObject {
         let approvedNamespaces = JSON.parse(
             Helpers.buildSupportedNamespaces(approvedChainIds,
                                              [approvedAccount.address],
-                                             requestHandler.getSupportedMethods())
+                                             SessionRequest.getSupportedMethods())
         )
         wcSDK.buildApprovedNamespaces(sessionProposal.params, approvedNamespaces)
     }
@@ -81,7 +82,7 @@ QObject {
             d.currentSessionProposal = sessionProposal
 
             let supportedNamespacesStr = Helpers.buildSupportedNamespacesFromModels(
-                root.flatNetworks, root.validAccounts, requestHandler.getSupportedMethods())
+                root.flatNetworks, root.validAccounts, SessionRequest.getSupportedMethods())
             wcSDK.buildApprovedNamespaces(sessionProposal.params, JSON.parse(supportedNamespacesStr))
         }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequest.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequest.qml
@@ -1,0 +1,58 @@
+pragma Singleton
+
+import QtQml 2.15
+
+import utils 1.0
+
+QtObject {
+    /// Supported methods
+    property QtObject methods: QtObject {
+        readonly property QtObject personalSign: QtObject {
+            readonly property string name: Constants.personal_sign
+            readonly property string userString: qsTr("sign")
+            readonly property string requestDisplay: qsTr("sign this message")
+
+            function buildDataObject(message) { return {message} }
+            function getMessageFromData(data) { return data.message }
+        }
+        readonly property QtObject signTypedData_v4: QtObject {
+            readonly property string name: "eth_signTypedData_v4"
+            readonly property string userString: qsTr("sign typed data")
+            readonly property string requestDisplay: qsTr("sign this message")
+
+            function buildDataObject(message) { return {message} }
+            function getMessageFromData(data) { return data.message }
+        }
+
+        readonly property QtObject signTransaction: QtObject {
+            readonly property string name: "eth_signTransaction"
+            readonly property string userString: qsTr("sign transaction")
+            readonly property string requestDisplay: qsTr("sign this transaction")
+
+            function buildDataObject(tx) { return {tx} }
+            function getTxFromData(data) { return data.tx }
+        }
+
+        readonly property QtObject sendTransaction: QtObject {
+            readonly property string name: "eth_sendTransaction"
+            readonly property string userString: qsTr("send transaction")
+            //function buildDataObject(message) { return {/* TODO #15126 */}}
+        }
+        readonly property var all: [personalSign, signTypedData_v4, signTransaction, sendTransaction]
+    }
+
+    function getSupportedMethods() {
+        return methods.all.map(function(method) {
+            return method.name
+        })
+    }
+
+    function methodToUserString(method) {
+        for (let i = 0; i < methods.all.length; i++) {
+            if (methods.all[i].name === method) {
+                return methods.all[i].userString
+            }
+        }
+        return ""
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequest.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequest.qml
@@ -30,7 +30,7 @@ QtObject {
             readonly property string requestDisplay: qsTr("sign this transaction")
 
             function buildDataObject(tx) { return {tx} }
-            function getTxFromData(data) { return data.tx }
+            function getTxObjFromData(data) { return data.tx }
         }
 
         readonly property QtObject sendTransaction: QtObject {

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/qmldir
@@ -1,1 +1,2 @@
 SessionRequestResolved 1.0 SessionRequestResolved.qml
+singleton SessionRequest 1.0 SessionRequest.qml

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2054,8 +2054,11 @@ Item {
             }
 
             onDisplayToastMessage: (message, isErr) => {
-                Global.displayToastMessage(message, "", isErr ? "warning" : "checkmark-circle", false,
-                    isErr ? Constants.ephemeralNotificationType.danger : Constants.ephemeralNotificationType.success, "")
+                Global.displayToastMessage(message, "",
+                    isErr ? "warning" : "checkmark-circle", false,
+                    isErr ? Constants.ephemeralNotificationType.danger
+                          : Constants.ephemeralNotificationType.success,
+                    "")
             }
         }
     }

--- a/ui/imports/shared/popups/walletconnect/DAppRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppRequestModal.qml
@@ -443,7 +443,7 @@ StatusDialog {
                     break
                 }
                 case SessionRequest.methods.signTransaction.name: {
-                    let tx = SessionRequest.methods.signTransaction.getTxFromData(root.payloadData)
+                    let tx = SessionRequest.methods.signTransaction.getTxObjFromData(root.payloadData)
                     payloadToDisplay = JSON.stringify(tx, null, 2)
                     userDisplayNaming = SessionRequest.methods.signTransaction.requestDisplay
                     break

--- a/ui/imports/shared/stores/DAppsStore.qml
+++ b/ui/imports/shared/stores/DAppsStore.qml
@@ -33,6 +33,27 @@ QObject {
         return controller.signTypedDataV4(address, password, typedDataJson)
     }
 
+    // Remove leading zeros from hex number as expected by status-go
+    function stripLeadingZeros(hexNumber) {
+        let fixed = hexNumber.replace(/^0x0*/, '0x')
+        return fixed == '0x' ? '0x0' : fixed;
+    }
+
+    // Returns the hex encoded signature of the transaction or empty string if error
+    function signTransaction(topic, id, address, chainId, password, txObj) {
+        // Strip leading zeros from numbers as expected by status-go
+        let tx = {
+            data: txObj.data,
+            from: txObj.from,
+            gasLimit: stripLeadingZeros(txObj.gasLimit),
+            gasPrice: stripLeadingZeros(txObj.gasPrice),
+            nonce: stripLeadingZeros(txObj.nonce),
+            to: txObj.to,
+            value: stripLeadingZeros(txObj.value)
+        }
+        return controller.signTransaction(address, chainId, password, JSON.stringify(tx))
+    }
+
     /// \c getDapps triggers an async response to \c dappsListReceived
     function getDapps() {
         return controller.getDapps()


### PR DESCRIPTION
### Updates #15126

`HEAD~2` Uses status-go's endpoints:

- `wallet_buildTransactions` to format the transaction
- `wallet_signMessage` to sign the transaction
- `wallet_buildRawTransaction` to format the final signed transaction

Also

- `HEAD` fix(dapps): failure if case sensitivity mismatch in account address
- `HEAD~1` feat(dapps) fix missing list of dapps in wallet connect
- `HEAD~3` chore(dApps) support multiple actions in DAppRequestModal
  - Also fix minor issue and add improvements

https://github.com/status-im/status-desktop/assets/47554641/80bdd75a-c149-4779-8c11-7f5142467af7

