### PR TITLE
chore(SendModal): factor out and create new `SendRecipientInput` component 

### DIFF
--- a/storybook/pages/SendRecipientInputPage.qml
+++ b/storybook/pages/SendRecipientInputPage.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import Storybook 1.0
+
+import utils 1.0
+
+import shared.popups.send.controls 1.0
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Rectangle {
+            SplitView.fillHeight: true
+            SplitView.fillWidth: true
+            color: Theme.palette.baseColor2
+
+            SendRecipientInput {
+                anchors.centerIn: parent
+                interactive: ctrlInteractive.checked
+                checkMarkVisible: ctrlCheckmark.checked
+                Component.onCompleted: forceActiveFocus()
+
+                onClearClicked: logs.logEvent("SendRecipientInput::clearClicked", [], arguments)
+                onValidateInputRequested: logs.logEvent("SendRecipientInput::validateInputRequested", [], arguments)
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            logsView.logText: logs.logText
+
+            ColumnLayout {
+                TextEdit {
+                    readOnly: true
+                    selectByMouse: true
+                    text: "valid address: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc4"
+                }
+
+                Switch {
+                    id: ctrlInteractive
+                    text: "Interactive"
+                    checked: true
+                }
+
+                Switch {
+                    id: ctrlCheckmark
+                    text: "Checkmark visible"
+                    checked: false
+                }
+            }
+        }
+    }
+}
+
+// category: Controls
+
+// https://www.figma.com/design/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=9707-106469&t=MeyLezc91kfFYcm9-0
+// https://www.figma.com/design/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=10259-120493&t=MeyLezc91kfFYcm9-0
+// https://www.figma.com/design/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=9019-88679&t=MeyLezc91kfFYcm9-0
+// https://www.figma.com/design/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=9707-105782&t=MeyLezc91kfFYcm9-0
+

--- a/storybook/qmlTests/tests/tst_SendRecipientInput.qml
+++ b/storybook/qmlTests/tests/tst_SendRecipientInput.qml
@@ -1,0 +1,183 @@
+import QtQuick 2.15
+import QtTest 1.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
+import shared.popups.send.controls 1.0
+
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    Component {
+        id: componentUnderTest
+        SendRecipientInput {
+            anchors.centerIn: parent
+            focus: true
+        }
+    }
+
+    SignalSpy {
+        id: signalSpyClearClicked
+        target: controlUnderTest
+        signalName: "clearClicked"
+    }
+
+    SignalSpy {
+        id: signalSpyValidateInputRequested
+        target: controlUnderTest
+        signalName: "validateInputRequested"
+    }
+
+    property SendRecipientInput controlUnderTest: null
+
+    TestCase {
+        name: "SendRecipientInput"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            signalSpyClearClicked.clear()
+            signalSpyValidateInputRequested.clear()
+            QClipboardProxy.clear()
+        }
+
+        function test_basicGeometry() {
+            verify(!!controlUnderTest)
+            verify(controlUnderTest.width > 0)
+            verify(controlUnderTest.height > 0)
+        }
+
+        function test_textInput() {
+            verify(!!controlUnderTest)
+
+            verify(controlUnderTest.input.edit.focus)
+            verify(controlUnderTest.interactive)
+            compare(controlUnderTest.placeholderText, qsTr("Enter an ENS name or address"))
+
+            keyClick(Qt.Key_0)
+            keyClick(Qt.Key_X)
+            keyClick(Qt.Key_D)
+            keyClick(Qt.Key_E)
+            keyClick(Qt.Key_A)
+            keyClick(Qt.Key_D)
+            keyClick(Qt.Key_B)
+            keyClick(Qt.Key_E)
+            keyClick(Qt.Key_E)
+            keyClick(Qt.Key_F)
+
+            const plainText = StatusQUtils.StringUtils.plainText(controlUnderTest.text)
+
+            // input's text should be what we typed,
+            compare(plainText, "0xdeadbeef")
+            // ... and for each letter pressed the signal `validateInputRequested` should be emitted
+            compare(signalSpyValidateInputRequested.count, plainText.length)
+        }
+
+        function test_interactive() {
+            verify(!!controlUnderTest)
+            verify(controlUnderTest.input.edit.focus)
+            verify(controlUnderTest.interactive)
+
+            controlUnderTest.interactive = false
+
+            keyClick(Qt.Key_A)
+            keyClick(Qt.Key_B)
+            keyClick(Qt.Key_C)
+
+            const plainText = StatusQUtils.StringUtils.plainText(controlUnderTest.text)
+
+            // when non-interactive, any text input should be ignored
+            compare(plainText, "")
+        }
+
+        function test_pasteButton() {
+            verify(!!controlUnderTest)
+            const pasteButton = findChild(controlUnderTest, "pasteButton")
+            verify(!!pasteButton)
+            compare(pasteButton.visible, false)
+
+            // copy sth to clipboard
+            controlUnderTest.text = "0xdeadbeef"
+            controlUnderTest.input.edit.selectAll()
+            controlUnderTest.input.edit.copy()
+
+            // paste button should be visible if input is empty and clipboard is not
+            compare(pasteButton.visible, false)
+            controlUnderTest.input.edit.clear()
+            compare(pasteButton.visible, true)
+        }
+
+        function test_pasteUsingButton() {
+            verify(!!controlUnderTest)
+            const pasteButton = findChild(controlUnderTest, "pasteButton")
+            verify(!!pasteButton)
+            tryCompare(pasteButton, "visible", false)
+
+            const richTextToTest = "<b>this is bold text</b>"
+
+            // copy rich text to clipboard
+            controlUnderTest.text = richTextToTest
+            controlUnderTest.input.edit.selectAll()
+            controlUnderTest.input.edit.copy()
+            controlUnderTest.input.edit.clear()
+            compare(controlUnderTest.input.edit.length , 0)
+
+            compare(pasteButton.visible, true)
+            mouseClick(pasteButton)
+            verify(!controlUnderTest.text.includes("<b>this is bold text</b>"))
+        }
+
+        function test_pasteUsingKbdShortcut() {
+            verify(!!controlUnderTest)
+            const pasteButton = findChild(controlUnderTest, "pasteButton")
+            verify(!!pasteButton)
+            tryCompare(pasteButton, "visible", false)
+
+            const richTextToTest = "<b>this is bold text</b>"
+
+            // copy rich text to clipboard
+            controlUnderTest.text = richTextToTest
+            controlUnderTest.input.edit.selectAll()
+            controlUnderTest.input.edit.copy()
+            controlUnderTest.input.edit.clear()
+            compare(controlUnderTest.input.edit.length , 0)
+
+            compare(pasteButton.visible, true)
+            keySequence(StandardKey.Paste)
+            verify(!controlUnderTest.text.includes("<b>this is bold text</b>"))
+        }
+
+        function test_clearButton() {
+            verify(!!controlUnderTest)
+            verify(controlUnderTest.input.edit.focus)
+            verify(controlUnderTest.interactive)
+
+            const clearButton = findChild(controlUnderTest, "clearButton")
+            compare(clearButton.visible, false)
+
+            controlUnderTest.text = "0xdeadbeef"
+
+            // clear button should be visible with some text
+            verify(clearButton.visible)
+            mouseClick(clearButton)
+            compare(StatusQUtils.StringUtils.plainText(controlUnderTest.text), "")
+            compare(signalSpyClearClicked.count, 1)
+
+            // and when interactive
+            controlUnderTest.interactive = false
+            compare(clearButton.visible, false)
+        }
+
+        function test_checkmark() {
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.checkMarkVisible, false)
+            controlUnderTest.checkMarkVisible = true
+            const checkmarkIcon = findChild(controlUnderTest, "checkmarkIcon")
+            verify(!!checkmarkIcon)
+            verify(checkmarkIcon.visible)
+        }
+    }
+}

--- a/storybook/src/Models/WalletSendAccountsModel.qml
+++ b/storybook/src/Models/WalletSendAccountsModel.qml
@@ -13,7 +13,8 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             walletType: "",
             position: 0,
-            canSend: true
+            canSend: true,
+            migratedToKeycard: false
         },
         {
             name: "Hot wallet (generated)",
@@ -24,7 +25,8 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             walletType: Constants.generatedWalletType,
             position: 3,
-            canSend: true
+            canSend: true,
+            migratedToKeycard: false
         },
         {
             name: "Family (seed)",
@@ -35,7 +37,8 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             walletType: Constants.seedWalletType,
             position: 1,
-            canSend: true
+            canSend: true,
+            migratedToKeycard: false
         },
         {
             name: "Tag Heuer (watch)",
@@ -46,7 +49,8 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             walletType: Constants.watchWalletType,
             position: 2,
-            canSend: false
+            canSend: false,
+            migratedToKeycard: false
         },
         {
             name: "Fab (key)",
@@ -57,7 +61,8 @@ ListModel {
             preferredSharingChainIds: "5:420:421613",
             walletType: Constants.keyWalletType,
             position: 4,
-            canSend: true
+            canSend: true,
+            migratedToKeycard: true
         }
     ]
 

--- a/storybook/src/Models/WalletSendAccountsModel.qml
+++ b/storybook/src/Models/WalletSendAccountsModel.qml
@@ -10,8 +10,10 @@ ListModel {
             colorId: Constants.walletAccountColors.primary,
             color: "#2A4AF5",
             address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
+            preferredSharingChainIds: "5:420:421613",
             walletType: "",
             position: 0,
+            canSend: true
         },
         {
             name: "Hot wallet (generated)",
@@ -19,8 +21,10 @@ ListModel {
             colorId: Constants.walletAccountColors.army,
             color: "#216266",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
+            preferredSharingChainIds: "5:420:421613",
             walletType: Constants.generatedWalletType,
             position: 3,
+            canSend: true
         },
         {
             name: "Family (seed)",
@@ -28,8 +32,10 @@ ListModel {
             colorId: Constants.walletAccountColors.magenta,
             color: "#EC266C",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8882",
+            preferredSharingChainIds: "5:420:421613",
             walletType: Constants.seedWalletType,
             position: 1,
+            canSend: true
         },
         {
             name: "Tag Heuer (watch)",
@@ -37,8 +43,10 @@ ListModel {
             colorId: Constants.walletAccountColors.copper,
             color: "#CB6256",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8883",
+            preferredSharingChainIds: "5:420:421613",
             walletType: Constants.watchWalletType,
             position: 2,
+            canSend: false
         },
         {
             name: "Fab (key)",
@@ -46,8 +54,10 @@ ListModel {
             colorId: Constants.walletAccountColors.camel,
             color: "#C78F67",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8884",
+            preferredSharingChainIds: "5:420:421613",
             walletType: Constants.keyWalletType,
             position: 4,
+            canSend: true
         }
     ]
 

--- a/storybook/stubs/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/storybook/stubs/AppLayouts/Wallet/stores/TokensStore.qml
@@ -4,6 +4,7 @@ QtObject {
     id: root
 
     property var plainTokensBySymbolModel
+    property bool showCommunityAssetsInSend
     property bool displayAssetsBelowBalance
     property var getDisplayAssetsBelowBalanceThresholdDisplayAmount
     property double tokenListUpdatedAt

--- a/storybook/stubs/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/storybook/stubs/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -56,7 +56,7 @@ QtObject {
         joinRole: "communityId"
     }
 
-    property var assetsController: QtObject {
+    readonly property var assetsController: QtObject {
         property int revision
 
         function filterAcceptsSymbol(symbol) {

--- a/storybook/stubs/shared/stores/send/TransactionStore.qml
+++ b/storybook/stubs/shared/stores/send/TransactionStore.qml
@@ -71,8 +71,9 @@ QtObject {
         return textAddrss
     }
 
-    function resolveENS(value) {
-        return root.mainModuleInst.resolvedENS("", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc4", "") // return some valid address
+    function resolveENS(value: string) {
+        if (!!value && value.endsWith(".eth"))
+            root.mainModuleInst.resolvedENS("", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc4", "") // return some valid address
     }
 
     function getAsset(assetsList, symbol) {

--- a/storybook/stubs/shared/stores/send/TransactionStore.qml
+++ b/storybook/stubs/shared/stores/send/TransactionStore.qml
@@ -13,21 +13,26 @@ QtObject {
     id: root
 
     readonly property CurrenciesStore currencyStore: CurrenciesStore {}
+
+    readonly property TokensStore tokensStore: TokensStore {}
     
     readonly property var accounts: WalletSendAccountsModel {
-        Component.onCompleted: selectedSenderAccount = accounts.get(0)
+        Component.onCompleted: selectedSenderAccountAddress = accounts.get(0).address
     }
 
     property WalletAssetsStore walletAssetStore
 
-    property QtObject tmpActivityController: QtObject {
+    property QtObject tmpActivityController0: QtObject {
+        property ListModel model: ListModel{}
+    }
+    property QtObject tmpActivityController1: QtObject {
         property ListModel model: ListModel{}
     }
 
     property var flatNetworksModel: NetworksModel.flatNetworks
     property var fromNetworksRouteModel: NetworksModel.sendFromNetworks
     property var toNetworksRouteModel: NetworksModel.sendToNetworks
-    property var selectedSenderAccount: accounts.get(0)
+    property string selectedSenderAccountAddress
     readonly property QtObject collectiblesModel: ManageCollectiblesModel {}
     readonly property QtObject nestedCollectiblesModel: WalletNestedCollectiblesModel {}
 
@@ -53,6 +58,12 @@ QtObject {
                            address: "0x2B748A02e06B159C7C3E98F5064577B96E55A7b4",
                            chainShortNames: "eth:arb1"
                        })
+            append({
+                       name: "some saved ENS name ",
+                       ens: ["me@status.eth"],
+                       address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc4",
+                       chainShortNames: "eth:arb1:opt"
+                   })
         }
     }
 
@@ -60,8 +71,8 @@ QtObject {
         return textAddrss
     }
 
-    function resolveENS() {
-        return ""
+    function resolveENS(value) {
+        return root.mainModuleInst.resolvedENS("", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc4", "") // return some valid address
     }
 
     function getAsset(assetsList, symbol) {
@@ -120,8 +131,8 @@ QtObject {
         return "OPT"
     }
 
-    function plainText(text) {
-        return text
+    function plainText(htmlFragment) {
+        return SQUtils.StringUtils.plainText(htmlFragment)
     }
 
     function prepareTransactionsForAddress(address) {
@@ -150,11 +161,11 @@ QtObject {
         }
     }
 
-    function setSenderAccountByAddress(address) {
+    function setSenderAccount(address) {
         for (let i = 0; i < accounts.count; i++) {
             const acc = accounts.get(i)
-            if (acc.address === address && accounts.canSend) {
-                selectedSenderAccount = accounts.get(i)
+            if (acc.address === address && acc.canSend) {
+                selectedSenderAccountAddress = acc.address
                 break
             }
         }
@@ -197,6 +208,9 @@ QtObject {
         root.showUnPreferredChains = !root.showUnPreferredChains
     }
 
+    function setAllNetworksAsRoutePreferredChains() {
+    }
+
     function setRouteEnabledFromChains(chainId) {
     }
 
@@ -230,9 +244,4 @@ QtObject {
     function formatCurrencyAmountFromBigInt(balance, symbol, decimals, options = null) {
         return currencyStore.formatCurrencyAmountFromBigInt(balance, symbol, decimals, options)
     }
-
-    // Property and methods below are used to apply advanced token management settings to the SendModal
-    property bool showCommunityAssetsInSend: true
-    property bool balanceThresholdEnabled: true
-    property real balanceThresholdAmount
 }

--- a/ui/StatusQ/include/StatusQ/QClipboardProxy.h
+++ b/ui/StatusQ/include/StatusQ/QClipboardProxy.h
@@ -55,6 +55,7 @@ public:
     Q_INVOKABLE bool isValidImageUrl(const QUrl &url, const QStringList &acceptedExtensions) const;
     Q_INVOKABLE qint64 getFileSize(const QUrl &url) const;
     Q_INVOKABLE void copyTextToClipboard(const QString& text);
+    Q_INVOKABLE void clear();
 
 signals:
     void contentChanged();

--- a/ui/StatusQ/include/StatusQ/stringutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/stringutilsinternal.h
@@ -19,6 +19,8 @@ public:
 
     Q_INVOKABLE QString extractDomainFromLink(const QString& link) const;
 
+    Q_INVOKABLE QString plainText(const QString& htmlFragment) const;
+
 private:
     QQmlEngine* m_engine{nullptr};
 };

--- a/ui/StatusQ/src/QClipboardProxy.cpp
+++ b/ui/StatusQ/src/QClipboardProxy.cpp
@@ -92,3 +92,8 @@ void QClipboardProxy::copyTextToClipboard(const QString &text)
 {
     m_clipboard->setText(text);
 }
+
+void QClipboardProxy::clear()
+{
+    m_clipboard->clear();
+}

--- a/ui/StatusQ/src/StatusQ/Controls/StatusClearButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusClearButton.qml
@@ -10,6 +10,6 @@ StatusFlatRoundButton {
     icon.height: 16
     implicitWidth: 24
     implicitHeight: 24
-    icon.color: Theme.palette.baseColor1
+    icon.color: Theme.palette.directColor9
     backgroundHoverColor: "transparent"
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -455,7 +455,7 @@ Item {
             onKeyPressed: {
                 root.keyPressed(event);
             }
-            onEditChanged: {
+            onEditClicked: {
                 root.editClicked();
             }
             onEditingFinished: {

--- a/ui/StatusQ/src/StatusQ/Core/Utils/StringUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/StringUtils.qml
@@ -16,4 +16,8 @@ QtObject {
     function extractDomainFromLink(link) {
         return Internal.StringUtils.extractDomainFromLink(link)
     }
+
+    function plainText(htmlFragment) {
+        return Internal.StringUtils.plainText(htmlFragment)
+    }
 }

--- a/ui/StatusQ/src/stringutilsinternal.cpp
+++ b/ui/StatusQ/src/stringutilsinternal.cpp
@@ -5,6 +5,7 @@
 #include <QQmlEngine>
 #include <QQmlFileSelector>
 #include <QUrl>
+#include <QTextDocumentFragment>
 
 StringUtilsInternal::StringUtilsInternal(QQmlEngine* engine, QObject* parent)
     : m_engine(engine)
@@ -72,4 +73,9 @@ QString StringUtilsInternal::extractDomainFromLink(const QString& link) const
         return {};
     }
     return url.host();
+}
+
+QString StringUtilsInternal::plainText(const QString &htmlFragment) const
+{
+    return QTextDocumentFragment::fromHtml(htmlFragment).toPlainText();
 }

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -222,7 +222,7 @@ StatusDialog {
 
         if(!!popup.preSelectedRecipient) {
             recipientLoader.selectedRecipientType = popup.preSelectedRecipientType
-            if (popup.preSelectedRecipientType == TabAddressSelectorView.Type.Address) {
+            if (popup.preSelectedRecipientType === TabAddressSelectorView.Type.Address) {
                 recipientLoader.selectedRecipient = {address: popup.preSelectedRecipient}
             } else {
                 recipientLoader.selectedRecipient = popup.preSelectedRecipient
@@ -327,7 +327,6 @@ StatusDialog {
                         id: holdingSelector
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        // assetsModel: popup.store.processedAssetsModel
                         assetsModel: assetsAdaptor.model
                         collectiblesModel: popup.preSelectedAccount ? popup.nestedCollectiblesModel : null
                         networksModel: popup.store.flatNetworksModel

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -246,16 +246,14 @@ StatusDialog {
         AccountSelectorHeader {
             id: accountSelector
             model: SortFilterProxyModel {
-                sourceModel: SortFilterProxyModel {
-                    sourceModel: popup.store.accounts
-                    filters: [
-                        ValueFilter {
-                            roleName: "canSend"
-                            value: true
-                        }
-                    ]
-                }
+                sourceModel: popup.store.accounts
 
+                filters: [
+                    ValueFilter {
+                        roleName: "canSend"
+                        value: true
+                    }
+                ]
                 sorters: RoleSorter { roleName: "position"; sortOrder: Qt.AscendingOrder }
                 proxyRoles: [
                     FastExpressionRole {

--- a/ui/imports/shared/popups/send/controls/SendRecipientInput.qml
+++ b/ui/imports/shared/popups/send/controls/SendRecipientInput.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+StatusInput {
+    id: root
+
+    property bool interactive: true
+    property bool checkMarkVisible
+
+    signal clearClicked()
+    signal validateInputRequested()
+
+    placeholderText: qsTr("Enter an ENS name or address")
+    input.background.color: Theme.palette.indirectColor1
+    input.background.border.width: 0
+    input.implicitHeight: 56
+    rightPadding: 12
+    input.clearable: false // custom button below
+    input.edit.readOnly: !root.interactive
+    multiline: false
+    input.edit.textFormat: TextEdit.RichText
+
+    input.rightComponent: RowLayout {
+        StatusButton {
+            objectName: "pasteButton"
+            font.weight: Font.Normal
+            borderColor: Theme.palette.primaryColor1
+            borderWidth: 1
+            size: StatusBaseButton.Size.Tiny
+            text: qsTr("Paste")
+            visible: root.input.edit.length === 0 && root.input.edit.canPaste
+            focusPolicy: Qt.NoFocus
+            onClicked: {
+                root.input.edit.forceActiveFocus()
+                root.text = QClipboardProxy.text // paste plain text
+                root.input.edit.cursorPosition = root.input.edit.length
+                root.validateInputRequested()
+            }
+        }
+        StatusIcon {
+            objectName: "checkmarkIcon"
+            Layout.preferredWidth: 16
+            Layout.preferredHeight: 16
+            icon: "tiny/checkmark"
+            color: Theme.palette.primaryColor1
+            visible: root.checkMarkVisible
+        }
+        StatusClearButton {
+            objectName: "clearButton"
+            visible: root.input.edit.length !== 0 && root.interactive
+            onClicked: {
+                root.input.edit.clear()
+                root.clearClicked()
+            }
+        }
+    }
+
+    Connections {
+        target: root.input
+        function onKeyPressed(event) {
+            if (event.matches(StandardKey.Paste)) {
+                event.accepted = true
+                root.text = QClipboardProxy.text // paste plain text
+            }
+        }
+    }
+
+    Keys.onTabPressed: event.accepted = true
+    Keys.onReleased: root.validateInputRequested()
+}

--- a/ui/imports/shared/popups/send/controls/qmldir
+++ b/ui/imports/shared/popups/send/controls/qmldir
@@ -10,3 +10,4 @@ BalanceExceeded 1.0 BalanceExceeded.qml
 CollectibleBackButtonWithInfo 1.0 CollectibleBackButtonWithInfo.qml
 CollectibleNestedDelegate 1.0 CollectibleNestedDelegate.qml
 HeaderTitleText 1.0 HeaderTitleText.qml
+SendRecipientInput 1.0 SendRecipientInput.qml

--- a/ui/imports/shared/popups/send/models/SendModalAssetsAdaptor.qml
+++ b/ui/imports/shared/popups/send/models/SendModalAssetsAdaptor.qml
@@ -13,7 +13,7 @@ QObject {
 
     // Controller providing information about visibility and order defined
     // by a user (token management)
-    required property ManageTokensController controller
+    required property /*ManageTokensController*/ var controller
 
     property bool showCommunityAssets: false
 

--- a/ui/imports/shared/popups/send/views/RecipientView.qml
+++ b/ui/imports/shared/popups/send/views/RecipientView.qml
@@ -175,24 +175,14 @@ Loader {
 
     Component {
         id: addressRecipient
-        StatusInput {
-            id: recipientInput
+        SendRecipientInput {
             width: parent.width
             height: visible ? implicitHeight: 0
             visible: !root.isBridgeTx && !!root.selectedAsset
-
-            placeholderText: qsTr("Enter an ENS name or address")
-            input.background.color: Theme.palette.indirectColor1
-            input.background.border.width: 0
-            input.implicitHeight: 56
-            input.clearable: false // custom button below
-            input.edit.readOnly: !root.interactive
-            multiline: false
-            input.edit.textFormat: TextEdit.RichText
             text: root.addressText
 
             function validateInput() {
-                const plainText = store.plainText(recipientInput.text)
+                const plainText = store.plainText(text)
                 root.isLoading()
                 if (Utils.isValidEns(plainText)) {
                     d.isPending = true
@@ -202,38 +192,10 @@ Loader {
                 }
             }
 
-            input.rightComponent: RowLayout {
-                StatusButton {
-                    font.weight: Font.Normal
-                    borderColor: Theme.palette.primaryColor1
-                    size: StatusBaseButton.Size.Tiny
-                    text: qsTr("Paste")
-                    visible: recipientInput.input.edit.length === 0 && recipientInput.input.edit.canPaste
-                    focusPolicy: Qt.NoFocus
-                    onClicked: {
-                        recipientInput.input.edit.forceActiveFocus()
-                        recipientInput.input.edit.paste()
-                        recipientInput.input.edit.cursorPosition = recipientInput.input.edit.length
-                        recipientInput.validateInput()
-                    }
-                }
-                StatusIcon {
-                    Layout.preferredWidth: 16
-                    Layout.preferredHeight: 16
-                    icon: "tiny/checkmark"
-                    color: Theme.palette.primaryColor1
-                    visible: root.ready
-                }
-                StatusClearButton {
-                    visible: recipientInput.input.edit.length !== 0 && root.interactive
-                    onClicked: {
-                        recipientInput.input.edit.clear()
-                        d.clearValues()
-                    }
-                }
-            }
-            Keys.onTabPressed: event.accepted = true
-            Keys.onReleased: recipientInput.validateInput()
+            interactive: root.interactive
+            checkMarkVisible: root.ready
+            onClearClicked: d.clearValues()
+            onValidateInputRequested: validateInput()
         }
     }
 

--- a/ui/imports/shared/popups/send/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/popups/send/views/TabAddressSelectorView.qml
@@ -16,8 +16,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
-import utils 1.0
-
 import "../panels"
 import "../controls"
 import "../views"
@@ -137,11 +135,13 @@ Item {
                     }
                     onClicked: recipientSelected({name: model.name,
                                                      address: model.address,
-                                                     color: model.color,
+                                                     colorId: model.colorId,
                                                      emoji: model.emoji,
                                                      walletType: model.walletType,
                                                      currencyBalance: model.currencyBalance,
-                                                     preferredSharingChainIds: model.preferredSharingChainIds},
+                                                     preferredSharingChainIds: model.preferredSharingChainIds,
+                                                     migratedToKeycard: model.migratedToKeycard
+                                                 },
                                                  TabAddressSelectorView.Type.Account)
                 }
 


### PR DESCRIPTION
### What does the PR do

(Separate commits to unbreak SendModal in StoryBook)

- some minor visual fixes (padding & clear button color)
- make it always paste plain text, eventhough the base component has to stay RichText
- use it in SendModal->RecipientView
- add a storybook page
- added QML tests

Fixes https://github.com/status-im/status-desktop/issues/15252

### Affected areas

SendModal->RecipientView->SendRecipientInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

SendRecipientInput component:
![image](https://github.com/status-im/status-desktop/assets/5377645/8e4c66f5-32a9-4de2-a4db-c6684f2a833a)

Used in SendModal:

![image](https://github.com/status-im/status-desktop/assets/5377645/21ce0e21-5685-4b44-bb09-317212d465e8)

![image](https://github.com/status-im/status-desktop/assets/5377645/dfc79dd4-f8c9-467f-9fcd-2bffb5e08333)
