### PR TITLE
feat: SwapModal UI fixes

### DIFF
--- a/storybook/pages/SwapInputPanelPage.qml
+++ b/storybook/pages/SwapInputPanelPage.qml
@@ -26,6 +26,31 @@ SplitView {
 
     Logs { id: logs }
 
+    ListModel {
+        id: plainTokensModel
+        ListElement {
+            key: "aave"
+            name: "Aave"
+            symbol: "AAVE"
+            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
+            communityId: ""
+        }
+        ListElement {
+            key: "usdc"
+            name: "USDC"
+            symbol: "USDC"
+            image: ""
+            communityId: ""
+        }
+        ListElement {
+            key: "hst"
+            name: "Decision Token"
+            symbol: "HST"
+            image: "https://etherscan.io/token/images/horizonstate2_28.png"
+            communityId: ""
+        }
+    }
+
     QtObject {
         id: d
 
@@ -80,6 +105,7 @@ SplitView {
                 currencyStore: d.adaptor.currencyStore
                 flatNetworksModel: d.adaptor.swapStore.flatNetworks
                 processedAssetsModel: d.adaptor.walletAssetsStore.groupedAccountAssetsModel
+                plainTokensBySymbolModel: plainTokensModel
 
                 selectedNetworkChainId: d.swapInputParamsForm.selectedNetworkChainId
                 selectedAccountAddress: d.swapInputParamsForm.selectedAccountAddress
@@ -106,6 +132,7 @@ SplitView {
                 currencyStore: d.adaptor.currencyStore
                 flatNetworksModel: d.adaptor.swapStore.flatNetworks
                 processedAssetsModel: d.adaptor.walletAssetsStore.groupedAccountAssetsModel
+                plainTokensBySymbolModel: plainTokensModel
 
                 selectedNetworkChainId: d.swapInputParamsForm.selectedNetworkChainId
                 selectedAccountAddress: d.swapInputParamsForm.selectedAccountAddress
@@ -201,7 +228,6 @@ SplitView {
                 TextField {
                     Layout.fillWidth: true
                     id: ctrlToTokenKey
-                    text: "STT"
                 }
             }
             RowLayout {

--- a/storybook/pages/TokenSelectorAssetDelegatePage.qml
+++ b/storybook/pages/TokenSelectorAssetDelegatePage.qml
@@ -12,9 +12,9 @@ import StatusQ.Core.Utils 0.1
 import Storybook 1.0
 import Models 1.0
 
-import SortFilterProxyModel 0.2
-
 import AppLayouts.Wallet.views 1.0
+
+import utils 1.0
 
 SplitView {
     id: root
@@ -46,6 +46,7 @@ SplitView {
                 name: "Ethereum"
                 symbol: "ETH"
                 currencyBalanceAsString: "14,456.42 USD"
+                iconSource: Constants.tokenIcon(symbol)
                 balancesModel: ListModel {
                     readonly property var data: [
                         { chainId: 1, balanceAsString: "1234.50", iconUrl: "network/Network=Ethereum" },

--- a/storybook/pages/TokenSelectorPage.qml
+++ b/storybook/pages/TokenSelectorPage.qml
@@ -23,6 +23,31 @@ SplitView {
 
     Logs { id: logs }
 
+    ListModel {
+        id: plainTokensModel
+        ListElement {
+            key: "aave"
+            name: "Aave"
+            symbol: "AAVE"
+            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
+            communityId: ""
+        }
+        ListElement {
+            key: "usdc"
+            name: "USDC"
+            symbol: "USDC"
+            image: ""
+            communityId: ""
+        }
+        ListElement {
+            key: "hst"
+            name: "Decision Token"
+            symbol: "HST"
+            image: "https://etherscan.io/token/images/horizonstate2_28.png"
+            communityId: ""
+        }
+    }
+
     QtObject {
         id: d
 
@@ -41,9 +66,11 @@ SplitView {
 
         readonly property var adaptor: TokenSelectorViewAdaptor {
             assetsModel: d.assetsStore.groupedAccountAssetsModel
+            plainTokensBySymbolModel: plainTokensModel
             flatNetworksModel: d.flatNetworks
             currentCurrency: d.currencyStore.currentCurrency
 
+            showAllTokens: ctrlShowAllTokens.checked
             enabledChainIds: ctrlNetwork.currentValue ? [ctrlNetwork.currentValue] : []
             accountAddress: ctrlAccount.currentValue ?? ""
             showCommunityAssets: ctrlShowCommunityAssets.checked
@@ -75,8 +102,8 @@ SplitView {
     }
 
     LogsAndControlsPanel {
-        SplitView.minimumHeight: 320
-        SplitView.preferredHeight: 320
+        SplitView.minimumHeight: 340
+        SplitView.preferredHeight: 340
 
         logsView.logText: logs.logText
 
@@ -111,6 +138,15 @@ SplitView {
                     }
                 }
 
+                Switch {
+                    id: ctrlShowAllTokens
+                    text: "Show all tokens"
+                    onToggled: {
+                        // NB: ComboBox doesn't like changing models at runtime
+                        tokenSelector.model = null
+                        tokenSelector.model = d.adaptor.outputAssetsModel
+                    }
+                }
                 Switch {
                     id: ctrlShowCommunityAssets
                     text: "Show community assets"

--- a/storybook/pages/TokenSelectorViewPage.qml
+++ b/storybook/pages/TokenSelectorViewPage.qml
@@ -27,6 +27,31 @@ SplitView {
 
     Logs { id: logs }
 
+    ListModel {
+        id: plainTokensModel
+        ListElement {
+            key: "aave"
+            name: "Aave"
+            symbol: "AAVE"
+            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
+            communityId: ""
+        }
+        ListElement {
+            key: "usdc"
+            name: "USDC"
+            symbol: "USDC"
+            image: ""
+            communityId: ""
+        }
+        ListElement {
+            key: "hst"
+            name: "Decision Token"
+            symbol: "HST"
+            image: "https://etherscan.io/token/images/horizonstate2_28.png"
+            communityId: ""
+        }
+    }
+
     QtObject {
         id: d
 
@@ -69,10 +94,12 @@ SplitView {
 
         readonly property var adaptor: TokenSelectorViewAdaptor {
             assetsModel: d.assetsStore.groupedAccountAssetsModel
+            plainTokensBySymbolModel: plainTokensModel
             flatNetworksModel: d.flatNetworks
             enabledChainIds: d.enabledChainIds
             currentCurrency: d.currencyStore.currentCurrency
 
+            showAllTokens: ctrlShowAllTokens.checked
             accountAddress: ctrlAccount.currentValue ?? ""
             showCommunityAssets: ctrlShowCommunityAssets.checked
             searchString: ctrlSearch.text
@@ -99,6 +126,7 @@ SplitView {
 
             // tokensKey, name, symbol, decimals, currentCurrencyBalance (computed), marketDetails, balances -> [ chainId, address, balance, iconUrl ]
             TokenSelectorView {
+                id: tokenSelector
                 anchors.fill: parent
 
                 model: d.adaptor.outputAssetsModel
@@ -170,6 +198,16 @@ SplitView {
                         Layout.fillWidth: true
                         id: ctrlSearch
                         placeholderText: "Token name or symbol"
+                    }
+                }
+                Switch {
+                    id: ctrlShowAllTokens
+                    text: "Show all tokens"
+                    checked: true
+                    onToggled: {
+                        // NB: ListView doesn't like changing models at runtime
+                        tokenSelector.model = null
+                        tokenSelector.model = d.adaptor.outputAssetsModel
                     }
                 }
                 Switch {

--- a/storybook/pages/WalletAccountListItemPage.qml
+++ b/storybook/pages/WalletAccountListItemPage.qml
@@ -20,7 +20,7 @@ SplitView {
             emoji: emojiField.text
             walletColor: walletColorField.text
             currencyBalance: QtObject {
-                readonly property double amount: parseInt(currencyBalanceField.text)
+                readonly property double amount: parseFloat(currencyBalanceField.text)
                 readonly property string symbol: "USD"
                 readonly property int displayDecimals: 4
                 readonly property bool stripTrailingZeroes: false

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -21,6 +21,17 @@ Item {
     width: 600
     height: 400
 
+    ListModel {
+        id: plainTokensModel
+        ListElement {
+            key: "aave"
+            name: "Aave"
+            symbol: "AAVE"
+            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
+            communityId: ""
+        }
+    }
+
     QtObject {
         id: d
 
@@ -47,6 +58,7 @@ Item {
 
         readonly property var tokenSelectorAdaptor: TokenSelectorViewAdaptor {
             assetsModel: d.adaptor.walletAssetsStore.groupedAccountAssetsModel
+            plainTokensBySymbolModel: plainTokensModel
             flatNetworksModel: d.adaptor.swapStore.flatNetworks
             currentCurrency: d.adaptor.currencyStore.currentCurrency
 
@@ -62,6 +74,7 @@ Item {
             currencyStore: d.adaptor.currencyStore
             flatNetworksModel: d.adaptor.swapStore.flatNetworks
             processedAssetsModel: d.adaptor.walletAssetsStore.groupedAccountAssetsModel
+            plainTokensBySymbolModel: plainTokensModel
         }
     }
 

--- a/storybook/qmlTests/tests/tst_TokenSelector.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelector.qml
@@ -13,6 +13,17 @@ Item {
     width: 600
     height: 400
 
+    ListModel {
+        id: plainTokensModel
+        ListElement {
+            key: "aave"
+            name: "Aave"
+            symbol: "AAVE"
+            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
+            communityId: ""
+        }
+    }
+
     QtObject {
         id: d
 
@@ -28,6 +39,7 @@ Item {
 
         readonly property var adaptor: TokenSelectorViewAdaptor {
             assetsModel: d.assetsStore.groupedAccountAssetsModel
+            plainTokensBySymbolModel: plainTokensModel
             flatNetworksModel: d.flatNetworks
             currentCurrency: "USD"
 
@@ -216,6 +228,32 @@ Item {
             verify(!!ethDelegate)
             tryCompare(ethDelegate, "tokensKey", "ETH")
             compare(ethDelegate.ListView.section, "Popular assets")
+        }
+
+        function test_plainTokenDelegate() {
+            verify(!!controlUnderTest)
+
+            d.adaptor.showAllTokens = true
+            const tokensKey = "aave"
+
+            mouseClick(controlUnderTest)
+            waitForItemPolished(controlUnderTest)
+
+            const listview = findChild(controlUnderTest.popup.contentItem, "tokenSelectorListview")
+            verify(!!listview)
+            waitForItemPolished(listview)
+
+            const delegate = findChild(listview, "tokenSelectorAssetDelegate_%1".arg(tokensKey))
+            verify(!!delegate)
+            tryCompare(delegate, "tokensKey", tokensKey)
+            tryCompare(delegate, "currencyBalanceAsString", "")
+
+            // click the delegate, verify the signal has been fired and has the correct "tokensKey" as argument
+            mouseClick(delegate)
+            tryCompare(signalSpy, "count", 1)
+            compare(signalSpy.signalArguments[0][0], tokensKey)
+            compare(controlUnderTest.currentTokensKey, tokensKey)
+            d.adaptor.showAllTokens = false
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_TokenSelectorView.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelectorView.qml
@@ -36,7 +36,6 @@ Item {
         id: componentUnderTest
         TokenSelectorView {
             anchors.fill: parent
-
             model: d.adaptor.outputAssetsModel
         }
     }

--- a/storybook/qmlTests/tests/tst_TokenSelectorViewAdaptor.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelectorViewAdaptor.qml
@@ -13,6 +13,17 @@ Item {
     width: 600
     height: 400
 
+    ListModel {
+        id: plainTokensModel
+        ListElement {
+            key: "aave"
+            name: "Aave"
+            symbol: "AAVE"
+            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
+            communityId: ""
+        }
+    }
+
     QtObject {
         id: d
 
@@ -33,6 +44,7 @@ Item {
             assetsModel: d.assetsStore.groupedAccountAssetsModel
             flatNetworksModel: d.flatNetworks
             currentCurrency: "USD"
+            plainTokensBySymbolModel: plainTokensModel
         }
     }
 
@@ -72,6 +84,20 @@ Item {
 
             // turning them back off, verify we are back to the original number of items
             controlUnderTest.showCommunityAssets = false
+            tryCompare(controlUnderTest.outputAssetsModel, "count", originalCount)
+        }
+
+        function test_allTokens() {
+            verify(!!controlUnderTest)
+
+            const originalCount = controlUnderTest.outputAssetsModel.count
+
+            // turn on showing all tokens, verify we now have more items
+            controlUnderTest.showAllTokens = true
+            tryVerify(() => controlUnderTest.outputAssetsModel.count > originalCount)
+
+            // turning them back off, verify we are back to the original number of items
+            controlUnderTest.showAllTokens = false
             tryCompare(controlUnderTest.outputAssetsModel, "count", originalCount)
         }
 

--- a/storybook/src/Models/WalletAccountsModel.qml
+++ b/storybook/src/Models/WalletAccountsModel.qml
@@ -44,7 +44,7 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             currencyBalance: ({amount: 1.25,
                                   symbol: "USD",
-                                  displayDecimals: 4,
+                                  displayDecimals: 2,
                                   stripTrailingZeroes: false}),
             migratedToKeycard: true
         },
@@ -70,7 +70,7 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             currencyBalance: ({amount: 10,
                                   symbol: "USD",
-                                  displayDecimals: 4,
+                                  displayDecimals: 2,
                                   stripTrailingZeroes: false}),
             migratedToKeycard: false
         },
@@ -105,7 +105,7 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             currencyBalance: ({amount: 110.05,
                                   symbol: "USD",
-                                  displayDecimals: 4,
+                                  displayDecimals: 2,
                                   stripTrailingZeroes: false}),
             migratedToKeycard: false
         },
@@ -122,7 +122,7 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             currencyBalance: ({amount: 3,
                                   symbol: "USD",
-                                  displayDecimals: 4,
+                                  displayDecimals: 2,
                                   stripTrailingZeroes: false}),
             migratedToKeycard: false
         },
@@ -148,7 +148,7 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             currencyBalance: ({amount: 999,
                                   symbol: "USD",
-                                  displayDecimals: 4,
+                                  displayDecimals: 2,
                                   stripTrailingZeroes: false}),
             migratedToKeycard: false
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -351,6 +351,8 @@ Rectangle {
                     Layout.alignment: Qt.AlignVCenter
                     padding: 0
 
+                    ScrollBar.horizontal.policy: root.tagsScrollBarVisible ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+
                     Row {
                         id: row
                         spacing: 4

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -227,7 +227,7 @@ QtObject {
     }
 
     function elideAndFormatWalletAddress(address) {
-        return elideText(address, 5, 3).replace(
+        return elideText(address, 6, 4).replace(
                     "0x", "0" + String.fromCodePoint(0x00D7))
     }
 

--- a/ui/app/AppLayouts/Wallet/controls/EditSlippagePanel.qml
+++ b/ui/app/AppLayouts/Wallet/controls/EditSlippagePanel.qml
@@ -95,12 +95,9 @@ Control {
             }
             StatusTextWithLoadingState {
                 text: {
-                    let amount = !!root.toTokenAmount ? SQUtils.AmountsArithmetic.fromString(root.toTokenAmount) : NaN
-                    let percentageAmount = 0
-                    if(!Number.isNaN(amount)) {
-                        percentageAmount = (amount - ((amount/100) * slippageSelector.value))
-                    }
-                    return ("%1 %2").arg(LocaleUtils.numberToLocaleString(percentageAmount)).arg(d.selectedToTokenSymbol)
+                    const amount = !!root.toTokenAmount ? SQUtils.AmountsArithmetic.fromString(root.toTokenAmount).times(1 - slippageSelector.value/100)
+                                                        : 0
+                    return ("%1 %2").arg(LocaleUtils.numberToLocaleString(amount.toFixed())).arg(d.selectedToTokenSymbol)
                 }
                 font.pixelSize: 13
                 font.weight: Font.Medium

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.15
 
 import StatusQ 0.1
 import StatusQ.Components 0.1
@@ -84,7 +85,6 @@ ComboBox {
 
     popup.width: 380
     popup.x: root.width - popup.width
-    popup.y: root.height
     popup.margins: Style.current.halfPadding
     popup.background: Rectangle {
         color: Theme.palette.statusSelect.menuItemBackgroundColor
@@ -172,7 +172,8 @@ ComboBox {
         tokensKey: model.tokensKey
         name: model.name
         symbol: model.symbol
-        currencyBalanceAsString: model.currencyBalanceAsString
+        currencyBalanceAsString: model.currencyBalanceAsString ?? ""
+        iconSource: model.iconSource
         balancesModel: model.balances
 
         onAssetSelected: (tokensKey) => root.selectToken(tokensKey)
@@ -192,20 +193,19 @@ ComboBox {
     Component {
         id: iconTextContentItem
         RowLayout {
-            readonly property string currentSymbol: d.isTokenSelected ? ModelUtils.getByKey(model, "tokensKey", d.currentTokensKey, "symbol")
-                                                                      : ""
             spacing: root.spacing
             StatusRoundedImage {
                 objectName: "tokenSelectorIcon"
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
-                image.source: Constants.tokenIcon(parent.currentSymbol)
+                image.source: ModelUtils.getByKey(model, "tokensKey", d.currentTokensKey, "iconSource")
+                image.sourceSize: Qt.size(width*root.Screen.devicePixelRatio, height*root.Screen.devicePixelRatio)
             }
             StatusBaseText {
                 objectName: "tokenSelectorContentItemText"
                 font.pixelSize: 28
                 color: root.hovered ? Theme.palette.blue : Theme.palette.darkBlue
-                text: parent.currentSymbol
+                text: ModelUtils.getByKey(model, "tokensKey", d.currentTokensKey, "symbol")
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -28,6 +28,7 @@ Control {
     required property CurrenciesStore currencyStore
     required property var flatNetworksModel
     required property var processedAssetsModel
+    property var plainTokensBySymbolModel // optional all tokens model, no balances
 
     property int selectedNetworkChainId: -1
     property string selectedAccountAddress
@@ -54,6 +55,7 @@ Control {
     readonly property string selectedHoldingId: holdingSelector.currentTokensKey
     readonly property double value: amountToSendInput.cryptoValueToSendFloat
     readonly property string rawValue: amountToSendInput.cryptoValueToSend
+    readonly property int rawValueMultiplierIndex: amountToSendInput.multiplierIndex
     readonly property bool valueValid: amountToSendInput.inputNumberValid
     readonly property bool amountEnteredGreaterThanBalance: value > maxSendButton.maxSafeValue
 
@@ -83,17 +85,19 @@ Control {
         property var selectedHolding: SQUtils.ModelUtils.getByKey(holdingSelector.model, "tokensKey", holdingSelector.currentTokensKey)
 
         readonly property bool isSelectedHoldingValidAsset: !!selectedHolding
-        readonly property double maxFiatBalance: isSelectedHoldingValidAsset ? selectedHolding.currencyBalance : 0
-        readonly property double maxCryptoBalance: isSelectedHoldingValidAsset ? selectedHolding.currentBalance : 0
+        readonly property double maxFiatBalance: isSelectedHoldingValidAsset && !!selectedHolding.currencyBalance ? selectedHolding.currencyBalance : 0
+        readonly property double maxCryptoBalance: isSelectedHoldingValidAsset && !!selectedHolding.currentBalance ? selectedHolding.currentBalance : 0
         readonly property double maxInputBalance: amountToSendInput.inputIsFiat ? maxFiatBalance : maxCryptoBalance
         readonly property string inputSymbol: amountToSendInput.inputIsFiat ? root.currencyStore.currentCurrency
                                                                             : (!!selectedHolding ? selectedHolding.symbol : "")
 
         readonly property var adaptor: TokenSelectorViewAdaptor {
             assetsModel: root.processedAssetsModel
+            plainTokensBySymbolModel: root.plainTokensBySymbolModel
             flatNetworksModel: root.flatNetworksModel
             currentCurrency: root.currencyStore.currentCurrency
 
+            showAllTokens: true
             enabledChainIds: root.selectedNetworkChainId !== -1 ? [root.selectedNetworkChainId] : []
             accountAddress: root.selectedAccountAddress || ""
             searchString: holdingSelector.searchString
@@ -206,7 +210,7 @@ Control {
                 input.input.edit.color: !input.valid ? Theme.palette.dangerColor1 : maxSendButton.hovered ? Theme.palette.baseColor1
                                                                                                           : Theme.palette.directColor1
 
-                multiplierIndex: !!d.selectedHolding ? d.selectedHolding.decimals : 0
+                multiplierIndex: d.selectedHolding && d.selectedHolding.decimals ? d.selectedHolding.decimals : 0
 
                 maxInputBalance: (root.swapSide === SwapInputPanel.SwapSide.Receive || !d.isSelectedHoldingValidAsset) ? Number.POSITIVE_INFINITY
                                                                                                                        : maxSendButton.maxSafeValue

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -24,6 +24,8 @@ StatusDialog {
     required property SwapInputParamsForm swapInputParamsForm
     required property SwapModalAdaptor swapAdaptor
 
+    property var plainTokensBySymbolModel: swapAdaptor.walletAssetsStore.walletTokensStore.plainTokensBySymbolModel
+
     objectName: "swapModal"
 
     implicitWidth: 556
@@ -156,6 +158,7 @@ StatusDialog {
                     currencyStore: root.swapAdaptor.currencyStore
                     flatNetworksModel: root.swapAdaptor.swapStore.flatNetworks
                     processedAssetsModel: root.swapAdaptor.walletAssetsStore.groupedAccountAssetsModel
+                    plainTokensBySymbolModel: root.plainTokensBySymbolModel
 
                     tokenKey: root.swapInputParamsForm.fromTokensKey
                     tokenAmount: root.swapInputParamsForm.fromTokenAmount
@@ -168,9 +171,12 @@ StatusDialog {
                     swapExchangeButtonWidth: swapExchangeButton.width
 
                     onSelectedHoldingIdChanged: root.swapInputParamsForm.fromTokensKey = selectedHoldingId
-                    onValueChanged: {
+                    onRawValueChanged: {
                         if(root.swapInputParamsForm.fromTokensKey === selectedHoldingId) {
-                            root.swapInputParamsForm.fromTokenAmount = !tokenAmount && value === 0 ? "" : value.toLocaleString(locale, 'f', -128)
+                            const amount = !tokenAmount && value === 0 ? "" :
+                                                                         SQUtils.AmountsArithmetic.div(SQUtils.AmountsArithmetic.fromString(rawValue),
+                                                                                                       SQUtils.AmountsArithmetic.fromNumber(1, rawValueMultiplierIndex)).toString()
+                            root.swapInputParamsForm.fromTokenAmount = amount
                         }
                     }
                     onValueValidChanged: d.fetchSuggestedRoutes()
@@ -189,6 +195,7 @@ StatusDialog {
                     currencyStore: root.swapAdaptor.currencyStore
                     flatNetworksModel: root.swapAdaptor.swapStore.flatNetworks
                     processedAssetsModel: root.swapAdaptor.walletAssetsStore.groupedAccountAssetsModel
+                    plainTokensBySymbolModel: root.plainTokensBySymbolModel
 
                     tokenKey: root.swapInputParamsForm.toTokenKey
                     tokenAmount: root.swapAdaptor.validSwapProposalReceived && root.swapAdaptor.toToken ? root.swapAdaptor.swapOutputData.toTokenAmount: root.swapInputParamsForm.toTokenAmount

--- a/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
@@ -16,6 +17,7 @@ ItemDelegate {
     required property string name
     required property string symbol
     required property string currencyBalanceAsString
+    required property string iconSource
     // expected structure: balancesModel -> model.balances submodel [chainId: int, balance: BigIntString] + flatNetworks [account:string, iconUrl: string]
     required property var balancesModel
 
@@ -34,7 +36,7 @@ ItemDelegate {
 
     icon.width: 32
     icon.height: 32
-    icon.source: Constants.tokenIcon(symbol)
+    icon.source: iconSource
 
     enabled: interactive
 
@@ -55,6 +57,7 @@ ItemDelegate {
             Layout.preferredWidth: root.icon.width
             Layout.preferredHeight: root.icon.height
             image.source: root.icon.source
+            image.sourceSize: Qt.size(width*root.Screen.devicePixelRatio, height*root.Screen.devicePixelRatio)
         }
 
         ColumnLayout {

--- a/ui/app/AppLayouts/Wallet/views/TokenSelectorView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TokenSelectorView.qml
@@ -6,7 +6,7 @@ StatusListView {
     id: root
 
     // expected model structure:
-    // tokensKey, name, symbol, decimals, currencyBalanceAsString (computed), marketDetails, balances -> [ chainId, address, balance, iconUrl ]
+    // tokensKey, name, symbol, decimals, currencyBalanceAsString (computed), iconSource, marketDetails, balances -> [ chainId, address, balance, iconUrl ]
 
     // output API
     signal tokenSelected(string tokensKey)
@@ -20,7 +20,8 @@ StatusListView {
         tokensKey: model.tokensKey
         name: model.name
         symbol: model.symbol
-        currencyBalanceAsString: model.currencyBalanceAsString
+        currencyBalanceAsString: model.currencyBalanceAsString ?? ""
+        iconSource: model.iconSource
         balancesModel: model.balances
 
         onAssetSelected: (tokensKey) => root.tokenSelected(tokensKey)

--- a/ui/imports/shared/controls/AccountSelector.qml
+++ b/ui/imports/shared/controls/AccountSelector.qml
@@ -24,7 +24,7 @@ import shared.controls 1.0
     currencyBalance         [var]    - fiat currency balance
         amount              [number] - amount of currency e.g. 1234
         symbol              [string] - currency symbol e.g. "USD"
-        optDisplayDecimals  [number] - optional number of decimals to display
+        displayDecimals     [number] - optional number of decimals to display
         stripTrailingZeroes [bool]   - strip trailing zeroes
     walletType              [string] - wallet type e.g. Constants.watchWalletType. See `Constants` for possible values
     migratedToKeycard       [bool]   - whether account is migrated to keycard
@@ -42,7 +42,7 @@ StatusComboBox {
     property string selectedAddress: ""
     // output property for selected account
     readonly property alias currentAccount: selectedEntry.item
-    readonly property string currentAccountAddress: root.control.currentValue ?? ""
+    readonly property string currentAccountAddress: d.currentAccountSelection
 
     // styling options
     type: StatusComboBox.Type.Secondary
@@ -99,6 +99,8 @@ StatusComboBox {
 
         required property var model
 
+        tagsScrollBarVisible: false
+
         width: ListView.view.width
         name: model.name
         address: model.address
@@ -122,7 +124,7 @@ StatusComboBox {
         id: selectedEntry
         sourceModel: root.model ?? null
         key: "address"
-        value: control.currentValue
+        value: d.currentAccountSelection
     }
 
     QtObject {

--- a/ui/imports/shared/controls/AccountSelectorHeader.qml
+++ b/ui/imports/shared/controls/AccountSelectorHeader.qml
@@ -20,6 +20,10 @@ AccountSelector {
         objectName: "headerBackground"
         radius: 8
         color: d.headerStyleBackgroundColor
+
+        HoverHandler {
+            cursorShape: root.enabled ? Qt.PointingHandCursor : undefined
+        }
     }
 
     contentItem: RowLayout {
@@ -48,8 +52,7 @@ AccountSelector {
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
-            font.pixelSize: 15
-            color: Theme.palette.indirectColor1
+            color: Utils.getContrastingColor(d.headerStyleBackgroundColor)
         }
     }
 

--- a/ui/imports/shared/controls/WalletAccountListItem.qml
+++ b/ui/imports/shared/controls/WalletAccountListItem.qml
@@ -40,12 +40,13 @@ StatusListItem {
     title: root.name
     subTitle:{
         if(!!root.address) {
-            let elidedAddress = StatusQUtils.Utils.elideText(root.address,6,4)
+            let elidedAddress = StatusQUtils.Utils.elideAndFormatWalletAddress(root.address)
             return sensor.containsMouse ? root.chainShortNames ||  Utils.richColorText(elidedAddress, Theme.palette.directColor1) : elidedAddress
         }
         return ""
     }
     statusListItemSubTitle.wrapMode: Text.NoWrap
+    statusListItemSubTitle.font.family: Theme.palette.monoFont.name
     asset.emoji: root.emoji
     asset.color: root.walletColor
     asset.name: root.emoji ? "filled-account": ""
@@ -82,6 +83,7 @@ StatusListItem {
         }
     ]
 
+    tagsScrollBarVisible: false
     inlineTagModel: !!root.accountBalance && !!root.accountBalance.formattedBalance ? 1 : 0
     inlineTagDelegate: StatusListItemTag {
         objectName: "inlineTagDelegate_" +  index

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -834,6 +834,15 @@ QtObject {
         return 0
     }
 
+    function getContrastingColor(color) {
+        const hexcolor = color.toString()
+        const r = parseInt(hexcolor.substring(1,3), 16);
+        const g = parseInt(hexcolor.substring(3,5), 16);
+        const b = parseInt(hexcolor.substring(5,7), 16);
+        const yiq = ((r*299)+(g*587)+(b*114))/1000;
+        return (yiq >= 128) ? Theme.palette.black : Theme.palette.white;
+    }
+
     function getPathForDisplay(path) {
         return path.split("/").join(" / ")
     }


### PR DESCRIPTION
### What does the PR do

- AccountsSelector: update / improve  component to cover swap design specs (Fixes #14779)
- SwapModal: add scrolling support (Fixes #15276)
- TokenSelector: support showing all known (plain) tokens (Fixes #15278)

See the respective commits for further details

### Affected areas

SwapModal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Dialog expanded and scrolled down:
![image](https://github.com/status-im/status-desktop/assets/5377645/a23ba3ae-227f-457c-b11c-cf3d02f3e573)

Account selector (correct subbalances, font and sorting):
![image](https://github.com/status-im/status-desktop/assets/5377645/ce66fa3e-e020-49d3-be7f-9523628ea1dc)

Token selector with sections + plain tokens:
![image](https://github.com/status-im/status-desktop/assets/5377645/bcdc5c54-65d7-4851-a258-8a5a4cf7f591)

