### PR TITLE
fix(SendModal): Allow to send 0

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -447,7 +447,6 @@ StatusDialog {
                                 SQUtils.AmountsArithmetic.fromString(amount)) === -1
 
                         readonly property bool ready: valid && !empty && !balanceExceeded
-                                                      && amount !== "0"
 
                         readonly property string selectedSymbol:
                             !!d.selectedHolding && !!d.selectedHolding.symbol


### PR DESCRIPTION
### What does the PR do

This PR unblocks sending `0` in `SendModal`.

Note: When providing `0` routes are not found, it requires further investigation probably on status-go side.

Closes: #15720

[Screencast from 23.07.2024 11:00:12.webm](https://github.com/user-attachments/assets/f6496c63-c59b-4e8d-8ca3-e44218cb406c)


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

`SendModal`