### PR TITLE
feat(wallet)_: Implement Manual Wallet Reload Functionality

### DIFF
--- a/src/app/modules/main/wallet_section/controller.nim
+++ b/src/app/modules/main/wallet_section/controller.nim
@@ -68,3 +68,6 @@ proc getKeypairByAccountAddress*(self: Controller, address: string): KeypairDto 
 
 proc hasPairedDevices*(self: Controller): bool =
   return self.walletAccountService.hasPairedDevices()
+
+proc reloadAccountTokens*(self: Controller) =
+  self.walletAccountService.reloadAccountTokens()

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -120,3 +120,6 @@ method resetRpcStats*(self: AccessInterface) {.base.} =
 
 method canProfileProveOwnershipOfProvidedAddresses*(self: AccessInterface, addresses: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method reloadAccountTokens*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -283,8 +283,11 @@ method load*(self: Module) =
     self.setTotalCurrencyBalance()
     self.notifyFilterChanged()
   self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
+    let args = TokensPerAccountArgs(e)
     self.setTotalCurrencyBalance()
     self.notifyModulesBalanceIsLoaded()
+    self.view.setLastReloadTimestamp(args.timestamp)
+    self.view.setIsAccountTokensReloading(false)
   self.events.on(SIGNAL_TOKENS_PRICES_UPDATED) do(e:Args):
     self.setTotalCurrencyBalance()
     self.notifyFilterChanged()
@@ -522,3 +525,7 @@ method canProfileProveOwnershipOfProvidedAddresses*(self: Module, addresses: str
     if keypair.migratedToKeycard():
       return false
   return true
+
+method reloadAccountTokens*(self: Module) =
+  self.view.setIsAccountTokensReloading(true)
+  self.controller.reloadAccountTokens()

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -276,6 +276,8 @@ QtObject:
   proc lastReloadTimestampChanged*(self: View) {.signal.}
 
   proc setLastReloadTimestamp*(self: View, lastReloadTimestamp: int64) =
+    if lastReloadTimestamp == self.lastReloadTimestamp:
+      return
     self.lastReloadTimestamp = lastReloadTimestamp
     self.lastReloadTimestampChanged()
 
@@ -289,6 +291,8 @@ QtObject:
   proc isAccountTokensReloadingChanged*(self: View) {.signal.}
 
   proc setIsAccountTokensReloading*(self: View, isAccountTokensReloading: bool) =
+    if isAccountTokensReloading == self.isAccountTokensReloading:
+      return
     self.isAccountTokensReloading = isAccountTokensReloading
     self.isAccountTokensReloadingChanged()
 

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -29,6 +29,8 @@ QtObject:
       walletReady: bool
       addressFilters: string
       currentCurrency: string
+      isAccountTokensReloading: bool
+      lastReloadTimestamp: int64
 
   proc setup(self: View) =
     self.QObject.setup
@@ -267,3 +269,33 @@ QtObject:
 
   proc canProfileProveOwnershipOfProvidedAddresses*(self: View, addresses: string): bool {.slot.} =
     return self.delegate.canProfileProveOwnershipOfProvidedAddresses(addresses)
+
+  proc reloadAccountTokens*(self: View) {.slot.} =
+    self.delegate.reloadAccountTokens()
+
+  proc lastReloadTimestampChanged*(self: View) {.signal.}
+
+  proc setLastReloadTimestamp*(self: View, lastReloadTimestamp: int64) =
+    self.lastReloadTimestamp = lastReloadTimestamp
+    self.lastReloadTimestampChanged()
+
+  proc getLastReloadTimestamp(self: View): QVariant {.slot.} =
+    return newQVariant(self.lastReloadTimestamp)
+
+  QtProperty[QVariant] lastReloadTimestamp:
+    read = getLastReloadTimestamp
+    notify = lastReloadTimestampChanged
+  
+  proc isAccountTokensReloadingChanged*(self: View) {.signal.}
+
+  proc setIsAccountTokensReloading*(self: View, isAccountTokensReloading: bool) =
+    self.isAccountTokensReloading = isAccountTokensReloading
+    self.isAccountTokensReloadingChanged()
+
+  proc getIsAccountTokensReloading(self: View): bool {.slot.} =
+    return self.isAccountTokensReloading
+
+  QtProperty[bool] isAccountTokensReloading:
+    read = getIsAccountTokensReloading
+    notify = isAccountTokensReloadingChanged
+

--- a/src/app_service/service/wallet_account/signals_and_payloads.nim
+++ b/src/app_service/service/wallet_account/signals_and_payloads.nim
@@ -72,6 +72,7 @@ type DerivedAddressesArgs* = ref object of Args
 type TokensPerAccountArgs* = ref object of Args
   accountAddresses*: seq[string]
   accountTokens*: seq[GroupedTokenItem]
+  timestamp*: int64
 
 type KeycardActivityArgs* = ref object of Args
   success*: bool

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -331,3 +331,6 @@ rpc(getBalancesByChain, "wallet"):
   chainIds: seq[int]
   addresses: seq[string]
   tokenAddresses: seq[string]
+
+rpc(restartWalletReloadTimer, "wallet"):
+  discard

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -55,6 +55,9 @@ Button {
     property int type: StatusBaseButton.Type.Normal
     property int textPosition: StatusBaseButton.TextPosition.Right
 
+    // use Size.Small as default value to not change old behavior which had default size of 20x20
+    property int  loadingIndicatorSize: StatusBaseButton.Size.Small
+
     property bool isRoundIcon: false
 
     QtObject {
@@ -69,8 +72,10 @@ Button {
         }
 
         readonly property bool iconOnly: root.display === AbstractButton.IconOnly || root.text === ""
-        readonly property int iconSize: {
-            switch(root.size) {
+        readonly property int iconSize: mapIconSize(root.size)
+
+        function mapIconSize(buttonSize) {
+            switch(buttonSize) {
             case StatusBaseButton.Size.Tiny:
                 return 16
             case StatusBaseButton.Size.Small:
@@ -152,6 +157,7 @@ Button {
                 StatusIcon {
                     icon: root.icon.name
                     rotation: root.asset.rotation
+                    mirror: root.asset.mirror
                     opacity: !root.loading && root.icon.name !== "" && root.display !== AbstractButton.TextOnly
                     color: root.icon.color
                 }
@@ -221,6 +227,8 @@ Button {
     Loader {
         anchors.centerIn: parent
         active: root.loading
+        width: d.mapIconSize(root.loadingIndicatorSize)
+        height: width
         sourceComponent: StatusLoadingIndicator {
             color: d.textColor
         }

--- a/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
@@ -13,6 +13,7 @@ QtObject {
     property color hoverColor
     property color disabledColor
     property int rotation
+    property bool mirror
 
     property bool isLetterIdenticon
     property bool useAcronymForLetterIdenticon: true

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -104,6 +104,9 @@ QtObject {
     readonly property var activityDetailsController: walletSectionInst.activityDetailsController
     readonly property var walletConnectController: walletSectionInst.walletConnectController
 
+    readonly property bool isAccountTokensReloading: walletSectionInst.isAccountTokensReloading
+    readonly property double lastReloadTimestamp: walletSectionInst.lastReloadTimestamp
+
     signal savedAddressAddedOrUpdated(added: bool, name: string, address: string, errorMsg: string)
     signal savedAddressDeleted(name: string, address: string, errorMsg: string)
 


### PR DESCRIPTION
### What does the PR do

This PR implements the manual wallet reload functionality. It introduces the following key changes:

* Adds a manual reload button to the wallet header.
* Integrates a throttle mechanism to prevent frequent reloads.
* Updates the backend to support wallet reload functionality via RPC.
* Enhances UI components to reflect the loading state and display the last reload timestamp.

resolves: #13652
blocked by: https://github.com/status-im/status-go/pull/5461

### Affected areas

* Wallet: Added manual reload functionality and UI enhancements.
* Backend: Added support for wallet reload via RPC.
* StatusQ: Enhanced button and loader components to support new functionality.

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)



https://github.com/status-im/status-desktop/assets/16547115/f497b73c-831d-4a1b-8d9b-774911d20612


- [x] I've checked the design and this PR matches it

