### PR TITLE
fix(dApps): Added default dApp icon according to the new spec. Extracting dApp name from its url, if no name is provided through walletconnect API.

### DIFF
--- a/storybook/pages/DappsComboBoxPage.qml
+++ b/storybook/pages/DappsComboBoxPage.qml
@@ -28,19 +28,19 @@ SplitView {
         ListModel {
             id: dappsModel
             ListElement {
-                name: "Test dApp 1"
+                name: ""
                 url: "https://dapp.test/1"
                 iconUrl: "https://se-sdk-dapp.vercel.app/assets/eip155:1.png"
             }
             ListElement {
                 name: "Test dApp 2"
                 url: "https://dapp.test/2"
-                iconUrl: "https://react-app.walletconnect.com/assets/eip155-1.png"
+                iconUrl: ""
             }
             ListElement {
-                name: "Test dApp 3"
+                name: ""
                 url: "https://dapp.test/3"
-                iconUrl: "https://react-app.walletconnect.com/assets/eip155-1.png"
+                iconUrl: ""
             }
             ListElement {
                 name: "Test dApp 4 - very long name !!!!!!!!!!!!!!!!"

--- a/ui/imports/shared/popups/walletconnect/controls/DAppDelegate.qml
+++ b/ui/imports/shared/popups/walletconnect/controls/DAppDelegate.qml
@@ -6,6 +6,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 
 MouseArea {
     id: root
@@ -36,13 +37,16 @@ MouseArea {
                 visible: !fallbackImage.visible
             }
 
-            StatusIcon {
+            StatusSmartIdenticon {
                 id: fallbackImage
 
                 anchors.fill: parent
 
-                icon: "dapp"
-                color: Theme.palette.baseColor1
+                name: dAppCaption.text ?? "dapp"
+                asset.charactersLen: 2
+                asset.color: Theme.palette.primaryColor1
+                asset.letterIdenticonBgWithAlpha: true
+                asset.useAcronymForLetterIdenticon: false
 
                 visible: iconImage.isLoading || iconImage.isError || !root.iconUrl
             }
@@ -63,7 +67,9 @@ MouseArea {
             Layout.rightMargin: 12
 
             StatusBaseText {
-                text: root.name
+                id: dAppCaption
+
+                text: root.name ? root.name : SQUtils.StringUtils.extractDomainFromLink(root.url)
 
                 Layout.fillWidth: true
 


### PR DESCRIPTION

Closes #15593

### What does the PR do

1. If there is no name provided via WC API, name would be extracted from the dApp url
2. If there is no url for dApp icon provided, it will be constructed based on dApp name, similarly to  Wallet User avatar component [15593](https://github.com/status-im/status-desktop/issues/15593#issuecomment-2236471549) . 

### Affected areas

dApp DAppDelegate


### Screenshot of functionality (including design for comparison)
![image](https://github.com/user-attachments/assets/6abaf7a9-175f-4272-b97b-ac0b3ac184cd)


- [x] I've checked the design and this PR matches it

### How to test

-For now (according to [15593](https://github.com/status-im/status-desktop/issues/15593) yearn.fi does not provide neither name nor icon, so its a good candidate to test the fallback logic.

### Risk 

Fallback dApp icon changed from "dapp" to avatar-like icon constructed based on dApp name.
Fallback dApp name will now depend on dApp url

- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.


