### PR TITLE
fix(TokenSelector): Crash when try to search token in SwapModal

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -135,25 +135,25 @@ ComboBox {
             model: root.popup.visible ? root.delegateModel : null
             currentIndex: root.highlightedIndex
 
-            section.property: searchBox.text === "" ? "sectionName" : ""
+            section.property: "sectionName"
             section.delegate: StatusBaseText {
                 required property string section
+                visible: searchBox.text === ""
                 width: parent.width
                 elide: Text.ElideRight
-                text: section
+                text: visible ? section : ""
                 color: Theme.palette.baseColor1
                 padding: Style.current.padding
             }
         }
         StatusBaseText {
             Layout.fillWidth: true
-            Layout.preferredHeight: 60
+            Layout.fillHeight: true
             Layout.alignment: Qt.AlignCenter
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             visible: listview.count === 0
             color: Theme.palette.baseColor1
-
             text: qsTr("No assets found")
         }
     }


### PR DESCRIPTION
### What does the PR do

- fix crash deep in ListView section handling; turns out ListView doesn't like `section.property` being empty

Fixes #15445

### Affected areas

TokenSelector, SwapModal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-07-04 00-51-14.webm](https://github.com/status-im/status-desktop/assets/5377645/b60e1413-2d04-4c8c-a37a-15d042cee3ad)


### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)
- new code, no risk

### How to test

- How should one proceed with testing this PR.
  - Try a search and delete characters
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


