### PR TITLE
fix(wallet): Repeat transaction updates

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -6,6 +6,7 @@ import StatusQ.Models 0.1
 import utils 1.0
 
 import SortFilterProxyModel 0.2
+import StatusQ.Core.Utils 0.1 as SQUtils
 
 QtObject {
     id: root
@@ -106,5 +107,27 @@ QtObject {
 
     function getDetailedCollectible(chainId, contractAddress, tokenId) {
         walletSection.collectibleDetailsController.getDetailedCollectible(chainId, contractAddress, tokenId)
+    }
+
+    function hasNFT(ownerAddress, chainId, tokenId, tokenAddress) {
+        const uid = getUidForData(tokenId, tokenAddress, chainId)
+        ownerAddress = ownerAddress.toLowerCase()
+        const ownership = SQUtils.ModelUtils.getByKey(_allCollectiblesModel, "uid", uid, "ownership")
+        if (!ownership)
+            return false
+
+        for (let i = 0; i < ownership.count; i++) {
+            const accountAddress = SQUtils.ModelUtils.get(ownership, i, "accountAddress").toLowerCase()
+            if (accountAddress !== ownerAddress)
+                continue
+            const tokenBalanceStr = SQUtils.ModelUtils.get(ownership, i, "balance").toLowerCase()
+            if (tokenBalanceStr !== "")
+                return true
+        }
+        return false
+    }
+
+    function getUidForData(tokenId, tokenAddress, chainId) {
+        return _allCollectiblesModel.getUidForData(tokenId, tokenAddress, chainId)
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -311,17 +311,9 @@ QtObject {
 
     function getAssetForSendTx(tx) {
         if (tx.isNFT) {
-            return {
-                uid: tx.tokenID,
-                chainId: tx.chainId,
-                name: tx.nftName,
-                imageUrl: tx.nftImageUrl,
-                collectionUid: "",
-                collectionName: ""
-            }
-        } else {
-            return tx.symbol
+            return collectiblesStore.getUidForData(tx.tokenID, tx.tokenAddress, tx.chainId)
         }
+        return tx.symbol
     }
 
     function isTxRepeatable(tx) {
@@ -332,12 +324,14 @@ QtObject {
         if (!res || res.walletType === Constants.watchWalletType)
             return false
 
-        if (tx.isNFT) {
-            // TODO #12275: check if account owns enough NFT
-        } else {
-            // TODO #12275: Check if account owns enough tokens
+        if (!tx.amount) {
+            // Ignore incorrect transactions
+            return false
         }
 
+        if (tx.isNFT && !root.collectiblesStore.hasNFT(tx.sender, tx.chainId, tx.tokenID, tx.tokenAddress)) {
+            return false
+        }
         return true
     }
 

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -767,7 +767,7 @@ Item {
                     property alias tx: d.transaction
 
                     visible: {
-                        if (!d.isTransactionValid || root.overview.isWatchOnlyAccount)
+                        if (!d.isTransactionValid || root.overview.isWatchOnlyAccount || root.overview.isAllAccounts)
                             return false
 
                         return WalletStores.RootStore.isTxRepeatable(tx)
@@ -780,7 +780,8 @@ Item {
                                                                       tx.recipient,
                                                                       asset,
                                                                       tx.isNFT,
-                                                                      tx.amount)
+                                                                      tx.amount,
+                                                                      tx.chainId)
 
                         root.sendModal.preSelectedAccountAddress = req.preSelectedAccount.address
                         root.sendModal.preSelectedRecipient = req.preSelectedRecipient
@@ -789,6 +790,7 @@ Item {
                         root.sendModal.preSelectedHoldingType = req.preSelectedHoldingType
                         root.sendModal.preSelectedSendType = req.preSelectedSendType
                         root.sendModal.preDefinedAmountToSend = req.preDefinedAmountToSend
+                        root.sendModal.preSelectedChainId = req.preSelectedChainId
                         root.sendModal.onlyAssets = false
                         root.sendModal.open()
                     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1626,6 +1626,7 @@ Item {
             property int preSelectedHoldingType: Constants.TokenType.Unknown
             property int preSelectedSendType: Constants.SendType.Unknown
             property string preDefinedAmountToSend
+            property int preSelectedChainId: 0
             property bool onlyAssets: false
 
             sourceComponent: SendPopups.SendModal {
@@ -1644,6 +1645,7 @@ Item {
                     sendModal.preSelectedAccountAddress = ""
                     sendModal.preSelectedRecipient = undefined
                     sendModal.preDefinedAmountToSend = ""
+                    sendModal.preSelectedChainId = 0
                 }
             }
             onLoaded: {
@@ -1651,8 +1653,9 @@ Item {
                     item.preSelectedAccountAddress = sendModal.preSelectedAccountAddress
                 }
                 if (!!sendModal.preSelectedRecipient) {
-                    item.preSelectedRecipient = sendModal.preSelectedRecipient
+                    // NOTE Should be assigned in that order: type then recipient
                     item.preSelectedRecipientType = sendModal.preSelectedRecipientType
+                    item.preSelectedRecipient = sendModal.preSelectedRecipient
                 }
                 if(sendModal.preSelectedSendType !== Constants.SendType.Unknown) {
                     item.preSelectedSendType = sendModal.preSelectedSendType
@@ -1663,6 +1666,9 @@ Item {
                 }
                 if(preDefinedAmountToSend != "") {
                     item.preDefinedAmountToSend = preDefinedAmountToSend
+                }
+                if(!!sendModal.preSelectedChainId) {
+                    item.preSelectedChainId = sendModal.preSelectedChainId
                 }
             }
         }

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -200,7 +200,7 @@ StatusListItem {
 
         readonly property bool isLightTheme: Style.current.name === Constants.lightThemeName
         property color animatedBgColor
-        property int txType: walletRootStore.transactionType(modelData)
+        property int txType: walletRootStore.transactionType(root.modelData)
 
         function addressesEqual(address1, address2) {
             return address1.toUpperCase() == address2.toUpperCase()

--- a/ui/imports/shared/popups/send/Helpers.qml
+++ b/ui/imports/shared/popups/send/Helpers.qml
@@ -29,9 +29,9 @@ QtObject {
             preSelectedRecipientType: Helpers.RecipientAddressObjectType.Address,
             preSelectedRecipient: null,
             preSelectedHoldingType: Constants.TokenType.Unknown,
-            preSelectedHolding: null,
             preSelectedHoldingID: "",
             preDefinedAmountToSend: "",
+            preSelectedChainId: 0,
             preSelectedSendType: Constants.SendType.Transfer
         }
     }
@@ -43,7 +43,8 @@ QtObject {
                                          recipientAddress,
                                          token,
                                          isCollectible,
-                                         amount) {
+                                         amount,
+                                         chainId) {
         let req = createSendModalRequirements()
 
         req.preSelectedSendType = Constants.SendType.Transfer
@@ -70,14 +71,9 @@ QtObject {
             req.preSelectedRecipient = recipientAddress
         }
 
-        // Holdings related properties:
-        if (isCollectible) {
-            req.preSelectedHoldingType = Constants.TokenType.ERC721
-            req.preSelectedHolding = token
-        } else {
-            req.preSelectedHoldingType = Constants.TokenType.ERC20
-            req.preSelectedHoldingID = token
-        }
+        req.preSelectedHoldingType = isCollectible ? Constants.TokenType.ERC721 : Constants.TokenType.ERC20
+        req.preSelectedHoldingID = token
+        req.preSelectedChainId = chainId
 
         req.preDefinedAmountToSend = LocaleUtils.numberToLocaleString(amount)
 

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -40,6 +40,7 @@ StatusDialog {
     property alias preSelectedRecipientType: recipientInputLoader.selectedRecipientType
 
     property string preDefinedAmountToSend
+    property int preSelectedChainId: 0
     property string stickersPackId
 
     // token symbol
@@ -146,6 +147,10 @@ StatusDialog {
         readonly property bool isSelectedHoldingValidAsset: !!selectedHolding && selectedHoldingType === Constants.TokenType.ERC20
 
         onSelectedHoldingChanged: {
+            if (!selectedHolding) {
+                return
+            }
+
             if (d.selectedHoldingType === Constants.TokenType.ERC20) {
                 if(!d.ensOrStickersPurpose && store.sendType !== Constants.SendType.Bridge)
                     store.setSendType(Constants.SendType.Transfer)
@@ -250,6 +255,11 @@ StatusDialog {
             const delocalized = popup.preDefinedAmountToSend.replace(",", ".")
 
             amountToSend.setValue(delocalized)
+        }
+        
+        if (!!popup.preSelectedChainId) {
+            popup.preDefinedAmountToSend = popup.preDefinedAmountToSend.replace(Qt.locale().decimalPoint, '.')
+            store.updateRoutePreferredChains(popup.preSelectedChainId)
         }
 
         if (!!popup.stickersPackId) {

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -324,15 +324,17 @@ ColumnLayout {
                                                               tx.recipient,
                                                               asset,
                                                               tx.isNFT,
-                                                              tx.amount)
+                                                              tx.amount,
+                                                              tx.chainId)
 
                 root.sendModal.preSelectedAccountAddress = req.preSelectedAccount.address
                 root.sendModal.preSelectedRecipient = req.preSelectedRecipient
                 root.sendModal.preSelectedRecipientType = req.preSelectedRecipientType
-                root.sendModal.preSelectedHoldingID = req.preSelectedHoldingID ?? req.preSelectedHolding.uid
+                root.sendModal.preSelectedHoldingID = req.preSelectedHoldingID
                 root.sendModal.preSelectedHoldingType = req.preSelectedHoldingType
                 root.sendModal.preSelectedSendType = req.preSelectedSendType
                 root.sendModal.preDefinedAmountToSend = req.preDefinedAmountToSend
+                root.sendModal.preSelectedChainId = req.preSelectedChainId
                 root.sendModal.onlyAssets = false
                 root.sendModal.open()
             }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12275

### What does the PR do

* Fixed opening send modal with pre selected data
* Added chainid as preselected data to specify preferred networks (e.g. tx was done on Opti, then it should calculate routers on Opti)
* Added check if account contains NFT to repeat the transaction
* Fixed setting pre selected recipient 
* Replaced incorrect usage of tokenID as identifier for collectibles with uid.

### Affected areas

* Activity list
* Send modal

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/52f04561-c57f-4ec3-aaa9-678d3ce4c29d

