### PR TITLE
feat(wallet): upgrade paraswap api to v6.2

### DIFF
--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -333,7 +333,7 @@ QtObject:
   # All Approvals triggered from the app will be to perform a swap on Paraswap
   proc getApprovalSpender*(self: ActivityEntry): string {.slot.} =
     if self.isMultiTransaction() and self.metadata.activityType == backend.ActivityType.Approve:
-      return PARASWAP_V5_APPROVE_CONTRACT_ADDRESS
+      return PARASWAP_V6_2_CONTRACT_ADDRESS
     return ""
 
   QtProperty[string] approvalSpender:
@@ -346,7 +346,7 @@ QtObject:
     if self.isMultiTransaction() and 
     self.metadata.activityType == backend.ActivityType.Swap and
     self.getChainIdIn() == 0:   # Differentiate between Swaps triggered from the app and external detected Swaps
-      return PARASWAP_V5_SWAP_CONTRACT_ADDRESS
+      return PARASWAP_V6_2_CONTRACT_ADDRESS
     return ""
 
   QtProperty[string] interactedContractAddress:

--- a/src/app_service/common/wallet_constants.nim
+++ b/src/app_service/common/wallet_constants.nim
@@ -12,3 +12,4 @@ const
 
   PARASWAP_V5_APPROVE_CONTRACT_ADDRESS* = "0x216B4B4Ba9F3e719726886d34a177484278Bfcae" # Same address for all supported chains
   PARASWAP_V5_SWAP_CONTRACT_ADDRESS* = "0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57" # Same address for all supported chains
+  PARASWAP_V6_2_CONTRACT_ADDRESS* = "0x6a000f20005980200259b80c5102003040001068" # Same address for all supported chains

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapApproveCapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapApproveCapModal.qml
@@ -45,7 +45,7 @@ SignTransactionModalBase {
     property string serviceProviderHostname: Constants.swap.paraswapHostname
     property string serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl
     property string serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-desktop/issues/15329
-    property string serviceProviderContractAddress: Constants.swap.paraswapApproveContractAddress
+    property string serviceProviderContractAddress: Constants.swap.paraswapV6_2ContractAddress
     property string serviceProviderIcon: Style.png("swap/%1".arg(Constants.swap.paraswapIcon)) // FIXME svg
 
     title: qsTr("Approve spending cap")

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -568,16 +568,23 @@ QtObject {
     // TODO: https://github.com/status-im/status-desktop/issues/15329
     // Get DApp data from the backend
     function getDappDetails(chainId, contractAddress) {
-        console.log("getDappDetails", chainId, contractAddress)
         switch (contractAddress) {
-            case Constants.swap.paraswapApproveContractAddress:
-            case Constants.swap.paraswapSwapContractAddress:
+            case Constants.swap.paraswapV5ApproveContractAddress:
+            case Constants.swap.paraswapV5SwapContractAddress:
                 return {
                     "icon": Style.png("swap/%1".arg(Constants.swap.paraswapIcon)),
                     "url": Constants.swap.paraswapHostname,
                     "name": Constants.swap.paraswapName,
-                    "approvalContractAddress": Constants.swap.paraswapContractAddress,
-                    "swapContractAddress": Constants.swap.paraswapContractAddress,
+                    "approvalContractAddress": Constants.swap.paraswapV5ApproveContractAddress,
+                    "swapContractAddress": Constants.swap.paraswapV5SwapContractAddress,
+                }
+            case Constants.swap.paraswapV6_2ContractAddress:
+                return {
+                    "icon": Style.png("swap/%1".arg(Constants.swap.paraswapIcon)),
+                    "url": Constants.swap.paraswapUrl,
+                    "name": Constants.swap.paraswapName,
+                    "approvalContractAddress": Constants.swap.paraswapV6_2ContractAddress,
+                    "swapContractAddress": Constants.swap.paraswapV6_2ContractAddress,
                 }
         }
         return undefined

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1439,8 +1439,9 @@ QtObject {
         readonly property string paraswapIcon: "paraswap"
         readonly property string paraswapHostname: "app.paraswap.io"
         readonly property string paraswapUrl: "https://www.paraswap.io/"
-        readonly property string paraswapApproveContractAddress: "0x216B4B4Ba9F3e719726886d34a177484278Bfcae"
-        readonly property string paraswapSwapContractAddress: "0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57"
+        readonly property string paraswapV5ApproveContractAddress: "0x216B4B4Ba9F3e719726886d34a177484278Bfcae"
+        readonly property string paraswapV5SwapContractAddress: "0xDEF171Fe48CF0115B1d80b88dc8eAB59176FEe57"
+        readonly property string paraswapV6_2ContractAddress: "0x6a000f20005980200259b80c5102003040001068"
         readonly property string paraswapTermsAndConditionUrl: "https://files.paraswap.io/tos_v4.pdf"
 
         // TOOD #15874: Unify with WalletUtils router error code handling


### PR DESCRIPTION
Closes #15755

### What does the PR do

bumps status-go to get https://github.com/status-im/status-go/pull/5572
Adapt contract addresses to the ones used by Paraswap V6.2

### Affected areas

Swap

### Screenshot of functionality (including design for comparison)

![image](https://github.com/user-attachments/assets/de417004-2ce2-40e2-9feb-e05c376bfc49)
![image](https://github.com/user-attachments/assets/5f5e9326-541b-4fcc-b605-79f183201f5f)7
![image](https://github.com/user-attachments/assets/f7ebb7cc-b657-4946-a2a1-22aac6bb9199)

Made Swaps on the 3 chains. 
https://etherscan.io/tx/0xcb356077e3e7c9a19bcd9a2784de8f548a4d8ce35e093d8df97ca4a0cba03e96
https://optimistic.etherscan.io/tx/0x9f4508b65109a5341f72e04d8be36b23cb0399e16be2f549610ab25d13bebc4d
https://arbiscan.io/tx/0xe8f8b3747067c139f2ca23c1ccab78b6fa953bb990aa27b85add98b5ef64517e

Approve dialog looks correct, showing the new contract address.
Swap dialog looks correct.
Fees transferred to the new Fee Vault contract on all of them

Found a UI bug while testing this, reported here: https://github.com/status-im/status-desktop/issues/16200