### PR TITLE
chore: reworked scroll method

### DIFF
--- a/test/e2e/gui/components/back_up_your_seed_phrase_popup.py
+++ b/test/e2e/gui/components/back_up_your_seed_phrase_popup.py
@@ -17,7 +17,7 @@ class BackUpYourSeedPhrasePopUp(BasePopup):
 
     def __init__(self):
         super(BackUpYourSeedPhrasePopUp, self).__init__()
-        self._scroll = Scroll(names.o_Flickable)
+        self._scroll = Scroll(names.generalView_StatusScrollView)
         self._i_have_a_pen_and_paper_check_box = CheckBox(names.i_have_a_pen_and_paper_StatusCheckBox)
         self._i_know_where_i_ll_store_it_check_box = CheckBox(names.i_know_where_I_ll_store_it_StatusCheckBox)
         self._i_am_ready_to_write_down_seed_phrase_check_box = CheckBox(names.i_am_ready_to_write_down_StatusCheckBox)
@@ -45,7 +45,7 @@ class BackUpYourSeedPhrasePopUp(BasePopup):
 
     @allure.step('Set know where will store it checkbox')
     def set_know_where_store_it(self, value: bool):
-        self._scroll.vertical_scroll_to(self._i_know_where_i_ll_store_it_check_box)
+        self._scroll.vertical_scroll_down(self._i_know_where_i_ll_store_it_check_box)
         self._i_know_where_i_ll_store_it_check_box.set(value)
         return self
 

--- a/test/e2e/gui/components/community/create_community_popups.py
+++ b/test/e2e/gui/components/community/create_community_popups.py
@@ -37,7 +37,7 @@ class CreateCommunityPopup(BasePopup):
 
     def __init__(self):
         super().__init__()
-        self._scroll = Scroll(names.o_Flickable)
+        self._scroll = Scroll(names.generalView_StatusScrollView )
         self._name_text_edit = TextEdit(names.createCommunityNameInput_TextEdit)
         self._description_text_edit = TextEdit(names.createCommunityDescriptionInput_TextEdit)
         self._add_logo_button = Button(names.addButton_StatusRoundButton2)
@@ -61,38 +61,38 @@ class CreateCommunityPopup(BasePopup):
 
     @allure.step('Get archive support checkbox state')
     def is_archive_checkbox_checked(self) -> bool:
-        self._scroll.vertical_scroll_to(self._archive_support_checkbox)
+        self._scroll.vertical_scroll_down(self._archive_support_checkbox)
         return self._archive_support_checkbox.is_checked
 
     @allure.step('Get request to join checkbox state')
     def is_request_to_join_checkbox_checked(self) -> bool:
-        self._scroll.vertical_scroll_to(self._request_to_join_checkbox)
+        self._scroll.vertical_scroll_down(self._request_to_join_checkbox)
         return self._request_to_join_checkbox.is_checked
 
     @allure.step('Get pin messaged checkbox state')
     def is_pin_messages_checkbox_checked(self) -> bool:
-        self._scroll.vertical_scroll_to(self._pin_messages_checkbox)
+        self._scroll.vertical_scroll_down(self._pin_messages_checkbox)
         return self._pin_messages_checkbox.is_checked
 
     @allure.step('Get community name')
     def get_name(self) -> str:
-        self._scroll.vertical_scroll_to(self._name_text_edit)
+        self._scroll.vertical_scroll_down(self._name_text_edit)
         return self._name_text_edit.text
 
     @allure.step('Set community name')
     def set_name(self, value: str):
-        self._scroll.vertical_scroll_to(self._name_text_edit)
+        self._scroll.vertical_scroll_down(self._name_text_edit)
         self._name_text_edit.text = value
 
     @property
     @allure.step('Get community description')
     def description(self) -> str:
-        self._scroll.vertical_scroll_to(self._description_text_edit)
+        self._scroll.vertical_scroll_down(self._description_text_edit)
         return self._description_text_edit.text
 
     @allure.step('Set community name')
     def set_description(self, value: str):
-        self._scroll.vertical_scroll_to(self._description_text_edit)
+        self._scroll.vertical_scroll_down(self._description_text_edit)
         self._description_text_edit.text = value
 
     @property
@@ -131,14 +131,14 @@ class CreateCommunityPopup(BasePopup):
 
     @allure.step('Set community logo without file upload dialog')
     def set_logo_without_file_upload_dialog(self, path):
-        self._scroll.vertical_scroll_to(self._add_logo_button)
+        self._scroll.vertical_scroll_down(self._add_logo_button)
         fileuri = pathlib.Path(str(path)).as_uri()
         self._cropped_image_logo_item.object.cropImage(fileuri)
         return PictureEditPopup()
 
     @allure.step('Set community banner without file upload dialog')
     def set_banner_without_file_upload_dialog(self, path):
-        self._scroll.vertical_scroll_to(self._add_banner_button)
+        self._scroll.vertical_scroll_down(self._add_banner_button)
         fileuri = pathlib.Path(str(path)).as_uri()
         self._cropped_image_banner_item.object.cropImage(fileuri)
         return PictureEditPopup()
@@ -149,8 +149,9 @@ class CreateCommunityPopup(BasePopup):
 
     @allure.step('Set community color')
     def set_color(self, value: str):
-        self._scroll.vertical_scroll_to(self._select_color_button)
+        self._scroll.vertical_scroll_down(self._select_color_button)
         self._select_color_button.click()
+        self._scroll.vertical_scroll_down(self._select_color_button)
         ColorSelectPopup().wait_until_appears().select_color(value)
 
     @allure.step('Get community tags')
@@ -163,7 +164,7 @@ class CreateCommunityPopup(BasePopup):
 
     @allure.step('Set community tags')
     def set_tags(self, values: typing.List[str]):
-        self._scroll.vertical_scroll_to(self._choose_tag_button)
+        self._scroll.vertical_scroll_down(self._choose_tag_button)
         self._choose_tag_button.click()
         TagsSelectPopup().wait_until_appears().select_tags(values)
 

--- a/test/e2e/gui/components/wallet/back_up_your_seed_phrase_popup.py
+++ b/test/e2e/gui/components/wallet/back_up_your_seed_phrase_popup.py
@@ -16,7 +16,7 @@ class BackUpYourSeedPhrasePopUp(BasePopup):
 
     def __init__(self):
         super(BackUpYourSeedPhrasePopUp, self).__init__()
-        self._scroll = Scroll(names.o_Flickable)
+        self._scroll = Scroll(names.generalView_StatusScrollView)
         self._i_have_a_pen_and_paper_check_box = CheckBox(names.mainWallet_AddEditAccountPopup_HavePenAndPaperCheckBox)
         self._i_know_where_i_ll_store_it_check_box = CheckBox(
             names.mainWallet_AddEditAccountPopup_StoringSeedPhraseConfirmedCheckBox)
@@ -43,7 +43,7 @@ class BackUpYourSeedPhrasePopUp(BasePopup):
 
     @allure.step('Set know where will store it checkbox')
     def set_know_where_store_it(self, value: bool):
-        self._scroll.vertical_down_to(self._i_know_where_i_ll_store_it_check_box)
+        self._scroll.vertical_scroll_down(self._i_know_where_i_ll_store_it_check_box)
         self._i_know_where_i_ll_store_it_check_box.set(value)
         return self
 

--- a/test/e2e/gui/components/wallet/wallet_account_popups.py
+++ b/test/e2e/gui/components/wallet/wallet_account_popups.py
@@ -21,7 +21,7 @@ GENERATED_PAGES_LIMIT = 20
 class AccountPopup(BasePopup):
     def __init__(self):
         super(AccountPopup, self).__init__()
-        self._scroll = Scroll(names.o_Flickable)
+        self._scroll = Scroll(names.generalView_StatusScrollView)
         self._name_text_edit = TextEdit(names.mainWallet_AddEditAccountPopup_AccountName)
         self._name_text_input = QObject(names.mainWallet_AddEditAccountPopup_AccountNameComponent)
         self._emoji_button = Button(names.mainWallet_AddEditAccountPopup_AccountEmojiPopupButton)
@@ -144,7 +144,7 @@ class AccountPopup(BasePopup):
             self._address_combobox_button.click()
             GeneratedAddressesList().wait_until_appears().select(index)
             if value != DerivationPath.ETHEREUM.value:
-                self._scroll.vertical_scroll_to(self._non_eth_checkbox)
+                self._scroll.vertical_scroll_down(self._non_eth_checkbox)
                 self._non_eth_checkbox.set(True)
         else:
             self._derivation_path_text_edit.type_text(str(index))

--- a/test/e2e/gui/elements/scroll.py
+++ b/test/e2e/gui/elements/scroll.py
@@ -11,8 +11,26 @@ LOG = logging.getLogger(__name__)
 
 class Scroll(QObject):
 
+    @allure.step('Scroll vertical down to object {1}')
+    def vertical_scroll_down(self, element: QObject, timeout_sec: int = 5, attempts: int = 2):
+        started_at = time.monotonic()
+        while not element.is_visible:
+            self.object.scrollPageDown()
+            time.sleep(0.1)
+            if time.monotonic() - started_at > timeout_sec:
+                raise LookupError(f'Object not found: {element}')
+
+    @allure.step('Scroll vertical up to object {1}')
+    def vertical_scroll_up(self, element: QObject, timeout_sec: int = 5):
+        started_at = time.monotonic()
+        while not element.is_visible:
+            self.object.scrollPageUp()
+            time.sleep(0.1)
+            if time.monotonic() - started_at > timeout_sec:
+                raise LookupError(f'Object not found: {element}')
+
     @allure.step('Scroll vertical to object {1}')
-    def vertical_scroll_to(self, element: QObject, timeout_sec: int = 5):
+    def old_vertical_scroll_to(self, element: QObject, timeout_sec: int = 5):
         started_at = time.monotonic()
         step = 10
         direction = 1

--- a/test/e2e/gui/mocked_keycard_controller.py
+++ b/test/e2e/gui/mocked_keycard_controller.py
@@ -78,7 +78,7 @@ class MockedKeycardController(Window):
     @allure.step('Choose custom keycard from initial keycard state dropdown')
     def choose_custom_keycard(self):
         if not self._keycard_state_button.is_visible:
-            self._scroll.vertical_scroll_to(self._keycard_state_button)
+            self._scroll.vertical_scroll_down(self._keycard_state_button)
         self._keycard_state_button.click()
         self._custom_keycard_item.click()
         time.sleep(1)
@@ -87,14 +87,14 @@ class MockedKeycardController(Window):
     @allure.step('Input custom keycard details to custom text field')
     def input_custom_keycard_details(self, details: str, index: int):
         fields = self.get_text_fields
-        self._scroll.vertical_scroll_to(QObject(real_name=driver.objectMap.realName(fields[index])))
+        self._scroll.vertical_scroll_down(QObject(real_name=driver.objectMap.realName(fields[index])))
         driver.type(fields[index], details)
         time.sleep(1)
 
     @allure.step('Choose not Status keycard from initial keycard state dropdown')
     def choose_not_status_keycard(self):
         if not self._keycard_state_button.is_visible:
-            self._scroll.vertical_scroll_to(self._keycard_state_button)
+            self._scroll.vertical_scroll_down(self._keycard_state_button)
         self._keycard_state_button.click()
         self._not_status_keycard_item.click()
         time.sleep(1)
@@ -103,7 +103,7 @@ class MockedKeycardController(Window):
     @allure.step('Choose empty keycard from initial keycard state dropdown')
     def choose_empty_keycard(self):
         if not self._keycard_state_button.is_visible:
-            self._scroll.vertical_scroll_to(self._keycard_state_button)
+            self._scroll.vertical_scroll_down(self._keycard_state_button)
         self._keycard_state_button.click()
         self._empty_keycard_item.click()
         time.sleep(1)
@@ -112,7 +112,7 @@ class MockedKeycardController(Window):
     @allure.step('Choose keycard with MAX pairing slots reached from initial keycard state dropdown')
     def choose_max_slots_reached_keycard(self):
         if not self._keycard_state_button.is_visible:
-            self._scroll.vertical_scroll_to(self._keycard_state_button)
+            self._scroll.vertical_scroll_down(self._keycard_state_button)
         self._keycard_state_button.click()
         self._max_slots_reached_item.click()
         time.sleep(1)
@@ -121,7 +121,7 @@ class MockedKeycardController(Window):
     @allure.step('Choose keycard with mnemonic and metadata from initial keycard state dropdown')
     def choose_mnemonic_metadata_keycard(self):
         if not self._keycard_state_button.is_visible:
-            self._scroll.vertical_scroll_to(self._keycard_state_button)
+            self._scroll.vertical_scroll_down(self._keycard_state_button)
         self._keycard_state_button.click()
         self._mnemonic_metadata_item.click()
         time.sleep(1)

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -37,6 +37,7 @@ secureYourSeedPhraseBanner_ModuleWarning = {"container": statusDesktop_mainWindo
 
 # Scroll
 o_Flickable = {"container": statusDesktop_mainWindow_overlay, "type": "Flickable", "unnamed": 1, "visible": True}
+generalView_StatusScrollView = {"container": statusDesktop_mainWindow_overlay, "id": "generalView", "type": "StatusScrollView", "unnamed": 1, "visible": True}
 
 # Context Menu
 o_StatusListView = {"container": statusDesktop_mainWindow_overlay, "type": "StatusListView", "unnamed": 1, "visible": True}

--- a/test/e2e/gui/screens/community_settings.py
+++ b/test/e2e/gui/screens/community_settings.py
@@ -110,7 +110,7 @@ class EditCommunityView(QObject):
 
     def __init__(self):
         super().__init__(communities_names.mainWindow_communityEditPanelScrollView_EditSettingsPanel)
-        self._scroll = Scroll(communities_names.communityEditPanelScrollView_Flickable)
+        self._scroll = Scroll(communities_names.mainWindow_communityEditPanelScrollView_EditSettingsPanel)
         self._name_text_edit = TextEdit(communities_names.communityEditPanelScrollView_communityNameInput_TextEdit)
         self._description_text_edit = TextEdit(
             communities_names.communityEditPanelScrollView_communityDescriptionInput_TextEdit)
@@ -199,56 +199,56 @@ class EditCommunityView(QObject):
     @color.setter
     @allure.step('Set community color')
     def color(self, value: str):
-        self._scroll.vertical_scroll_to(self._select_color_button)
+        self._scroll.vertical_scroll_down(self._select_color_button)
         self._select_color_button.click()
         ColorSelectPopup().wait_until_appears().select_color(value)
 
     @property
     @allure.step('Get community tags')
     def tags(self):
-        self._scroll.vertical_scroll_to(self._choose_tag_button)
+        self._scroll.vertical_scroll_down(self._choose_tag_button)
         return [str(tag.title) for tag in driver.fiandAllObjects(self._tag_item.real_name)]
 
     @tags.setter
     @allure.step('Set community tags')
     def tags(self, values: typing.List[str]):
-        self._scroll.vertical_scroll_to(self._choose_tag_button)
+        self._scroll.vertical_scroll_down(self._choose_tag_button)
         self._choose_tag_button.click()
         TagsSelectPopup().wait_until_appears().select_tags(values)
 
     @property
     @allure.step('Get community intro')
     def intro(self) -> str:
-        self._scroll.vertical_scroll_to(self._intro_text_edit)
+        self._scroll.vertical_scroll_down(self._intro_text_edit)
         return self._intro_text_edit.text
 
     @intro.setter
     @allure.step('Set community intro')
     def intro(self, value: str):
-        self._scroll.vertical_scroll_to(self._intro_text_edit)
+        self._scroll.vertical_scroll_down(self._intro_text_edit)
         self._intro_text_edit.text = value
 
     @property
     @allure.step('Get community outro')
     def outro(self) -> str:
-        self._scroll.vertical_scroll_to(self._outro_text_edit)
+        self._scroll.vertical_scroll_down(self._outro_text_edit)
         return self._outro_text_edit.text
 
     @outro.setter
     @allure.step('Set community outro')
     def outro(self, value: str):
-        self._scroll.vertical_scroll_to(self._outro_text_edit)
+        self._scroll.vertical_scroll_down(self._outro_text_edit)
         self._outro_text_edit.text = value
 
     @property
     @allure.step('Get pin message checkbox state')
     def pin_message_checkbox_state(self) -> bool:
-        self._scroll.vertical_scroll_to(self._pin_messages_checkbox)
+        self._scroll.vertical_scroll_down(self._pin_messages_checkbox)
         return self._pin_messages_checkbox.object.checked
 
     @allure.step('Edit community')
     def edit(self, name, description, intro, outro, logo, banner):
-        self._scroll.vertical_scroll_to(self._name_text_edit)
+        self._scroll.vertical_scroll_down(self._name_text_edit)
         self.name = name
         self.description = description
         self.set_logo_without_file_upload_dialog(logo)

--- a/test/e2e/gui/screens/community_settings_tokens.py
+++ b/test/e2e/gui/screens/community_settings_tokens.py
@@ -84,7 +84,7 @@ class TokensView(QObject):
 class TokensOwnerTokenSettingsView(QObject):
     def __init__(self):
         super(TokensOwnerTokenSettingsView, self).__init__(communities_names.mainWindow_ownerTokenPage_SettingsPage)
-        self._scroll = Scroll(communities_names.o_Flickable)
+        self._scroll = Scroll(communities_names.mainWindow_OwnerTokenWelcomeView)
         self._owner_token_section = QObject(communities_names.ownerToken_InfoPanel)
         self._token_master_token_section = QObject(communities_names.tokenMasterToken_InfoPanel)
         self._next_button = Button(communities_names.next_StatusButton)
@@ -95,7 +95,7 @@ class TokensOwnerTokenSettingsView(QObject):
     @allure.step('Get all text from owner token panel')
     def get_text_labels_from_owner_token_panel(self) -> list:
         if not self._owner_token_section.is_visible:
-            self._scroll.vertical_scroll_to(self._owner_token_section)
+            self._scroll.vertical_scroll_down(self._owner_token_section)
         owner_token_text_labels = []
         for item in driver.findAllObjects(self._owner_token_text_object.real_name):
             owner_token_text_labels.append(item)
@@ -129,7 +129,7 @@ class TokensOwnerTokenSettingsView(QObject):
     @allure.step('Get all text from master token panel')
     def get_text_labels_from_master_token_panel(self) -> list:
         if not self._token_master_token_section.is_visible:
-            self._scroll.vertical_scroll_to(self._token_master_token_section)
+            self._scroll.vertical_scroll_down(self._token_master_token_section)
         master_token_text_labels = []
         for item in driver.findAllObjects(self._token_master_text_object.real_name):
             master_token_text_labels.append(item)
@@ -138,7 +138,7 @@ class TokensOwnerTokenSettingsView(QObject):
     @allure.step('Click next button')
     def click_next(self):
         if not self._next_button.is_visible:
-            self._scroll.vertical_down_to(self._next_button)
+            self._scroll.vertical_scroll_down(self._next_button)
         self._next_button.click()
         return EditOwnerTokenView().wait_until_appears()
 
@@ -146,7 +146,7 @@ class TokensOwnerTokenSettingsView(QObject):
 class EditOwnerTokenView(QObject):
     def __init__(self):
         super(EditOwnerTokenView, self).__init__(communities_names.mainWindow_editOwnerTokenView_EditOwnerTokenView)
-        self._scroll = Scroll(communities_names.editOwnerTokenView_Flickable)
+        self._scroll = Scroll(communities_names.mainWindow_editOwnerTokenView_EditOwnerTokenView)
         self._select_account_combobox = QObject(communities_names.editOwnerTokenView_CustomComboItem)
         self._select_network_filter = QObject(communities_names.editOwnerTokenView_netFilter_NetworkFilter)
         self._select_network_combobox = QObject(communities_names.editOwnerTokenView_comboBox_ComboBox)
@@ -258,7 +258,7 @@ class EditOwnerTokenView(QObject):
     @allure.step('Select Mainnet network')
     def select_mainnet_network(self, attempts: int = 2):
         if not self._fees_box.is_visible:
-            self._scroll.vertical_down_to(self._fees_box)
+            self._scroll.vertical_scroll_down(self._fees_box)
         self._select_network_filter.click()
         try:
             self._mainnet_network_item.wait_until_appears()
@@ -273,7 +273,7 @@ class EditOwnerTokenView(QObject):
     @allure.step('Click mint button')
     def click_mint(self):
         if not self._mint_button.is_visible:
-            self._scroll.vertical_down_to(self._mint_button)
+            self._scroll.vertical_scroll_down(self._mint_button)
         self._mint_button.click()
         return SignTransactionPopup().wait_until_appears()
 

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -35,7 +35,7 @@ class LeftPanel(QObject):
         super().__init__(messaging_names.mainWindow_contactColumnLoader_Loader)
         self._start_chat_button = Button(messaging_names.mainWindow_startChatButton_StatusIconTabButton)
         self._search_text_edit = TextEdit(messaging_names.mainWindow_search_edit_TextEdit)
-        self._scroll = Scroll(messaging_names.scrollView_Flickable)
+        self._scroll = Scroll(messaging_names.mainWindow_scrollView_StatusScrollView)
         self._chats_list = List(messaging_names.chatList_ListView)
         self._chat_list_item = QObject(messaging_names.scrollView_StatusChatListItem)
         self._chats_scroll = QObject(messaging_names.mainWindow_scrollView_StatusScrollView)

--- a/test/e2e/gui/screens/settings.py
+++ b/test/e2e/gui/screens/settings.py
@@ -2,6 +2,7 @@ import time
 
 import allure
 
+import driver
 from gui.components.back_up_your_seed_phrase_popup import BackUpYourSeedPhrasePopUp
 from gui.elements.object import QObject
 from gui.elements.scroll import Scroll
@@ -23,14 +24,14 @@ class LeftPanel(QObject):
     def __init__(self):
         super().__init__(settings_names.mainWindow_LeftTabView)
         self._settings_section_template = QObject(settings_names.scrollView_MenuItem_StatusNavigationListItem)
-        self._scroll = Scroll(settings_names.scrollView_Flickable)
+        self._scroll = Scroll(settings_names.mainWindow_scrollView_StatusScrollView)
         self._settings_section_back_up_seed_option = QObject(settings_names.settingsBackUpSeedPhraseOption)
         self._settings_section_wallet_option = QObject(settings_names.settingsWalletOption)
 
     def _open_settings(self, object_name: str):
         self._settings_section_template.real_name['objectName'] = object_name
         if not self._settings_section_template.is_visible:
-            self._scroll.vertical_down_to(self._settings_section_template)
+            self._scroll.vertical_scroll_down(self._settings_section_template)
         self._settings_section_template.click()
 
     @allure.step('Check back up seed option menu item presence')

--- a/test/e2e/gui/screens/settings_advanced.py
+++ b/test/e2e/gui/screens/settings_advanced.py
@@ -11,7 +11,7 @@ class AdvancedSettingsView(QObject):
 
     def __init__(self):
         super().__init__(settings_names.mainWindow_AdvancedView)
-        self._scroll = Scroll(settings_names.settingsContentBaseScrollView_Flickable)
+        self._scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self._manage_community_on_testnet_button = Button(
             settings_names.manageCommunitiesOnTestnetButton_StatusSettingsLineButton)
         self._enable_creation_community_button = Button(settings_names.enableCreateCommunityButton_StatusSettingsLineButton)
@@ -20,18 +20,18 @@ class AdvancedSettingsView(QObject):
 
     @allure.step('Switch manage community on testnet option')
     def switch_manage_on_community(self):
-        self._scroll.vertical_down_to(self._manage_community_on_testnet_button)
+        self._scroll.vertical_scroll_down(self._manage_community_on_testnet_button)
         self._manage_community_on_testnet_button.click()
 
     @allure.step('Enable creation of communities')
     def enable_creation_of_communities(self):
-        self._scroll.vertical_down_to(self._enable_creation_community_button)
+        self._scroll.vertical_scroll_down(self._enable_creation_community_button)
         self._enable_creation_community_button.click()
 
     @allure.step('Switch waku mode')
     def switch_waku_mode(self, mode):
         if not self._manage_community_on_testnet_button.is_visible:
-            self._scroll.vertical_down_to(self._manage_community_on_testnet_button)
+            self._scroll.vertical_scroll_down(self._manage_community_on_testnet_button)
         if mode == 'light':
             self._light_mode_button.click()
         elif mode == 'relay':
@@ -41,7 +41,7 @@ class AdvancedSettingsView(QObject):
     @allure.step('Verify waku mode enabled states')
     def is_waku_mode_enabled(self, mode):
         if not self._manage_community_on_testnet_button.is_visible:
-            self._scroll.vertical_down_to(self._manage_community_on_testnet_button)
+            self._scroll.vertical_scroll_down(self._manage_community_on_testnet_button)
         if mode == 'light':
             return self._light_mode_button.is_checked
         elif mode == 'relay':

--- a/test/e2e/gui/screens/settings_keycard.py
+++ b/test/e2e/gui/screens/settings_keycard.py
@@ -13,7 +13,7 @@ class KeycardSettingsView(QObject):
 
     def __init__(self):
         super(KeycardSettingsView, self).__init__(settings_names.mainWindow_KeycardView)
-        self._scroll = Scroll(settings_names.settingsContentBaseScrollView_Flickable)
+        self._scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self._setup_keycard_with_existing_account_button = Button(settings_names.setupFromExistingKeycardAccount_StatusListItem)
         self._create_new_keycard_account_button = Button(settings_names.createNewKeycardAccount_StatusListItem)
         self._import_restore_via_seed_phrase_button = Button(settings_names.importRestoreKeycard_StatusListItem)
@@ -55,10 +55,11 @@ class KeycardSettingsView(QObject):
         assert self._setup_keycard_with_existing_account_button.is_visible, f'Setup keycard with existing account not visible'
         assert self._create_new_keycard_account_button.is_visible, f'Create new keycard button not visible'
         assert self._import_restore_via_seed_phrase_button.is_visible, f'Import and restore via seed phrase button not visible'
-        self._scroll.vertical_down_to(self._import_from_keycard_button)
+        self._scroll.vertical_scroll_down(self._import_from_keycard_button)
         assert driver.waitFor(lambda: self._import_from_keycard_button.is_visible,
                               configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Import keycard button not visible'
         assert driver.waitFor(lambda: self._check_whats_on_keycard_button.is_visible,
                               configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Check whats new keycard button not visible'
+        self._scroll.vertical_scroll_down(self._factory_reset_keycard_button)
         assert driver.waitFor(lambda: self._factory_reset_keycard_button.is_visible,
                               configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Factory reset keycard button not visible'

--- a/test/e2e/gui/screens/settings_password.py
+++ b/test/e2e/gui/screens/settings_password.py
@@ -12,7 +12,7 @@ class ChangePasswordView(QObject):
 
     def __init__(self):
         super().__init__(settings_names.mainWindow_PasswordView)
-        self._scroll_view = Scroll(settings_names.settingsContentBaseScrollView_Flickable)
+        self._scroll_view = Scroll(settings_names.settingsContentBase_ScrollView)
         self._change_password_button = Button(names.change_password_menu_change_password_button)
         self._current_password_text_field = TextEdit(names.change_password_menu_current_password)
         self._new_password_text_field = TextEdit(names.change_password_menu_new_password)

--- a/test/e2e/gui/screens/settings_profile.py
+++ b/test/e2e/gui/screens/settings_profile.py
@@ -17,7 +17,7 @@ class ProfileSettingsView(QObject):
 
     def __init__(self):
         super().__init__(settings_names.mainWindow_MyProfileView)
-        self._scroll_view = Scroll(settings_names.settingsContentBaseScrollView_Flickable)
+        self._scroll_view = Scroll(settings_names.settingsContentBase_ScrollView)
         self._display_name_text_field = TextEdit(settings_names.displayName_TextEdit)
         self._save_button = Button(names.mainWindow_Save_changes_StatusButton)
         self._bio_text_field = TextEdit(settings_names.bio_TextEdit)

--- a/test/e2e/gui/screens/settings_wallet.py
+++ b/test/e2e/gui/screens/settings_wallet.py
@@ -29,7 +29,7 @@ class WalletSettingsView(QObject):
 
     def __init__(self):
         super().__init__(settings_names.mainWindow_WalletView)
-        self._scroll = Scroll(settings_names.settingsContentBaseScrollView_Flickable)
+        self._scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self._wallet_settings_add_new_account_button = Button(settings_names.settings_Wallet_MainView_AddNewAccountButton)
         self._wallet_network_button = Button(settings_names.settings_Wallet_MainView_Networks)
         self._account_order_button = Button(settings_names.settingsContentBaseScrollView_accountOrderItem_StatusListItem)
@@ -112,7 +112,7 @@ class WalletSettingsView(QObject):
                 for child in walk_children(item):
                     if getattr(child, 'objectName', '') == 'more-icon':
                         more_button = QObject(real_name=driver.objectMap.realName(child))
-                        self._scroll.vertical_down_to(more_button)
+                        self._scroll.vertical_scroll_down(more_button)
                         more_button.click()
                         break
 
@@ -307,7 +307,7 @@ class EditNetworkSettings(WalletSettingsView):
         self._network_revert_to_default = Button(settings_names.editNetworkRevertButton)
         self._network_save_changes = Button(settings_names.editNetworkSaveButton)
         self._network_edit_view_back_button = Button(settings_names.main_toolBar_back_button)
-        self._network_edit_scroll = Scroll(settings_names.settingsContentBaseScrollView_Flickable)
+        self._network_edit_scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self._network_edit_main_rpc_url_error_message = QObject(settings_names.mainRpcUrlInputObject)
         self._network_edit_failover_rpc_url_error_message = QObject(settings_names.failoverRpcUrlInputObject)
 
@@ -321,7 +321,7 @@ class EditNetworkSettings(WalletSettingsView):
 
     @allure.step('Click Revert to default button and redirect to Networks screen')
     def click_revert_to_default_and_go_to_networks_main_screen(self, attempts: int = 2):
-        self._network_edit_scroll.vertical_down_to(self._network_revert_to_default)
+        self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
         self._network_revert_to_default.click()
         try:
             return NetworkWalletSettings().wait_until_appears()
@@ -347,7 +347,7 @@ class EditNetworkSettings(WalletSettingsView):
                 assert self._network_failover_json_rpc_url.exists, f"Failover JSON RPC URL input field is not present"
                 assert self._network_block_explorer.exists, f"Block explorer input field is not present"
 
-                self._network_edit_scroll.vertical_down_to(self._network_acknowledgment_checkbox)
+                self._network_edit_scroll.vertical_scroll_down(self._network_acknowledgment_checkbox)
                 assert driver.waitFor(lambda: self._network_acknowledgment_checkbox.exists,
                                       configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f"Acknowldegment checkbox is not present"
 
@@ -372,7 +372,7 @@ class EditNetworkSettings(WalletSettingsView):
                 assert self._network_failover_json_rpc_url.exists, f"Failover JSON RPC URL input field is not present"
                 assert self._network_block_explorer.exists, f"Block explorer input field is not present"
 
-                self._network_edit_scroll.vertical_down_to(self._network_acknowledgment_checkbox)
+                self._network_edit_scroll.vertical_scroll_down(self._network_acknowledgment_checkbox)
                 assert driver.waitFor(lambda: self._network_acknowledgment_checkbox.exists,
                                       configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f"Acknowldegment checkbox is not present"
 
@@ -409,11 +409,11 @@ class EditNetworkSettings(WalletSettingsView):
         match network_tab:
             case WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
                 self._live_network_tab.click()
-                self._network_edit_scroll.vertical_down_to(self._network_acknowledgment_checkbox)
+                self._network_edit_scroll.vertical_scroll_down(self._network_acknowledgment_checkbox)
                 self._network_acknowledgment_checkbox.set(value)
             case WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
                 self._test_network_tab.click()
-                self._network_edit_scroll.vertical_down_to(self._network_acknowledgment_checkbox)
+                self._network_edit_scroll.vertical_scroll_down(self._network_acknowledgment_checkbox)
                 self._network_acknowledgment_checkbox.set(value)
         return self
 
@@ -436,7 +436,7 @@ class EditNetworkSettings(WalletSettingsView):
     def revert_to_default(self, attempts=2):
         current_value_main = self._network_main_json_rpc_url.text
         current_value_failover = self._network_failover_json_rpc_url.text
-        self._network_edit_scroll.vertical_down_to(self._network_revert_to_default)
+        self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
         self._network_revert_to_default.click()
         if (current_value_main == self._network_main_json_rpc_url.text
                 and current_value_failover == self._network_failover_json_rpc_url.text):
@@ -446,7 +446,7 @@ class EditNetworkSettings(WalletSettingsView):
 
     @allure.step('Click Revert to default button and redirect to Networks screen')
     def click_revert_to_default_and_go_to_networks_main_screen(self):
-        self._network_edit_scroll.vertical_down_to(self._network_revert_to_default)
+        self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
         self._network_revert_to_default.click()
         return NetworkWalletSettings().wait_until_appears()
 


### PR DESCRIPTION
### What does the PR do

- Reworked scroll method, created 2 new methods - one for scrolling up and one for scrolling down
- Replaced all verticall_scroll_to to verticall_scroll_down (because we always scroll down in our tests for now)

The advantages of these methods:
- they never scroll infinitely, always till the end (or till the beginning) of scroll view object
- the object is always 100% visible, before it happened that only top of the object was visible
I also left old methods, if all will be good, we will just delete them later

CI runs:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2281/
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2283/
