### PR TITLE
fix(sharedAddress): hide non fully imported accounts from shared address

### DIFF
--- a/storybook/src/Models/WalletAccountsModel.qml
+++ b/storybook/src/Models/WalletAccountsModel.qml
@@ -11,6 +11,7 @@ ListModel {
             color: "#2A4AF5",
             address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240",
             walletType: "",
+            canSend: true,
             position: 0,
             assets: [
                 {
@@ -55,6 +56,7 @@ ListModel {
             color: "#216266",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881",
             walletType: Constants.generatedWalletType,
+            canSend: true,
             position: 3,
             assets: [
                 {
@@ -81,6 +83,7 @@ ListModel {
             color: "#EC266C",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8882",
             walletType: Constants.seedWalletType,
+            canSend: true,
             position: 1,
             assets: [
                 {
@@ -116,6 +119,7 @@ ListModel {
             color: "#CB6256",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8883",
             walletType: Constants.watchWalletType,
+            canSend: false,
             position: 2,
             assets: [
             ],
@@ -133,6 +137,7 @@ ListModel {
             color: "#C78F67",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8884",
             walletType: Constants.keyWalletType,
+            canSend: true,
             position: 4,
             assets: [
                 {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -555,13 +555,7 @@ QtObject {
     }
 
     // Needed for TX in chat for stickers and via contact
-    readonly property var accounts: SortFilterProxyModel {
-        sourceModel: walletSectionAccounts.accounts
-        filters: ValueFilter {
-            roleName: "canSend"
-            value: true
-        }
-    }
+    readonly property var accounts: walletSectionAccounts.accounts
     property string currentCurrency: walletSection.currentCurrency
     property CurrenciesStore currencyStore: CurrenciesStore {}
     property var savedAddressesModel: walletSectionSavedAddresses.model

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -555,7 +555,13 @@ QtObject {
     }
 
     // Needed for TX in chat for stickers and via contact
-    readonly property var accounts: walletSectionAccounts.accounts
+    readonly property var accounts: SortFilterProxyModel {
+        sourceModel: walletSectionAccounts.accounts
+        filters: ValueFilter {
+            roleName: "canSend"
+            value: true
+        }
+    }
     property string currentCurrency: walletSection.currentCurrency
     property CurrenciesStore currencyStore: CurrenciesStore {}
     property var savedAddressesModel: walletSectionSavedAddresses.model

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -36,9 +36,8 @@ QObject {
     readonly property var nonWatchAccounts: SortFilterProxyModel {
         sourceModel: root.swapStore.accounts
         filters: ValueFilter {
-            roleName: "walletType"
-            value: Constants.watchWalletType
-            inverted: true
+            roleName: "canSend"
+            value: true
         }
         sorters: [
             RoleSorter { roleName: "currencyBalanceDouble"; sortOrder: Qt.DescendingOrder },

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -80,9 +80,8 @@ QtObject {
             }
         ]
         filters: ValueFilter {
-            roleName: "walletType"
-            value: Constants.watchWalletType
-            inverted: true
+            roleName: "canSend"
+            value: true
         }
     }
 


### PR DESCRIPTION
Fixes #15471

We only filtered out watch only accounts, but we also need to make sure it was a fully imported account, ie an account that is usable, hence why using `canSend`. It is the same property they use in the SendTransaction modal

All wallet accounts (seedAccount is the one that wasn't fully imported back):
![image](https://github.com/status-im/status-desktop/assets/11926403/00b10750-df86-4c43-8079-11a23117c7e6)

Available shared addresses:
![image](https://github.com/status-im/status-desktop/assets/11926403/7b6e6289-92a0-401f-bcd6-d35e1a3b5a12)
