### PR TITLE
feat(@desktop/wallet): Show total fees instead of approval fees if aproval is needed on the swapmodal

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1340,7 +1340,7 @@ Item {
             compare(signButton.text, qsTr("Approve %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                        root.swapAdaptor.swapOutputData.approvalGasFees,
+                        root.swapAdaptor.swapOutputData.totalFees,
                         root.swapAdaptor.currencyStore.currentCurrency))
 
             // simulate user click on approve button and approval failed
@@ -1354,7 +1354,7 @@ Item {
             compare(signButton.text, qsTr("Approving %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                        root.swapAdaptor.swapOutputData.approvalGasFees,
+                        root.swapAdaptor.swapOutputData.totalFees,
                         root.swapAdaptor.currencyStore.currentCurrency))
 
             // simulate approval tx was unsuccessful
@@ -1368,7 +1368,7 @@ Item {
             compare(signButton.text, qsTr("Approve %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                        root.swapAdaptor.swapOutputData.approvalGasFees,
+                        root.swapAdaptor.swapOutputData.totalFees,
                         root.swapAdaptor.currencyStore.currentCurrency))
 
             // simulate user click on approve button and successful approval tx made
@@ -1383,7 +1383,7 @@ Item {
             compare(signButton.text, qsTr("Approving %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                        root.swapAdaptor.swapOutputData.approvalGasFees,
+                        root.swapAdaptor.swapOutputData.totalFees,
                         root.swapAdaptor.currencyStore.currentCurrency))
 
             // simulate approval tx was successful
@@ -1521,7 +1521,6 @@ Item {
             root.swapFormData.fromTokensKey = "ETH"
             root.swapFormData.fromTokenAmount = valueToExchangeString
             root.swapFormData.toTokenKey = data.key
-            console.error("root.swapFormData.toTokenKey = ",root.swapFormData.toTokenKey)
 
             // Launch popup
             launchAndVerfyModal()

--- a/storybook/stubs/shared/stores/CurrenciesStore.qml
+++ b/storybook/stubs/shared/stores/CurrenciesStore.qml
@@ -24,7 +24,7 @@ QtObject {
     }
 
     function getFiatValue(balance, cryptoSymbol) {
-        return balance
+        return parseFloat(balance)
     }
 
     function getCurrencyAmount(amount, symbol) {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -358,16 +358,9 @@ StatusDialog {
                             }
 
                             if(root.swapAdaptor.validSwapProposalReceived) {
-                                if(root.swapAdaptor.swapOutputData.approvalNeeded) {
-                                    let approvalGasFeesFiat = root.swapAdaptor.currencyStore.getFiatValue(root.swapAdaptor.swapOutputData.approvalGasFees, Constants.ethToken)
-                                    return root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                                                approvalGasFeesFiat,
-                                                root.swapAdaptor.currencyStore.currentCurrency)
-                                } else {
-                                    return root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                                                root.swapAdaptor.swapOutputData.totalFees,
-                                                root.swapAdaptor.currencyStore.currentCurrency)
-                                }
+                                return root.swapAdaptor.currencyStore.formatCurrencyAmount(
+                                            root.swapAdaptor.swapOutputData.totalFees,
+                                            root.swapAdaptor.currencyStore.currentCurrency)
                             }
 
                             return "--"


### PR DESCRIPTION
fixes #15505

### What does the PR do

show total fees on the swap modal on swap modal when approval is needed

### Affected areas

SwaoModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/144802e2-4539-4ecd-8185-fbbd403f4704

The fees for actual swap in this recording was very low and hence the total fees with approval gets approx rounded off!

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
