### PR TITLE
15628 metrics after update

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -25,6 +25,8 @@ const LAS_KEY_TRANSLATIONS_ENABLED = "global/translations_enabled"
 const DEFAULT_LAS_KEY_TRANSLATIONS_ENABLED = false
 const DEFAULT_LAS_KEY_CREATE_COMMUNITIES_ENABLED = false
 const LAS_KEY_REFRESH_TOKEN_ENABLED = "global/refresh_token_enabled"
+const LAS_KEY_METRICS_POPUP_SEEN = "global/metrics_popup_seen"
+const DEFAULT_LAS_KEY_METRICS_POPUP_SEEN = false
 
 QtObject:
   type LocalAppSettings* = ref object of QObject
@@ -229,3 +231,16 @@ QtObject:
 
   QtProperty[string] walletConnectProjectID:
     read = getWalletConnectProjectID
+
+
+  proc refreshMetricsPopupSeen*(self: LocalAppSettings) {.signal.}
+  proc getMetricsPopupSeen*(self: LocalAppSettings): bool {.slot.} =
+    self.settings.value(LAS_KEY_METRICS_POPUP_SEEN, newQVariant(DEFAULT_LAS_KEY_METRICS_POPUP_SEEN)).boolVal
+  proc setMetricsPopupSeen*(self: LocalAppSettings, enabled: bool) {.slot.} =
+    self.settings.setValue(LAS_KEY_METRICS_POPUP_SEEN, newQVariant(enabled))
+    self.refreshMetricsPopupSeen()
+
+  QtProperty[bool] metricsPopupSeen:
+    read = getMetricsPopupSeen
+    write = setMetricsPopupSeen
+    notify = refreshMetricsPopupSeen

--- a/storybook/pages/MetricsEnablePopupPage.qml
+++ b/storybook/pages/MetricsEnablePopupPage.qml
@@ -1,0 +1,39 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import shared.popups 1.0
+
+import Storybook 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Item {
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: popup.open()
+        }
+    }
+
+    MetricsEnablePopup {
+        id: popup
+        anchors.centerIn: parent
+        modal: false
+        visible: true
+        isOnboarding: true
+    }
+}
+
+// category: Popups
+
+// https://www.figma.com/design/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=24721-503547&t=a7IsC44aG7YQuInQ-0

--- a/test/e2e/gui/components/onboarding/share_usage_data_popup.py
+++ b/test/e2e/gui/components/onboarding/share_usage_data_popup.py
@@ -1,0 +1,18 @@
+import allure
+
+from gui.components.base_popup import BasePopup
+from gui.elements.button import Button
+from gui.objects_map import names
+
+
+class ShareUsageDataPopup(BasePopup):
+
+    def __init__(self):
+        self._not_now_button = Button(names.not_now_StatusButton )
+        self._share_usage_data_button = Button(names.share_usage_data_StatusButton)
+        super(ShareUsageDataPopup, self).__init__()
+
+    @allure.step('Click not now button')
+    def skip(self):
+        self._not_now_button.click()
+        self.wait_until_hidden()

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -12,6 +12,7 @@ from gui.components.community.invite_contacts import InviteContactsPopup
 from gui.components.context_menu import ContextMenu
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
+from gui.components.onboarding.share_usage_data_popup import ShareUsageDataPopup
 from gui.components.splash_screen import SplashScreen
 from gui.components.toast_message import ToastMessage
 from gui.components.online_identifier import OnlineIdentifier
@@ -174,6 +175,7 @@ class MainWindow(Window):
 
     @allure.step('Sign Up user')
     def sign_up(self, user_account: UserAccount = constants.user.user_account_one):
+        share_updates_popup = ShareUsageDataPopup()
         BeforeStartedPopUp().get_started()
         welcome_screen = WelcomeToStatusView().wait_until_appears()
         profile_view = welcome_screen.get_keys().generate_new_keys()
@@ -190,14 +192,19 @@ class MainWindow(Window):
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE:
             BetaConsentPopup().confirm()
+        if share_updates_popup.exists:
+            share_updates_popup.skip()
         return self
 
     @allure.step('Log in user')
     def log_in(self, user_account: UserAccount):
+        share_updates_popup = ShareUsageDataPopup()
         LoginView().log_in(user_account)
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE:
             BetaConsentPopup().confirm()
+        if share_updates_popup.exists:
+            share_updates_popup.skip()
         return self
 
     @allure.step('Authorize user')

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -127,6 +127,10 @@ i_m_ready_to_use_Status_Desktop_Beta_StatusButton = {"container": statusDesktop_
 headline_StatusTitleSubtitle = {"container": statusDesktop_mainWindow_overlay, "id": "headline", "type": "StatusTitleSubtitle", "unnamed": 1, "visible": True}
 keys_exist_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 
+# Share Usage Data Popup
+not_now_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "notShareMetricsButton", "type": "StatusButton", "visible": True}
+share_usage_data_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "shareMetricsButton", "type": "StatusButton", "visible": True}
+
 """ Communities """
 
 # Create Community Banner

--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -13,9 +13,9 @@ LeftTabView_ScrollView = {"container": mainWindow_LeftTabView, "type": "StatusSc
 LeftTabProfileMenu = {"container": LeftTabView_ScrollView, "objectName": "leftTabViewProfileMenu", "type": "MenuPanel", "visible": True}
 mainWindow_Settings_StatusNavigationPanelHeadline = {"container": mainWindow_LeftTabView, "type": "StatusNavigationPanelHeadline", "unnamed": 1, "visible": True}
 mainWindow_scrollView_StatusScrollView = {"container": mainWindow_LeftTabView, "id": "scrollView", "type": "StatusScrollView", "unnamed": 1, "visible": True}
-scrollView_MenuItem_StatusNavigationListItem = {"container": LeftTabView_ScrollView, "type": "StatusNavigationListItem", "visible": True}
+scrollView_MenuItem_StatusNavigationListItem = {"container": mainWindow_scrollView_StatusScrollView, "type": "StatusNavigationListItem", "visible": True}
 scrollView_Flickable = {"container": mainWindow_scrollView_StatusScrollView, "type": "Flickable", "unnamed": 1, "visible": True}
-settingsBackUpSeedPhraseOption = {"container": LeftTabView_ScrollView, "objectName": "18-MainMenuItem", "type": "StatusNavigationListItem", "visible": True}
+settingsBackUpSeedPhraseOption = {"container": mainWindow_scrollView_StatusScrollView, "objectName": "19-MainMenuItem", "type": "StatusNavigationListItem", "visible": True}
 settingsWalletOption = {"container": LeftTabView_ScrollView, "objectName": "5-AppMenuItem", "type": "StatusNavigationListItem", "visible": True}
 
 # Communities View

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -52,12 +52,14 @@ class WelcomeToStatusView(QObject):
     def get_keys(self) -> 'KeysView':
         self._i_am_new_to_status_button.click()
         time.sleep(1)
+        ShareUsageDataPopup().skip()
         return KeysView().wait_until_appears()
 
     @allure.step('Open Sign by syncing form')
     def sync_existing_user(self) -> 'SignBySyncingView':
         self._i_already_use_status_button.click()
         time.sleep(1)
+        ShareUsageDataPopup().skip()
         return SignBySyncingView().wait_until_appears()
 
 
@@ -84,19 +86,16 @@ class KeysView(OnboardingView):
     @allure.step('Open Profile view')
     def generate_new_keys(self) -> 'YourProfileView':
         self._generate_key_button.click()
-        ShareUsageDataPopup().skip()
         return YourProfileView().verify_profile_view_present()
 
     @allure.step('Open Keycard Init view')
     def generate_key_for_new_keycard(self) -> 'KeycardInitView':
         self._generate_key_for_new_keycard_button.click()
-        ShareUsageDataPopup().skip()
         return KeycardInitView().wait_until_appears()
 
     @allure.step('Open Import Seed Phrase view')
     def open_import_seed_phrase_view(self) -> 'ImportSeedPhraseView':
         self._import_seed_phrase_button.click()
-        ShareUsageDataPopup().skip()
         return ImportSeedPhraseView().wait_until_appears()
 
     @allure.step('Open Enter Seed Phrase view')

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -13,6 +13,7 @@ import driver
 from constants import ColorCodes
 from driver.objects_access import walk_children
 from gui.components.onboarding.keys_already_exist_popup import KeysAlreadyExistPopup
+from gui.components.onboarding.share_usage_data_popup import ShareUsageDataPopup
 from gui.components.os.open_file_dialogs import OpenFileDialog
 from gui.components.picture_edit_popup import PictureEditPopup
 from gui.components.splash_screen import SplashScreen
@@ -83,16 +84,19 @@ class KeysView(OnboardingView):
     @allure.step('Open Profile view')
     def generate_new_keys(self) -> 'YourProfileView':
         self._generate_key_button.click()
+        ShareUsageDataPopup().skip()
         return YourProfileView().verify_profile_view_present()
 
     @allure.step('Open Keycard Init view')
     def generate_key_for_new_keycard(self) -> 'KeycardInitView':
         self._generate_key_for_new_keycard_button.click()
+        ShareUsageDataPopup().skip()
         return KeycardInitView().wait_until_appears()
 
     @allure.step('Open Import Seed Phrase view')
     def open_import_seed_phrase_view(self) -> 'ImportSeedPhraseView':
         self._import_seed_phrase_button.click()
+        ShareUsageDataPopup().skip()
         return ImportSeedPhraseView().wait_until_appears()
 
     @allure.step('Open Enter Seed Phrase view')

--- a/test/e2e/gui/screens/settings.py
+++ b/test/e2e/gui/screens/settings.py
@@ -91,7 +91,7 @@ class LeftPanel(QObject):
         return ChangePasswordView()
 
     @allure.step('Choose back up seed phrase in settings')
-    @handle_settings_opening(BackUpYourSeedPhrasePopUp, '18-MainMenuItem')
+    @handle_settings_opening(BackUpYourSeedPhrasePopUp, '19-MainMenuItem')
     def open_back_up_seed_phrase(self, click_attempts: int = 2) -> 'BackUpYourSeedPhrasePopUp':
         assert BackUpYourSeedPhrasePopUp().exists, 'Back up your seed phrase modal was not opened'
         return BackUpYourSeedPhrasePopUp()
@@ -103,7 +103,7 @@ class LeftPanel(QObject):
         return SyncingSettingsView()
 
     @allure.step('Choose sign out and quit in settings')
-    @handle_settings_opening(SignOutPopup, '17-ExtraMenuItem')
+    @handle_settings_opening(SignOutPopup, '18-ExtraMenuItem')
     def open_sign_out_and_quit(self, click_attempts: int = 2) -> 'SignOutPopup':
         assert SignOutPopup().exists, 'Sign out modal was not opened'
         return SignOutPopup()

--- a/test/e2e/tests/settings/test_settings_back_up_seed.py
+++ b/test/e2e/tests/settings/test_settings_back_up_seed.py
@@ -1,6 +1,8 @@
 import allure
 import pytest
 from allure_commons._allure import step
+
+import driver
 from . import marks
 
 import configs
@@ -16,7 +18,8 @@ pytestmark = marks
 def test_back_up_seed_phrase(main_screen: MainWindow):
     with step('Check back up seed phrase option is visible for new account'):
         settings = main_screen.left_panel.open_settings()
-        assert settings.left_panel.settings_section_back_up_seed_option.exists, f"Back up seed option is not present"
+        assert driver.waitFor(lambda: settings.left_panel.settings_section_back_up_seed_option.wait_until_appears,
+                              configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f"Back up seed option is not present"
         if not configs.system.TEST_MODE:
             assert BackUpSeedPhraseBanner().does_back_up_seed_banner_exist(), "Back up seed banner is not present"
             assert BackUpSeedPhraseBanner().is_back_up_now_button_present(), 'Back up now button is not present'

--- a/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
@@ -201,10 +201,7 @@ StatusModal {
             type: StatusBaseButton.Type.Danger
             text: qsTr("Delete Category")
             onClicked: {
-                Global.openPopup(deleteCategoryConfirmationDialogComponent, {
-                    "headerSettings.title": qsTr("Delete '%1' category").arg(nameInput.text),
-                    confirmationText: qsTr("Are you sure you want to delete '%1' category? Channels inside the category won’t be deleted.").arg(nameInput.text)
-                })
+                Global.openPopup(deleteCategoryConfirmationDialogComponent)
             }
         },
         StatusButton {

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -8,6 +8,7 @@ import StatusQ.Core.Theme 0.1
 
 import utils 1.0
 import shared.popups.keycard 1.0
+import shared.stores 1.0
 
 import "controls"
 import "views"
@@ -18,6 +19,7 @@ OnboardingBasePage {
     id: root
 
     property var startupStore: StartupStore {}
+    property var metricsStore: MetricsStore {}
 
     backButtonVisible: root.startupStore.currentStartupState ? root.startupStore.currentStartupState.displayBackButton
                                                              : false
@@ -233,6 +235,7 @@ following the \"Add existing Status user\" flow, using your seed phrase.")
         id: keysMainViewComponent
         KeysMainView {
             startupStore: root.startupStore
+            metricsStore: root.metricsStore
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -19,7 +19,6 @@ OnboardingBasePage {
     id: root
 
     property var startupStore: StartupStore {}
-    property var metricsStore: MetricsStore {}
 
     backButtonVisible: root.startupStore.currentStartupState ? root.startupStore.currentStartupState.displayBackButton
                                                              : false
@@ -235,7 +234,6 @@ following the \"Add existing Status user\" flow, using your seed phrase.")
         id: keysMainViewComponent
         KeysMainView {
             startupStore: root.startupStore
-            metricsStore: root.metricsStore
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding/stores/StartupStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/StartupStore.qml
@@ -115,14 +115,6 @@ QtObject {
         return root.startupModuleInst.getSeedPhrase()
     }
 
-    function toggleCentralizedMetrics(enabled) {
-        metrics.toggleCentralizedMetrics(enabled)
-    }
-
-    function isCentralizedMetricsEnabled() {
-        return metrics.isCentralizedMetricsEnabled()
-    }
-
     function validateLocalPairingConnectionString(connectionString) {
         return root.startupModuleInst.validateLocalPairingConnectionString(connectionString)
     }

--- a/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
@@ -23,7 +23,6 @@ Item {
     id: root
 
     property StartupStore startupStore
-    property MetricsStore metricsStore
 
     Component.onCompleted: {
         if (button1.visible) {
@@ -39,17 +38,8 @@ Item {
         readonly property int infoTextWidth: d.infoWidth - 2 * d.infoMargin
         readonly property int imgKeysWH: 160
         readonly property int imgSeedPhraseWH: 257
-
-
-        function showMetricsAndRunAction(action) {
-            if (root.startupStore.currentStartupState.stateType === Constants.startupState.welcomeNewStatusUser) {
-                metricsEnablePopup.actionOnClose = action
-                metricsEnablePopup.visible = true
-            } else {
-                action()
-            }
-        }
     }
+
     ColumnLayout {
         anchors.centerIn: parent
         height: Constants.onboarding.loginHeight
@@ -233,12 +223,12 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             visible: text !== ""
             onClicked: {
-                d.showMetricsAndRunAction(root.startupStore.doPrimaryAction)
+                root.startupStore.doPrimaryAction()
             }
             Keys.onPressed: {
                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     event.accepted = true
-                    d.showMetricsAndRunAction(root.startupStore.doPrimaryAction)
+                    root.startupStore.doPrimaryAction()
                 }
             }
         }
@@ -261,7 +251,7 @@ Item {
                     parent.font.underline = false
                 }
                 onClicked: {
-                    d.showMetricsAndRunAction(root.startupStore.doSecondaryAction)
+                    root.startupStore.doSecondaryAction()
                 }
             }
         }
@@ -297,7 +287,7 @@ Item {
                             Qt.openUrlExternally(button3.link)
                             return
                         }
-                        d.showMetricsAndRunAction(root.startupStore.doTertiaryAction)
+                        root.startupStore.doTertiaryAction()
                     }
                 }
             }
@@ -319,24 +309,6 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
         }
-    }
-
-    component MetricsEnablePopupWithActionOnClose: MetricsEnablePopup {
-        property var actionOnClose
-    }
-
-    MetricsEnablePopupWithActionOnClose {
-        id: metricsEnablePopup
-        isOnboarding: true
-
-        function finalAction(enable) {
-            if (!!actionOnClose)
-                actionOnClose()
-            root.metricsStore.toggleCentralizedMetrics(enable)
-        }
-
-        onAccepted: finalAction(true)
-        onRejected: finalAction(false)
     }
 
     states: [

--- a/ui/app/AppLayouts/Onboarding/views/WelcomeView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/WelcomeView.qml
@@ -24,6 +24,14 @@ Item {
         btnNewUser.forceActiveFocus()
     }
 
+    QtObject {
+        id: d
+
+        function showMetricsAndRunAction(action) {
+            Global.openMetricsEnablePopupRequested(true, popup => popup.closed.connect(() => action()))
+        }
+    }
+
     BeforeGetStartedModal {
         id: beforeGetStartedModal
         onClosed: {
@@ -81,12 +89,12 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("I am new to Status")
             onClicked: {
-                root.startupStore.doPrimaryAction()
+                d.showMetricsAndRunAction(root.startupStore.doPrimaryAction)
             }
             Keys.onPressed: {
                 if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                     event.accepted = true
-                    root.startupStore.doPrimaryAction()
+                    d.showMetricsAndRunAction(root.startupStore.doPrimaryAction)
                 }
             }
         }
@@ -98,7 +106,7 @@ Item {
             anchors.topMargin: Style.current.bigPadding
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
-                root.startupStore.doSecondaryAction()
+                d.showMetricsAndRunAction(root.startupStore.doSecondaryAction)
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -44,7 +44,7 @@ StatusSectionLayout {
     required property WalletAssetsStore walletAssetsStore
     required property CollectiblesStore collectiblesStore
     required property SharedStores.CurrenciesStore currencyStore
-    required property SharedStores.MetricsStore metricsStore
+    required property bool isCentralizedMetricsEnabled
 
     backButtonName: root.store.backButtonName
     notificationCount: activityCenterStore.unreadNotificationsCount
@@ -463,8 +463,7 @@ StatusSectionLayout {
             active: false
             asynchronous: true
             sourceComponent: PrivacyAndSecurityView {
-                metricsStore: root.metricsStore
-
+                isCentralizedMetricsEnabled: root.isCentralizedMetricsEnabled
                 implicitWidth: parent.width
                 implicitHeight: parent.height
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -44,6 +44,7 @@ StatusSectionLayout {
     required property WalletAssetsStore walletAssetsStore
     required property CollectiblesStore collectiblesStore
     required property SharedStores.CurrenciesStore currencyStore
+    required property SharedStores.MetricsStore metricsStore
 
     backButtonName: root.store.backButtonName
     notificationCount: activityCenterStore.unreadNotificationsCount
@@ -455,6 +456,20 @@ StatusSectionLayout {
                     textFormat: Text.MarkdownText
                     text: SQUtils.StringUtils.readTextFile(":/imports/assets/docs/privacy.mdwn")
                 }
+            }
+        }
+
+        Loader {
+            active: false
+            asynchronous: true
+            sourceComponent: PrivacyAndSecurityView {
+                metricsStore: root.metricsStore
+
+                implicitWidth: parent.width
+                implicitHeight: parent.height
+
+                sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.privacyAndSecurity)
+                contentWidth: d.contentWidth
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
@@ -134,6 +134,9 @@ QtObject {
 
     property ListModel settingsMenuItems: ListModel {
         Component.onCompleted: {
+            append({subsection: Constants.settingsSubsection.privacyAndSecurity,
+                       text: qsTr("Privacy and security"),
+                       icon: "security"})
             append({subsection: Constants.settingsSubsection.appearance,
                        text: qsTr("Appearance"),
                        icon: "appearance"})

--- a/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
@@ -23,39 +23,28 @@ import SortFilterProxyModel 0.2
 SettingsContentBase {
     id: root
 
-    required property MetricsStore metricsStore
+    required property bool isCentralizedMetricsEnabled
 
-    Component.onCompleted: {
-        enableMetricsSwitch.checked = metricsStore.isCentralizedMetricsEnabled()
-    }
-
-    function enableMetrics(enable) {
-        enableMetricsSwitch.checked = enable
-        metricsStore.toggleCentralizedMetrics(enable)
+    function refreshSwitch() {
+        enableMetricsSwitch.checked = Qt.binding(function() { return root.isCentralizedMetricsEnabled })
     }
 
     ColumnLayout {
         StatusListItem {
             Layout.preferredWidth: root.contentWidth
             title: qsTr("Share usage data with Status")
+            subTitle: qsTr("From all profiles on device")
             components: [
                 StatusSwitch {
                     id: enableMetricsSwitch
+                    checked: root.isCentralizedMetricsEnabled
                     onClicked: {
-                        Global.openPopup(metricsEnabledPopupComponent)
+                        Global.openMetricsEnablePopupRequested(false, popup => popup.toggleMetrics.connect(refreshSwitch))
                     }
                 }
             ]
             onClicked: {
-                Global.openPopup(metricsEnabledPopupComponent)
-            }
-        }
-
-        Component {
-            id: metricsEnabledPopupComponent
-            MetricsEnablePopup {
-                onAccepted: root.enableMetrics(true)
-                onRejected: root.enableMetrics(false)
+                Global.openMetricsEnablePopupRequested(false, popup => popup.toggleMetrics.connect(refreshSwitch))
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import utils 1.0
+import shared.panels 1.0
+import shared.popups 1.0
+import shared.stores 1.0
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import AppLayouts.Profile.stores 1.0
+
+import "../popups"
+
+import SortFilterProxyModel 0.2
+
+SettingsContentBase {
+    id: root
+
+    required property MetricsStore metricsStore
+
+    Component.onCompleted: {
+        enableMetricsSwitch.checked = metricsStore.isCentralizedMetricsEnabled()
+    }
+
+    function enableMetrics(enable) {
+        enableMetricsSwitch.checked = enable
+        metricsStore.toggleCentralizedMetrics(enable)
+    }
+
+    ColumnLayout {
+        StatusListItem {
+            Layout.preferredWidth: root.contentWidth
+            title: qsTr("Share usage data with Status")
+            components: [
+                StatusSwitch {
+                    id: enableMetricsSwitch
+                    onClicked: {
+                        Global.openPopup(metricsEnabledPopupComponent)
+                    }
+                }
+            ]
+            onClicked: {
+                Global.openPopup(metricsEnabledPopupComponent)
+            }
+        }
+
+        Component {
+            id: metricsEnabledPopupComponent
+            MetricsEnablePopup {
+                onAccepted: root.enableMetrics(true)
+                onRejected: root.enableMetrics(false)
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/views/qmldir
+++ b/ui/app/AppLayouts/Profile/views/qmldir
@@ -6,3 +6,4 @@ CommunitiesView 1.0 CommunitiesView.qml
 LanguageView 1.0 LanguageView.qml
 NotificationsView 1.0 NotificationsView.qml
 SyncingView 1.0 SyncingView.qml
+PrivacyAndSecurityView 1.0 PrivacyAndSecurityView.qml

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -72,6 +72,7 @@ Item {
     property NetworkConnectionStore networkConnectionStore: NetworkConnectionStore {}
     property CommunityTokensStore communityTokensStore: CommunityTokensStore {}
     property CommunitiesStore communitiesStore: CommunitiesStore {}
+    property MetricsStore metricsStore: MetricsStore {}
     readonly property WalletStore.TokensStore tokensStore: WalletStore.RootStore.tokensStore
     readonly property WalletStore.WalletAssetsStore walletAssetsStore: WalletStore.RootStore.walletAssetsStore
     readonly property WalletStore.CollectiblesStore walletCollectiblesStore: WalletStore.RootStore.collectiblesStore
@@ -1440,6 +1441,7 @@ Item {
                             walletAssetsStore: appMain.walletAssetsStore
                             collectiblesStore: appMain.walletCollectiblesStore
                             currencyStore: appMain.currencyStore
+                            metricsStore: appMain.metricsStore
                         }
                     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -72,7 +72,6 @@ Item {
     property NetworkConnectionStore networkConnectionStore: NetworkConnectionStore {}
     property CommunityTokensStore communityTokensStore: CommunityTokensStore {}
     property CommunitiesStore communitiesStore: CommunitiesStore {}
-    property MetricsStore metricsStore: MetricsStore {}
     readonly property WalletStore.TokensStore tokensStore: WalletStore.RootStore.tokensStore
     readonly property WalletStore.WalletAssetsStore walletAssetsStore: WalletStore.RootStore.walletAssetsStore
     readonly property WalletStore.CollectiblesStore walletCollectiblesStore: WalletStore.RootStore.collectiblesStore
@@ -82,6 +81,7 @@ Item {
         tokensStore: appMain.tokensStore
         currencyStore: appMain.currencyStore
     }
+    required property bool isCentralizedMetricsEnabled
 
     // set from main.qml
     property var sysPalette
@@ -1441,7 +1441,7 @@ Item {
                             walletAssetsStore: appMain.walletAssetsStore
                             collectiblesStore: appMain.walletCollectiblesStore
                             currencyStore: appMain.currencyStore
-                            metricsStore: appMain.metricsStore
+                            isCentralizedMetricsEnabled: appMain.isCentralizedMetricsEnabled
                         }
                     }
 

--- a/ui/imports/shared/popups/MetricsEnablePopup.qml
+++ b/ui/imports/shared/popups/MetricsEnablePopup.qml
@@ -16,6 +16,8 @@ StatusModal {
 
     property bool isOnboarding: false
 
+    signal toggleMetrics(bool enabled)
+
     width: 640
     title: qsTr("Help us improve Status")
     hasCloseButton: true
@@ -90,7 +92,8 @@ StatusModal {
         StatusButton {
             text: qsTr("Share usage data")
             onClicked: {
-                root.accept()
+                root.toggleMetrics(true)
+                close()
             }
             objectName: "shareMetricsButton"
         }
@@ -100,7 +103,8 @@ StatusModal {
         StatusButton {
             text: qsTr("Not now")
             onClicked: {
-                root.reject()
+                root.toggleMetrics(false)
+                close()
             }
             objectName: "notShareMetricsButton"
             normalColor: "transparent"

--- a/ui/imports/shared/popups/MetricsEnablePopup.qml
+++ b/ui/imports/shared/popups/MetricsEnablePopup.qml
@@ -1,0 +1,109 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+StatusModal {
+    id: root
+
+    property bool isOnboarding: false
+
+    width: 640
+    title: qsTr("Help us improve Status")
+    hasCloseButton: true
+    verticalPadding: 20
+
+    closePolicy: Popup.CloseOnEscape
+
+    component Paragraph: StatusBaseText {
+        lineHeightMode: Text.FixedHeight
+        lineHeight: 22
+        visible: true
+        wrapMode: Text.Wrap
+    }
+
+    component AgreementSection: ColumnLayout {
+        property alias title: titleItem.text
+        property alias body: bodyItem.text
+        spacing: 8
+        Paragraph {
+            id: titleItem
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            font.weight: Font.Bold
+        }
+
+        Paragraph {
+            id: bodyItem
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+
+    StatusScrollView {
+        id: scrollView
+        anchors.fill: parent
+        contentWidth: availableWidth
+
+        ColumnLayout {
+            id: layout
+            width: scrollView.availableWidth
+            spacing: 20
+
+            Paragraph {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                text: qsTr("Collecting usage data helps us improve Status.")
+            }
+
+            AgreementSection {
+                title: qsTr("What we will receive:")
+                body: qsTr(" •  IP address
+ •  Universally Unique Identifiers of device
+ •  Logs of actions within the app, including button presses and screen visits")
+            }
+
+            AgreementSection {
+                title: qsTr("What we won’t receive:")
+                body: qsTr(" •  Your profile information
+ •  Your addresses
+ •  Information you input and send")
+            }
+
+            Paragraph {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                text: qsTr("Usage data will be shared from all profiles added to device. %1").arg(root.isOnboarding ? "Sharing usage data can be turned off anytime in Settings / Privacy and Security." : "")
+            }
+        }
+    }
+
+    rightButtons: [
+        StatusButton {
+            text: qsTr("Share usage data")
+            onClicked: {
+                root.accept()
+            }
+            objectName: "shareMetricsButton"
+        }
+    ]
+
+    leftButtons: [
+        StatusButton {
+            text: qsTr("Not now")
+            onClicked: {
+                root.reject()
+            }
+            objectName: "notShareMetricsButton"
+            normalColor: "transparent"
+        }
+    ]
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -31,5 +31,6 @@ SendContactRequestModal 1.0 SendContactRequestModal.qml
 SettingsDirtyToastMessage 1.0 SettingsDirtyToastMessage.qml
 UnblockContactConfirmationDialog 1.0 UnblockContactConfirmationDialog.qml
 UserAgreementPopup 1.0 UserAgreementPopup.qml
+MetricsEnablePopup 1.0 MetricsEnablePopup.qml
 UserStatusContextMenu 1.0 UserStatusContextMenu.qml
 ImageContextMenu 1.0 ImageContextMenu.qml

--- a/ui/imports/shared/stores/MetricsStore.qml
+++ b/ui/imports/shared/stores/MetricsStore.qml
@@ -7,7 +7,5 @@ QtObject {
         metrics.toggleCentralizedMetrics(enabled)
     }
 
-    function isCentralizedMetricsEnabled() {
-        return metrics.isCentralizedMetricsEnabled()
-    }
+    readonly property bool isCentralizedMetricsEnabled : metrics.isCentralizedMetricsEnabled
 }

--- a/ui/imports/shared/stores/MetricsStore.qml
+++ b/ui/imports/shared/stores/MetricsStore.qml
@@ -1,0 +1,13 @@
+import QtQml 2.15
+
+QtObject {
+    id: root
+
+    function toggleCentralizedMetrics(enabled) {
+        metrics.toggleCentralizedMetrics(enabled)
+    }
+
+    function isCentralizedMetricsEnabled() {
+        return metrics.isCentralizedMetricsEnabled()
+    }
+}

--- a/ui/imports/shared/stores/qmldir
+++ b/ui/imports/shared/stores/qmldir
@@ -6,5 +6,6 @@ ChartStoreBase 1.0 ChartStoreBase.qml
 PermissionsStore 1.0 PermissionsStore.qml
 TokenBalanceHistoryStore 1.0 TokenBalanceHistoryStore.qml
 TokenMarketValuesStore 1.0 TokenMarketValuesStore.qml
+MetricsStore 1.0 MetricsStore.qml
 NetworkConnectionStore 1.0 NetworkConnectionStore.qml
 DAppsStore 1.0 DAppsStore.qml

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -349,10 +349,11 @@ QtObject {
         readonly property int keycard: 14
         readonly property int about_terms: 15 // a subpage under "About"
         readonly property int about_privacy: 16 // a subpage under "About"
+        readonly property int privacyAndSecurity: 17
 
         // special treatment; these do not participate in the main settings' StackLayout
-        readonly property int signout: 17
-        readonly property int backUpSeed: 18
+        readonly property int signout: 18
+        readonly property int backUpSeed: 19
     }
 
     readonly property QtObject walletSettingsSubsection: QtObject {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -109,6 +109,9 @@ QtObject {
     // BuyCrypto
     signal openBuyCryptoModalRequested()
 
+    // Metrics
+    signal openMetricsEnablePopupRequested(bool isOnboarding, var cb)
+
     /////////////////////////////////////////////////////
     // WalletConnect POC - to remove
     signal popupWalletConnect()


### PR DESCRIPTION
Add new settings page for metrics management - Privacy and security
Showing metrics popup: 1. on welcome screen, 2. on Settings/Privacy page and 3. after login when the popup has not been shown yet
Remember whether metrics popup was shown: metrics_popup_seen added to local settings.

Issue #15628

https://github.com/user-attachments/assets/769e5871-ba73-44aa-9a40-80db99482700

https://github.com/user-attachments/assets/64adda39-6e6e-472b-a946-658378a5a54c

