### PR TITLE
Timeout for tests added so hanging test fail after timeout rather then stuck forever

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -83,7 +83,7 @@ pipeline {
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
     /* STATUS_RUNTIME_TEST_MODE = 'True' */
 
-    QT_LOGGING_RULES = '*.warning=true;qt.qpa.*info=true'
+    QT_LOGGING_RULES = '*.warning=true'
     QT_DEBUG_PLUGINS = 1
   }
 

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -82,6 +82,8 @@ pipeline {
 
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
     /* STATUS_RUNTIME_TEST_MODE = 'True' */
+
+    QT_LOGGING_RULES='*.warning=true'
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -82,10 +82,6 @@ pipeline {
 
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
     /* STATUS_RUNTIME_TEST_MODE = 'True' */
-
-    QT_LOGGING_RULES = '*.warning=true'
-    QT_DEBUG_PLUGINS = 1
-    QT_QPA_PLATFORM_PLUGIN_PATH = '/opt/qt/5.15.2/gcc_64/plugins'
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -83,7 +83,8 @@ pipeline {
     /* Runtime flag to make testing of the app easier.  Switched off: unpredictable app behavior under new tests */
     /* STATUS_RUNTIME_TEST_MODE = 'True' */
 
-    QT_LOGGING_RULES='*.warning=true'
+    QT_LOGGING_RULES = '*.warning=true;qt.qpa.*info=true'
+    QT_DEBUG_PLUGINS = 1
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -85,6 +85,7 @@ pipeline {
 
     QT_LOGGING_RULES = '*.warning=true'
     QT_DEBUG_PLUGINS = 1
+    QT_QPA_PLATFORM_PLUGIN_PATH = '/opt/qt/5.15.2/gcc_64/plugins'
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -161,9 +161,10 @@ pipeline {
           ]) {
             /* Keep the --reruns flag first, or it won't work */
             sh """
-              python3 -m pytest --reruns=1 ${flags.join(" ")} \
+              python3 -m pytest --reruns=1 --timeout=180 ${flags.join(" ")} \
                 --disable-warnings \
-                --alluredir=./allure-results
+                --alluredir=./allure-results \
+                -o timeout_func_only=true
             """
           }
         }


### PR DESCRIPTION
CI run:
here I checked that it works and test is timing out on permissions tests which was broken and stuck forever (used old build)
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2164/allure/#suites/ea35bd66d78deeec4a096260dd1d8144/991d57c78fc381bd

here I ran all tests to make sure all works good for all tests (actual master build)
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2168/

After investigating I came to the conclusion that the best option to cover any issues (not only when the app crashes and stuck forever, but other possible cases which causes hanging tests too) is to set global timeout using pytest-timeout. 

So when it's set globally, test would fail in case test execution takes more than 3 minutes, but test run will continue. It also works for hanging tests until we don't find the reason.

The problem was to combine it with rerun. It turned out that they are incompatible. So I was looking for a way to combine it. After investigation 2 options were found and tested and one of them implemented.

-o timeout_func_only=true - in this case they are not conflicting and also timeout set for both attempts