### PR TITLE
Fixes for mint owner token test

### DIFF
--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -105,11 +105,12 @@ o_Flickable = {"container": mainWindow_OwnerTokenWelcomeView, "type": "Flickable
 mainWindow_editOwnerTokenView_EditOwnerTokenView = {"container": mainWindow_StatusWindow, "id": "editOwnerTokenView", "type": "EditOwnerTokenView", "unnamed": 1, "visible": True}
 editOwnerTokenView_Flickable = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "Flickable", "unnamed": 1, "visible": True}
 editOwnerTokenView_CustomComboItem = {"checkable": False, "container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "CustomComboItem", "unnamed": 1, "visible": True}
-editOwnerTokenView_comboBox_ComboBox = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "id": "comboBox", "occurrence": 2, "type": "ComboBox", "unnamed": 1, "visible": True}
+editOwnerTokenView_netFilter_NetworkFilter = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "netFilter", "type": "NetworkFilter", "visible": True}
+editOwnerTokenView_comboBox_ComboBox = {"container": editOwnerTokenView_netFilter_NetworkFilter, "id": "comboBox", "occurrence": 2, "type": "ComboBox", "unnamed": 1, "visible": True}
 mainnet_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_overlay, "index": 0, "objectName": "Mainnet", "type": "NetworkSelectItemDelegate", "visible": True}
 optimism_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_overlay, "index": 1, "objectName": "Optimism", "type": "NetworkSelectItemDelegate", "visible": True}
 arbitrum_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_overlay, "index": 2, "objectName": "Arbitrum", "type": "NetworkSelectItemDelegate", "visible": True}
-editOwnerTokenView_Mint_StatusButton = {"checkable": False, "container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "StatusButton", "unnamed": 1, "visible": True}
+editOwnerTokenView_Mint_StatusButton = {"checkable": False, "container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "mintButton", "type": "StatusButton", "visible": True}
 editOwnerTokenView_FeeRow = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "FeeRow", "unnamed": 1, "visible": True}
 editOwnerTokenView_fees_StatusBaseText = {"container": editOwnerTokenView_FeeRow, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 

--- a/test/e2e/gui/screens/community_settings_tokens.py
+++ b/test/e2e/gui/screens/community_settings_tokens.py
@@ -147,6 +147,7 @@ class EditOwnerTokenView(QObject):
         super(EditOwnerTokenView, self).__init__(communities_names.mainWindow_editOwnerTokenView_EditOwnerTokenView)
         self._scroll = Scroll(communities_names.editOwnerTokenView_Flickable)
         self._select_account_combobox = QObject(communities_names.editOwnerTokenView_CustomComboItem)
+        self._select_network_filter = QObject(communities_names.editOwnerTokenView_netFilter_NetworkFilter)
         self._select_network_combobox = QObject(communities_names.editOwnerTokenView_comboBox_ComboBox)
         self._mainnet_network_item = QObject(communities_names.mainnet_NetworkSelectItemDelegate)
         self._mint_button = Button(communities_names.editOwnerTokenView_Mint_StatusButton)
@@ -254,9 +255,9 @@ class EditOwnerTokenView(QObject):
 
     @allure.step('Select Mainnet network')
     def select_mainnet_network(self, attempts: int = 2):
-        if not self._select_network_combobox.is_visible:
-            self._scroll.vertical_down_to(self._select_network_combobox)
-        self._select_network_combobox.click()
+        if not self._select_network_filter.is_visible:
+            self._scroll.vertical_down_to(self._select_network_filter)
+        self._select_network_filter.click()
         try:
             self._mainnet_network_item.wait_until_appears()
             self._mainnet_network_item.click()

--- a/test/e2e/tests/communities/test_communities_mint_owner_token.py
+++ b/test/e2e/tests/communities/test_communities_mint_owner_token.py
@@ -117,7 +117,7 @@ def test_mint_owner_token(keys_screen, main_window, user_account):
             assert edit_owner_token_view.get_destructible_box_content(1) == 'Yes'
 
     with step('Select Mainnet network'):
-        select_network = edit_owner_token_view.select_mainnet_network()
+        edit_owner_token_view.select_mainnet_network()
 
     with step('Verify fees title and gas fees exist'):
         assert driver.waitFor(lambda: edit_owner_token_view.get_fee_title == 'Mint ' + community_params[

--- a/ui/app/AppLayouts/Communities/views/EditOwnerTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditOwnerTokenView.qml
@@ -220,6 +220,7 @@ StatusScrollView {
             Layout.bottomMargin: Style.current.padding
 
             enabled: root.feeText && !root.feeErrorText
+            objectName: "mintButton"
             text: qsTr("Mint")
 
             onClicked: root.mintClicked()
@@ -272,6 +273,7 @@ StatusScrollView {
 
         NetworkFilter {
             id: netFilter
+            objectName: "netFilter"
 
             Layout.fillWidth: true
 


### PR DESCRIPTION
### What does the PR do

Fixed mint owner test, so now it should always scroll to the objects, added object names

CI run: https://ci.status.im/job/status-desktop/job/e2e/job/manual/2148/

### Affected areas
test/e2e/tests/communities/test_communities_mint_owner_token.py
ui/app/AppLayouts/Communities/views/EditOwnerTokenView.qml