### PR TITLE
Redirect qt logs to nim-chronicles

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -87,11 +87,11 @@ proc ensureDirectories*(dataDir, tmpDir, logDir: string) =
 
 proc logHandlerCallback(messageType: cint, message: cstring, category: cstring, file: cstring, function: cstring, line: cint) {.cdecl, exportc.} =
   logScope:
+    chroniclesLineNumbers = false
     topics = "qt"
-    text = $message
-    source_file = $file & ":" & $line
-    function = $function
     category = $category
+    file = $file & ":" & $line
+    text = $message
 
   case int(messageType):
     of 0: # QtDebugMsg

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -86,6 +86,15 @@ proc ensureDirectories*(dataDir, tmpDir, logDir: string) =
   createDir(logDir)
 
 proc logHandlerCallback(messageType: cint, message: cstring, category: cstring, file: cstring, function: cstring, line: cint) {.cdecl, exportc.} =
+  # Initialize Nim GC stack bottom for foreign threads
+  # https://status-im.github.io/nim-style-guide/interop.html#calling-nim-code-from-other-languages
+  when declared(setupForeignThreadGc): 
+    setupForeignThreadGc()
+  when declared(nimGC_setStackBottom):
+    var locals {.volatile, noinit.}: pointer
+    locals = addr(locals)
+    nimGC_setStackBottom(locals)
+
   var text = $message
   let fileString = $file
 

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -89,7 +89,7 @@ proc logHandlerCallback(messageType: cint, message: cstring, category: cstring, 
   logScope:
     topics = "qt"
     text = $message
-    file = $file & ":" & $line
+    source_file = $file & ":" & $line
     function = $function
     category = $category
 

--- a/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
+++ b/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
@@ -64,6 +64,10 @@ DOS_API void DOS_CALL dos_qtwebview_initialize(void);
 
 DOS_API void DOS_CALL dos_qguiapplication_try_enable_threaded_renderer();
 
+typedef void (DOS_CALL *MessageHandlerCallback)(int type, const char* data, const char* category, const char* file, const char* func, int line);
+
+DOS_API void dos_installMessageHandler(MessageHandlerCallback logHandler);
+
 /// \brief Create a QGuiApplication
 /// \note The created QGuiApplication should be freed by calling dos_qguiapplication_delete()
 DOS_API void DOS_CALL dos_qguiapplication_create();

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -197,13 +197,13 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
         return;
     }
 
-    QByteArray localMsg = msg.toLocal8Bit();
+    auto localMessage = msg.toLocal8Bit();
+    const char* message = localMessage.constData();
     const char* category = context.category ? context.category : "";
     const char* file = context.file ? context.file : "";
     const char* function = context.function ? context.function : "";
-
     int messageType = int(type);
-    const char* message = localMsg.constData();
+
     messageHandlerCallback(messageType, message, category, file, function, context.line);
 }
 


### PR DESCRIPTION
Requires: https://github.com/status-im/nimqml/pull/58

## Description

Advantages:

1. QML/Qt logs will appear in file logs, not just terminal
2. Add timestamps to each message
3. Display with colour in terminal

Disadvantages:

1. The text has to be a `static[string]`. It means I have to put it to the
```nim
# possible:
let qtMessage = "binding loop" # coming from C++/QML as variable
warn "qt message", qtMessage

# not possible:
warn qtMessage
```

2. There's a file already in the log properties. Adding another one is a bit of a mess:
```
file=nim_status_client.nim:93 text="qrc:/imports/shared/stores/PermissionsStore.qml:98:9: Unable to assign [undefined] to QAbstractItemModel*" file=qrc:/imports/shared/stores/PermissionsStore.qml line=98
```

## Affected areas

logs

## Screenshot

<img width="2510" alt="image" src="https://github.com/status-im/status-desktop/assets/25482501/e690eb34-ab29-477a-bd64-93c6cce3cdb0">
