### PR TITLE
chore: add gdb run task for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -819,6 +819,11 @@ run-linux: nim_status_client
 	LD_LIBRARY_PATH="$(QT5_LIBDIR)":"$(STATUSGO_LIBDIR)":"$(STATUSKEYCARDGO_LIBDIR):$(LD_LIBRARY_PATH)" \
 	./bin/nim_status_client $(ARGS)
 
+run-linux-gdb: nim_status_client
+	echo -e "\033[92mRunning:\033[39m bin/nim_status_client"
+	LD_LIBRARY_PATH="$(QT5_LIBDIR)":"$(STATUSGO_LIBDIR)":"$(STATUSKEYCARDGO_LIBDIR):$(LD_LIBRARY_PATH)" \
+	gdb -ex=r ./bin/nim_status_client $(ARGS)
+
 run-macos: nim_status_client
 	mkdir -p bin/StatusDev.app/Contents/{MacOS,Resources}
 	cp Info.dev.plist bin/StatusDev.app/Contents/Info.plist


### PR DESCRIPTION
### What does the PR do

adds `run-linux-gdb` task to the makefile.
When executed, this tasks runs the app binary in gdb to enable capturing the backtrace and doing other debugging actions.

### Affected areas

No user impact

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
