### PR TITLE
fix(wallet)_: Disable send button on router errors & visually indicate gas issues

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -656,7 +656,7 @@ StatusDialog {
         maxFiatFees: popup.isLoading ? "..." : d.currencyStore.formatCurrencyAmount(d.totalFeesInFiat, d.currencyStore.currentCurrency)
         totalTimeEstimate: popup.isLoading? "..." : d.totalTimeEstimate
         pending: d.isPendingTx || popup.isLoading
-        visible: recipientInputLoader.ready && (amountToSend.ready || d.isCollectiblesTransfer) && !d.errorMode
+        visible: recipientInputLoader.ready && (amountToSend.ready || d.isCollectiblesTransfer) && !d.errorMode && !d.routerError
 
         onNextButtonClicked: popup.sendTransaction()
     }

--- a/ui/imports/shared/popups/send/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/popups/send/views/NetworkCardsComponent.qml
@@ -95,6 +95,7 @@ Item {
                     onTokenBalanceChanged: maxAdvancedValue = model.tokenBalance.amount
                     property var toNetworks: model.toNetworks
                     property int routeOnNetwork: 0
+                    readonly property bool hasGas: model.hasGas
                     onToNetworksChanged: d.draw()
 
                     primaryText: model.chainName
@@ -236,7 +237,7 @@ Item {
                             fromN.routeOnNetwork += 1
                             toN.routeOnNetwork += 1
                             toN.bentLine = toN.objectName !== fromN.objectName
-                            let routeColor = root.errorMode ? Theme.palette.dangerColor1 : toN.preferred ? '#627EEA' : Theme.palette.pinColor1
+                            let routeColor = root.errorMode || !fromN.hasGas ? Theme.palette.dangerColor1 : toN.preferred ? '#627EEA' : Theme.palette.pinColor1
                             StatusQUtils.Utils.drawArrow(ctx, fromN.x + fromN.width,
                                                          fromN.y + fromN.cardIconPosition + yOffsetFrom,
                                                          toNetworksLayout.x + toN.x,


### PR DESCRIPTION


### What does the PR do

This PR fixes a bug in the wallet's transaction flow where the send button was not disabled when the router encountered router errors, leading to failed transactions. It also adds a visual indicator (red arrow) for networks that lack sufficient gas for a transaction, providing more helpful feedback to users.

Closes #15700 #15701

### Affected areas

* SendModal.qml
* NetworkCardsComponent.qml

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
<img width="1312" alt="image" src="https://github.com/user-attachments/assets/9cd8f652-e146-4cf7-9f6a-172cb89d7cc1">

- [ ] I've checked the design and this PR matches it



### Impact on end user

 - Users will no longer be able to initiate a transaction when the router detects errors, preventing failed transactions and potential loss of funds.
 - Users will receive clearer feedback about why a network is unsuitable for a transaction (e.g., insufficient gas), leading to a better overall user experience.

### How to test

1. make sure to test on account that have balances:
 mainnet Eth = 0 and usdc (or any other crypto money other than Eth) = 10
 optimism Eth > 0.1 and usdc = 10
2. try to send 12 usdc (any amount that is greater than 10 and less than 20
3. observe the send button not showing up
4. navigate to the advanced tab and see which network doesn't have enough gas

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.




