### PR TITLE
fix: Fixing windows crash after onboarding

### DIFF
--- a/src/app/modules/main/browser_section/current_account/module.nim
+++ b/src/app/modules/main/browser_section/current_account/module.nim
@@ -18,6 +18,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
     currentAccountIndex: int
@@ -35,10 +36,12 @@ proc newModule*(
   result.events = events
   result.currentAccountIndex = 0
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = newController(result, walletAccountService, networkService, tokenService, currencyService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
 
 proc switchAccount*(self: Module, accountIndex: int) =
@@ -69,7 +72,7 @@ proc switchAccount*(self: Module, accountIndex: int) =
   self.view.setData(accountItem)
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("browserSectionCurrentAccount", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("browserSectionCurrentAccount", self.viewVariant)
 
   self.events.on(SIGNAL_KEYPAIR_SYNCED) do(e: Args):
     let args = KeypairArgs(e)

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -16,6 +16,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
     walletAccountService: wallet_account_service.Service
@@ -32,10 +33,12 @@ proc newModule*(
   result.events = events
   result.walletAccountService = walletAccountService
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, walletAccountService, networkService, currencyService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
   self.controller.delete
 
@@ -63,7 +66,7 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) 
   self.view.setItems(items)
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionAccounts", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionAccounts", self.viewVariant)
   self.controller.init()
   self.view.load()
 

--- a/src/app/modules/main/wallet_section/all_collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/module.nim
@@ -22,6 +22,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: all_collectibles_controller.Controller
     collectiblesController: collectibles_controller.Controller
     moduleLoaded: bool
@@ -48,15 +49,17 @@ proc newModule*(
   result.collectiblesController = collectiblesController
 
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
   self.controller.delete
   self.collectiblesController.delete
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionAllCollectibles", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionAllCollectibles", self.viewVariant)
 
   self.events.on(SIGNAL_COLLECTIBLE_PREFERENCES_UPDATED) do(e: Args):
     let args = ResultArgs(e)

--- a/src/app/modules/main/wallet_section/all_tokens/module.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/module.nim
@@ -20,6 +20,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
     addresses: seq[string]
@@ -36,16 +37,18 @@ proc newModule*(
   result.delegate = delegate
   result.events = events
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, events, tokenService, walletAccountService, settingsService, communityTokensService)
   result.moduleLoaded = false
   result.addresses = @[]
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
   self.controller.delete
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionAllTokens", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionAllTokens", self.viewVariant)
 
   self.events.on(SIGNAL_CURRENCY_UPDATED) do(e:Args):
     self.controller.rebuildMarketData()

--- a/src/app/modules/main/wallet_section/assets/module.nim
+++ b/src/app/modules/main/wallet_section/assets/module.nim
@@ -17,6 +17,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
 
@@ -32,14 +33,16 @@ proc newModule*(
   result.delegate = delegate
   result.events = events
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = newController(result, walletAccountService, networkService, tokenService, currencyService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionAssets", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionAssets", self.viewVariant)
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
     self.view.modelsUpdated()

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/module.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/module.nim
@@ -14,6 +14,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
 
@@ -26,10 +27,12 @@ proc newModule*(
   result.delegate = delegate
   result.events = events
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(result, events, transactionService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
   self.controller.delete
 
@@ -46,7 +49,7 @@ method updateCryptoServices*(self: Module, cryptoServices: seq[CryptoRampDto]) =
   self.view.setItems(items)
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionBuySellCrypto", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionBuySellCrypto", self.viewVariant)
   self.controller.fetchCryptoServices()
   self.controller.init()
   self.view.load()

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -56,6 +56,7 @@ type
     moduleLoaded: bool
     controller: controller.Controller
     view: View
+    viewVariant: QVariant
     filter: Filter
 
     # shared modules
@@ -171,6 +172,7 @@ proc newModule*(
   result.walletConnectController = wc_controller.newController(result.walletConnectService, walletAccountService)
 
   result.view = newView(result, result.activityController, result.tmpActivityControllers, result.activityDetailsController, result.collectibleDetailsController, result.walletConnectController)
+  result.viewVariant = newQVariant(result.view)
 
 method delete*(self: Module) =
   self.accountsModule.delete
@@ -181,6 +183,7 @@ method delete*(self: Module) =
   self.buySellCryptoModule.delete
   self.sendModule.delete
   self.controller.delete
+  self.viewVariant.delete
   self.view.delete
   self.activityController.delete
   for i in 0..self.tmpActivityControllers.len-1:
@@ -257,7 +260,7 @@ method setFilterAllAddresses*(self: Module) =
   self.notifyFilterChanged()
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSection", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSection", self.viewVariant)
 
   self.events.on(SIGNAL_KEYPAIR_SYNCED) do(e: Args):
     let args = KeypairArgs(e)

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -18,6 +18,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
     isAllAccounts: bool
@@ -32,15 +33,17 @@ proc newModule*(
   result.delegate = delegate
   result.events = events
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = newController(result, walletAccountService, currencyService)
   result.moduleLoaded = false
   result.isAllAccounts = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionOverview", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionOverview", self.viewVariant)
   self.controller.init()
   self.view.load()
 

--- a/src/app/modules/main/wallet_section/saved_addresses/module.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/module.nim
@@ -13,6 +13,7 @@ type
   Module* = ref object of io_interface.AccessInterface
     delegate: delegate_interface.AccessInterface
     view: View
+    viewVariant: QVariant
     moduleLoaded: bool
     controller: Controller
 
@@ -24,10 +25,12 @@ proc newModule*(
   result = Module()
   result.delegate = delegate
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
   result.controller = newController(result, events, savedAddressService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
 
 method loadSavedAddresses*(self: Module) =
@@ -45,7 +48,7 @@ method loadSavedAddresses*(self: Module) =
   )
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionSavedAddresses", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionSavedAddresses", self.viewVariant)
 
   self.loadSavedAddresses()
   self.controller.init()

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -48,6 +48,7 @@ type
     delegate: delegate_interface.AccessInterface
     events: EventEmitter
     view: View
+    viewVariant: QVariant
     controller: controller.Controller
     # Get the list of owned collectibles by the currently selected account
     collectiblesController: collectiblesc.Controller
@@ -82,10 +83,12 @@ proc newModule*(
   )
   result.nestedCollectiblesModel = nested_collectibles.newModel(result.collectiblesController.getModel())
   result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
 
   result.moduleLoaded = false
 
 method delete*(self: Module) =
+  self.viewVariant.delete
   self.view.delete
   self.controller.delete
   self.nestedCollectiblesModel.delete
@@ -162,7 +165,7 @@ proc refreshNetworks*(self: Module) =
   self.view.setNetworkItems(fromNetworks, toNetworks)
 
 method load*(self: Module) =
-  singletonInstance.engine.setRootContextProperty("walletSectionSend", newQVariant(self.view))
+  singletonInstance.engine.setRootContextProperty("walletSectionSend", self.viewVariant)
 
   # these connections should be part of the controller's init method
   self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e:Args):


### PR DESCRIPTION
### What does the PR do

Closes: #15035 

The app is crashing when the QVariant set as module context property gets collected. Not sure why it happens more often in the onboarding flow and on windows.

#### Next steps:

1. Integrate `nim-libbacktrace` to help debugging nim crashes where there is no call stack provided by nim and analyse if we can use it on release builds or only for debugging purposes.
Once we release the app there will be no way to debug such crashes unless we reproduce. And even then it's very difficult to do and time consuming.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Wallet
