### PR TITLE
fix(SeedPhrasePopup): fixed popup size when there is 1 item in the list.

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -147,7 +147,7 @@ Item {
             if (textToCheck === "") {
                 return;
             }
-            
+
             for (var i = 0; i < inputList.count; i++) {
                 if (inputList.get(i).seedWord.startsWith(textToCheck)) {
                     filteredList.insert(filteredList.count, {"seedWord": inputList.get(i).seedWord});
@@ -191,7 +191,7 @@ Item {
                     break;
                 }
             }
-            
+
             root.keyPressed(event);
         }
         onEditClicked: {
@@ -206,11 +206,14 @@ Item {
     Popup {
         id: suggListContainer
         contentWidth: seedSuggestionsList.width
-        contentHeight: ((seedSuggestionsList.count <= 5) ? seedSuggestionsList.count : 5) *34 + 16
+        contentHeight: ((seedSuggestionsList.count <= 5) ? seedSuggestionsList.count : 5) *34
         x: 16
         y: seedWordInput.height + 4
         topPadding: 8
         bottomPadding: 8
+        leftPadding: 0
+        rightPadding: 0
+
         visible: ((filteredList.count > 0) && seedWordInput.input.edit.activeFocus)
         background: Rectangle {
             id: statusMenuBackgroundContent
@@ -242,6 +245,7 @@ Item {
             clip: true
             ScrollBar.vertical: ScrollBar { }
             model: root.filteredList
+
             delegate: Item {
                 id: txtDelegate
                 width: suggWord.contentWidth


### PR DESCRIPTION
Fixes: #15478

### What does the PR do

For the Popup component inside StatusSeedPhraseInput `contentHeight` was calculated incorrectly (it contained top and bottom margins of the popup). Previous logic was calculating `height`, therefore margins had to be included.

### Affected areas

StatusQ.Controls.StatusSeedPhraseInput

### StatusQ checklist

- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/8b7f3ab7-26d5-4892-b314-314c8210fd4a

