### PR TITLE
chore: sleep a little to avoid race conditions on intel

### DIFF
--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -97,6 +97,11 @@ QtObject:
   proc init*(self: Service) =
     if self.doLogging:
       debug "init keycard using ", pairingsJson=status_const.KEYCARDPAIRINGDATAFILE
+    # Do not remove the sleep 700
+    # This sleep prevents a crash on intel MacOS
+    # with errors like bad flushGen 12 in prepareForSweep; sweepgen 0
+    if status_const.IS_MACOS and status_const.IS_INTEL:
+      sleep 700
     let initResp = keycard_go.keycardInitFlow(status_const.KEYCARDPAIRINGDATAFILE)
     if self.doLogging:
       debug "initialization response: ", initResp
@@ -170,8 +175,14 @@ QtObject:
       debug "keycardResumeFlow", kcServiceCurrFlow=($self.currentFlow), payload=payload, response=response
 
   proc cancelCurrentFlow*(self: Service) =
+    # Do not remove the sleep 700
+    # This sleep prevents a crash on intel MacOS
+    # with errors like bad flushGen 12 in prepareForSweep; sweepgen 0
+    if status_const.IS_MACOS and status_const.IS_INTEL:
+      sleep 700
     let response = keycard_go.keycardCancelFlow()
-    sleep(200)
+    # sleep 200 is needed for cancel flow
+    sleep 200
     self.currentFlow = KCSFlowType.NoFlow
     self.busy = false
     if self.doLogging:

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -3,6 +3,7 @@ include env_cli_vars
 ## Added a constant here cause it's easier to check the app how it behaves
 ## on other platform if we just change the value here
 const IS_MACOS* = defined(macosx)
+const IS_INTEL* = defined(amd64)
 # For future supporting fingerprints on other platforms
 const SUPPORTS_FINGERPRINT* = IS_MACOS
 # This is changed during compilation by reading the VERSION file


### PR DESCRIPTION
## Summary

With the help of build flags this PR sleep for 0.7 seconds before we make calls to the following status-go functions that crash on intel MacOS.
- `keycard_go.keycardInitFlow`
- `keycard_go.keycardCancelFlow`
- `status_go.initializeApplication`

As per my investigations this crash happens due to a race condition and was not consistently reproducible. Sometimes it would happen and other times it would not.
I know for sure it used to happen in these places and adding a tiny sleep before calling them made sure that the crashes weren't reproducible for me.

I think a 2.1 second delay during onboarding would be acceptable vs the existing condition of the desktop app straight up crashing.

fixes: #15134 

