### PR TITLE
fix(wakunodes): temporarily hide "add waku nodes" in advanced settings

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/WakuNodesModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/WakuNodesModal.qml
@@ -57,6 +57,7 @@ StatusModal {
             }
 
             StatusBaseText {
+                visible: false // FIXME: hide for now (https://github.com/status-im/status-go/issues/5597)
                 text: qsTr("Add a new node")
                 color: Theme.palette.primaryColor1
                 width: parent.width

--- a/ui/app/AppLayouts/Profile/popups/WakuStoreModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/WakuStoreModal.qml
@@ -116,6 +116,7 @@ StatusModal {
             }
 
             StatusBaseText {
+                visible: false // FIXME: hide for now (https://github.com/status-im/status-go/issues/5597)
                 text: qsTr("Add a new node")
                 color: Theme.palette.primaryColor1
                 width: parent.width


### PR DESCRIPTION
Fixes #14929

Correct fix should be done as part of https://github.com/status-im/status-go/issues/5597 after dependency tasks are done

### What does the PR do
Hides "add waku node" buttons until https://github.com/status-im/status-go/issues/5597 is completed 

https://github.com/user-attachments/assets/cd590a82-2932-4511-b5b2-f738bbc205f8

