### PR TITLE
Fix scroll to edit network button

### DIFF
--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -127,8 +127,8 @@ editNetworkMainRpcInput = {"container": statusDesktop_mainWindow, "objectName": 
 editNetworkFailoverRpcUrlInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkFailoverRpcUrlInput", "type": "TextEdit", "visible": True}
 editNetworkExplorerInput = {"container": statusDesktop_mainWindow, "objectName": "editNetworkExplorerInput", "type": "TextEdit"}
 editNetworkAknowledgmentCheckbox = {"container": statusDesktop_mainWindow, "objectName": "editNetworkAknowledgmentCheckbox", "type": "StatusCheckBox", "visible": True}
-editNetworkRevertButton = {"container": statusDesktop_mainWindow, "objectName": "editNetworkRevertButton", "type": "StatusButton"}
-editNetworkSaveButton = {"container": statusDesktop_mainWindow, "objectName": "editNetworkSaveButton", "type": "StatusButton"}
+editNetworkRevertButton = {"container": statusDesktop_mainWindow, "objectName": "editNetworkRevertButton", "type": "StatusButton", "visible": True}
+editNetworkSaveButton = {"container": statusDesktop_mainWindow, "objectName": "editNetworkSaveButton", "type": "StatusButton", "visible": True}
 mainRpcUrlInputObject = {"container": settingsContentBase_ScrollView, "objectName": "mainRpcInputObject", "type": "StatusInput", "visible": True}
 failoverRpcUrlInputObject = {"container": settingsContentBase_ScrollView, "objectName": "failoverRpcUrlInputObject", "type": "StatusInput", "visible": True}
 

--- a/test/e2e/gui/screens/settings_wallet.py
+++ b/test/e2e/gui/screens/settings_wallet.py
@@ -375,8 +375,7 @@ class EditNetworkSettings(WalletSettingsView):
 
     @allure.step('Click Revert to default button and redirect to Networks screen')
     def click_revert_to_default_and_go_to_networks_main_screen(self, attempts: int = 2):
-        if not self._network_revert_to_default.is_visible:
-            self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
+        self._network_edit_scroll.vertical_scroll_down(self._network_revert_to_default)
         self._network_revert_to_default.click()
         try:
             return RPCChangeRestartPopup().wait_until_appears()


### PR DESCRIPTION
### What does the PR do

Removed condition for scroll, because for some reason test always considered button edit network as visible. So now tests always scroll to this button and all good.

CI run:
https://ci.status.im/job/status-desktop/job/e2e/job/manual/2428/allure/#suites/c6abfc71b8927eeb22d04f5e7f84bb0e/a28d19583c11aa60/