### PR TITLE
chore: attach geth.log to allure report when running autotests

### DIFF
--- a/test/e2e/driver/aut.py
+++ b/test/e2e/driver/aut.py
@@ -119,7 +119,7 @@ class AUT:
         LOG.info('Stopping AUT: %s', self.path)
         self.detach_context()
         local_system.kill_process(self.pid)
-        time.sleep(1)
+        time.sleep(1) # FIXME: Implement waiting for process to actually exit.
 
     @allure.step("Start and attach AUT")
     def launch(self) -> 'AUT':

--- a/test/e2e/driver/server.py
+++ b/test/e2e/driver/server.py
@@ -44,7 +44,7 @@ class SquishServer:
             return
         LOG.info('Stopping Squish Server with PID: %d', cls.pid)
         local_system.kill_process(cls.pid)
-        time.sleep(1)
+        time.sleep(1) # FIXME: Implement waiting for process to actually exit.
         cls.pid = None
         cls.port = None
 

--- a/test/e2e/fixtures/aut.py
+++ b/test/e2e/fixtures/aut.py
@@ -24,9 +24,14 @@ def application_logs():
     yield
     if configs.testpath.STATUS_DATA.exists():
         for app_data in configs.testpath.STATUS_DATA.iterdir():
-            for log in (app_data / 'logs').glob('*.log'):
-                allure.attach.file(log, name=str(log.name), attachment_type=allure.attachment_type.TEXT)
-                log.unlink()  # FIXME: it does not work on Windows, permission error
+            for log_dir in ['logs', 'data']:
+                log_path = app_data / log_dir
+                for log in log_path.glob('*.log'):
+                    allure.attach.file(log, name=str(log.name), attachment_type=allure.attachment_type.TEXT)
+                    try:
+                        log.unlink()  # FIXME: it does not work on Windows, permission error
+                    except PermissionError:
+                        print(f"Permission error: {log} could not be deleted.")
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does the PR do

attach geth.log to allure report when running autotests

Fixes https://github.com/status-im/status-desktop/issues/15339

<img width="1840" alt="Screenshot 2024-06-28 at 16 44 49" src="https://github.com/status-im/status-desktop/assets/82375995/6a47a8cf-64e7-43e3-abb5-d5ec684b7f66">


### Affected areas

e2e tests