### PR TITLE
chore: temp remove the wrong test case reference

### DIFF
--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -123,7 +123,7 @@ def test_member_role_cannot_add_edit_and_delete_channels(main_screen: MainWindow
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/edit/737079',
                  'Member not holding permission cannot see channel (view-only permission)')
-@pytest.mark.case(737079)
+# @pytest.mark.case(737079) # FIXME need to migrate all references to new test rail project first
 @pytest.mark.parametrize('user_data_one, user_data_two, asset, amount, channel_description', [
     (configs.testpath.TEST_USER_DATA / 'squisher', configs.testpath.TEST_USER_DATA / 'athletic', 'ETH', '10',
      'description')


### PR DESCRIPTION
### What does the PR do

Close #15564 

Remove reference to the test case which was not present in project directory , therefore nightly test runs were always failing on pre setup

**TODO**: refactor Testrail fixture: add error handling and do not fail the pre setup if test run was not created. This will be done separately as it requires re-writing the whole test rail integration logic

Test run with the fix https://ethstatus.testrail.net/index.php?/runs/view/17279
Jenkins job https://ci.status.im/job/status-desktop/job/e2e/job/manual/2317/

### Affected areas

End to end tests

