### PR TITLE
chore: build the error reporting mechanism

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
@@ -3,12 +3,14 @@ import QtQuick.Controls 2.14
 import QtGraphicalEffects 1.13
 
 import StatusQ.Core 0.1
+import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 
 TabButton {
-    id: statusSwitchTabButton
+    id: root
 
     property int fontPixelSize: 15
+    property bool showBetaTag: false
 
     contentItem: Item {
         height: 36
@@ -21,16 +23,23 @@ TabButton {
             onPressed: mouse.accepted = false
             onReleased: mouse.accepted = false
 
-            StatusBaseText {
-                id: label
-                text: statusSwitchTabButton.text
-                color: statusSwitchTabButton.checked ?
-                    Theme.palette.statusSwitchTab.selectedTextColor :
-                    Theme.palette.statusSwitchTab.textColor
-                font.weight: Font.Medium
-                font.pixelSize: statusSwitchTabButton.fontPixelSize
-                horizontalAlignment: Text.AlignHCenter
+            Row {
                 anchors.centerIn: parent
+                spacing: 8
+
+                StatusBaseText {
+                    id: label
+                    text: root.text
+                    color: root.checked ?
+                               Theme.palette.statusSwitchTab.selectedTextColor :
+                               Theme.palette.statusSwitchTab.textColor
+                    font.weight: Font.Medium
+                    font.pixelSize: root.fontPixelSize
+                }
+
+                StatusBetaTag {
+                    visible: root.showBetaTag
+                }
             }
         }
     }
@@ -39,7 +48,7 @@ TabButton {
         id: controlBackground
         implicitHeight: 36
         implicitWidth: 148
-        color: statusSwitchTabButton.checked ?
+        color: root.checked ?
             Theme.palette.statusSwitchTab.buttonBackgroundColor :
             "transparent"
         radius: 8

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -130,4 +130,225 @@ QtObject {
         }
         return networkString
     }
+
+
+
+    function getRouterErrorBasedOnCode(code) {
+        switch(code) {
+        case Constants.routerErrorCodes.processor.errFailedToParseBaseFee:
+        case Constants.routerErrorCodes.processor.errFailedToParsePercentageFee:
+        case Constants.routerErrorCodes.processor.errContractNotFound:
+        case Constants.routerErrorCodes.processor.errNetworkNotFound:
+        case Constants.routerErrorCodes.processor.errTokenNotFound:
+        case Constants.routerErrorCodes.processor.errNoEstimationFound:
+        case Constants.routerErrorCodes.processor.errNotAvailableForContractType:
+        case Constants.routerErrorCodes.processor.errNoBonderFeeFound:
+        case Constants.routerErrorCodes.processor.errContractTypeNotSupported:
+        case Constants.routerErrorCodes.processor.errFromChainNotSupported:
+        case Constants.routerErrorCodes.processor.errToChainNotSupported:
+        case Constants.routerErrorCodes.processor.errTxForChainNotSupported:
+        case Constants.routerErrorCodes.processor.errENSResolverNotFound:
+        case Constants.routerErrorCodes.processor.errENSRegistrarNotFound:
+        case Constants.routerErrorCodes.processor.errToAndFromTokensMustBeSet:
+        case Constants.routerErrorCodes.processor.errCannotResolveTokens:
+        case Constants.routerErrorCodes.processor.errPriceRouteNotFound:
+        case Constants.routerErrorCodes.processor.errConvertingAmountToBigInt:
+        case Constants.routerErrorCodes.processor.errNoChainSet:
+        case Constants.routerErrorCodes.processor.errNoTokenSet:
+        case Constants.routerErrorCodes.processor.errToTokenShouldNotBeSet:
+        case Constants.routerErrorCodes.processor.errFromAndToChainsMustBeDifferent:
+        case Constants.routerErrorCodes.processor.errFromAndToChainsMustBeSame:
+        case Constants.routerErrorCodes.processor.errFromAndToTokensMustBeDifferent:
+        case Constants.routerErrorCodes.processor.errContextCancelled:
+        case Constants.routerErrorCodes.processor.errContextDeadlineExceeded:
+        case Constants.routerErrorCodes.processor.errPriceTimeout:
+        case Constants.routerErrorCodes.processor.errNotEnoughLiquidity:
+            return qsTr("processor internal error")
+        case Constants.routerErrorCodes.processor.errTransferCustomError:
+        case Constants.routerErrorCodes.processor.errERC721TransferCustomError:
+        case Constants.routerErrorCodes.processor.errERC1155TransferCustomError:
+        case Constants.routerErrorCodes.processor.errBridgeHopCustomError:
+        case Constants.routerErrorCodes.processor.errBridgeCellerCustomError:
+        case Constants.routerErrorCodes.processor.errSwapParaswapCustomError:
+        case Constants.routerErrorCodes.processor.errENSRegisterCustomError:
+        case Constants.routerErrorCodes.processor.errENSReleaseCustomError:
+        case Constants.routerErrorCodes.processor.errENSPublicKeyCustomError:
+        case Constants.routerErrorCodes.processor.errStickersBuyCustomError:
+            return qsTr("processor network error")
+        case Constants.routerErrorCodes.router.errENSRegisterRequiresUsernameAndPubKey:
+        case Constants.routerErrorCodes.router.errENSRegisterTestnetSTTOnly:
+        case Constants.routerErrorCodes.router.errENSRegisterMainnetSNTOnly:
+        case Constants.routerErrorCodes.router.errENSReleaseRequiresUsername:
+        case Constants.routerErrorCodes.router.errENSSetPubKeyRequiresUsernameAndPubKey:
+        case Constants.routerErrorCodes.router.errStickersBuyRequiresPackID:
+        case Constants.routerErrorCodes.router.errSwapRequiresToTokenID:
+        case Constants.routerErrorCodes.router.errSwapTokenIDMustBeDifferent:
+        case Constants.routerErrorCodes.router.errSwapAmountInAmountOutMustBeExclusive:
+        case Constants.routerErrorCodes.router.errSwapAmountInMustBePositive:
+        case Constants.routerErrorCodes.router.errSwapAmountOutMustBePositive:
+        case Constants.routerErrorCodes.router.errLockedAmountNotSupportedForNetwork:
+        case Constants.routerErrorCodes.router.errLockedAmountNotNegative:
+        case Constants.routerErrorCodes.router.errLockedAmountExceedsTotalSendAmount:
+        case Constants.routerErrorCodes.router.errLockedAmountLessThanSendAmountAllNetworks:
+        case Constants.routerErrorCodes.router.errNativeTokenNotFound:
+        case Constants.routerErrorCodes.router.errDisabledChainFoundAmongLockedNetworks:
+        case Constants.routerErrorCodes.router.errENSSetPubKeyInvalidUsername:
+        case Constants.routerErrorCodes.router.errLockedAmountExcludesAllSupported:
+        case Constants.routerErrorCodes.router.errTokenNotFound:
+        case Constants.routerErrorCodes.router.errNoBestRouteFound:
+        case Constants.routerErrorCodes.router.errCannotCheckReceiverBalance:
+        case Constants.routerErrorCodes.router.errCannotCheckLockedAmounts:
+            return qsTr("router network error")
+        case Constants.routerErrorCodes.router.errNotEnoughTokenBalance:
+            return qsTr("not enough token balance")
+        case Constants.routerErrorCodes.router.errNotEnoughNativeBalance:
+            return qsTr("not enough ETH")
+        default:
+            return qsTr("unknown processor error")
+        }
+    }
+
+    function getRouterErrorDetailsOnCode(code, details) {
+        switch(code) {
+        case Constants.routerErrorCodes.processor.errFailedToParseBaseFee:
+            return qsTr("failed to parse base fee")
+        case Constants.routerErrorCodes.processor.errFailedToParsePercentageFee:
+            return qsTr("failed to parse percentage fee")
+        case Constants.routerErrorCodes.processor.errContractNotFound:
+            return qsTr("contract not found")
+        case Constants.routerErrorCodes.processor.errNetworkNotFound:
+            return qsTr("network not found")
+        case Constants.routerErrorCodes.processor.errTokenNotFound:
+            return qsTr("token not found")
+        case Constants.routerErrorCodes.processor.errNoEstimationFound:
+            return qsTr("no estimation found")
+        case Constants.routerErrorCodes.processor.errNotAvailableForContractType:
+            return qsTr("not available for contract type")
+        case Constants.routerErrorCodes.processor.errNoBonderFeeFound:
+            return qsTr("no bonder fee found")
+        case Constants.routerErrorCodes.processor.errContractTypeNotSupported:
+            return qsTr("contract type not supported")
+        case Constants.routerErrorCodes.processor.errFromChainNotSupported:
+            return qsTr("from chain not supported")
+        case Constants.routerErrorCodes.processor.errToChainNotSupported:
+            return qsTr("to chain not supported")
+        case Constants.routerErrorCodes.processor.errTxForChainNotSupported:
+            return qsTr("tx for chain not supported")
+        case Constants.routerErrorCodes.processor.errENSResolverNotFound:
+            return qsTr("ens resolver not found")
+        case Constants.routerErrorCodes.processor.errENSRegistrarNotFound:
+            return qsTr("ens registrar not found")
+        case Constants.routerErrorCodes.processor.errToAndFromTokensMustBeSet:
+            return qsTr("to and from tokens must be set")
+        case Constants.routerErrorCodes.processor.errCannotResolveTokens:
+            return qsTr("cannot resolve tokens")
+        case Constants.routerErrorCodes.processor.errPriceRouteNotFound:
+            return qsTr("price route not found")
+        case Constants.routerErrorCodes.processor.errConvertingAmountToBigInt:
+            return qsTr("converting amount issue")
+        case Constants.routerErrorCodes.processor.errNoChainSet:
+            return qsTr("no chain set")
+        case Constants.routerErrorCodes.processor.errNoTokenSet:
+            return qsTr("no token set")
+        case Constants.routerErrorCodes.processor.errToTokenShouldNotBeSet:
+            return qsTr("to token should not be set")
+        case Constants.routerErrorCodes.processor.errFromAndToChainsMustBeDifferent:
+            return qsTr("from and to chains must be different")
+        case Constants.routerErrorCodes.processor.errFromAndToChainsMustBeSame:
+            return qsTr("from and to chains must be same")
+        case Constants.routerErrorCodes.processor.errFromAndToTokensMustBeDifferent:
+            return qsTr("from and to tokens must be different")
+        case Constants.routerErrorCodes.processor.errContextCancelled:
+            return qsTr("context cancelled")
+        case Constants.routerErrorCodes.processor.errContextDeadlineExceeded:
+            return qsTr("context deadline exceeded")
+        case Constants.routerErrorCodes.processor.errPriceTimeout:
+            return qsTr("fetching price timeout")
+        case Constants.routerErrorCodes.processor.errNotEnoughLiquidity:
+            return qsTr("not enough liquidity")
+
+        case Constants.routerErrorCodes.processor.errTransferCustomError:
+        case Constants.routerErrorCodes.processor.errERC721TransferCustomError:
+        case Constants.routerErrorCodes.processor.errERC1155TransferCustomError:
+        case Constants.routerErrorCodes.processor.errBridgeHopCustomError:
+        case Constants.routerErrorCodes.processor.errBridgeCellerCustomError:
+        case Constants.routerErrorCodes.processor.errSwapParaswapCustomError:
+        case Constants.routerErrorCodes.processor.errENSRegisterCustomError:
+        case Constants.routerErrorCodes.processor.errENSReleaseCustomError:
+        case Constants.routerErrorCodes.processor.errENSPublicKeyCustomError:
+        case Constants.routerErrorCodes.processor.errStickersBuyCustomError:
+            return details
+        case Constants.routerErrorCodes.router.errENSRegisterRequiresUsernameAndPubKey:
+            return qsTr("username and public key are required for registering ens name")
+        case Constants.routerErrorCodes.router.errENSRegisterTestnetSTTOnly:
+            return qsTr("only STT is supported for registering ens name on testnet")
+        case Constants.routerErrorCodes.router.errENSRegisterMainnetSNTOnly:
+            return qsTr("only SNT is supported for registering ens name on mainnet")
+        case Constants.routerErrorCodes.router.errENSReleaseRequiresUsername:
+            return qsTr("username is required for releasing ens name")
+        case Constants.routerErrorCodes.router.errENSSetPubKeyRequiresUsernameAndPubKey:
+            return qsTr("username and public key are required for setting public key")
+        case Constants.routerErrorCodes.router.errStickersBuyRequiresPackID:
+            return qsTr("stickers pack id is required for buying stickers")
+        case Constants.routerErrorCodes.router.errSwapRequiresToTokenID:
+            return qsTr("to token is required for Swap")
+        case Constants.routerErrorCodes.router.errSwapTokenIDMustBeDifferent:
+            return qsTr("from and to token must be different")
+        case Constants.routerErrorCodes.router.errSwapAmountInAmountOutMustBeExclusive:
+            return qsTr("only one of amount to send or receiving amount can be set")
+        case Constants.routerErrorCodes.router.errSwapAmountInMustBePositive:
+            return qsTr("amount to send must be positive")
+        case Constants.routerErrorCodes.router.errSwapAmountOutMustBePositive:
+            return qsTr("receiving amount must be positive")
+        case Constants.routerErrorCodes.router.errLockedAmountNotSupportedForNetwork:
+            return qsTr("locked amount is not supported for the selected network")
+        case Constants.routerErrorCodes.router.errLockedAmountNotNegative:
+            return qsTr("locked amount must not be negative")
+        case Constants.routerErrorCodes.router.errLockedAmountExceedsTotalSendAmount:
+            return qsTr("locked amount exceeds the total amount to send")
+        case Constants.routerErrorCodes.router.errLockedAmountLessThanSendAmountAllNetworks:
+            return qsTr("locked amount is less than the total amount to send, but all networks are locked")
+        case Constants.routerErrorCodes.router.errNativeTokenNotFound:
+            return qsTr("native token not found")
+        case Constants.routerErrorCodes.router.errDisabledChainFoundAmongLockedNetworks:
+            return qsTr("disabled chain found among locked networks")
+        case Constants.routerErrorCodes.router.errENSSetPubKeyInvalidUsername:
+            return qsTr("a valid username, ending in '.eth', is required for setting public key")
+        case Constants.routerErrorCodes.router.errLockedAmountExcludesAllSupported:
+            return qsTr("all supported chains are excluded, routing impossible")
+        case Constants.routerErrorCodes.router.errTokenNotFound:
+            return qsTr("token not found")
+        case Constants.routerErrorCodes.router.errNoBestRouteFound:
+            return qsTr("no best route found")
+        case Constants.routerErrorCodes.router.errCannotCheckReceiverBalance:
+            return qsTr("cannot check balance")
+        case Constants.routerErrorCodes.router.errCannotCheckLockedAmounts:
+            return qsTr("cannot check locked amounts")
+        case Constants.routerErrorCodes.router.errNotEnoughTokenBalance:
+        case Constants.routerErrorCodes.router.errNotEnoughNativeBalance:
+            try {
+                const jsonObj = JSON.parse(details)
+
+                let chain = Constants.openseaExplorerLinks.ethereum
+                switch(jsonObj.chainId) {
+                case Constants.chains.optimismChainId:
+                    case Constants.chains.optimismSepoliaChainId:
+                    chain = Constants.openseaExplorerLinks.optimism
+                    break
+                case Constants.chains.arbitrumChainId:
+                    case Constants.chains.arbitrumSepoliaChainId:
+                    chain = Constants.openseaExplorerLinks.arbitrum
+                    break
+                }
+
+                return qsTr("not enough balance for %1 on %2 chain").arg(jsonObj.token).arg(chain)
+            }
+            catch (e) {
+                return ""
+            }
+
+        default:
+            return ""
+        }
+    }
 }

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -77,6 +77,8 @@ StatusDialog {
         if(!!popup.selectedAccount && !!popup.selectedAccount.address && !!holdingSelector.selectedItem
                 && recipientInputLoader.ready && (amountToSend.ready || d.isCollectiblesTransfer)) {
             popup.isLoading = true
+            d.routerError = ""
+            d.routerErrorDetails = ""
             popup.store.suggestedRoutes(d.isCollectiblesTransfer ? "1" : amountToSend.amount, "0", d.extraParamsJson)
         }
     })
@@ -125,6 +127,11 @@ StatusDialog {
                 || networkSelector.errorMode
                 || !(amountToSend.ready || d.isCollectiblesTransfer)
         }
+
+        // This way of displaying errors is just first aid, we have to build better way of handilg errors on the UI side
+        // and remove `d.errorType`
+        property string routerError: ""
+        property string routerErrorDetails: ""
 
         readonly property string uuid: Utils.uuid()
         property bool isPendingTx: false
@@ -634,6 +641,9 @@ StatusDialog {
                 totalFeesInFiat: d.totalFeesInFiat
                 fromNetworksList: fromNetworksRouteModel
                 toNetworksList: toNetworksRouteModel
+
+                routerError: d.routerError
+                routerErrorDetails: d.routerErrorDetails
             }
         }
     }
@@ -655,6 +665,12 @@ StatusDialog {
         target: popup.store.walletSectionSendInst
         function onSuggestedRoutesReady(txRoutes, errCode, errDescription) {
             popup.bestRoutes =  txRoutes.suggestedRoutes
+
+            if (errCode !== "") {
+                d.routerError = WalletUtils.getRouterErrorBasedOnCode(errCode)
+                d.routerErrorDetails = "%1 - %2".arg(errCode).arg(WalletUtils.getRouterErrorDetailsOnCode(errCode, errDescription))
+            }
+
             let gasTimeEstimate = txRoutes.gasTimeEstimate
             d.totalTimeEstimate = WalletUtils.getLabelForEstimatedTxTime(gasTimeEstimate.totalTime)
             let totalTokenFeesInFiat = 0

--- a/ui/imports/shared/popups/send/views/NetworkSelector.qml
+++ b/ui/imports/shared/popups/send/views/NetworkSelector.qml
@@ -11,6 +11,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 import shared.popups.send.controls 1.0
+import shared.controls 1.0
 
 Item {
     id: root
@@ -35,6 +36,9 @@ Item {
     property int errorType: Constants.NoError
     property var bestRoutes
     property double totalFeesInFiat
+
+    property string routerError: ""
+    property string routerErrorDetails: ""
 
     signal reCalculateSuggestedRoute()
 
@@ -150,5 +154,42 @@ Item {
         store: root.store
         gasFiatAmount: root.totalFeesInFiat
         errorType: root.errorType
+    }
+
+    ErrorTag {
+        id: errorTag
+
+        property bool showDetails: false
+
+        anchors.top: fees.visible? fees.bottom : stackLayout.bottom
+        anchors.topMargin: Style.current.bigPadding
+        anchors.horizontalCenter: parent.horizontalCenter
+        visible: root.routerError !== ""
+        text: root.routerError
+        buttonText: showDetails? qsTr("hide details") : qsTr("show details")
+        buttonVisible: root.routerErrorDetails !== ""
+        onButtonClicked: {
+            showDetails = !showDetails
+        }
+    }
+
+    Rectangle {
+        width: parent.width
+        implicitHeight: childrenRect.height + 2*Style.current.padding
+        anchors.top: errorTag.bottom
+        anchors.topMargin: Style.current.padding
+        visible: errorTag.visible && errorTag.showDetails
+        color: Theme.palette.dangerColor3
+        radius: 8
+        border.width: 1
+        border.color: Theme.palette.dangerColor2
+
+        StatusBaseText {
+            anchors.centerIn: parent
+            width: parent.width - 2*Style.current.bigPadding
+            text: root.routerErrorDetails
+            font.pixelSize: Style.current.tertiaryTextFontSize
+            elide: Text.ElideRight
+        }
     }
 }

--- a/ui/imports/shared/popups/send/views/NetworkSelector.qml
+++ b/ui/imports/shared/popups/send/views/NetworkSelector.qml
@@ -60,9 +60,11 @@ Item {
         }
         StatusSwitchTabButton {
             text: qsTr("Advanced")
+            showBetaTag: true
         }
         StatusSwitchTabButton {
             text: qsTr("Custom")
+            enabled: false
         }
     }
 
@@ -104,6 +106,8 @@ Item {
                 reCalculateSuggestedRoute: function() {
                     root.reCalculateSuggestedRoute()
                 }
+
+                showBetaTag: root.bestRoutes.count > 1
             }
         }
 

--- a/ui/imports/shared/popups/send/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/popups/send/views/NetworksSimpleRoutingView.qml
@@ -30,6 +30,8 @@ RowLayout {
     property int errorType: Constants.NoError
     property string selectedSymbol
 
+    property bool showBetaTag: false
+
     spacing: 10
 
     StatusRoundIcon {
@@ -42,13 +44,21 @@ RowLayout {
         Layout.alignment: Qt.AlignTop
         Layout.preferredWidth: root.width
         spacing: 4
-        StatusBaseText {
+        Row {
             Layout.maximumWidth: parent.width
-            font.pixelSize: 15
-            font.weight: Font.Medium
-            color: Theme.palette.directColor1
-            text: qsTr("Networks")
-            wrapMode: Text.WordWrap
+            spacing: 8
+
+            StatusBaseText {
+                font.pixelSize: 15
+                font.weight: Font.Medium
+                color: Theme.palette.directColor1
+                text: qsTr("Networks")
+                wrapMode: Text.WordWrap
+            }
+
+            StatusBetaTag {
+                visible: root.showBetaTag
+            }
         }
         StatusBaseText {
             Layout.maximumWidth: parent.width

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -15,6 +15,15 @@ QtObject {
         readonly property int appEncryptionProcess: 3
     }
 
+    readonly property QtObject chains: QtObject {
+        readonly property int mainnetChainId: 1
+        readonly property int sepoliaChainId: 11155111
+        readonly property int optimismChainId: 10
+        readonly property int optimismSepoliaChainId: 11155420
+        readonly property int arbitrumChainId: 42161
+        readonly property int arbitrumSepoliaChainId: 421614
+    }
+
     readonly property QtObject startupFlow: QtObject {
         readonly property string general: "General"
         readonly property string firstRunNewUserNewKeys: "FirstRunNewUserNewKeys"
@@ -1046,6 +1055,77 @@ QtObject {
         SendAmountExceedsBalance,
         NoRoute,
         NoError
+    }
+
+    readonly property QtObject routerErrorCodes: QtObject {
+        readonly property QtObject processor: QtObject {
+            readonly property string errFailedToParseBaseFee           : "WPP-001"
+            readonly property string errFailedToParsePercentageFee     : "WPP-002"
+            readonly property string errContractNotFound               : "WPP-003"
+            readonly property string errNetworkNotFound                : "WPP-004"
+            readonly property string errTokenNotFound                  : "WPP-005"
+            readonly property string errNoEstimationFound              : "WPP-006"
+            readonly property string errNotAvailableForContractType    : "WPP-007"
+            readonly property string errNoBonderFeeFound               : "WPP-008"
+            readonly property string errContractTypeNotSupported       : "WPP-009"
+            readonly property string errFromChainNotSupported          : "WPP-010"
+            readonly property string errToChainNotSupported            : "WPP-011"
+            readonly property string errTxForChainNotSupported         : "WPP-012"
+            readonly property string errENSResolverNotFound            : "WPP-013"
+            readonly property string errENSRegistrarNotFound           : "WPP-014"
+            readonly property string errToAndFromTokensMustBeSet       : "WPP-015"
+            readonly property string errCannotResolveTokens            : "WPP-016"
+            readonly property string errPriceRouteNotFound             : "WPP-017"
+            readonly property string errConvertingAmountToBigInt       : "WPP-018"
+            readonly property string errNoChainSet                     : "WPP-019"
+            readonly property string errNoTokenSet                     : "WPP-020"
+            readonly property string errToTokenShouldNotBeSet          : "WPP-021"
+            readonly property string errFromAndToChainsMustBeDifferent : "WPP-022"
+            readonly property string errFromAndToChainsMustBeSame      : "WPP-023"
+            readonly property string errFromAndToTokensMustBeDifferent : "WPP-024"
+            readonly property string errTransferCustomError            : "WPP-025"
+            readonly property string errERC721TransferCustomError      : "WPP-026"
+            readonly property string errERC1155TransferCustomError     : "WPP-027"
+            readonly property string errBridgeHopCustomError           : "WPP-028"
+            readonly property string errBridgeCellerCustomError        : "WPP-029"
+            readonly property string errSwapParaswapCustomError        : "WPP-030"
+            readonly property string errENSRegisterCustomError         : "WPP-031"
+            readonly property string errENSReleaseCustomError          : "WPP-032"
+            readonly property string errENSPublicKeyCustomError        : "WPP-033"
+            readonly property string errStickersBuyCustomError         : "WPP-034"
+            readonly property string errContextCancelled               : "WPP-035"
+            readonly property string errContextDeadlineExceeded        : "WPP-036"
+            readonly property string errPriceTimeout                   : "WPP-037"
+            readonly property string errNotEnoughLiquidity             : "WPP-038"
+        }
+
+        readonly property QtObject router: QtObject {
+            readonly property string errENSRegisterRequiresUsernameAndPubKey      : "WR-001"
+            readonly property string errENSRegisterTestnetSTTOnly                 : "WR-002"
+            readonly property string errENSRegisterMainnetSNTOnly                 : "WR-003"
+            readonly property string errENSReleaseRequiresUsername                : "WR-004"
+            readonly property string errENSSetPubKeyRequiresUsernameAndPubKey     : "WR-005"
+            readonly property string errStickersBuyRequiresPackID                 : "WR-006"
+            readonly property string errSwapRequiresToTokenID                     : "WR-007"
+            readonly property string errSwapTokenIDMustBeDifferent                : "WR-008"
+            readonly property string errSwapAmountInAmountOutMustBeExclusive      : "WR-009"
+            readonly property string errSwapAmountInMustBePositive                : "WR-010"
+            readonly property string errSwapAmountOutMustBePositive               : "WR-011"
+            readonly property string errLockedAmountNotSupportedForNetwork        : "WR-012"
+            readonly property string errLockedAmountNotNegative                   : "WR-013"
+            readonly property string errLockedAmountExceedsTotalSendAmount        : "WR-014"
+            readonly property string errLockedAmountLessThanSendAmountAllNetworks : "WR-015"
+            readonly property string errNotEnoughTokenBalance                     : "WR-016"
+            readonly property string errNotEnoughNativeBalance                    : "WR-017"
+            readonly property string errNativeTokenNotFound                       : "WR-018"
+            readonly property string errDisabledChainFoundAmongLockedNetworks     : "WR-019"
+            readonly property string errENSSetPubKeyInvalidUsername               : "WR-020"
+            readonly property string errLockedAmountExcludesAllSupported          : "WR-021"
+            readonly property string errTokenNotFound                             : "WR-022"
+            readonly property string errNoBestRouteFound                          : "WR-023"
+            readonly property string errCannotCheckReceiverBalance                : "WR-024"
+            readonly property string errCannotCheckLockedAmounts                  : "WR-025"
+        }
     }
 
     enum LoginType {


### PR DESCRIPTION
This PR brings `status-go` changes which close #15693
- https://github.com/status-im/status-go/pull/5615

and also introduces displaying routing errors in the UI, which closes #15396 


Closes #15396 #15693


How it was

![image](https://github.com/user-attachments/assets/ae3e2514-f083-4f0c-80ab-8b9441206653)


Now

<img width="571" alt="2" src="https://github.com/user-attachments/assets/eecc1e8f-8f37-466c-a040-3db67c32eb9b">


<img width="567" alt="3" src="https://github.com/user-attachments/assets/cf83819c-e79d-4aff-a56e-4dbf6b478529">


<img width="574" alt="5" src="https://github.com/user-attachments/assets/d8ab7ccf-52a1-410b-9651-27077e9c500b">


<img width="567" alt="4" src="https://github.com/user-attachments/assets/6c76ce6c-b6bf-4a9a-9656-0c23d0b56fc3">
