### PR TITLE
fix(dapps) various UX fixes for Wallet Connect

### DIFF
--- a/storybook/qmlTests/tests/tst_ConnectDAppModal.qml
+++ b/storybook/qmlTests/tests/tst_ConnectDAppModal.qml
@@ -125,16 +125,17 @@ Item {
             compare(chainSelector.selection.length, NetworksModel.flatNetworks.count)
             compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count)
 
-            // User should be able to deselect a chain
-            mouseClick(chainSelector)
-            waitForItemPolished(chainSelector)
-            const networkSelectorList = findChild(chainSelector, "networkSelectorList")
-            verify(networkSelectorList, "Network selector list should be present")
-            mouseClick(networkSelectorList.itemAtIndex(0))
-            compare(chainSelector.selection.length, NetworksModel.flatNetworks.count - 1)
-            compare(chainSelector.selection[0], NetworksModel.flatNetworks.get(1).chainId)
-            compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count - 1)
-            compare(dappModal.selectedChains[0], NetworksModel.flatNetworks.get(1).chainId)
+            // TODO uncomment after we enable chain selection (maybe v2.31)
+            // // User should be able to deselect a chain
+            // mouseClick(chainSelector)
+            // waitForItemPolished(chainSelector)
+            // const networkSelectorList = findChild(chainSelector, "networkSelectorList")
+            // verify(networkSelectorList, "Network selector list should be present")
+            // mouseClick(networkSelectorList.itemAtIndex(0))
+            // compare(chainSelector.selection.length, NetworksModel.flatNetworks.count - 1)
+            // compare(chainSelector.selection[0], NetworksModel.flatNetworks.get(1).chainId)
+            // compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count - 1)
+            // compare(dappModal.selectedChains[0], NetworksModel.flatNetworks.get(1).chainId)
         }
 
         function test_connectedState() {
@@ -269,7 +270,7 @@ Item {
             mouseClick(accountsList.itemAtIndex(1))
             compare(dappModal.selectedAccountAddress, accountSelector.currentAccountAddress)
             compare(dappModal.selectedAccountAddress, selectAddress)
-    
+
             const preselectedAddress = accountSelector.currentAccountAddress
 
             mouseClick(accountSelector)
@@ -296,24 +297,25 @@ Item {
             compare(chainSelector.selection[0], NetworksModel.flatNetworks.get(0).chainId)
             compare(chainSelector.selection[1],  NetworksModel.flatNetworks.get(1).chainId)
 
-            // User should be able to deselect a chain
-            mouseClick(chainSelector)
-            waitForItemPolished(chainSelector)
-            const networkSelectorList = findChild(chainSelector, "networkSelectorList")
-            verify(networkSelectorList, "Network selector list should be present")
-            mouseClick(networkSelectorList.itemAtIndex(0))
-            compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count - 1)
-            compare(dappModal.selectedChains[0], NetworksModel.flatNetworks.get(1).chainId)
+            // TODO uncomment after we enable chain selection (maybe v2.31)
+            // // User should be able to deselect a chain
+            // mouseClick(chainSelector)
+            // waitForItemPolished(chainSelector)
+            // const networkSelectorList = findChild(chainSelector, "networkSelectorList")
+            // verify(networkSelectorList, "Network selector list should be present")
+            // mouseClick(networkSelectorList.itemAtIndex(0))
+            // compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count - 1)
+            // compare(dappModal.selectedChains[0], NetworksModel.flatNetworks.get(1).chainId)
 
-            waitForItemPolished(networkSelectorList)
-            mouseClick(networkSelectorList.itemAtIndex(1))
-            compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count - 2)
-            compare(dappModal.selectedChains[0], NetworksModel.flatNetworks.get(2).chainId)
-            
-            const connectButton = findChild(dappModal, "primaryActionButton")
-            verify(!!connectButton, "Connect button should be present")
-            compare(connectButton.visible, true)
-            compare(connectButton.enabled, true)
+            // waitForItemPolished(networkSelectorList)
+            // mouseClick(networkSelectorList.itemAtIndex(1))
+            // compare(dappModal.selectedChains.length, NetworksModel.flatNetworks.count - 2)
+            // compare(dappModal.selectedChains[0], NetworksModel.flatNetworks.get(2).chainId)
+
+            // const connectButton = findChild(dappModal, "primaryActionButton")
+            // verify(!!connectButton, "Connect button should be present")
+            // compare(connectButton.visible, true)
+            // compare(connectButton.enabled, true)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -271,10 +271,12 @@ DappsComboBox {
             connectDappLoader.sessionTopic = null
 
             if (pairWCLoader.item) {
-                pairWCLoader.item.close()
+                // Allow user to get the uri valid confirmation
+                pairWCLoader.item.pairingValidated(Pairing.errors.dappReadyForApproval)
+                connectDappTimer.start()
+            } else {
+                connectDappLoader.active = true
             }
-
-            connectDappLoader.active = true
         }
 
         function onApproveSessionResult(session, err) {
@@ -294,6 +296,20 @@ DappsComboBox {
             sessionRequestLoader.request = request
             sessionRequestLoader.requestHandled = false
             sessionRequestLoader.active = true
+        }
+    }
+
+    // Used between transitioning from PairWCModal to ConnectDAppModal
+    Timer {
+        id: connectDappTimer
+
+        interval: 500
+        running: false
+        repeat: false
+
+        onTriggered: {
+            pairWCLoader.item.close()
+            connectDappLoader.active = true
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -63,7 +63,7 @@ QObject {
         let info = Helpers.extractInfoFromPairUri(uri)
         wcSDK.getActiveSessions((sessions) => {
             // Check if the URI is already paired
-            var validationState = Pairing.errors.ok
+            var validationState = Pairing.errors.uriOk
             for (let key in sessions) {
                 if (sessions[key].pairingTopic == info.topic) {
                     validationState = Pairing.errors.alreadyUsed
@@ -72,7 +72,7 @@ QObject {
             }
 
             // Check if expired
-            if (validationState == Pairing.errors.ok) {
+            if (validationState == Pairing.errors.uriOk) {
                 const now = (new Date().getTime())/1000
                 if (info.expiry < now) {
                     validationState = Pairing.errors.expired
@@ -159,9 +159,8 @@ QObject {
                 }
                 return
             }
-            if (!(approvedNamespaces.eip155.accounts) || approvedNamespaces.eip155.accounts.length === 0
-                || (!(approvedNamespaces.eip155.chains) || approvedNamespaces.eip155.chains.length === 0)
-            ) {
+            const an = approvedNamespaces.eip155
+            if (!(an.accounts) || an.accounts.length === 0 || (!(an.chains) || an.chains.length === 0)) {
                 d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
                 return
             }

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -150,13 +150,19 @@ QObject {
         }
 
         function onBuildApprovedNamespacesResult(approvedNamespaces, error) {
-            if(error) {
+            if(error || !approvedNamespaces) {
                 // Check that it contains Non conforming namespaces"
                 if (error.includes("Non conforming namespaces")) {
                     d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
                 } else {
                     d.reportPairErrorState(Pairing.errors.unknownError)
                 }
+                return
+            }
+            if (!(approvedNamespaces.eip155.accounts) || approvedNamespaces.eip155.accounts.length === 0
+                || (!(approvedNamespaces.eip155.chains) || approvedNamespaces.eip155.chains.length === 0)
+            ) {
+                d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
                 return
             }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -52,7 +52,8 @@ QObject {
     readonly property var flatNetworks: root.walletRootStore.filteredFlatModel
 
     function validatePairingUri(uri) {
-        if(Helpers.containsOnlyEmoji(uri)) {
+        // Check if emoji inside the URI
+        if(Constants.regularExpressions.emoji.test(uri)) {
             root.pairingValidated(Pairing.errors.tooCool)
             return
         } else if(!Helpers.validURI(uri)) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -69,18 +69,13 @@ function buildSupportedNamespaces(chainIds, addresses, methods) {
 }
 
 function validURI(uri) {
-    var regex = /^wc:[0-9a-fA-F-]*@([1-9][0-9]*)(\?([a-zA-Z-]+=[^&]+)(&[a-zA-Z-]+=[^&]+)*)?$/
+    const regex = /^wc:[0-9a-fA-F-]*@([1-9][0-9]*)(\?([a-zA-Z-]+=[^&]+)(&[a-zA-Z-]+=[^&]+)*)?$/
     return regex.test(uri)
 }
 
-function containsOnlyEmoji(uri) {
-    var emojiRegex = new RegExp("[\\u203C-\\u3299\\u1F000-\\u1F644]");
-    return !emojiRegex.test(uri);
-}
-
 function extractInfoFromPairUri(uri) {
-    var topic = ""
-    var expiry = NaN
+    let topic = ""
+    let expiry = NaN
     // Extract topic and expiry from wc:99fdcac5cc081ac8c1181b4c38c5dc49fb5eb212706d5c94c445be549765e7f0@2?expiryTimestamp=1720090818&relay-protocol=irn&symKey=c6b67d94174bd42d16ff288220ce9b8966e5b56a2d3570a30d5b0a760f1953f0
     const regex = /wc:([0-9a-fA-F]*)/
     const match = uri.match(regex)
@@ -88,11 +83,11 @@ function extractInfoFromPairUri(uri) {
         topic = match[1]
     }
 
-    var parts = uri.split('?')
+    let parts = uri.split('?')
     if (parts.length > 1) {
-        var params = parts[1].split('&')
+        const params = parts[1].split('&')
         for (let i = 0; i < params.length; i++) {
-            var keyVal = params[i].split('=')
+            const keyVal = params[i].split('=')
             if (keyVal[0] === 'expiryTimestamp') {
                 expiry = parseInt(keyVal[1])
             }

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/Pairing.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/Pairing.qml
@@ -5,12 +5,13 @@ import QtQml 2.15
 QtObject {
     readonly property QtObject errors: QtObject {
         readonly property int notChecked: 0
-        readonly property int ok: 1
+        readonly property int uriOk: 1
         readonly property int tooCool: 2
         readonly property int invalidUri: 3
         readonly property int alreadyUsed: 4
         readonly property int expired: 5
         readonly property int unsupportedNetwork: 6
         readonly property int unknownError: 7
+        readonly property int dappReadyForApproval: 8
     }
 }

--- a/ui/imports/shared/popups/walletconnect/PairWCModal.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal.qml
@@ -29,7 +29,7 @@ StatusDialog {
 
     function pairingValidated(validationState) {
         uriInput.errorState = validationState
-        if (validationState === Pairing.errors.ok) {
+        if (validationState === Pairing.errors.uriOk) {
             d.doPair()
         }
     }
@@ -52,6 +52,7 @@ StatusDialog {
             id: uriInput
 
             pending: uriInput.errorState === Pairing.errors.notChecked
+                  || uriInput.errorState === Pairing.errors.uriOk
 
             onTextChanged: {
                 root.isPairing = false
@@ -91,7 +92,7 @@ StatusDialog {
                 enabled: uriInput.valid
                       && !root.isPairing
                       && uriInput.text.length > 0
-                      && uriInput.errorState === Pairing.errors.ok
+                      && uriInput.errorState === Pairing.errors.uriOk
 
                 onClicked: {
                     d.doPair()

--- a/ui/imports/shared/popups/walletconnect/private/ContextCard.qml
+++ b/ui/imports/shared/popups/walletconnect/private/ContextCard.qml
@@ -82,7 +82,7 @@ Rectangle {
                 showTitle: true
                 multiSelection: root.multipleChainSelection
                 showAllSelectedText: false
-                selectionAllowed: !root.connectionAttempted && root.chainsModel.ModelCount.count > 1
+                selectionAllowed: false
             }
         }
     }


### PR DESCRIPTION
fixes: #15591
fixes: #15638
fixes: #15594
fixes: #15673

`HEAD` fix(dapps) emoji in wallet connect uri error

`HEAD~1` feat(dapps) don't allow user selection of networks while connecting

`HEAD~2` fix(dapps) Wallet Connect url validation

- When the pairing response is received the UX is validated and after half second UX is moved to the approval process (`ConnectedDAppModal`)    
- The static url validation state `Pairing.errors.ok` was directly responsible for the validation action in UX. With current change the validation is now based on the pairing response.

`HEAD~3`  fix(dapps) unsupported protocol Wallet Connect corner case

- We have no easy way to check the protocol and provide a customized error message. Therefore we generalizes the error message to network not supported.
