### PR TITLE
fix(keycard): login using keycard with multiple profiles stuck

### DIFF
--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -163,8 +163,6 @@ QtObject:
       debug "keycardStartFlow", kcServiceCurrFlow=($self.currentFlow), payload=payload, response=response
 
   proc resumeFlow(self: Service, payload: JsonNode) =
-    if self.busy:
-      return
     self.busy = true
     self.updateLocalPayloadForCurrentFlow(payload)
     let response = keycard_go.keycardResumeFlow($payload)
@@ -172,11 +170,10 @@ QtObject:
       debug "keycardResumeFlow", kcServiceCurrFlow=($self.currentFlow), payload=payload, response=response
 
   proc cancelCurrentFlow*(self: Service) =
-    if self.busy:
-      return
     let response = keycard_go.keycardCancelFlow()
     sleep(200)
     self.currentFlow = KCSFlowType.NoFlow
+    self.busy = false
     if self.doLogging:
       debug "keycardCancelFlow", kcServiceCurrFlow=($self.currentFlow), response=response
 


### PR DESCRIPTION
Fixes #15033

### What does the PR do

Allow resuming and cancelling the flow when keycard service state is busy. Reset the state properly.

In case of multiple profiles, starting a login flow might result in "already running". if the keycard is not inserted, at the time of attempt to start login flow, it normally return ok, but later fires a signal with error which resets busy state to false.
if during login flow keycard is found, no error is emitted, busy state is not reset to false. On next attempt to resume the Login flow (when pin code is entered) or cancel the flow (when profile is switched), the flow was not resumed/cancelled because of busy state flag set.

### Affected areas

Onboarding->Login in with keycard

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/15627093/72d432e9-654f-4db3-87da-eac95860b322




### Impact on end user

Able to login with multiple profiles

### How to test

Please read issue description.

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.