### PR TITLE
feat: display message outgoing state

### DIFF
--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -546,6 +546,8 @@ QtObject:
     let ind = self.findIndexForMessageId(messageId)
     if(ind == -1):
       return
+    if self.items[ind].outgoingStatus == PARSED_TEXT_OUTGOING_STATUS_DELIVERED:
+      return
     self.items[ind].outgoingStatus = status
     let index = self.createIndex(ind, 0, nil)
     defer: index.delete

--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -29,6 +29,7 @@ SplitView {
                 isContact: true
                 isAReply: false
                 trustIndicator: StatusContactVerificationIcons.TrustedType.Verified
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
             }
             ListElement {
                 timestamp: 1657937930135
@@ -39,6 +40,7 @@ SplitView {
                 isContact: false
                 isAReply: false
                 trustIndicator: StatusContactVerificationIcons.TrustedType.Untrustworthy
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
             }
             ListElement {
                 timestamp: 1667937930159
@@ -49,6 +51,7 @@ SplitView {
                 isContact: true
                 isAReply: true
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
             }
             ListElement {
                 timestamp: 1667937930489
@@ -59,6 +62,46 @@ SplitView {
                 isContact: true
                 isAReply: true
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq123456790"
+                senderDisplayName: "Alice"
+                contentType: StatusMessage.ContentType.Text
+                message: "Sending message"
+                isAReply: false
+                isContact: true
+                isSending: true
+                amISender: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Sending
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq123456790"
+                senderDisplayName: "Alice"
+                contentType: StatusMessage.ContentType.Text
+                message: "Sent message"
+                isAReply: false
+                isContact: true
+                isSending: true
+                amISender: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Sent
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq123456790"
+                senderDisplayName: "Alice"
+                contentType: StatusMessage.ContentType.Text
+                message: "Delivered message"
+                isAReply: false
+                isContact: true
+                isSending: true
+                amISender: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Delivered
             }
         }
         readonly property var colorHash: ListModel {
@@ -90,10 +133,15 @@ SplitView {
                 delegate: StatusMessage {
                     width: ListView.view.width
                     timestamp: model.timestamp
+                    isAReply: model.isAReply
+                    isSending: model.isSending
+                    outgoingStatus: model.outgoingStatus
+
                     messageDetails {
                         readonly property bool isEnsVerified: model.senderDisplayName.endsWith(".eth")
                         messageText: model.message
                         contentType: model.contentType
+                        amISender: model.amISender
                         sender.id: isEnsVerified ? "" : model.senderId
                         sender.displayName: model.senderDisplayName
                         sender.isContact: model.isContact
@@ -106,7 +154,6 @@ SplitView {
                         }
                     }
 
-                    isAReply: model.isAReply
                     replyDetails {
                         amISender: true
                         sender.id: "0xdeadbeef"

--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -72,7 +72,6 @@ SplitView {
                 message: "Sending message"
                 isAReply: false
                 isContact: true
-                isSending: true
                 amISender: true
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
                 outgoingStatus: StatusMessage.OutgoingStatus.Sending
@@ -85,10 +84,10 @@ SplitView {
                 message: "Sent message"
                 isAReply: false
                 isContact: true
-                isSending: true
                 amISender: true
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
                 outgoingStatus: StatusMessage.OutgoingStatus.Sent
+                resendError: ""
             }
             ListElement {
                 timestamp: 1719769718000
@@ -98,10 +97,36 @@ SplitView {
                 message: "Delivered message"
                 isAReply: false
                 isContact: true
-                isSending: true
                 amISender: true
                 trustIndicator: StatusContactVerificationIcons.TrustedType.None
                 outgoingStatus: StatusMessage.OutgoingStatus.Delivered
+                resendError: ""
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq123456790"
+                senderDisplayName: "Alice"
+                contentType: StatusMessage.ContentType.Text
+                message: "Expired message"
+                isAReply: false
+                isContact: true
+                amISender: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Expired
+                resendError: ""
+            }
+            ListElement {
+                timestamp: 1719769718000
+                senderId: "zq123456790"
+                senderDisplayName: "Alice"
+                contentType: StatusMessage.ContentType.Text
+                message: "Message with resend error"
+                isAReply: false
+                isContact: true
+                amISender: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.None
+                outgoingStatus: StatusMessage.OutgoingStatus.Expired
+                resendError: "can't send message on Tuesday"
             }
         }
         readonly property var colorHash: ListModel {
@@ -134,8 +159,8 @@ SplitView {
                     width: ListView.view.width
                     timestamp: model.timestamp
                     isAReply: model.isAReply
-                    isSending: model.isSending
                     outgoingStatus: model.outgoingStatus
+                    resendError: model.outgoingStatus === StatusMessage.OutgoingStatus.Expired ? model.resendError : ""
 
                     messageDetails {
                         readonly property bool isEnsVerified: model.senderDisplayName.endsWith(".eth")
@@ -170,6 +195,7 @@ SplitView {
                     onProfilePictureClicked: logs.logEvent("StatusMessage::profilePictureClicked")
                     onReplyProfileClicked: logs.logEvent("StatusMessage::replyProfileClicked")
                     onReplyMessageClicked: logs.logEvent("StatusMessage::replyMessageClicked")
+                    onResendClicked: logs.logEvent("StatusMessage::resendClicked")
                 }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -7,8 +7,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
 import StatusQ.Controls 0.1
 
-import utils 1.0
-
 import "./private/statusMessage"
 
 Control {

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -35,7 +35,8 @@ Control {
         Unknown = 0,
         Sending,
         Sent,
-        Delivered
+        Delivered,
+        Expired
     }
 
     property list<Item> quickActions
@@ -60,8 +61,6 @@ Control {
     property bool hasMention: false
     property bool isPinned: false
     property string pinnedBy: ""
-    property bool hasExpired: false
-    property bool isSending: false
     property string resendError: ""
     property int outgoingStatus: StatusMessage.OutgointStatus.Unknown
     property double timestamp: 0
@@ -265,15 +264,14 @@ Control {
                             sender: root.messageDetails.sender
                             amISender: root.messageDetails.amISender
                             messageOriginInfo: root.messageDetails.messageOriginInfo
-                            showResendButton: root.hasExpired && root.messageDetails.amISender && !editMode && !root.isInPinnedPopup
-                            showSendingLoader: root.isSending && root.messageDetails.amISender && !editMode
-                            resendError: root.messageDetails.amISender && !editMode ? root.resendError : ""
+                            resendError: root.messageDetails.amISender ? root.resendError : ""
                             onClicked: root.senderNameClicked(sender, mouse)
                             onResendClicked: root.resendClicked()
                             timestamp: root.timestamp
                             showFullTimestamp: root.isInPinnedPopup
                             displayNameClickable: root.profileClickable
                             outgoingStatus: root.outgoingStatus
+                            showOutgointStatusLabel: root.hovered && !root.isInPinnedPopup
                         }
                     }
                     Loader {

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -7,6 +7,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
 import StatusQ.Controls 0.1
 
+import utils 1.0
+
 import "./private/statusMessage"
 
 Control {
@@ -27,6 +29,13 @@ Control {
         SystemMessageMutualEventAccepted = 16,
         SystemMessageMutualEventRemoved = 17,
         BridgeMessage = 18
+    }
+
+    enum OutgoingStatus {
+        Unknown = 0,
+        Sending,
+        Sent,
+        Delivered
     }
 
     property list<Item> quickActions
@@ -54,6 +63,7 @@ Control {
     property bool hasExpired: false
     property bool isSending: false
     property string resendError: ""
+    property int outgoingStatus: StatusMessage.OutgointStatus.Unknown
     property double timestamp: 0
     property var reactionsModel: []
 
@@ -111,6 +121,7 @@ Control {
     }
 
     hoverEnabled: (!root.isActiveMessage && !root.disableHover)
+    opacity: outgoingStatus === StatusMessage.OutgoingStatus.Sending ? 0.5 : 1.0
     background: Rectangle {
         color: {
             if (root.overrideBackground)
@@ -262,6 +273,7 @@ Control {
                             timestamp: root.timestamp
                             showFullTimestamp: root.isInPinnedPopup
                             displayNameClickable: root.profileClickable
+                            outgoingStatus: root.outgoingStatus
                         }
                     }
                     Loader {

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -28,6 +28,7 @@ Item {
     property bool displayNameClickable: true
     property string messageOriginInfo: ""
     property bool showFullTimestamp
+    property int outgoingStatus: StatusMessage.OutgoingStatus.Unknown
 
     signal clicked(var sender, var mouse)
     signal resendClicked()

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -219,11 +219,11 @@ Item {
             asynchronous: true
             sourceComponent: StatusButton {
                 Layout.fillHeight: true
-                verticalPadding: 0
+                verticalPadding: 1
                 horizontalPadding: 5
                 size: StatusBaseButton.Tiny
                 type: StatusBaseButton.Warning
-                font.pixelSize: 11
+                font.pixelSize: 9
                 text: qsTr("Resend")
                 onClicked: root.resendClicked()
             }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -144,7 +144,7 @@ Loader {
                              || messageContentType === Constants.messageContentType.communityInviteType || messageContentType === Constants.messageContentType.transactionType
 
     readonly property bool isExpired: d.getIsExpired(messageTimestamp, messageOutgoingStatus)
-    readonly property bool isSending: messageOutgoingStatus === Constants.sending && !isExpired
+    readonly property bool isSending: messageOutgoingStatus === Constants.messageOutgoingStatus.sending && !isExpired
 
     function openProfileContextMenu(sender, mouse, isReply = false) {
         if (isReply && !quotedMessageFrom) {
@@ -289,7 +289,8 @@ Loader {
         }
 
         function getIsExpired(messageTimeStamp, messageOutgoingStatus) {
-            return (messageOutgoingStatus === Constants.sending && (Math.floor(messageTimeStamp) + 180000) < Date.now()) || messageOutgoingStatus === Constants.expired
+            return (messageOutgoingStatus === Constants.messageOutgoingStatus.sending && (Math.floor(messageTimeStamp) + 180000) < Date.now())
+                || messageOutgoingStatus === Constants.expired
         }
 
         function convertContentType(value) {
@@ -329,6 +330,17 @@ Loader {
             case Constants.messageContentType.gapType:
             default:
                 return StatusMessage.ContentType.Unknown;
+            }
+        }
+
+        function convertOutgoingStatus(value) {
+            switch (value) {
+            case Constants.messageOutgoingStatus.sending:
+                return StatusMessage.OutgoingStatus.Sending
+            case Constants.messageOutgoingStatus.sent:
+                return StatusMessage.OutgoingStatus.Sent
+            case Constants.messageOutgoingStatus.delivered:
+                return StatusMessage.OutgoingStatus.Delivered
             }
         }
 
@@ -646,6 +658,7 @@ Loader {
                     return ProfileUtils.displayName(contact.localNickname, contact.name, contact.displayName, contact.alias)
                 }
                 isInPinnedPopup: root.isInPinnedPopup
+                outgoingStatus: d.convertOutgoingStatus(messageOutgoingStatus)
                 hasExpired: root.isExpired
                 isSending: root.isSending
                 resendError: root.resendError

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -124,7 +124,7 @@ Loader {
     property string deletedByContactIcon: ""
     property string deletedByContactColorHash: ""
 
-    property bool shouldRepeatHeader: d.getShouldRepeatHeader(messageTimestamp, prevMessageTimestamp, messageOutgoingStatus)
+    property bool shouldRepeatHeader: d.shouldRepeatHeader
 
     property bool hasMention: false
 
@@ -142,9 +142,6 @@ Loader {
     property bool isText: messageContentType === Constants.messageContentType.messageType || messageContentType === Constants.messageContentType.contactRequestType || isDiscordMessage || isBridgeMessage
     property bool isMessage: isEmoji || isImage || isSticker || isText || isAudio
                              || messageContentType === Constants.messageContentType.communityInviteType || messageContentType === Constants.messageContentType.transactionType
-
-    readonly property bool isExpired: d.getIsExpired(messageTimestamp, messageOutgoingStatus)
-    readonly property bool isSending: messageOutgoingStatus === Constants.messageOutgoingStatus.sending && !isExpired
 
     function openProfileContextMenu(sender, mouse, isReply = false) {
         if (isReply && !quotedMessageFrom) {
@@ -274,8 +271,8 @@ Loader {
         readonly property bool canPost: root.chatContentModule.chatDetails.canPost
         readonly property bool canView: canPost || root.chatContentModule.chatDetails.canView
 
-        function nextMessageHasHeader() {
-            if(!root.nextMessageAsJsonObj) {
+        function getNextMessageHasHeader() {
+            if (!root.nextMessageAsJsonObj) {
                 return false
             }
             return root.senderId !== root.nextMessageAsJsonObj.senderId ||
@@ -284,13 +281,27 @@ Loader {
         }
 
         function getShouldRepeatHeader(messageTimeStamp, prevMessageTimeStamp, messageOutgoingStatus) {
-            return ((messageTimeStamp - prevMessageTimeStamp) / 60 / 1000) > Constants.repeatHeaderInterval 
+            return ((messageTimeStamp - prevMessageTimeStamp) / 60 / 1000) > Constants.repeatHeaderInterval
                 || d.getIsExpired(messageTimeStamp, messageOutgoingStatus)
         }
 
         function getIsExpired(messageTimeStamp, messageOutgoingStatus) {
             return (messageOutgoingStatus === Constants.messageOutgoingStatus.sending && (Math.floor(messageTimeStamp) + 180000) < Date.now())
                 || messageOutgoingStatus === Constants.expired
+        }
+
+        property bool isExpired: false
+        property bool shouldRepeatHeader: false
+        property bool nextMessageHasHeader: false
+
+        Component.onCompleted: {
+            onTimeChanged()
+        }
+
+        function onTimeChanged() {
+            isExpired = getIsExpired(root.messageTimestamp, root.messageOutgoingStatus)
+            shouldRepeatHeader = getShouldRepeatHeader(root.messageTimestamp, root.prevMessageTimestamp, root.messageOutgoingStatus)
+            nextMessageHasHeader = getNextMessageHasHeader()
         }
 
         function convertContentType(value) {
@@ -366,6 +377,13 @@ Loader {
 
         function correctBridgeNameCapitalization(bridgeName) {
             return (bridgeName === "discord") ? "Discord" : bridgeName
+        }
+    }
+
+    Connections {
+        target: StatusSharedUpdateTimer
+        onTriggered: {
+            d.onTimeChanged()
         }
     }
 
@@ -658,9 +676,9 @@ Loader {
                     return ProfileUtils.displayName(contact.localNickname, contact.name, contact.displayName, contact.alias)
                 }
                 isInPinnedPopup: root.isInPinnedPopup
-                outgoingStatus: d.convertOutgoingStatus(messageOutgoingStatus)
-                hasExpired: root.isExpired
-                isSending: root.isSending
+                outgoingStatus: d.isExpired ? StatusMessage.OutgoingStatus.Expired
+                                            : d.convertOutgoingStatus(messageOutgoingStatus)
+
                 resendError: root.resendError
                 reactionsModel: root.reactionsModel
                 linkPreviewModel: root.linkPreviewModel
@@ -676,7 +694,7 @@ Loader {
                             root.senderId !== root.prevMessageSenderId || root.prevMessageDeleted
                 isActiveMessage: d.isMessageActive
                 topPadding: showHeader ? Style.current.halfPadding : 0
-                bottomPadding: showHeader && d.nextMessageHasHeader() ? Style.current.halfPadding : 2
+                bottomPadding: showHeader && d.nextMessageHasHeader ? Style.current.halfPadding : 2
                 disableHover: root.disableHover ||
                               (delegate.hideQuickActions && !d.addReactionAllowed) ||
                               (root.chatLogView && root.chatLogView.moving) ||

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -2,6 +2,7 @@ pragma Singleton
 
 import QtQuick 2.13
 
+import StatusQ.Components 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Core.Theme 0.1
 
@@ -1202,11 +1203,13 @@ QtObject {
     }
 
     // Message outgoing status
-    readonly property string sending: "sending"
-    readonly property string sent: "sent"
-    readonly property string delivered: "delivered"
-    readonly property string expired: "expired"
-    readonly property string failedResending: "failedResending"
+    readonly property QtObject messageOutgoingStatus: QtObject {
+        readonly property string sending: "sending"
+        readonly property string sent: "sent"
+        readonly property string delivered: "delivered"
+        readonly property string expired: "expired"
+        readonly property string failedResending: "failedResending"
+    }
 
     readonly property QtObject appTranslatableConstants: QtObject {
         readonly property string loginAccountsListAddNewUser: "LOGIN-ACCOUNTS-LIST-ADD-NEW-USER"


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/15293

### What does the PR do

1. Show corresponding icon and text for message outgoing state: sending/sent/delivered/error
2. Improve UI of the sending error and `Resend` button
3. Make the expire time calculation "live" using `StatusSharedUpdateTimer`
4. Lock `Delivered` state. 
There's a bug that `Delivered` state change to `Sent` at some point. 
The reasons for this should be fixed on status-go side anyway:
    - https://github.com/status-im/status-go/issues/5464

### Affected areas

chat

### StatusQ checklist

- [x] update storybook app
- [x] test changes in both light and dark theme?

### Screenshot of functionality

#### Storybook:

https://github.com/status-im/status-desktop/assets/25482501/345dc8f8-7db3-408b-b809-5a6880e5f79e

#### In-app:

https://github.com/status-im/status-desktop/assets/25482501/67969c64-cbcf-45ea-bab4-c13623f0474d

With no internet connection and expire time set to 10 seconds (normal time 3 minutes):

https://github.com/status-im/status-desktop/assets/25482501/00a159e0-82ab-497c-91c2-c96d1bca7e76

### Impact on end user

Allows to see if the message was successfully sent and/or delivered.

### How to test

- Send a message, check that the state changes from `Sending` to `Sent`
- For 1-1 and group messages it should also change to `Delivered` when you see the message on the other end
- With no internet connection the "Sending failed" label appears after 3 minutes

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.