### PR TITLE
[CHERRY-PICK] fix(Wallet): Hiding assets from wallet's main view doesn't work

### DIFF
--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -190,7 +190,7 @@ SplitView {
                 onAssetClicked: logs.logEvent(`asset clicked: ${key}`)
 
                 onHideRequested: logs.logEvent(`hide requested: ${key}`)
-                onHideCommunityAssets: logs.logEvent(`hide community assets requested: ${communityKey}`)
+                onHideCommunityAssetsRequested: logs.logEvent(`hide community assets requested: ${communityKey}`)
                 onManageTokensRequested: logs.logEvent(`manage tokens requested`)
             }
         }

--- a/ui/StatusQ/src/wallet/managetokenscontroller.cpp
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.cpp
@@ -3,7 +3,6 @@
 #include "tokendata.h"
 
 #include <QElapsedTimer>
-#include <QMutableHashIterator>
 
 ManageTokensController::ManageTokensController(QObject* parent)
     : QObject(parent)
@@ -69,7 +68,7 @@ void ManageTokensController::showHideRegularToken(const QString& symbol, bool fl
             emit tokenHidden(shownItem->symbol, shownItem->name);
         }
     }
-    requestSaveSettings(serializeSettingsAsJson());
+    emit requestSaveSettings(serializeSettingsAsJson());
 }
 
 void ManageTokensController::showHideCommunityToken(const QString& symbol, bool flag)
@@ -90,7 +89,7 @@ void ManageTokensController::showHideCommunityToken(const QString& symbol, bool 
     m_communityTokensModel->saveCustomSortOrder();
     rebuildCommunityTokenGroupsModel();
     rebuildHiddenCommunityTokenGroupsModel();
-    requestSaveSettings(serializeSettingsAsJson());
+    emit requestSaveSettings(serializeSettingsAsJson());
 }
 
 void ManageTokensController::showHideGroup(const QString& groupId, bool flag)
@@ -122,7 +121,7 @@ void ManageTokensController::showHideGroup(const QString& groupId, bool flag)
     rebuildCommunityTokenGroupsModel();
     m_communityTokenGroupsModel->applySort();
     rebuildHiddenCommunityTokenGroupsModel();
-    requestSaveSettings(serializeSettingsAsJson());
+    emit requestSaveSettings(serializeSettingsAsJson());
 }
 
 void ManageTokensController::showHideCollectionGroup(const QString& groupId, bool flag)
@@ -154,7 +153,7 @@ void ManageTokensController::showHideCollectionGroup(const QString& groupId, boo
     rebuildCollectionGroupsModel();
     m_collectionGroupsModel->applySort();
     rebuildHiddenCollectionGroupsModel();
-    requestSaveSettings(serializeSettingsAsJson());
+    emit requestSaveSettings(serializeSettingsAsJson());
 }
 
 // Used in testing
@@ -196,7 +195,10 @@ QStringList ManageTokensController::hiddenCollectionGroups() const
     return {m_hiddenCollectionGroups.constBegin(), m_hiddenCollectionGroups.constEnd()};
 }
 
-void ManageTokensController::revert() { requestLoadSettings(); }
+void ManageTokensController::revert()
+{
+    emit requestLoadSettings();
+}
 
 void ManageTokensController::savingStarted()
 {
@@ -219,7 +221,7 @@ void ManageTokensController::savingFinished()
     incRevision();
 
     setSettingsDirty(false);
-    requestLoadSettings();
+    emit requestLoadSettings();
 }
 
 void ManageTokensController::loadingStarted()
@@ -310,7 +312,10 @@ void ManageTokensController::classBegin()
     // empty on purpose
 }
 
-void ManageTokensController::componentComplete() { requestLoadSettings(); }
+void ManageTokensController::componentComplete()
+{
+    emit requestLoadSettings();
+}
 
 void ManageTokensController::setSourceModel(QAbstractItemModel* newSourceModel)
 {
@@ -341,7 +346,7 @@ void ManageTokensController::setSourceModel(QAbstractItemModel* newSourceModel)
         connect(m_sourceModel, &QAbstractItemModel::rowsInserted, this, &ManageTokensController::parseSourceModel);
         return;
     } else {
-        requestLoadSettings();
+        emit requestLoadSettings();
     }
 }
 

--- a/ui/StatusQ/src/wallet/managetokensmodel.h
+++ b/ui/StatusQ/src/wallet/managetokensmodel.h
@@ -7,7 +7,6 @@
 #include <QLoggingCategory>
 
 #include <optional>
-#include <tuple>
 
 Q_DECLARE_LOGGING_CATEGORY(manageTokens)
 

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokenMenuButton.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokenMenuButton.qml
@@ -7,6 +7,8 @@ import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Popups 0.1
 
+import utils 1.0
+
 StatusFlatButton {
     id: root
 
@@ -20,7 +22,7 @@ StatusFlatButton {
     property bool isCommunityToken
     property bool isCollectible
 
-    readonly property bool hideEnabled: model.symbol !== "ETH"
+    readonly property bool hideEnabled: model.symbol !== Constants.ethToken
     readonly property bool menuVisible: menuLoader.active
 
     signal moveRequested(int from, int to)

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensDelegate.qml
@@ -104,7 +104,7 @@ DropArea {
                 groupId: isCollection ? model.collectionUid : model.communityId
                 isCommunityToken: root.isCommunityToken
                 isCollectible: root.isCollectible
-                isCollection: isCollectible && !model.isSelfCollection
+                isCollection: isCollectible && !model.isSelfCollection && !isCommunityToken
                 onMoveRequested: (from, to) => root.ListView.view.model.moveItem(from, to)
                 onShowHideRequested: function(symbol, flag) {
                     if (isCommunityToken)

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -75,6 +75,21 @@ RightTabBaseView {
             readonly property var detailedCollectibleActivityController: RootStore.tmpActivityController0
         }
 
+        Component {
+            id: confirmHideCommunityAssetsPopup
+
+            ConfirmHideCommunityAssetsPopup {
+                destroyOnClose: true
+
+                required property string communityId
+
+                onConfirmButtonClicked: {
+                    RootStore.walletAssetsStore.assetsController.showHideGroup(communityId, false /*hide*/)
+                    close();
+                }
+            }
+        }
+
         // StackLayout.currentIndex === 0
         ColumnLayout {
             spacing: 0
@@ -227,11 +242,25 @@ RightTabBaseView {
                         onSwapRequested: root.launchSwapModal(key)
                         onReceiveRequested: root.launchShareAddressModal()
                         onCommunityClicked: Global.switchToCommunity(communityKey)
+
+                        onHideRequested: (key) => {
+                                             const token = ModelUtils.getByKey(model, "key", key)
+                                             Global.openConfirmHideAssetPopup(token.symbol, token.name, token.icon, !!token.communityId)
+                                         }
+                        onHideCommunityAssetsRequested:
+                            (communityKey) => {
+                                const community = ModelUtils.getByKey(model, "communityId", communityKey)
+                                confirmHideCommunityAssetsPopup.createObject(root, {
+                                                                                 name: community.communityName,
+                                                                                 icon: community.communityIcon,
+                                                                                 communityId: communityKey }
+                                                                             ).open()
+                            }
                         onManageTokensRequested: Global.changeAppSectionBySectionType(
                                                      Constants.appSection.profile,
                                                      Constants.settingsSubsection.wallet,
                                                      Constants.walletSettingsSubsection.manageAssets)
-                        onAssetClicked: {
+                        onAssetClicked: (key) => {
                             const token = ModelUtils.getByKey(model, "key", key)
 
                             SharedStores.RootStore.getHistoricalDataForToken(

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -24,6 +24,7 @@ import AppLayouts.Chat.stores 1.0 as ChatStore
 import shared.popups 1.0
 import shared.status 1.0
 import shared.stores 1.0
+import shared.views 1.0
 
 import utils 1.0
 
@@ -376,7 +377,7 @@ QtObject {
     }
 
     function openConfirmHideAssetPopup(assetSymbol, assetName, assetImage, isCommunityToken) {
-        openPopup(confirmHideAssetPopup, { assetSymbol, assetName, assetImage, isCommunityToken })
+        openPopup(confirmHideAssetPopup, { symbol: assetSymbol, name: assetName, icon: assetImage, isCommunityToken })
     }
 
     function openConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage, isCommunityToken) {
@@ -1168,35 +1169,24 @@ QtObject {
                 destroyOnClose: true
                 communitiesStore: root.communitiesStore
 
-                onHideClicked: (tokenSymbol, tokenName, tokenImage, isAsset) => isAsset ? root.openConfirmHideAssetPopup(tokenSymbol, tokenName, tokenImage)
-                                                                                        : root.openConfirmHideCollectiblePopup(tokenSymbol, tokenName, tokenImage)
+                onHideClicked: (tokenSymbol, tokenName, tokenImage, isAsset) => isAsset ? root.openConfirmHideAssetPopup(tokenSymbol, tokenName, tokenImage, true)
+                                                                                        : root.openConfirmHideCollectiblePopup(tokenSymbol, tokenName, tokenImage, true)
             }
         },
         Component {
             id: confirmHideAssetPopup
-            ConfirmationDialog {
-
-                property string assetSymbol
-                property string assetName
-                property string assetImage
-                property bool isCommunityToken
-
-                width: 520
+            ConfirmHideAssetPopup {
                 destroyOnClose: true
-                confirmButtonLabel: qsTr("Hide asset")
-                cancelBtnType: ""
-                showCancelButton: true
-                headerSettings.title: qsTr("Hide %1 (%2)").arg(assetName).arg(assetSymbol)
-                headerSettings.asset.name: assetImage
-                confirmationText: qsTr("Are you sure you want to hide %1 (%2)? You will no longer see or be able to interact with this asset anywhere inside Status.").arg(assetName).arg(assetSymbol)
-                onCancelButtonClicked: close()
+
+                required property bool isCommunityToken
+
                 onConfirmButtonClicked: {
                     if (isCommunityToken)
-                        root.walletAssetsStore.assetsController.showHideCommunityToken(assetSymbol, false)
+                        root.walletAssetsStore.assetsController.showHideCommunityToken(symbol, false)
                     else
-                        root.walletAssetsStore.assetsController.showHideRegularToken(assetSymbol, false)
+                        root.walletAssetsStore.assetsController.showHideRegularToken(symbol, false)
                     close()
-                    Global.displayToastMessage(qsTr("%1 (%2) successfully hidden. You can toggle asset visibility via %3.").arg(assetName).arg(assetSymbol)
+                    Global.displayToastMessage(qsTr("%1 (%2) successfully hidden. You can toggle asset visibility via %3.").arg(name).arg(symbol)
                                                .arg(`<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.wallet}/${Constants.walletSettingsSubsection.manageHidden}">` + qsTr("Settings", "Go to Settings") + "</a>"),
                                                "",
                                                "checkmark-circle",

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -75,7 +75,7 @@ Control {
     signal assetClicked(string key)
     signal communityClicked(string communityKey)
     signal hideRequested(string key)
-    signal hideCommunityAssets(string communityKey)
+    signal hideCommunityAssetsRequested(string communityKey)
     signal manageTokensRequested
 
     QtObject {
@@ -279,10 +279,8 @@ Control {
             onReceiveRequested: root.receiveRequested(key)
             onSwapRequested: root.swapRequested(key)
 
-            onHideRequested:
-                confirmHideAssetPopup.createObject(parent, { model }).open()
-            onCommunityHideRequested:
-                confirmHideCommunityAssetsPopup.createObject(parent, { model }).open()
+            onHideRequested: root.hideRequested(key)
+            onCommunityHideRequested: root.hideCommunityAssetsRequested(communityKey)
 
             onManageTokensRequested: root.manageTokensRequested()
         }
@@ -293,41 +291,6 @@ Control {
 
         CommunityAssetsInfoPopup {
             destroyOnClose: true
-        }
-    }
-
-    Component {
-        id: confirmHideAssetPopup
-
-        ConfirmHideAssetPopup {
-            destroyOnClose: true
-
-            required property var model
-
-            symbol: model.symbol
-            name: model.name
-            icon: model.icon
-
-            onConfirmButtonClicked: {
-                root.hideRequested(model.key)
-                close()
-            }
-        }
-    }
-
-    Component {
-        id: confirmHideCommunityAssetsPopup
-
-        ConfirmHideCommunityAssetsPopup {
-            required property var model
-
-            name: model.communityName
-            icon: model.communityIcon
-
-            onConfirmButtonClicked: {
-                root.hideCommunityAssets(model.communityId)
-                close();
-            }
         }
     }
 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 
-import QtQml 2.14
+import QtQml 2.15
 
 QtObject {
     id: root


### PR DESCRIPTION
Backport of PR https://github.com/status-im/status-desktop/pull/15811

### What does the PR do

- partially reuse the already available Global/Popups methods to hide assets (which also emit proper notifications); those are needed as anotehr shared modal from Popups uses it too (may come from outside of Wallet)
- some warnings cleanup in the controller

Fixes #15777
