### PR TITLE
fix(import): fix import community popup

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -702,7 +702,6 @@ proc getChatItemFromChatDto(
   var viewersCanPostReactions = true
   var missingEncryptionKey = false
   if self.controller.isCommunity:
-    let communityChat = community.getCommunityChat(chatDto.id)
     # NOTE: workaround for new community chat, which is delivered in chatDto before the community will know about that
     if community.hasCommunityChat(chatDto.id):
       let communityChat = community.getCommunityChat(chatDto.id)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -277,8 +277,12 @@ QtObject {
         openPopup(importCommunitiesPopupComponent)
     }
 
-    function openCommunityIntroPopup(communityId, name, introMessage,
-                                     imageSrc, isInvitationPending) {
+    function openCommunityIntroPopup(communityId,
+                                    name,
+                                    introMessage,
+                                    imageSrc,
+                                    isInvitationPending
+                                    ) {
         openPopup(communityJoinDialogPopup,
                   {communityId: communityId,
                    communityName: name,
@@ -712,11 +716,11 @@ QtObject {
                 store: root.communitiesStore
                 onJoinCommunityRequested: {
                     close()
+                    communitiesStore.spectateCommunity(communityId)
                     openCommunityIntroPopup(communityId,
                                             communityDetails.name,
                                             communityDetails.introMessage,
                                             communityDetails.image,
-                                            communityDetails.access,
                                             root.rootStore.isMyCommunityRequestPending(communityId))
                 }
                 onClosed: destroy()


### PR DESCRIPTION
Fixes #15526

Fixes the import popup showing the wrong state. That was because a param was removed from the function, but not from the call to that function, so `true` was passed in `invitationPending` when it shouldn't have.

I also added a call to `spectateCommunity` before the community intro popup so that the community spectated beforee sending the request

[importPopupFix.webm](https://github.com/user-attachments/assets/18c6f99d-b2ad-4cf9-b80c-90426ff5b6f6)
