### PR TITLE
fix(networks): enable network before mint or airdrop

### DIFF
--- a/src/app/modules/main/wallet_section/networks/view.nim
+++ b/src/app/modules/main/wallet_section/networks/view.nim
@@ -91,6 +91,9 @@ QtObject:
     let (chainIds, enable) = self.flatNetworks.networksToChangeStateOnUserActionFor(chainId, self.areTestNetworksEnabled)
     self.delegate.setNetworksState(chainIds, enable)
 
+  proc enableNetwork*(self: View, chainId: int) {.slot.} =
+    self.delegate.setNetworksState(@[chainId], enable = true)
+
   proc getNetworkShortNames*(self: View, preferredNetworks: string): string {.slot.} =
     return self.flatNetworks.getNetworkShortNames(preferredNetworks, self.areTestNetworksEnabled)
   

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -235,6 +235,7 @@ StackLayout {
             id: communitySettingsView
             rootStore: root.rootStore
             walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
+            enabledChainIds: WalletStore.RootStore.networkFilters
             onEnableNetwork: WalletStore.RootStore.enableNetwork(chainId)
             tokensStore: root.tokensStore
             sendModalPopup: root.sendModalPopup

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -235,6 +235,7 @@ StackLayout {
             id: communitySettingsView
             rootStore: root.rootStore
             walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
+            onEnableNetwork: WalletStore.RootStore.enableNetwork(chainId)
             tokensStore: root.tokensStore
             sendModalPopup: root.sendModalPopup
             transactionStore: root.transactionStore

--- a/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
@@ -39,6 +39,7 @@ StackView {
     signal airdropClicked(var airdropTokens, var addresses, string feeAccountAddress)
     signal navigateToMintTokenSettings(bool isAssetType)
     signal registerAirdropFeeSubscriber(var feeSubscriber)
+    signal enableNetwork(int chainId)
 
     function navigateBack() {
         pop(StackView.Immediate)
@@ -120,6 +121,7 @@ StackView {
                 feeErrorText: feesSubscriber.feesError
                 feesPerSelectedContract: feesSubscriber.feesPerContract
                 feesAvailable: !!feesSubscriber.airdropFeesResponse
+                onEnableNetwork: root.enableNetwork(chainId)
 
                 onAirdropClicked: {
                     root.airdropClicked(airdropTokens, addresses, feeAccountAddress)

--- a/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
@@ -33,6 +33,8 @@ StackView {
     required property var membersModel
     required property var accountsModel
 
+    required property string enabledChainIds
+
     property int viewWidth: 560 // by design
     property string previousPageName: depth > 1 ? qsTr("Airdrops") : ""
 
@@ -121,6 +123,7 @@ StackView {
                 feeErrorText: feesSubscriber.feesError
                 feesPerSelectedContract: feesSubscriber.feesPerContract
                 feesAvailable: !!feesSubscriber.airdropFeesResponse
+                enabledChainIds: root.enabledChainIds
                 onEnableNetwork: root.enableNetwork(chainId)
 
                 onAirdropClicked: {

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -49,6 +49,9 @@ StackView {
     // It will monitorize if Owner and/or TMaster token items are included in the `tokensModel` despite the deployment state
     property bool ownerOrTMasterTokenItemsExist: false
 
+    property string enabledChainIds
+    property string networkThatIsNotActive
+
     // Models:
     property var tokensModel
     property var membersModel
@@ -290,7 +293,7 @@ StackView {
                 // Minted tokens will use ALWAYS the same chain where the owner token was deployed.
                 chainId: newTokenPage.ownerTokenChainId
                 chainName: newTokenPage.chainName
-                chainIcon: newTokenPage.chainIcon
+                chainIcon: newTokenPage.chainIconownerTokenChainId
             }
 
             property TokenObject collectible: TokenObject {
@@ -303,8 +306,12 @@ StackView {
             }
 
             Component.onCompleted: {
-                // Activate wallet network in case it is not
-                root.enableNetwork(newTokenPage.ownerTokenChainId)
+                 // If the tokens' network is not activated, show a warning to the user
+                if (!root.enabledChainIds.includes(newTokenPage.ownerTokenChainId)) {
+                    root.networkThatIsNotActive = newTokenPage.chainName
+                } else {
+                    root.networkThatIsNotActive = ""
+                }
             }
 
             property bool isAssetView: false
@@ -377,6 +384,12 @@ StackView {
                         feeText: deployFeeSubscriber.feeText
                         feeErrorText: deployFeeSubscriber.feeErrorText
                         isFeeLoading: !deployFeeSubscriber.feesResponse
+
+                        networkThatIsNotActive: root.networkThatIsNotActive
+                        onEnableNetwork: {
+                            root.enableNetwork(newTokenPage.ownerTokenChainId)
+                            root.networkThatIsNotActive = ""
+                        }
 
                         onPreviewClicked: {
                             const properties = {

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -83,6 +83,8 @@ StackView {
     signal startTokenHoldersManagement(int chainId, string address)
     signal stopTokenHoldersManagement()
 
+    signal enableNetwork(int chainId)
+
     function navigateBack() {
         pop(StackView.Immediate)
     }
@@ -300,7 +302,10 @@ StackView {
                 chainIcon: newTokenPage.chainIcon
             }
 
-
+            Component.onCompleted: {
+                // Activate wallet network in case it is not
+                root.enableNetwork(newTokenPage.ownerTokenChainId)
+            }
 
             property bool isAssetView: false
             property int validationMode: StatusInput.ValidationMode.OnlyWhenDirty

--- a/ui/app/AppLayouts/Communities/panels/NetworkWarningPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/NetworkWarningPanel.qml
@@ -1,0 +1,26 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+
+RowLayout {
+    id: root
+
+    property string networkThatIsNotActive
+    signal enableNetwork
+
+    spacing: 6
+
+    WarningPanel {
+        id: wantedNetworkNotActive
+        Layout.fillWidth: true
+        text: qsTr("The owner token is minted on a network that isn't selected. Click here to enable it:")
+    }
+
+    StatusButton {
+        text: qsTr("Enable %1").arg(root.networkThatIsNotActive)
+        Layout.alignment: Qt.AlignVCenter
+        onClicked: root.enableNetwork()
+    }
+}

--- a/ui/app/AppLayouts/Communities/panels/qmldir
+++ b/ui/app/AppLayouts/Communities/panels/qmldir
@@ -19,6 +19,7 @@ MembersSettingsPanel 1.0 MembersSettingsPanel.qml
 MembersTabPanel 1.0 MembersTabPanel.qml
 MintTokensFooterPanel 1.0 MintTokensFooterPanel.qml
 MintTokensSettingsPanel 1.0 MintTokensSettingsPanel.qml
+NetworkWarningPanel 1.0 NetworkWarningPanel.qml
 OverviewSettingsChart 1.0 OverviewSettingsChart.qml
 OverviewSettingsFooter 1.0 OverviewSettingsFooter.qml
 OverviewSettingsPanel 1.0 OverviewSettingsPanel.qml

--- a/ui/app/AppLayouts/Communities/popups/BurnTokensPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/BurnTokensPopup.qml
@@ -26,6 +26,7 @@ StatusDialog {
     property int multiplierIndex
     property url tokenSource
     property string chainName
+    property string networkThatIsNotActive
 
     readonly property alias amountToBurn: d.amountToBurn
     readonly property alias selectedAccountAddress: d.accountAddress
@@ -41,6 +42,7 @@ StatusDialog {
 
     signal burnClicked(string burnAmount, string accountAddress)
     signal cancelClicked
+    signal enableNetwork
 
     QtObject {
         id: d
@@ -185,6 +187,14 @@ StatusDialog {
                                                   ? "" : root.feeText
                 readonly property bool error: d.isFeeError
             }
+        }
+
+        NetworkWarningPanel {
+            visible: !!root.networkThatIsNotActive
+            Layout.fillWidth: true
+
+            networkThatIsNotActive: root.networkThatIsNotActive
+            onEnableNetwork: root.enableNetwork()
         }
     }
 

--- a/ui/app/AppLayouts/Communities/popups/RemotelyDestructPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/RemotelyDestructPopup.qml
@@ -19,6 +19,7 @@ StatusDialog {
     property alias model: tokenHoldersPanel.model
     property string collectibleName
     property string chainName
+    property string networkThatIsNotActive
 
     // Fees related properties:
     property bool isFeeLoading
@@ -38,6 +39,7 @@ StatusDialog {
     property var accounts
 
     signal remotelyDestructClicked(var walletsAndAmounts, string accountAddress)
+    signal enableNetwork
 
     QtObject {
         id: d
@@ -103,7 +105,7 @@ StatusDialog {
             id: feesBox
 
             Layout.fillWidth: true
-            Layout.bottomMargin: 16
+            Layout.bottomMargin: networkWarningPanel.visible ? 0 : 16
             Layout.leftMargin: 16
             Layout.rightMargin: 16
 
@@ -128,6 +130,19 @@ StatusDialog {
                                                       "" : root.feeText
                 readonly property bool error: d.isFeeError
             }
+        }
+
+        NetworkWarningPanel {
+            id: networkWarningPanel
+
+            visible: !!root.networkThatIsNotActive
+            Layout.fillWidth: true
+            Layout.bottomMargin: 16
+            Layout.leftMargin: 18
+            Layout.rightMargin: 18
+
+            networkThatIsNotActive: root.chainName
+            onEnableNetwork: root.enableNetwork()
         }
     }
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -51,6 +51,8 @@ StatusSectionLayout {
     required property bool isPendingOwnershipRequest
     signal finaliseOwnershipClicked
 
+    signal enableNetwork(int chainId)
+
     readonly property string filteredSelectedTags: {
         let tagsArray = []
         if (community && community.tags) {
@@ -372,6 +374,8 @@ StatusSectionLayout {
 
             onStopTokenHoldersManagement: communityTokensStore.stopTokenHoldersManagement()
 
+            onEnableNetwork: root.enableNetwork(chainId)
+
             onMintCollectible:
                 communityTokensStore.deployCollectible(
                     root.community.id, collectibleItem)
@@ -525,6 +529,7 @@ StatusSectionLayout {
             assetsModel: assetsModelLoader.item
             collectiblesModel: collectiblesModelLoader.item
             membersModel: community.members
+            onEnableNetwork: root.enableNetwork(chainId)
 
             accountsModel: root.walletAccountsModel
             onAirdropClicked: communityTokensStore.airdrop(

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -40,6 +40,8 @@ StatusSectionLayout {
     property bool communitySettingsDisabled
     property var sendModalPopup
 
+    required property string enabledChainIds
+
     required property var walletAccountsModel // name, address, emoji, color
 
     readonly property bool isOwner: community.memberRole === Constants.memberRole.owner
@@ -335,6 +337,7 @@ StatusSectionLayout {
             readonly property string sectionName: qsTr("Tokens")
             readonly property string sectionIcon: "token"
             readonly property bool sectionEnabled: true
+            enabledChainIds: root.enabledChainIds
 
             readonly property CommunityTokensStore communityTokensStore:
                 rootStore.communityTokensStore
@@ -529,6 +532,7 @@ StatusSectionLayout {
             assetsModel: assetsModelLoader.item
             collectiblesModel: collectiblesModelLoader.item
             membersModel: community.members
+            enabledChainIds: root.enabledChainIds
             onEnableNetwork: root.enableNetwork(chainId)
 
             accountsModel: root.walletAccountsModel

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -101,6 +101,8 @@ StatusScrollView {
 
     signal navigateToMintTokenSettings(bool isAssetType)
 
+    signal enableNetwork(int chainId)
+
     function selectToken(key, amount, type) {
         if(selectedHoldingsModel)
             selectedHoldingsModel.clear()
@@ -161,6 +163,7 @@ StatusScrollView {
                 key, amount, type,
                 tokenText: amountLocalized + " " + modelItem.name,
                 tokenImage: modelItem.iconSource,
+                networkId: modelItem.chainId,
                 networkText: modelItem.chainName,
                 networkImage: Style.svg(modelItem.chainIcon),
                 remainingSupply: modelItem.remainingSupply,
@@ -296,6 +299,9 @@ StatusScrollView {
                     const entry = d.prepareEntry(key, amount, Constants.TokenType.ERC20)
                     entry.valid = true
 
+                    // Activate wallet network in case it is not
+                    root.enableNetwork(entry.networkId)
+
                     selectedHoldingsModel.append(entry)
                     dropdown.close()
                 }
@@ -303,6 +309,9 @@ StatusScrollView {
                 onAddCollectible: {
                     const entry = d.prepareEntry(key, amount, Constants.TokenType.ERC721)
                     entry.valid = true
+
+                    // Activate wallet network in case it is not
+                    root.enableNetwork(entry.networkId)
 
                     selectedHoldingsModel.append(entry)
                     dropdown.close()

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -46,8 +46,6 @@ StatusScrollView {
     required property bool feesAvailable
 
     property string enabledChainIds
-    property string networkThatIsNotActive
-    property int networkIdThatIsNotActive
 
     property int viewWidth: 560 // by design
 
@@ -130,6 +128,9 @@ StatusScrollView {
         readonly property bool showFees: root.selectedHoldingsModel.count > 0
                                          && airdropRecipientsSelector.valid
                                          && airdropRecipientsSelector.count > 0
+
+        property string networkThatIsNotActive
+        property int networkIdThatIsNotActive
 
         readonly property var selectedContractKeysAndAmounts: {
             //Depedencies:
@@ -299,14 +300,14 @@ StatusScrollView {
                                 root.selectedHoldingsModel, ["key", "amount"])
                 }
 
-                function checkIfWeShouldShowNetworkWarning(entry) {
+                function isChainEnabled(entry) {
                     // If the tokens' network is not activated, show a warning to the user
-                    if (!root.enabledChainIds.includes(entry.networkId)) {
-                        root.networkThatIsNotActive = entry.networkText
-                        root.networkIdThatIsNotActive = entry.networkId
+                    if (!!entry && !root.enabledChainIds.includes(entry.networkId)) {
+                        d.networkThatIsNotActive = entry.networkText
+                        d.networkIdThatIsNotActive = entry.networkId
                     } else {
-                        root.networkThatIsNotActive = ""
-                        root.networkIdThatIsNotActive = 0
+                        d.networkThatIsNotActive = ""
+                        d.networkIdThatIsNotActive = 0
                     }
                 }
 
@@ -317,7 +318,7 @@ StatusScrollView {
                     selectedHoldingsModel.append(entry)
                     dropdown.close()
 
-                    checkIfWeShouldShowNetworkWarning(entry)
+                    isChainEnabled(entry)
                 }
 
                 onAddCollectible: {
@@ -327,7 +328,7 @@ StatusScrollView {
                     selectedHoldingsModel.append(entry)
                     dropdown.close()
 
-                    checkIfWeShouldShowNetworkWarning(entry)
+                    isChainEnabled(entry)
                 }
 
                 onUpdateAsset: {
@@ -576,27 +577,15 @@ StatusScrollView {
                      recipientsCountInstantiator.maximumRecipientsCount < airdropRecipientsSelector.count
         }
 
-        RowLayout {
-            spacing: 6
-            visible: !!root.networkThatIsNotActive
+        NetworkWarningPanel {
+            visible: !!d.networkThatIsNotActive
             Layout.fillWidth: true
             Layout.topMargin: Style.current.padding
-
-            WarningPanel {
-                id: wantedNetworkNotActive
-                Layout.fillWidth: true
-                text: qsTr("The token you selected is on a Network that you haven't selected in the Wallet. Click here to enable it:")
-
-            }
-
-            StatusButton {
-                text: qsTr("Enable %1").arg(root.networkThatIsNotActive)
-                Layout.alignment: Qt.AlignVCenter
-                onClicked: {
-                    root.enableNetwork(root.networkIdThatIsNotActive)
-                    root.networkThatIsNotActive = ""
-                    root.networkIdThatIsNotActive = 0
-                }
+            networkThatIsNotActive: d.networkThatIsNotActive
+            onEnableNetwork: {
+                root.enableNetwork(d.networkIdThatIsNotActive)
+                d.networkThatIsNotActive = ""
+                d.networkIdThatIsNotActive = 0
             }
         }
 

--- a/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
@@ -256,25 +256,13 @@ StatusScrollView {
             }
         }
 
-        RowLayout {
-            spacing: 6
+        NetworkWarningPanel {
             visible: !!root.networkThatIsNotActive
             Layout.fillWidth: true
             Layout.topMargin: Style.current.padding
 
-            WarningPanel {
-                id: wantedNetworkNotActive
-                Layout.fillWidth: true
-                text: qsTr("The owner token is minted on a network that isn't selected. Click here to enable it:")
-            }
-
-            StatusButton {
-                text: qsTr("Enable %1").arg(root.networkThatIsNotActive)
-                Layout.alignment: Qt.AlignVCenter
-                onClicked: {
-                    root.enableNetwork()
-                }
-            }
+            networkThatIsNotActive: root.networkThatIsNotActive
+            onEnableNetwork: root.enableNetwork()
         }
 
         CustomSwitchRowComponent {

--- a/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
@@ -44,6 +44,9 @@ StatusScrollView {
     property string feeErrorText
     property bool isFeeLoading
 
+    property string networkThatIsNotActive
+    signal enableNetwork
+
     readonly property string feeLabel:
         isAssetView ? qsTr("Mint asset on %1").arg(root.token.chainName)
                     : qsTr("Mint collectible on %1").arg(root.token.chainName)
@@ -249,6 +252,27 @@ StatusScrollView {
                     text: token.chainName
                     color: Theme.palette.baseColor1
                     visible: !!text
+                }
+            }
+        }
+
+        RowLayout {
+            spacing: 6
+            visible: !!root.networkThatIsNotActive
+            Layout.fillWidth: true
+            Layout.topMargin: Style.current.padding
+
+            WarningPanel {
+                id: wantedNetworkNotActive
+                Layout.fillWidth: true
+                text: qsTr("The owner token is minted on a network that isn't selected. Click here to enable it:")
+            }
+
+            StatusButton {
+                text: qsTr("Enable %1").arg(root.networkThatIsNotActive)
+                Layout.alignment: Qt.AlignVCenter
+                onClicked: {
+                    root.enableNetwork()
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -373,6 +373,10 @@ QtObject {
         networksModule.toggleNetwork(chainId)
     }
 
+    function enableNetwork(chainId) {
+        networksModule.enableNetwork(chainId)
+    }
+
     function copyToClipboard(text) {
         globalUtils.copyToClipboard(text)
     }


### PR DESCRIPTION
Fixes #15507

Makes sure to enable the network where the owner token was minted before minting or airdroping a token. This makes sure that the account selector shows the right balance and there is no ETH error before doing the transation

[activate-network.webm](https://github.com/user-attachments/assets/49c60a4b-3f7d-4ae3-a431-8c74d438c434)
