### PR TITLE
fix(wallet)_: Temporarily disable Max Amount button pending #15709

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -274,7 +274,9 @@ Item {
             verify(!maxTagButton.text.endsWith("ETH"))
         }
 
+        // FIXME: This should be enabled after #15709 is resolved
         function test_clickingMaxButton() {
+            skip("maxTabButton is diabled")
             controlUnderTest = createTemporaryObject(componentUnderTest, root, {tokenKey: "ETH"})
             verify(!!controlUnderTest)
             waitForRendering(controlUnderTest)
@@ -355,21 +357,24 @@ Item {
 
                 waitForRendering(controlUnderTest)
                 verify(maxTagButton.visible)
+		 // FIXME: maxTagButton should be enabled after #15709 is resolved
+                verify(!maxTagButton.enabled)
                 verify(!maxTagButton.text.endsWith(modelItemToTest.symbol))
                 tryCompare(maxTagButton, "type", modelItemToTest.currentBalance === 0 ? StatusBaseButton.Type.Danger : StatusBaseButton.Type.Normal)
 
                 // check input value and state
-                mouseClick(maxTagButton)
-                waitForRendering(amountToSendInput)
+                if (maxTagButton.enabled) {
+                    mouseClick(maxTagButton)
+                    waitForRendering(amountToSendInput)
 
-                tryCompare(amountToSendInput.input, "text", modelItemToTest.currentBalance === 0 ? "" : maxTagButton.maxSafeValueAsString)
-                compare(controlUnderTest.value, maxTagButton.maxSafeValue)
-                verify(modelItemToTest.currentBalance === 0 ? !controlUnderTest.valueValid : controlUnderTest.valueValid)
-                const marketPrice = !!amountToSendInput.selectedHolding ? amountToSendInput.selectedHolding.marketDetails.currencyPrice.amount : 0
-                compare(bottomItemText.text, d.adaptor.formatCurrencyAmount(
-                            maxTagButton.maxSafeValue * marketPrice,
-                            d.adaptor.currencyStore.currentCurrency))
-
+                    tryCompare(amountToSendInput.input, "text", modelItemToTest.currentBalance === 0 ? "" : maxTagButton.maxSafeValueAsString)
+                    compare(controlUnderTest.value, maxTagButton.maxSafeValue)
+                    verify(modelItemToTest.currentBalance === 0 ? !controlUnderTest.valueValid : controlUnderTest.valueValid)
+                    const marketPrice = !!amountToSendInput.selectedHolding ? amountToSendInput.selectedHolding.marketDetails.currencyPrice.amount : 0
+                    compare(bottomItemText.text, d.adaptor.formatCurrencyAmount(
+                                maxTagButton.maxSafeValue * marketPrice,
+                                d.adaptor.currencyStore.currentCurrency))
+                }
                 amountToSendInput.input.input.edit.clear()
             }
         }

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1173,6 +1173,8 @@ Item {
 
             // check states for the pay input selector
             verify(maxTagButton.visible)
+	    // FIXME: maxTagButton should be enabled after #15709 is resolved
+            verify(!maxTagButton.enabled);
             let maxPossibleValue = WalletUtils.calculateMaxSafeSendAmount(expectedToken.currentBalance, expectedToken.symbol)
             let truncmaxPossibleValue = Math.trunc(maxPossibleValue*100)/100
             compare(maxTagButton.text, qsTr("Max. %1").arg(truncmaxPossibleValue === 0 ? Qt.locale().zeroDigit
@@ -1184,15 +1186,16 @@ Item {
             compare(amountToSendInput.input.placeholderText, LocaleUtils.numberToLocaleString(0))
             tryCompare(bottomItemText, "text", root.swapAdaptor.currencyStore.formatCurrencyAmount(valueToExchange * expectedToken.marketDetails.currencyPrice.amount, root.swapAdaptor.currencyStore.currentCurrency))
 
-            // click on max button
-            mouseClick(maxTagButton)
-            waitForItemPolished(payPanel)
+            if (maxTagButton.enabled) {
+                // click on max button
+                mouseClick(maxTagButton)
+                waitForItemPolished(payPanel)
 
-            verify(amountToSendInput.interactive)
-            verify(amountToSendInput.input.input.edit.cursorVisible)
-            tryCompare(amountToSendInput.input, "text", maxPossibleValue === 0 ? "" : maxPossibleValue.toLocaleString(Qt.locale(), 'f', -128))
-            tryCompare(bottomItemText, "text", root.swapAdaptor.currencyStore.formatCurrencyAmount(maxPossibleValue * expectedToken.marketDetails.currencyPrice.amount, root.swapAdaptor.currencyStore.currentCurrency))
-
+                verify(amountToSendInput.interactive)
+                verify(amountToSendInput.input.input.edit.cursorVisible)
+                tryCompare(amountToSendInput.input, "text", maxPossibleValue === 0 ? "" : maxPossibleValue.toLocaleString(Qt.locale(), 'f', -128))
+                tryCompare(bottomItemText, "text", root.swapAdaptor.currencyStore.formatCurrencyAmount(maxPossibleValue * expectedToken.marketDetails.currencyPrice.amount, root.swapAdaptor.currencyStore.currentCurrency))
+            }
             closeAndVerfyModal()
         }
 

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -277,6 +277,8 @@ Control {
                                                   { noSymbol: !amountToSendInput.inputIsFiat })
 
                 visible: d.isSelectedHoldingValidAsset && root.swapSide === SwapInputPanel.SwapSide.Pay
+                // FIXME: This should be enabled after #15709 is resolved
+                enabled: false
 
                 onClicked: {
                     if (maxSafeValue)

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -419,6 +419,8 @@ StatusDialog {
                         Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
 
                         visible: d.isSelectedHoldingValidAsset && !d.isCollectiblesTransfer
+                        // FIXME: This should be enabled after #15709 is resolved
+                        enabled: false
 
                         onClicked: {
                             if (maxSafeValue > 0) {


### PR DESCRIPTION
### What does the PR do

 - This commit temporarily disable the MaxAmount button in the `SwapInputPanel` and `SendModal` components.
 - The MaxAmount button will be reintroduced with the correct behavior in issue #15709 for the 2.31 release.
 - closes: #15710

### Affected areas

 * sendModal
 * swapModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?


### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

### Screenshot
<img width="1312" alt="image" src="https://github.com/user-attachments/assets/8b582f92-26f1-47ea-8558-fbb49d5e3abe">

