### PR TITLE
feature(connector)_: Add model join to handle connected dApps

### DIFF
--- a/src/app/core/signals/remote_signals/connector.nim
+++ b/src/app/core/signals/remote_signals/connector.nim
@@ -17,6 +17,16 @@ type ConnectorSendTransactionSignal* = ref object of Signal
   chainId*: int
   txArgs*: string
 
+type ConnectorGrantDAppPermissionSignal* = ref object of Signal
+  url*: string
+  name*: string
+  iconUrl*: string
+
+type ConnectorRevokeDAppPermissionSignal* = ref object of Signal
+  url*: string
+  name*: string
+  iconUrl*: string
+
 proc fromEvent*(T: type ConnectorSendRequestAccountsSignal, event: JsonNode): ConnectorSendRequestAccountsSignal =
   result = ConnectorSendRequestAccountsSignal()
   result.url = event["event"]{"url"}.getStr()
@@ -32,3 +42,15 @@ proc fromEvent*(T: type ConnectorSendTransactionSignal, event: JsonNode): Connec
   result.requestId = event["event"]{"requestId"}.getStr()
   result.chainId = event["event"]{"chainId"}.getInt()
   result.txArgs = event["event"]{"txArgs"}.getStr()
+
+proc fromEvent*(T: type ConnectorGrantDAppPermissionSignal, event: JsonNode): ConnectorGrantDAppPermissionSignal =
+  result = ConnectorGrantDAppPermissionSignal()
+  result.url = event["event"]{"url"}.getStr()
+  result.name = event["event"]{"name"}.getStr()
+  result.iconUrl = event["event"]{"iconUrl"}.getStr()
+
+proc fromEvent*(T: type ConnectorRevokeDAppPermissionSignal, event: JsonNode): ConnectorRevokeDAppPermissionSignal =
+  result = ConnectorRevokeDAppPermissionSignal()
+  result.url = event["event"]{"url"}.getStr()
+  result.name = event["event"]{"name"}.getStr()
+  result.iconUrl = event["event"]{"iconUrl"}.getStr()

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -68,6 +68,8 @@ type SignalType* {.pure.} = enum
   CommunityTokenAction = "communityToken.communityTokenAction"
   ConnectorSendRequestAccounts = "connector.sendRequestAccounts"
   ConnectorSendTransaction = "connector.sendTransaction"
+  ConnectorGrantDAppPermission = "connector.dAppPermissionGranted"
+  ConnectorRevokeDAppPermission = "connector.dAppPermissionRevoked"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -137,6 +137,8 @@ QtObject:
       of SignalType.CommunityTokenAction: CommunityTokenActionSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorSendRequestAccounts: ConnectorSendRequestAccountsSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorSendTransaction: ConnectorSendTransactionSignal.fromEvent(jsonSignal)
+      of SignalType.ConnectorGrantDAppPermission: ConnectorGrantDAppPermissionSignal.fromEvent(jsonSignal)
+      of SignalType.ConnectorRevokeDAppPermission: ConnectorRevokeDAppPermissionSignal.fromEvent(jsonSignal)
       else: Signal()
 
     result.signalType = signalType

--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -14,6 +14,8 @@ logScope:
 
 const SIGNAL_CONNECTOR_SEND_REQUEST_ACCOUNTS* = "ConnectorSendRequestAccounts"
 const SIGNAL_CONNECTOR_EVENT_CONNECTOR_SEND_TRANSACTION* = "ConnectorSendTransaction"
+const SIGNAL_CONNECTOR_GRANT_DAPP_PERMISSION* = "ConnectorGrantDAppPermission"
+const SIGNAL_CONNECTOR_REVOKE_DAPP_PERMISSION* = "ConnectorRevokeDAppPermission"
 
 # Enum with events
 type Event* = enum
@@ -65,6 +67,22 @@ QtObject:
 
       self.events.emit(SIGNAL_CONNECTOR_EVENT_CONNECTOR_SEND_TRANSACTION, data)
     )
+    self.events.on(SignalType.ConnectorGrantDAppPermission.event, proc(e: Args) =
+      if self.eventHandler == nil:
+        return
+
+      var data = ConnectorGrantDAppPermissionSignal(e)
+
+      self.events.emit(SIGNAL_CONNECTOR_GRANT_DAPP_PERMISSION, data)
+    )
+    self.events.on(SignalType.ConnectorRevokeDAppPermission.event, proc(e: Args) =
+      if self.eventHandler == nil:
+        return
+
+      var data = ConnectorRevokeDAppPermissionSignal(e)
+
+      self.events.emit(SIGNAL_CONNECTOR_REVOKE_DAPP_PERMISSION, data)
+    )
 
   proc registerEventsHandler*(self: Service, handler: EventHandlerFn) =
     self.eventHandler = handler
@@ -112,3 +130,11 @@ QtObject:
 
   proc rejectDappConnect*(self: Service, requestId: string): bool =
     rejectRequest(self, requestId, status_go.requestAccountsRejectedFinishedRpc, "requestAccountsRejectedFinishedRpc failed: ")
+
+  proc recallDAppPermission*(self: Service, dAppUrl: string): bool =
+    try:
+      return status_go.recallDAppPermissionFinishedRpc(dAppUrl)
+
+    except Exception as e:
+      error "recallDAppPermissionFinishedRpc failed: ", err=e.msg
+      return false

--- a/src/backend/connector.nim
+++ b/src/backend/connector.nim
@@ -20,6 +20,9 @@ type SendTransactionAcceptedArgs* = ref object of RootObj
 type RejectedArgs* = ref object of RootObj
   requestId* {.serializedFieldName("requestId").}: string
 
+type RecallDAppPermissionArgs* = ref object of RootObj
+  dAppUrl* {.serializedFieldName("dAppUrl").}: string
+
 rpc(requestAccountsAccepted, "connector"):
   args: RequestAccountsAcceptedArgs
 
@@ -31,6 +34,9 @@ rpc(sendTransactionRejected, "connector"):
 
 rpc(requestAccountsRejected, "connector"):
   args: RejectedArgs
+
+rpc(recallDAppPermission, "connector"):
+  dAppUrl: string
 
 proc isSuccessResponse(rpcResponse: RpcResponse[JsonNode]): bool =
   return rpcResponse.error.isNil
@@ -46,3 +52,6 @@ proc sendTransactionAcceptedFinishedRpc*(args: SendTransactionAcceptedArgs): boo
 
 proc sendTransactionRejectedFinishedRpc*(args: RejectedArgs): bool =
   return isSuccessResponse(sendTransactionRejected(args))
+
+proc recallDAppPermissionFinishedRpc*(dAppUrl: string): bool =
+  return isSuccessResponse(recallDAppPermission(dAppUrl))

--- a/ui/app/AppLayouts/Wallet/services/dapps/ConnectorDAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/ConnectorDAppsListProvider.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.15
+import StatusQ.Core.Utils 0.1
+import AppLayouts.Wallet.services.dapps 1.0
+import shared.stores 1.0
+import utils 1.0
+
+QObject {
+    id: root
+
+    readonly property alias dappsModel: d.dappsModel
+
+    function addSession(session) {
+        d.addSession(session)
+    }
+
+    function revokeSession(session) {
+        d.revokeSession(session)
+    }
+
+    function getActiveSession(dAppUrl) {
+        return d.getActionSession(dAppUrl)
+    }
+
+    QObject {
+        id: d
+
+        property ListModel dappsModel: ListModel {
+            id: dapps
+        }
+
+        function addSession(dappInfo) {
+            let dappItem = JSON.parse(dappInfo)
+            dapps.append(dappItem)
+        }
+
+        function revokeSession(dappInfo) {
+            let dappItem = JSON.parse(dappInfo)
+            for (let i = 0; i < dapps.count; i++) {
+                let existingDapp = dapps.get(i)
+                if (existingDapp.url === dappItem.url) {
+                    dapps.remove(i)
+                    break
+                }
+            }
+        }
+
+        function revokeAllSessions() {
+            for (let i = 0; i < dapps.count; i++) {
+                dapps.remove(i)
+            }
+        }
+
+        function getActionSession(dAppUrl) {
+            for (let i = 0; i < dapps.count; i++) {
+                let existingDapp = dapps.get(i)
+
+                if (existingDapp.url === dAppUrl) {
+                    return JSON.stringify({
+                        name: existingDapp.name,
+                        url: existingDapp.url,
+                        icon: existingDapp.iconUrl
+                    });
+                }
+            }
+
+            return null
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -39,6 +39,8 @@ WalletConnectSDKBase {
     property string requestId: ""
     property alias requestsModel: requests
 
+    readonly property string invalidDAppUrlError: "Invalid dappInfo: URL is missing"
+
     projectId: ""
 
     implicitWidth: 1
@@ -472,14 +474,15 @@ WalletConnectSDKBase {
         target: root.wcService
 
         function onRevokeSession(dAppUrl) {
-            if (dAppUrl) {
-                controller.recallDAppPermission(dAppUrl)
-                const session = { url: dAppUrl, name: "", icon: "" }
-                root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
-                root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dAppUrl), false);
-            } else {
-                console.warn("Invalid dappInfo: URL is missing")
+            if (!dAppUrl) {
+                console.warn(invalidDAppUrlError)
+                return
             }
+
+            controller.recallDAppPermission(dAppUrl)
+            const session = { url: dAppUrl, name: "", icon: "" }
+            root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
+            root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dAppUrl), false)
         }
     }
 
@@ -552,12 +555,12 @@ WalletConnectSDKBase {
             let dappItem = JSON.parse(dappInfoString)
             const { url, name, icon: iconUrl } = dappItem
 
-            if (url) {
-                const session = { url, name, iconUrl };
-                root.wcService.connectorDAppsProvider.addSession(JSON.stringify(session));
-            } else {
-                console.warn("Invalid dappInfo: URL is missing")
+            if (!url) {
+                console.warn(invalidDAppUrlError)
+                return
             }
+            const session = { url, name, iconUrl }
+            root.wcService.connectorDAppsProvider.addSession(JSON.stringify(session))
         }
 
         onDappRevokeDAppPermission: function(dappInfoString) {
@@ -568,12 +571,12 @@ WalletConnectSDKBase {
                 "iconUrl": dappItem.icon
             }
 
-            if (session.url) {
-                root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
-                root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dappItem.url), false);
-            } else {
-                console.warn("Invalid dappInfo: URL is missing")
+            if (!session.url) {
+                console.warn(invalidDAppUrlError)
+                return
             }
+            root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
+            root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dappItem.url), false)
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -103,10 +103,10 @@ WalletConnectSDKBase {
                 return null
             }
 
-            let session = getActiveSessions(root.dappInfo)
+            let session = getActiveSession(root.dappInfo)
 
             if (session === null) {
-                console.error("DAppsRequestHandler.lookupSession: error finding session for topic", obj.topic)
+                console.error("Connector.lookupSession: error finding session for requestId ", obj.requestId)
                 return
             }
             obj.resolveDappInfoFromSession(session)
@@ -254,7 +254,7 @@ WalletConnectSDKBase {
         }
 
         function acceptSessionRequest(topic, method, id, signature) {
-            console.debug(`WC DappsConnectorSDK.acceptSessionRequest; topic: "${topic}", id: ${root.requestId}, signature: "${signature}"`)
+            console.debug(`Connector DappsConnectorSDK.acceptSessionRequest; requestId: ${root.requestId}, signature: "${signature}"`)
 
             sessionRequestLoader.active = false
             controller.approveTransactionRequest(requestId, signature)
@@ -262,7 +262,7 @@ WalletConnectSDKBase {
             root.wcService.displayToastMessage(qsTr("Successfully signed transaction from %1").arg(root.dappInfo.url), false)
         }
 
-        function getActiveSessions(dappInfos) {
+        function getActiveSession(dappInfos) {
             let sessionTemplate = (dappUrl, dappName, dappIcon) => {
                 return {
                     "peer": {
@@ -279,7 +279,16 @@ WalletConnectSDKBase {
                 };
             }
 
-            return sessionTemplate(dappInfos.url, dappInfos.name, dappInfos.icon)
+            let sessionString = root.wcService.connectorDAppsProvider.getActiveSession(dappInfos.url)
+            if (sessionString === null) {
+                console.error("Connector.lookupSession: error finding session for requestId ", root.requestId)
+
+                return
+            }
+
+            let session = JSON.parse(sessionString);
+
+            return sessionTemplate(session.url, session.name, session.icon)
         }
 
         function authenticate(request) {
@@ -349,6 +358,11 @@ WalletConnectSDKBase {
             onDecline: {
                 connectDappLoader.active = false
                 rejectSession(root.requestId)
+            }
+
+            onDisconnect: {
+                connectDappLoader.active = false;
+                controller.recallDAppPermission(root.dappInfo.url)
             }
         }
     }
@@ -455,6 +469,21 @@ WalletConnectSDKBase {
     }
 
     Connections {
+        target: root.wcService
+
+        function onRevokeSession(dAppUrl) {
+            if (dAppUrl) {
+                controller.recallDAppPermission(dAppUrl)
+                const session = { url: dAppUrl, name: "", icon: "" }
+                root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
+                root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dAppUrl), false);
+            } else {
+                console.warn("Invalid dappInfo: URL is missing")
+            }
+        }
+    }
+
+    Connections {
         target: controller
 
         onDappValidatesTransaction: function(requestId, dappInfoString) {
@@ -518,11 +547,40 @@ WalletConnectSDKBase {
             connectDappLoader.active = true
             root.requestId = requestId
         }
+
+        onDappGrantDAppPermission: function(dappInfoString) {
+            let dappItem = JSON.parse(dappInfoString)
+            const { url, name, icon: iconUrl } = dappItem
+
+            if (url) {
+                const session = { url, name, iconUrl };
+                root.wcService.connectorDAppsProvider.addSession(JSON.stringify(session));
+            } else {
+                console.warn("Invalid dappInfo: URL is missing")
+            }
+        }
+
+        onDappRevokeDAppPermission: function(dappInfoString) {
+            let dappItem = JSON.parse(dappInfoString)
+            let session = {
+                "url": dappItem.url,
+                "name": dappItem.name,
+                "iconUrl": dappItem.icon
+            }
+
+            if (session.url) {
+                root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
+                root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dappItem.url), false);
+            } else {
+                console.warn("Invalid dappInfo: URL is missing")
+            }
+        }
     }
 
     approveSession: function(requestId, account, selectedChains) {
         controller.approveDappConnectRequest(requestId, account, JSON.stringify(selectedChains))
-        root.wcService.displayToastMessage(qsTr("Successfully authenticated %1").arg(root.dappInfo.url), false)
+        const { url, name, icon: iconUrl } = root.dappInfo;
+        root.wcService.displayToastMessage(qsTr("Successfully authenticated %1").arg(url), false);
     }
 
     rejectSession: function(requestId) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -32,10 +32,25 @@ QObject {
     required property DAppsStore store
     required property var walletRootStore
 
-    readonly property alias dappsModel: dappsProvider.dappsModel
+    readonly property var dappsModel: ConcatModel {
+        markerRoleName: "source"
+
+        sources: [
+            SourceModel {
+                model: dappsProvider.dappsModel
+                markerRoleValue: "walletConnect"
+            },
+            SourceModel {
+                model: connectorDAppsProvider.dappsModel
+                markerRoleValue: "connector"
+            }
+        ]
+    }
     readonly property alias requestHandler: requestHandler
 
     readonly property bool isServiceAvailableForAddressSelection: dappsProvider.supportedAccountsModel.ModelCount.count
+
+    readonly property alias connectorDAppsProvider: connectorDAppsProvider
 
     readonly property var validAccounts: SortFilterProxyModel {
         sourceModel: d.supportedAccountsModel
@@ -127,6 +142,8 @@ QObject {
                 }
             }
         });
+
+        root.revokeSession(url)
     }
 
     function getDApp(dAppUrl) {
@@ -140,6 +157,8 @@ QObject {
     // Emitted as a response to WalletConnectService.validatePairingUri or other WalletConnectService.pair
     // and WalletConnectService.approvePair errors
     signal pairingValidated(int validationState)
+
+    signal revokeSession(string dAppUrl)
 
     readonly property Connections sdkConnections: Connections {
         target: wcSDK
@@ -291,6 +310,10 @@ QObject {
         }
 
         selectedAddress: root.walletRootStore.selectedAddress
+    }
+
+    ConnectorDAppsListProvider {
+        id: connectorDAppsProvider
     }
 
     // Timeout for the corner case where the URL was already dismissed and the SDK doesn't respond with an error nor advances with the proposal

--- a/ui/app/AppLayouts/Wallet/services/dapps/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/qmldir
@@ -5,5 +5,6 @@ DappsConnectorSDK 1.0 DappsConnectorSDK.qml
 
 DAppsListProvider 1.0 DAppsListProvider.qml
 DAppsRequestHandler 1.0 DAppsRequestHandler.qml
+ConnectorDAppsListProvider 1.0 ConnectorDAppsListProvider.qml
 
 DAppsHelpers 1.0 helpers.js


### PR DESCRIPTION
fixes https://github.com/status-im/status-desktop/issues/15885

Waits for https://github.com/status-im/status-go/pull/5646

### What does the PR do

This PR contains the changes to be able to see the list of connected DApps on the Status desktop for Connector service. It also contains changes to managed `DAppPermissionGranted` and `DAppPermissionRevoked`

### Affected areas

- Connected DApps list

### Screenshot of functionality (including design for comparison)

[Screencast from 2024-08-02 01-51-36.webm](https://github.com/user-attachments/assets/4e3f9149-1c5a-459e-a75b-d8f6d07201b7)

### Impact on end user

Similar to other PR's this PR reuses some Wallet connect functionalities. I performed test to make sure Wallet Connect still works as expected

### How to test

Please refer to the video to test. Please be aware that this PR requires setting the `FLAG_DAPPS_ENABLED` flag to `enabled` since it enables seeing the list of DApps.

Or use : https://app.uniswap.org/swap

### Risk 

Very low risk since Connector service duplicated some WC facilities which live isolated and would not create regression by definition.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.