### PR TITLE
tests: fix broken reference in links preview test

### DIFF
--- a/test/e2e/constants/links.py
+++ b/test/e2e/constants/links.py
@@ -1,5 +1,5 @@
 # Links for link preview tests
 external_link = 'https://github.com/status-im/status-desktop/issues/12018'
 link_to_status_community = 'https://status.app/c/G4IAAMSIuU08Lm3oHzSz695ImidijVBxyoFDGEiSYAvADsk9ZVOKYlT2b-lHStyz1MqqkK2Xa4FwoUiq3LBgWsYI_ht6hWXCyLu0TGAk0dGu8IyQWtDSdIXOQ3hWscLjkTo5Vg5-eyUuV8jOVv7khJ_uTofT_TijN-sB#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9'
-status_user_profile_link = 'https://status.app/u/CwaACgsKCXRlc3RfdXNlcgM=#zQ3shVjsBFo6eiAJvhzHFAgqVXjbNGbkLco7xvffFZRiPPftL'
+status_user_profile_link = 'https://status.app/u/iwWACgoKCHF3ZWVydHR5Aw==#zQ3shaZbuPnPRw7btzD8AD3Apty32MMjExBDRe8vts3tag29D'
 

--- a/test/e2e/tests/messages/test_messaging_link_previews.py
+++ b/test/e2e/tests/messages/test_messaging_link_previews.py
@@ -23,8 +23,8 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704589', 'Status user profile link preview')
 @pytest.mark.case(704596, 704578, 704578)
 @pytest.mark.parametrize('community_name, domain_link, user_name, domain_link_2, user_emoji_hash',
-                         [pytest.param('Status', 'status.app', 'test_user', 'github.com',
-                                       '0x047bc087919ee9875fcca0a01f46261c3c1d8ecbb9cd95f95903316190bd81946909cceb5fcda5d9f1a442fa20f71b5aa0f938cad87e83d45211bf5803352c9010')
+                         [pytest.param('Status', 'status.app', 'qweertty', 'github.com',
+                                       '0x04c369e2e5d20c8e35cc2c7802cd7a58af3d4d54d537a3c05fd72e012dd9535b881b2c852b7cc11b211126eeeae6364b5fc024ee6ffa5a462905e6e8604729aec6')
                           ])
 def test_link_previews(multiple_instances, community_name, domain_link, user_name, domain_link_2, user_emoji_hash):
     user_one: UserAccount = constants.user_with_random_attributes_1


### PR DESCRIPTION
### What does the PR do

Replace old references in test of links preview

### Affected areas

Tests

### CI run

https://ci.status.im/job/status-desktop/job/e2e/job/manual/2319/

<img width="1840" alt="Screenshot 2024-07-15 at 12 43 42" src="https://github.com/user-attachments/assets/37da2dfb-84b0-4f9b-a950-f87c9640473b">
