### PR TITLE
[CherryPick]:: fix(@desktop/wallet): fix for Swap Input parameters reset when balances are reloaded

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -479,5 +479,40 @@ Item {
             compare(controlUnderTest.selectedHoldingId, tokenKeyToTest)
             compare(controlUnderTest.amountEnteredGreaterThanBalance, false)
         }
+
+        function test_if_values_not_reset_on_modelReset() {
+            const tokenKeyToTest = "ETH"
+            let numberTestedString = "1.0001"
+            let modelItemToTest = ModelUtils.getByKey(d.tokenSelectorAdaptor.outputAssetsModel, "tokensKey", tokenKeyToTest)
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {
+                                                         swapSide: SwapInputPanel.SwapSide.Pay,
+                                                         tokenKey: tokenKeyToTest,
+                                                         tokenAmount: numberTestedString
+                                                     })
+            verify(!!controlUnderTest)
+            waitForRendering(controlUnderTest)
+
+
+            const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
+            verify(!!amountToSendInput)
+
+            let numberTested = LocaleUtils.numberFromLocaleString(numberTestedString, amountToSendInput.input.locale)
+
+            compare(amountToSendInput.input.text, numberTestedString)
+            compare(controlUnderTest.value, numberTested)
+            compare(controlUnderTest.rawValue, AmountsArithmetic.fromNumber(amountToSendInput.input.text, modelItemToTest.decimals).toString())
+            compare(controlUnderTest.valueValid, true)
+            compare(controlUnderTest.selectedHoldingId, tokenKeyToTest)
+            compare(controlUnderTest.amountEnteredGreaterThanBalance, false)
+
+            d.tokenSelectorAdaptor.assetsModel.modelReset()
+
+            compare(amountToSendInput.input.text, numberTestedString)
+            compare(controlUnderTest.value, numberTested)
+            compare(controlUnderTest.rawValue, AmountsArithmetic.fromNumber(amountToSendInput.input.text, modelItemToTest.decimals).toString())
+            compare(controlUnderTest.valueValid, true)
+            compare(controlUnderTest.selectedHoldingId, tokenKeyToTest)
+            compare(controlUnderTest.amountEnteredGreaterThanBalance, false)
+        }
     }
 }

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -1064,6 +1064,7 @@ Item {
 
             const receivePanel = findChild(controlUnderTest, "receivePanel")
             verify(!!receivePanel)
+            waitForRendering(receivePanel)
             const amountToSendInput = findChild(receivePanel, "amountToSendInput")
             verify(!!amountToSendInput)
             const bottomItemText = findChild(receivePanel, "bottomItemText")

--- a/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
@@ -188,6 +188,7 @@ QObject {
 
     ConcatModel {
         id: concatModel
+        propagateResets: true
         sources: [
             SourceModel {
                 model: renamedTokensBySymbolModel

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -122,17 +122,6 @@ Control {
         }
     }
 
-    /* TODO: remove after https://github.com/status-im/status-desktop/issues/15604 is
-    implemented as this is hack to set token values correctly when model is reset */
-    Connections {
-        target: holdingSelector.model
-        function onRowsInserted() {
-            if(!!tokenKey) {
-                root.reevaluateSelectedId()
-            }
-        }
-    }
-
     background: Shape {
         id: shape
 


### PR DESCRIPTION
fixes #15785

cherry-pick of https://github.com/status-im/status-desktop/pull/15927

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->

### Cool Spaceship Picture

<!-- optional but cool -->
