### PR TITLE
fix(dapps): isolate wallet connect functionality for profile

### DIFF
--- a/src/backend/wallet_connect.nim
+++ b/src/backend/wallet_connect.nim
@@ -49,6 +49,7 @@ proc disconnectSession*(topic: string): bool =
     error "wallet_disconnectWalletConnectSession failed: ", "msg", e.msg
     return false
 
+# returns nil if error
 proc getActiveSessions*(validAtTimestamp: int): JsonNode =
   try:
     let rpcRes = getWalletConnectActiveSessions(validAtTimestamp)
@@ -57,7 +58,8 @@ proc getActiveSessions*(validAtTimestamp: int): JsonNode =
 
     let jsonResultStr = rpcRes.result.getStr()
     if jsonResultStr == "null":
-      return nil
+      # nil means error
+      return newJArray()
 
     if rpcRes.result.kind != JArray:
       error "Unexpected result kind: ", rpcRes.result.kind

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -644,7 +644,7 @@ Item {
             verify(eip155.hasOwnProperty("methods"))
             verify(eip155.methods.length > 0)
             verify(eip155.hasOwnProperty("events"))
-            verify(eip155.events.length > 0)
+            compare(eip155.events.length, 2)
         }
     }
 

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -280,6 +280,25 @@ Item {
             compare(sdk.getActiveSessionsCallbacks.length, 1, "expected DAppsRequestHandler call sdk.getActiveSessions")
         }
 
+        // Tests that the request is ignored if not in the current profile (don't have the PK for the address)
+        function test_onSessionRequestEventMissingAddress() {
+            let sdk = handler.sdk
+
+            let testAddressUpper = "0xY"
+            let chainId = 2
+            let method = "personal_sign"
+            let message = "hello world"
+            let params = [`"${Helpers.strToHex(message)}"`, `"${testAddressUpper}"`]
+            let topic = "b536a"
+            let session = JSON.parse(Testing.formatSessionRequest(chainId, method, params, topic))
+            // Expect to have calls to getActiveSessions from service initialization
+            let prevRequests = sdk.getActiveSessionsCallbacks.length
+            sdk.sessionRequestEvent(session)
+
+            compare(sdk.getActiveSessionsCallbacks.length, 0, "expected DAppsRequestHandler don't call sdk.getActiveSessions")
+            compare(sdk.rejectSessionRequestCalls.length, 0, "expected no call to service.rejectSessionRequest")
+        }
+
         function test_balanceCheck_data() {
             return [{
                 tag: "have_enough_funds",

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 
 import StatusQ.Core.Utils 0.1
 
+import AppLayouts.Wallet.services.dapps 1.0
+
 import shared.stores 1.0
 
 import utils 1.0
@@ -11,6 +13,7 @@ QObject {
 
     required property WalletConnectSDKBase sdk
     required property DAppsStore store
+    required property var supportedAccountsModel
 
     readonly property alias dappsModel: d.dappsModel
 
@@ -46,11 +49,12 @@ QObject {
             }
 
             getActiveSessionsFn = () => {
-                sdk.getActiveSessions((sessions) => {
+                sdk.getActiveSessions((allSessions) => {
                     root.store.dappsListReceived.disconnect(dappsListReceivedFn);
 
                     let tmpMap = {}
                     var topics = []
+                    const sessions = Helpers.filterActiveSessionsForKnownAccounts(allSessions, root.supportedAccountsModel)
                     for (let key in sessions) {
                         let dapp = sessions[key].peer.metadata
                         if (!!dapp.icons && dapp.icons.length > 0) {
@@ -61,7 +65,7 @@ QObject {
                         tmpMap[dapp.url] = dapp;
                         topics.push(key)
                     }
-                    // TODO #14755: on SDK dApps refresh update the model that has data source from persistence instead of using reset
+                    // TODO #15075: on SDK dApps refresh update the model that has data source from persistence instead of using reset
                     dapps.clear();
                     // Iterate tmpMap and fill dapps
                     for (let key in tmpMap) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -36,7 +36,7 @@ QObject {
     readonly property alias requestHandler: requestHandler
 
     readonly property var validAccounts: SortFilterProxyModel {
-        sourceModel: root.walletRootStore.nonWatchAccounts
+        sourceModel: d.supportedAccountsModel
         proxyRoles: [
             FastExpressionRole {
                 name: "colorizedChainPrefixes"
@@ -108,10 +108,11 @@ QObject {
     }
 
     function disconnectDapp(url) {
-        wcSDK.getActiveSessions((sessions) => {
-            for (let key in sessions) {
-                let dapp = sessions[key].peer.metadata
-                let topic = sessions[key].topic
+        wcSDK.getActiveSessions((allSessions) => {
+            const sessions = Helpers.filterActiveSessionsForKnownAccounts(allSessions, d.supportedAccountsModel)
+            for (let session in sessions) {
+                let dapp = session.peer.metadata
+                let topic = session.topic
                 if (dapp.url == url) {
                     wcSDK.disconnectSession(topic)
                 }
@@ -218,6 +219,8 @@ QObject {
     QObject {
         id: d
 
+        readonly property var supportedAccountsModel: root.walletRootStore.nonWatchAccounts
+
         property var currentSessionProposal: null
         property var acceptedSessionProposal: null
 
@@ -255,6 +258,7 @@ QObject {
 
         sdk: root.wcSDK
         store: root.store
+        supportedAccountsModel: d.supportedAccountsModel
     }
 
     // Timeout for the corner case where the URL was already dismissed and the SDK doesn't respond with an error nor advances with the proposal

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -100,3 +100,23 @@ function extractInfoFromPairUri(uri) {
     }
     return { topic, expiry }
 }
+
+function filterActiveSessionsForKnownAccounts(sessions, accountsModel) {
+    let knownSessions = ({})
+    Object.keys(sessions).forEach((topic) => {
+        const session = sessions[topic]
+        const eip155Addresses = session.namespaces.eip155.accounts
+        const accountSet = new Set(
+            eip155Addresses.map(eip155Address => eip155Address.split(':').pop().trim())
+        );
+        const uniqueAddresses = Array.from(accountSet);
+        const firstAccount = SQUtils.ModelUtils.getFirstModelEntryIf(accountsModel, (account) => {
+            return uniqueAddresses.includes(account.address)
+        })
+        if (!firstAccount) {
+            return
+        }
+        knownSessions[topic] = session
+    })
+    return knownSessions
+}


### PR DESCRIPTION
### Closes #14888, #15707

`HEAD` fix(dapps): filter out dApps connected on other profiles

- Add helper function to filter out dApps with sessions that don't have any supported account in the available accounts list.
- Use helper function to filter out dApps connected on other profiles when listing dApps in the dApps list.
- When disconnecting an app only disconnect sessions for the current profile.

`HEAD~1` fix(dapps) don't show Wallet Connect state from other profiles
    
- Ignore session requests events that include accounts in other profiles

`HEAD~2` fix(dapps) minor wallet connect fixes and improvements

  - don't report error in case of status-go returning nil instead
  of an empty array.
  - fix misleading alias to AmountsArithmetic
  - minor improvements requested in previous discussions

### Affected areas

`dApps`
maybe connector @kounkou?

### StatusQ checklist

- [x] ~~add documentation if necessary (new component, new feature)~~
- [x] ~~update sandbox app~~
- [x] ~~test changes in both light and dark theme?~~

### Screenshot of functionality (including design for comparison)

| Before | After |
| ------ | ------|
| <img src="https://github.com/user-attachments/assets/3e39f38a-1d95-43a8-9904-c21f9e10e680" height="200"> |  <img src="https://github.com/user-attachments/assets/d0692b17-07d5-4870-a79b-9c1b36a82e38" height="200">|

### Impact on end user

User will see and receive only relevant info

### How to test

- Have two profile with different accounts
- Connect on one profile with an app and check it is display and receives the request from the connected dapps
- Switch on the other profile and check there is no dapp listed and no request is received and connect with another dapp and check that the other dapp is in the list and receives requests
- Switch to the other profile and check that the other dapp is not listed, and doesn't receive requests

### Risk 

- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.

### Cool Spaceship Picture

<img src="https://github.com/user-attachments/assets/b9a2eec5-c09d-4335-ac1a-35d09190ecd6" width="100">

