### PR TITLE
feat: Show wallet footer on all accounts screen

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -208,7 +208,7 @@ Item {
             sendModal: root.sendModalPopup
             networkConnectionStore: root.networkConnectionStore
 
-            headerButton.text: RootStore.overview.ens || StatusQUtils.Utils.elideText(RootStore.overview.mixedcaseAddress, 6, 4)
+            headerButton.text: RootStore.overview.ens || StatusQUtils.Utils.elideAndFormatWalletAddress(RootStore.overview.mixedcaseAddress)
             headerButton.visible: !RootStore.overview.isAllAccounts
             onLaunchShareAddressModal: Global.openShowQRPopup({
                                                                   switchingAccounsEnabled: true,
@@ -282,7 +282,6 @@ Item {
             readonly property bool isCommunityCollectible: !!walletStore.currentViewedCollectible ? walletStore.currentViewedCollectible.communityId !== "" : false
             readonly property bool isOwnerCommunityCollectible: isCommunityCollectible ? (walletStore.currentViewedCollectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) : false
 
-            visible: !RootStore.showAllAccounts || Global.featureFlags.swapEnabled
             width: parent.width
             height: visible ? 61: implicitHeight
             walletStore: RootStore
@@ -331,7 +330,7 @@ Item {
             }
             onLaunchBridgeModal: {
                 root.sendModalPopup.preSelectedSendType = Constants.SendType.Bridge
-                root.sendModalPopup.preSelectedRecipient = root.sendModalPopup.preSelectedAccount.address
+                root.sendModalPopup.preSelectedRecipient = root.sendModalPopup.preSelectedAccount
                 root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
                 root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
                 root.sendModalPopup.onlyAssets = true

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -1,17 +1,14 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Popups 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 
 import utils 1.0
-import shared.controls 1.0
 import shared.stores.send 1.0
-
-import "../controls"
-import "../popups"
 
 Rectangle {
     id: root
@@ -35,7 +32,7 @@ Rectangle {
         id: d
         readonly property bool isCollectibleViewed: !!walletStore.currentViewedHoldingID &&
                                                     (walletStore.currentViewedHoldingType === Constants.TokenType.ERC721 ||
-                                                    walletStore.currentViewedHoldingType === Constants.TokenType.ERC1155)
+                                                     walletStore.currentViewedHoldingType === Constants.TokenType.ERC1155)
         readonly property bool isCollectibleSoulbound: isCollectibleViewed && !!walletStore.currentViewedCollectible && walletStore.currentViewedCollectible.soulbound
     }
 
@@ -55,20 +52,21 @@ Rectangle {
             text: root.isCommunityOwnershipTransfer ? qsTr("Send Owner token to transfer %1 Community ownership").arg(root.communityName) : qsTr("Send")
             interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
             onClicked: {
-                root.transactionStore.setSenderAccount(root.walletStore.selectedAddress)
+                root.transactionStore.setSenderAccount(root.walletStore.selectedAddress ||
+                                                       SQUtils.ModelUtils.get(root.walletStore.nonWatchAccounts, 0, "address"))
                 root.launchSendModal()
             }
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be sent to another wallet") : networkConnectionStore.sendBuyBridgeToolTipText
-            visible: !walletStore.overview.isWatchOnlyAccount && walletStore.overview.canSend && !root.walletStore.showAllAccounts
+            visible: walletStore.overview.canSend
         }
 
         StatusFlatButton {
             icon.name: "receive"
             text: qsTr("Receive")
-            visible: !root.walletStore.showAllAccounts
             onClicked: function () {
-                root.transactionStore.setReceiverAccount(root.walletStore.selectedAddress)
-                launchShareAddressModal()
+                root.transactionStore.setSenderAccount(root.walletStore.selectedAddress ||
+                                                       SQUtils.ModelUtils.get(root.walletStore.nonWatchAccounts, 0, "address"))
+                root.launchShareAddressModal()
             }
         }
 
@@ -78,29 +76,23 @@ Rectangle {
             interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
             onClicked: root.launchBridgeModal()
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be bridged to another wallet") :  networkConnectionStore.sendBuyBridgeToolTipText
-            visible: !walletStore.overview.isWatchOnlyAccount && !root.isCommunityOwnershipTransfer && walletStore.overview.canSend && !root.walletStore.showAllAccounts
+            visible: !root.isCommunityOwnershipTransfer && walletStore.overview.canSend
         }
 
         StatusFlatButton {
-            id: buySellBtn
-
-            visible: !root.isCommunityOwnershipTransfer && !root.walletStore.showAllAccounts
+            visible: !root.isCommunityOwnershipTransfer
             icon.name: "token"
             text: qsTr("Buy")
             onClicked: Global.openBuyCryptoModalRequested()
-        }        
+        }
 
         StatusFlatButton {
-            id: swap
-
-            interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
-            visible: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount
-            tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be swapped") :  networkConnectionStore.sendBuyBridgeToolTipText
+            interactive: !d.isCollectibleViewed && networkConnectionStore.sendBuyBridgeEnabled
+            visible: Global.featureFlags.swapEnabled
+            tooltip.text: d.isCollectibleViewed ? qsTr("Collectibles cannot be swapped") : networkConnectionStore.sendBuyBridgeToolTipText
             icon.name: "swap"
             text: qsTr("Swap")
             onClicked: root.launchSwapModal()
         }
     }
 }
-
-


### PR DESCRIPTION
### What does the PR do

- always show the wallet footer
- initiate the Send/Buy/Swap modals with the currently selected account, or the first non-watch account otherwise
- the Swap button still stays hidden behind the respective feature flag; and disabled when viewing a collectible
- cleanup (unused) includes

Fixes #14732

### Affected areas

WalletLayout, WalletFooter

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-07-12 18-25-14.webm](https://github.com/user-attachments/assets/829ed256-3367-4e5c-a266-afee2a55f6d1)
