### PR TITLE
Fix for community name

### DIFF
--- a/test/e2e/tests/communities/test_communities_categories.py
+++ b/test/e2e/tests/communities/test_communities_categories.py
@@ -87,7 +87,7 @@ def test_create_edit_remove_community_category(main_screen: MainWindow, category
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
 def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
-        community_screen = main_screen.left_panel.select_community('Super community')
+        community_screen = main_screen.left_panel.select_community('Community with 2 users')
 
     with step('Verify that member cannot add category'):
         with step('Verify that create channel or category button is not present'):

--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -84,7 +84,7 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
 def test_member_role_cannot_add_edit_and_delete_channels(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
-        community_screen = main_screen.left_panel.select_community('Super community')
+        community_screen = main_screen.left_panel.select_community('Community with 2 users')
     with step('Verify that member cannot add new channel'):
         with step('Verify that create channel or category button is not present'):
             assert not community_screen.left_panel.does_create_channel_or_category_button_exist()


### PR DESCRIPTION
Fixed community name to one from user data

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2185/allure/#suites/804b25da7c0d1c4c7f8a050c6a89e043/7185f754fe8983f1/

(1 fail - mint owner token, fixed in another PR, 1 - slow contact requests)