### PR TITLE
fix(wallet)_: SendModel scrollbar overlaps with tokens

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -391,7 +391,7 @@ Rectangle {
                 anchors.top: statusListItemTertiaryTitle.bottom
                 anchors.topMargin: visible ? 2 : 0
                 width: Math.min(statusListItemTagsSlotInline.width, statusListItemTagsSlotInline.availableWidth, parent.width)
-                height: visible ? contentHeight : 0
+                height: visible ? contentHeight + 16 : 0
                 padding: 0
                 ScrollBar.horizontal.policy: root.tagsScrollBarVisible ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
 

--- a/ui/imports/shared/popups/send/views/TokenListView.qml
+++ b/ui/imports/shared/popups/send/views/TokenListView.qml
@@ -219,6 +219,7 @@ Item {
         id: tokenDelegate
         TokenBalancePerChainDelegate {
             width: tokenList.width
+            tagsScrollBarVisible: true
 
             balancesModel: LeftJoinModel {
                 leftModel: !!model & !!model.balancesModel ? model.balancesModel : null


### PR DESCRIPTION
### What does the PR do
- Adjusted StatusListItem height to account for scrollbar visibility by adding 16 pixels to contentHeight when tags are visible.
- Set tagsScrollBarVisible to true in TokenListView to ensure the scrollbar is displayed as needed.

fixes: #13620 

### Affected areas

- Wallet
- UI components related to StatusListItem and TokenListView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/16547115/9e2cd71d-6f05-4e19-b40a-d405ea2db863)

### Impact on end user

The user will have a proper scrollbar that doesn't overlap with tags underneath when tags are visible.

### How to test

1. navigate to wallet -> chose any account
2. at the bottom click send
3. if you have account with balances too big you will start to see scrollbar

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

