### PR TITLE
fix(wallet): Update preferred networks even when empty

### DIFF
--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -143,10 +143,8 @@ QtObject:
   proc updatePreferredSharingChainsForAddress*(self: KeyPairAccountModel, address, prodPreferredChainIds, testPreferredChainIds: string) =
     for i in 0 ..< self.items.len:
       if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
-        if prodPreferredChainIds.len > 0:
-          self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
-        if testPreferredChainIds.len > 0:
-          self.items[i].setTestPreferredChainIds(testPreferredChainIds)
+        self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
+        self.items[i].setTestPreferredChainIds(testPreferredChainIds)
 
   proc updateAccountHiddenInTotalBalance*(self: KeyPairAccountModel, address: string, hideFromTotalBalance: bool) =
     for i in 0 ..< self.items.len:


### PR DESCRIPTION
Fixes #15822

### What does the PR do

* Allow to deselect preferred chains

### Affected areas

Wallet account view / Receive modal