### PR TITLE
fix: validate if RawMessage from DB is valid before sending it

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -3,7 +3,7 @@ import os
 
 const DEFAULT_FLAG_DAPPS_ENABLED = false
 const DEFAULT_FLAG_SWAP_ENABLED = false
-const DEFAULT_FLAG_CONNECTOR_ENABLED = false
+const DEFAULT_FLAG_CONNECTOR_ENABLED = true
 
 proc boolToEnv(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"


### PR DESCRIPTION
### What does the PR do

During sending RawMessage, we calculate ID.
If RawMessage with ID A was not stored to raw_messages after the send and msg A payload/sender/type data was changed and stored to the DB, next time we will try to send this msg, it will calculate msg ID as B due to changed content and upsertRawMessageToWatch will never increase send_count for message A, and it will be sending in the loop all the time

Closes # https://github.com/status-im/status-desktop/issues/15466

### Affected areas

Sending private RawMessages

