### PR TITLE
Fix some nightly fails and disabled keycard mock in nightly

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -40,7 +40,7 @@ pipeline {
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
       description: 'Decides whether the mocked status-keycard-go library is built.',
-      defaultValue: isNightlyBuild
+      defaultValue: false
     )
   }
 

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -32,7 +32,7 @@ pipeline {
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
       description: 'Decides whether the mocked status-keycard-go library is built.',
-      defaultValue: isNightlyBuild
+      defaultValue: false
     )
   }
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -34,6 +34,7 @@ def setup_session_scope(
         init_testrail_api,
         prepare_test_directory,
         start_squish_server,
+        close_apps_before_start
 ):
     LOG.info('Session startup...')
     yield

--- a/test/e2e/fixtures/aut.py
+++ b/test/e2e/fixtures/aut.py
@@ -1,13 +1,16 @@
 import allure
 import os
+
 import pytest
 import logging
 import configs
 import constants
+from configs import get_platform
 from constants import UserAccount
 from driver.aut import AUT
 from gui.main_window import MainWindow
 from scripts.utils import system_path
+from scripts.utils.local_system import get_pid_by_process_name, kill_process
 from scripts.utils.system_path import SystemPath
 
 LOG = logging.getLogger(__name__)
@@ -87,3 +90,14 @@ def user_account(request) -> UserAccount:
 def main_screen(user_account: UserAccount, main_window: MainWindow) -> MainWindow:
     main_window.authorize_user(user_account)
     return main_window
+
+@pytest.fixture(scope="session")
+def close_apps_before_start():
+    if get_platform() == "Windows":
+        name = 'Status.exe'
+    else:
+        name = 'nim_status_client'
+    running_pids = get_pid_by_process_name(name)
+    if running_pids is not None:
+        for pid in running_pids:
+            kill_process(pid)

--- a/test/e2e/gui/components/community/community_channel_popups.py
+++ b/test/e2e/gui/components/community/community_channel_popups.py
@@ -48,7 +48,7 @@ class NewChannelPopup(ChannelPopup):
                 raise err
 
     def save(self):
-        self._save_create_button.click()
+        self._save_create_button.click(timeout=5)
 
 
 class EditChannelPopup(ChannelPopup):

--- a/test/e2e/gui/components/settings/block_user_popup.py
+++ b/test/e2e/gui/components/settings/block_user_popup.py
@@ -25,7 +25,7 @@ class BlockUserPopup(BasePopup):
 
     @allure.step('Block user')
     def block(self):
-        self._block_user_button.click()
+        self._block_user_button.click(timeout=5)
 
     @allure.step('Get warning text')
     def get_warning_text(self) -> str:

--- a/test/e2e/scripts/utils/local_system.py
+++ b/test/e2e/scripts/utils/local_system.py
@@ -3,7 +3,6 @@ import os
 import signal
 import subprocess
 import typing
-import platform
 
 import allure
 import psutil
@@ -46,7 +45,6 @@ def kill_process(pid):
     except Exception as e:
         print(f"Failed to terminate process {pid}: {e}")
 
-
 @allure.step('System execute command')
 def execute(
         command: list,
@@ -76,3 +74,14 @@ def run(
         timeout=timeout_sec,
         check=True
     )
+
+@allure.step('Get pid by process name')
+def get_pid_by_process_name(name):
+    pid_list = []
+    for proc in psutil.process_iter():
+        try:
+            if proc.name() == name and proc.status() != 'zombie':
+                pid_list.append(proc.pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return pid_list if len(pid_list) > 0 else None


### PR DESCRIPTION
### What does the PR do

- Disabled keycard mock in nightly until bug is fixed
- Added fixture to close all running apps before session if there are any
- Increased timeout for clicking some buttons
- There are still a couple of fails, will continue investigation

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2398/allure/