### PR TITLE
Separate environment for keycard tests

### DIFF
--- a/test/e2e/configs/_local.ci.py
+++ b/test/e2e/configs/_local.ci.py
@@ -5,3 +5,4 @@ LOG_LEVEL = logging.getLevelName(os.getenv('LOG_LEVEL', 'INFO'))
 UPDATE_VP_ON_FAIL = False
 DEV_BUILD = False
 AUT_PATH = os.getenv('AUT_PATH')
+os.environ['STATUS_RUNTIME_USE_MOCKED_KEYCARD'] = 'False'

--- a/test/e2e/configs/_local.default.py
+++ b/test/e2e/configs/_local.default.py
@@ -1,6 +1,8 @@
 import logging
+import os
 
 LOG_LEVEL = logging.DEBUG
 DEV_BUILD = False
 AUT_PATH = "path to the application (.app or .AppImage)"
+os.environ['STATUS_RUNTIME_USE_MOCKED_KEYCARD'] = 'False'
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -44,7 +44,8 @@ def setup_function_scope(
         caplog,
         generate_test_data,
         check_result,
-        application_logs
+        application_logs,
+        keycard_controller
 ):
     # FIXME: broken due to KeyError: <_pytest.stash.StashKey object at 0x7fd1ba6d78c0>
     # caplog.set_level(configs.LOG_LEVEL)

--- a/test/e2e/fixtures/aut.py
+++ b/test/e2e/fixtures/aut.py
@@ -1,4 +1,5 @@
 import allure
+import os
 import pytest
 import logging
 import configs
@@ -18,6 +19,10 @@ def options(request):
         return request.param
     return ''
 
+@pytest.fixture
+def keycard_controller(request):
+    if 'settings_keycard' in str(getattr(request, 'fspath')):
+        os.environ['STATUS_RUNTIME_USE_MOCKED_KEYCARD'] = 'True'
 
 @pytest.fixture
 def application_logs():

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -169,9 +169,7 @@ class MainWindow(Window):
         super(MainWindow, self).__init__(names.statusDesktop_mainWindow)
         self.left_panel = LeftPanel()
 
-    # TODO: we need to handle all the issues with keycard mock var before using keycard  window in tests
     def prepare(self) -> 'Window':
-        #   MockedKeycardController().wait_until_appears().hide()
         return super().prepare()
 
     @allure.step('Sign Up user')


### PR DESCRIPTION
### What does the PR do

So now environment variable for keycard controller set only for keycard tests. For the rest it's turned off and no need to handle keycard controller.

For now I enabled only 1 keycard test, will work on the rest as a separate task

CI runs:
keycard test - https://ci.status.im/job/status-desktop/job/e2e/job/manual/2298/
critical tests - https://ci.status.im/job/status-desktop/job/e2e/job/manual/2299/

