### PR TITLE
fix(StatusStickerPackClickPopup): display correct detailed contents of a sticker pack

### DIFF
--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -25,7 +25,6 @@ QtObject:
     StickerPackList* = ref object of QAbstractListModel
       delegate: io_interface.AccessInterface
       packs*: seq[StickerPackView]
-      packIdToRetrieve*: int
       foundStickers*: QVariant
 
   proc setup(self: StickerPackList) = self.QAbstractListModel.setup
@@ -127,10 +126,6 @@ QtObject:
         it.pending = pending)
     self.dataChanged(index, index, @[StickerPackRoles.Installed.int, StickerPackRoles.Bought.int,
       StickerPackRoles.Pending.int])
-
-  proc getStickers*(self: StickerPackList): QVariant {.slot.} =
-    let packInfo = self.packs[self.packIdToRetrieve]
-    result = newQVariant(packInfo.stickers)
 
   # We cannot return QVariant from the proc which has arguments.
   # First findStickersById has to be called, then getFoundStickers

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -263,7 +263,10 @@ Item {
             anchors.leftMargin: Style.current.padding / 2
             width: 24
             height: 24
-            type: StatusRoundButton.Type.Secondary
+            icon.width: 16
+            icon.height: 16
+            horizontalPadding: 0
+            verticalPadding: 0
             onClicked: {
                 root.backClicked()
             }

--- a/ui/imports/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/imports/shared/status/StatusStickerPackClickPopup.qml
@@ -15,7 +15,7 @@ import shared.popups.send 1.0
 import shared.stores.send 1.0
 
 //TODO remove this dependency!
-import "../../../app/AppLayouts/Chat/stores"
+import AppLayouts.Chat.stores 1.0
 import AppLayouts.Wallet.stores 1.0
 
 // TODO: replace with StatusModal
@@ -37,7 +37,9 @@ ModalPopup {
     property var stickers;
     signal buyClicked(string packId)
 
-    Component.onCompleted: {
+    onAboutToShow: {
+        stickersModule.getInstalledStickerPacks()
+
         const idx = stickersModule.stickerPacks.findIndexById(packId, false);
         if(idx === -1) close();
         const item = SQUtils.ModelUtils.get(stickersModule.stickerPacks, idx)
@@ -45,7 +47,7 @@ ModalPopup {
         author = item.author
         thumbnail = item.thumbnail
         price = item.price
-        stickers = stickersModule.stickerPacks.getStickers()
+        stickers = item.stickers
         installed = item.installed
         bought = item.bought
         pending = item.pending
@@ -80,7 +82,7 @@ ModalPopup {
                 preSelectedRecipient: stickerPackDetailsPopup.store.stickersStore.getStickersMarketAddress()
                 preDefinedAmountToSend: LocaleUtils.numberToLocaleString(parseFloat(price))
                 preSelectedHoldingID: {
-                    let token = ModelUtils.getByKey(root.walletAssetsStore.groupedAccountAssetsModel, "tokensKey", stickerPackDetailsPopup.store.stickersStore.getStatusTokenKey())
+                    let token = SQUtils.ModelUtils.getByKey(stickerPackDetailsPopup.walletAssetsStore.groupedAccountAssetsModel, "tokensKey", stickerPackDetailsPopup.store.stickersStore.getStatusTokenKey())
                     return !!token && !!token.symbol ? token.symbol : ""
                 }
                 preSelectedHoldingType: Constants.TokenType.ERC20


### PR DESCRIPTION
### What does the PR do

- just use the `model.stickers` to access the submodel, remove dead NIM code
- make sure that the installed sticker packs are loaded, even before first opening the Sticker popup
- StatusStickerMarket: fix the back button
- fix launching the Buy stickers modal (SendModal)

Fixes #15718

### Affected areas

StatusStickerPackClickPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-07-23 17-39-17.webm](https://github.com/user-attachments/assets/b64362f2-e12d-40ac-ab5f-bbeb5f444512)

