### PR TITLE
chore: fix revealed addresses loose by token master

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -391,7 +391,7 @@ Rectangle {
                 anchors.top: statusListItemTertiaryTitle.bottom
                 anchors.topMargin: visible ? 2 : 0
                 width: Math.min(statusListItemTagsSlotInline.width, statusListItemTagsSlotInline.availableWidth, parent.width)
-                height: visible ? contentHeight : 0
+                height: visible ? contentHeight + 16 : 0
                 padding: 0
                 ScrollBar.horizontal.policy: root.tagsScrollBarVisible ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
 

--- a/ui/imports/shared/popups/send/views/TokenListView.qml
+++ b/ui/imports/shared/popups/send/views/TokenListView.qml
@@ -219,6 +219,7 @@ Item {
         id: tokenDelegate
         TokenBalancePerChainDelegate {
             width: tokenList.width
+            tagsScrollBarVisible: true
 
             balancesModel: LeftJoinModel {
                 leftModel: !!model & !!model.balancesModel ? model.balancesModel : null


### PR DESCRIPTION
### What does the PR do

1. If TokenMaster restores his account by a seed phrase - send him requests to join with revealed addresses
2. If a member edits the shared address, the token master receives it only when a control node approves the new addresses
3. Filter our outdated edit shared address and privileged user sync messages
4. Fixed changing privileged permissions (TM -> admin, admin -> TM)

status-go PR: https://github.com/status-im/status-go/pull/5383

Closes: https://github.com/status-im/status-desktop/issues/15139

### Affected areas

Sharing revealed addresses

