### PR TITLE
feat(@desktop/wallet): Display for L1 fees on a transaction as per design

### DIFF
--- a/ui/imports/shared/popups/send/controls/GasSelector.qml
+++ b/ui/imports/shared/popups/send/controls/GasSelector.qml
@@ -50,11 +50,13 @@ Item {
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
                 title: qsTr("%1 transaction fee").arg(root.getNetworkName(modelData.fromNetwork))
                 subTitle: {
-                    let fee = root.formatCurrencyAmount(totalGasAmountEth, Constants.ethToken)
+                    let primaryFee = root.formatCurrencyAmount(totalGasAmountEth, Constants.ethToken)
                     if (modelData.gasFees.eip1559Enabled && modelData.gasFees.l1GasFee > 0) {
-                        fee += "\n(L1 %1)".arg(root.formatCurrencyAmount(totalGasAmountL1Eth, Constants.ethToken))
+                        return qsTr("L1 fee: %1\nL2 fee: %2")
+                        .arg(root.formatCurrencyAmount(totalGasAmountL1Eth, Constants.ethToken))
+                        .arg(primaryFee)
                     }
-                    return fee
+                    return primaryFee
                 }
                 property double totalGasAmountL1Eth: {
                     const l1FeeInGWei = modelData.gasFees.l1GasFee


### PR DESCRIPTION
feat(@desktop/wallet): Display for L1 fees on a transaction as per design

fixes #14208

### What does the PR do

show l1  and l2 fees for optimism as per new design https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?type=design&node-id=22652-265707&mode=design&t=FzBHjGy3ckdRF9mn-4

### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/db109729-3f8d-434d-b45e-9fee5c57b105

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

User will be able to see the L1 and L2 fee distinction more clearly as shown in the attached video

### How to test

- How should one proceed with testing this PR.
Try to launch SendModal and observe the fees section in advanced view

- What kind of user flows should be checked?
Send between different chains 
eg: 
Mainnet -> Mainnet
Optimism-> Optimism
Arbitrum -> Arbitrum
Optimism -> Mainnet etc...

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
