### PR TITLE
fix: can't proceed further when clicking back button on any of keycards screens

### DIFF
--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -175,6 +175,7 @@ QtObject:
     if self.busy:
       return
     let response = keycard_go.keycardCancelFlow()
+    sleep(200)
     self.currentFlow = KCSFlowType.NoFlow
     if self.doLogging:
       debug "keycardCancelFlow", kcServiceCurrFlow=($self.currentFlow), response=response


### PR DESCRIPTION
I've tested this and was able to reproduce it, but it was nothing wrong in the code implementation itself, it's up to the keycard lib low-level things. What we're doing, when the user clicks to run any flow, we ensure that it can be run successfully by calling the cancel flow immediately before it, but in some cases even the cancel flow is called it doesn't invalidate all the things on the lib side if at the moment when we run next flow, because of that we may see `"already running"` response, so in this PR we just delay the next flow call for 200ms after calling the cancel flow. Tested the app a lot after it and couldn't reproduce the issue.


Fixes: #15113