### PR TITLE
chore: Use optimized endpoint to get communities with images

### DIFF
--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -27,7 +27,7 @@ proc getCuratedCommunities*(): RpcResponse[JsonNode] =
   result = callPrivateRPC("curatedCommunities".prefix, payload)
 
 proc getAllCommunities*(): RpcResponse[JsonNode] =
-  result = callPrivateRPC("communities".prefix)
+  result = callPrivateRPC("serializedCommunities".prefix)
 
 proc isDisplayNameDupeOfCommunityMember*(displayName: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("isDisplayNameDupeOfCommunityMember".prefix, %* [displayName])


### PR DESCRIPTION
fixes #15340

### What does the PR do
The twin of mobile PR: https://github.com/status-im/status-mobile/pull/20481
Use `wakuext_serialisedCommunities` instead of `wakuext_communities` API which returns image media server URLs instead of base64 blobs.

works seamlessly

### Affected areas
Any place in the app showing community images (banner, logo, thumbnail)

### Screenshot of functionality (including design for comparison)
Here I've logged incoming json with communities and show that the community logo is present as the media server URL.

https://github.com/status-im/status-desktop/assets/1083341/0f571c9b-edf6-4afb-8546-197d0ecdde7b
