### PR TITLE
fix(statusProfileNavBarTabButton): Fixed backgound color and ring for…

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -29,15 +29,15 @@ import shared.popups.send 1.0
 import shared.popups.send.views 1.0
 import shared.stores.send 1.0
 
+import StatusQ 0.1
+import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Layout 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
-import StatusQ.Core 0.1
-import StatusQ.Core.Utils 0.1
-import StatusQ 0.1
 
 import AppLayouts.Browser.stores 1.0 as BrowserStores
 import AppLayouts.stores 1.0
@@ -1967,7 +1967,7 @@ Item {
                 if (showQR.showSingleAccount || showQR.showForSavedAddress) {
                     return showQR.selectedAccount
                 }
-                return selectedReceiverAccount.item ?? ModelUtils.get(appMain.transactionStore.accounts, 0)
+                return selectedReceiverAccount.item ?? SQUtils.ModelUtils.get(appMain.transactionStore.accounts, 0)
             }
 
             onUpdateSelectedAddress: (address) => {

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -153,7 +153,7 @@ QtObject {
             root.setSignerStateChanged(communityId, communityName, status, url)
         }
 
-        function onOwnershipLost(communityId, communityName) {
+        function onOwnershipNodeLost(communityId, communityName) {
             root.ownershipLost(communityId, communityName)
         }
 

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 
-import QtQuick 2.13
+import QtQuick 2.15
 
 import shared 1.0
 
@@ -280,7 +280,7 @@ QtObject {
         }
     }
 
-      function validatePINs(item, firstPINField, repeatPINField) {
+    function validatePINs(item, firstPINField, repeatPINField) {
         switch (item) {
             case "first":
                 if (firstPINField.pinInput === "") {


### PR DESCRIPTION
… StatusNavBarTabButton that's displayed at left bottom of the main window.

Fixed signal typo in CommunityTokensStore.
Closes #15479.

### What does the PR do

it looks like name clashing in AppMain.qml, specifically for QML Singleton Utils (at \ui\imports\utils\qmldir) and StatusQ.Core.Utils.
Fixed by adding a Qualifier to qml singleton import statement: `import utils 1.0 as QmlUtils`

### Affected areas
AppMain.qml


https://github.com/status-im/status-desktop/assets/5157464/cf5c8425-dd16-4f69-acb6-442a0be1fe54

