### PR TITLE
fix: Removed duplicated text in Token Popup by reusing existing supportedTokenSources mapping

### DIFF
--- a/storybook/pages/TokenListPopupPage.qml
+++ b/storybook/pages/TokenListPopupPage.qml
@@ -73,7 +73,7 @@ SplitView {
                         modal: false
                         closePolicy: Popup.NoAutoClose
 
-                        sourceName: delegate.name
+                        title: qsTr("%1 Token List").arg(delegate.name)
                         sourceImage: delegate.image
                         sourceUrl: delegate.source
                         sourceVersion: delegate.version

--- a/ui/app/AppLayouts/Profile/panels/SupportedTokenListsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/SupportedTokenListsPanel.qml
@@ -89,11 +89,19 @@ StatusListView {
             readonly property TokenListPopup popup: TokenListPopup {
                 parent: root
 
-                sourceName: delegate.name
                 sourceImage: delegate.image
                 sourceUrl: delegate.source
                 sourceVersion: delegate.version
                 tokensCount: delegate.tokensCount
+
+                title: {
+                    // Similar to Constants.getSupportedTokenSourceImage
+                    if (delegate.name === Constants.supportedTokenSources.uniswap ||
+                            delegate.name === Constants.supportedTokenSources.status)
+                        return delegate.name;
+
+                    return qsTr("%1 Token List").arg(delegate.name)
+                }
 
                 tokensListModel: SortFilterProxyModel {
                     sourceModel: root.tokensListModel

--- a/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
@@ -16,7 +16,6 @@ import shared.panels 1.0
 StatusDialog {
     id: root
 
-    required property string sourceName
     required property string sourceImage
     required property string sourceUrl
     required property string sourceVersion
@@ -65,7 +64,7 @@ StatusDialog {
     }
 
     header: StatusDialogHeader {
-        headline.title: qsTr("%1 Token List").arg(root.sourceName)
+        headline.title: root.title
         headline.subtitle: qsTr("%n token(s)", "", root.tokensCount)
         actions.closeButton.onClicked: root.close()
         leftComponent: StatusSmartIdenticon {

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -19,20 +19,20 @@ QtObject {
     readonly property var sourcesOfTokensModel: SortFilterProxyModel {
         sourceModel: !!root._allTokensModule ? root._allTokensModule.sourcesOfTokensModel : null
         proxyRoles: FastExpressionRole {
-            function sourceImage(sourceKey) {
-                return Constants.getSupportedTokenSourceImage(sourceKey)
+            function sourceImage(name) {
+                return Constants.getSupportedTokenSourceImage(name)
             }
             name: "image"
-            expression: sourceImage(model.key)
-            expectedRoles: ["key"]
+            expression: sourceImage(model.name)
+            expectedRoles: ["name"]
         }
         filters: AnyOf {
             ValueFilter {
-                roleName: "key"
+                roleName: "name"
                 value: Constants.supportedTokenSources.uniswap
             }
             ValueFilter {
-                roleName: "key"
+                roleName: "name"
                 value: Constants.supportedTokenSources.status
             }
         }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1194,11 +1194,11 @@ QtObject {
         return url.indexOf("DEFAULT-TOKEN") !== -1
     }
 
-    function getSupportedTokenSourceImage(key, useDefault=true) {
-        if (key === supportedTokenSources.uniswap)
+    function getSupportedTokenSourceImage(name, useDefault=true) {
+        if (name === supportedTokenSources.uniswap)
             return Style.png("tokens/UNI")
 
-        if (key === supportedTokenSources.status)
+        if (name === supportedTokenSources.status)
             return Style.png("tokens/SNT")
 
         if (useDefault)


### PR DESCRIPTION

fixes #14366

### What does the PR do

Modified TokenListPopup to use Constants.supportedTokenSources to match to known Token sources for the popup title similarly to the logic for Token Source Image (SNT/UNI/Default)

### Affected areas

TokenListPopup 

### Screenshot of functionality (including design for comparison)

![image](https://github.com/user-attachments/assets/c8d15733-2140-468d-b9f8-baae1f48efb0)


- [x] I've checked the design and this PR matches it

