### PR TITLE
[CHERRY-PICK] fix(wallet): Update preferred networks even when empty (#15841)

### DIFF
--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -143,10 +143,8 @@ QtObject:
   proc updatePreferredSharingChainsForAddress*(self: KeyPairAccountModel, address, prodPreferredChainIds, testPreferredChainIds: string) =
     for i in 0 ..< self.items.len:
       if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
-        if prodPreferredChainIds.len > 0:
-          self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
-        if testPreferredChainIds.len > 0:
-          self.items[i].setTestPreferredChainIds(testPreferredChainIds)
+        self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
+        self.items[i].setTestPreferredChainIds(testPreferredChainIds)
 
   proc updateAccountHiddenInTotalBalance*(self: KeyPairAccountModel, address: string, hideFromTotalBalance: bool) =
     for i in 0 ..< self.items.len:


### PR DESCRIPTION
Cherrypick of https://github.com/status-im/status-desktop/pull/15841 for release