### PR TITLE
fix: Improve code snippets display in chats

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -69,6 +69,43 @@ Item {
 
             return Utils.getMessageWithStyle(formattedMessage)
         }
+
+        function highlightCodeBlocks(text) {
+            var codeBlockPattern = /```([^`]+)```/g;
+
+            text = text.replace(/<code>([\s\S]+?)<\/code>/g, function(match, codeBlock) {
+                return '```' + codeBlock + '```';
+            });
+
+            var highlightedText = text.replace(codeBlockPattern, function(match, codeBlock) {
+                var codeBlock = addLineSpaces(codeBlock)
+                return "<pre style=\"background-color:" + Theme.palette.baseColor2 + "; padding: 10px;\"><code>" +
+                    highlightSyntax(codeBlock) + "</code></pre>";
+            });
+            return highlightedText.replace(/\n/g, "<br>");
+        }
+
+        function addLineSpaces(code) {
+            return code.split("\n")
+                    .map((line, index) => index === 0 ? `\n ${line}` : ` ${line}`)
+                    .join("\n");
+        }
+
+        function highlightSyntax(code) {
+            var keywords = "\\b(abstract|arguments|await|boolean|break|byte|case|catch|char|class|const|continue|" +
+                        "debugger|default|delete|do|double|else|enum|eval|export|extends|false|final|finally|float|" +
+                        "for|function|goto|if|implements|import|in|instanceof|int|interface|let|long|native|new|null|" +
+                        "package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|" +
+                        "throws|transient|true|try|typeof|var|void|volatile|while|with|yield|" +
+                        "uint32_t|uint64_t|void|char|float|double|bool|long|short|int|" +
+                        "signed|unsigned|const|volatile|static|inline|extern|mutable|class|struct|namespace|using|public|private|protected|virtual|template|typename|new|delete|sizeof|define)\\b";
+            var strings = /'[^']*'|"[^"]*"|`[^`]*`/g;
+
+            code = code.replace(strings, '<span style="color: green;">$&</span>');
+            code = code.replace(new RegExp(keywords, 'g'), '<span style="color: brown;">$1</span>');
+
+            return code;
+        }
     }
 
     Rectangle {
@@ -92,7 +129,7 @@ Item {
         anchors.leftMargin: d.isQuote ? 8 : 0
         anchors.right: parent.right
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
-        text: d.text
+        text: d.highlightCodeBlocks(d.text)
         selectedTextColor: Theme.palette.directColor1
         selectionColor: Theme.palette.primaryColor3
         color: d.isQuote ? Theme.palette.baseColor1 : Theme.palette.directColor1


### PR DESCRIPTION
### What does the PR do

It is sometimes hard to read certain messages containing code snippets or block of texts, logs, etc. in Status app chat. This can be prevent a user to use Status desktop or even consider the Status app for exchanges involving a lot of code snippets or blocks of text. The following PR is an attempt to reduce friction with displaying code snippets/block of text.

Please take a look at the following example : 

**BEFORE**

![Screenshot from 2024-06-18 23-47-10](https://github.com/status-im/status-desktop/assets/2589171/b42e3c3a-cc91-46bf-85e9-b7586c31963a)

**AFTER - LIGHT**

**Example**

![Screenshot from 2024-06-18 23-47-07](https://github.com/status-im/status-desktop/assets/2589171/b33ab03a-814c-48a8-bbb5-70a1d9e14b36)

**AFTER - DARK**

![Screenshot from 2024-06-19 00-07-19](https://github.com/status-im/status-desktop/assets/2589171/02c5bdbd-4e3f-4e7f-9b8a-d3c1ac0382b9)

**Other examples... feel free to resquest for more**

![Screenshot from 2024-06-18 23-36-39](https://github.com/status-im/status-desktop/assets/2589171/489beec9-7460-4083-ad32-dc0caf0a34b6)


### Affected areas

- Chat message display
