### PR TITLE
Share wallet address and default account values in send/receive/bridge tests

### DIFF
--- a/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_default_account_values.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_default_account_values.py
@@ -12,6 +12,8 @@ from gui.components.signing_phrase_popup import SigningPhrasePopup
 @pytest.mark.parametrize('default_name, address, name, color, emoji', [
     pytest.param('Account 1', '0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5', 'sunglasses')
 ])
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 @pytest.mark.local_run
 @pytest.mark.skipif('jenkins' in str(testpath.ROOT),
                     reason="https://github.com/status-im/status-desktop/issues/14862, https://github.com/status-im/status-desktop/issues/14509")


### PR DESCRIPTION
### What does the PR do

- Test for share wallet address popup verifications (user guide section) - ci run https://ci.status.im/job/status-desktop/job/e2e/job/manual/2443/allure/#suites/f59b4938eea2b74826b801325557e3dc/7375ba37ff634a5c/
- Test for verifications for default account values in send/receive/bridge popups (skipped for now, we need to think how to create a mark for such tests which pass only locally for now, but to not include them to ci runs at the same time - will be done in a separate task) 