### PR TITLE
fix(swapModal): Fixing flaky tests (hopefully)

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -410,21 +410,23 @@ Item {
 
                 let delToTest = assetSelectorList.itemAtIndex(i)
                 verify(!!delToTest)
-                mouseClick(delToTest)
+                if(delToTest.interactive) {
+                    mouseClick(delToTest)
 
-                // check input value and state
-                waitForRendering(controlUnderTest)
+                    // check input value and state
+                    waitForItemPolished(controlUnderTest)
 
-                compare(amountToSendInput.input.text, "5.42")
-                const marketPrice = !!amountToSendInput.selectedHolding ? amountToSendInput.selectedHolding.marketDetails.currencyPrice.amount : 0
-                tryCompare(bottomItemText, "text", d.adaptor.formatCurrencyAmount(
-                               numberTested * marketPrice,
-                               d.adaptor.currencyStore.currentCurrency))
-                compare(controlUnderTest.value, numberTested)
-                compare(controlUnderTest.rawValue, AmountsArithmetic.fromNumber(amountToSendInput.input.text, modelItemToTest.decimals).toString())
-                compare(controlUnderTest.valueValid, numberTested <= maxTagButton.maxSafeValue)
-                compare(controlUnderTest.selectedHoldingId, modelItemToTest.tokensKey)
-                compare(controlUnderTest.amountEnteredGreaterThanBalance, numberTested > maxTagButton.maxSafeValue)
+                    compare(amountToSendInput.input.text, "5.42")
+                    const marketPrice = !!amountToSendInput.selectedHolding ? amountToSendInput.selectedHolding.marketDetails.currencyPrice.amount : 0
+                    tryCompare(bottomItemText, "text", d.adaptor.formatCurrencyAmount(
+                                   numberTested * marketPrice,
+                                   d.adaptor.currencyStore.currentCurrency))
+                    compare(controlUnderTest.value, numberTested)
+                    compare(controlUnderTest.rawValue, AmountsArithmetic.fromNumber(amountToSendInput.input.text, modelItemToTest.decimals).toString())
+                    compare(controlUnderTest.valueValid, numberTested <= maxTagButton.maxSafeValue)
+                    compare(controlUnderTest.selectedHoldingId, modelItemToTest.tokensKey)
+                    compare(controlUnderTest.amountEnteredGreaterThanBalance, numberTested > maxTagButton.maxSafeValue)
+                }
             }
         }
 

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -141,6 +141,7 @@ Item {
             mouseClick(accountsModalHeader)
             waitForRendering(accountsModalHeader)
             verify(!!accountsModalHeader.control.popup.opened)
+            mouseMove(accountsModalHeader)
             return accountsModalHeader
         }
 
@@ -565,6 +566,7 @@ Item {
             formValuesChanged.wait()
             root.swapFormData.toTokenKey = root.swapAdaptor.walletAssetsStore.walletTokensStore.plainTokensBySymbolModel.get(1).key
             root.swapFormData.fromTokenAmount = "0.001"
+            waitForRendering(receivePanel)
             formValuesChanged.wait()
             root.swapFormData.selectedNetworkChainId = root.swapAdaptor.filteredFlatNetworksModel.get(0).chainId
             formValuesChanged.wait()
@@ -606,6 +608,7 @@ Item {
 
             // edit some params to retry swap
             root.swapFormData.fromTokenAmount = "0.00011"
+            waitForRendering(receivePanel)
             formValuesChanged.wait()
 
             // wait for fetchSuggestedRoutes function to be called
@@ -655,6 +658,7 @@ Item {
 
             // edit some params to retry swap
             root.swapFormData.fromTokenAmount = "0.012"
+            waitForRendering(receivePanel)
             formValuesChanged.wait()
 
             // wait for fetchSuggestedRoutes function to be called


### PR DESCRIPTION
### What does the PR do

Closes: #15272

Changes: 
1. Move the mouse to hover the account selector after opening. IDK why but sometimes the cursor is hovering the first row and triggers a hover state making the subtitle to change
2. Adding `waitForRendering` after setting the amount to swap. For some reason the Backpressure starts much later (if ever). Seems to fix it. Now I hope it's really fixing the issue and not making it less detectable..

Maybe the real fix would be to refactor the tests and rely on signals instead of `wait`. Synchronising the tests with the implementation is quite difficult because we have both timers and delayed bindings