### PR TITLE
fix(dApps): improved logic for the connected dApps list to always display as many dApps as possible.

### DIFF
--- a/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
@@ -88,7 +88,15 @@ Popup {
             id: listViewWrapper
             Layout.fillWidth: true
             Layout.preferredHeight: listView.contentHeight
-            Layout.maximumHeight: 290
+
+            // TODO: uncomment maximumHeight: 290 and remove fillHeight: true
+            // after status app upgrades to
+            // a Qt version that has ListView scrolling with mouse wheel and
+            // touchpad fixed.
+            // https://github.com/status-im/status-desktop/issues/15595
+            // Layout.maximumHeight: 290
+            Layout.fillHeight: true
+
             visible: !listPlaceholder.visible
 
             Rectangle {


### PR DESCRIPTION
Fixes(partially): #15595.

### What does the PR do

Allowed connected dApps list to grow in height as much as possible (max height will be the height of the app window). That will allow the end user to see and disconnect with more dApps without the need to scroll. The scroll of ListView using some mouse wheels and some touchpad devices is working incorrectly. It looks like there were several attempts of Qt company to fix that problem, but issue still occurs at least on macOS and Qt5.15.13

### Affected areas

dApps

### Screenshot of functionality (including design for comparison)

![image](https://github.com/user-attachments/assets/3de7aca8-304a-405d-a3e7-4c074c0f3c2e)

