### PR TITLE
15077 show own collectibles in permissions

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1004,7 +1004,8 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
           tokenCriteriaItem.amount,
           tokenCriteriaItem.`type`,
           tokenCriteriaItem.ensPattern,
-          criteriaResult.criteria[index]
+          criteriaResult.criteria[index],
+          tokenCriteriaItem.addresses
         )
 
         if criteriaResult.criteria[index] == false:
@@ -1521,11 +1522,12 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
   let tokenCriteriaJsonObj = tokenCriteriaJson.parseJson
   for tokenCriteria in tokenCriteriaJsonObj:
 
+    let tokenKey = tokenCriteria{"key"}.getStr()
     var tokenCriteriaDto = tokenCriteria.toTokenCriteriaDto
     if tokenCriteriaDto.`type` == TokenType.ERC20:
-      tokenCriteriaDto.decimals = self.controller.getTokenDecimals(tokenCriteriaDto.symbol)
+      tokenCriteriaDto.decimals = self.controller.getTokenDecimals(tokenKey)
 
-    let contractAddresses = self.controller.getContractAddressesForToken(tokenCriteriaDto.symbol)
+    let contractAddresses = self.controller.getContractAddressesForToken(tokenKey)
     if contractAddresses.len == 0 and tokenCriteriaDto.`type` != TokenType.ENS:
       if permissionId == "":
         self.onCommunityTokenPermissionCreationFailed(communityId)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -433,6 +433,12 @@ proc getKeypairByKeyUid*(self: Controller, keyUid: string): KeypairDto =
 proc getKeypairs*(self: Controller): seq[KeypairDto] =
   return self.walletAccountService.getKeypairs()
 
+proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAccountDto] =
+  return self.walletAccountService.getWalletAccounts()
+
+proc getEnabledChainIds*(self: Controller): seq[int] =
+  return self.walletAccountService.getEnabledChainIds()
+
 proc disconnectKeycardReponseSignal(self: Controller) =
   self.events.disconnect(self.connectionKeycardResponse)
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -549,8 +549,9 @@ method requestCancelDiscordChannelImport*(self: Module, discordChannelId: string
 proc createCommunityTokenItem(self: Module, token: CommunityTokensMetadataDto, communityId: string, supply: string,
     infiniteSupply: bool, privilegesLevel: int): TokenListItem =
   let communityTokenDecimals = if token.tokenType == TokenType.ERC20: 18 else: 0
+  let key = if token.tokenType == TokenType.ERC721: token.getContractIdFromFirstAddress() else: token.symbol
   result = initTokenListItem(
-    key = token.symbol,
+    key = key,
     name = token.name,
     symbol = token.symbol,
     color = "", # community tokens don't have `color`
@@ -911,7 +912,8 @@ proc applyPermissionResponse*(self: Module, communityId: string, permissions: Ta
         tokenCriteriaItem.amount,
         tokenCriteriaItem.`type`,
         tokenCriteriaItem.ensPattern,
-        criteriaResult.criteria[index]
+        criteriaResult.criteria[index],
+        tokenCriteriaItem.addresses
       )
 
       if criteriaResult.criteria[index] == false:

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -64,7 +64,7 @@ QtObject:
   proc hasCollectibleData(self: CollectiblesEntry): bool =
     return self.data != nil and isSome(self.data.collectibleData)
 
-  proc getCollectibleData(self: CollectiblesEntry): backend.CollectibleData =
+  proc getCollectibleData*(self: CollectiblesEntry): backend.CollectibleData =
     return self.data.collectibleData.get()
 
   proc hasCollectionData(self: CollectiblesEntry): bool =

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -18,6 +18,7 @@ type
     CollectionUid
     CollectionName
     CollectionSlug
+    CollectionImageUrl
     IsLoading
     Ownership
     # Community-related roles
@@ -139,6 +140,7 @@ QtObject:
       CollectibleRole.CollectionUid.int:"collectionUid",
       CollectibleRole.CollectionName.int:"collectionName",
       CollectibleRole.CollectionSlug.int:"collectionSlug",
+      CollectibleRole.CollectionImageUrl.int:"collectionImageUrl",
       CollectibleRole.IsLoading.int:"isLoading",
       CollectibleRole.Ownership.int:"ownership",
       CollectibleRole.CommunityId.int:"communityId",
@@ -153,9 +155,7 @@ QtObject:
 
     if (index.row < 0 or index.row >= self.getCount()):
       return
-
     let enumRole = role.CollectibleRole
-
     if index.row < self.items.len:
       let item = self.items[index.row]
       case enumRole:
@@ -183,6 +183,8 @@ QtObject:
         result = newQVariant(item.getCollectionName())
       of CollectibleRole.CollectionSlug:
         result = newQVariant(item.getCollectionSlug())
+      of CollectibleRole.CollectionImageUrl:
+        result = newQVariant(item.getCollectionImageURL())
       of CollectibleRole.IsLoading:
         result = newQVariant(false)
       of CollectibleRole.Ownership:
@@ -195,6 +197,10 @@ QtObject:
         result = newQVariant(item.getTokenType())
       of CollectibleRole.Soulbound:
         result = newQVariant(item.getSoulbound())
+      else:
+        result = newQVariant()
+    else:
+      result = newQVariant()
 
   proc resetCollectibleItems(self: Model, newItems: seq[CollectiblesEntry] = @[]) =
     self.beginResetModel()

--- a/src/app/modules/shared_models/token_criteria_item.nim
+++ b/src/app/modules/shared_models/token_criteria_item.nim
@@ -1,4 +1,5 @@
-import stew/shims/strformat
+import stew/shims/strformat, tables
+import backend/collectibles_types
 
 type
   TokenCriteriaItem* = object
@@ -8,6 +9,7 @@ type
     `type`*: int
     ensPattern*: string
     criteriaMet*: bool
+    addresses*: Table[int, string]
 
 proc initTokenCriteriaItem*(
   symbol: string,
@@ -15,7 +17,8 @@ proc initTokenCriteriaItem*(
   amount: string,
   `type`: int,
   ensPattern: string,
-  criteriaMet: bool
+  criteriaMet: bool,
+  addresses: Table[int, string]
 ): TokenCriteriaItem =
   result.symbol = symbol
   result.name = name
@@ -23,6 +26,7 @@ proc initTokenCriteriaItem*(
   result.ensPattern = ensPattern
   result.amount = amount
   result.criteriaMet = criteriaMet
+  result.addresses = addresses
 
 proc `$`*(self: TokenCriteriaItem): string =
   result = fmt"""TokenCriteriaItem(
@@ -31,7 +35,8 @@ proc `$`*(self: TokenCriteriaItem): string =
     amount: {self.amount},
     type: {self.type},
     ensPattern: {self.ensPattern},
-    criteriaMet: {self.criteriaMet}
+    criteriaMet: {self.criteriaMet},
+    addresses: {self.addresses}
     ]"""
 
 proc getType*(self: TokenCriteriaItem): int =
@@ -51,3 +56,12 @@ proc getEnsPattern*(self: TokenCriteriaItem): string =
 
 proc getCriteriaMet*(self: TokenCriteriaItem): bool =
   return self.criteriaMet
+
+proc getAddresses*(self: TokenCriteriaItem): Table[int, string] =
+  return self.addresses
+
+proc getContractIdFromFirstAddress*(self: TokenCriteriaItem): string =
+  for chainID, address in self.addresses:
+    let contractId = ContractID(chainID: chainID, address: address)
+    return contractId.toString()
+  return ""

--- a/src/app/modules/shared_models/token_criteria_model.nim
+++ b/src/app/modules/shared_models/token_criteria_model.nim
@@ -61,6 +61,8 @@ QtObject:
       of ModelRole.Key:
         if item.getType() == ord(TokenType.ENS):
           result = newQVariant(item.getEnsPattern())
+        elif item.getType() == ord(TokenType.ERC721):
+          result = newQVariant(item.getContractIdFromFirstAddress())
         else:
           result = newQVariant(item.getSymbol())
       of ModelRole.Type:

--- a/src/app/modules/shared_models/token_permission_item.nim
+++ b/src/app/modules/shared_models/token_permission_item.nim
@@ -80,7 +80,8 @@ proc buildTokenPermissionItem*(tokenPermission: CommunityTokenPermissionDto, cha
       tc.amountInWei,
       tc.`type`.int,
       tc.ensPattern,
-      false # tokenCriteriaMet will be updated by a call to checkPermissionsToJoin
+      false, # tokenCriteriaMet will be updated by a call to checkPermissionsToJoin
+      tc.contractAddresses
     )
 
     tokenCriteriaItems.add(tokenCriteriaItem)

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -138,7 +138,6 @@ QtObject:
       else:
         offset = self.tempItems.len
     self.fetchFromStart = false
-
     let response = backend_collectibles.getOwnedCollectiblesAsync(self.requestId, self.chainIds, self.addresses, self.filter, offset, FETCH_BATCH_COUNT_DEFAULT, self.dataType, self.fetchCriteria)
     if response.error != nil:
       self.model.setIsFetching(false)

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -151,6 +151,13 @@ proc toContractID*(t: string): ContractID =
   var parts = t.split("+")
   return ContractID(chainID: parts[0].parseInt(), address: parts[1])
 
+proc isContractID*(t: string): bool =
+  try:
+    discard toContractID(t)
+    return true
+  except Exception:
+    return false
+
 # CollectibleUniqueID
 proc `$`*(self: CollectibleUniqueID): string =
   return fmt"""CollectibleUniqueID(

--- a/ui/app/AppLayouts/Communities/controls/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ExtendedDropdownContent.qml
@@ -127,12 +127,20 @@ Item {
                     AnyOf {
                         enabled: root.showAllTokensMode
 
-                        /*
-                        // this category is not used
                         ValueFilter {
                             roleName: "category"
                             value: TokenCategories.Category.Own
-                        }*/
+                        }
+
+                        ValueFilter {
+                            roleName: "category"
+                            value: TokenCategories.Category.General
+                        }
+
+                        ValueFilter {
+                            roleName: "category"
+                            value: TokenCategories.Category.Community
+                        }
 
                         AllOf {
                             ValueFilter {

--- a/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
@@ -95,7 +95,7 @@ StatusListView {
 
         name: model.name
         shortName: model.shortName ?? ""
-        iconSource: model.iconSource ?? ""
+        iconSource: model.iconSource ? model.iconSource : Style.png("tokens/DEFAULT-TOKEN")
         showSubItemsIcon: !!model.subItems && model.subItems.count > 0
         selected: root.checkedKeys.includes(model.key)
         amount: {

--- a/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
@@ -273,8 +273,7 @@ StackView {
                     const holdings = dirtyValues.holdingsRequired ?
                                        ModelUtils.modelToArray(
                                            dirtyValues.selectedHoldingsModel,
-                                           ["key", "type", "amount"]) : []
-
+                                           ["key", "type", "amount", "symbol"]) : []
                     const channels = root.showChannelSelector ?
                                    ModelUtils.modelToArray(
                                        dirtyValues.selectedChannelsModel, ["key"]) :
@@ -295,9 +294,8 @@ StackView {
                     const holdings = dirtyValues.holdingsRequired ?
                                        ModelUtils.modelToArray(
                                            dirtyValues.selectedHoldingsModel,
-                                           ["key", "type", "amount"])
+                                           ["key", "type", "amount", "symbol"])
                                      : []
-
                     const channels = ModelUtils.modelToArray(
                                        dirtyValues.selectedChannelsModel, ["key"])
 

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -245,9 +245,10 @@ StatusScrollView {
 
                 function addItem(type, item, amount) {
                     const key = item.key
+                    const symbol = item.symbol
 
                     d.dirtyValues.selectedHoldingsModel.append(
-                                { type, key, amount })
+                                { type, key, amount, symbol })
                 }
 
                 function prepareUpdateIndex(key) {
@@ -310,7 +311,7 @@ StatusScrollView {
 
                     d.dirtyValues.selectedHoldingsModel.set(
                                 itemIndex,
-                                { type: Constants.TokenType.ERC721, key, amount: String(amount) })
+                                { type: Constants.TokenType.ERC721, key, amount: String(amount), symbol: modelItem.symbol })
                     dropdown.close()
                 }
 

--- a/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
+++ b/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
@@ -37,14 +37,17 @@ SortFilterProxyModel {
                 return item.decimals
             }
 
-            function getText(type, key, amount) {
+            function getText(type, key, amount, defaultText) {
                 const model = type === Constants.TokenType.ERC20
                             ? assetsModel
                             : collectiblesModel
-                const item = PermissionsHelpers.getTokenByKey(model, key)
 
-                const name = getName(type, item, key)
+                let item = PermissionsHelpers.getTokenByKey(model, key)
+                let name = getName(type, item, key)
                 const decimals = getDecimals(type, item)
+
+                if (name === "")
+                    name = defaultText
 
                 return PermissionsHelpers.setHoldingsTextFormat(
                             type, name, amount, decimals)
@@ -55,9 +58,9 @@ SortFilterProxyModel {
             expression: {
                 _assetsChanges.revision
                 _collectiblesChanges.revision
-                return getText(model.type, model.key, model.amount)
+                return getText(model.type, model.key, model.amount, model.symbol)
             }
-            expectedRoles: ["type", "key", "amount"]
+            expectedRoles: ["type", "key", "amount", "symbol", "shortName"]
         },
         FastExpressionRole {
             name: "imageSource"


### PR DESCRIPTION
### What does the PR do

Enable using non community NFTs in permissions.

Using symbol as a key(identifier) in permissions and collectibles model was not sufficient.
The pr introduced change in "key" format.

Used to be:
- key was a symbol for all token types

Now:
- ERC20 - key is still a symbol
- ERC721 - key has new format: chainId+address[+tokenId]

Additionally collectibles model has collection-specific roles: collection image and collectionUid.

_NOTES_
1. If there is no available collection (not token) image we display a default icon.
2. The member who wants to join, will see only default icon for now. 

![image](https://github.com/status-im/status-desktop/assets/61889657/a2a02b26-0b69-4bef-aa7e-557bc490b2e4)

![image](https://github.com/status-im/status-desktop/assets/61889657/10473537-de0e-4409-9d5d-614253616196)


