### PR TITLE
fix(muted): reevaluate section badge when unmuting

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -132,7 +132,6 @@ proc init*(self: Controller) =
     let chat = self.chatService.getChatById(args.chatId)
     self.delegate.onMarkMessageAsUnread(chat)
 
-
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)
     self.delegate.onCommunityChannelDeletedOrChatLeft(args.chatId)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -948,6 +948,7 @@ method onCategoryUnmuted*(self: Module, categoryId: string) =
 
 method changeMutedOnChat*(self: Module, chatId: string, muted: bool) =
   self.view.chatsModel().changeMutedOnItemById(chatId, muted)
+  self.updateParentBadgeNotifications()
 
 proc changeCanPostValues*(self: Module, chatId: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool) =
   self.view.chatsModel().changeCanPostValues(chatId, canPost, canView, canPostReactions, viewersCanPostReactions)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -575,6 +575,11 @@ QtObject:
         error "error while mute chat ", msg
         return
 
+      # There is no response except an error, so we can just modify the chat ourselves
+      var chat = self.chats[chatID]
+      chat.muted = true
+      self.updateOrAddChat(chat)
+
       self.events.emit(SIGNAL_CHAT_MUTED, ChatArgs(chatId: chatId))
     except Exception as e:
       let errDesription = e.msg
@@ -592,6 +597,11 @@ QtObject:
         let msg = response.error.message & " chatId=" & chatId
         error "error while unmute chat ", msg
         return
+
+      # There is no response except an error, so we can just modify the chat ourselves
+      var chat = self.chats[chatID]
+      chat.muted = false
+      self.updateOrAddChat(chat)
 
       self.events.emit(SIGNAL_CHAT_UNMUTED, ChatArgs(chatId: chatId))
     except Exception as e:


### PR DESCRIPTION
Fixes #11093

When unmuting a channel, reevaluate the section badge so that it appears if there were unread messages in that channel

Also fixes an issue where the chat muted property was not set correctly in the cache after muting or unmuting

[unmute.webm](https://github.com/status-im/status-desktop/assets/11926403/1de2d94f-250f-4b7d-a683-95de6336d5d6)
