### PR TITLE
feat(connector)_: turn feature flag on

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -3,7 +3,7 @@ import os
 
 const DEFAULT_FLAG_DAPPS_ENABLED = false
 const DEFAULT_FLAG_SWAP_ENABLED = false
-const DEFAULT_FLAG_CONNECTOR_ENABLED = false
+const DEFAULT_FLAG_CONNECTOR_ENABLED = true
 
 proc boolToEnv(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"


### PR DESCRIPTION
### What does the PR do

This PR turns on the feature flag for Connector

### Affected areas

- Any screen will be able to see popup  when triggered for `request account` or `sign transacation` from a DApp or equivalent

### Screenshot of functionality (including design for comparison)

Refer to : 

- [Create connection](https://github.com/status-im/status-desktop/pull/15565)
- [Sign transaction](https://github.com/status-im/status-desktop/pull/15662)

### Impact on end user

User will now be able to request connection with account and/oor sign transactions

### How to test

Please refer to above PR's for testing

### Risk 

No specific risks.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.