### PR TITLE
feat(StatusQ): Generic attachd type for providing model count

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(StatusQ SHARED
         include/StatusQ/functionaggregator.h
         include/StatusQ/groupingmodel.h
         include/StatusQ/leftjoinmodel.h
+        include/StatusQ/modelcount.h
         include/StatusQ/modelentry.h
         include/StatusQ/modelsyncedcontainer.h
         include/StatusQ/modelutilsinternal.h
@@ -130,6 +131,7 @@ add_library(StatusQ SHARED
         src/functionaggregator.cpp
         src/groupingmodel.cpp
         src/leftjoinmodel.cpp
+        src/modelcount.cpp
         src/modelentry.cpp
         src/modelutilsinternal.cpp
         src/movablemodel.cpp

--- a/ui/StatusQ/include/StatusQ/modelcount.h
+++ b/ui/StatusQ/include/StatusQ/modelcount.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+
+class QAbstractItemModel;
+
+class ModelCount : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+public:
+    explicit ModelCount(QObject* parent = nullptr);
+
+    static ModelCount* qmlAttachedProperties(QObject* object);
+
+    int count() const;
+
+signals:
+    void countChanged();
+
+private:
+    int m_intermediateCount = 0;
+};
+
+QML_DECLARE_TYPEINFO(ModelCount, QML_HAS_ATTACHED_PROPERTIES)

--- a/ui/StatusQ/src/modelcount.cpp
+++ b/ui/StatusQ/src/modelcount.cpp
@@ -1,0 +1,44 @@
+#include "StatusQ/modelcount.h"
+
+#include <QAbstractItemModel>
+
+ModelCount::ModelCount(QObject* parent) : QObject(parent)
+{
+    auto model = qobject_cast<QAbstractItemModel*>(parent);
+
+    if (model == nullptr)
+        return;
+
+    connect(model, &QAbstractItemModel::rowsInserted,
+            this, &ModelCount::countChanged);
+    connect(model, &QAbstractItemModel::rowsRemoved,
+            this, &ModelCount::countChanged);
+
+    auto storeIntermediateCount = [this, model] {
+        this->m_intermediateCount = model->rowCount();
+    };
+
+    auto emitIfChanged = [this, model] {
+        if (this->m_intermediateCount != model->rowCount())
+            emit this->countChanged();
+    };
+
+    connect(model, &QAbstractItemModel::modelAboutToBeReset, this, storeIntermediateCount);
+    connect(model, &QAbstractItemModel::layoutAboutToBeChanged, storeIntermediateCount);
+
+    connect(model, &QAbstractItemModel::modelReset, this, emitIfChanged);
+    connect(model, &QAbstractItemModel::layoutChanged, this, emitIfChanged);
+}
+
+ModelCount* ModelCount::qmlAttachedProperties(QObject* object)
+{
+    return new ModelCount(object);
+}
+
+int ModelCount::count() const
+{
+    if (auto model = qobject_cast<QAbstractItemModel*>(parent()))
+        return model->rowCount();
+
+    return 0;
+}

--- a/ui/StatusQ/src/plugin.cpp
+++ b/ui/StatusQ/src/plugin.cpp
@@ -12,6 +12,7 @@
 #include "StatusQ/functionaggregator.h"
 #include "StatusQ/groupingmodel.h"
 #include "StatusQ/leftjoinmodel.h"
+#include "StatusQ/modelcount.h"
 #include "StatusQ/modelentry.h"
 #include "StatusQ/modelutilsinternal.h"
 #include "StatusQ/movablemodel.h"
@@ -70,6 +71,9 @@ public:
         qmlRegisterSingletonType<QClipboardProxy>("StatusQ", 0, 1, "QClipboardProxy", &QClipboardProxy::qmlInstance);
         qmlRegisterType<ModelEntry>("StatusQ", 0, 1, "ModelEntry");
         qmlRegisterType<SnapshotObject>("StatusQ", 0, 1, "SnapshotObject");
+
+        qmlRegisterUncreatableType<ModelCount>("StatusQ", 0, 1,
+                                               "ModelCount", "This is attached type, cannot be created directly.");
 
         qmlRegisterSingletonType<ModelUtilsInternal>(
             "StatusQ.Internal", 0, 1, "ModelUtils", &ModelUtilsInternal::qmlInstance);

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -115,3 +115,7 @@ add_test(NAME SnapshotObjectTest COMMAND SnapshotObjectTest)
 add_executable(GroupingModelTest tst_GroupingModel.cpp)
 target_link_libraries(GroupingModelTest PRIVATE Qt5::Qml StatusQ StatusQTestLib)
 add_test(NAME GroupingModelTest COMMAND GroupingModelTest)
+
+add_executable(ModelCountTest tst_ModelCount.cpp)
+target_link_libraries(ModelCountTest PRIVATE StatusQ StatusQTestLib)
+add_test(NAME ModelCountTest COMMAND ModelCountTest)

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.cpp
@@ -134,6 +134,15 @@ void TestModel::reset()
     endResetModel();
 }
 
+void TestModel::resetAndClear()
+{
+    beginResetModel();
+    std::for_each(m_data.begin(), m_data.end(), [](auto& e) {
+        e.second.clear();
+    });
+    endResetModel();
+}
+
 void TestModel::initRoles()
 {
     m_roles.reserve(m_data.size());

--- a/ui/StatusQ/tests/src/TestHelpers/testmodel.h
+++ b/ui/StatusQ/tests/src/TestHelpers/testmodel.h
@@ -29,6 +29,9 @@ public:
     // emits modelAboutToBeReset/modelReset, content remains the same
     void reset();
 
+    // emits modelAboutToBeReset/modelReset, content is removed
+    void resetAndClear();
+
 private:
     void initRoles();
 

--- a/ui/StatusQ/tests/tst_ModelCount.cpp
+++ b/ui/StatusQ/tests/tst_ModelCount.cpp
@@ -1,0 +1,63 @@
+#include <QtTest>
+
+#include <StatusQ/modelcount.h>
+
+#include <TestHelpers/testmodel.h>
+
+
+class TestModelCount : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void modelCountTest()
+    {
+        TestModel model({
+            { "name", { "a", "b", "c", "d" }}
+        });
+
+        ModelCount modelCount(&model);
+
+        QCOMPARE(modelCount.count(), 4);
+
+        QSignalSpy spy(&modelCount, &ModelCount::countChanged);
+
+        model.insert(1, { "e" });
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(modelCount.count(), 5);
+
+        model.remove(0);
+
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(modelCount.count(), 4);
+
+        model.update(0, 0, "aa");
+
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(modelCount.count(), 4);
+
+        model.invert();
+
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(modelCount.count(), 4);
+
+        model.removeEverySecond();
+
+        QCOMPARE(spy.count(), 3);
+        QCOMPARE(modelCount.count(), 2);
+
+        model.reset();
+
+        QCOMPARE(spy.count(), 3);
+        QCOMPARE(modelCount.count(), 2);
+
+        model.resetAndClear();
+
+        QCOMPARE(spy.count(), 4);
+        QCOMPARE(modelCount.count(), 0);
+    }
+};
+
+QTEST_MAIN(TestModelCount)
+#include "tst_ModelCount.moc"


### PR DESCRIPTION
### What does the PR do

Introduces attached type `ModelCount` providing model count for arbitrary `QAbstractItemModel`. Works with both UI models like `ListModel`, all proxy models, and NIM models. Doesn't rely on `count` property in source model. It gives a possibility to skip implementation of `count` in nim models, which is boilerplate code repeated in many models.

Closes: #15374

Example:
Whenever in existing code we have:
```
            channelsListModel: model.channelsListModel.rowCount()
                                    ? channelsSelectionModel : communityItemModel
```
such binding is unreliable because won't be reevaluated appropriately on count change.

Now it can be fixed easily with `ModelCount`:
```
            channelsListModel: model.channelsListModel.ModelCount.count
                                    ? channelsSelectionModel : communityItemModel
```
which is fully responsive to count changes of the model.
