### PR TITLE
fix(wallet): cross chain send transaction is detected now as send not bridge

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -557,4 +557,20 @@ QtObject {
         const prefix = Constants.socialLinkPrefixesByType[Constants.socialLinkType.twitter]
         return prefix + twitterHandle
     }
+
+    function transactionType(transaction) {
+        // Cross chain Send to another recipient is not a bridge, though involves bridging
+        if (transaction.txType == Constants.TransactionType.Bridge && transaction.sender !== transaction.recipient) {
+            if (root.showAllAccounts) {
+                const addresses = root.addressFilters
+                if (addresses.indexOf(transaction.sender) > -1)
+                    return Constants.TransactionType.Send
+
+                return Constants.TransactionType.Receive
+            }
+            return addressesEqual(root.selectedAddress, transaction.sender) ? Constants.TransactionType.Send : Constants.TransactionType.Receive
+        }
+
+        return transaction.txType
+    }
 }

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -102,7 +102,7 @@ Item {
         }
         readonly property real feeEthValue: d.details ? RootStore.getFeeEthValue(d.details.totalFees) : 0
         readonly property real feeFiatValue: d.isTransactionValid ? RootStore.getFiatValue(d.feeEthValue, Constants.ethToken) : 0
-        readonly property int transactionType: d.isTransactionValid ? transaction.txType : Constants.TransactionType.Send
+        readonly property int transactionType: d.isTransactionValid ? WalletStores.RootStore.transactionType(transaction) : Constants.TransactionType.Send
         readonly property bool isBridge: d.transactionType === Constants.TransactionType.Bridge
 
         property string decodedInputData: ""


### PR DESCRIPTION
### What does the PR do

This transaction is detected on status-go side as bridge transaction, because of the way we parse transfers and connect them to one multi-transaction entry. This ideally must be fixed on status-go side to check sender/recipient address to differentiate between cross-chain send and bridge, but it might require much more handling, as Send transaction is expected to store different values, than Bridge, and activity filters might also need fixing on status-go and clients sides.
We have an upcoming UI changes to support multi-transaction details (Check figma links in the linked issue), so we will address this in the PR for that design.

For now, we need to display correct recipient for this transaction type.

### Affected areas

Activity view, transaction details

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/15627093/dcf39601-6372-412f-ba2d-2d2dfaf751a2



### How to test

- Check the video

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Closes #14577 