### PR TITLE
fix(profile): fix missing ring in own profile

### DIFF
--- a/storybook/qmlTests/tests/tst_ContactDetails.qml
+++ b/storybook/qmlTests/tests/tst_ContactDetails.qml
@@ -108,7 +108,7 @@ Item {
             compare(contactDetails.profileStore.displayName,"myDisplayName", "Expected the profile store to be set")
             compare(contactDetails.displayName, contactDetails.profileStore.displayName, "Expected the display name to be set")
             compare(contactDetails.ensName, contactDetails.profileStore.name, "Expected the ens name to be set")
-            compare(contactDetails.ensVerified, true, "Expected the ensVerified to be set")
+            compare(contactDetails.ensVerified, false, "Expected the ensVerified to be set")
             compare(contactDetails.localNickname, "", "Expected the local nickname to be empty")
             compare(contactDetails.alias, contactDetails.profileStore.username, "Expected the alias to be set")
             compare(contactDetails.icon, contactDetails.profileStore.icon, "Expected the icon to be set")

--- a/ui/app/AppLayouts/Profile/helpers/ContactDetails.qml
+++ b/ui/app/AppLayouts/Profile/helpers/ContactDetails.qml
@@ -78,7 +78,7 @@ QObject {
         readonly property var ownProfile: QObject {
             readonly property string displayName: root.profileStore.displayName
             readonly property string ensName: root.profileStore.name
-            readonly property bool isEnsVerified: root.profileStore.name !== ""
+            readonly property bool isEnsVerified: root.profileStore.name !== "" && Utils.isValidEns(root.profileStore.name)
             readonly property string localNickname: ""
             readonly property string alias: root.profileStore.username
             readonly property string icon: root.profileStore.icon


### PR DESCRIPTION
Fixes #15314

The problem is that we used the `name` property to know if we have an ENS name, but we actually set it to whatever is available, so we need to validate that it's an ENS name

As seen here:
https://github.com/status-im/status-desktop/blob/7a7dbb631c11edf7e63594eddbc7beffa42ab646/src/app/global/user_profile.nim#L98-L103

![image](https://github.com/status-im/status-desktop/assets/11926403/9e25a6c1-4d05-46d8-b5a6-3879ba839049)
