### PR TITLE
15647 dapps watched accounts and keycard accounts shouldnt be considered for wallet connect interactions

### DIFF
--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -427,6 +427,8 @@ Item {
                 // Name mismatch between storybook and production
                 readonly property var groupedAccountAssetsModel: groupedAccountsAssetsModel
             }
+
+            readonly property string selectedAddress: ""
         }
 
         onDisplayToastMessage: (message, isErr) => {

--- a/storybook/pages/DappsComboBoxPage.qml
+++ b/storybook/pages/DappsComboBoxPage.qml
@@ -17,12 +17,21 @@ SplitView {
             id: connectedDappComboBox
             anchors.top: parent.top
             anchors.horizontalCenter: parent.horizontalCenter
-            model: emptyModelCheckbox.checked ? emptyModel : dappsModel
+            model: emptyModelCheckbox.checked ? emptyModel : smallModelCheckbox.checked ? smallModel: dappsModel
             popup.visible: true
         }
 
         ListModel {
             id: emptyModel
+        }
+
+        ListModel {
+            id: smallModel
+            ListElement {
+                name: "SMALL Model"
+                url: "https://dapp.test/1"
+                iconUrl: "https://se-sdk-dapp.vercel.app/assets/eip155:1.png"
+            }
         }
 
         ListModel {
@@ -94,6 +103,12 @@ SplitView {
             CheckBox {
                 id: emptyModelCheckbox
                 text: "Empty model"
+                checked: false
+            }
+
+            CheckBox {
+                id: smallModelCheckbox
+                text: "Small model"
                 checked: false
             }
         }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -133,8 +133,11 @@ Item {
 
                 spacing: 8
 
-                visible: !root.walletStore.showSavedAddresses && Global.featureFlags.dappsEnabled
+                visible: !root.walletStore.showSavedAddresses
+                         && Global.featureFlags.dappsEnabled
+                         && Global.walletConnectService.isServiceAvailableForAddressSelection
                 enabled: !!Global.walletConnectService
+
 
                 wcService: Global.walletConnectService
                 loginType: root.store.loginType

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
@@ -1,6 +1,9 @@
 import QtQuick 2.15
 
+import StatusQ 0.1
 import StatusQ.Core.Utils 0.1
+
+import SortFilterProxyModel 0.2
 
 import AppLayouts.Wallet.services.dapps 1.0
 
@@ -15,7 +18,24 @@ QObject {
     required property DAppsStore store
     required property var supportedAccountsModel
 
-    readonly property alias dappsModel: d.dappsModel
+    property string selectedAddress: ""
+
+    readonly property SortFilterProxyModel dappsModel: SortFilterProxyModel {
+        objectName: "DAppsModelFiltered"
+        sourceModel: d.dappsModel
+
+        filters: FastExpressionFilter {
+            enabled: !!root.selectedAddress
+
+            function isAddressIncluded(accountAddressesSubModel, selectedAddress) {
+                const addresses = ModelUtils.modelToFlatArray(accountAddressesSubModel, "address")
+                return addresses.includes(root.selectedAddress)
+            }
+            expression: isAddressIncluded(model.accountAddresses, root.selectedAddress)
+
+            expectedRoles: "accountAddresses"
+        }
+    }
 
     function updateDapps() {
         d.updateDappsModel()
@@ -26,6 +46,7 @@ QObject {
 
         property ListModel dappsModel: ListModel {
             id: dapps
+            objectName: "DAppsModel"
         }
 
         property var dappsListReceivedFn: null
@@ -33,10 +54,24 @@ QObject {
         function updateDappsModel()
         {
             dappsListReceivedFn = (dappsJson) => {
+                root.store.dappsListReceived.disconnect(dappsListReceivedFn);
                 dapps.clear();
 
                 let dappsList = JSON.parse(dappsJson);
                 for (let i = 0; i < dappsList.length; i++) {
+                    const cachedEntry = dappsList[i];
+                    let accountAddresses = cachedEntry.accountAddresses
+                    if (!accountAddresses) {
+                        accountAddresses = [{address: ''}];
+                    }
+
+                    const dappEntryWithRequiredRoles = {
+                        description: cachedEntry.description,
+                        url: cachedEntry.url,
+                        name: cachedEntry.name,
+                        iconUrl: cachedEntry.url,
+                        accountAddresses: cachedEntry.accountAddresses
+                    }
                     dapps.append(dappsList[i]);
                 }
             }
@@ -49,27 +84,45 @@ QObject {
             }
 
             getActiveSessionsFn = () => {
-                sdk.getActiveSessions((allSessions) => {
+                sdk.getActiveSessions((allSessionsAllProfiles) => {
                     root.store.dappsListReceived.disconnect(dappsListReceivedFn);
 
-                    let tmpMap = {}
-                    var topics = []
-                    const sessions = DAppsHelpers.filterActiveSessionsForKnownAccounts(allSessions, root.supportedAccountsModel)
-                    for (const key in sessions) {
-                        const dapp = sessions[key].peer.metadata
+                    const dAppsMap = {}
+                    const topics = []
+                    const sessions = DAppsHelpers.filterActiveSessionsForKnownAccounts(allSessionsAllProfiles, supportedAccountsModel)
+                    for (const sessionID in sessions) {
+                        const session = sessions[sessionID]
+                        const dapp = session.peer.metadata
                         if (!!dapp.icons && dapp.icons.length > 0) {
                             dapp.iconUrl = dapp.icons[0]
                         } else {
                             dapp.iconUrl = ""
                         }
-                        tmpMap[dapp.url] = dapp;
-                        topics.push(key)
+                        const accounts = DAppsHelpers.getAccountsInSession(session)
+                        const existingDApp = dAppsMap[dapp.url]
+                        if (existingDApp) {
+                            // In Qt5.15.2 this is the way to make a "union" of two arrays
+                            // more modern syntax (ES-6) is not available yet
+                            const combinedAddresses = new Set(existingDApp.accountAddresses.concat(dapp.accountAddresses));
+                            existingDApp.accountAddresses = Array.from(combinedAddresses);
+                        } else {
+                            dapp.accountAddresses = accounts
+                            dAppsMap[dapp.url] = dapp
+                        }
+
+                        topics.push(sessionID)
                     }
+
                     // TODO #15075: on SDK dApps refresh update the model that has data source from persistence instead of using reset
                     dapps.clear();
-                    // Iterate tmpMap and fill dapps
-                    for (const key in tmpMap) {
-                        dapps.append(tmpMap[key]);
+
+                    // Iterate dAppsMap and fill dapps
+                    for (const topic in dAppsMap) {
+                        const dAppEntry = dAppsMap[topic];
+                        // Due to ListModel converting flat array to empty nested ListModel
+                        // having array of key value pair fixes the problem
+                        dAppEntry.accountAddresses = dAppEntry.accountAddresses.filter(account => (!!account)).map(account => ({address: account}));
+                        dapps.append(dAppEntry);
                     }
 
                     root.store.updateWalletConnectSessions(JSON.stringify(topics))

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -121,3 +121,12 @@ function filterActiveSessionsForKnownAccounts(sessions, accountsModel) {
     })
     return knownSessions
 }
+
+function getAccountsInSession(session) {
+    const eip155Addresses = session.namespaces.eip155.accounts
+    const accountSet = new Set(
+        eip155Addresses.map(eip155Address => eip155Address.split(':').pop().trim())
+    );
+    const uniqueAddresses = Array.from(accountSet);
+    return uniqueAddresses
+}

--- a/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import QtQml 2.15
 import QtQuick.Controls 2.15
 import QtQml.Models 2.15
 import QtQuick.Layouts 1.15
@@ -46,9 +47,25 @@ Popup {
         }
     }
 
+    // workaround for https://bugreports.qt.io/browse/QTBUG-87804
+    Binding on margins {
+        id: workaroundBinding
+
+        when: false
+        restoreMode: Binding.RestoreBindingOrValue
+    }
+
+    onImplicitContentHeightChanged: {
+        workaroundBinding.value = root.margins + 1
+        workaroundBinding.when = true
+        workaroundBinding.when = false
+    }
+
     contentItem: ColumnLayout {
         id: mainLayout
+
         spacing: 0
+
         ShapeRectangle {
             id: listPlaceholder
 
@@ -112,7 +129,6 @@ Popup {
                 anchors.leftMargin: Style.current.halfPadding
                 anchors.rightMargin: anchors.leftMargin
                 model: root.delegateModel
-                ScrollBar.vertical: null
             }
             Rectangle {
                 id: footer


### PR DESCRIPTION
fix(dApps): Improved handling of connected dApps.


closes: https://github.com/status-im/status-desktop/issues/15589
closes: https://github.com/status-im/status-desktop/issues/15647

### What does the PR do

1. Hiding DApps button on not supported wallet account selection
2. Filtering DApps in connected dApps list based on account selection

### Affected areas

dApps

### StatusQ checklist

- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/e8d21d57-3af4-4b27-b4fa-5e94eff17f97

- [x] I've checked the design and this PR matches it


### Impact on end user

End users can see DApps button only when either all accounts are selected, or supported wallet address is selected (non watched, not keycard accounts).
In addition to that, the dApps list will show only dApps connected to the selected wallet address

### How to test

Please create several wallet accounts, at least 1 watched address and 1 keycard address

### Risk 

Described potential risks and worst case scenarios.

- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.

### Cool Spaceship Picture
🚀
<!-- optional but cool -->
