### PR TITLE
fix(community): community tokens disappear when minting of a new token is finished

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -333,6 +333,12 @@ proc createCommunitySectionItem[T](self: Module[T], communityDetails: CommunityD
     # We will update the model later when we finish loading the accounts
     self.controller.asyncGetRevealedAccountsForAllMembers(communityDetails.id)
 
+    # If there are tokens already in the model, we should keep the existing community tokens, until
+    # getCommunityTokensDetailsAsync will trigger onCommunityTokensDetailsLoaded
+    let existingCommunity = self.view.model().getItemById(communityDetails.id)
+    if not existingCommunity.isEmpty() and not existingCommunity.communityTokens.isNil:
+      communityTokensItems = existingCommunity.communityTokens.items
+
   let (unviewedCount, notificationsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
     communityDetails.id,
     communityDetails.muted,


### PR DESCRIPTION
fixes #15076

### What does the PR do
When a new token is minted and `SIGNAL_COMMUNITIES_UPDATE` is emitted, we recreate the `SectionItem` with the updated `CommunityDto`.
After this, `SectionItem.communityTokens` is empty and will be retrieved asynchronously via `getCommunityTokensDetailsAsync`.
In this PR, old `communityTokens` are kept until `onCommunityTokensDetailsLoaded` updates the tokens.

### Affected areas
Communities

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/11d44e03-849e-4adf-9819-f5c8bec52e7a


https://github.com/status-im/status-desktop/assets/1083341/739bd549-d703-4869-b971-63e8d45986ca


