### PR TITLE
[Wallet] Review and fix potential failures of AccountSelector, NetworkFilter and ModelEntry

### DIFF
--- a/ui/StatusQ/include/StatusQ/modelentry.h
+++ b/ui/StatusQ/include/StatusQ/modelentry.h
@@ -4,6 +4,7 @@
 #include <QPointer>
 #include <QQmlEngine>
 #include <QQmlPropertyMap>
+#include <QStringList>
 
 class ModelEntry : public QObject
 {
@@ -60,6 +61,8 @@ protected:
     void tryItemResetOrUpdate();
     void resetItem();
     void updateItem(const QList<int>& roles = {});
+    QStringList fillItem(const QList<int>& roles = {});
+    void notifyItemChanges(const QStringList& roles);
 
     QModelIndex findIndexInRange(int start, int end, const QList<int>& roles = {}) const;
     bool itemHasCorrectRoles() const;

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -139,11 +139,6 @@ Item {
 
         property SwapInputParamsForm swapFormData: SwapInputParamsForm {
             selectedAccountAddress: RootStore.selectedAddress
-            selectedNetworkChainId: {
-                // Without this when we switch testnet mode, the correct network is not evaluated
-                RootStore.areTestNetworksEnabled
-                return StatusQUtils.ModelUtils.get(RootStore.filteredFlatModel, 0, "chainId")
-            }
         }
 
         function displayAllAddresses() {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -442,7 +442,7 @@ StatusDialog {
             accountAddress: root.swapAdaptor.selectedAccount.address
             accountEmoji: root.swapAdaptor.selectedAccount.emoji
             accountColor: Utils.getColorForId(root.swapAdaptor.selectedAccount.colorId)
-            accountBalanceFormatted: payPanel.accountBalanceFormatted // FIXME https://github.com/status-im/status-desktop/issues/15554
+            accountBalanceFormatted: root.swapAdaptor.selectedAccount.accountBalance.formattedBalance
 
             networkShortName: networkFilter.singleSelectionItemData.shortName
             networkName: networkFilter.singleSelectionItemData.chainName

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -38,6 +38,7 @@ QObject {
     // Probably this data transformation should live there since they have common base.
     readonly property var nonWatchAccounts: SortFilterProxyModel {
         sourceModel: root.swapStore.accounts
+        delayed: true // Delayed to allow `processAccountBalance` dependencies to be resolved
         filters: ValueFilter {
             roleName: "canSend"
             value: true
@@ -49,7 +50,17 @@ QObject {
         proxyRoles: [
             FastExpressionRole {
                 name: "accountBalance"
-                expression: d.processAccountBalance(model.address)
+                expression: {
+                    // dependencies
+                    root.swapFormData.fromTokensKey
+                    root.fromToken
+                    root.fromToken.symbol
+                    root.fromToken.decimals
+                    root.swapFormData.selectedNetworkChainId
+                    root.swapFormData.fromTokensKey
+
+                    return d.processAccountBalance(model.address)
+                }
                 expectedRoles: ["address"]
             },
             FastExpressionRole {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -36,6 +36,7 @@ QtObject {
 
     /* This property holds networks currently selected in the Wallet Main layout  */
     readonly property var networkFilters: networksModule.enabledChainIds
+    readonly property var networkFiltersArray: networkFilters.split(":").filter(Boolean).map(Number)
 
     readonly property string defaultSelectedKeyUid: userProfile.keyUid
     readonly property bool defaultSelectedKeyUidMigratedToKeycard: userProfile.isKeycardUser

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -158,7 +158,7 @@ RightTabBaseView {
                             id: assetsViewAdaptor
 
                             accounts: RootStore.addressFilters
-                            chains: RootStore.networkFilters
+                            chains: RootStore.networkFiltersArray
 
                             marketValueThreshold:
                                 RootStore.tokensStore.displayAssetsBelowBalance

--- a/ui/imports/shared/views/AssetsViewAdaptor.qml
+++ b/ui/imports/shared/views/AssetsViewAdaptor.qml
@@ -27,7 +27,7 @@ QObject {
         image               [url]    - token's icon for custom tokens
         decimals            [int]    - number of decimal places, e.g. 18 for ETH
         balances            [model]  - submodel of balances per chain/account
-            chainId         [string] - unique identifier of a chain
+            chainId         [int]    - unique identifier of a chain
             account         [string] - unique identifier of an account
             balance         [string] - balance in basic unit as big integer string
         marketDetails       [object] - object holding market details
@@ -53,7 +53,7 @@ QObject {
     // should return empty string if no error found
     property var chainsError: chains => ""
 
-    // list of chain identifiers used for balance calculation
+    // array[Number]list of chain identifiers used for balance calculation
     property var chains: []
 
     // list of accounts used for balance calculation


### PR DESCRIPTION
### What does the PR do

Closes #15554 

Changes:

1. [chore(ModelEntry): Emit itemChanged event when the ModelEntry points …](https://github.com/status-im/status-desktop/commit/3d135d9a730c925d3b9f6bcbc5625a0088071660)
Adding `itemChanged` signal when ModelEntry points to another row in the model

2. [fix(Swap): Fixing the account balance in the swap modal](https://github.com/status-im/status-desktop/commit/39e72f071c61ba11ba17663fb8987fc7ccdb5eb3)
The root cause of this issue is the improper computation of the  `accountBalance`  expression role in the accounts model. Its value depends on another model (`filteredBalancesModel`) and by the time the expression role gets computed the proper `balance ` is not ready in the `filteredBalancesModel`.

This is a quick fix, but maybe the real fix should be restructuring the adapter and the model dependencies. I'd look out for any `ModelUtils` usage and replace it with a declarative approach if possible.

3. [fix(Swap): Remove unnecessary default chain pre-selection](https://github.com/status-im/status-desktop/commit/c0132c1f186352e9fbdcd411c8655cdd925434d9)
This shouldn't be needed! @Khushboo-dev-cpp Please have a look, maybe you can find some failing points.

4. [fix(AssetsView): Align the selected chains data type in the assets vi…](https://github.com/status-im/status-desktop/commit/2bda93f84b1ea1903b8a77d33d625fbf7b35626d) 
Nim chain selection is a colon separated string, but the assets adapter expects a chainId array for the selection


### Affected areas

Swap
AssetsView

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

I think this is the only commit with an impact on the end user
[fix(AssetsView): Align the selected chains data type in the assets vi…](https://github.com/status-im/status-desktop/commit/2bda93f84b1ea1903b8a77d33d625fbf7b35626d) 

It's fixing the AssetsView. Now the view is filtered based on the selected networks

Before:
https://github.com/user-attachments/assets/51ab89be-21c7-4cae-a9da-171ab12ab52d

After:

https://github.com/user-attachments/assets/fcb6b4bf-a241-45a4-b021-1f68161a89ca

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
