### PR TITLE
fix(Sync): unbreak sync instructions page layout

### DIFF
--- a/ui/imports/shared/views/SyncingCodeInstructions.qml
+++ b/ui/imports/shared/views/SyncingCodeInstructions.qml
@@ -42,16 +42,13 @@ ColumnLayout {
     }
 
     StackLayout {
-        Layout.fillWidth: false
         Layout.alignment: Qt.AlignHCenter
-        implicitWidth: Math.max(mobileSync.implicitWidth, desktopSync.implicitWidth)
-        implicitHeight: Math.max(mobileSync.implicitHeight, desktopSync.implicitHeight)
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.max(mobileSync.implicitHeight, desktopSync.implicitHeight)
         currentIndex: switchTabBar.currentIndex
 
         GetSyncCodeMobileInstructions {
             id: mobileSync
-            Layout.fillHeight: true
-            Layout.fillWidth: false
             Layout.alignment: Qt.AlignHCenter
 
             purpose: root.purpose
@@ -60,8 +57,6 @@ ColumnLayout {
 
         GetSyncCodeDesktopInstructions {
             id: desktopSync
-            Layout.fillHeight: true
-            Layout.fillWidth: false
             Layout.alignment: Qt.AlignHCenter
 
             purpose: root.purpose

--- a/ui/imports/shared/views/SyncingDeviceView.qml
+++ b/ui/imports/shared/views/SyncingDeviceView.qml
@@ -15,7 +15,7 @@ import SortFilterProxyModel 0.2
 Item {
     id: root
 
-    property alias devicesModel: sfpModel.sourceModel
+    property var devicesModel
     property string userDisplayName
     property string userColorId
     property string userColorHash
@@ -177,7 +177,7 @@ Item {
             clip: true
 
             model: SortFilterProxyModel {
-                id: sfpModel
+                sourceModel: root.devicesModel
                 filters: [
                     ValueFilter {
                         enabled: true


### PR DESCRIPTION
### What does the PR do

Iterates: #14668

### Affected areas

Settings/Sync

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Device list:
![image](https://github.com/user-attachments/assets/242dfa27-b973-40c5-bcc2-0bcc2c201232)

Instructions:
![image](https://github.com/user-attachments/assets/36f81187-756e-4e9e-8fdb-fd9283580929)

Sync code:
![image](https://github.com/user-attachments/assets/10197a91-cafe-481a-9875-427b21107433)

SB:
![image](https://github.com/user-attachments/assets/48082419-519a-4f44-b805-b8a0d4905eec)
