### PR TITLE
fix(@desktop/wallet): Swap modal - Pay input amount - deleting 1 decimal deletes the entire number

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1788,8 +1788,10 @@ Item {
 
         function test_deleteing_input_characters_data() {
             return [
-                        {input: "0.001"},
-                        {input: "1.00015"},
+                        {input: "0.001", locale: Qt.locale("en_US")},
+                        {input: "1.00015", locale: Qt.locale("en_US")},
+                        {input: "0.001", locale: Qt.locale("pl_PL")},
+                        {input: "1.90015", locale: Qt.locale("pl_PL")},
                         /* TODO uncomment after https://discord.com/channels/@me/927512790296563712/1260937239140241408
                         {input: "100.000000000000151001"},
                         {input: "1.0200000000000151001"} */
@@ -1804,6 +1806,7 @@ Item {
 
             const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
             verify(!!amountToSendInput)
+            amountToSendInput.input.locale = data.locale
 
             // Launch popup
             launchAndVerfyModal()
@@ -1812,9 +1815,10 @@ Item {
 
             //TODO: should not be needed after https://github.com/status-im/status-desktop/issues/15417
             amountToSendInput.input.input.cursorPosition = data.input.length
+            let amountToTestInLocale = data.input.replace('.', amountToSendInput.input.locale.decimalPoint)
             for(let i =0; i< data.input.length; i++) {
                 keyClick(Qt.Key_Backspace)
-                let expectedAmount = data.input.substring(0, data.input.length - (i+1))
+                let expectedAmount = amountToTestInLocale.substring(0, data.input.length - (i+1))
                 compare(amountToSendInput.input.text, expectedAmount)
             }
         }

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -108,15 +108,16 @@ Control {
                 amountToSendInput.input.input.edit.clear()
                 return
             }
-            let amountToSet = SQUtils.AmountsArithmetic.fromString(tokenAmount).toFixed().replace('.', LocaleUtils.userInputLocale.decimalPoint)
+            let amountToSet = SQUtils.AmountsArithmetic.fromString(tokenAmount).toFixed()
             /* When deleting characters after a decimal point
             eg: 0.000001 being deleted we have 0.00000 and it should not be updated to 0
             and thats why we compare with toFixed()
             also when deleting a numbers last digit, we should not update the text to 0
-            instead it should remain empty as entered by the user*/
-            if (SQUtils.AmountsArithmetic.fromString(amountToSendInput.input.text).toFixed() !== amountToSet &&
+            instead it should remain empty as entered by the user */
+            let currentInputTextAmount = SQUtils.AmountsArithmetic.fromString(amountToSendInput.input.text.replace(amountToSendInput.input.locale.decimalPoint,'.')).toFixed()
+            if (currentInputTextAmount !== amountToSet &&
                     !(amountToSet === "0" && !amountToSendInput.input.text)) {
-                amountToSendInput.input.text = amountToSet
+                amountToSendInput.input.text = amountToSet.replace('.', amountToSendInput.input.locale.decimalPoint)
             }
         }
     }
@@ -264,13 +265,13 @@ Control {
                 readonly property double maxSafeValue: WalletUtils.calculateMaxSafeSendAmount(
                                                            d.maxInputBalance, d.inputSymbol)
                 readonly property string maxSafeValueAsString: maxSafeValue.toLocaleString(
-                                                                   LocaleUtils.userInputLocale, 'f', -128)
+                                                                   amountToSendInput.input.locale, 'f', -128)
 
                 markAsInvalid: (!amountToSendInput.input.valid && !!amountToSendInput.input.text)
                                || d.maxInputBalance === 0
 
                 formattedValue:
-                    d.maxInputBalance === 0 ? LocaleUtils.userInputLocale.zeroDigit
+                    d.maxInputBalance === 0 ? amountToSendInput.input.locale.zeroDigit
                                             : root.currencyStore.formatCurrencyAmount(
                                                   maxSafeValue, d.inputSymbol,
                                                   { noSymbol: !amountToSendInput.inputIsFiat })


### PR DESCRIPTION
fixes #15818

### What does the PR do

The issue was only visible when formatting was with , separator such as DE etc, not visible when locale is EN
Ive adapted the logic so that its locale agnostic and also added tests so that the issue is not reintroduced in the future. 

### Affected areas

SwapModal.qml


### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/6ad41e30-9050-4d83-84f2-927000dec3f4

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->

### Cool Spaceship Picture

<!-- optional but cool -->
