### PR TITLE
feat(MonitoringTool): Search improved

### DIFF
--- a/monitoring/ModelInspectionPane.qml
+++ b/monitoring/ModelInspectionPane.qml
@@ -83,6 +83,8 @@ Pane {
         }
 
         Label {
+            visible: listView.count
+
             text: "Hint: use right/left button click on a column " +
                   "header to adjust width, press cell content to " +
                   "see full value"

--- a/ui/include/StatusDesktop/Monitoring/Monitor.h
+++ b/ui/include/StatusDesktop/Monitoring/Monitor.h
@@ -26,7 +26,7 @@ public:
     Q_INVOKABLE QString typeName(const QVariant &obj) const;
     Q_INVOKABLE QJSValue modelRoles(QAbstractItemModel *model) const;
 
-    Q_INVOKABLE QObject* findChild(QObject* obj, const QString& name) const;
+    Q_INVOKABLE QObject* findChild(QObject* parent, const QString& name) const;
 
     static Monitor& instance();
     static QObject* qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine);


### PR DESCRIPTION
Closes: #15181

### What does the PR do

Now the search traverses freely over all objects, including those created by `ListView`, `Repeater` and similar. Parents are predefined in code, no longer needed to provide them manually. All of them are test until the given object name is found.

### Screenshot of functionality (including design for comparison)

[Screencast from 26.06.2024 20:32:41.webm](https://github.com/status-im/status-desktop/assets/20650004/7a97396a-ea4b-47fc-ac58-df45d3d35923)

