### PR TITLE
fix(SwapModal): ErrorTag looks wrong

### DIFF
--- a/storybook/qmlTests/tests/tst_ErrorTag.qml
+++ b/storybook/qmlTests/tests/tst_ErrorTag.qml
@@ -42,7 +42,21 @@ Item {
         function test_noDefaultButton() {
             verify(!!controlUnderTest)
             const button = findChild(controlUnderTest, "rightComponentButton")
-            tryCompare(button, "visible", false)
+            compare(button, null)
+        }
+
+        function test_correctWidthWithButtonOrWithout() {
+            verify(!!controlUnderTest)
+            waitForRendering(controlUnderTest)
+            const origWidth = controlUnderTest.width
+            controlUnderTest.buttonText = "Buy crypto"
+            controlUnderTest.buttonVisible = true
+            waitForRendering(controlUnderTest)
+            const widthWithButton = controlUnderTest.width
+            verify(widthWithButton > origWidth)
+            controlUnderTest.buttonVisible = false
+            waitForRendering(controlUnderTest)
+            verify(controlUnderTest.width < widthWithButton)
         }
 
         function test_buttonClick() {
@@ -60,9 +74,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.loading = true
             const button = findChild(controlUnderTest, "rightComponentButton")
-            verify(!!button)
-            tryCompare(button, "visible", false)
-            mouseClick(button)
+            compare(button, null)
             tryCompare(signalSpy, "count", 0)
         }
     }

--- a/ui/imports/shared/controls/ErrorTag.qml
+++ b/ui/imports/shared/controls/ErrorTag.qml
@@ -19,7 +19,7 @@ InformationTag {
 
     implicitHeight: 33
     leftPadding: 10
-    rightPadding: 4
+    rightPadding: buttonVisible ? 4 : 8
     verticalPadding: 4
     spacing: 6
 
@@ -50,20 +50,22 @@ InformationTag {
         value: true
     }
 
-    rightComponent: StatusButton {
-        objectName: "rightComponentButton"
-        horizontalPadding: 8
+    rightComponent: buttonVisible ? rightButtonComponent : undefined
 
-        visible: root.buttonVisible
-
-        size: StatusBaseButton.Size.Tiny
-        font.pixelSize: priv.fontPixelSize
-        type: StatusBaseButton.Type.Danger
-        normalColor: priv.foregroundColor
-        hoverColor: Theme.palette.hoverColor(normalColor)
-        textColor: Theme.palette.white
-        radius: root.bgRadius
-        text: root.buttonText
-        onClicked: root.buttonClicked()
+    Component {
+        id: rightButtonComponent
+        StatusButton {
+            objectName: "rightComponentButton"
+            horizontalPadding: 8
+            size: StatusBaseButton.Size.Tiny
+            font.pixelSize: priv.fontPixelSize
+            type: StatusBaseButton.Type.Danger
+            normalColor: priv.foregroundColor
+            hoverColor: Theme.palette.hoverColor(normalColor)
+            textColor: Theme.palette.white
+            radius: root.bgRadius
+            text: root.buttonText
+            onClicked: root.buttonClicked()
+        }
     }
 }

--- a/ui/imports/shared/controls/InformationTag.qml
+++ b/ui/imports/shared/controls/InformationTag.qml
@@ -86,6 +86,8 @@ Control {
         }
         Loader {
             id: rightComponent
+            Layout.preferredWidth: active ? implicitWidth : 0
+            active: !!sourceComponent
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

- wrap the ErrorTag in a Component, and set the width from there
- added tests for the component width with/without the button

Fixes #15788

### Affected areas

SwapModal, ErrorTag

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

W/O button:
![image](https://github.com/user-attachments/assets/e7db1b89-82ac-4aff-b407-66fd82272b48)

With button:
![image](https://github.com/user-attachments/assets/be20380b-5c4d-4e24-9840-ecc760a71805)


