### PR TITLE
fix(airdrop): sending an airdrop using a secondary account (better UX)

### DIFF
--- a/src/app_service/service/community_tokens/dto/community_token.nim
+++ b/src/app_service/service/community_tokens/dto/community_token.nim
@@ -159,5 +159,6 @@ type
     Success,
     Infura,
     Balance,
+    Revert,
     Other
 

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -1018,6 +1018,8 @@ QtObject:
     var errorCode = ComputeFeeErrorCode.Other
     if errorMessage.contains("403 Forbidden") or errorMessage.contains("exceed"):
       errorCode = ComputeFeeErrorCode.Infura
+    if errorMessage.contains("execution reverted"):
+      errorCode = ComputeFeeErrorCode.Revert
     return errorCode
 
   proc burnTokens*(self: Service, communityId: string, password: string, contractUniqueKey: string, amount: Uint256, addressFrom: string) =

--- a/ui/app/AppLayouts/Communities/helpers/AirdropFeesSubscriber.qml
+++ b/ui/app/AppLayouts/Communities/helpers/AirdropFeesSubscriber.qml
@@ -46,6 +46,9 @@ QtObject {
         if (airdropFeesResponse.errorCode === Constants.ComputeFeeErrorCode.Infura)
             return qsTr("Infura error")
 
+        if (airdropFeesResponse.errorCode === Constants.ComputeFeeErrorCode.Revert)
+            return qsTr("Estimation reverted. Make sure you are using the account that owns the TokenMaster or Owner Token.")
+
         return qsTr("Unknown error")
     }
     readonly property string totalFee: {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1053,6 +1053,7 @@ QtObject {
         Success,
         Infura,
         Balance,
+        Revert,
         Other
     }
 


### PR DESCRIPTION
Fixes #15382

So there is no easy way from the models and data we currently have in the client to know which account minted the owner token.

So the easiest way to help the user is just to catch the error and show a better message.

[airdrop-message.webm](https://github.com/status-im/status-desktop/assets/11926403/5aa8c3bf-f4bc-4b65-a033-584034450ac2)

