### PR TITLE
fix(wallet): Disable adding new watch-only accounts

### DIFF
--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -9,6 +9,8 @@ import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
 import utils 1.0
+import StatusQ 0.1
+import SortFilterProxyModel 0.2
 
 import "../stores"
 import "../panels"
@@ -48,6 +50,20 @@ Item {
     QtObject {
         id: d
         readonly property bool isEdit: root.store.editMode
+
+        readonly property SortFilterProxyModel originModelWithoutWatchOnlyAcc: SortFilterProxyModel {
+            id: originModelWithoutWatchOnlyAcc
+            objectName: "originModelWithoutWatchOnlyAcc"
+            sourceModel: root.store.originModel
+
+            readonly property string addWatchOnlyAccKeyUid: Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
+            filters: [
+                FastExpressionFilter {
+                    expression: model.keyPair.keyUid !== originModelWithoutWatchOnlyAcc.addWatchOnlyAccKeyUid
+                    expectedRoles: ["keyPair"]
+                }
+            ]
+        }
 
         function openEmojiPopup(showLeft) {
             if (!root.store.emojiPopup) {
@@ -171,7 +187,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 userProfilePublicKey: root.store.userProfilePublicKey
-                originModel: root.store.editMode? [] : root.store.originModel
+                originModel: root.store.editMode? [] : d.originModelWithoutWatchOnlyAcc
                 selectedOrigin: root.store.selectedOrigin
                 caretVisible: !root.store.editMode
                 enabled: !root.store.editMode


### PR DESCRIPTION
 

### What does the PR do

closes: #15933 

### Affected areas

- Wallet -> addAccount

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/25a8e231-6f46-4b0f-8a26-4f199f729ccb">


### Impact on end user

User will not be able to add new watch only accounts



### Risk 


Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.


