### PR TITLE
e2e: specify linux plugin platform for QT

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -76,6 +76,9 @@ pipeline {
 
     TESTRAIL_URL = 'https://ethstatus.testrail.net'
     TESTRAIL_PROJECT_ID = 17
+    /* Override QT xcb plugin with linux to avoid errors like:
+     * "Could not load the Qt platform plugin "xcb" in "" even though it was found." */
+    QT_QPA_PLATFORM = "linuxfb"
 
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
     /* STATUS_RUNTIME_TEST_MODE = 'True' */


### PR DESCRIPTION
## Summary

In this PR we specify `QT_QPA_PLATFORM` to  `linuxfb`
reference -> https://doc.qt.io/qt-5/embedded-linux.html#linuxfb
This ensures we do not rely on `xcb` for e2e tests on linux hosts. 

Helps us fix the following error : 
```
"Could not load the Qt platform plugin "xcb" in "" even though it was found."
```


fixes: #13811
