### PR TITLE
fix(Wallet/BridgeModal): Incorrect preselected recipient value

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -331,7 +331,6 @@ Item {
             }
             onLaunchBridgeModal: {
                 root.sendModalPopup.preSelectedSendType = Constants.SendType.Bridge
-                root.sendModalPopup.preSelectedRecipient = root.sendModalPopup.preSelectedAccount.address
                 root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
                 root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
                 root.sendModalPopup.onlyAssets = true

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -170,9 +170,19 @@ StatusDialog {
     onOpened: {
         amountToSendInput.input.input.edit.forceActiveFocus()
 
+        // IMPORTANT: This step must be the first one since it's storing the send type
+        // into the backend at this stage so that, before this assignement, some properties
+        // should not have the correct value, like `d.isBridgeTx`
         if(popup.preSelectedSendType !== Constants.SendType.Unknown) {
             store.setSendType(popup.preSelectedSendType)
         }
+
+        // To be removed once bridge is splitted to a different component:
+        if(d.isBridgeTx && !!popup.preSelectedAccount) {
+            // Default preselected type is `Helpers.RecipientAddressObjectType.Address` coinciding with bridge usecase
+            popup.preSelectedRecipient = popup.preSelectedAccount.address
+        }
+
         if (!!popup.preSelectedHoldingID
                 && popup.preSelectedHoldingType > Constants.TokenType.Native
                 && popup.preSelectedHoldingType < Constants.TokenType.Unknown) {

--- a/ui/imports/shared/popups/send/views/NetworkSelector.qml
+++ b/ui/imports/shared/popups/send/views/NetworkSelector.qml
@@ -89,7 +89,7 @@ Item {
                 errorMode: root.errorMode
                 errorType: root.errorType
                 fromNetworksList: root.fromNetworksList
-                toNetworksList: root.suggestedToNetworksList
+                suggestedToNetworksList: root.suggestedToNetworksList
                 // Collectibles don't have a symbol
                 selectedSymbol: !!root.selectedAsset && !!root.selectedAsset.symbol ? root.selectedAsset.symbol: ""
                 weiToEth: function(wei) {

--- a/ui/imports/shared/popups/send/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/popups/send/views/NetworksAdvancedCustomRoutingView.qml
@@ -79,7 +79,8 @@ ColumnLayout {
                 Layout.fillWidth: true
                 font.pixelSize: 15
                 color: Theme.palette.baseColor1
-                text: qsTr("The networks where the recipient will receive tokens. Amounts calculated automatically for the lowest cost.")
+                text: isBridgeTx ? qsTr("Routes will be automatically calculated to give you the lowest cost.") :
+                                  qsTr("The networks where the recipient will receive tokens. Amounts calculated automatically for the lowest cost.")
                 wrapMode: Text.WordWrap
             }
             Loader {

--- a/ui/imports/shared/popups/send/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/popups/send/views/NetworksSimpleRoutingView.qml
@@ -54,7 +54,7 @@ RowLayout {
             Layout.maximumWidth: parent.width
             font.pixelSize: 15
             color: Theme.palette.baseColor1
-            text: isBridgeTx ? qsTr("Choose the network to bridge token to") :
+            text: isBridgeTx ? qsTr("Routes will be automatically calculated to give you the lowest cost.") :
                               qsTr("The networks where the recipient will receive tokens. Amounts calculated automatically for the lowest cost.")
             wrapMode: Text.WordWrap
         }
@@ -134,8 +134,8 @@ RowLayout {
             contentItem: StatusListItem {
                 id: card
                 objectName: chainName
-                leftPadding: 5
-                rightPadding: 5
+                leftPadding: 16
+                rightPadding: 6
                 implicitWidth: 410
                 title: chainName
                 subTitle: root.formatCurrencyAmount(tokenBalance.amount, root.selectedSymbol)
@@ -144,14 +144,17 @@ RowLayout {
                 asset.height: 32
                 asset.name: Style.svg("tiny/" + iconUrl)
                 asset.isImage: true
-                border.color: gasRectangle.checked ? Theme.palette.primaryColor2 : "transparent"
+                border.color: gasRectangle.checked ? Theme.palette.primaryColor1 : Theme.palette.primaryColor2
                 color: {
-                    if (sensor.containsMouse || highlighted ||  gasRectangle.checked) {
-                        return Theme.palette.statusListItem.backgroundColor
+                    if (sensor.containsMouse) {
+                        return Theme.palette.baseColor2
                     }
-                    return Theme.palette.baseColor2
+                    Theme.palette.statusListItem.backgroundColor
                 }
-                onClicked: gasRectangle.toggle()
+                onClicked: {
+                    if(!gasRectangle.checked)
+                        gasRectangle.toggle()
+                }
             }
             onCheckedChanged: {
                 store.setRouteDisabledChains(chainId, !gasRectangle.checked)

--- a/ui/imports/shared/popups/send/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/popups/send/views/NetworksSimpleRoutingView.qml
@@ -22,13 +22,14 @@ RowLayout {
     property bool isBridgeTx: false
     property bool isCollectiblesTransfer: false
     property var fromNetworksList
-    property var toNetworksList
+    property var suggestedToNetworksList
     property var weiToEth: function(wei) {}
     property var formatCurrencyAmount: function () {}
     property var reCalculateSuggestedRoute: function() {}
     property bool errorMode: false
     property int errorType: Constants.NoError
     property string selectedSymbol
+
     spacing: 10
 
     StatusRoundIcon {
@@ -57,6 +58,7 @@ RowLayout {
                               qsTr("The networks where the recipient will receive tokens. Amounts calculated automatically for the lowest cost.")
             wrapMode: Text.WordWrap
         }
+
         ScrollView {
             Layout.fillWidth: true
             Layout.preferredHeight: visible ? row.height + 10 : 0
@@ -70,18 +72,20 @@ RowLayout {
             Column {
                 id: row
                 spacing: Style.current.padding
+
+                // TODO: This transformation should come from an adaptor outside this component
+                LeftJoinModel {
+                    id: toNetworksListLeftJoinModel
+
+                    leftModel: root.suggestedToNetworksList
+                    rightModel: root.store.flatNetworksModel
+                    joinRole: "chainId"
+                }
+
                 Repeater {
                     id: repeater
                     objectName: "networksList"
-                    model: LeftJoinModel {
-                        leftModel: {
-                            const m = isBridgeTx ? root.fromNetworksList : root.toNetworksList
-                            return !!m ? m : null
-                        }
-                        rightModel: root.store.flatNetworksModel
-                        joinRole: "chainId"
-                    }
-
+                    model: isBridgeTx ? root.fromNetworksList : toNetworksListLeftJoinModel
                     delegate: isBridgeTx ? networkItem : routeItem
                 }
             }


### PR DESCRIPTION
Fixes #15629

### What does the PR do

- Fixes issue when opening `BridgeModal`. Preselected recipient object assignement was wrong.
- Fixes issue showing available networks in `Simple` tab.
- Small UI fixes to be more accurate with new design and solve some UX issues like the one commented [here](https://github.com/status-im/status-desktop/issues/15216#issuecomment-2202911932)

### Affected areas

Opening Bridge Modal

### Screenshot of functionality

https://github.com/user-attachments/assets/79f41041-c57b-438c-8724-8f221390800a

### How to test
- What kind of user flows should be checked? Opening `BridgeModal` from the flows it can be open and be able to see the networks in `Simple` tab