### PR TITLE
feat:[UI - Swap] Create new TokenSelector component

### DIFF
--- a/storybook/pages/SwapInputPanelPage.qml
+++ b/storybook/pages/SwapInputPanelPage.qml
@@ -30,12 +30,12 @@ SplitView {
         id: d
 
         readonly property SwapInputParamsForm swapInputParamsForm: SwapInputParamsForm {
-            selectedNetworkChainId: ctrlSelectedNetworkChainId.currentValue
+            selectedAccountAddress: ctrlAccount.currentValue ?? ""
+            selectedNetworkChainId: ctrlSelectedNetworkChainId.currentValue ?? -1
             fromTokensKey: ctrlFromTokensKey.text
             fromTokenAmount: ctrlFromTokenAmount.text
             toTokenKey: ctrlToTokenKey.text
             toTokenAmount: ctrlToTokenAmount.text
-            selectedAccountAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
         }
 
         readonly property SwapModalAdaptor adaptor: SwapModalAdaptor {
@@ -78,7 +78,11 @@ SplitView {
 
                 currencyStore: d.adaptor.currencyStore
                 flatNetworksModel: d.adaptor.swapStore.flatNetworks
-                processedAssetsModel: d.adaptor.processedAssetsModel
+                processedAssetsModel: d.adaptor.walletAssetsStore.groupedAccountAssetsModel
+
+                selectedNetworkChainId: d.swapInputParamsForm.selectedNetworkChainId
+                selectedAccountAddress: d.swapInputParamsForm.selectedAccountAddress
+                nonInteractiveTokensKey: receivePanel.selectedHoldingId
 
                 tokenKey: d.swapInputParamsForm.fromTokensKey
                 tokenAmount: d.swapInputParamsForm.fromTokenAmount
@@ -99,8 +103,12 @@ SplitView {
                 }
 
                 currencyStore: d.adaptor.currencyStore
-                flatNetworksModel: d.adaptor.filteredFlatNetworksModel
-                processedAssetsModel: d.adaptor.processedAssetsModel
+                flatNetworksModel: d.adaptor.swapStore.flatNetworks
+                processedAssetsModel: d.adaptor.walletAssetsStore.groupedAccountAssetsModel
+
+                selectedNetworkChainId: d.swapInputParamsForm.selectedNetworkChainId
+                selectedAccountAddress: d.swapInputParamsForm.selectedAccountAddress
+                nonInteractiveTokensKey: payPanel.selectedHoldingId
 
                 tokenKey: d.swapInputParamsForm.toTokenKey
                 tokenAmount: d.swapInputParamsForm.toTokenAmount
@@ -145,6 +153,24 @@ SplitView {
                     currentIndex: -1 // all chains
                 }
             }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Label { text: "Account:" }
+                ComboBox {
+                    Layout.fillWidth: true
+                    id: ctrlAccount
+                    textRole: "name"
+                    valueRole: "address"
+                    displayText: currentText || "All accounts"
+                    model: SortFilterProxyModel {
+                        sourceModel: d.adaptor.swapStore.accounts
+                        sorters: RoleSorter { roleName: "position" }
+                    }
+                    currentIndex: -1
+                }
+            }
+
 
             RowLayout {
                 Layout.fillWidth: true

--- a/storybook/pages/SwapModalPage.qml
+++ b/storybook/pages/SwapModalPage.qml
@@ -35,13 +35,6 @@ SplitView {
         function launchPopup() {
             swapModal.createObject(root)
         }
-        function getNetwork() {
-            let selectedChain = -1
-            if (networksComboBox.model.count > 0 && networksComboBox.currentIndex >= 0) {
-                selectedChain = ModelUtils.get(networksComboBox.model, networksComboBox.currentIndex, "chainId")
-            }
-            return selectedChain
-        }
 
         readonly property SwapTransactionRoutes dummySwapTransactionRoutes: SwapTransactionRoutes{}
     }
@@ -103,19 +96,11 @@ SplitView {
                 closePolicy: Popup.CloseOnEscape
                 destroyOnClose: true
                 swapInputParamsForm: SwapInputParamsForm {
-                    selectedAccountAddress: accountComboBox.currentValue ?? ""
-
-                    selectedNetworkChainId: d.getNetwork()
-                    fromTokensKey: fromTokenComboBox.currentValue
-                    fromTokenAmount: swapInput.text
-                    toTokenKey: toTokenComboBox.currentValue
                     onSelectedAccountAddressChanged: {
                         if (selectedAccountAddress !== accountComboBox.currentValue)
                             accountComboBox.currentIndex = accountComboBox.indexOfValue(selectedAccountAddress)
                     }
-                    Binding on selectedAccountAddress {
-                        value: accountComboBox.currentValue ?? ""
-                    }
+                    fromTokenAmount: swapInput.text
                 }
                 swapAdaptor: SwapModalAdaptor {
                     swapStore: dSwapStore
@@ -132,12 +117,27 @@ SplitView {
                 Binding {
                     target: swapInputParamsForm
                     property: "fromTokensKey"
-                    value: fromTokenComboBox.currentValue
+                    value: fromTokenComboBox.currentValue ?? ""
                 }
                 Binding {
                     target: swapInputParamsForm
                     property: "toTokenKey"
-                    value: toTokenComboBox.currentValue
+                    value: toTokenComboBox.currentValue ?? ""
+                }
+                Binding {
+                    target: swapInputParamsForm
+                    property: "selectedNetworkChainId"
+                    value: networksComboBox.currentValue ?? -1
+                }
+                Binding {
+                    target: swapInputParamsForm
+                    property: "selectedAccountAddress"
+                    value: accountComboBox.currentValue ?? ""
+                }
+                Binding {
+                    target: swapInputParamsForm
+                    property: "fromTokenAmount"
+                    value: swapInput.text
                 }
             }
         }
@@ -184,6 +184,7 @@ SplitView {
             ComboBox {
                 id: networksComboBox
                 textRole: "chainName"
+                valueRole: "chainId"
                 model: d.filteredNetworksModel
                 currentIndex: 0
                 onCountChanged: currentIndex = 0
@@ -201,7 +202,7 @@ SplitView {
 
             StatusInput {
                 id: swapInput
-                Layout.preferredWidth: 100
+                Layout.preferredWidth: 250
                 label: "Token amount to swap"
                 text: ""
             }

--- a/storybook/pages/TokenSelectorPage.qml
+++ b/storybook/pages/TokenSelectorPage.qml
@@ -1,0 +1,164 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
+
+import StatusQ.Core.Theme 0.1
+
+import Storybook 1.0
+import Models 1.0
+
+import SortFilterProxyModel 0.2
+
+import AppLayouts.Wallet.controls 1.0
+import AppLayouts.Wallet.stores 1.0
+import AppLayouts.Wallet.adaptors 1.0
+
+import shared.stores 1.0
+import utils 1.0
+
+SplitView {
+    id: root
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    QtObject {
+        id: d
+
+        readonly property var flatNetworks: NetworksModel.flatNetworks
+        readonly property var currencyStore: CurrenciesStore {}
+        readonly property var assetsStore: WalletAssetsStore {
+            id: thisWalletAssetStore
+            walletTokensStore: TokensStore {
+                plainTokensBySymbolModel: TokensBySymbolModel {}
+            }
+            readonly property var baseGroupedAccountAssetModel: GroupedAccountsAssetsModel {}
+            assetsWithFilteredBalances: thisWalletAssetStore.groupedAccountsAssetsModel
+        }
+
+        readonly property var walletAccountsModel: WalletAccountsModel {}
+
+        readonly property var adaptor: TokenSelectorViewAdaptor {
+            assetsModel: d.assetsStore.groupedAccountAssetsModel
+            flatNetworksModel: d.flatNetworks
+            currentCurrency: d.currencyStore.currentCurrency
+
+            enabledChainIds: ctrlNetwork.currentValue ? [ctrlNetwork.currentValue] : []
+            accountAddress: ctrlAccount.currentValue ?? ""
+            showCommunityAssets: ctrlShowCommunityAssets.checked
+            searchString: tokenSelector.searchString
+        }
+    }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        background: Rectangle {
+            color: Theme.palette.baseColor3
+        }
+
+        TokenSelector {
+            id: tokenSelector
+            anchors.centerIn: parent
+
+            nonInteractiveDelegateKey: ctrlNonInteractiveDelegateKey.text
+
+            model: d.adaptor.outputAssetsModel
+            onTokenSelected: (tokensKey) => {
+                                 console.warn("!!! TOKEN SELECTED:", tokensKey)
+                                 logs.logEvent("TokenSelector::onTokenSelected", ["tokensKey"], arguments)
+                             }
+            onActivated: ctrlSelectedAsset.currentIndex = ctrlSelectedAsset.indexOfValue(currentTokensKey)
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 320
+        SplitView.preferredHeight: 320
+
+        logsView.logText: logs.logText
+
+        RowLayout {
+            anchors.fill: parent
+
+            ColumnLayout {
+                RowLayout {
+                    Layout.fillWidth: true
+                    Label { text: "Selected asset:" }
+                    ComboBox {
+                        Layout.fillWidth: true
+                        id: ctrlSelectedAsset
+                        model: d.assetsStore.groupedAccountAssetsModel
+                        textRole: "name"
+                        valueRole: "tokensKey"
+                        displayText: currentText || "N/A"
+                        onActivated: tokenSelector.selectToken(currentValue)
+                    }
+                    TextField {
+                        id: ctrlNonInteractiveDelegateKey
+                        placeholderText: "Non interactive delegate token key"
+                    }
+                }
+
+                Button {
+                    text: "Reset"
+                    onClicked: {
+                        tokenSelector.reset()
+                        ctrlSelectedAsset.currentIndex = -1
+                        ctrlNonInteractiveDelegateKey.clear()
+                    }
+                }
+
+                Switch {
+                    id: ctrlShowCommunityAssets
+                    text: "Show community assets"
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    Label { text: "Network:" }
+                    ComboBox {
+                        Layout.fillWidth: true
+                        id: ctrlNetwork
+                        textRole: "chainName"
+                        valueRole: "chainId"
+                        displayText: currentText || "All networks"
+                        model: d.flatNetworks
+                        currentIndex: -1
+                    }
+                }
+                Label {
+                    Layout.alignment: Qt.AlignRight
+                    text: "Selected: %1".arg(ctrlNetwork.currentValue ? ctrlNetwork.currentValue.toString() : "All")
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    Label { text: "Account:" }
+                    ComboBox {
+                        Layout.fillWidth: true
+                        id: ctrlAccount
+                        textRole: "name"
+                        valueRole: "address"
+                        displayText: currentText || "All accounts"
+                        model: SortFilterProxyModel {
+                            sourceModel: d.walletAccountsModel
+                            sorters: RoleSorter { roleName: "position" }
+                        }
+                        currentIndex: -1
+                    }
+                }
+                Label {
+                    Layout.alignment: Qt.AlignRight
+                    text: "Selected: %1".arg(ctrlAccount.currentValue ?? "all")
+                }
+
+                Item { Layout.fillHeight: true }
+            }
+        }
+    }
+}
+
+// category: Controls
+
+// https://www.figma.com/design/TS0eQX9dAZXqZtELiwKIoK/Swap---Milestone-1?node-id=3406-231273&t=Ncl9lN1umbGEMxOn-0

--- a/storybook/qmlTests/tests/tst_TokenSelector.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelector.qml
@@ -1,0 +1,221 @@
+import QtQuick 2.15
+import QtTest 1.15
+import QtQml 2.15
+
+import Models 1.0
+
+import AppLayouts.Wallet.controls 1.0
+import AppLayouts.Wallet.stores 1.0
+import AppLayouts.Wallet.adaptors 1.0
+
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    QtObject {
+        id: d
+
+        readonly property var flatNetworks: NetworksModel.flatNetworks
+        readonly property var assetsStore: WalletAssetsStore {
+            id: thisWalletAssetStore
+            walletTokensStore: TokensStore {
+                plainTokensBySymbolModel: TokensBySymbolModel {}
+            }
+            readonly property var baseGroupedAccountAssetModel: GroupedAccountsAssetsModel {}
+            assetsWithFilteredBalances: thisWalletAssetStore.groupedAccountsAssetsModel
+        }
+
+        readonly property var adaptor: TokenSelectorViewAdaptor {
+            assetsModel: d.assetsStore.groupedAccountAssetsModel
+            flatNetworksModel: d.flatNetworks
+            currentCurrency: "USD"
+
+            Binding on searchString {
+                value: controlUnderTest ? controlUnderTest.searchString : ""
+                restoreMode: Binding.RestoreNone
+            }
+        }
+    }
+
+    Component {
+        id: componentUnderTest
+        TokenSelector {
+            anchors.centerIn: parent
+            model: d.adaptor.outputAssetsModel
+        }
+    }
+
+    SignalSpy {
+        id: signalSpy
+        target: controlUnderTest
+        signalName: "tokenSelected"
+    }
+
+    property TokenSelector controlUnderTest: null
+
+    TestCase {
+        name: "TokenSelector"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            signalSpy.clear()
+        }
+
+        function test_basicGeometry() {
+            verify(!!controlUnderTest)
+            verify(controlUnderTest.width > 0)
+            verify(controlUnderTest.height > 0)
+        }
+
+        function test_clickEthToken() {
+            verify(!!controlUnderTest)
+
+            mouseClick(controlUnderTest)
+            waitForItemPolished(controlUnderTest)
+
+            const listview = findChild(controlUnderTest.popup.contentItem, "tokenSelectorListview")
+            verify(!!listview)
+            waitForItemPolished(listview)
+
+            const tokensKey = "ETH"
+            const delegate = findChild(listview, "tokenSelectorAssetDelegate_%1".arg(tokensKey))
+            verify(!!delegate)
+            tryCompare(delegate, "tokensKey", tokensKey)
+
+            // click the delegate, verify the signal has been fired and has the correct "tokensKey" as argument
+            mouseClick(delegate)
+            tryCompare(signalSpy, "count", 1)
+            compare(signalSpy.signalArguments[0][0], tokensKey)
+            compare(controlUnderTest.currentTokensKey, tokensKey)
+
+            // close the popup, reopen and verify our token is highlighted
+            controlUnderTest.popup.close()
+            mouseClick(controlUnderTest)
+            tryCompare(controlUnderTest.popup, "opened", true)
+            tryCompare(delegate, "highlighted", true)
+        }
+
+        function test_clickNonInteractiveToken() {
+            verify(!!controlUnderTest)
+
+            const tokensKey = "STT"
+            controlUnderTest.nonInteractiveDelegateKey = tokensKey
+
+            mouseClick(controlUnderTest)
+            waitForItemPolished(controlUnderTest)
+
+            const listview = findChild(controlUnderTest.popup.contentItem, "tokenSelectorListview")
+            verify(!!listview)
+            waitForItemPolished(listview)
+
+            const delegate = findChild(listview, "tokenSelectorAssetDelegate_%1".arg(tokensKey))
+            verify(!!delegate)
+            tryCompare(delegate, "tokensKey", tokensKey)
+            tryCompare(delegate, "interactive", false)
+
+            mouseClick(delegate)
+            tryCompare(signalSpy, "count", 0)
+            tryCompare(controlUnderTest, "currentTokensKey", "")
+        }
+
+        function test_selectToken() {
+            verify(!!controlUnderTest)
+
+            const tokensKey = "STT"
+            controlUnderTest.selectToken(tokensKey)
+            tryCompare(signalSpy, "count", 1)
+            compare(signalSpy.signalArguments[0][0], tokensKey)
+            tryCompare(controlUnderTest, "currentTokensKey", tokensKey)
+
+            const listview = findChild(controlUnderTest.popup.contentItem, "tokenSelectorListview")
+            verify(!!listview)
+            mouseClick(controlUnderTest)
+            const delegate = findChild(listview, "tokenSelectorAssetDelegate_%1".arg(tokensKey))
+            verify(!!delegate)
+            tryCompare(delegate, "tokensKey", tokensKey)
+            tryCompare(delegate, "highlighted", true)
+        }
+
+        function test_selectNonexistingToken() {
+            verify(!!controlUnderTest)
+
+            const tokensKey = "0x6b175474e89094c44da98b954eedeac495271d0f" // MET
+
+            // not available by default
+            controlUnderTest.selectToken(tokensKey)
+            tryCompare(signalSpy, "count", 1)
+            compare(signalSpy.signalArguments[0][0], "")
+            tryCompare(controlUnderTest, "currentTokensKey", "")
+
+            // enable community assets, now should be available, try to select it
+            d.adaptor.showCommunityAssets = true
+            controlUnderTest.selectToken(tokensKey)
+            tryCompare(signalSpy, "count", 2)
+            compare(signalSpy.signalArguments[1][0], tokensKey)
+            tryCompare(controlUnderTest, "currentTokensKey", tokensKey)
+
+            // disable community assets to simulate token gone
+            d.adaptor.showCommunityAssets = false
+
+            // control should reset itself back
+            tryCompare(signalSpy, "count", 3)
+            compare(signalSpy.signalArguments[2][0], "")
+            tryCompare(controlUnderTest, "currentTokensKey", "")
+        }
+
+        function test_search() {
+            verify(!!controlUnderTest)
+
+            mouseClick(controlUnderTest)
+            waitForItemPolished(controlUnderTest)
+
+            const originalCount = controlUnderTest.count
+            verify(originalCount > 0)
+
+            // verify the search box has focus
+            const searchBox = findChild(controlUnderTest.popup.contentItem, "searchBox")
+            verify(!!searchBox)
+            tryCompare(searchBox.input.edit, "focus", true)
+
+            // type "dAi"
+            keyClick(Qt.Key_D)
+            keyClick(Qt.Key_A, Qt.ShiftModifier)
+            keyClick(Qt.Key_I)
+
+            // search yields 1 result
+            waitForItemPolished(controlUnderTest)
+            tryCompare(controlUnderTest, "count", 1)
+
+            // closing the popup should clear the search and put the view back to original count
+            controlUnderTest.popup.close()
+            mouseClick(controlUnderTest)
+            tryCompare(searchBox.input.edit, "text", "")
+            tryCompare(controlUnderTest, "count", originalCount)
+        }
+
+        function test_sections() {
+            verify(!!controlUnderTest)
+
+            d.adaptor.enabledChainIds = [10] // filter Optimism chain only
+
+            mouseClick(controlUnderTest)
+            waitForItemPolished(controlUnderTest)
+
+            const listview = findChild(controlUnderTest.popup.contentItem, "tokenSelectorListview")
+            verify(!!listview)
+            waitForItemPolished(listview)
+
+            const sttDelegate = findChild(listview, "tokenSelectorAssetDelegate_STT")
+            verify(!!sttDelegate)
+            tryCompare(sttDelegate, "tokensKey", "STT")
+            compare(sttDelegate.ListView.section, "Your assets on Optimism")
+
+            const ethDelegate = findChild(listview, "tokenSelectorAssetDelegate_ETH")
+            verify(!!ethDelegate)
+            tryCompare(ethDelegate, "tokensKey", "ETH")
+            compare(ethDelegate.ListView.section, "Popular assets")
+        }
+    }
+}

--- a/storybook/src/Models/GroupedAccountsAssetsModel.qml
+++ b/storybook/src/Models/GroupedAccountsAssetsModel.qml
@@ -19,11 +19,9 @@ ListModel {
                 { account: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", chainId: 1, balance: "122082928968121891" },
                 { account: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", chainId: 420, balance: "1013151281976507736" },
                 { account: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", chainId: 421613, balance: "473057568699284613" },
-                { account: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", chainId: 420, balance: "307400931315122839" },
                 { account: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", chainId: 11155111, balance: "307400931315122839" },
                 { account: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", chainId: 420, balance: "122082928968121891" },
                 { account: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", chainId: 421613, balance: "0" },
-                { account: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", chainId: 420, balance: "559133758939097000" }
             ]
         },
         {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -20,8 +20,8 @@ Item {
     property alias popup: comboBox.popup
 
     property alias currentIndex: comboBox.currentIndex
-    property alias currentValue: comboBox.currentValue
-    property alias currentText: comboBox.currentText
+    readonly property alias currentValue: comboBox.currentValue
+    readonly property alias currentText: comboBox.currentText
 
     property alias label: labelItem.text
     property alias validationError: validationErrorItem.text

--- a/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
@@ -23,6 +23,7 @@ QObject {
       - balances: submodel -> [ chainId:int, account:string, balance:BigIntString, iconUrl:string ]
 
       Computed values:
+      - currentBalance: double (amount of tokens)
       - currencyBalance: double (e.g. `1000.42` in user's fiat currency)
       - currencyBalanceAsString: string (e.g. "1 000,42 CZK" formatted as a string according to the user's locale)
       - balanceAsString: string (`1.42` formatted as e.g. "1,42" in user's locale)
@@ -63,11 +64,16 @@ QObject {
             }
         ]
 
-        // FIXME optionally sort/filter by wallet controller as well
         sorters: [
+            RoleSorter {
+                roleName: "sectionId"
+            },
             RoleSorter {
                 roleName: "currencyBalance"
                 sortOrder: Qt.DescendingOrder
+            },
+            RoleSorter {
+                roleName: "name"
             }
         ]
     }
@@ -93,6 +99,20 @@ QObject {
             readonly property string currencyBalanceAsString:
                 currencyBalance ? LocaleUtils.currencyAmountToLocaleString({amount: currencyBalance, symbol: root.currentCurrency, displayDecimals})
                                 : ""
+
+            readonly property string sectionId: {
+                if (root.enabledChainIds.length === 1) {
+                    return currentBalance ? "section_%1".arg(root.enabledChainIds[0]) : "section_zzz"
+                }
+                return ""
+            }
+            readonly property string sectionName: {
+                if (root.enabledChainIds.length === 1) {
+                    return currentBalance ? qsTr("Your assets on %1").arg(ModelUtils.getByKey(root.flatNetworksModel, "chainId", root.enabledChainIds[0], "chainName"))
+                                          : qsTr("Popular assets")
+                }
+                return ""
+            }
 
             readonly property var balances: this
 
@@ -160,7 +180,7 @@ QObject {
             }
         }
 
-        exposedRoles: ["balances", "currencyBalance", "currencyBalanceAsString", "balanceAsString"]
+        exposedRoles: ["balances", "currentBalance", "currencyBalance", "currencyBalanceAsString", "balanceAsString", "sectionId", "sectionName"]
         expectedRoles: ["communityId", "balances", "decimals", "marketDetails"]
     }
 }

--- a/ui/app/AppLayouts/Wallet/controls/EditSlippagePanel.qml
+++ b/ui/app/AppLayouts/Wallet/controls/EditSlippagePanel.qml
@@ -61,7 +61,7 @@ Control {
         StatusBaseText {
             Layout.fillWidth: true
             Layout.topMargin: -12
-            text: qsTr("Maximum deviation in price due to market volatility and liquidity allowed before the swap is cancelled. (0.5% default).")
+            text: qsTr("Maximum deviation in price due to market volatility and liquidity allowed before the swap is cancelled. (%L1% default).").arg(slippageSelector.defaultValue)
             wrapMode: Text.Wrap
             color: Theme.palette.directColor5
         }

--- a/ui/app/AppLayouts/Wallet/controls/MaxSendButton.qml
+++ b/ui/app/AppLayouts/Wallet/controls/MaxSendButton.qml
@@ -21,17 +21,10 @@ StatusButton {
 
     locale: LocaleUtils.userInputLocale
 
-    QtObject {
-        id: d
-
-        readonly property string maxInputBalanceFormatted:
-            root.formatCurrencyAmount(Math.trunc(root.maxSafeValue*100)/100, root.symbol)
-    }
-
     implicitHeight: 22
 
     type: valid ? StatusBaseButton.Type.Normal : StatusBaseButton.Type.Danger
-    text: qsTr("Max. %1").arg(value === 0 ? locale.zeroDigit : d.maxInputBalanceFormatted)
+    text: qsTr("Max. %1").arg(value === 0 ? locale.zeroDigit : root.formatCurrencyAmount(maxSafeValue, root.symbol))
 
     horizontalPadding: 8
     verticalPadding: 3

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -183,7 +183,9 @@ StatusComboBox {
             value: root.selection[0] ?? -1
         }
 
-        readonly property string singleSelectionIconUrl: singleSelectionItem.item.iconUrl ?? ""
+        readonly property string singleSelectionIconUrl: singleSelectionItem.item.iconUrl ? (singleSelectionItem.item.isTest ? singleSelectionItem.item.iconUrl + "-test"
+                                                                                                                             : singleSelectionItem.item.iconUrl)
+                                                                                          : ""
         readonly property string singleCelectionChainName: singleSelectionItem.item.chainName ?? ""
 
         readonly property string titleText: {

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -1,0 +1,212 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtGraphicalEffects 1.0
+
+import StatusQ 0.1
+import StatusQ.Components 0.1
+import StatusQ.Components.private 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import AppLayouts.Wallet.views 1.0
+
+import utils 1.0
+import shared.controls 1.0
+
+ComboBox {
+    id: root
+
+    // expected model structure:
+    // tokensKey, name, symbol, decimals, currencyBalanceAsString (computed), marketDetails, balances -> [ chainId, address, balance, iconUrl ]
+
+    // input API
+    property string nonInteractiveDelegateKey
+
+    // output API
+    readonly property string currentTokensKey: d.currentTokensKey
+    readonly property alias searchString: searchBox.text
+
+    /**
+      Emitted when a token gets selected
+      */
+    signal tokenSelected(string tokensKey)
+
+    // manipulation
+    function selectToken(tokensKey) {
+        const idx = ModelUtils.indexOf(model, "tokensKey", tokensKey)
+        if (idx === -1) {
+            console.warn("TokenSelector::selectToken: unknown tokensKey:", tokensKey)
+            tokensKey = ""
+        }
+
+        currentIndex = idx
+        d.currentTokensKey = tokensKey
+        root.tokenSelected(tokensKey)
+    }
+
+    function reset() {
+        selectToken("")
+    }
+
+    QtObject {
+        id: d
+
+        // NB: internal tracking; the ComboBox currentValue is not persistent,
+        // i.e. relying on currentValue is not safe
+        property string currentTokensKey
+
+        readonly property bool isTokenSelected: !!currentTokensKey
+
+        // NB: handle cases when our currently selected token disappears from the model -> reset
+        readonly property Connections _conn: Connections {
+            target: model ?? null
+            function onModelReset() {
+                if (d.isTokenSelected && !root.popup.opened)
+                    root.selectToken(d.currentTokensKey)
+            }
+            function onRowsRemoved() {
+                if (d.isTokenSelected && !root.popup.opened)
+                    root.selectToken(d.currentTokensKey)
+            }
+        }
+    }
+
+    font.family: Theme.palette.baseFont.name
+    font.pixelSize: Style.current.additionalTextSize
+    spacing: Style.current.halfPadding
+    verticalPadding: 10
+    leftPadding: 12
+    rightPadding: leftPadding + indicator.width + spacing
+    opacity: enabled ? 1 : 0.3
+
+    popup.width: 380
+    popup.x: root.width - popup.width
+    popup.y: root.height
+    popup.margins: Style.current.halfPadding
+    popup.background: Rectangle {
+        color: Theme.palette.statusSelect.menuItemBackgroundColor
+        radius: Style.current.radius
+        layer.enabled: true
+        layer.effect: DropShadow {
+            horizontalOffset: 0
+            verticalOffset: 4
+            radius: 12
+            samples: 25
+            spread: 0.2
+            color: Theme.palette.dropShadow
+        }
+    }
+    popup.contentItem: ColumnLayout {
+        spacing: 0
+        SearchBox {
+            Layout.fillWidth: true
+            id: searchBox
+            objectName: "searchBox"
+
+            input.leftPadding: root.leftPadding
+            input.rightPadding: root.leftPadding
+            minimumHeight: 56
+            maximumHeight: 56
+            placeholderText: qsTr("Search asset name or symbol")
+            input.showBackground: false
+            focus: visible
+            onVisibleChanged: if (!visible) input.edit.clear()
+        }
+        StatusDialogDivider {
+            Layout.fillWidth: true
+            visible: listview.count
+        }
+        StatusListView {
+            id: listview
+            objectName: "tokenSelectorListview"
+            Layout.fillWidth: true
+            Layout.preferredHeight: contentHeight
+            Layout.fillHeight: true
+
+            model: root.popup.visible ? root.delegateModel : null
+            currentIndex: root.highlightedIndex
+
+            section.property: "sectionName"
+            section.delegate: StatusBaseText {
+                required property string section
+                width: parent.width
+                elide: Text.ElideRight
+                text: section
+                color: Theme.palette.baseColor1
+                padding: Style.current.padding
+            }
+        }
+    }
+
+    background: StatusComboboxBackground {
+        border.width: 0
+        color: {
+            if (d.isTokenSelected)
+                return "transparent"
+            return root.hovered ? Theme.palette.primaryColor2 : Theme.palette.primaryColor3
+        }
+    }
+
+    contentItem: Loader {
+        height: 40 // by design
+        sourceComponent: d.isTokenSelected ? iconTextContentItem : textContentItem
+    }
+
+    indicator: StatusComboboxIndicator {
+        anchors.right: parent.right
+        anchors.rightMargin: root.leftPadding
+        anchors.verticalCenter: parent.verticalCenter
+        color: Theme.palette.primaryColor1
+    }
+
+    delegate: TokenSelectorAssetDelegate {
+        required property var model
+        required property int index
+
+        highlighted: tokensKey === d.currentTokensKey
+        interactive: tokensKey !== root.nonInteractiveDelegateKey
+
+        tokensKey: model.tokensKey
+        name: model.name
+        symbol: model.symbol
+        currencyBalanceAsString: model.currencyBalanceAsString
+        balancesModel: model.balances
+
+        onAssetSelected: (tokensKey) => root.selectToken(tokensKey)
+    }
+
+    Component {
+        id: textContentItem
+        StatusBaseText {
+            objectName: "holdingSelectorsContentItemText"
+            font.pixelSize: root.font.pixelSize
+            font.weight: Font.Medium
+            color: Theme.palette.primaryColor1
+            text: qsTr("Select asset")
+        }
+    }
+
+    Component {
+        id: iconTextContentItem
+        RowLayout {
+            readonly property string currentSymbol: d.isTokenSelected ? ModelUtils.getByKey(model, "tokensKey", d.currentTokensKey, "symbol")
+                                                                      : ""
+            spacing: root.spacing
+            StatusRoundedImage {
+                objectName: "holdingSelectorsTokenIcon"
+                Layout.preferredWidth: 20
+                Layout.preferredHeight: 20
+                image.source: Constants.tokenIcon(parent.currentSymbol)
+            }
+            StatusBaseText {
+                objectName: "holdingSelectorsContentItemText"
+                font.pixelSize: 28
+                color: root.hovered ? Theme.palette.blue : Theme.palette.darkBlue
+                text: parent.currentSymbol
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/controls/qmldir
+++ b/ui/app/AppLayouts/Wallet/controls/qmldir
@@ -18,3 +18,4 @@ ConnectedDappsButton 1.0 ConnectedDappsButton.qml
 CollectibleLinksTags 1.0 CollectibleLinksTags.qml
 SwapExchangeButton 1.0 SwapExchangeButton.qml
 EditSlippagePanel 1.0 EditSlippagePanel.qml
+TokenSelector 1.0 TokenSelector.qml

--- a/ui/imports/shared/controls/SlippageSelector.qml
+++ b/ui/imports/shared/controls/SlippageSelector.qml
@@ -8,6 +8,7 @@ Control {
     id: root
 
     property double value: d.defaultValue
+    readonly property double defaultValue: d.defaultValue
     readonly property bool valid: customInput.activeFocus && customInput.valid
                                   || buttons.value !== null
     readonly property bool isEdited: root.value !== d.defaultValue


### PR DESCRIPTION
### What does the PR do

- create new dedicated (asset) token selector component
- integrate it into `SwapInputPanel`, `SwapModalAdaptor` and `SwapModal`
- add respective SB page and QML tests suite

Fixes #14783

### Affected areas

TokenSelector, SwapInputPanel, SwapModal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

SwapModal:
![image](https://github.com/status-im/status-desktop/assets/5377645/29caf697-1b86-4b66-9e31-4f8e76ffce01)

SwapInputPanel:
![image](https://github.com/status-im/status-desktop/assets/5377645/37415830-a0d5-4ba3-8f1c-9c4b81403f73)

TokenSelector:
![image](https://github.com/status-im/status-desktop/assets/5377645/22ff0718-d477-4455-9fd4-8423165297eb)
