### PR TITLE
fix(Wallet/SendModal): Using community assets in SendModal unblocked

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -178,6 +178,9 @@ Item {
 
                 spacing: 8
                 StatusListItem {
+                    // Temporarily disabled, refer to https://github.com/status-im/status-desktop/issues/15955 for details.
+                    visible: false
+
                     Layout.fillWidth: true
                     title: qsTr("Show community assets when sending tokens")
 
@@ -199,6 +202,7 @@ Item {
                     }
                 }
                 StatusDialogDivider {
+                    visible: false
                     Layout.fillWidth: true
                 }
                 StatusListItem {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -318,10 +318,11 @@ Item {
                                                       root.sendModalPopup)
                     return
                 }
+
                 // Common send modal popup:
                 root.sendModalPopup.preSelectedAccountAddress = fromAddress
                 root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
-                root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
+                root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingTokensKey
                 root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
                 root.sendModalPopup.onlyAssets = false
                 root.sendModalPopup.open()

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelectorNew.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelectorNew.qml
@@ -162,8 +162,7 @@ Control {
                 const entry = ModelUtils.getByKey(assetsModel, "tokensKey", key)
                 highlightedKey = key
 
-                setCurrentAndClose(entry.symbol,
-                                   Constants.tokenIcon(entry.symbol))
+                setCurrentAndClose(entry.symbol, entry.iconSource)
                 root.assetSelected(key)
             }
 

--- a/ui/app/AppLayouts/Wallet/panels/TokenSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/TokenSelectorPanel.qml
@@ -267,8 +267,6 @@ Control {
 
                         section.property: "type"
                         section.delegate: StatusBaseText {
-                            id: sectionTitle
-
                             color: Theme.palette.baseColor1
                             topPadding: Style.current.padding
 

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -108,7 +108,9 @@ QtObject {
     }
 
     // Property and methods below are used to apply advanced token management settings to the SendModal
-    readonly property bool showCommunityAssetsInSend: root._allTokensModule.showCommunityAssetWhenSendingTokens
+
+    // Temporarily disabled, refer to https://github.com/status-im/status-desktop/issues/15955 for details.
+    readonly property bool showCommunityAssetsInSend: true //root._allTokensModule.showCommunityAssetWhenSendingTokens
     readonly property bool displayAssetsBelowBalance: root._allTokensModule.displayAssetsBelowBalance
 
     signal displayAssetsBelowBalanceThresholdChanged()

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -214,11 +214,10 @@ RightTabBaseView {
                         swapVisible: Global.featureFlags.swapEnabled
 
                         onSendRequested: {
-                            const symbol = ModelUtils.getByKey(model, "key", key, "symbol")
                             const modal = root.sendModal
 
                             modal.preSelectedSendType = Constants.SendType.Transfer
-                            modal.preSelectedHoldingID = symbol
+                            modal.preSelectedHoldingID = key
                             modal.preSelectedHoldingType = Constants.TokenType.ERC20
                             modal.onlyAssets = true
                             modal.open()


### PR DESCRIPTION
### What does the PR do

- Fixes send modal to open correctly with pre-selected community-minted assets
- Fixes `TokenSelectorNew` to display icons of community minted assets properly
- Temporarily hides switch `Show community assets when sending tokens` in token management, advanced tab
- Temporarily sets fixed `true` value to `TokensStore.showCommunityAssetsInSend`

Closes: #15766 


Follow-up task: https://github.com/status-im/status-desktop/issues/15955

[Screencast from 01.08.2024 12:20:02.webm](https://github.com/user-attachments/assets/9bfb9d58-fbfa-44ce-8a7d-a3540dc737b8)


### Affected areas
`SendModal`, `ManageTokensView`, `TokensStore`

