### PR TITLE
fix: recalculation is not happening when changing amounts in custom bridge flow

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -612,7 +612,7 @@ StatusDialog {
                 interactive: popup.interactive
                 selectedRecipient: popup.preSelectedRecipient
                 ensAddressOrEmpty: recipientInputLoader.resolvedENSAddress
-                amountToSend: amountToSend.cryptoValueToSendFloat
+                amountToSend: amountToSend.asNumber
                 minSendCryptoDecimals: amountToSend.minSendCryptoDecimals
                 minReceiveCryptoDecimals: amountToSend.minReceiveCryptoDecimals
                 selectedAsset: d.selectedHolding


### PR DESCRIPTION
It was about `cryptoValueToSendFloat` property which doesn't exist in the new `AmountToSendNew` component.

Fixes: #15699