### PR TITLE
15217 UI   wallet stability ensure  review all the entry points for send

### DIFF
--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -138,12 +138,18 @@ QtObject:
       else:
         offset = self.tempItems.len
     self.fetchFromStart = false
-    let response = backend_collectibles.getOwnedCollectiblesAsync(self.requestId, self.chainIds, self.addresses, self.filter, offset, FETCH_BATCH_COUNT_DEFAULT, self.dataType, self.fetchCriteria)
-    if response.error != nil:
+    try:
+      let response = backend_collectibles.getOwnedCollectiblesAsync(self.requestId, self.chainIds, self.addresses, self.filter, offset, FETCH_BATCH_COUNT_DEFAULT, self.dataType, self.fetchCriteria)
+      if response.error != nil:
+        self.model.setIsFetching(false)
+        self.model.setIsError(true)
+        self.fetchFromStart = true
+        error "error fetching collectibles entries: ", response.error
+    except Exception as e:
+      error "error fetching collectibles entries: ", e.msg
       self.model.setIsFetching(false)
       self.model.setIsError(true)
       self.fetchFromStart = true
-      error "error fetching collectibles entries: ", response.error
 
   proc onModelLoadMoreItems(self: Controller) {.slot.} =
     if self.loadType.isAutoLoad():

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -112,6 +112,7 @@ SplitView {
                                             qsTr("%1 community collectibles are now visible").arg(communityName), "", "checkmark-circle",
                                             false, Constants.ephemeralNotificationType.success, "")
         }
+        ownedAccountsModel: WalletAccountsModel {}
         networkFilters: d.networksChainsCurrentlySelected
         addressFilters: d.addressesSelected
         filterVisible: ctrlFilterVisible.checked

--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -197,7 +197,7 @@ SplitView {
                 closePolicy: Popup.NoAutoClose
                 onlyAssets: loader.onlyAssets
                 store: txStore
-                preSelectedAccount: loader.preSelectedAccount
+                preSelectedAccountAddress: loader.preSelectedAccount.address
                 preDefinedAmountToSend: loader.preDefinedAmountToSend
                 preSelectedRecipient: loader.preSelectedRecipient
                 preSelectedSendType: loader.preSelectedSendType

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -441,7 +441,7 @@ StatusSectionLayout {
                 y: (Math.abs(browserHeader.mapFromGlobal(headerPoint).y) +
                     browserHeader.anchors.topMargin + Style.current.halfPadding)
                 onSendTriggered: {
-                    sendTransactionModal.preSelectedAccount = selectedAccount
+                    sendTransactionModal.preSelectedAccountAddress = selectedAccount.address
                     sendTransactionModal.open()
                 }
                 onReload: {

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -761,7 +761,6 @@ StackView {
                                                                       root.communityName,
                                                                       root.communityLogo,
                                                                       tokenViewPage.token,
-                                                                      root.accounts,
                                                                       root.sendModalPopup)
 
             // helper properties to pass data through popups

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -47,7 +47,6 @@ StackLayout {
     property bool isControlNode: false
     property int loginType: Constants.LoginType.Password
     property bool communitySettingsDisabled
-    property var accounts // Wallet accounts model. Expected roles: address, name, color, emoji, walletType
     property var ownerToken: null
 
     property string overviewChartData: ""
@@ -137,7 +136,6 @@ StackLayout {
                                                               root.name,
                                                               root.logoImageData,
                                                               root.ownerToken,
-                                                              root.accounts,
                                                               root.sendModalPopup)
                         } else {
                             Global.openPopup(transferOwnershipAlertPopup, { mode: TransferOwnershipAlertPopup.Mode.TransferOwnership })

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
@@ -27,7 +27,6 @@ StatusDialog {
 
     // Transaction related props:
     property var token // Expected roles: accountAddress, key, chainId, name, artworkSource
-    property var accounts
     property var sendModalPopup
 
     signal cancelClicked
@@ -112,7 +111,7 @@ StatusDialog {
                 onClicked: {
                     // Pre-populated dialog with the relevant Owner token info:
                     root.sendModalPopup.preSelectedSendType = Constants.SendType.ERC721Transfer
-                    root.sendModalPopup.preSelectedAccount = ModelUtils.getByKey(root.accounts, "address", token.accountAddress)
+                    root.sendModalPopup.preSelectedAccountAddress = token.accountAddress
                     const store = WalletStores.RootStore.currentActivityFiltersStore
                     const uid = store.collectiblesList.getUidForData(token.key, token.tokenAddress, token.chainId);
                     root.sendModalPopup.preSelectedHoldingID = uid

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -198,7 +198,6 @@ StatusSectionLayout {
 
             sendModalPopup: root.sendModalPopup
             ownerToken: tokensModelChangesTracker.ownerToken
-            accounts: root.walletAccountsModel
 
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
 

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -305,20 +305,21 @@ Item {
                                                               })
             onLaunchSendModal: {
                 if(isCommunityOwnershipTransfer) {
-                    let tokenItem = walletStore.currentViewedCollectible
-                    Global.openTransferOwnershipPopup(walletStore.currentViewedCollectible.communityId,
+                    const tokenItem = walletStore.currentViewedCollectible
+                    const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
+
+                    Global.openTransferOwnershipPopup(tokenItem.communityId,
                                                       tokenItem.communityName,
                                                       tokenItem.communityImage,
                                                       {
-                                                          "key": walletStore.currentViewedHoldingID,
+                                                          "key": tokenItem.tokenId,
                                                           "privilegesLevel": tokenItem.communityPrivilegesLevel,
                                                           "chainId": tokenItem.chainId,
                                                           "name": tokenItem.name,
                                                           "artworkSource": tokenItem.artworkSource,
-                                                          "accountAddress": leftTab.currentAddress,
+                                                          "accountAddress": ownership.accountAddress,
                                                           "tokenAddress": tokenItem.contractAddress
                                                       },
-                                                      walletStore.accounts,
                                                       root.sendModalPopup)
                 } else {
                     // Common send modal popup:

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -309,7 +309,7 @@ Item {
                     const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
 
                     Global.openTransferOwnershipPopup(tokenItem.communityId,
-                                                      tokenItem.communityName,
+                                                      footer.communityName,
                                                       tokenItem.communityImage,
                                                       {
                                                           "key": tokenItem.tokenId,
@@ -321,14 +321,20 @@ Item {
                                                           "tokenAddress": tokenItem.contractAddress
                                                       },
                                                       root.sendModalPopup)
-                } else {
-                    // Common send modal popup:
-                    root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
-                    root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
-                    root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
-                    root.sendModalPopup.onlyAssets = false
-                    root.sendModalPopup.open()
+                    return
                 }
+
+                if (isHoldingSelected) {
+                    const tokenItem = walletStore.currentViewedCollectible
+                    const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
+                    root.sendModalPopup.preSelectedAccountAddress = ownership.accountAddress
+                }
+                // Common send modal popup:
+                root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
+                root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
+                root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
+                root.sendModalPopup.onlyAssets = false
+                root.sendModalPopup.open()
             }
             onLaunchBridgeModal: {
                 root.sendModalPopup.preSelectedSendType = Constants.SendType.Bridge

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -283,7 +283,7 @@ Item {
             readonly property bool isCommunityCollectible: !!walletStore.currentViewedCollectible ? walletStore.currentViewedCollectible.communityId !== "" : false
             readonly property bool isOwnerCommunityCollectible: isCommunityCollectible ? (walletStore.currentViewedCollectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) : false
 
-            visible: !RootStore.showAllAccounts || Global.featureFlags.swapEnabled
+            visible: anyActionAvailable
             width: parent.width
             height: visible ? 61: implicitHeight
             walletStore: RootStore
@@ -303,7 +303,7 @@ Item {
                                                                   changingPreferredChainsEnabled: true,
                                                                   hasFloatingButtons: true
                                                               })
-            onLaunchSendModal: {
+            onLaunchSendModal: (fromAddress) => {
                 if(isCommunityOwnershipTransfer) {
                     const tokenItem = walletStore.currentViewedCollectible
                     const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
@@ -312,24 +312,19 @@ Item {
                                                       footer.communityName,
                                                       tokenItem.communityImage,
                                                       {
-                                                          "key": tokenItem.tokenId,
-                                                          "privilegesLevel": tokenItem.communityPrivilegesLevel,
-                                                          "chainId": tokenItem.chainId,
-                                                          "name": tokenItem.name,
-                                                          "artworkSource": tokenItem.artworkSource,
-                                                          "accountAddress": ownership.accountAddress,
-                                                          "tokenAddress": tokenItem.contractAddress
+                                                          key: tokenItem.tokenId,
+                                                          privilegesLevel: tokenItem.communityPrivilegesLevel,
+                                                          chainId: tokenItem.chainId,
+                                                          name: tokenItem.name,
+                                                          artworkSource: tokenItem.artworkSource,
+                                                          accountAddress: fromAddress,
+                                                          tokenAddress: tokenItem.contractAddress
                                                       },
                                                       root.sendModalPopup)
                     return
                 }
-
-                if (isHoldingSelected) {
-                    const tokenItem = walletStore.currentViewedCollectible
-                    const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
-                    root.sendModalPopup.preSelectedAccountAddress = ownership.accountAddress
-                }
                 // Common send modal popup:
+                root.sendModalPopup.preSelectedAccountAddress = fromAddress
                 root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
                 root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
                 root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
@@ -358,7 +353,7 @@ Item {
 
             ModelEntry {
                 id: selectedCommunityForCollectible
-                sourceModel: footer.isCommunityCollectible ? root.communitiesStore.communitiesList : null
+                sourceModel: !!footer.walletStore.currentViewedCollectible && footer.isCommunityCollectible ? root.communitiesStore.communitiesList : null
                 key: "id"
                 value: footer.walletStore.currentViewedCollectible.communityId
             }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
+import StatusQ 0.1
 import StatusQ.Layout 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
@@ -290,14 +291,13 @@ Item {
             networkConnectionStore: root.networkConnectionStore
             isCommunityOwnershipTransfer: footer.isHoldingSelected && footer.isOwnerCommunityCollectible
             communityName: {
-                if (!walletStore.currentViewedCollectible)
-                    return ""
-                const name = walletStore.currentViewedCollectible.communityName
-                const id = walletStore.currentViewedCollectible.communityId
-                if (name === id)
-                    return Utils.compactAddress(id, 4)
-                return name
+                if (selectedCommunityForCollectible.available)
+                    return selectedCommunityForCollectible.item.name
+                if (isCommunityCollectible)
+                    return Utils.compactAddress(walletStore.currentViewedCollectible.communityId, 4)
+                return ""
             }
+
             onLaunchShareAddressModal: Global.openShowQRPopup({
                                                                   switchingAccounsEnabled: true,
                                                                   changingPreferredChainsEnabled: true,
@@ -354,6 +354,13 @@ Item {
                 }
                 d.swapFormData.defaultToTokenKey = RootStore.areTestNetworksEnabled ? Constants.swap.testStatusTokenKey : Constants.swap.mainnetStatusTokenKey
                 Global.openSwapModalRequested(d.swapFormData)
+            }
+
+            ModelEntry {
+                id: selectedCommunityForCollectible
+                sourceModel: footer.isCommunityCollectible ? root.communitiesStore.communitiesList : null
+                key: "id"
+                value: footer.walletStore.currentViewedCollectible.communityId
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.13
+import QtQml 2.15
 
 import StatusQ 0.1
 import StatusQ.Popups 0.1
@@ -48,6 +49,7 @@ Rectangle {
         Binding on collectibleOwnerAddress {
             when: d.isCollectibleViewed && !!root.walletStore.currentViewedCollectible && !!root.walletStore.currentViewedCollectible.ownership.ModelCount.count
             value: SQUtils.ModelUtils.get(root.walletStore.currentViewedCollectible.ownership, 0).accountAddress
+            restoreMode: Binding.RestoreBindingOrValue
         }
 
         readonly property ModelEntry owningAccount: ModelEntry {
@@ -65,9 +67,12 @@ Rectangle {
     RowLayout {
         anchors.centerIn: parent
         height: parent.height
+        width: Math.min(parent.width, implicitWidth)
         spacing:  Style.current.padding
 
         StatusFlatButton {
+            Layout.fillWidth: true
+            Layout.maximumWidth: implicitWidth
             objectName: "walletFooterSendButton"
             icon.name: "send"
             text: root.isCommunityOwnershipTransfer ? qsTr("Send Owner token to transfer %1 Community ownership").arg(root.communityName) : qsTr("Send")
@@ -113,7 +118,7 @@ Rectangle {
             icon.name: "token"
             text: qsTr("Buy")
             onClicked: Global.openBuyCryptoModalRequested()
-        }        
+        }
 
         StatusFlatButton {
             id: swap

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -2,9 +2,11 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.13
 
+import StatusQ 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 
 import utils 1.0
 import shared.controls 1.0
@@ -37,6 +39,22 @@ Rectangle {
                                                     (walletStore.currentViewedHoldingType === Constants.TokenType.ERC721 ||
                                                     walletStore.currentViewedHoldingType === Constants.TokenType.ERC1155)
         readonly property bool isCollectibleSoulbound: isCollectibleViewed && !!walletStore.currentViewedCollectible && walletStore.currentViewedCollectible.soulbound
+
+        readonly property bool isCollectibleOwned: d.owningAccount.available
+
+        readonly property bool hideCollectibleTransferActions: isCollectibleViewed && !isCollectibleOwned
+
+        property string collectibleOwnerAddress
+        Binding on collectibleOwnerAddress {
+            when: d.isCollectibleViewed && !!root.walletStore.currentViewedCollectible && !!root.walletStore.currentViewedCollectible.ownership.ModelCount.count
+            value: SQUtils.ModelUtils.get(root.walletStore.currentViewedCollectible.ownership, 0).accountAddress
+        }
+
+        readonly property ModelEntry owningAccount: ModelEntry {
+            sourceModel: d.isCollectibleViewed ? root.walletStore.nonWatchAccounts : null
+            key: "address"
+            value: d.collectibleOwnerAddress ?? ""
+        }
     }
 
     StatusModalDivider {
@@ -55,11 +73,14 @@ Rectangle {
             text: root.isCommunityOwnershipTransfer ? qsTr("Send Owner token to transfer %1 Community ownership").arg(root.communityName) : qsTr("Send")
             interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
             onClicked: {
-                root.transactionStore.setSenderAccount(root.walletStore.selectedAddress)
+                if (!!root.walletStore.selectedAddress)
+                    root.transactionStore.setSenderAccount(root.walletStore.selectedAddress)
                 root.launchSendModal()
             }
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be sent to another wallet") : networkConnectionStore.sendBuyBridgeToolTipText
-            visible: !walletStore.overview.isWatchOnlyAccount && walletStore.overview.canSend && !root.walletStore.showAllAccounts
+            visible: !walletStore.overview.isWatchOnlyAccount
+                        && walletStore.overview.canSend
+                        && !d.hideCollectibleTransferActions
         }
 
         StatusFlatButton {
@@ -78,7 +99,11 @@ Rectangle {
             interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
             onClicked: root.launchBridgeModal()
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be bridged to another wallet") :  networkConnectionStore.sendBuyBridgeToolTipText
-            visible: !walletStore.overview.isWatchOnlyAccount && !root.isCommunityOwnershipTransfer && walletStore.overview.canSend && !root.walletStore.showAllAccounts
+            visible: !walletStore.overview.isWatchOnlyAccount
+                        && !root.isCommunityOwnershipTransfer
+                        && walletStore.overview.canSend
+                        && !root.walletStore.showAllAccounts 
+                        && !d.hideCollectibleTransferActions
         }
 
         StatusFlatButton {
@@ -94,7 +119,7 @@ Rectangle {
             id: swap
 
             interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
-            visible: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount
+            visible: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount && !d.hideCollectibleTransferActions
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be swapped") :  networkConnectionStore.sendBuyBridgeToolTipText
             icon.name: "swap"
             text: qsTr("Swap")

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -327,7 +327,7 @@ QtObject {
             return false
 
         let res = SQUtils.ModelUtils.getByKey(root.accounts, "address", tx.sender)
-        if (!res || res.object.walletType === Constants.watchWalletType)
+        if (!res || res.walletType === Constants.watchWalletType)
             return false
 
         if (tx.isNFT) {

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -265,31 +265,26 @@ RightTabBaseView {
 
                             stack.currentIndex = 1
                         }
-                        onSendRequested: (symbol, tokenType) => {
+                        onSendRequested: (symbol, tokenType, fromAddress) => {
                             const collectible = ModelUtils.getByKey(controller.sourceModel, "symbol", symbol)
-                            if (collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) {
-                                const ownerAccountItem = ModelUtils.get(collectible.ownership, 0)
+                            if (!!collectible && collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) {
                                 Global.openTransferOwnershipPopup(collectible.communityId,
                                                                   collectible.communityName,
                                                                   collectible.communityImage,
                                                                   {
-                                                                      "key": collectible.tokenId,
-                                                                      "privilegesLevel": collectible.communityPrivilegesLevel,
-                                                                      "chainId": collectible.chainId,
-                                                                      "name": collectible.name,
-                                                                      "artworkSource": collectible.communityImage,
-                                                                      "accountAddress": ownerAccountItem.accountAddress,
-                                                                      "tokenAddress": collectible.contractAddress
+                                                                      key: collectible.tokenId,
+                                                                      privilegesLevel: collectible.communityPrivilegesLevel,
+                                                                      chainId: collectible.chainId,
+                                                                      name: collectible.name,
+                                                                      artworkSource: collectible.communityImage,
+                                                                      accountAddress: fromAddress,
+                                                                      tokenAddress: collectible.contractAddress
                                                                   },
                                                                   root.sendModal)
                                 return
-                                                            
                             }
-
-                            if (!!collectible) {
-                                const ownerAccountItem = ModelUtils.get(collectible.ownership, 0)
-                                root.sendModal.preSelectedAccountAddress = ownerAccountItem.accountAddress
-                            }
+                        
+                            root.sendModal.preSelectedAccountAddress = fromAddress
                             root.sendModal.preSelectedHoldingID = symbol
                             root.sendModal.preSelectedHoldingType = tokenType
                             root.sendModal.preSelectedSendType = tokenType === Constants.TokenType.ERC721 ?

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -782,7 +782,7 @@ Item {
                                                                       tx.isNFT,
                                                                       tx.amount)
 
-                        root.sendModal.preSelectedAccount = req.preSelectedAccount
+                        root.sendModal.preSelectedAccountAddress = req.preSelectedAccount.address
                         root.sendModal.preSelectedRecipient = req.preSelectedRecipient
                         root.sendModal.preSelectedRecipientType = req.preSelectedRecipientType
                         root.sendModal.preSelectedHoldingID = req.preSelectedHoldingID

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1511,7 +1511,7 @@ Item {
                 this.active = false
             }
 
-            property var preSelectedAccount
+            property string preSelectedAccountAddress
             property var preSelectedRecipient
             property int preSelectedRecipientType
             property string preSelectedHoldingID
@@ -1533,14 +1533,14 @@ Item {
                     sendModal.preSelectedSendType = Constants.SendType.Unknown
                     sendModal.preSelectedHoldingID = ""
                     sendModal.preSelectedHoldingType = Constants.TokenType.Unknown
-                    sendModal.preSelectedAccount = undefined
+                    sendModal.preSelectedAccountAddress = ""
                     sendModal.preSelectedRecipient = undefined
                     sendModal.preDefinedAmountToSend = ""
                 }
             }
             onLoaded: {
-                if (!!sendModal.preSelectedAccount) {
-                    item.preSelectedAccount = sendModal.preSelectedAccount
+                if (!!sendModal.preSelectedAccountAddress) {
+                    item.preSelectedAccountAddress = sendModal.preSelectedAccountAddress
                 }
                 if (!!sendModal.preSelectedRecipient) {
                     item.preSelectedRecipient = sendModal.preSelectedRecipient

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -345,8 +345,8 @@ QtObject {
         openPopup(importControlNodePopup, { community })
     }
 
-    function openTransferOwnershipPopup(communityId, communityName, communityLogo, token, accounts, sendModalPopup) {
-        openPopup(transferOwnershipPopup, { communityId, communityName, communityLogo, token, accounts, sendModalPopup })
+    function openTransferOwnershipPopup(communityId, communityName, communityLogo, token, sendModalPopup) {
+        openPopup(transferOwnershipPopup, { communityId, communityName, communityLogo, token, sendModalPopup })
     }
 
     function openConfirmExternalLinkPopup(link, domain) {

--- a/ui/imports/shared/controls/AccountSelector.qml
+++ b/ui/imports/shared/controls/AccountSelector.qml
@@ -122,6 +122,11 @@ StatusComboBox {
         sourceModel: root.model ?? null
         key: "address"
         value: d.currentAccountSelection
+        onAvailableChanged: {
+            if (!available) {
+                d.resetSelection()
+            }
+        }
     }
 
     QtObject {
@@ -131,6 +136,15 @@ StatusComboBox {
         Binding on currentAccountSelection {
             value: root.selectedAddress || root.currentValue
         }
+
+        function resetSelection() {
+            currentAccountSelection = ""
+        }
+    }
+
+    Component.onCompleted: {
+        if (!selectedEntry.available)
+            d.resetSelection()
     }
 }
 

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -230,7 +230,6 @@ StatusDialog {
                 holdingSelector.currentTab = TokenSelectorPanel.Tabs.Collectibles
             }
         }
-
         if(!!popup.preDefinedAmountToSend) {
             // TODO: At this stage the number should not be localized. However
             // in many places when initializing popup the number is provided

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -107,7 +107,7 @@ StatusDialog {
             return Constants.NoError
         }
 
-        readonly property double maxFiatBalance: isSelectedHoldingValidAsset ? selectedHolding.currentCurrencyBalance : 0
+        readonly property double maxFiatBalance: isSelectedHoldingValidAsset ? selectedHolding.currencyBalance : 0
         readonly property double maxCryptoBalance: isSelectedHoldingValidAsset ? selectedHolding.currentBalance : 0
         readonly property double maxInputBalance: amountToSend.fiatMode ? maxFiatBalance : maxCryptoBalance
 
@@ -194,9 +194,9 @@ StatusDialog {
         }
 
         // To be removed once bridge is splitted to a different component:
-        if(d.isBridgeTx && !!popup.preSelectedAccount) {
+        if(d.isBridgeTx && !!popup.preSelectedAccountAddress) {
             // Default preselected type is `Helpers.RecipientAddressObjectType.Address` coinciding with bridge usecase
-            popup.preSelectedRecipient = popup.preSelectedAccount.address
+            popup.preSelectedRecipient = popup.preSelectedAccountAddress
         }
 
         if (!!popup.preSelectedHoldingID

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -33,7 +33,7 @@ import "./views"
 StatusDialog {
     id: popup
 
-    property var preSelectedAccount: selectedAccount
+    property string preSelectedAccountAddress: store.selectedSenderAccountAddress
 
     // Recipient properties definition
     property alias preSelectedRecipient: recipientInputLoader.selectedRecipient
@@ -64,7 +64,7 @@ StatusDialog {
     }
 
     // In case selected address is incorrect take first account from the list
-    readonly property var selectedAccount: selectedSenderAccountEntry.item ?? SQUtils.ModelUtils.get(store.accounts, 0)
+    readonly property alias selectedAccount: selectedSenderAccountEntry.item
 
     property var sendTransaction: function() {
         d.isPendingTx = true
@@ -72,7 +72,7 @@ StatusDialog {
     }
 
     property var recalculateRoutesAndFees: Backpressure.debounce(popup, 600, function() {
-        if(!!popup.preSelectedAccount && !!holdingSelector.selectedItem
+        if(!!popup.selectedAccount && !!popup.selectedAccount.address && !!holdingSelector.selectedItem
                 && recipientInputLoader.ready && (amountToSend.ready || d.isCollectiblesTransfer)) {
             popup.isLoading = true
             popup.store.suggestedRoutes(d.isCollectiblesTransfer ? "1" : amountToSend.amount)
@@ -215,8 +215,8 @@ StatusDialog {
                 holdingSelector.selectedItem = entry
             } else {
                 const entry = SQUtils.ModelUtils.getByKey(
-                                popup.store.collectiblesModel,
-                                "uid", popup.preSelectedHoldingID)
+                                popup.collectiblesStore.allCollectiblesModel,
+                                "symbol", popup.preSelectedHoldingID)
 
                 d.selectedHoldingType = entry.tokenType
                 d.selectedHolding = entry
@@ -275,7 +275,7 @@ StatusDialog {
                     }
                 ]
             }
-            selectedAddress: !!popup.preSelectedAccount && !!popup.preSelectedAccount.address ? popup.preSelectedAccount.address : ""
+            selectedAddress: popup.preSelectedAccountAddress
             onCurrentAccountAddressChanged: {
                 store.setSenderAccount(currentAccountAddress)
 
@@ -348,7 +348,7 @@ StatusDialog {
 
                             flatNetworksModel: popup.store.flatNetworksModel
                             currentCurrency: popup.store.currencyStore.currentCurrency
-                            accountAddress: popup.preSelectedAccount ? popup.preSelectedAccount.address : ""
+                            accountAddress: popup.selectedAccount.address
                             showCommunityAssets: popup.store.tokensStore.showCommunityAssetsInSend
                         }
 
@@ -358,7 +358,7 @@ StatusDialog {
                             active: !d.isBridgeTx
 
                             sourceComponent: CollectiblesSelectionAdaptor {
-                                accountKey: popup.preSelectedAccount ? popup.preSelectedAccount.address : ""
+                                accountKey: popup.selectedAccount.address
 
                                 collectiblesModel: SortFilterProxyModel {
                                     sourceModel: collectiblesStore ? collectiblesStore.jointCollectiblesBySymbolModel : null
@@ -568,14 +568,14 @@ StatusDialog {
             }
 
             // Only request transactions history update if visually needed:
-            onRecentRecipientsTabSelected: popup.store.updateRecentRecipientsActivity(popup.preSelectedAccount)
+            onRecentRecipientsTabSelected: popup.store.updateRecentRecipientsActivity(popup.selectedAccount.address)
 
             Connections {
                 target: popup
-                function onPreSelectedAccountChanged() {
+                function onSelectedAccountChanged() {
                     // Only request transactions history update if visually needed:
                     if(recipientsPanel.recentRecipientsTabVisible) {
-                        popup.store.updateRecentRecipientsActivity(popup.preSelectedAccount)
+                        popup.store.updateRecentRecipientsActivity(popup.selectedAccount.address)
                     }
                 }
             }

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -184,9 +184,9 @@ QtObject {
         return currencyStore.formatCurrencyAmountFromBigInt(balance, symbol, decimals, options)
     }
 
-    function updateRecentRecipientsActivity(walletAccount) {
-        if(walletAccount && walletAccount.address) {
-            _tmpActivityController1.setFilterAddressesJson(JSON.stringify([walletAccount.address]),
+    function updateRecentRecipientsActivity(accountAddress) {
+        if(!!accountAddress) {
+            _tmpActivityController1.setFilterAddressesJson(JSON.stringify([accountAddress]),
                                                                       false)
         }
         _tmpActivityController1.updateFilter()

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -311,7 +311,7 @@ ColumnLayout {
                 if (!overview.isWatchOnlyAccount && !tx)
                     return false
                 return WalletStores.RootStore.isTxRepeatable(tx)
-        }
+            }
 
             onTriggered: {
                 if (!tx)

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -311,7 +311,7 @@ ColumnLayout {
                 if (!overview.isWatchOnlyAccount && !tx)
                     return false
                 return WalletStores.RootStore.isTxRepeatable(tx)
-            }
+        }
 
             onTriggered: {
                 if (!tx)
@@ -326,11 +326,10 @@ ColumnLayout {
                                                               tx.isNFT,
                                                               tx.amount)
 
-                root.sendModal.preSelectedAccount = req.preSelectedAccount
+                root.sendModal.preSelectedAccountAddress = req.preSelectedAccount.address
                 root.sendModal.preSelectedRecipient = req.preSelectedRecipient
                 root.sendModal.preSelectedRecipientType = req.preSelectedRecipientType
-                root.sendModal.preSelectedHolding = req.preSelectedHolding
-                root.sendModal.preSelectedHoldingID = req.preSelectedHoldingID
+                root.sendModal.preSelectedHoldingID = req.preSelectedHoldingID ?? req.preSelectedHolding.uid
                 root.sendModal.preSelectedHoldingType = req.preSelectedHoldingType
                 root.sendModal.preSelectedSendType = req.preSelectedSendType
                 root.sendModal.preDefinedAmountToSend = req.preDefinedAmountToSend

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -64,7 +64,6 @@ QtObject {
                                       string communityName,
                                       string communityLogo,
                                       var token,
-                                      var accounts,
                                       var sendModalPopup)
     signal openFinaliseOwnershipPopup(string communityId)
     signal openDeclineOwnershipPopup(string communityId, string communityName)


### PR DESCRIPTION
### What does the PR do

closes #15217

This PR goes through all places where Send modal can be invoked from and fixes the identified issues.

General rules used when pre-filling the Send modal:
1. If the Send modal is launched in the context of an account, the account is pre-selected
2. If the Send modal is not launched in the context of an account, the first account in the list is pre-selected
3. If the Send modal is launched in the context of an asset, the asset is pre-selected
4. If the Send modal is launched in the context of a collectible, the collectible and owning account is pre-selected.
5. If the Send modal is launched in the context of a transaction, the account, receiver, token and about is pre-selected.


#### This PR does not cover:
"Repeat transaction" when an airdrop is selected. Will be handled in https://github.com/status-im/status-desktop/issues/12275

#### Changes:
1. [fix: Fixing crash on status-go exception when calling `getOwnedCollec…](https://github.com/status-im/status-desktop/commit/8839b4095de40104083dbf4a548034874d3e65ca) - Fixing a crash on status-go exception. It was happening when the account selection is empty
7. [chore(AccountSelector): Default to the first item in the account sele…](https://github.com/status-im/status-desktop/commit/0baafc1bef9b6d2517f4471e006be68ad630b9ac) - Update the account selector to default to the first item in the list if the pre-selected address is invalid (E.g. watch-only account)
8. https://github.com/status-im/status-desktop/commit/200917277164dbc4ecadbf85ab5ce067d1771c9e - Updating `SendModal` to accept account address for preselection instead of account model item. There are places in the app where the account model item is not available and it shouldn't be a prerequisite to forward the account model to every place where the send modal can be opened.
9. [fix(Send): Fine tune the Send action on collectibles](https://github.com/status-im/status-desktop/commit/2db2e2238cff60435aa144b8b0a4ea3ce93348f2) - Disable the `Send` button if the collectible is soul bound, hide the `Send` button if the collectible is owned by a watch-only account.
10. [fix(Send): Fixing Send button text on wallet footer on owner collecti…](https://github.com/status-im/status-desktop/commit/b622cd32f77e79d528b91a6d39e26241c5018cac) - The `Send` button text was not showing the community name. I've used the communities model to extract the name
11. [fix(SendModal): Fixing "Repeat transaction" action in Activity view a…](https://github.com/status-im/status-desktop/commit/82e55038ced995e3aa4831444addbf55db3a484c) - The repeat transaction was broken due to invalid amount parsing and wrong transaction processing before reaching the SendModal.

### Affected areas

SendModal - all the places where it can be launched from
Account selector
Buy sticker
Buy ENS

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
#### Default account and token selection

https://github.com/user-attachments/assets/1259ef86-992e-4772-9f24-2872fba0c233

#### Prefilled receiver address

https://github.com/user-attachments/assets/a3afb187-2c85-4bc4-8950-e2cffecd43e0

#### Repeat transaction

https://github.com/user-attachments/assets/338b536a-bf7d-4f8f-a1e6-58ec8df1ff0c

#### Preselecting accounts and tokens when sending collectibles + Disable/hide Send button for soulbound/not owned tokens

https://github.com/user-attachments/assets/8b8ea3f4-6e75-49a6-9999-8f3ac9d87b83


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

The user can launch Send modal from multiple places and the expect data is pre-filled based on context.

### How to test

- How should one proceed with testing this PR.
Go through all the places where Send can be invoked from and check if the preselected account, token, receiver address and amount match the preselection rules mentioned above:
1. Wallet footer (Assets, Collectibles, Asset details, Collectibles details, Activity, Activity details)
2. Assets/Collectibles context menu
3. Sent transaction context menu and Sent transaction details
4. Transfer ownership
- What kind of user flows should be checked?
1. Different wallet account layout configuration (E.g. The first account is watch-only, the first account is not watch-only, Changing the account order and re-launching the Send modal with different configurations)
2. Trying Send modal when `All accounts` is selected for assets, watch-only collectibles, watch-only community collectibles, owned collectibles, owned community collectibles, sent transactions
3. Transfer community ownership from `Community settings` and from `Wallet`

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

