### PR TITLE
Chore/no send no swap

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -71,7 +71,7 @@ Rectangle {
 
         readonly property bool buyActionAvailable: !root.isCommunityOwnershipTransfer && !root.walletStore.showAllAccounts
 
-        readonly property bool swapActionAvailable: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount && !d.hideCollectibleTransferActions
+        readonly property bool swapActionAvailable: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount && walletStore.overview.canSend && !d.hideCollectibleTransferActions
 
         function getFirstUserOwnedAddress(ownershipModel, accountsModel) {
             if (!ownershipModel) return ""


### PR DESCRIPTION
### What does the PR do

Swap action wasn't hidden when account cannot send transaction

It could be reproduced by
* add new master key for accB within accA
* wait for sync
* Restore accA from seed phrase 
* accB is visible too but we don't have master key anymore

### Affected areas

Wallet footer

### Screenshot of functionality (including design for comparison)

Account with key:
![image](https://github.com/user-attachments/assets/07b3935b-92ab-4e51-b3e4-edc6dc8cd484)

Account without key:
![image](https://github.com/user-attachments/assets/bd6499e0-5369-47bc-b681-be9f8078bbd2)
