### PR TITLE
fix(wallet): use env USE_MOCKED_KEYCARD for mocked keycard window

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -138,6 +138,9 @@ QtObject:
   QtProperty[bool] testEnvironment:
     read = getTestEnvironment
 
+  proc displayMockedKeycardWindow*(self: LocalAppSettings): bool {.slot.} =
+    return DISPLAY_MOCKED_KEYCARD_WINDOW
+
   proc fakeLoadingScreenEnabledChanged*(self: LocalAppSettings) {.signal.}
   proc getFakeLoadingScreenEnabled*(self: LocalAppSettings): bool {.slot.} =
     self.settings.value(LAS_KEY_FAKE_LOADING_SCREEN_ENABLED, newQVariant(DEFAULT_FAKE_LOADING_SCREEN_ENABLED)).boolVal

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -184,7 +184,7 @@ QtObject:
   ## Used in test env only, for testing keycard flows
   proc registerMockedKeycard*(self: Service, cardIndex: int, readerState: int, keycardState: int,
   mockedKeycard: string, mockedKeycardHelper: string) =
-    if not singletonInstance.localAppSettings.getTestEnvironment():
+    if not singletonInstance.localAppSettings.displayMockedKeycardWindow():
       error "registerMockedKeycard can be used only in test env"
       return
     let response = keycard_go.mockedLibRegisterKeycard(cardIndex, readerState, keycardState, mockedKeycard, mockedKeycardHelper)
@@ -192,7 +192,7 @@ QtObject:
       debug "mockedLibRegisterKeycard", kcServiceCurrFlow=($self.currentFlow), cardIndex=cardIndex, readerState=readerState, keycardState=keycardState, mockedKeycard=mockedKeycard, mockedKeycardHelper=mockedKeycardHelper, response=response
 
   proc pluginMockedReaderAction*(self: Service) =
-    if not singletonInstance.localAppSettings.getTestEnvironment():
+    if not singletonInstance.localAppSettings.displayMockedKeycardWindow():
       error "pluginMockedReaderAction can be used only in test env"
       return
     let response = keycard_go.mockedLibReaderPluggedIn()
@@ -200,7 +200,7 @@ QtObject:
       debug "mockedLibReaderPluggedIn", kcServiceCurrFlow=($self.currentFlow), response=response
 
   proc unplugMockedReaderAction*(self: Service) =
-    if not singletonInstance.localAppSettings.getTestEnvironment():
+    if not singletonInstance.localAppSettings.displayMockedKeycardWindow():
       error "unplugMockedReaderAction can be used only in test env"
       return
     let response = keycard_go.mockedLibReaderUnplugged()
@@ -208,7 +208,7 @@ QtObject:
       debug "mockedLibReaderUnplugged", kcServiceCurrFlow=($self.currentFlow), response=response
 
   proc insertMockedKeycardAction*(self: Service, cardIndex: int) =
-    if not singletonInstance.localAppSettings.getTestEnvironment():
+    if not singletonInstance.localAppSettings.displayMockedKeycardWindow():
       error "insertMockedKeycardAction can be used only in test env"
       return
     let response = keycard_go.mockedLibKeycardInserted(cardIndex)
@@ -216,7 +216,7 @@ QtObject:
       debug "mockedLibKeycardInserted", kcServiceCurrFlow=($self.currentFlow), cardIndex=cardIndex, response=response
 
   proc removeMockedKeycardAction*(self: Service) =
-    if not singletonInstance.localAppSettings.getTestEnvironment():
+    if not singletonInstance.localAppSettings.displayMockedKeycardWindow():
       error "removeMockedKeycardAction can be used only in test env"
       return
     let response = keycard_go.mockedLibKeycardRemoved()

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -36,6 +36,7 @@ let
 
   # runtime variables
   TEST_MODE_ENABLED* = desktopConfig.testMode
+  DISPLAY_MOCKED_KEYCARD_WINDOW* = desktopConfig.displayMockedKeycardWindow
   WALLET_ENABLED* = desktopConfig.enableWallet
   TORRENT_CONFIG_PORT* = desktopConfig.defaultTorentConfigPort
   WAKU_V2_PORT* = desktopConfig.defaultWakuV2Port

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -217,6 +217,11 @@ type StatusDesktopConfig = object
     desc: "Determines if the fleet selection UI is enabled"
     name: "ENABLE_FLEET_SELECTION"
     abbr: "enable-fleet-selection" .}: bool
+  displayMockedKeycardWindow* {.
+    defaultValue: false
+    desc: "Determines if the app should use mocked keycard"
+    name: "USE_MOCKED_KEYCARD"
+    abbr: "use-mocked-keycard" .}: bool
 
 
 # On macOS the first time when a user gets the "App downloaded from the

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -99,7 +99,7 @@ StatusWindow {
 
         property var mockedKeycardControllerWindow
         function runMockedKeycardControllerWindow() {
-            if (localAppSettings.testEnvironment) {
+            if (localAppSettings.displayMockedKeycardWindow()) {
                 if (!!d.mockedKeycardControllerWindow) {
                     d.mockedKeycardControllerWindow.close()
                 }


### PR DESCRIPTION
### What does the PR do

TEST_MODE env var was used to display keycard window, but it is not need for any tests except for keycard tests, but it causes delays and e2e test failures. Use a separate STATUS_RUNTIME_USE_MOCKED_KEYCARD env var for it

### Affected areas

tests for keycard

### Impact on end user

No

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Fixes #15504 
