### PR TITLE
ci: enable keycard mock lib as there are now tests running for it

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -3,6 +3,7 @@ library 'status-jenkins-lib@v1.8.18'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
+def isNightlyBuild = utils.isNightlyBuild()
 
 pipeline {
   agent {
@@ -39,7 +40,7 @@ pipeline {
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
       description: 'Decides whether the mocked status-keycard-go library is built.',
-      defaultValue: false
+      defaultValue: isNightlyBuild
     )
   }
 

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -3,6 +3,7 @@ library 'status-jenkins-lib@v1.8.18'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
+def isNightlyBuild = utils.isNightlyBuild()
 
 pipeline {
   agent { label 'linux && x86_64 && nix-2.14' }
@@ -31,7 +32,7 @@ pipeline {
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
       description: 'Decides whether the mocked status-keycard-go library is built.',
-      defaultValue: false
+      defaultValue: isNightlyBuild
     )
   }
 


### PR DESCRIPTION
### What does the PR do

Just enable keycard mock lib as we have tests now for it. I want it only in nightly builds. 

@siddarthkay pls help me to confirm it will happen only in nightly builds for now