### PR TITLE
fix(@desktop/wallet): Swap:: calculate proposal even if amount entered is more than balance

### DIFF
--- a/src/app/core/signals/remote_signals/wallet.nim
+++ b/src/app/core/signals/remote_signals/wallet.nim
@@ -61,10 +61,12 @@ proc fromEvent*(T: type WalletSignal, signalType: SignalType, jsonSignal: JsonNo
         let bestRouteJsonNode = event["Best"]
         result.bestRouteRaw = $bestRouteJsonNode
         result.bestRoute = bestRouteJsonNode.toTransactionPathsDtoV2()
-      if event.contains("details"):
-        result.error = event["details"].getStr
-      if event.contains("code"):
-        result.errorCode = event["code"].getStr
+      if event.contains("ErrorResponse"):
+        let errorResponseJsonNode = event["ErrorResponse"]
+        if errorResponseJsonNode.contains("details"):
+          result.error = errorResponseJsonNode["details"].getStr
+        if errorResponseJsonNode.contains("code"):
+          result.errorCode = errorResponseJsonNode["code"].getStr
     except:
       error "Error parsing best route"
     return

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -45,7 +45,7 @@ StatusDialog {
         }
 
         function fetchSuggestedRoutes() {
-            if (payPanel.valueValid && root.swapInputParamsForm.isFormFilledCorrectly()) {
+            if (root.swapInputParamsForm.isFormFilledCorrectly()) {
                 root.swapAdaptor.validSwapProposalReceived = false
                 root.swapAdaptor.swapProposalLoading = true
                 root.swapAdaptor.approvalPending = false
@@ -219,7 +219,6 @@ StatusDialog {
                             root.swapInputParamsForm.fromTokenAmount = amount
                         }
                     }
-                    onValueValidChanged: d.fetchSuggestedRoutes()
                 }
 
                 SwapInputPanel {
@@ -294,13 +293,14 @@ StatusDialog {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: Style.current.smallPadding
                 text: {
-                    if (payPanel.amountEnteredGreaterThanBalance) {
+                    if (root.swapAdaptor.swapOutputData.hasError) {
+                      return qsTr("An error has occured, please try again")
+                    } else if (payPanel.amountEnteredGreaterThanBalance) {
                         return qsTr("Insufficient funds for swap")
                     }
-                    return qsTr("An error has occured, please try again")
                 }
                 buttonText: qsTr("Buy crypto")
-                buttonVisible: payPanel.amountEnteredGreaterThanBalance
+                buttonVisible: !root.swapAdaptor.swapOutputData.hasError && payPanel.amountEnteredGreaterThanBalance
                 onButtonClicked: Global.openBuyCryptoModalRequested()
             }
         }


### PR DESCRIPTION
fixes #15509
status-go part: https://github.com/status-im/status-go/pull/5506

QA note: Please check for side impacts cause here -> Check that getting routes / route error didn't break for the other types of txs (Send, Bridge). No need to perform the Tx, just the getting routes part.

### What does the PR do

Lets user fetch swap proposals even when they dont have sufficient balance. 


### Affected areas

SwapModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/f7f55248-d0a0-4daa-a8f7-cdd60129005a

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
