### PR TITLE
fix(DAppSignRequestModal): correctly compute text painted height

### DIFF
--- a/storybook/pages/DAppSignRequestModalPage.qml
+++ b/storybook/pages/DAppSignRequestModalPage.qml
@@ -86,6 +86,11 @@ SplitView {
                 }
                 }
             }',
+            "
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis quam. In dapibus augue non sapien. Praesent id justo in neque elementum ultrices. Morbi scelerisque luctus velit. Vivamus ac leo pretium faucibus. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat. Nullam eget nisl. Aliquam erat volutpat.
+
+            Proin pede metus, vulputate nec, fermentum fringilla, vehicula vitae, justo.  Fusce nibh. Etiam quis quam. In dapibus augue non sapien. Praesent id justo in neque elementum ultrices.  Fusce nibh. Etiam quis quam. In dapibus augue non sapien. Praesent id justo in neque elementum ultrices.  Fusce nibh. Etiam quis quam. In dapibus augue non sapien. Praesent id justo in neque elementum ultrices.   Fusce nibh. Etiam quis quam. In dapibus augue non sapien. Praesent id justo in neque elementum ultrices.
+            ",
             '"tx":{"data":"0x","from":"0xE2d622C817878dA5143bBE06866ca8E35273Ba8a","gasLimit":"0x5208","gasPrice":"0x048ddbc5","nonce":"0x2a","to":"0xE2d622C817878dA5143bBE06866ca8E35273Ba8a","value":"0x00"}',
             ""
         ]
@@ -104,7 +109,7 @@ SplitView {
             }
             ComboBox {
                 id: contentToSignComboBox
-                model: ["Long content to sign", "Short content to sign", "Empty content to sign"]
+                model: ["Long content to sign", "Middle content to sign", "Short content to sign", "Empty content to sign"]
                 currentIndex: 0
             }
             CheckBox {

--- a/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
@@ -127,6 +127,7 @@ SignTransactionModalBase {
     ContentPanel {
         Layout.fillWidth: true
         Layout.fillHeight: true
+        Layout.bottomMargin: Style.current.bigPadding
         payloadToDisplay: root.requestPayload
         visible: !!root.requestPayload
     }

--- a/ui/imports/shared/popups/walletconnect/panels/ContentPanel.qml
+++ b/ui/imports/shared/popups/walletconnect/panels/ContentPanel.qml
@@ -18,8 +18,8 @@ Rectangle {
     color: "transparent"
     radius: 8
 
-    implicitHeight: d.expanded ? contentText.implicitHeight + (2 * contentText.anchors.margins) : 
-                                    Math.min(contentText.implicitHeight + (2 * contentText.anchors.margins), 200)
+    implicitHeight: d.expanded ? contentText.implicitHeight + (2 * contentText.anchors.margins)
+                               : Math.min(contentText.implicitHeight + (2 * contentText.anchors.margins), d.maxContentHeight)
 
     HoverHandler {
         id: hoverHandler
@@ -38,20 +38,7 @@ Rectangle {
         lineHeightMode: Text.FixedHeight
         lineHeight: 18
 
-        wrapMode: Text.WrapAnywhere
-
-        StatusFlatButton {
-            objectName: "expandButton"
-            anchors.top: parent.top
-            anchors.right: parent.right
-            icon.name: d.expanded ? "collapse" : "expand"
-            icon.color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
-            hoverColor: "transparent"
-            visible: d.canExpand && hoverHandler.hovered
-            onClicked: {
-                d.expanded = !d.expanded
-            }
-        }
+        wrapMode: Text.Wrap
 
         layer.enabled: !d.expanded && d.canExpand
         layer.effect: OpacityMask {
@@ -68,10 +55,25 @@ Rectangle {
         }
     }
 
+    StatusFlatButton {
+        objectName: "expandButton"
+        anchors.top: parent.top
+        anchors.topMargin: 4
+        anchors.right: parent.right
+        anchors.rightMargin: 4
+        icon.name: d.expanded ? "collapse" : "expand"
+        icon.color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+        hoverColor: "transparent"
+        visible: d.canExpand && hoverHandler.hovered
+        onClicked: {
+            d.expanded = !d.expanded
+        }
+    }
+
     QtObject {
         id: d
         readonly property int maxContentHeight: 350
         property bool expanded: false
-        property bool canExpand: contentText.implicitHeight > maxContentHeight
+        readonly property bool canExpand: contentText.paintedHeight + (2 * contentText.anchors.margins) > maxContentHeight
     }
 }


### PR DESCRIPTION
### What does the PR do

- fixes text overflowing the box height

Fixes #15650

### Affected areas

DAppSignRequestModal

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-07-29 14-32-39.webm](https://github.com/user-attachments/assets/e454d3ab-8088-4e0f-a86c-1f584c63b9cd)
