### PR TITLE
fix(@desktop/wallet): Fix for notification showing from to token symbol and to token amount

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -464,7 +464,7 @@ proc connectForNotificationsOnly[T](self: Module[T]) =
     let args = TransactionSentArgs(e)
     self.view.showToastTransactionSent(args.chainId, args.txHash, args.uuid, args.error,
       ord(args.txType), args.fromAddress, args.toAddress, args.fromTokenKey, args.fromAmount,
-      args.fromTokenKey, args.toAmount)
+      args.toTokenKey, args.toAmount)
 
   self.events.on(MARK_WALLET_ADDRESSES_AS_SHOWN) do(e:Args):
     let args = WalletAddressesArgs(e)

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -423,7 +423,6 @@ QtObject:
           $route.gasAmount, gasFees, route.gasFees.eip1559Enabled, $route.gasFees.maxPriorityFeePerGas, $route.gasFees.maxFeePerGasM)
         txData.to = parseAddress(to_addr).some
         if sendType == SendType.Swap:
-          totalAmountToReceive += route.amountOut
           txData.slippagePercentage = slippagePercentage
 
         paths.add(self.createPath(route, txData, tokenSymbol, to_addr))
@@ -547,7 +546,6 @@ QtObject:
           )
         txData.data = data
         if sendType == SendType.Swap:
-          totalAmountToReceive += route.amountOut
           txData.slippagePercentage = slippagePercentage
 
         let path = self.createPath(route, txData, mtCommand.toAsset, mtCommand.toAddress)


### PR DESCRIPTION
### What does the PR do

When swapping the notification showed from to token symbo and amount.

This PR fixes that

### Affected areas

SwapModal notifications

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

**`Swap ERC20`**

https://github.com/user-attachments/assets/5d2a0e12-bf1a-432a-870a-43bf71d7b59e

**`Swap ETH`**

https://github.com/user-attachments/assets/f8df0046-7cd4-47f7-a108-ad808c29cb15

**`Approve ERC20`**

https://github.com/user-attachments/assets/09aa01f9-0924-4e27-b0fb-fda1ec6f7bee

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->

### Cool Spaceship Picture

<!-- optional but cool -->
