### PR TITLE
chore: router v2 integration

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -3,7 +3,10 @@
 type SignalType* {.pure.} = enum
   Message = "messages.new"
   MessageDelivered = "message.delivered"
+  ## Wallet Signals
   Wallet = "wallet"
+  WalletSignTransactions = "wallet.sign.transactions"
+  WalletSuggestedRoutes = "wallet.suggested.routes"
   NodeReady = "node.ready"
   NodeCrashed = "node.crashed"
   NodeStarted = "node.started"

--- a/src/app/core/signals/remote_signals/wallet.nim
+++ b/src/app/core/signals/remote_signals/wallet.nim
@@ -1,4 +1,4 @@
-import json, options, sequtils, sugar, chronicles
+import json, options, chronicles
 
 import base
 import signal_type
@@ -20,6 +20,7 @@ type WalletSignal* = ref object of Signal
   requestId*: Option[int]
   txHashes*: seq[string]
   uuid*: string
+  bestRouteRaw*: string
   bestRoute*: seq[TransactionPathDtoV2]
   error*: string
   errorCode*: string
@@ -57,7 +58,9 @@ proc fromEvent*(T: type WalletSignal, signalType: SignalType, jsonSignal: JsonNo
       if event.contains("Uuid"):
         result.uuid = event["Uuid"].getStr()
       if event.contains("Best"):
-        result.bestRoute = event["Best"].getElems().map(x => x.toTransactionPathDtoV2())
+        let bestRouteJsonNode = event["Best"]
+        result.bestRouteRaw = $bestRouteJsonNode
+        result.bestRoute = bestRouteJsonNode.toTransactionPathsDtoV2()
       if event.contains("details"):
         result.error = event["details"].getStr
       if event.contains("code"):

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -26,7 +26,7 @@ QtObject:
     result.setup()
     result.events = events
 
-  # This method might be called with `ChroniclesLogs` event from `nim_status_client`. 
+  # This method might be called with `ChroniclesLogs` event from `nim_status_client`.
   # In such case we must not log anything to prevent recursive calls.
   # I tried to make a better solution, but ended up with such workaround, check out PR for more details.
   proc processSignal(self: SignalsManager, statusSignal: string, allowLogging: bool) =
@@ -79,7 +79,10 @@ QtObject:
       of SignalType.EnvelopeSent: EnvelopeSentSignal.fromEvent(jsonSignal)
       of SignalType.EnvelopeExpired: EnvelopeExpiredSignal.fromEvent(jsonSignal)
       of SignalType.WhisperFilterAdded: WhisperFilterSignal.fromEvent(jsonSignal)
-      of SignalType.Wallet: WalletSignal.fromEvent(jsonSignal)
+      of SignalType.Wallet,
+        SignalType.WalletSignTransactions,
+        SignalType.WalletSuggestedRoutes:
+        WalletSignal.fromEvent(signalType, jsonSignal)
       of SignalType.NodeReady,
         SignalType.NodeCrashed,
         SignalType.NodeStarted,

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -1,4 +1,4 @@
-import stint, options
+import Tables, options
 import app/modules/shared_models/currency_amount
 import app_service/service/transaction/dto
 import app/modules/shared_models/collectibles_model as collectibles
@@ -24,8 +24,18 @@ method refreshWalletAccounts*(self: AccessInterface) {.base.} =
 method getTokenBalance*(self: AccessInterface, address: string, chainId: int, tokensKey: string): CurrencyAmount {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method suggestedRoutes*(self: AccessInterface, accountFrom: string, accountTo: string, amount: UInt256, token: string, toToken: string,
-  disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[int], sendType: SendType, lockedInAmounts: string) {.base.} =
+method suggestedRoutes*(self: AccessInterface,
+  sendType: SendType,
+  accountFrom: string,
+  accountTo: string,
+  token: string,
+  amountIn: string,
+  toToken: string = "",
+  amountOut: string = "",
+  disabledFromChainIDs: seq[int] = @[],
+  disabledToChainIDs: seq[int] = @[],
+  lockedInAmounts: Table[string, string] = initTable[string, string](),
+  extraParamsTable: Table[string, string] = initTable[string, string]()) {.base.} =
     raise newException(ValueError, "No implementation available")
 
 method suggestedRoutesReady*(self: AccessInterface, suggestedRoutes: SuggestedRoutesDto) {.base.} =

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -12,6 +12,8 @@ import app_service/service/keycard/service as keycard_service
 import app_service/service/keycard/constants as keycard_constants
 import app/modules/shared/wallet_utils
 import app_service/service/transaction/dto
+import app_service/service/transaction/dtoV2
+import app_service/service/transaction/dto_conversion
 import app/modules/shared_models/currency_amount
 import app_service/service/token/service
 import app_service/service/network/network_item as network_service_item
@@ -284,7 +286,11 @@ method authenticateAndTransfer*(self: Module, fromAddr: string, toAddr: string, 
 
 method authenticateAndTransferWithPaths*(self: Module, fromAddr: string, toAddr: string, assetKey: string, toAssetKey: string, uuid: string,
   sendType: SendType, selectedTokenName: string, selectedTokenIsOwnerToken: bool, rawPaths: string, slippagePercentage: Option[float]) =
-  self.tmpSendTransactionDetails.paths = rawPaths.convertToTransactionPathsDto()
+  # Temporary until transaction service rework is completed
+  let pathsV2 = rawPaths.toTransactionPathsDtoV2()
+  let pathsV1 = pathsV2.convertToOldRoute().addFirstSimpleBridgeTxFlag()
+  
+  self.tmpSendTransactionDetails.paths = pathsV1
   self.tmpSendTransactionDetails.slippagePercentage = slippagePercentage
   self.authenticateAndTransfer(fromAddr, toAddr, assetKey, toAssetKey, uuid, sendType, selectedTokenName, selectedTokenIsOwnerToken)
 

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -339,11 +339,6 @@ method transactionWasSent*(self: Module, chainId: int, txHash, uuid, error: stri
     return
   self.view.sendTransactionSentSignal(chainId, txHash, uuid, error)
 
-method suggestedRoutes*(self: Module, accountFrom: string, accountTo: string, amount: UInt256, token: string, toToken: string,
-  disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[int], sendType: SendType, lockedInAmounts: string) =
-  self.controller.suggestedRoutes(accountFrom, accountTo, amount, token, toToken, disabledFromChainIDs,
-    disabledToChainIDs, preferredChainIDs, sendType, lockedInAmounts)
-
 method suggestedRoutesReady*(self: Module, suggestedRoutes: SuggestedRoutesDto) =
   self.tmpSendTransactionDetails.paths = suggestedRoutes.best
   self.tmpSendTransactionDetails.slippagePercentage = none(float)
@@ -362,6 +357,32 @@ method suggestedRoutesReady*(self: Module, suggestedRoutes: SuggestedRoutesDto) 
     toNetworksModel = toNetworksModel,
     rawPaths = suggestedRoutes.rawBest)
   self.view.setTransactionRoute(transactionRoutes)
+
+method suggestedRoutes*(self: Module,
+  sendType: SendType,
+  accountFrom: string,
+  accountTo: string,
+  token: string,
+  amountIn: string,
+  toToken: string = "",
+  amountOut: string = "",
+  disabledFromChainIDs: seq[int] = @[],
+  disabledToChainIDs: seq[int] = @[],
+  lockedInAmounts: Table[string, string] = initTable[string, string](),
+  extraParamsTable: Table[string, string] = initTable[string, string]()) =
+  self.controller.suggestedRoutes(
+    sendType,
+    accountFrom,
+    accountTo,
+    token,
+    amountIn,
+    toToken,
+    amountOut,
+    disabledFromChainIDs,
+    disabledToChainIDs,
+    lockedInAmounts,
+    extraParamsTable
+  )
 
 method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) =
   if addresses.len == 0:

--- a/src/app/modules/main/wallet_section/send/network_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_model.nim
@@ -205,12 +205,12 @@ QtObject:
         disbaledChains.add(item.getChainId())
     return disbaledChains
 
-  proc getRouteLockedChainIds*(self: NetworkModel): string =
-    var jsonObject = newJObject()
+  proc getRouteLockedChainIds*(self: NetworkModel): Table[string, string] =
+    var lockedChains: Table[string, string]
     for item in self.items:
       if item.getLocked():
-        jsonObject[$item.getChainId()] = %* ("0x" & item.getLockedAmount())
-    return $jsonObject
+        lockedChains[$item.getChainId()] = "0x" & item.getLockedAmount()
+    return lockedChains
 
   proc updateRoutePreferredChains*(self: NetworkModel, chainIds: string) =
     try:
@@ -232,12 +232,6 @@ QtObject:
     except:
       discard
 
-  proc getRoutePreferredNetworkChainIds*(self: NetworkModel): seq[int] =
-    var preferredChains: seq[int] = @[]
-    for item in self.items:
-      if item.getIsPreferred():
-        preferredChains.add(item.getChainId())
-    return preferredChains
 
   proc disableRouteUnpreferredChains*(self: NetworkModel) =
     for i in 0 ..< self.items.len:

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -1,4 +1,5 @@
-import json, times, strutils, sugar, os, re, chronicles
+import json, times, stint, strutils, sugar, os, re, chronicles
+
 import nimcrypto
 import account_constants
 
@@ -7,12 +8,12 @@ import ../../constants as main_constants
 const STATUS_DOMAIN* = ".stateofus.eth"
 const ETH_DOMAIN* = ".eth"
 
-proc arrayContains*[T](arr: seq[T], value: T): bool = 
+proc arrayContains*[T](arr: seq[T], value: T): bool =
   return arr.any(x => x == value)
 
 proc hashPassword*(password: string, lower: bool = true): string =
   let hashed = "0x" & $keccak_256.digest(password)
-  
+
   if lower:
     return hashed.toLowerAscii()
 
@@ -71,7 +72,7 @@ proc validateLink*(link: string): bool =
 proc isPathOutOfTheDefaultStatusDerivationTree*(path: string): bool =
   if not path.startsWith(account_constants.PATH_WALLET_ROOT&"/") or
     path.count("'") != 3 or
-    path.count("/") != 5: 
+    path.count("/") != 5:
       return true
   return false
 
@@ -82,3 +83,11 @@ proc intersectSeqs*[T](seq1, seq2: seq[T]): seq[T] =
   for item in seq1:
     if item in seq2:
       result.add(item)
+
+proc stringToUint256*(value: string): Uint256 =
+  var parsedValue = stint.u256(0)
+  try:
+    parsedValue = value.parse(Uint256)
+  except Exception as e:
+    discard
+  return parsedValue

--- a/src/app_service/service/eth/dto/transaction.nim
+++ b/src/app_service/service/eth/dto/transaction.nim
@@ -16,7 +16,8 @@ type
     nonce*: Option[Nonce]        # (optional) integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce
     txType*: string
 
-    chainID*: Option[int]     # (optional) chainID in case of a bridge hop transaction
+    chainID*: Option[int]     # (optional) source chainID
+    chainIDTo*: Option[int]     # (optional) destination chainID
     symbol*: Option[string]      # (optional) symbol in case of a bridge hop transaction
     recipient*: Option[Address]  # (optional) recipient in case of a bridge hop transaction
     amount*: Option[UInt256]         # (optional) amount in case of a bridge hop transaction
@@ -25,6 +26,8 @@ type
 
     tokenID*: Option[UInt256]     # (optional) chainID in case of a ERC721 transaction
 
+    tokenIdFrom*: Option[string]    # (optional) source token symbol
+    tokenIdTo*: Option[string]    # (optional) destination token symbol
     slippagePercentage*: Option[float]    # (optional) max slippage percentage allowed in case of a Swap transaction
 
 proc `%`*(x: TransactionDataDto): JsonNode =
@@ -49,6 +52,8 @@ proc `%`*(x: TransactionDataDto): JsonNode =
     result["nonce"] = %x.nonce.unsafeGet
   if x.chainID.isSome:
     result["chainId"] = %x.chainID.unsafeGet
+  if x.chainIDTo.isSome:
+    result["chainIdTo"] = %x.chainIDTo.unsafeGet
   if x.symbol.isSome:
     result["symbol"] = %x.symbol.unsafeGet
   if x.recipient.isSome:
@@ -61,6 +66,10 @@ proc `%`*(x: TransactionDataDto): JsonNode =
     result["bonderFee"] = %x.bonderFee.unsafeGet
   if x.tokenID.isSome:
     result["tokenID"] = %x.tokenID.unsafeGet
+  if x.tokenIdFrom.isSome:
+    result["tokenIdFrom"] = %x.tokenIdFrom.unsafeGet
+  if x.tokenIdTo.isSome:
+    result["tokenIdTo"] = %x.tokenIdTo.unsafeGet
   if x.slippagePercentage.isSome:
     result["slippagePercentage"] = %x.slippagePercentage.unsafeGet
 

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -1,4 +1,4 @@
-import json, strutils, stint, json_serialization, stew/shims/strformat, sugar, sequtils
+import json, strutils, stint, json_serialization, stew/shims/strformat
 
 import
   web3/ethtypes
@@ -334,7 +334,7 @@ proc convertToTransactionPathsDto*(jsonObj: JsonNode): seq[TransactionPathDto] =
 
 proc convertToTransactionPathsDto*(paths: string): seq[TransactionPathDto] =
   return paths.parseJson.convertToTransactionPathsDto()
-  
+
 type
   FeesDto* = ref object
     totalFeesInEth*: float
@@ -384,19 +384,3 @@ type
     amountToReceive*: UInt256
     toNetworks*: seq[SendToNetwork]
 
-proc `$`*(self: SuggestedRoutesDto): string =
-  return fmt"""SuggestedRoutesDto(
-    best:{self.best},
-    rawBest:{self.rawBest},
-    gasTimeEstimate:{self.gasTimeEstimate},
-    amountToReceive:{self.amountToReceive},
-    toNetworks:{self.toNetworks},
-  )"""
-
-proc convertToSuggestedRoutesDto*(jsonObj: JsonNode): SuggestedRoutesDto =
-  result = SuggestedRoutesDto()
-  result.rawBest = $jsonObj["suggestedRoutes"]["best"]
-  result.best = result.rawBest.convertToTransactionPathsDto()
-  result.gasTimeEstimate = jsonObj["suggestedRoutes"]["gasTimeEstimate"].convertToFeesDto()
-  result.amountToReceive = stint.u256(jsonObj["suggestedRoutes"]["amountToReceive"].getStr)
-  result.toNetworks = jsonObj["suggestedRoutes"]["toNetworks"].getElems().map(x => x.convertSendToNetwork())

--- a/src/app_service/service/transaction/dtoV2.nim
+++ b/src/app_service/service/transaction/dtoV2.nim
@@ -1,0 +1,79 @@
+# import json, json_serialization, stint
+
+# import ../network/dto, ../token/dto
+
+# include  app_service/common/json_utils
+
+import json, strutils, stint, json_serialization
+
+import
+  web3/ethtypes
+
+include  ../../common/json_utils
+import ../network/dto, ../token/dto
+
+type
+  SuggestedLevelsForMaxFeesPerGasDto* = ref object
+    low*: UInt256
+    medium*: UInt256
+    high*: UInt256
+
+type
+  TransactionPathDtoV2* = ref object
+    processorName*: string
+    fromChain*: NetworkDto
+    toChain*: NetworkDto
+    fromToken*: TokenDto
+    amountIn*: UInt256
+    amountInLocked*: bool
+    amountOut*: UInt256
+    suggestedLevelsForMaxFeesPerGas*: SuggestedLevelsForMaxFeesPerGasDto
+    txBaseFee*: UInt256
+    txPriorityFee*: UInt256
+    txGasAmount*: uint64
+    txBonderFees*: UInt256
+    txTokenFees*: UInt256
+    txL1Fee*: UInt256
+    approvalRequired*: bool
+    approvalAmountRequired*: UInt256
+    approvalContractAddress*: string
+    approvalBaseFee*: UInt256
+    approvalPriorityFee*: UInt256
+    approvalGasAmount*: uint64
+    approvalL1Fee*: UInt256
+    estimatedTime*: int
+
+proc toSuggestedLevelsForMaxFeesPerGasDto*(jsonObj: JsonNode): SuggestedLevelsForMaxFeesPerGasDto =
+  result = SuggestedLevelsForMaxFeesPerGasDto()
+  var value: string
+  if jsonObj.getProp("low", value):
+    result.low = stint.fromHex(UInt256, $value)
+  if jsonObj.getProp("medium", value):
+    result.medium = stint.fromHex(UInt256, $value)
+  if jsonObj.getProp("high", value):
+    result.high = stint.fromHex(UInt256, $value)
+
+proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
+  result = TransactionPathDtoV2()
+  discard jsonObj.getProp("ProcessorName", result.processorName)
+  result.fromChain = Json.decode($jsonObj["FromChain"], NetworkDto, allowUnknownFields = true)
+  result.toChain = Json.decode($jsonObj["ToChain"], NetworkDto, allowUnknownFields = true)
+  result.fromToken = Json.decode($jsonObj["FromToken"], TokenDto, allowUnknownFields = true)
+  result.amountIn = stint.fromHex(UInt256, jsonObj{"AmountIn"}.getStr)
+  discard jsonObj.getProp("AmountInLocked", result.amountInLocked)
+  result.amountOut = stint.fromHex(UInt256, jsonObj{"AmountOut"}.getStr)
+  result.suggestedLevelsForMaxFeesPerGas = jsonObj["SuggestedLevelsForMaxFeesPerGas"].toSuggestedLevelsForMaxFeesPerGasDto()
+  result.txBaseFee = stint.fromHex(UInt256, jsonObj{"TxBaseFee"}.getStr)
+  result.txPriorityFee = stint.fromHex(UInt256, jsonObj{"TxPriorityFee"}.getStr)
+  discard jsonObj.getProp("TxGasAmount", result.txGasAmount)
+  result.txBonderFees = stint.fromHex(UInt256, jsonObj{"TxBonderFees"}.getStr)
+  result.txTokenFees = stint.fromHex(UInt256, jsonObj{"TxTokenFees"}.getStr)
+  result.txL1Fee = stint.fromHex(UInt256, jsonObj{"TxL1Fee"}.getStr)
+  discard jsonObj.getProp("ApprovalRequired", result.approvalRequired)
+  result.approvalAmountRequired = stint.fromHex(UInt256, jsonObj{"ApprovalAmountRequired"}.getStr)
+  discard jsonObj.getProp("ApprovalContractAddress", result.approvalContractAddress)
+  result.approvalBaseFee = stint.fromHex(UInt256, jsonObj{"ApprovalBaseFee"}.getStr)
+  result.approvalPriorityFee = stint.fromHex(UInt256, jsonObj{"ApprovalPriorityFee"}.getStr)
+  discard jsonObj.getProp("ApprovalGasAmount", result.approvalGasAmount)
+  result.approvalL1Fee = stint.fromHex(UInt256, jsonObj{"ApprovalL1Fee"}.getStr)
+  result.estimatedTime = jsonObj{"EstimatedTime"}.getInt

--- a/src/app_service/service/transaction/dtoV2.nim
+++ b/src/app_service/service/transaction/dtoV2.nim
@@ -5,6 +5,7 @@
 # include  app_service/common/json_utils
 
 import json, strutils, stint, json_serialization
+import sequtils, sugar
 
 import
   web3/ethtypes
@@ -24,6 +25,7 @@ type
     fromChain*: NetworkDto
     toChain*: NetworkDto
     fromToken*: TokenDto
+    toToken*: TokenDto
     amountIn*: UInt256
     amountInLocked*: bool
     amountOut*: UInt256
@@ -59,6 +61,7 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   result.fromChain = Json.decode($jsonObj["FromChain"], NetworkDto, allowUnknownFields = true)
   result.toChain = Json.decode($jsonObj["ToChain"], NetworkDto, allowUnknownFields = true)
   result.fromToken = Json.decode($jsonObj["FromToken"], TokenDto, allowUnknownFields = true)
+  result.toToken = Json.decode($jsonObj["ToToken"], TokenDto, allowUnknownFields = true)
   result.amountIn = stint.fromHex(UInt256, jsonObj{"AmountIn"}.getStr)
   discard jsonObj.getProp("AmountInLocked", result.amountInLocked)
   result.amountOut = stint.fromHex(UInt256, jsonObj{"AmountOut"}.getStr)
@@ -77,3 +80,9 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   discard jsonObj.getProp("ApprovalGasAmount", result.approvalGasAmount)
   result.approvalL1Fee = stint.fromHex(UInt256, jsonObj{"ApprovalL1Fee"}.getStr)
   result.estimatedTime = jsonObj{"EstimatedTime"}.getInt
+
+proc toTransactionPathsDtoV2*(jsonObj: JsonNode): seq[TransactionPathDtoV2] =
+  return jsonObj.getElems().map(x => x.toTransactionPathDtoV2())
+
+proc toTransactionPathsDtoV2*(rawPaths: string): seq[TransactionPathDtoV2] =
+  return rawPaths.parseJson.toTransactionPathsDtoV2()

--- a/src/app_service/service/transaction/dto_conversion.nim
+++ b/src/app_service/service/transaction/dto_conversion.nim
@@ -1,0 +1,74 @@
+import strutils, stint, chronicles, algorithm
+
+import app_service/common/conversion
+
+import ./dto, ./dtoV2
+
+proc sortAsc[T](t1, t2: T): int =
+  if (t1.fromNetwork.chainId > t2.fromNetwork.chainId): return 1
+  elif (t1.fromNetwork.chainId < t2.fromNetwork.chainId): return -1
+  else: return 0
+
+proc convertToOldRoute*(route: seq[TransactionPathDtoV2]): seq[TransactionPathDto] =
+  const
+    gweiDecimals = 9
+    ethDecimals = 18
+  for p in route:
+    var
+      fees = SuggestedFeesDto()
+      trPath = TransactionPathDto()
+
+    try:
+      # prepare fees
+      fees.gasPrice = 0
+      var value = conversion.wei2Eth(input = p.txBaseFee, decimals = gweiDecimals)
+      fees.baseFee = parseFloat(value)
+      value = conversion.wei2Eth(input = p.txPriorityFee, decimals = gweiDecimals)
+      fees.maxPriorityFeePerGas = parseFloat(value)
+      value = conversion.wei2Eth(input = p.suggestedLevelsForMaxFeesPerGas.low, decimals = gweiDecimals)
+      fees.maxFeePerGasL = parseFloat(value)
+      value = conversion.wei2Eth(input = p.suggestedLevelsForMaxFeesPerGas.medium, decimals = gweiDecimals)
+      fees.maxFeePerGasM = parseFloat(value)
+      value = conversion.wei2Eth(input = p.suggestedLevelsForMaxFeesPerGas.high, decimals = gweiDecimals)
+      fees.maxFeePerGasH = parseFloat(value)
+      value = conversion.wei2Eth(input = p.txL1Fee, decimals = gweiDecimals)
+      fees.l1GasFee = parseFloat(value)
+      fees.eip1559Enabled = true
+
+      # prepare tx path
+      trPath.bridgeName = p.processorName
+      trPath.fromNetwork = p.fromChain
+      trPath.toNetwork = p.toChain
+      trPath.fromToken = p.fromToken
+      trPath.toToken = p.toToken
+      trPath.gasFees = fees
+      # trPath.cost = not in use for old approach in the desktop app
+      value = conversion.wei2Eth(input = p.txTokenFees, decimals = p.fromToken.decimals)
+      trPath.tokenFees = parseFloat(value)
+      value = conversion.wei2Eth(input = p.txBonderFees, decimals = p.fromToken.decimals)
+      trPath.bonderFees = value
+      trPath.tokenFees += parseFloat(value) # we add bonder fees to the token fees cause in the UI, atm, we show only token fees
+      trPath.maxAmountIn = stint.fromHex(UInt256, "0x0")
+      trPath.amountIn = p.amountIn
+      trPath.amountOut = p.amountOut
+      trPath.approvalRequired = p.approvalRequired
+      trPath.approvalAmountRequired = p.approvalAmountRequired
+      trPath.approvalContractAddress = p.approvalContractAddress
+      trPath.amountInLocked = p.amountInLocked
+      trPath.estimatedTime = p.estimatedTime
+      trPath.gasAmount = p.txGasAmount
+
+      value = conversion.wei2Eth(p.suggestedLevelsForMaxFeesPerGas.medium,  decimals = ethDecimals)
+      trPath.approvalGasFees = parseFloat(value) * float64(p.approvalGasAmount)
+      value = conversion.wei2Eth(p.approvalL1Fee,  decimals = ethDecimals)
+      trPath.approvalGasFees += parseFloat(value)
+
+      trPath.isFirstSimpleTx = false
+      trPath.isFirstBridgeTx = false
+    except Exception as e:
+      error "Error converting to old path", msg = e.msg
+
+    # add tx path to the list
+    result.add(trPath)
+
+  result.sort(sortAsc[TransactionPathDto])

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -188,10 +188,6 @@ QObject {
         return root.currencyStore.formatCurrencyAmountFromBigInt(balance, symbol, decimals, options)
     }
 
-    function getAllChainIds() {
-        return ModelUtils.joinModelEntries(root.filteredFlatNetworksModel, "chainId", ":")
-    }
-
     function getDisabledChainIds(enabledChainId) {
         let disabledChainIds = []
         let chainIds = ModelUtils.modelToFlatArray(root.filteredFlatNetworksModel, "chainId")
@@ -203,8 +199,8 @@ QObject {
         return disabledChainIds.join(":")
     }
 
-    function fetchSuggestedRoutes(cryptoValueRaw) {
-        if (root.swapFormData.isFormFilledCorrectly() && !!cryptoValueRaw) {
+    function fetchSuggestedRoutes(cryptoValueInRaw) {
+        if (root.swapFormData.isFormFilledCorrectly() && !!cryptoValueInRaw) {
             root.swapProposalLoading = true
             root.swapOutputData.reset()
 
@@ -214,12 +210,10 @@ QObject {
             let account = selectedAccountEntry.item
             let accountAddress = account.address
             let disabledChainIds = getDisabledChainIds(root.swapFormData.selectedNetworkChainId)
-            let preferedChainIds = getAllChainIds()
 
             root.swapStore.fetchSuggestedRoutes(accountAddress, accountAddress,
-                                                cryptoValueRaw, root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey,
-                                                disabledChainIds, disabledChainIds, preferedChainIds,
-                                                Constants.SendType.Swap, "")
+                                                cryptoValueInRaw, "0", root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey,
+                                                disabledChainIds, disabledChainIds, Constants.SendType.Swap, "")
         } else {
             root.swapProposalLoading = false
         }
@@ -230,7 +224,7 @@ QObject {
         let accountAddress = account.address
 
         root.swapStore.authenticateAndTransfer(d.uuid, accountAddress, accountAddress,
-            root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey, 
+            root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey,
             Constants.SendType.Approve, "", false, root.swapOutputData.rawPaths, "")
     }
 
@@ -239,7 +233,7 @@ QObject {
         let accountAddress = account.address
 
         root.swapStore.authenticateAndTransfer(d.uuid, accountAddress, accountAddress,
-            root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey, 
+            root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey,
             Constants.SendType.Swap, "", false, root.swapOutputData.rawPaths, root.swapFormData.selectedSlippage)
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
@@ -25,11 +25,12 @@ QtObject {
         }
     }
 
-    function fetchSuggestedRoutes(accountFrom, accountTo, amount, tokenFrom, tokenTo,
-        disabledFromChainIDs, disabledToChainIDs, preferredChainIDs, sendType, lockedInAmounts) {
-        const value = AmountsArithmetic.fromNumber(amount)
-        root.walletSectionSendInst.fetchSuggestedRoutesWithParameters(accountFrom, accountTo, value.toFixed(),
-            tokenFrom, tokenTo, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs, sendType, lockedInAmounts)
+    function fetchSuggestedRoutes(accountFrom, accountTo, amountIn, amountOut, tokenFrom, tokenTo,
+        disabledFromChainIDs, disabledToChainIDs, sendType, lockedInAmounts) {
+        const valueIn = AmountsArithmetic.fromNumber(amountIn)
+        const valueOut = AmountsArithmetic.fromNumber(amountOut)
+        root.walletSectionSendInst.fetchSuggestedRoutesWithParameters(accountFrom, accountTo, valueIn.toFixed(), valueOut.toFixed(),
+            tokenFrom, tokenTo, disabledFromChainIDs, disabledToChainIDs, sendType, lockedInAmounts)
     }
 
     function authenticateAndTransfer(uuid, accountFrom, accountTo,

--- a/ui/imports/shared/popups/send/controls/GasSelector.qml
+++ b/ui/imports/shared/popups/send/controls/GasSelector.qml
@@ -57,9 +57,9 @@ Item {
                     return fee
                 }
                 property double totalGasAmountL1Eth: {
-                    let maxFees = modelData.gasFees.maxFeePerGasM
-                    let gasPrice = modelData.gasFees.eip1559Enabled? maxFees : modelData.gasFees.gasPrice
-                    return root.getGasEthValue(gasPrice , modelData.gasFees.l1GasFee)
+                    const l1FeeInGWei = modelData.gasFees.l1GasFee
+                    const l1FeeInEth = globalUtils.wei2Eth(l1FeeInGWei, 9)
+                    return l1FeeInEth
                 }
 
                 property double totalGasAmountEth: {

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -66,9 +66,10 @@ QtObject {
         walletSectionSendInst.authenticateAndTransfer(uuid)
     }
 
-    function suggestedRoutes(amount) {
-        const value = AmountsArithmetic.fromNumber(amount)
-        walletSectionSendInst.suggestedRoutes(value.toFixed())
+    function suggestedRoutes(amountIn, amountOut = "0", extraParamsJson = "") {
+        const valueIn = AmountsArithmetic.fromNumber(amountIn)
+        const valueOut = AmountsArithmetic.fromNumber(amountOut)
+        walletSectionSendInst.suggestedRoutes(valueIn.toFixed(), valueOut.toFixed(), extraParamsJson)
     }
 
     function resolveENS(value) {


### PR DESCRIPTION
An asynchronous which was before on the Nim side, is not achieved on the status-go side and the result is handled by handling `"wallet.suggested.routes"` signal sent from the status-go side.

Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/5426

Apart from that change nothing should be changed in terms of UI, and nothing is refactored (even the SendModal popup deserves a big refactor to get it back to the good and maintainable path), what's really done is just a simple router v2 integration, by mapping new to the old path params.

Closes: #15204