### PR TITLE
chore: changes for tests stability

### DIFF
--- a/test/e2e/gui/components/profile_popup.py
+++ b/test/e2e/gui/components/profile_popup.py
@@ -111,6 +111,7 @@ class ProfilePopupFromMembers(ProfilePopup):
 
     @allure.step('Click review contact request button')
     def review_contact_request(self):
+        assert driver.waitFor(lambda: self._review_request_button.is_visible, 15000)
         self._review_request_button.click()
         return AcceptRequestFromProfile().wait_until_appears()
 

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -36,7 +36,7 @@ class AllowNotificationsView(QObject):
     @allure.step("Start using Status")
     def start_using_status(self):
         # TODO https://github.com/status-im/status-desktop/issues/15345
-        self._start_using_status_button.click(timeout=10)
+        self._start_using_status_button.click(timeout=15)
         self.wait_until_hidden()
 
 
@@ -420,7 +420,7 @@ class YourEmojihashAndIdenticonRingView(OnboardingView):
     @allure.step('Click next in your emojihash and identicon ring view')
     def next(self):
         # TODO https://github.com/status-im/status-desktop/issues/15345
-        self._next_button.click(timeout=10)
+        self._next_button.click(timeout=15)
         time.sleep(1)
         if configs.system.get_platform() == "Darwin":
             return AllowNotificationsView().wait_until_appears()

--- a/test/e2e/gui/screens/settings_wallet.py
+++ b/test/e2e/gui/screens/settings_wallet.py
@@ -251,6 +251,11 @@ class NetworkWalletSettings(WalletSettingsView):
         self._wallet_network_item_goerli_sensor = QObject(settings_names.networkSettingsNetworks_Mainnet_Goerli_sensor)
         self._wallet_network_item_goerli_testlabel = TextLabel(settings_names.networkSettingsNetowrks_Mainnet_Testlabel)
 
+    @allure.step('Wait until appears {0}')
+    def wait_until_appears(self):
+        self._testnet_mode_toggle.wait_until_appears(10000)
+        return self
+
     @allure.step('Check networks item title')
     def get_network_item_attribute_by_id_and_attr_name(self, attribute_name, network_id):
         self._wallet_network_item_template.real_name['objectName'] = RegularExpression(
@@ -319,15 +324,20 @@ class EditNetworkSettings(WalletSettingsView):
     def click_test_network_tab(self):
         self._test_network_tab.click()
 
+    @allure.step('Check revert button state')
+    def check_revert_button_state(self):
+        return driver.waitForObjectExists(self._network_revert_to_default, configs.timeouts.UI_LOAD_TIMEOUT_MSEC).enabled
+
     @allure.step('Click Revert to default button and redirect to Networks screen')
     def click_revert_to_default_and_go_to_networks_main_screen(self, attempts: int = 2):
-        self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
+        if not self._network_revert_to_default.is_visible:
+            self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
         self._network_revert_to_default.click()
         try:
             return NetworkWalletSettings().wait_until_appears()
         except AssertionError:
             if attempts:
-                return self.click_revert_to_default_and_go_to_networks_main_screen(attempts - 1)
+                self.click_revert_to_default_and_go_to_networks_main_screen(attempts - 1)
             else:
                 raise f"Networks screen was not opened"
 

--- a/test/e2e/tests/messages/test_messaging_group_chat.py
+++ b/test/e2e/tests/messages/test_messaging_group_chat.py
@@ -122,7 +122,7 @@ def test_group_chat(multiple_instances, user_data_one, user_data_two, user_data_
                     assert chat_message_2 in message_item
 
             with step('Leave group'):
-                messages_screen.left_panel.open_leave_group_popup(group_chat_new_name).confirm_leaving()
+                messages_screen.group_chat.leave_group().confirm_leaving()
 
             with step('Check that group name is not displayed on left panel'):
                 assert driver.waitFor(lambda: group_chat_new_name not in messages_screen.left_panel.get_chats_names,

--- a/test/e2e/tests/online_identifier/test_online_identifier.py
+++ b/test/e2e/tests/online_identifier/test_online_identifier.py
@@ -9,7 +9,7 @@ from allure import step
 import configs
 import constants
 import driver
-from constants import UserAccount
+from constants import UserAccount, ColorCodes
 from gui.components.changes_detected_popup import ChangesDetectedToastMessage
 from gui.main_window import MainWindow
 from . import marks
@@ -49,7 +49,8 @@ def test_switch_state_to_offline_online_automatic(multiple_instances, user_data_
     user_two: UserAccount = constants.user_account_two
     main_screen = MainWindow()
 
-    with (multiple_instances(user_data=user_data_one) as aut_one, multiple_instances(user_data=user_data_two) as aut_two):
+    with (multiple_instances(user_data=user_data_one) as aut_one, multiple_instances(
+            user_data=user_data_two) as aut_two):
         with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
             for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
                 aut.attach()
@@ -67,7 +68,10 @@ def test_switch_state_to_offline_online_automatic(multiple_instances, user_data_
             aut_one.attach()
             main_screen.prepare()
             community_screen = main_screen.left_panel.select_community('Community with 2 users')
-            assert community_screen.right_panel.member_is_offline(1)
+            time.sleep(2)
+            assert driver.waitFor(
+                lambda: community_screen.right_panel.member_state(user_two.name) == ColorCodes.GRAY.value,
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Actual state is {community_screen.right_panel.member_state(user_two.name)}'
             main_screen.hide()
 
         with step(f'User {user_two.name}, switch state to online'):
@@ -80,8 +84,9 @@ def test_switch_state_to_offline_online_automatic(multiple_instances, user_data_
             aut_one.attach()
             main_screen.prepare()
             time.sleep(2)
-            assert driver.waitFor(lambda: community_screen.right_panel.member_is_online(1),
-                                  configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            assert driver.waitFor(
+                lambda: community_screen.right_panel.member_state(user_two.name) == ColorCodes.GREEN.value,
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Actual state is {community_screen.right_panel.member_state(user_two.name)}'
             main_screen.hide()
 
         with step(f'User {user_two.name}, switch state to automatic'):
@@ -97,5 +102,7 @@ def test_switch_state_to_offline_online_automatic(multiple_instances, user_data_
         with step(f'User {user_one.name}, sees {user_two.name} as online'):
             aut_one.attach()
             main_screen.prepare()
-            assert community_screen.right_panel.member_is_online(1)
+            assert driver.waitFor(
+                lambda: community_screen.right_panel.member_state(user_two.name) == ColorCodes.GREEN.value,
+                configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Actual state is {community_screen.right_panel.member_state(user_two.name)}'
             main_screen.hide()


### PR DESCRIPTION
### What does the PR do

- Reworked some methods to make tests more stable on CI
- Also reworked edit_network test to make it fail on correct step (but didn't fix it yet, need to investigate further)
- Increased timeout in a couple of buttons when click

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2273/ (fails are known - waku issues, edit network, which will be fixed later, need to investigate)
