### PR TITLE
[SwapModal]: Fix for can approve Swap with no amount entered Fix/15553

### DIFF
--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -8,6 +8,7 @@ import Storybook 1.0
 import Models 1.0
 
 import AppLayouts.Wallet.popups.swap 1.0
+import shared.stores 1.0
 
 import utils 1.0
 
@@ -73,6 +74,8 @@ SplitView {
                     destroyOnClose: true
                     modal: false
                     closePolicy: Popup.NoAutoClose
+
+                    currencyStore: CurrenciesStore{}
 
                     fromTokenSymbol: ctrlFromSymbol.text
                     fromTokenAmount: ctrlFromAmount.text

--- a/storybook/qmlTests/tests/tst_SwapSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapSignModal.qml
@@ -8,6 +8,7 @@ import Models 1.0
 import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Wallet.popups.swap 1.0
+import shared.stores 1.0
 
 import utils 1.0
 
@@ -16,10 +17,17 @@ Item {
     width: 600
     height: 400
 
+    QtObject {
+        id: d
+        readonly property var currencyStore: CurrenciesStore{}
+    }
+
     Component {
         id: componentUnderTest
         SwapSignModal {
             anchors.centerIn: parent
+
+            currencyStore: d.currencyStore
 
             fromTokenSymbol: "DAI"
             fromTokenAmount: "100.07"
@@ -95,7 +103,8 @@ Item {
 
             // title & subtitle
             compare(controlUnderTest.title, qsTr("Sign Swap"))
-            compare(controlUnderTest.subtitle, qsTr("1000.1235 SNT to 1.42 %2").arg(data.toTokenSymbol)) // subtitle rounded amounts
+            compare(controlUnderTest.subtitle, qsTr("%1 to %2").arg(d.currencyStore.formatCurrencyAmount(controlUnderTest.fromTokenAmount, controlUnderTest.fromTokenSymbol))
+                    .arg(d.currencyStore.formatCurrencyAmount(controlUnderTest.toTokenAmount, controlUnderTest.toTokenSymbol)))
 
             // info box
             const headerText = findChild(controlUnderTest.contentItem, "headerText")

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -461,6 +461,8 @@ StatusDialog {
         SwapSignModal {
             destroyOnClose: true
 
+            currencyStore: root.swapAdaptor.currencyStore
+
             loginType: root.swapAdaptor.selectedAccount.migratedToKeycard ? Constants.LoginType.Keycard : root.loginType
             feesLoading: root.swapAdaptor.swapProposalLoading
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -47,13 +47,13 @@ StatusDialog {
 
         function fetchSuggestedRoutes() {
             if (root.swapInputParamsForm.isFormFilledCorrectly()) {
-                root.swapAdaptor.validSwapProposalReceived = false
                 root.swapAdaptor.swapProposalLoading = true
-                root.swapAdaptor.approvalPending = false
-                root.swapAdaptor.approvalSuccessful = false
-                root.swapAdaptor.swapOutputData.resetPathInfoAndError()
-                debounceFetchSuggestedRoutes()
             }
+            root.swapAdaptor.validSwapProposalReceived = false
+            root.swapAdaptor.approvalPending = false
+            root.swapAdaptor.approvalSuccessful = false
+            root.swapAdaptor.swapOutputData.resetPathInfoAndError()
+            debounceFetchSuggestedRoutes()
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
@@ -18,6 +18,8 @@ import utils 1.0
 SignTransactionModalBase {
     id: root
 
+    required property var currencyStore
+
     required property string fromTokenSymbol
     required property string fromTokenAmount
     required property string fromTokenContractAddress
@@ -45,8 +47,9 @@ SignTransactionModalBase {
 
     title: qsTr("Sign Swap")
     //: e.g. (swap) 100 DAI to 100 USDT
-    subtitle: qsTr("%1 %2 to %3 %4").arg(formatBigNumber(fromTokenAmount, 4)).arg(fromTokenSymbol) // FIXME get the correct number of decimals to display from the "symbol"
-        .arg(formatBigNumber(toTokenAmount, 4)).arg(toTokenSymbol)
+    subtitle: qsTr("%1 to %2")
+    .arg(root.currencyStore.formatCurrencyAmount(fromTokenAmount, fromTokenSymbol))
+    .arg(root.currencyStore.formatCurrencyAmount(toTokenAmount, toTokenSymbol))
 
     gradientColor: Utils.setColorAlpha(root.accountColor, 0.05) // 5% of wallet color
     fromImageSource: Constants.tokenIcon(root.fromTokenSymbol)


### PR DESCRIPTION
#15553 , #15605 
### What does the PR do

reset output params when any of the values in the form changes and 
wrong value when amount entered with more that 4 decimal places in SwapSignModal

### Affected areas

SwapModal.qml, SwapSignModal.qml

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/cb27ce1f-126f-4daa-b450-d29a8d492738

https://github.com/user-attachments/assets/2c8868cf-7cb5-4d17-9933-64318e2adfa6

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->

### Cool Spaceship Picture

<!-- optional but cool -->
