### PR TITLE
fix(airdrop): Incorrect default amount when airdropping a community token or setting token permission

### DIFF
--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -42,8 +42,8 @@ Input {
         const amountNumber = SQUtils.AmountsArithmetic.toNumber(
                                amount, multiplierIndex)
 
-        root.text = LocaleUtils.numberToLocaleString(amountNumber, -1,
-                                                     root.locale)
+        const precision = LocaleUtils.fractionalPartLength(amountNumber)
+        root.text = LocaleUtils.numberToLocaleString(amountNumber, precision, root.locale)
     }
 
     onTextChanged: d.validate()


### PR DESCRIPTION
(regression after https://github.com/status-im/status-desktop/commit/a12a6a4894c087a3c3ffac23b97cc457570656c1)

fixes #15264 

### What does the PR do

Restores the old approach:
When calling `LocaleUtils.numberToLocaleString`, calculates number precision for amount text based on `fractionalPartLength`

As far as I can see, `multiplierIndex` for collectibles is always 0. Previously the default `precision` was -1, which made the effective precision value for collectibles 0. 
```
    function numberToLocaleString(num, precision = -1, locale = null) {
        locale = locale || Qt.locale()

        if (precision === -1)
            precision = fractionalPartLength(num)

        return num.toLocaleString(locale, 'f', precision)
    }
```

After changing it to -128, the resulting string became 1000000.
```
    function numberToLocaleString(num, precision = -128 /* QLocale::FloatingPointShortest */, locale = null) {
        locale = locale || Qt.locale()

        return num.toLocaleString(locale, 'f', precision)
    }
```

If there is another preferred approach, please let me know
### Affected areas
AmountInput -> Airdrops, Permissions

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/1083341/cefbab1e-4b73-4a9e-8626-6d203a441d48
