### PR TITLE
fix: inconsistent/incorrect decimal value formatting

### DIFF
--- a/storybook/pages/DAppSignRequestModalPage.qml
+++ b/storybook/pages/DAppSignRequestModalPage.qml
@@ -3,8 +3,11 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+
 import shared.popups.walletconnect 1.0
+
 import utils 1.0
+
 import Storybook 1.0
 
 SplitView {
@@ -23,6 +26,9 @@ SplitView {
             id: dappSignRequestModal
 
             loginType: loginType.currentValue
+            formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2)
+                             + (noSymbolOption ? "" : " " + (symbol || Qt.locale().currencySymbol(Locale.CurrencyIsoCode)))
+
             visible: true
             modal: false
             closePolicy: Popup.NoAutoClose
@@ -35,7 +41,6 @@ SplitView {
             networkName: "Ethereum"
             networkIconPath: "https://picsum.photos/200/200"
 
-            currentCurrency: "EUR"
             fiatFees: fiatFees.text
             cryptoFees: "0.001"
             estimatedTime: "3-5 minutes"

--- a/storybook/pages/SwapApproveCapModalPage.qml
+++ b/storybook/pages/SwapApproveCapModalPage.qml
@@ -75,6 +75,9 @@ SplitView {
                     modal: false
                     closePolicy: Popup.NoAutoClose
 
+                    formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2)
+                                     + (noSymbolOption ? "" : " " + (symbol || Qt.locale().currencySymbol(Locale.CurrencyIsoCode)))
+
                     fromTokenSymbol: ctrlFromSymbol.text
                     fromTokenAmount: ctrlFromAmount.text
                     fromTokenContractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F"
@@ -83,15 +86,15 @@ SplitView {
                     accountAddress: priv.selectedAccount.address
                     accountEmoji: priv.selectedAccount.emoji
                     accountColor: Utils.getColorForId(priv.selectedAccount.colorId)
-                    accountBalanceFormatted: "120.55489 USD"
+                    accountBalanceFormatted: formatBigNumber(120.55489)
 
                     networkShortName: priv.selectedNetwork.shortName
                     networkName: priv.selectedNetwork.chainName
                     networkIconPath: Style.svg(priv.selectedNetwork.iconUrl)
                     networkBlockExplorerUrl: priv.selectedNetwork.blockExplorerURL
 
-                    fiatFees: "1.54 USD"
-                    cryptoFees: "0.001 ETH"
+                    fiatFees: formatBigNumber("1.542567673454567457567678678678989234")
+                    cryptoFees: formatBigNumber("0.001", "ETH")
                     estimatedTime: ctrlEstimatedTime.currentValue
 
                     loginType: ctrlLoginType.currentIndex

--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -8,7 +8,6 @@ import Storybook 1.0
 import Models 1.0
 
 import AppLayouts.Wallet.popups.swap 1.0
-import shared.stores 1.0
 
 import utils 1.0
 
@@ -75,7 +74,8 @@ SplitView {
                     modal: false
                     closePolicy: Popup.NoAutoClose
 
-                    currencyStore: CurrenciesStore{}
+                    formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2)
+                                     + (noSymbolOption ? "" : " " + (symbol || Qt.locale().currencySymbol(Locale.CurrencyIsoCode)))
 
                     fromTokenSymbol: ctrlFromSymbol.text
                     fromTokenAmount: ctrlFromAmount.text
@@ -98,8 +98,8 @@ SplitView {
                     serviceProviderName: Constants.swap.paraswapName
                     serviceProviderURL: Constants.swap.termsAndConditionParaswapUrl
 
-                    fiatFees: "1.54 EUR"
-                    cryptoFees: "0.001 ETH"
+                    fiatFees: formatBigNumber(42.542567, "EUR")
+                    cryptoFees: formatBigNumber(0.06, "ETH")
                     slippage: 0.5
 
                     loginType: ctrlLoginType.currentIndex

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -384,7 +384,6 @@ Item {
             compare(args.fiatMaxFees.toString(), args.ethMaxFees.toString(), "expected fiatMaxFees to be set")
             verify(args.haveEnoughFunds, "expected haveEnoughFunds to be set")
             compare(args.haveEnoughForFees, data.expect.haveEnoughForFees, "expected haveEnoughForFees to be set")
-            compare(args.symbol, "$", "expected symbol to be set")
             verify(!!args.feesInfo, "expected feesInfo to be set")
         }
     }

--- a/storybook/qmlTests/tests/tst_SwapApproveCapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapApproveCapModal.qml
@@ -21,6 +21,7 @@ Item {
         id: componentUnderTest
         SwapApproveCapModal {
             anchors.centerIn: parent
+            formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2) + (noSymbolOption ? "" : " " + symbol)
 
             fromTokenSymbol: "DAI"
             fromTokenAmount: "100.07"
@@ -88,8 +89,8 @@ Item {
             // info box
             const headerText = findChild(controlUnderTest.contentItem, "headerText")
             verify(!!headerText)
-            compare(headerText.text, qsTr("Set %1 %2 spending cap in %3 for %4 on %5")
-                    .arg(controlUnderTest.formatBigNumber(controlUnderTest.fromTokenAmount)).arg(controlUnderTest.fromTokenSymbol)
+            compare(headerText.text, qsTr("Set %1 spending cap in %2 for %3 on %4")
+                    .arg(controlUnderTest.formatBigNumber(controlUnderTest.fromTokenAmount, controlUnderTest.fromTokenSymbol))
                     .arg(controlUnderTest.accountName).arg(controlUnderTest.serviceProviderURL).arg(controlUnderTest.networkName))
 
             const fromImageHidden = findChild(controlUnderTest.contentItem, "fromImageIdenticon")
@@ -107,7 +108,7 @@ Item {
             const spendingCapBox = findChild(controlUnderTest.contentItem, "spendingCapBox")
             verify(!!spendingCapBox)
             compare(spendingCapBox.caption, qsTr("Set spending cap"))
-            compare(spendingCapBox.primaryText, controlUnderTest.formatBigNumber(controlUnderTest.fromTokenAmount))
+            compare(spendingCapBox.primaryText, controlUnderTest.formatBigNumber(controlUnderTest.fromTokenAmount, root.fromTokenSymbol, {noSymbol: true}))
         }
 
         function test_accountInfo() {

--- a/storybook/qmlTests/tests/tst_SwapSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapSignModal.qml
@@ -8,7 +8,6 @@ import Models 1.0
 import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Wallet.popups.swap 1.0
-import shared.stores 1.0
 
 import utils 1.0
 
@@ -17,17 +16,12 @@ Item {
     width: 600
     height: 400
 
-    QtObject {
-        id: d
-        readonly property var currencyStore: CurrenciesStore{}
-    }
-
     Component {
         id: componentUnderTest
         SwapSignModal {
             anchors.centerIn: parent
 
-            currencyStore: d.currencyStore
+            formatBigNumber: (number, symbol, noSymbolOption) => parseFloat(number).toLocaleString(Qt.locale(), 'f', 2) + (noSymbolOption ? "" : " " + symbol)
 
             fromTokenSymbol: "DAI"
             fromTokenAmount: "100.07"
@@ -106,13 +100,13 @@ Item {
 
             // title & subtitle
             compare(controlUnderTest.title, qsTr("Sign Swap"))
-            compare(controlUnderTest.subtitle, qsTr("%1 to %2").arg(d.currencyStore.formatCurrencyAmount(controlUnderTest.fromTokenAmount, controlUnderTest.fromTokenSymbol))
-                    .arg(d.currencyStore.formatCurrencyAmount(controlUnderTest.toTokenAmount, controlUnderTest.toTokenSymbol)))
+            compare(controlUnderTest.subtitle, qsTr("%1 to %2").arg(controlUnderTest.formatBigNumber(controlUnderTest.fromTokenAmount, controlUnderTest.fromTokenSymbol))
+                    .arg(controlUnderTest.formatBigNumber(controlUnderTest.toTokenAmount, controlUnderTest.toTokenSymbol)))
 
             // info box
             const headerText = findChild(controlUnderTest.contentItem, "headerText")
             verify(!!headerText)
-            compare(headerText.text, qsTr("Swap 1000.123456789 SNT to 1.42 %3 in %1 on %2").arg(controlUnderTest.accountName).arg(controlUnderTest.networkName).arg(data.toTokenSymbol))
+            compare(headerText.text, qsTr("Swap 1,000.12 SNT to 1.42 %3 in %1 on %2").arg(controlUnderTest.accountName).arg(controlUnderTest.networkName).arg(data.toTokenSymbol))
             const fromImage = findChild(controlUnderTest.contentItem, "fromImageIdenticon")
             verify(!!fromImage)
             compare(fromImage.asset.name, Constants.tokenIcon(controlUnderTest.fromTokenSymbol))
@@ -124,7 +118,7 @@ Item {
             const payBox = findChild(controlUnderTest.contentItem, "payBox")
             verify(!!payBox)
             compare(payBox.caption, qsTr("Pay"))
-            compare(payBox.primaryText, "%1 %2".arg(controlUnderTest.fromTokenAmount).arg(controlUnderTest.fromTokenSymbol))
+            compare(payBox.primaryText, "1,000.12 SNT")
             compare(payBox.secondaryText, SQUtils.Utils.elideAndFormatWalletAddress(controlUnderTest.fromTokenContractAddress))
 
             // receive box

--- a/storybook/stubs/shared/stores/CurrenciesStore.qml
+++ b/storybook/stubs/shared/stores/CurrenciesStore.qml
@@ -41,11 +41,6 @@ QtObject {
     }
 
     function getCurrentCurrencyAmount(amount) {
-        return ({
-                    amount: amount,
-                    symbol: root.currentCurrency,
-                    displayDecimals: 2,
-                    stripTrailingZeroes: false
-                })
+        return getCurrencyAmount(amount, root.currentCurrency)
     }
 }

--- a/ui/StatusQ/src/StatusQ/Validators/AmountValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Validators/AmountValidator.qml
@@ -11,7 +11,7 @@ import StatusQ 0.1
   - marks empty input and consisting only of decimal point as Intermediate
   - limits allowed char set - digits and (only when maxDecimalDigits is not 0)
     two decimal point characters are available (".", ",")
-  - replaces entered decimal point to the one provied via decimalPoint property
+  - replaces entered decimal point to the one provided via decimalPoint property
   - blocks attemps of entering more then one decimal point char
   - limits number of integral part specified by maxIntegralDigits
   - trims number of decimal part specified by maxDecimalDigits

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -158,6 +158,7 @@ DappsComboBox {
             id: dappRequestModal
             objectName: "dappsRequestModal"
             loginType: request.account.migragedToKeycard ? Constants.LoginType.Keycard : root.loginType
+            formatBigNumber: (number, symbol, noSymbolOption) => root.wcService.walletRootStore.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
             visible: true
 
             property var feesInfo: null
@@ -174,7 +175,6 @@ DappsComboBox {
             networkName: request.network.chainName
             networkIconPath: Style.svg(request.network.iconUrl)
 
-            currentCurrency: ""
             fiatFees: request.maxFeesText
             cryptoFees: request.maxFeesEthText
             estimatedTime: ""
@@ -223,12 +223,11 @@ DappsComboBox {
                 function onMaxFeesUpdated(fiatMaxFees, ethMaxFees, haveEnoughFunds, haveEnoughFees, symbol, feesInfo) {
                     dappRequestModal.hasFees = !!ethMaxFees
                     dappRequestModal.feesLoading = !dappRequestModal.hasFees
-                    if (!hasFees) {
+                    if (!dappRequestModal.hasFees) {
                         return
                     }
-                    dappRequestModal.fiatFees = fiatMaxFees.toString()
-                    dappRequestModal.cryptoFees = ethMaxFees.toString()
-                    dappRequestModal.currentCurrency = symbol
+                    dappRequestModal.fiatFees = fiatMaxFees.toFixed()
+                    dappRequestModal.cryptoFees = ethMaxFees.toFixed()
                     dappRequestModal.enoughFundsForTransaction = haveEnoughFunds
                     dappRequestModal.enoughFundsForFees = haveEnoughFees
                     dappRequestModal.feesInfo = feesInfo

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -14,6 +14,7 @@ import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
 
 import shared.controls 1.0
+import shared.stores 1.0
 
 import utils 1.0
 
@@ -21,6 +22,16 @@ StatusDialog {
     id: root
 
     required property int loginType // RootStore.loginType -> Constants.LoginType enum
+
+    /**
+      Format a currency amount, represented as a float `number` as a string, e.g. "1.234",
+
+      @param `symbol` string (optional): e.g. "EUR" or "SNT"; defaults to the current currency short name (locale dependent)
+      @param `noSymbolOption` boolean (optional): omits the symbol in the final output
+
+      @return a formatted version of the amount, eg. "1,23 SNT" (decimal separator locale dependent, amount of decimals currency dependent)
+    */
+    required property var formatBigNumber// => (number:string, symbol?:string, noSymbolOption?:bool) {}
 
     property Component headerIconComponent
 
@@ -65,14 +76,6 @@ StatusDialog {
 
     width: 480
     padding: 0
-
-    function formatBigNumber(number: string, decimals = -1) {
-        if (!number)
-            return ""
-        const big = SQUtils.AmountsArithmetic.fromString(number)
-        const resultNum = decimals === -1 ? big.toFixed() : big.round(decimals).toFixed()
-        return resultNum.replace('.', Qt.locale().decimalPoint)
-    }
 
     function openLinkWithConfirmation(linkUrl) {
         Global.openLinkWithConfirmation(linkUrl, SQUtils.StringUtils.extractDomainFromLink(linkUrl))

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapApproveCapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapApproveCapModal.qml
@@ -56,7 +56,7 @@ SignTransactionModalBase {
     toImageSource: Constants.tokenIcon(root.fromTokenSymbol)
 
     //: e.g. "Set 100 DAI spending cap in <account name> for <service> on <network name>"
-    headerMainText: qsTr("Set %1 %2 spending cap in %3 for %4 on %5").arg(formatBigNumber(root.fromTokenAmount)).arg(root.fromTokenSymbol)
+    headerMainText: qsTr("Set %1 spending cap in %2 for %3 on %4").arg(formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol))
         .arg(root.accountName).arg(root.serviceProviderURL).arg(root.networkName)
     headerSubTextLayout: [
         StatusBaseText {
@@ -64,7 +64,7 @@ SignTransactionModalBase {
             horizontalAlignment: Qt.AlignHCenter
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             font.pixelSize: Style.current.additionalTextSize
-            text: qsTr("The smart contract specified will be able to spend up to %1 %2 of your current or future balance.").arg(formatBigNumber(root.fromTokenAmount)).arg(root.fromTokenSymbol)
+            text: qsTr("The smart contract specified will be able to spend up to %1 of your current or future balance.").arg(formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol))
         }
     ]
 
@@ -114,7 +114,7 @@ SignTransactionModalBase {
         Layout.bottomMargin: Style.current.bigPadding
         objectName: "spendingCapBox"
         caption: qsTr("Set spending cap")
-        primaryText: formatBigNumber(root.fromTokenAmount)
+        primaryText: formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol, true)
         listItemHeight: 44
         components: [
             StatusSmartIdenticon {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -428,6 +428,8 @@ StatusDialog {
         SwapApproveCapModal {
             destroyOnClose: true
 
+            formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
+
             loginType: root.swapAdaptor.selectedAccount.migratedToKeycard ? Constants.LoginType.Keycard : root.loginType
             feesLoading: root.swapAdaptor.swapProposalLoading
 
@@ -454,7 +456,7 @@ StatusDialog {
                 const feesInFloat = root.swapAdaptor.currencyStore.getFiatValue(root.swapAdaptor.swapOutputData.approvalGasFees, Constants.ethToken)
                 return root.swapAdaptor.currencyStore.formatCurrencyAmount(feesInFloat, root.swapAdaptor.currencyStore.currentCurrency)
             }
-            cryptoFees: root.swapAdaptor.currencyStore.formatCurrencyAmount(root.swapAdaptor.swapOutputData.approvalGasFees, Constants.ethToken)
+            cryptoFees: root.swapAdaptor.currencyStore.formatCurrencyAmount(parseFloat(root.swapAdaptor.swapOutputData.approvalGasFees), Constants.ethToken)
             estimatedTime: root.swapAdaptor.swapOutputData.estimatedTime
 
             serviceProviderName: root.swapAdaptor.swapOutputData.txProviderName
@@ -473,7 +475,7 @@ StatusDialog {
         SwapSignModal {
             destroyOnClose: true
 
-            currencyStore: root.swapAdaptor.currencyStore
+            formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 
             loginType: root.swapAdaptor.selectedAccount.migratedToKeycard ? Constants.LoginType.Keycard : root.loginType
             feesLoading: root.swapAdaptor.swapProposalLoading

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
@@ -18,8 +18,6 @@ import utils 1.0
 SignTransactionModalBase {
     id: root
 
-    required property var currencyStore
-
     required property string fromTokenSymbol
     required property string fromTokenAmount
     required property string fromTokenContractAddress
@@ -47,17 +45,15 @@ SignTransactionModalBase {
 
     title: qsTr("Sign Swap")
     //: e.g. (swap) 100 DAI to 100 USDT
-    subtitle: qsTr("%1 to %2")
-    .arg(root.currencyStore.formatCurrencyAmount(fromTokenAmount, fromTokenSymbol))
-    .arg(root.currencyStore.formatCurrencyAmount(toTokenAmount, toTokenSymbol))
+    subtitle: qsTr("%1 to %2").arg(formatBigNumber(fromTokenAmount, fromTokenSymbol)).arg(formatBigNumber(toTokenAmount, toTokenSymbol))
 
     gradientColor: Utils.setColorAlpha(root.accountColor, 0.05) // 5% of wallet color
     fromImageSource: Constants.tokenIcon(root.fromTokenSymbol)
     toImageSource: Constants.tokenIcon(root.toTokenSymbol)
 
     //: e.g. "Swap 100 DAI to 100 USDT in <account name> on <network chain name>"
-    headerMainText: qsTr("Swap %1 %2 to %3 %4 in %5 on %6").arg(formatBigNumber(root.fromTokenAmount)).arg(root.fromTokenSymbol)
-        .arg(formatBigNumber(root.toTokenAmount)).arg(root.toTokenSymbol).arg(root.accountName).arg(root.networkName)
+    headerMainText: qsTr("Swap %1 to %2 in %3 on %4").arg(formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol))
+        .arg(formatBigNumber(root.toTokenAmount, root.toTokenSymbol)).arg(root.accountName).arg(root.networkName)
     headerSubTextLayout: [
         StatusBaseText {
             font.pixelSize: Style.current.additionalTextSize
@@ -133,7 +129,7 @@ SignTransactionModalBase {
         Layout.bottomMargin: Style.current.bigPadding
         objectName: "payBox"
         caption: qsTr("Pay")
-        primaryText: "%1 %2".arg(formatBigNumber(root.fromTokenAmount)).arg(root.fromTokenSymbol)
+        primaryText: formatBigNumber(root.fromTokenAmount, root.fromTokenSymbol)
         secondaryText: root.fromTokenSymbol !== Constants.ethToken ? SQUtils.Utils.elideAndFormatWalletAddress(root.fromTokenContractAddress) : ""
         icon: Constants.tokenIcon(root.fromTokenSymbol)
         badge: root.networkIconPath
@@ -156,7 +152,7 @@ SignTransactionModalBase {
         Layout.bottomMargin: Style.current.bigPadding
         objectName: "receiveBox"
         caption: qsTr("Receive")
-        primaryText: "%1 %2".arg(formatBigNumber(root.toTokenAmount)).arg(root.toTokenSymbol)
+        primaryText: formatBigNumber(root.toTokenAmount, root.toTokenSymbol)
         secondaryText: root.toTokenSymbol !== Constants.ethToken ? SQUtils.Utils.elideAndFormatWalletAddress(root.toTokenContractAddress) : ""
         icon: Constants.tokenIcon(root.toTokenSymbol)
         badge: root.networkIconPath

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -36,7 +36,7 @@ SQUtils.QObject {
     signal sessionRequest(SessionRequestResolved request)
     signal displayToastMessage(string message, bool error)
     signal sessionRequestResult(/*model entry of SessionRequestResolved*/ var request, bool isSuccess)
-    signal maxFeesUpdated(real fiatMaxFees, var /* Big */ ethMaxFees, bool haveEnoughFunds, bool haveEnoughFees, string symbol, var feesInfo)
+    signal maxFeesUpdated(var /* Big */ fiatMaxFees, var /* Big */ ethMaxFees, bool haveEnoughFunds, bool haveEnoughFees, string symbol, var feesInfo)
     // Reports Constants.TransactionEstimatedTime values
     signal estimatedTimeUpdated(int estimatedTimeEnum)
 
@@ -209,7 +209,7 @@ SQUtils.QObject {
 
                 let fundsStatus = checkFundsStatus(st.feesInfo.maxFees, st.feesInfo.l1GasFee, account.address, obj.network.chainId, mainNet.chainId, interpreted.value)
 
-                root.maxFeesUpdated(st.fiatMaxFees.toNumber(), st.maxFeesEth, fundsStatus.haveEnoughFunds,
+                root.maxFeesUpdated(st.fiatMaxFees, st.maxFeesEth, fundsStatus.haveEnoughFunds,
                                     fundsStatus.haveEnoughForFees, st.symbol, st.feesInfo)
             })
 
@@ -479,7 +479,7 @@ SQUtils.QObject {
             let maxFeesEthStr = maxFeesEth.toString()
             let fiatMaxFeesStr = root.currenciesStore.getFiatValue(maxFeesEthStr, Constants.ethToken)
             let fiatMaxFees = BigOps.fromString(fiatMaxFeesStr)
-            let symbol = root.currenciesStore.currentCurrencySymbol
+            let symbol = root.currenciesStore.currentCurrency
 
             return {fiatMaxFees, maxFeesEth, symbol, feesInfo}
         }

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -368,6 +368,8 @@ WalletConnectSDKBase {
             id: dappRequestModal
             objectName: "connectorDappsRequestModal"
             loginType: request.account.migragedToKeycard ? Constants.LoginType.Keycard : root.loginType
+            formatBigNumber: (number, symbol, noSymbolOption) => root.wcService.walletRootStore.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
+
             visible: true
 
             dappName: request.dappName
@@ -382,7 +384,6 @@ WalletConnectSDKBase {
             networkName: request.network.chainName
             networkIconPath: Style.svg(request.network.iconUrl)
 
-            currentCurrency: ""
             fiatFees: request.maxFeesText
             cryptoFees: request.maxFeesEthText
             estimatedTime: ""

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -247,7 +247,7 @@ StatusDialog {
             // in localized version. It should be refactored to provide raw
             // number consistently. Only the displaying component should apply
             // final localized formatting.
-            const delocalized = popup.preDefinedAmountToSend.replace(",", ".")
+            const delocalized = popup.preDefinedAmountToSend.replace(LocaleUtils.userInputLocale.decimalPoint, ".")
 
             amountToSend.setValue(delocalized)
         }
@@ -478,7 +478,7 @@ StatusDialog {
                             if (!valid)
                                 return 0
 
-                            return parseFloat(text.replace(",", "."))
+                            return parseFloat(text.replace(LocaleUtils.userInputLocale.decimalPoint, "."))
                         }
                         readonly property int minSendCryptoDecimals:
                             !fiatMode ? LocaleUtils.fractionalPartLength(asNumber) : 0

--- a/ui/imports/shared/popups/send/views/AmountToSendNew.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSendNew.qml
@@ -32,7 +32,7 @@ Control {
     // detail of that component.
     readonly property alias text: textField.text
 
-    /* Decimal point character to be dispalyed. Both "." and "," will be
+    /* Decimal point character to be displayed. Both "." and "," will be
      * replaced by the provided decimal point on the fly */
     property alias decimalPoint: validator.decimalPoint
 
@@ -98,7 +98,7 @@ Control {
 
         readonly property string inputDelocalized:
             root.valid && textField.length !== 0
-                ? textField.text.replace(",", ".") : "0"
+                ? textField.text.replace(root.decimalPoint, ".") : "0"
 
         function removeDecimalTrailingZeros(num) {
             if (!num.includes("."))

--- a/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
@@ -33,7 +33,6 @@ SignTransactionModalBase {
     required property string networkName
     required property string networkIconPath
     // Fees
-    required property string currentCurrency
     required property string fiatFees
     required property string cryptoFees
     required property string estimatedTime
@@ -96,7 +95,7 @@ SignTransactionModalBase {
                 StatusTextWithLoadingState {
                     Layout.fillWidth: true
                     objectName: "footerFiatFeesText"
-                    text: "%1 %2".arg(formatBigNumber(root.fiatFees)).arg(root.currentCurrency)
+                    text: formatBigNumber(root.fiatFees, root.currentCurrency)
                     loading: root.feesLoading
                     customColor: root.enoughFundsForFees ? Theme.palette.directColor1 : Theme.palette.dangerColor1
                     elide: Qt.ElideMiddle
@@ -172,7 +171,7 @@ SignTransactionModalBase {
                 StatusTextWithLoadingState {
                     objectName: "fiatFeesText"
                     Layout.alignment: Qt.AlignRight
-                    text: "%1 %2".arg(formatBigNumber(root.fiatFees)).arg(root.currentCurrency)
+                    text: formatBigNumber(root.fiatFees, root.currentCurrency)
                     horizontalAlignment: Text.AlignRight
                     font.pixelSize: Style.current.additionalTextSize
                     loading: root.feesLoading
@@ -181,7 +180,7 @@ SignTransactionModalBase {
                 StatusTextWithLoadingState {
                     objectName: "cryptoFeesText"
                     Layout.alignment: Qt.AlignRight
-                    text: "%1 ETH".arg(formatBigNumber(root.cryptoFees))
+                    text: formatBigNumber(root.cryptoFees, Constants.ethToken)
                     horizontalAlignment: Text.AlignRight
                     font.pixelSize: Style.current.additionalTextSize
                     customColor: root.enoughFundsForFees ? Theme.palette.baseColor1 : Theme.palette.dangerColor1

--- a/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
@@ -104,7 +104,6 @@ Popup {
                 anchors.leftMargin: Style.current.halfPadding
                 anchors.rightMargin: anchors.leftMargin
                 model: root.delegateModel
-                ScrollBar.vertical: null
             }
             Rectangle {
                 id: footer

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -987,6 +987,17 @@ QtObject {
         return formatCurrencyAmount(decimalBalance, symbol, options)
     }
 
+    function formatBigNumber(number: string, symbol: string, noSymbolOption: bool) {
+        if (!number)
+            return "N/A"
+        if (!symbol)
+            symbol = root.currentCurrency
+        let options = {}
+        if (!!noSymbolOption)
+            options = {noSymbol: true}
+        return formatCurrencyAmount(parseFloat(number), symbol, options)
+    }
+
     function getFiatValue(cryptoAmount, cryptoSymbol) {
         var amount = _profileSectionModuleInst.ensUsernamesModule.getFiatValue(cryptoAmount, cryptoSymbol)
         return parseFloat(amount)


### PR DESCRIPTION
### What does the PR do

- format Big decimal numbers correctly according to the current locale; some precision loss is tolerated here for the display purposes
- fixes wrong decimal separators in some places and aligns with the standard in terms of number of decimals, as everywhere else in the app

Fixes #15612
Fixes #15790

### Affected areas

SwapApproveCapModal, SwapSignModal, DAppSignRequestModal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/8e79b80d-e356-457e-a346-d2ef99a917ee)

![image](https://github.com/user-attachments/assets/4ed8ef7f-2e13-4698-9593-8bbadfac96f8)

![image](https://github.com/user-attachments/assets/f4d667a4-9a9d-4782-9b9d-e5de004068d7)
