### PR TITLE
[CHERRY-PICK] chore: set missing message verification and confirmation for message sent enabled by default

### DIFF
--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -21,6 +21,8 @@ type
 
     wakuV2Nameserver*: Option[string]
     wakuV2LightClient*: bool
+    wakuV2EnableStoreConfirmationForMessagesSent*: bool
+    wakuV2EnableMissingMessageVerification*: bool
 
     logLevel*: Option[string]
     logFilePath*: string

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -233,6 +233,8 @@ QtObject:
         emoji: self.defaultWalletEmoji,
         logLevel: some(toStatusGoSupportedLogLevel(main_constants.LOG_LEVEL)),
         wakuV2LightClient: false,
+        wakuV2EnableMissingMessageVerification: true,
+        wakuV2EnableStoreConfirmationForMessagesSent: true,
         previewPrivacy: true,
         torrentConfigEnabled: some(false),
         torrentConfigPort: some(TORRENT_CONFIG_PORT),


### PR DESCRIPTION
cherry-pick of https://github.com/status-im/status-desktop/pull/15774

Status-go PR: https://github.com/status-im/status-go/pull/5631