### PR TITLE
fix(TokenSelector): Duplicate plain token entries

### DIFF
--- a/storybook/pages/TokenSelectorPage.qml
+++ b/storybook/pages/TokenSelectorPage.qml
@@ -46,6 +46,14 @@ SplitView {
             image: "https://etherscan.io/token/images/horizonstate2_28.png"
             communityId: ""
         }
+        // DAI should be filtered out
+        ListElement {
+            key: "DAI"
+            name: "Dai Stablecoin"
+            symbol: "DAI"
+            image: ""
+            communityId: ""
+        }
     }
 
     QtObject {

--- a/storybook/qmlTests/tests/tst_TokenSelectorViewAdaptor.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelectorViewAdaptor.qml
@@ -22,6 +22,14 @@ Item {
             image: "https://cryptologos.cc/logos/aave-aave-logo.png"
             communityId: ""
         }
+        // DAI should be filtered out
+        ListElement {
+            key: "DAI"
+            name: "Dai Stablecoin"
+            symbol: "DAI"
+            image: ""
+            communityId: ""
+        }
     }
 
     QtObject {
@@ -132,6 +140,17 @@ Item {
 
             // should have ~45.90 balance
             fuzzyCompare(delegate.currencyBalance, 45.90, 0.01)
+        }
+
+        function test_duplicatePlainTokens() {
+            verify(!!controlUnderTest)
+
+            controlUnderTest.showAllTokens = true
+            const searchText = "DAI"
+            controlUnderTest.searchString = searchText
+
+            // search yields 1 result
+            tryCompare(controlUnderTest.outputAssetsModel, "count", 1)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
@@ -60,7 +60,7 @@ QObject {
                 name: "sectionId"
                 expression: {
                     if (!model.currentBalance)
-                        return "section_zzz"
+                        return d.favoritesSectionId
 
                     if (root.enabledChainIds.length === 1)
                         return "section_%1".arg(root.enabledChainIds[0])
@@ -70,7 +70,7 @@ QObject {
             FastExpressionRole {
                 name: "sectionName"
                 function getSectionName(sectionId, hasBalance) {
-                    if (sectionId === "section_zzz")
+                    if (sectionId === d.favoritesSectionId)
                         return qsTr("Popular assets")
 
                     if (root.enabledChainIds.length === 1 && hasBalance)
@@ -115,7 +115,7 @@ QObject {
             },
             FastExpressionSorter {
                 expression: {
-                    if (modelLeft.sectionId === "section_zzz" && modelRight.sectionId === "section_zzz")
+                    if (modelLeft.sectionId === d.favoritesSectionId && modelRight.sectionId === d.favoritesSectionId)
                         return 0
 
                     const lhs = modelLeft.currencyBalance
@@ -136,6 +136,12 @@ QObject {
     }
 
     // internals
+    QtObject {
+        id: d
+
+        readonly property string favoritesSectionId: "section_zzz"
+    }
+
     RolesRenamingModel {
         id: renamedTokensBySymbolModel
         sourceModel: root.plainTokensBySymbolModel

--- a/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
@@ -106,6 +106,21 @@ QObject {
                 roleName: "communityId"
                 value: ""
                 enabled: !root.showCommunityAssets
+            },
+            // duplicate tokens filter
+            FastExpressionFilter {
+                function hasDuplicateKey(tokensKey) {
+                    return ModelUtils.indexOf(assetsObjectProxyModel, "tokensKey", tokensKey) > -1
+                }
+
+                expression: {
+                    if (model.which_model === "plain_tokens_model") {
+                        return !hasDuplicateKey(model.tokensKey)
+                    }
+                    return true
+                }
+                expectedRoles: ["which_model", "tokensKey"]
+                enabled: root.showAllTokens
             }
         ]
 

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -124,7 +124,6 @@ ComboBox {
         }
         StatusDialogDivider {
             Layout.fillWidth: true
-            visible: listview.count
         }
         StatusListView {
             id: listview
@@ -136,7 +135,7 @@ ComboBox {
             model: root.popup.visible ? root.delegateModel : null
             currentIndex: root.highlightedIndex
 
-            section.property: "sectionName"
+            section.property: searchBox.text === "" ? "sectionName" : ""
             section.delegate: StatusBaseText {
                 required property string section
                 width: parent.width
@@ -145,6 +144,17 @@ ComboBox {
                 color: Theme.palette.baseColor1
                 padding: Style.current.padding
             }
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 60
+            Layout.alignment: Qt.AlignCenter
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            visible: listview.count === 0
+            color: Theme.palette.baseColor1
+
+            text: qsTr("No assets found")
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -2,7 +2,6 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.0
-import QtQuick.Window 2.15
 
 import StatusQ 0.1
 import StatusQ.Components 0.1
@@ -84,8 +83,9 @@ ComboBox {
     opacity: enabled ? 1 : 0.3
 
     popup.width: 380
+    popup.height: 380
     popup.x: root.width - popup.width
-    popup.margins: Style.current.halfPadding
+    popup.margins: Style.current.xlPadding*2
     popup.background: Rectangle {
         color: Theme.palette.statusSelect.menuItemBackgroundColor
         radius: Style.current.radius
@@ -100,6 +100,13 @@ ComboBox {
         }
     }
     popup.contentItem: ColumnLayout {
+        Connections {
+            target: root.popup
+            function onOpened() {
+                listview.positionViewAtBeginning()
+            }
+        }
+
         spacing: 0
         SearchBox {
             Layout.fillWidth: true
@@ -199,7 +206,6 @@ ComboBox {
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
                 image.source: ModelUtils.getByKey(model, "tokensKey", d.currentTokensKey, "iconSource")
-                image.sourceSize: Qt.size(width*root.Screen.devicePixelRatio, height*root.Screen.devicePixelRatio)
             }
             StatusBaseText {
                 objectName: "tokenSelectorContentItemText"

--- a/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
@@ -57,7 +56,6 @@ ItemDelegate {
             Layout.preferredWidth: root.icon.width
             Layout.preferredHeight: root.icon.height
             image.source: root.icon.source
-            image.sourceSize: Qt.size(width*root.Screen.devicePixelRatio, height*root.Screen.devicePixelRatio)
         }
 
         ColumnLayout {


### PR DESCRIPTION
### What does the PR do
- filter out plain tokens from the adaptor if already present in the output model
- add a corresponding regression test
- hardcode the TokenSelector's popup height and increase margins
- fix sections in search mode
- add a placeholder for no search results

Fixes https://github.com/status-im/status-desktop/issues/15412

### Affected areas

TokenSelector[ViewAdaptor]

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/528f3c7f-4968-4e3d-8412-e179e91e5fb9)

