### PR TITLE
fix(wallet)_: Filter non-bridgeable assets in Bridge Modal

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/WalletAssetsStore.qml
@@ -101,4 +101,21 @@ QtObject {
         rightModel: _jointTokensBySymbolModel
         joinRole: "tokensKey"
     }
+
+    // This is hard coded for now, and should be updated whenever Hop add new tokens for support
+    // This should be dynamically fetched somehow in the future
+    readonly property var tokensSupportedByHopBridge: ["USDC", "USDC.e", "USDT", "DAI", "HOP", "SNX", "sUSD", "rETH", "MAGIC"]
+
+    readonly property SortFilterProxyModel bridgeableGroupedAccountAssetsModel: SortFilterProxyModel {
+        objectName: "bridgeableGroupedAccountAssetsModel"
+        sourceModel: root.groupedAccountAssetsModel
+
+        filters: [
+            FastExpressionFilter {
+                expression: root.tokensSupportedByHopBridge.includes(model.symbol)
+                expectedRoles: ["symbol"]
+            }
+        ]
+    }
 }
+

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -358,7 +358,9 @@ StatusDialog {
                         TokenSelectorViewAdaptor {
                             id: assetsAdaptor
 
-                            assetsModel: popup.store.walletAssetStore.groupedAccountAssetsModel
+                            assetsModel: d.isBridgeTx ?
+                                             popup.store.walletAssetStore.bridgeableGroupedAccountAssetsModel :
+                                             popup.store.walletAssetStore.groupedAccountAssetsModel
 
                             flatNetworksModel: popup.store.flatNetworksModel
                             currentCurrency: popup.store.currencyStore.currentCurrency


### PR DESCRIPTION

### What does the PR do
 - Implemented a bridgeableGroupedAccountAssetsModel in WalletAssetsStore.qml to dynamically filter assets based on their bridgeability.

closes: #15697

### Affected areas

- WalletAssetsStore.qml
- SendModal.qml

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it


### Impact on end user

Before:

- Non-bridgeable assets were displayed in the Bridge Modal, potentially causing confusion.
- Users could select non-bridgeable assets, leading to errors or failed transactions.

After:

- Only bridgeable assets are displayed in the Bridge Modal, ensuring a streamlined and error-free selection process.
- Users will not be able to choose assets that are incompatible with the Bridge, preventing unnecessary confusion and errors.

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 


Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

