### PR TITLE
fix(@desktop/chat): fix edited keyword for bridged messages

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -47,7 +47,7 @@ Item {
             isQuote = (formattedMessage.startsWith("<blockquote>") && formattedMessage.endsWith("</blockquote>"));
 
             if (root.isEdited) {
-                const index = formattedMessage.endsWith("code>") ? formattedMessage.length : formattedMessage.length - 4;
+                const index = formattedMessage.endsWith("code>") ? formattedMessage.length : (formattedMessage.endsWith(">") ? formattedMessage.length - 4 : formattedMessage.length);
                 const editedMessage = formattedMessage.slice(0, index)
                                     + ` <span class="isEdited">` + qsTr("(edited)") + `</span>`
                                     + formattedMessage.slice(index);


### PR DESCRIPTION
Issue #15291

I moved replacing newline to bridge [pr](https://github.com/status-im/matterbridge/pull/13)
Here, I fixed wrong displaying of "edited" keyword. I found this during testing.
It is a different problem, but let's kill 2 birds with 1 stone.