### PR TITLE
fix(wallet): Refresh receiver preferred chain ids

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -152,3 +152,15 @@ QtObject:
       if cmpIgnoreCase(item.address(), address) == 0 and item.walletType != "watch":
         return true
     return false
+
+  proc onPreferredSharingChainsUpdated*(self: Model, address, prodPreferredChainIds, testPreferredChainIds: string) =
+    var i = 0
+    for item in self.items.mitems:
+      if address == item.address:
+        item.prodPreferredChainIds = prodPreferredChainIds
+        item.testPreferredChainIds = testPreferredChainIds
+        let index = self.createIndex(i, 0, nil)
+        defer: index.delete
+        self.dataChanged(index, index, @[ModelRole.PreferredSharingChainIds.int])
+        break
+      i.inc

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -70,6 +70,10 @@ method load*(self: Module) =
   self.controller.init()
   self.view.load()
 
+  self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e: Args):
+    let args = AccountArgs(e)
+    self.view.onPreferredSharingChainsUpdated(args.account.keyUid, args.account.address, args.account.prodPreferredChainIds, args.account.testPreferredChainIds)
+
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -69,3 +69,6 @@ QtObject:
 
   proc getWalletAccountAsJson*(self: View, address: string): string {.slot.} =
     return $self.delegate.getWalletAccountAsJson(address)
+
+  proc onPreferredSharingChainsUpdated*(self: View, keyUid, address, prodPreferredChainIds, testPreferredChainIds: string) =
+    self.accounts.onPreferredSharingChainsUpdated(address, prodPreferredChainIds, testPreferredChainIds)


### PR DESCRIPTION
Fixes #15682

### What does the PR do

Refresh preferred chain ids after changing them in Receiver modal

### Affected areas

Receiver modal

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/72f1c2e5-e287-488d-94c7-c5c87e3710ee

