### PR TITLE
tests: test for adding account from settings is disabled

### DIFF
--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -20,6 +20,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/edit/703598',
                  'Add new account from wallet settings screen')
 @pytest.mark.case(703598)
+@pytest.mark.skip
 @pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
 @pytest.mark.parametrize('account_name, color, emoji, emoji_unicode',
                          [

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -20,7 +20,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/edit/703598',
                  'Add new account from wallet settings screen')
 @pytest.mark.case(703598)
-@pytest.mark.skip
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15286')
 @pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
 @pytest.mark.parametrize('account_name, color, emoji, emoji_unicode',
                          [


### PR DESCRIPTION
### What does the PR do

Disable add account test because the app segfaults with the following error

```
Critical: Error parsing my revealed addresses SyntaxError: JSON.parse: Parse error (qrc:/app/AppLayouts/stores/RootStore.qml:54, expression for myRevealedAddressesForCurrentCommunity)
```

I logged https://github.com/status-im/status-desktop/issues/15286 to investigate

### Affected areas

end-to-end tests

