### PR TITLE
chore: add ApplicationContext.isFrozen() function call after click

### DIFF
--- a/test/e2e/driver/squish_api.py
+++ b/test/e2e/driver/squish_api.py
@@ -13,5 +13,5 @@ def waitFor(condition, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     return True
 
 
-def isFrozen(timeout_msec):
-    return driver.currentApplicationContext().isFrozen(timeout_msec)
+def isFrozen(timeout_sec):
+    return driver.currentApplicationContext().isFrozen(timeout_sec)

--- a/test/e2e/gui/components/authenticate_popup.py
+++ b/test/e2e/gui/components/authenticate_popup.py
@@ -26,7 +26,8 @@ class AuthenticatePopup(BasePopup):
     @allure.step('Authenticate actions with password {0}')
     def authenticate(self, password: str):
         self._password_text_edit.type_text(password)
-        self._authenticate_button.click()
+        # TODO https://github.com/status-im/status-desktop/issues/15345
+        self._authenticate_button.click(timeout=10)
         self._authenticate_button.wait_until_hidden(10000)
 
     @allure.step('Check if authenticate button is present')

--- a/test/e2e/gui/components/wallet/wallet_account_popups.py
+++ b/test/e2e/gui/components/wallet/wallet_account_popups.py
@@ -161,7 +161,8 @@ class AccountPopup(BasePopup):
     def save_changes(self):
         assert driver.waitFor(lambda: self.is_save_changes_button_enabled(),
                               configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
-        self._add_save_account_confirmation_button.click()
+        # TODO https://github.com/status-im/status-desktop/issues/15345
+        self._add_save_account_confirmation_button.click(timeout=10)
         return self
 
     @allure.step('Get enabled state of (add account / save changes) button')

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -100,6 +100,7 @@ class QObject:
             x: int = None,
             y: int = None,
             button=None,
+            timeout=1,
     ):
         driver.mouseClick(
             self.object,
@@ -108,6 +109,13 @@ class QObject:
             button or driver.Qt.LeftButton
         )
         LOG.info('%s: is clicked with Qt.LeftButton', self)
+        LOG.info("Checking if application context is frozen")
+
+        if not isFrozen(timeout):
+            pass
+        else:
+            LOG.info("Application context did not respond after click")
+            raise Exception(f'Application UI is not responding within {timeout} second(s)')
 
     @allure.step('Native click {0}')
     def native_mouse_click(

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -36,7 +36,8 @@ class AllowNotificationsView(QObject):
 
     @allure.step("Start using Status")
     def start_using_status(self):
-        self._start_using_status_button.click()
+        # TODO https://github.com/status-im/status-desktop/issues/15345
+        self._start_using_status_button.click(timeout=10)
         self.wait_until_hidden()
 
 
@@ -417,7 +418,8 @@ class YourEmojihashAndIdenticonRingView(OnboardingView):
 
     @allure.step('Click next in your emojihash and identicon ring view')
     def next(self):
-        self._next_button.click()
+        # TODO https://github.com/status-im/status-desktop/issues/15345
+        self._next_button.click(timeout=10)
         time.sleep(1)
         if configs.system.get_platform() == "Darwin":
             return AllowNotificationsView().wait_until_appears()


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/15335
Opens https://github.com/status-im/status-desktop/issues/15345

- Implement usage of https://doc.qt.io/squish/squish-api.html#applicationcontext-isfrozen-function after click
- Add timeout param to click function and set it default to 1 second
- Pass non-default timeout (10 seconds) to the clicks, where application freezes (we will fix them later in the ticket above)

### Affected areas

end-to-end UI tests

### Additional information

We aim to UI respond within 0.2 seconds in future
