### PR TITLE
fix(wallet)_: filter out non-transferable collectibles in send modal

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -327,9 +327,14 @@ StatusDialog {
 
                             sourceComponent: CollectiblesSelectionAdaptor {
                                 accountKey: popup.preSelectedAccount ? popup.preSelectedAccount.address : ""
-                                collectiblesModel: collectiblesStore
-                                                   ? collectiblesStore.jointCollectiblesBySymbolModel
-                                                   : null
+
+                                collectiblesModel: SortFilterProxyModel {
+                                    sourceModel: collectiblesStore ? collectiblesStore.jointCollectiblesBySymbolModel : null
+                                    filters: ValueFilter {
+                                        roleName: "soulbound"
+                                        value: false
+                                    }
+                                }
                             }
                         }
 


### PR DESCRIPTION
### What does the PR do

This PR updates the SendModal.qml to filter out non-transferable (soulbound) collectibles from the send model, ensuring only transferable collectibles are displayed when sending.

### Affected areas

* wallet
### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://github.com/user-attachments/assets/eab29664-3b93-407d-9bba-f13c3b5e0bc3



### Impact on end user

The changes will ensure users only see transferable collectibles in the send model, improving user experience by preventing attempts to send non-transferable items.

### How to test

1. Open the send modal in the wallet.
2. Ensure that only transferable (non-soulbound) collectibles are displayed.
3. Verify that non-transferable (soulbound) collectibles are filtered out.

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

