### PR TITLE
fix(wallet): Reset value when chain is disabled in custom mode

### DIFF
--- a/ui/imports/shared/popups/send/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/popups/send/views/NetworkCardsComponent.qml
@@ -121,6 +121,7 @@ Item {
                     clickable: root.interactive
                     onClicked: {
                         store.toggleFromDisabledChains(model.chainId)
+                        store.lockCard(model.chainId, 0, false)
                         root.reCalculateSuggestedRoute()
                     }
                     onLockCard: {


### PR DESCRIPTION
Fixes #15403 

### What does the PR do

Remove chain from locked amounts when card is disabled.

### Affected areas

Send modal

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/eeaf1214-1f4c-4981-91bb-de6b0c773a79

