### PR TITLE
fix(SwapModal): Buy button not resizing with text

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -307,6 +307,7 @@ StatusDialog {
             ErrorTag {
                 objectName: "errorTag"
                 visible: d.isError
+                Layout.maximumWidth: parent.width
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: Style.current.smallPadding
                 text: root.swapAdaptor.errorMessage

--- a/ui/imports/shared/controls/ErrorTag.qml
+++ b/ui/imports/shared/controls/ErrorTag.qml
@@ -54,7 +54,6 @@ InformationTag {
         objectName: "rightComponentButton"
         horizontalPadding: 8
 
-        width: visible || root.loading ? implicitWidth : 0
         visible: root.buttonVisible
 
         size: StatusBaseButton.Size.Tiny


### PR DESCRIPTION
### What does the PR do

- also limit the max width in order for the ErrorTag not to overflow the modal width

Fixes #15687

### Affected areas

SwapModal, ErrorTag

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/8e1bfcc0-a501-42c1-bf2f-c6eb4c27327d)
