### PR TITLE
chore(beta): add beta tag to pairing screens

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
@@ -231,6 +231,14 @@ Item {
                     root.startupStore.doPrimaryAction()
                 }
             }
+
+            StatusBetaTag {
+                id: betaTagButton1
+                visible: true
+                anchors.left: button1.right
+                anchors.leftMargin: 8
+                anchors.verticalCenter: button1.verticalCenter
+            }
         }
 
         StatusBaseText {
@@ -335,6 +343,10 @@ Item {
                 text: qsTr("Scan or enter a sync code")
             }
             PropertyChanges {
+                target: betaTagButton1
+                visible: true
+            }
+            PropertyChanges {
                 target: button2
                 text: qsTr("I don’t have other device")
             }
@@ -364,6 +376,10 @@ Item {
             PropertyChanges {
                 target: button1
                 text: ""
+            }
+            PropertyChanges {
+                target: betaTagButton1
+                visible: false
             }
             PropertyChanges {
                 target: button2
@@ -397,6 +413,10 @@ Item {
                 text: qsTr("Generate new keys")
             }
             PropertyChanges {
+                target: betaTagButton1
+                visible: false
+            }
+            PropertyChanges {
                 target: button2
                 text: qsTr("Generate keys for a new Keycard")
             }
@@ -426,6 +446,10 @@ Item {
             PropertyChanges {
                 target: button1
                 text: qsTr("Import a seed phrase")
+            }
+            PropertyChanges {
+                target: betaTagButton1
+                visible: false
             }
             PropertyChanges {
                 target: button2
@@ -459,6 +483,10 @@ Item {
                 text: qsTr("Try to fetch profile again")
             }
             PropertyChanges {
+                target: betaTagButton1
+                visible: false
+            }
+            PropertyChanges {
                 target: button2
                 text: qsTr("Create new profile with the same chatkey")
             }
@@ -486,6 +514,10 @@ Item {
             PropertyChanges {
                 target: button1
                 text: qsTr("Continue")
+            }
+            PropertyChanges {
+                target: betaTagButton1
+                visible: false
             }
             PropertyChanges {
                 target: button2
@@ -517,6 +549,10 @@ Item {
             PropertyChanges {
                 target: button1
                 text: qsTr("Create replacement Keycard with seed phrase")
+            }
+            PropertyChanges {
+                target: betaTagButton1
+                visible: false
             }
             PropertyChanges {
                 target: button2

--- a/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
@@ -111,7 +111,8 @@ QtObject {
                        isExperimental: true})
             append({subsection: Constants.settingsSubsection.syncingSettings,
                        text: qsTr("Syncing"),
-                       icon: "rotate"})
+                       icon: "rotate",
+                       isExperimental: true})
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -169,17 +169,27 @@ SettingsContentBase {
 
                 spacing: 17
 
-                StatusBaseText {
-                    
-                    objectName: "syncNewDeviceTextLabel"
-
-                    Layout.fillWidth: true
+                Item {
+                    Layout.alignment: Qt.AlignHCenter
+                    height: syncNewDeviceText.height
+                    width: syncNewDeviceText.width
                     Layout.topMargin: -8
-                    horizontalAlignment: Text.AlignHCenter
-                    color: Theme.palette.primaryColor1
-                    font.pixelSize: 17
-                    font.weight: Font.Bold
-                    text: qsTr("Sync a New Device")
+
+                    StatusBaseText {
+                        id: syncNewDeviceText
+                        objectName: "syncNewDeviceTextLabel"
+
+                        color: Theme.palette.primaryColor1
+                        font.pixelSize: 17
+                        font.weight: Font.Bold
+                        text: qsTr("Sync a New Device")
+
+                        StatusBetaTag {
+                            anchors.left: parent.right
+                            anchors.leftMargin: 8
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
                 }
 
                 StatusBaseText {

--- a/ui/imports/shared/views/SyncingEnterCode.qml
+++ b/ui/imports/shared/views/SyncingEnterCode.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.14
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
@@ -42,6 +43,12 @@ ColumnLayout {
         StatusSwitchTabButton {
             text: root.secondTabName
         }
+    }
+
+    StatusBetaTag {
+        anchors.left: switchTabBar.right
+        anchors.leftMargin: 8
+        anchors.verticalCenter: switchTabBar.verticalCenter
     }
 
     StackLayout {


### PR DESCRIPTION
Fixes #15871

Adds a beta tag to the pairing screens on onboarding and settings

![image](https://github.com/user-attachments/assets/1d27ce88-c60d-47ee-98b1-7ad5ef6e16a1)
![image](https://github.com/user-attachments/assets/90414d42-53be-42f0-9a1a-555ab737b152)
![image](https://github.com/user-attachments/assets/eea5a188-bcc2-4b31-8e67-3f38bee7e986)
![image](https://github.com/user-attachments/assets/1e6915ee-298a-493e-9bc7-4da9359457ae)
