### PR TITLE
fix(wallet): Validate decimals for crypto when sending

### DIFF
--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -117,6 +117,10 @@ ColumnLayout {
         input.validate()
     }
 
+    onSelectedHoldingChanged: {
+        input.validate()
+    }
+
     StatusBaseText {
         text: root.caption
         font.pixelSize: 13
@@ -145,9 +149,17 @@ ColumnLayout {
                     errorMessage: ""
 
                     validate: (text) => {
-                                  var num = LocaleUtils.numberFromLocaleString(topAmountToSendInput.text,
+                                  const num = LocaleUtils.numberFromLocaleString(topAmountToSendInput.text,
                                                                                topAmountToSendInput.locale)
-                                  return !isNaN(num) && num > 0 && num <= root.maxInputBalance
+                                  if (isNaN(num) || num <= 0 || num > root.maxInputBalance) {
+                                      return false
+                                  }
+                                  if(!root.selectedHolding || !root.selectedHolding.marketDetails || !root.selectedHolding.marketDetails.currencyPrice) {
+                                      return false
+                                  }
+                                  const cryptoValueToSend = root.inputIsFiat ? num / root.selectedHolding.marketDetails.currencyPrice.amount : num
+                                  const cryptoValueToSendRaw = SQUtils.AmountsArithmetic.fromNumber(cryptoValueToSend, root.multiplierIndex).toString()
+                                  return cryptoValueToSendRaw >= 1
                               }
                 }
             ]


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/15373

### What does the PR do

Validate input with crypto decimals.
Both crypto and fiat input modes are handled.

### Affected areas

Send modal

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/69b57766-b865-4395-b03f-2b0cbd1863fb

