### PR TITLE
tests: replace seed recovery with new user creation instead

### DIFF
--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -26,8 +26,8 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703510', 'Join community via owner invite')
 @pytest.mark.case(703255, 703256, 703510)
 def test_join_community_and_pin_unpin_message(multiple_instances):
-    user_one: UserAccount = constants.user_account_one
-    user_two: UserAccount = constants.user_account_two
+    user_one: UserAccount = constants.user_with_random_attributes_1
+    user_two: UserAccount = constants.user_with_random_attributes_2
     community_params = deepcopy(constants.community_params)
     community_params['name'] = f'{datetime.now():%d%m%Y_%H%M%S}'
     main_screen = MainWindow()

--- a/test/e2e/tests/messages/test_messaging_1x1_chat.py
+++ b/test/e2e/tests/messages/test_messaging_1x1_chat.py
@@ -10,12 +10,13 @@ import driver
 from constants.images_paths import HEART_EMOJI_PATH, ANGRY_EMOJI_PATH, THUMBSUP_EMOJI_PATH, THUMBSDOWN_EMOJI_PATH, \
     LAUGHING_EMOJI_PATH, SAD_EMOJI_PATH
 from gui.screens.messages import MessagesScreen, ToolBar
-from tests.settings.settings_messaging import marks
 
 import configs.testpath
 import constants
 from constants import UserAccount
 from gui.main_window import MainWindow
+
+from . import marks
 
 pytestmark = marks
 

--- a/test/e2e/tests/messages/test_messaging_link_previews.py
+++ b/test/e2e/tests/messages/test_messaging_link_previews.py
@@ -10,9 +10,9 @@ from constants.links import external_link, link_to_status_community, status_user
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
 from gui.screens.messages import MessagesScreen, ToolBar
-from tests.settings.settings_messaging import marks
 
 import configs.testpath
+from . import marks
 
 pytestmark = marks
 


### PR DESCRIPTION
### What does the PR do

Replace account seed usage with new account creation in community test

### Affected areas

Tests
