### PR TITLE
fix(@desktop/wallet): Fixing issue in deleting characters from Input area

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1587,5 +1587,38 @@ Item {
             // check if fetch occurs automatically after 15 seconds
             fetchSuggestedRoutesCalled.wait()
         }
+
+        function test_deleteing_input_characters_data() {
+            return [
+                        {input: "0.001"},
+                        {input: "1.00015"},
+                        /* TODO uncomment after https://discord.com/channels/@me/927512790296563712/1260937239140241408
+                        {input: "100.000000000000151001"},
+                        {input: "1.0200000000000151001"} */
+                    ]
+        }
+
+        function test_deleteing_input_characters(data) {
+            root.swapFormData.fromTokenAmount = data.input
+            root.swapFormData.selectedAccountAddress = "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            root.swapFormData.selectedNetworkChainId = 11155111
+            root.swapFormData.fromTokensKey = "ETH"
+
+            const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
+            verify(!!amountToSendInput)
+
+            // Launch popup
+            launchAndVerfyModal()
+
+            waitForRendering(amountToSendInput)
+
+            //TODO: should not be needed after https://github.com/status-im/status-desktop/issues/15417
+            amountToSendInput.input.input.cursorPosition = data.input.length
+            for(let i =0; i< data.input.length; i++) {
+                keyClick(Qt.Key_Backspace)
+                let expectedAmount = data.input.substring(0, data.input.length - (i+1))
+                compare(amountToSendInput.input.text, expectedAmount)
+            }
+        }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -113,7 +113,13 @@ Control {
                 return
             }
             let amountToSet = SQUtils.AmountsArithmetic.fromString(tokenAmount).toFixed().replace('.', LocaleUtils.userInputLocale.decimalPoint)
-            if (amountToSendInput.input.text !== amountToSet) {
+            /* When deleting characters after a decimal point
+            eg: 0.000001 being deleted we have 0.00000 and it should not be updated to 0
+            and thats why we compare with toFixed()
+            also when deleting a numbers last digit, we should not update the text to 0
+            instead it should remain empty as entered by the user*/
+            if (SQUtils.AmountsArithmetic.fromString(amountToSendInput.input.text).toFixed() !== amountToSet &&
+                    !(amountToSet === "0" && !amountToSendInput.input.text)) {
                 amountToSendInput.input.text = amountToSet
             }
         }


### PR DESCRIPTION
fixes #15418

### What does the PR do

Entering numbers such as 0.00001 and deleting last character leads to text being set to 0
Also for a number like 100.01, deleting last character leads to text being set to 0
also when deleting a single digit number like 1, it sets to 0 instead of empty text.

This PR fixes above mentioned issues and also adds qml tests so that the issue doesnt come back

### Affected areas

SwapModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/aeba0e78-c065-45ef-b8a8-36d03aa2ef27

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.