### PR TITLE
fix(wallet): Constrain token name size to send modal width

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/TokenSelectorNew.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelectorNew.qml
@@ -22,6 +22,8 @@ Control {
     /** Expected model structure: see TokenSelectorPanel::collectiblesModel **/
     property alias collectiblesModel: tokenSelectorPanel.collectiblesModel
 
+    readonly property bool isTokenSelected: d.isTokenSelected
+
     signal assetSelected(string key)
     signal collectionSelected(string key)
     signal collectibleSelected(string key)
@@ -90,8 +92,10 @@ Control {
 
         RowLayout {
             spacing: Style.current.halfPadding
+            width: parent.width
 
             StatusRoundedImage {
+                id: tokenSelectorIcon
                 objectName: "tokenSelectorIcon"
                 Layout.preferredWidth: 20
                 Layout.preferredHeight: 20
@@ -102,12 +106,24 @@ Control {
                 objectName: "tokenSelectorContentItemText"
                 font.pixelSize: 28
                 color: root.hovered ? Theme.palette.blue : Theme.palette.darkBlue
+                Layout.maximumWidth: parent.width - (tokenSelectorIcon.width + comboboxIndicator.width + parent.spacing * 2)
+                elide: Text.ElideRight
+                Layout.alignment: Qt.AlignLeft
 
                 text: d.currentName
             }
 
-            StatusComboboxIndicator {
-                color: Theme.palette.primaryColor1
+            Item {
+                // Encapsulated into the item to not resize the icon
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                StatusComboboxIndicator {
+                    id: comboboxIndicator
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    color: Theme.palette.primaryColor1
+                }
             }
         }
     }

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -337,6 +337,7 @@ StatusDialog {
                 RowLayout {
                     spacing: 8
                     Layout.preferredHeight: 44
+                    Layout.maximumWidth: parent.width
 
                     HeaderTitleText {
                         id: modalHeader
@@ -354,6 +355,7 @@ StatusDialog {
                         assetsModel: assetsAdaptor.outputAssetsModel
                         collectiblesModel: collectiblesAdaptorLoader.active
                                            ? collectiblesAdaptorLoader.item.model : null
+                        Layout.fillWidth: isTokenSelected
 
                         TokenSelectorViewAdaptor {
                             id: assetsAdaptor


### PR DESCRIPTION
Fixes #15576 

### What does the PR do

Update send amount input layouts to properly resize with different token name lengths

### Affected areas

Send modal amount input

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/d4b3db66-c40f-4870-ab0d-31a87be8b34c

