### PR TITLE
fix missing required param to fix sign request popup display

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -89,7 +89,8 @@ WalletConnectSDKBase {
                 maxFeesText: "?",
                 maxFeesEthText: "?",
                 enoughFunds: enoughFunds,
-                estimatedTimeText: "?"
+                estimatedTimeText: "?",
+                preparedData: event.params.request.tx.data,
             })
             if (obj === null) {
                 console.error("Error creating SessionRequestResolved for event")


### PR DESCRIPTION
### What does the PR do

Wallet team updated the SessionRequestResolved.qml component adding a required param : `prepareData` which caused the Connector service sign request popup to render incorrectly.

Wallet PR that added required parameter : https://github.com/status-im/status-desktop/pull/15645

### Affected areas

- Connector popup screen

### Screenshot of functionality (including design for comparison)

- Screenshot before the fix

![Screenshot from 2024-07-23 17-50-48](https://github.com/user-attachments/assets/beda57e5-b900-4360-b6c8-269d85222b39)

- Screenshot after the fix

![Screenshot from 2024-07-23 17-51-34](https://github.com/user-attachments/assets/aa99c7fb-cb35-48dd-a2d2-0444df357f78)

### Impact on end user

No impact

### How to test

- Launch an instance of status-desktop
- Use postman or equivalent to send a `eth_sendTransaction` request

```bash
{
    "jsonrpc": "2.0",
    "id": 37,
    "method": "connector_callRPC",
    "params": [
        "{\"method\": \"eth_sendTransaction\", \"params\":[{\"from\":\"0x013233bcfdc038f1c73f1ab0643ed5a676c3dd6a\",\"to\":\"0x6f29cea3011904b143dea3a09f736f8cbf83c0c9\",\"gas\":\"0x41c0\",\"gasPrice\":\"0x4a0\",\"value\":\"0x8ac7230489e80000\",\"nonce\":null,\"maxFeePerGas\":\"0x4c800\",\"maxPriorityFeePerGas\":\"\",\"input\":\"0x2323\",\"data\":\"0x4465617220557365722c205765206b696e646c79207265717565737420796f757220617474656e74696f6e20746f207369676e2074686520666f6c6c6f77696e67206d6573736167652e205369676e696e672074686973206d657373616765206973206372756369616c20666f7220766572696679696e6720796f7572206964656e7469747920616e6420656e737572696e6720746865207365637572697479206f6620796f7572207472616e73616374696f6e732e\",\"MultiTransactionID\":0,\"Symbol\":\"\"}], \"url\": \"https://www.status-im.cn\", \"name\": \"StatusDApp\", \"iconUrl\": \"https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/osa.svg\" }"
    ]
}
```

### Risk 

Low to No risk

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
