### PR TITLE
fix: join community with keycard

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -732,10 +732,12 @@ method onDataSigned*(self: Module, keyUid: string, path: string, r: string, s: s
     # being here is not an error
     return
 
+  let vFixed = toLower(uint8(parseUint(v) + 27).toHex())
+
   for address, details in self.joiningCommunityDetails.addressesToShare.pairs:
     if details.keyUid != keyUid or details.path != path:
       continue
-    self.joiningCommunityDetails.addressesToShare[address].signature = "0x" & r & s & v
+    self.joiningCommunityDetails.addressesToShare[address].signature = "0x" & r & s & vFixed
     break
   self.signSharedAddressesForKeypair(keyUid, pin)
 

--- a/src/app/modules/main/wallet_section/poc_wallet_connect/controller.nim
+++ b/src/app/modules/main/wallet_section/poc_wallet_connect/controller.nim
@@ -96,7 +96,7 @@ QtObject:
     if keyUid.len == 0 or path.len == 0 or r.len == 0 or s.len == 0 or v.len == 0 or pin.len == 0:
       error "invalid data signed"
       return
-    let signature = "0x" & r & s & v // FIXME
+    let signature = "0x" & r & s & v
     if identifier == UNIQUE_WC_SESSION_REQUEST_SIGNING_IDENTIFIER:
       self.finishSessionRequest(signature)
     elif identifier == UNIQUE_WC_AUTH_REQUEST_SIGNING_IDENTIFIER:

--- a/src/app/modules/main/wallet_section/poc_wallet_connect/controller.nim
+++ b/src/app/modules/main/wallet_section/poc_wallet_connect/controller.nim
@@ -96,7 +96,7 @@ QtObject:
     if keyUid.len == 0 or path.len == 0 or r.len == 0 or s.len == 0 or v.len == 0 or pin.len == 0:
       error "invalid data signed"
       return
-    let signature = "0x" & r & s & v
+    let signature = "0x" & r & s & v // FIXME
     if identifier == UNIQUE_WC_SESSION_REQUEST_SIGNING_IDENTIFIER:
       self.finishSessionRequest(signature)
     elif identifier == UNIQUE_WC_AUTH_REQUEST_SIGNING_IDENTIFIER:


### PR DESCRIPTION
# Bug description

status-go uses `personal_sign` for signing the community join request.
It adds `\x19Ethereum Signed Message:\n32` prefix and hashes the result string, as per [EIP-191](https://eips.ethereum.org/EIPS/eip-191). 

But keycard doesn't do that, it expects a full-ready hash for signing.
As well it doesn't +27 for the `v` part of the signature.

# What does the PR do

1. Hash message before signing on keycard.
Reused status-go `HashMessage` function for this.

2. Add `27` to `signature.v` received from keycard.

# Decision record

1. I don't really like that we have to do these procedures manually on status-desktop side.
But changing status-go doesn't look possible, because `personal_sign` always prepends a prefix, there's no way to workaround it.

# Open questions

1. Another place we get r/s/v values from the keycard is here. I wasn't sure if we should add `27` here as well:
Would be nice if someone from wallet team could check it. cc @dlipicar @alaibe.
https://github.com/status-im/status-desktop/blob/82dbdbe2f00c5974b0caa0362c66146fc521fc4f/src/app/modules/main/wallet_section/poc_wallet_connect/controller.nim#L99

2. Can we fix the lost keycard community join requests?

// TBD, I'm testing it.

### Affected areas

- Joining communities with keycard

### Screenshot of functionality (including design for comparison)

### Impact on end user


### How to test

- Create an account with keycard
- Try to join a community (doesn't matter if it's token-gated or not)
- Ensure that the request reaches the control node

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.