### PR TITLE
fix_: prevent multiple http or websocket lauches

### DIFF
--- a/src/app_service/common/net_utils.nim
+++ b/src/app_service/common/net_utils.nim
@@ -1,0 +1,13 @@
+import net
+
+# Util function to test if a port is busy
+proc isPortBusy*(port: Port): bool =
+  var sock: Socket
+  try:
+    sock = newSocket()
+    sock.setSockOpt(OptReuseAddr, true)
+    sock.bindAddr(port)
+    sock.close()
+    return false
+  except OSError:
+    return true

--- a/src/app_service/service/accounts/dto/api_config.nim
+++ b/src/app_service/service/accounts/dto/api_config.nim
@@ -1,0 +1,43 @@
+import json
+
+include ../../../common/net_utils
+
+type APIConfig* = object
+  apiModules*: string
+  connectorEnabled*: bool
+  httpEnabled*: bool
+  httpHost*: string
+  httpPort*: int
+  wsEnabled*: bool
+  wsHost*: string
+  wsPort*: int
+
+proc checkAndSetPort(port: Port, isEnabled: var bool) =
+  if isPortBusy(port):
+    isEnabled = false
+
+proc defaultAPIConfig*(): APIConfig =
+  result.apiModules = "connector"
+  result.connectorEnabled = true
+
+  result.httpEnabled = true
+  checkAndSetPort(Port(8545), result.httpEnabled)
+  result.httpHost = "0.0.0.0"
+  result.httpPort = 8545
+
+  result.wsEnabled = true
+  checkAndSetPort(Port(8586), result.wsEnabled)
+  result.wsHost = "0.0.0.0"
+  result.wsPort = 8586
+
+proc toJson*(self: APIConfig): JsonNode =
+  return %* {
+    "apiModules": self.apiModules,
+    "connectorEnabled": self.connectorEnabled,
+    "httpEnabled": self.httpEnabled,
+    "httpHost": self.httpHost,
+    "httpPort": self.httpPort,
+    "wsEnabled": self.wsEnabled,
+    "wsHost": self.wsHost,
+    "wsPort": self.wsPort
+  }


### PR DESCRIPTION
fixes [5436](https://github.com/status-im/status-go/issues/5436)

### What does the PR do

In PR https://github.com/status-im/status-desktop/pull/15168, it is not possible to merge the changes otherwise launching 2 instances of status-desktop will be impossible since the port for HTTP and Websocket will be occupied.
During the standup @jrainville (Thank you) idea suggested to only have 1 instance running the HTTP/WS for now, and we agreed uppon that strategy.

### Affected areas

- [x] HTTP server
- [x] Websocket 

### Tests done

I launched 2 instances of the Status desktop application
I could query the only instance running HTTP and Websocket as expected

![Screenshot from 2024-06-28 13-51-14](https://github.com/status-im/status-desktop/assets/2589171/b6107674-d307-48ad-8648-e0e0a5a300f1)
