### PR TITLE
fix(dApps): sign popup appears during splash screen

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2177,7 +2177,7 @@ Item {
         id: walletConnectServiceLoader
 
         // It seems some of the functionality of the dapp connector depends on the WalletConnectService
-        active: Global.featureFlags.dappsEnabled || Global.featureFlags.connectorEnabled
+        active: (Global.featureFlags.dappsEnabled || Global.featureFlags.connectorEnabled) && appMain.visible
 
         sourceComponent: WalletConnectService {
             id: walletConnectService


### PR DESCRIPTION
Closes #15545 

### What does the PR do

Postponing walletconnect service loader until main app becomes visible, similarly to the walletLoader's logic. This is needed to prevent "sign popup" from showing up during app loading when there is an active request from one of the connected dApps 

### Affected areas

Wallet Connect


### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/6b67e48a-1c33-4aec-bcde-c73e317aad4d


### Impact on end user

End users will observe the Sign Request if there is one, only after the app fully starts, and the splash screen finishes.

### How to test

Please check the videos at https://github.com/status-im/status-desktop/issues/15545 , but instead of crashing the app just after connecting to the Rarible dApp, just quit the Status app, and start it again.

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.

