### PR TITLE
Fix/15330 overlapping swaps and double approve

### DIFF
--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -69,7 +69,8 @@ proc init*(self: Controller) =
     self.delegate.onUserAuthenticated(args.password, args.pin)
 
   self.events.on(SIGNAL_SUGGESTED_ROUTES_READY) do(e:Args):
-    self.delegate.suggestedRoutesReady(SuggestedRoutesArgs(e).suggestedRoutes)
+    let args = SuggestedRoutesArgs(e)
+    self.delegate.suggestedRoutesReady(args.uuid, args.suggestedRoutes)
 
   self.events.on(SignalType.WalletSignTransactions.event) do(e:Args):
     var data = WalletSignal(e)
@@ -108,6 +109,7 @@ proc authenticate*(self: Controller, keyUid = "") =
   self.events.emit(SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER, data)
 
 proc suggestedRoutes*(self: Controller,
+    uuid: string,
     sendType: SendType,
     accountFrom: string,
     accountTo: string,
@@ -119,7 +121,7 @@ proc suggestedRoutes*(self: Controller,
     disabledToChainIDs: seq[int] = @[],
     lockedInAmounts: Table[string, string] = initTable[string, string](),
     extraParamsTable: Table[string, string] = initTable[string, string]()) =
-  self.transactionService.suggestedRoutes(sendType, accountFrom, accountTo, token, amountIn, toToken, amountOut,
+  self.transactionService.suggestedRoutes(uuid, sendType, accountFrom, accountTo, token, amountIn, toToken, amountOut,
     disabledFromChainIDs, disabledToChainIDs, lockedInAmounts, extraParamsTable)
 
 proc transfer*(self: Controller, from_addr: string, to_addr: string, assetKey: string, toAssetKey: string,

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -25,6 +25,7 @@ method getTokenBalance*(self: AccessInterface, address: string, chainId: int, to
   raise newException(ValueError, "No implementation available")
 
 method suggestedRoutes*(self: AccessInterface,
+  uuid: string,
   sendType: SendType,
   accountFrom: string,
   accountTo: string,
@@ -38,7 +39,7 @@ method suggestedRoutes*(self: AccessInterface,
   extraParamsTable: Table[string, string] = initTable[string, string]()) {.base.} =
     raise newException(ValueError, "No implementation available")
 
-method suggestedRoutesReady*(self: AccessInterface, suggestedRoutes: SuggestedRoutesDto) {.base.} =
+method suggestedRoutesReady*(self: AccessInterface, uuid: string, suggestedRoutes: SuggestedRoutesDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method authenticateAndTransfer*(self: AccessInterface, from_addr: string, to_addr: string, assetKey: string,

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -345,7 +345,7 @@ method transactionWasSent*(self: Module, chainId: int, txHash, uuid, error: stri
     return
   self.view.sendTransactionSentSignal(chainId, txHash, uuid, error)
 
-method suggestedRoutesReady*(self: Module, suggestedRoutes: SuggestedRoutesDto) =
+method suggestedRoutesReady*(self: Module, uuid: string, suggestedRoutes: SuggestedRoutesDto) =
   self.tmpSendTransactionDetails.paths = suggestedRoutes.best
   self.tmpSendTransactionDetails.slippagePercentage = none(float)
   let paths = suggestedRoutes.best.map(x => self.convertTransactionPathDtoToSuggestedRouteItem(x))
@@ -357,6 +357,7 @@ method suggestedRoutesReady*(self: Module, suggestedRoutes: SuggestedRoutesDto) 
   toNetworksModel.setItems(networks)
   self.view.updatedNetworksWithRoutes(paths, gasTimeEstimate.getTotalFeesInEth())
   let transactionRoutes = newTransactionRoutes(
+    uuid = uuid,
     suggestedRoutes = suggestedRouteModel,
     gasTimeEstimate = gasTimeEstimate,
     amountToReceive = suggestedRoutes.amountToReceive,
@@ -365,6 +366,7 @@ method suggestedRoutesReady*(self: Module, suggestedRoutes: SuggestedRoutesDto) 
   self.view.setTransactionRoute(transactionRoutes)
 
 method suggestedRoutes*(self: Module,
+  uuid: string,
   sendType: SendType,
   accountFrom: string,
   accountTo: string,
@@ -377,6 +379,7 @@ method suggestedRoutes*(self: Module,
   lockedInAmounts: Table[string, string] = initTable[string, string](),
   extraParamsTable: Table[string, string] = initTable[string, string]()) =
   self.controller.suggestedRoutes(
+    uuid,
     sendType,
     accountFrom,
     accountTo,

--- a/src/app/modules/main/wallet_section/send/transaction_routes.nim
+++ b/src/app/modules/main/wallet_section/send/transaction_routes.nim
@@ -4,6 +4,7 @@ import ./gas_estimate_item, ./suggested_route_model, ./network_model
 
 QtObject:
   type TransactionRoutes* = ref object of QObject
+    uuid: string
     suggestedRoutes: SuggestedRouteModel
     gasTimeEstimate: GasEstimateItem
     amountToReceive: UInt256
@@ -11,6 +12,7 @@ QtObject:
     rawPaths: string
 
   proc setup*(self: TransactionRoutes,
+    uuid: string,
     suggestedRoutes: SuggestedRouteModel,
     gasTimeEstimate: GasEstimateItem,
     amountToReceive: UInt256,
@@ -18,6 +20,7 @@ QtObject:
     rawPaths: string
     ) =
       self.QObject.setup
+      self.uuid = uuid
       self.suggestedRoutes = suggestedRoutes
       self.gasTimeEstimate = gasTimeEstimate
       self.amountToReceive = amountToReceive
@@ -28,6 +31,7 @@ QtObject:
       self.QObject.delete
 
   proc newTransactionRoutes*(
+    uuid: string = "",
     suggestedRoutes: SuggestedRouteModel = newSuggestedRouteModel(),
     gasTimeEstimate: GasEstimateItem = newGasEstimateItem(),
     amountToReceive: UInt256 = stint.u256(0),
@@ -35,16 +39,24 @@ QtObject:
     rawPaths: string = ""
     ): TransactionRoutes =
     new(result, delete)
-    result.setup(suggestedRoutes, gasTimeEstimate, amountToReceive, toNetworksModel, rawPaths)
+    result.setup(uuid, suggestedRoutes, gasTimeEstimate, amountToReceive, toNetworksModel, rawPaths)
 
   proc `$`*(self: TransactionRoutes): string =
     result = fmt"""TransactionRoutes(
+      uuid: {self.uuid},
       suggestedRoutes: {self.suggestedRoutes},
       gasTimeEstimate: {self.gasTimeEstimate},
       amountToReceive: {self.amountToReceive},
       toNetworksModel: {self.toNetworksModel},
       rawPaths: {self.rawPaths},
       ]"""
+
+  proc uuidChanged*(self: TransactionRoutes) {.signal.}
+  proc getUuid*(self: TransactionRoutes): string {.slot.} =
+    return self.uuid
+  QtProperty[string] uuid:
+    read = getUuid
+    notify = uuidChanged
 
   proc suggestedRoutesChanged*(self: TransactionRoutes) {.signal.}
   proc getSuggestedRoutes*(self: TransactionRoutes): QVariant {.slot.} =

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -1,4 +1,5 @@
 import NimQml, Tables, json, sequtils, strutils, stint, sugar, options, chronicles
+import uuids
 
 import ./io_interface, ./accounts_model, ./account_item, ./network_model, ./network_item, ./suggested_route_item, ./transaction_routes
 import app/modules/shared_models/collectibles_model as collectibles
@@ -243,6 +244,7 @@ QtObject:
       error "Error parsing extraParamsJson: ", msg=e.msg
 
     self.delegate.suggestedRoutes(
+      $genUUID(),
       self.sendType,
       self.selectedSenderAccount.address(),
       self.selectedRecipient,
@@ -342,6 +344,7 @@ QtObject:
 
 # "Stateless" methods
   proc fetchSuggestedRoutesWithParameters*(self: View,
+    uuid: string,
     accountFrom: string,
     accountTo: string,
     amountIn: string,
@@ -361,6 +364,7 @@ QtObject:
         discard
       # Resolve the best route
       self.delegate.suggestedRoutes(
+        uuid,
         SendType(sendType),
         accountFrom,
         accountTo,

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -1,4 +1,4 @@
-import Tables, NimQml, chronicles, sequtils, sugar, stint, strutils, json, uuids, stew/shims/strformat
+import Tables, NimQml, chronicles, sequtils, sugar, stint, strutils, json, stew/shims/strformat
 
 import backend/collectibles as collectibles
 import backend/transactions as transactions
@@ -110,6 +110,7 @@ type
 
 type
   SuggestedRoutesArgs* = ref object of Args
+    uuid*: string
     suggestedRoutes*: SuggestedRoutesDto
 
 type
@@ -583,9 +584,10 @@ QtObject:
       amountToReceive: getTotalAmountToReceive(oldRoute),
       toNetworks: getToNetworksList(oldRoute),
     )
-    self.events.emit(SIGNAL_SUGGESTED_ROUTES_READY, SuggestedRoutesArgs(suggestedRoutes: suggestedDto))
+    self.events.emit(SIGNAL_SUGGESTED_ROUTES_READY, SuggestedRoutesArgs(uuid: uuid, suggestedRoutes: suggestedDto))
 
   proc suggestedRoutes*(self: Service,
+    uuid: string,
     sendType: SendType,
     accountFrom: string,
     accountTo: string,
@@ -605,7 +607,6 @@ QtObject:
       amountOutHex = "0x" & eth_utils.stripLeadingZeros(bigAmountOut.toHex)
 
     try:
-      let uuid = $genUUID()
       let res = eth.suggestedRoutesV2Async(uuid, ord(sendType), accountFrom, accountTo, amountInHex, amountOutHex, token,
         toToken, disabledFromChainIDs, disabledToChainIDs, lockedInAmounts, extraParamsTable)
     except CatchableError as e:

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -400,6 +400,10 @@ QtObject:
     except Exception as e:
       self.sendTransactionSentSignal(from_addr, to_addr, uuid, @[], RpcResponse[JsonNode](), fmt"Error sending token transfer transaction: {e.msg}")
 
+  proc mustIgnoreApprovalRequests(sendType: SendType): bool =
+    # Swap requires approvals to be done in advance in a separate Tx
+    return sendType == SendType.Swap
+
   # in case of collectibles transfer, assetKey is used to get the contract address and token id
   # in case of asset transfer, asset is valid and used to get the asset symbol and contract address
   proc transferToken(
@@ -461,7 +465,7 @@ QtObject:
         if not route.gasFees.eip1559Enabled:
           gasFees = $route.gasFees.gasPrice
 
-        if route.approvalRequired:
+        if route.approvalRequired and not mustIgnoreApprovalRequests(sendType):
           let approvalPath = self.createApprovalPath(route, mtCommand.fromAddress, toContractAddress, gasFees)
           paths.add(approvalPath)
 

--- a/storybook/pages/SwapModalPage.qml
+++ b/storybook/pages/SwapModalPage.qml
@@ -58,12 +58,12 @@ SplitView {
             readonly property var flatNetworks: NetworksModel.flatNetworks
             readonly property bool areTestNetworksEnabled: areTestNetworksEnabledCheckbox.checked
 
-            function fetchSuggestedRoutes(accountFrom, accountTo, amount, tokenFrom, tokenTo,
+            function fetchSuggestedRoutes(uuid, accountFrom, accountTo, amount, tokenFrom, tokenTo,
                                           disabledFromChainIDs, disabledToChainIDs, preferredChainIDs, sendType, lockedInAmounts) {
-                console.debug("fetchSuggestedRoutes called >> accountFrom = ",accountFrom, " accountTo =",
-                              accountTo, "amount = ",amount, " tokenFrom = ",tokenFrom, " tokenTo = ", tokenTo,
-                              " disabledFromChainIDs = ",disabledFromChainIDs, " disabledToChainIDs = ",disabledToChainIDs,
-                              " preferredChainIDs = ",preferredChainIDs, " sendType =", sendType, " lockedInAmounts = ",lockedInAmounts)
+                console.debug("fetchSuggestedRoutes called >> uuid = ", uuid, " accountFrom = ", accountFrom, " accountTo =",
+                              accountTo, "amount = ", amount, " tokenFrom = ", tokenFrom, " tokenTo = ", tokenTo,
+                              " disabledFromChainIDs = ", disabledFromChainIDs, " disabledToChainIDs = ", disabledToChainIDs,
+                              " preferredChainIDs = ", preferredChainIDs, " sendType =", sendType, " lockedInAmounts = ", lockedInAmounts)
             }
             function authenticateAndTransfer(uuid, accountFrom, accountTo, tokenFrom,
                                              tokenTo, sendType, tokenName, tokenIsOwnerToken, paths) {

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -34,7 +34,7 @@ Item {
         function getWei2Eth(wei, decimals) {
             return wei/(10**decimals)
         }
-        function fetchSuggestedRoutes(accountFrom, accountTo, amount, tokenFrom, tokenTo,
+        function fetchSuggestedRoutes(uuid, accountFrom, accountTo, amount, tokenFrom, tokenTo,
                                       disabledFromChainIDs, disabledToChainIDs, preferredChainIDs, sendType, lockedInAmounts) {}
     }
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -144,6 +144,10 @@ QObject {
     Connections {
         target: root.swapStore
         function onSuggestedRoutesReady(txRoutes) {
+            if (txRoutes.uuid !== d.uuid) {
+                // Suggested routes for a different fetch, ignore
+                return
+            }
             root.swapOutputData.reset()
             root.validSwapProposalReceived = false
             root.swapProposalLoading = false
@@ -207,17 +211,17 @@ QObject {
 
     function fetchSuggestedRoutes(cryptoValueInRaw) {
         if (root.swapFormData.isFormFilledCorrectly() && !!cryptoValueInRaw) {
-            root.swapProposalLoading = true
-            root.swapOutputData.reset()
-
             // Identify new swap with a different uuid
             d.uuid = Utils.uuid()
+
+            root.swapProposalLoading = true
+            root.swapOutputData.reset()
 
             let account = selectedAccountEntry.item
             let accountAddress = account.address
             let disabledChainIds = getDisabledChainIds(root.swapFormData.selectedNetworkChainId)
 
-            root.swapStore.fetchSuggestedRoutes(accountAddress, accountAddress,
+            root.swapStore.fetchSuggestedRoutes(d.uuid, accountAddress, accountAddress,
                                                 cryptoValueInRaw, "0", root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey,
                                                 disabledChainIds, disabledChainIds, Constants.SendType.Swap, "")
         } else {

--- a/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
@@ -25,11 +25,11 @@ QtObject {
         }
     }
 
-    function fetchSuggestedRoutes(accountFrom, accountTo, amountIn, amountOut, tokenFrom, tokenTo,
+    function fetchSuggestedRoutes(uuid, accountFrom, accountTo, amountIn, amountOut, tokenFrom, tokenTo,
         disabledFromChainIDs, disabledToChainIDs, sendType, lockedInAmounts) {
         const valueIn = AmountsArithmetic.fromNumber(amountIn)
         const valueOut = AmountsArithmetic.fromNumber(amountOut)
-        root.walletSectionSendInst.fetchSuggestedRoutesWithParameters(accountFrom, accountTo, valueIn.toFixed(), valueOut.toFixed(),
+        root.walletSectionSendInst.fetchSuggestedRoutesWithParameters(uuid, accountFrom, accountTo, valueIn.toFixed(), valueOut.toFixed(),
             tokenFrom, tokenTo, disabledFromChainIDs, disabledToChainIDs, sendType, lockedInAmounts)
     }
 


### PR DESCRIPTION
Closes #15330

### What does the PR do

Identify Swap `GetSuggestedRoutes` calls with an uuid to distinguish between multiple simultaneous requests. Suggested routes from old requests are now ignored.
Ignore `Approve` requests when sending Swap transactions, since they need to have been placed beforehand.

Tested by performing a swap. SuggestedRoutes were properly processed, Approval was properly performed, Swap was properly performed without 2nd Approve tx.
![image](https://github.com/status-im/status-desktop/assets/11161531/73014a09-7ba1-4564-a154-34d9a90ef6f0)

https://github.com/status-im/status-desktop/assets/11161531/b341c84d-cf92-4828-aff4-e3048e3e01a7

