### PR TITLE
feat(@desktop/wallet): Add connector Feature Flag

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -3,6 +3,7 @@ import os
 
 const DEFAULT_FLAG_DAPPS_ENABLED = false
 const DEFAULT_FLAG_SWAP_ENABLED = false
+const DEFAULT_FLAG_CONNECTOR_ENABLED = false
 
 proc boolToEnv(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"
@@ -11,11 +12,13 @@ QtObject:
   type FeatureFlags* = ref object of QObject
     dappsEnabled: bool
     swapEnabled: bool
+    connectorEnabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
     self.dappsEnabled = getEnv("FLAG_DAPPS_ENABLED", boolToEnv(DEFAULT_FLAG_DAPPS_ENABLED)) != "0"
     self.swapEnabled = getEnv("FLAG_SWAP_ENABLED", boolToEnv(DEFAULT_FLAG_SWAP_ENABLED)) != "0"
+    self.connectorEnabled = getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
 
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
@@ -35,3 +38,9 @@ QtObject:
 
   QtProperty[bool] swapEnabled:
     read = getSwapEnabled
+
+  proc getConnectorEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.connectorEnabled
+
+  QtProperty[bool] connectorEnabled:
+    read = getConnectorEnabled


### PR DESCRIPTION
### Description

Add feature flag for dapps connector

fixes #15550

### What does the PR do

Add feature flag for dapps connector. This is common practice for adding a feature flag. The feature flag will be able to be used in QML

### Affected areas

- NA

### Impact on end user

By using a feature flag, the end user will not see any impact on new under development feature

### How to test

- NA

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
