### PR TITLE
[CHERRY-PICK] fix(notif-indicator): evaluate the notifications on app start (#15872)

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -129,6 +129,8 @@ type
 method calculateProfileSectionHasNotification*[T](self: Module[T]): bool
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string)
 method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string)
+proc checkIfWeHaveNotifications[T](self: Module[T])
+
 
 proc newModule*[T](
   delegate: T,
@@ -745,6 +747,8 @@ method onChatsLoaded*[T](
   self.view.sectionsLoaded()
   if self.statusDeepLinkToActivate != "":
     self.activateStatusDeepLink(self.statusDeepLinkToActivate)
+
+  self.checkIfWeHaveNotifications()
 
 method onCommunityDataLoaded*[T](
   self: Module[T],


### PR DESCRIPTION
Fixes #15835

Cherry-pick of https://github.com/status-im/status-desktop/pull/15872

Evaluate if we have notification on app start (when chats are loaded) so that the notification icon can be shown if we open the app **not** in the chat (eg in the wallet)

