### PR TITLE
Chore/enable qt logging rules

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -82,6 +82,12 @@ pipeline {
 
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
     /* STATUS_RUNTIME_TEST_MODE = 'True' */
+
+    /* Logging rules let you enable or disable logging for categories */
+    QT_LOGGING_RULES = '*.warning=true'
+    
+    /* Set to a non-zero value to make Qt print out diagnostic information about the each (C++) plugin it tries to load. */
+    QT_DEBUG_PLUGINS = 0
   }
 
   stages {

--- a/test/e2e/driver/aut.py
+++ b/test/e2e/driver/aut.py
@@ -1,3 +1,5 @@
+import time
+
 import allure
 import logging
 import cv2
@@ -117,6 +119,7 @@ class AUT:
         LOG.info('Stopping AUT: %s', self.path)
         self.detach_context()
         local_system.kill_process(self.pid)
+        time.sleep(1)
 
     @allure.step("Start and attach AUT")
     def launch(self) -> 'AUT':

--- a/test/e2e/driver/server.py
+++ b/test/e2e/driver/server.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import typing
 
 import configs.testpath
@@ -43,6 +44,7 @@ class SquishServer:
             return
         LOG.info('Stopping Squish Server with PID: %d', cls.pid)
         local_system.kill_process(cls.pid)
+        time.sleep(1)
         cls.pid = None
         cls.port = None
 


### PR DESCRIPTION
### What does the PR do

- add env vars to help with debugging QT issues
- add small time sleep after we kill the process to let it go completely

