### PR TITLE
Fix walletconnect transaction fees not being sent

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -320,7 +320,6 @@ SQUtils.QObject {
                         actionResult = store.signTransaction(request.topic, request.id,
                                             request.account.address, request.network.chainId, password, txObj)
                     } else if (request.method === SessionRequest.methods.sendTransaction.name) {
-                        let txObj = SessionRequest.methods.sendTransaction.getTxObjFromData(request.data)
                         actionResult = store.sendTransaction(request.topic, request.id,
                                             request.account.address, request.network.chainId, password, txObj)
                     }

--- a/ui/imports/shared/stores/DAppsStore.qml
+++ b/ui/imports/shared/stores/DAppsStore.qml
@@ -57,8 +57,11 @@ QObject {
         if (txObj.data) { tx.data = txObj.data }
         if (txObj.from) { tx.from = txObj.from }
         if (txObj.gasLimit) { tx.gasLimit = stripLeadingZeros(txObj.gasLimit) }
+        if (txObj.gas) { tx.gas = stripLeadingZeros(txObj.gas) }
         if (txObj.gasPrice) { tx.gasPrice = stripLeadingZeros(txObj.gasPrice) }
         if (txObj.nonce) { tx.nonce = stripLeadingZeros(txObj.nonce) }
+        if (txObj.maxFeePerGas) { tx.maxFeePerGas = stripLeadingZeros(txObj.maxFeePerGas) }
+        if (txObj.maxPriorityFeePerGas) { tx.maxPriorityFeePerGas = stripLeadingZeros(txObj.maxPriorityFeePerGas) }
         if (txObj.to) { tx.to = txObj.to }
         if (txObj.value) { tx.value = stripLeadingZeros(txObj.value) }
         return tx


### PR DESCRIPTION
### What does the PR do

This PR fixes the issue where the dynamic fees are not used in the transaction that is built and sent by the backend.

### Affected areas

wallet-connect

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Impact on end user

The transactions are passing with the correct fees (maxFeePerGas and maxPriorityFeePerGas)

### How to test

- Establish wallet connect connection
- Try to send transaction 
- Check the transaction on etherscan
- Transaction should pass
- Raw transaction should include the dynamic fees (maxFeePerGas and maxPriorityFeePerGas)
