### PR TITLE
fix(@desktop/wallet): Swap "Approve" button becomes enabled before Approve Tx succeeds/fails

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -42,7 +42,11 @@ StatusDialog {
             interval: root.swapInputParamsForm.autoRefreshTime
             running: false
             repeat: false
-            onTriggered: d.fetchSuggestedRoutes()
+            onTriggered: {
+                if(!root.swapAdaptor.swapProposalLoading && !root.swapAdaptor.approvalPending) {
+                    d.fetchSuggestedRoutes()
+                }
+            }
         }
 
         function fetchSuggestedRoutes() {
@@ -83,8 +87,7 @@ StatusDialog {
             }
         }
         function onSuggestedRoutesReady() {
-            if(!root.swapAdaptor.swapProposalLoading)
-                d.autoRefreshTimer.restart()
+            d.autoRefreshTimer.restart()
         }
     }    
 


### PR DESCRIPTION
fixes #15784

### What does the PR do

The auto refresh occurred even though approval was pending

### Affected areas

SwapModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/bdfd1b55-4f5a-4ebb-b173-ad32a7aea98e

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->

### Cool Spaceship Picture

<!-- optional but cool -->
