### PR TITLE
Fixes for mint owner token test

### DIFF
--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -110,6 +110,10 @@ editOwnerTokenView_comboBox_ComboBox = {"container": editOwnerTokenView_netFilte
 mainnet_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_overlay, "index": 0, "objectName": "Mainnet", "type": "NetworkSelectItemDelegate", "visible": True}
 optimism_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_overlay, "index": 1, "objectName": "Optimism", "type": "NetworkSelectItemDelegate", "visible": True}
 arbitrum_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_overlay, "index": 2, "objectName": "Arbitrum", "type": "NetworkSelectItemDelegate", "visible": True}
+optimism_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionRadioButton_Optimism", "type": "StatusRadioButton", "visible": True}
+mainnet_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionRadioButton_Mainnet", "type": "StatusRadioButton", "visible": True}
+arbitrum_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionRadioButton_Arbitrum", "type": "StatusRadioButton", "visible": True}
+
 editOwnerTokenView_Mint_StatusButton = {"checkable": False, "container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "mintButton", "type": "StatusButton", "visible": True}
 editOwnerTokenView_FeeRow = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "FeeRow", "unnamed": 1, "visible": True}
 editOwnerTokenView_fees_StatusBaseText = {"container": editOwnerTokenView_FeeRow, "type": "StatusBaseText", "unnamed": 1, "visible": True}
@@ -122,6 +126,7 @@ editOwnerTokenView_remainingBox = {"container": mainWindow_editOwnerTokenView_Ed
 editOwnerTokenView_transferableBox = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "transferableBox", "type": "CustomPreviewBox", "visible": True}
 editOwnerTokenView_destructibleBox = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "destructibleBox", "type": "CustomPreviewBox", "visible": True}
 editOwnerTokenView_token_sale_icon_StatusIcon = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "token-sale-icon", "type": "StatusIcon", "visible": True}
+editOwnerTokenView_Fees_FeesBox = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "FeesBox", "unnamed": 1, "visible": True}
 
 # Minted tokens view
 mainWindow_MintedTokensView = {"container": mainWindow_StatusWindow, "type": "MintedTokensView", "unnamed": 1, "visible": True}

--- a/test/e2e/gui/screens/community_settings_tokens.py
+++ b/test/e2e/gui/screens/community_settings_tokens.py
@@ -7,6 +7,7 @@ import driver
 from constants.community_settings import MintOwnerTokensElements
 from gui.components.sign_transaction_popup import SignTransactionPopup
 from gui.elements.button import Button
+from gui.elements.check_box import CheckBox
 from gui.elements.object import QObject
 from gui.elements.scroll import Scroll
 from gui.elements.text_label import TextLabel
@@ -149,7 +150,7 @@ class EditOwnerTokenView(QObject):
         self._select_account_combobox = QObject(communities_names.editOwnerTokenView_CustomComboItem)
         self._select_network_filter = QObject(communities_names.editOwnerTokenView_netFilter_NetworkFilter)
         self._select_network_combobox = QObject(communities_names.editOwnerTokenView_comboBox_ComboBox)
-        self._mainnet_network_item = QObject(communities_names.mainnet_NetworkSelectItemDelegate)
+        self._mainnet_network_item = CheckBox(communities_names.mainnet_StatusRadioButton)
         self._mint_button = Button(communities_names.editOwnerTokenView_Mint_StatusButton)
         self._fees_text_object = TextLabel(communities_names.editOwnerTokenView_fees_StatusBaseText)
         self._crown_icon = QObject(communities_names.editOwnerTokenView_crown_icon_StatusIcon)
@@ -160,6 +161,7 @@ class EditOwnerTokenView(QObject):
         self._transferable_box = QObject(communities_names.editOwnerTokenView_transferableBox)
         self._destructible_box = QObject(communities_names.editOwnerTokenView_destructibleBox)
         self._edit_owner_token_text_object = TextLabel(communities_names.editOwnerTokenView_Owner_StatusBaseText)
+        self._fees_box = QObject(communities_names.editOwnerTokenView_Fees_FeesBox)
 
     @property
     @allure.step('Get fee title')
@@ -255,8 +257,8 @@ class EditOwnerTokenView(QObject):
 
     @allure.step('Select Mainnet network')
     def select_mainnet_network(self, attempts: int = 2):
-        if not self._select_network_filter.is_visible:
-            self._scroll.vertical_down_to(self._select_network_filter)
+        if not self._fees_box.is_visible:
+            self._scroll.vertical_down_to(self._fees_box)
         self._select_network_filter.click()
         try:
             self._mainnet_network_item.wait_until_appears()


### PR DESCRIPTION
### What does the PR do

Fix mint owner test

- It failed because locators for select network options have changed.  Now it's fixed
- Also I changed object we are scrolling to, just to make sure that select network combobox is always visible (for some reason sometimes it was not)

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2181/