### PR TITLE
StatusQ(ObjectProxyModel): const_cast removed from proxyObject method

### DIFF
--- a/ui/StatusQ/include/StatusQ/objectproxymodel.h
+++ b/ui/StatusQ/include/StatusQ/objectproxymodel.h
@@ -40,8 +40,7 @@ public:
     void setExposedRoles(const QStringList& exposedRoles);
     const QStringList& exposedRoles() const;
 
-    Q_INVOKABLE QObject* proxyObject(int index);
-    const QObject* proxyObject(int index) const;
+    Q_INVOKABLE QObject* proxyObject(int index) const;
 
 signals:
     void delegateChanged();

--- a/ui/StatusQ/src/objectproxymodel.cpp
+++ b/ui/StatusQ/src/objectproxymodel.cpp
@@ -162,7 +162,7 @@ const QStringList& ObjectProxyModel::exposedRoles() const
     return m_exposedRoles;
 }
 
-QObject* ObjectProxyModel::proxyObject(int index)
+QObject* ObjectProxyModel::proxyObject(int index) const
 {
     if (index >= m_container.size())
         return nullptr;
@@ -177,7 +177,6 @@ QObject* ObjectProxyModel::proxyObject(int index)
             ? creationContext : m_delegate->engine()->rootContext();
 
     auto context = new QQmlContext(parentContext);
-
     auto rowData = new QQmlPropertyMap(context);
     auto model = sourceModel();
 
@@ -205,11 +204,6 @@ QObject* ObjectProxyModel::proxyObject(int index)
     entry.rowData = rowData;
 
     return instance;
-}
-
-const QObject* ObjectProxyModel::proxyObject(int index) const
-{
-    return const_cast<ObjectProxyModel*>(this)->proxyObject(index);
 }
 
 void ObjectProxyModel::resetInternalData()


### PR DESCRIPTION
### What does the PR do

Investigating https://github.com/status-im/status-desktop/issues/15324 it was noticed that there is unnecessary `const_cast` used, which can be easily removed.

Closes: #15744
