### PR TITLE
fix launching multiple instances of status desktop including on windo…

### DIFF
--- a/src/app_service/common/net_utils.nim
+++ b/src/app_service/common/net_utils.nim
@@ -2,12 +2,12 @@ import net
 
 # Util function to test if a port is busy
 proc isPortBusy*(port: Port): bool =
-  var sock: Socket
+  result = false
+  let socket = newSocket()
+  defer: socket.close()
+
   try:
-    sock = newSocket()
-    sock.setSockOpt(OptReuseAddr, true)
-    sock.bindAddr(port)
-    sock.close()
-    return false
+    socket.connect("localhost", port)
+    result = true
   except OSError:
-    return true
+    result = false


### PR DESCRIPTION
### Description

fixes #15493

### What does the PR do

In previous [PR](https://github.com/status-im/status-desktop/pull/15168/files), the function to check if a port is busy was effective on Linux but failed to perform intended action on Windows altogether.

### Affected areas

- Starting another Status-desktop instance

### Impact on end user

- User can launch > 1 instance(s) of Status-desktop

### How to test

- Launch > 1 instance(s) of status-desktop and login in the application on Linux, MacOS, and Windows

### Tests performed

1- Launched 2 instances of status-desktop
2- Used Postman to test the websocket connection

![Screenshot 2024-07-10 135814](https://github.com/status-im/status-desktop/assets/2589171/a6d45451-4c26-4085-a561-11aeea8f8a6f)

### Risk 

- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.