### PR TITLE
fix(dapps) bad error from status-go api for WalletConnect

### DIFF
--- a/src/backend/wallet_connect.nim
+++ b/src/backend/wallet_connect.nim
@@ -57,8 +57,7 @@ proc getActiveSessions*(validAtTimestamp: int): JsonNode =
       return nil
 
     let jsonResultStr = rpcRes.result.getStr()
-    if jsonResultStr == "null":
-      # nil means error
+    if jsonResultStr == "null" or jsonResultStr == "":
       return newJArray()
 
     if rpcRes.result.kind != JArray:

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -48,14 +48,18 @@ function buildSupportedNamespacesFromModels(chainsModel, accountsModel, methods)
     }
     for (let i = 0; i < accountsModel.count; i++) {
         let entry = SQUtils.ModelUtils.get(accountsModel, i)
+        if (!entry || !entry.address) {
+            console.error("Invalid entry in accountsModel; skip reporting it", JSON.stringify(entry))
+            continue
+        }
         addresses.push(entry.address)
     }
     return buildSupportedNamespaces(chainIds, addresses, methods)
 }
 
 function buildSupportedNamespaces(chainIds, addresses, methods) {
-    var eipChainIds = []
-    var eipAddresses = []
+    let eipChainIds = []
+    let eipAddresses = []
     for (let i = 0; i < chainIds.length; i++) {
         let chainId = chainIds[i]
         eipChainIds.push(`"eip155:${chainId}"`)
@@ -65,7 +69,13 @@ function buildSupportedNamespaces(chainIds, addresses, methods) {
     }
     let methodsStr = methods.map(method => `"${method}"`).join(',')
     return `{
-        "eip155":{"chains": [${eipChainIds.join(',')}],"methods": [${methodsStr}],"events": ["accountsChanged", "chainChanged"],"accounts": [${eipAddresses.join(',')}]}}`
+        "eip155": {
+            "chains": [${eipChainIds.join(',')}],
+            "methods": [${methodsStr}],
+            "events": ["accountsChanged", "chainChanged"],
+            "accounts": [${eipAddresses.join(',')}]
+        }
+    }`
 }
 
 function validURI(uri) {


### PR DESCRIPTION
Updates: #15884, #15815

Also don't allow undefined values to be passed by addresses. I found and intermittent issue of not having any account selected. I could not reproduce it anymore but the logs showed reporting `undefined` values for addresses. Tracing back the code path I found a potential error if the lookup of addresses failed and don't allow injecting `undefined`.
