### PR TITLE
feat(dapp) handle pairing errors or timeout if no response

### DIFF
--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -88,6 +88,7 @@ Item {
                 }
             }
 
+            StatusBaseText { text: "Custom Accounts" }
             StatusTextArea {
                 text: settings.customAccounts
                 onTextChanged: {
@@ -99,7 +100,8 @@ Item {
                     })
                 }
                 Layout.fillWidth: true
-                Layout.preferredHeight: !!text ? 400 : -1
+                Layout.maximumHeight: 300
+                clip: true
             }
 
             Rectangle {

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -185,9 +185,9 @@ DappsComboBox {
     Connections {
         target: root.wcService
 
-        function onPairingUriValidated(validationState) {
+        function onPairingValidated(validationState) {
             if (pairWCLoader.item) {
-                pairWCLoader.item.pairingUriValidated(validationState)
+                pairWCLoader.item.pairingValidated(validationState)
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -131,7 +131,12 @@ QObject {
 
         function onBuildApprovedNamespacesResult(approvedNamespaces, error) {
             if(error) {
-                // TODO: error reporting
+                // Check that it contains Non conforming namespaces"
+                if (error.includes("Non conforming namespaces")) {
+                    root.pairingUriValidated(Pairing.uriErrors.unsupportedNetwork)
+                } else {
+                    root.pairingUriValidated(Pairing.uriErrors.unknownError)
+                }
                 return
             }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/Pairing.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/Pairing.qml
@@ -10,5 +10,7 @@ QtObject {
         readonly property int invalidUri: 3
         readonly property int alreadyUsed: 4
         readonly property int expired: 5
+        readonly property int unsupportedNetwork: 6
+        readonly property int unknownError: 7
     }
 }

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/Pairing.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/Pairing.qml
@@ -3,7 +3,7 @@ pragma Singleton
 import QtQml 2.15
 
 QtObject {
-    readonly property QtObject uriErrors: QtObject {
+    readonly property QtObject errors: QtObject {
         readonly property int notChecked: 0
         readonly property int ok: 1
         readonly property int tooCool: 2

--- a/ui/imports/shared/popups/walletconnect/PairWCModal.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal.qml
@@ -27,9 +27,9 @@ StatusDialog {
 
     property bool isPairing: false
 
-    function pairingUriValidated(validationState) {
+    function pairingValidated(validationState) {
         uriInput.errorState = validationState
-        if (validationState === Pairing.uriErrors.ok) {
+        if (validationState === Pairing.errors.ok) {
             d.doPair()
         }
     }
@@ -51,7 +51,7 @@ StatusDialog {
         WCUriInput {
             id: uriInput
 
-            pending: uriInput.errorState === Pairing.uriErrors.notChecked
+            pending: uriInput.errorState === Pairing.errors.notChecked
 
             onTextChanged: {
                 root.isPairing = false
@@ -91,7 +91,7 @@ StatusDialog {
                 enabled: uriInput.valid
                       && !root.isPairing
                       && uriInput.text.length > 0
-                      && uriInput.errorState === Pairing.uriErrors.ok
+                      && uriInput.errorState === Pairing.errors.ok
 
                 onClicked: {
                     d.doPair()

--- a/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
@@ -17,7 +17,7 @@ ColumnLayout {
     readonly property bool valid: input.valid && input.text.length > 0
     readonly property alias text: input.text
     property alias pending: input.pending
-    property int errorState: Pairing.uriErrors.notChecked
+    property int errorState: Pairing.errors.notChecked
 
     StatusBaseInput {
         id: input
@@ -37,22 +37,21 @@ ColumnLayout {
                 return true
             }
 
-            if(root.errorState === Pairing.uriErrors.tooCool) {
+            if(root.errorState === Pairing.errors.tooCool) {
                 errorText.text = qsTr("WalletConnect URI too cool")
-            } else if(root.errorState === Pairing.uriErrors.invalidUri) {
+            } else if(root.errorState === Pairing.errors.invalidUri) {
                 errorText.text = qsTr("WalletConnect URI invalid")
-            } else if(root.errorState === Pairing.uriErrors.alreadyUsed) {
+            } else if(root.errorState === Pairing.errors.alreadyUsed) {
                 errorText.text = qsTr("WalletConnect URI already used")
-            } else if(root.errorState === Pairing.uriErrors.expired) {
+            } else if(root.errorState === Pairing.errors.expired) {
                 errorText.text = qsTr("WalletConnect URI has expired")
-            }
-            if (errorText.text.length > 0) {
-                return false
-            } else if(root.errorState === Pairing.uriErrors.unsupportedNetwork) {
+            } else if(root.errorState === Pairing.errors.unsupportedNetwork) {
                 errorText.text = qsTr("dApp is requesting to connect on an unsupported network")
-                return false
-            } else if(root.errorState === Pairing.uriErrors.unknownError) {
-                errorText.text = qsTr("Unexpected error occurred, please try again")
+            } else if(root.errorState === Pairing.errors.unknownError) {
+                errorText.text = qsTr("Unexpected error occurred. Try again.")
+            }
+
+            if (errorText.text.length > 0) {
                 return false
             }
 

--- a/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
@@ -48,6 +48,12 @@ ColumnLayout {
             }
             if (errorText.text.length > 0) {
                 return false
+            } else if(root.errorState === Pairing.uriErrors.unsupportedNetwork) {
+                errorText.text = qsTr("dApp is requesting to connect on an unsupported network")
+                return false
+            } else if(root.errorState === Pairing.uriErrors.unknownError) {
+                errorText.text = qsTr("Unexpected error occurred, please try again")
+                return false
             }
 
             return true


### PR DESCRIPTION
### Closes #14676

- [x] Rebased on top of https://github.com/status-im/status-desktop/pull/15468

Found out while testing that in some corner cases there will be no response of error in case of pairing. This is handled now by showing a generic error message. The implementation is using a timer to handle this case.
Extend the logic to report errors in the pairing process.

https://github.com/status-im/status-desktop/assets/47554641/7ca91b1c-0db0-475e-994a-1809d0743ddb

