### PR TITLE
Wallet: swap/bridge buttons visibility adjusted

### DIFF
--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -175,6 +175,7 @@ SplitView {
                 sendEnabled: sendEnabledCheckBox.checked
                 swapEnabled: swapEnabledCheckBox.checked
                 swapVisible: swapVisibleCheckBox.checked
+                communitySwapVisible: communitySwapVisibleCheckBox.checked
 
                 balanceError: balanceErrorCheckBox.checked
                               ? "Balance error!" : ""
@@ -242,6 +243,11 @@ SplitView {
                 id: swapVisibleCheckBox
 
                 text: "swap visible"
+            }
+            CheckBox {
+                id: communitySwapVisibleCheckBox
+
+                text: "community swap visible"
             }
             CheckBox {
                 id: balanceErrorCheckBox

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -41,6 +41,9 @@ Rectangle {
         readonly property bool isCollectibleViewed: !!walletStore.currentViewedHoldingID &&
                                                     (walletStore.currentViewedHoldingType === Constants.TokenType.ERC721 ||
                                                     walletStore.currentViewedHoldingType === Constants.TokenType.ERC1155)
+
+        readonly property bool isCommunityAsset: !d.isCollectibleViewed && walletStore.currentViewedHoldingCommunityId !== ""
+
         readonly property bool isCollectibleSoulbound: isCollectibleViewed && !!walletStore.currentViewedCollectible && walletStore.currentViewedCollectible.soulbound
 
         readonly property var collectibleOwnership: isCollectibleViewed && walletStore.currentViewedCollectible ?
@@ -67,11 +70,16 @@ Rectangle {
                                                         && !root.isCommunityOwnershipTransfer
                                                         && walletStore.overview.canSend
                                                         && !root.walletStore.showAllAccounts
-                                                        && !d.hideCollectibleTransferActions
+                                                        && !d.isCollectibleViewed
+                                                        && !d.isCommunityAsset
 
         readonly property bool buyActionAvailable: !root.isCommunityOwnershipTransfer && !root.walletStore.showAllAccounts
 
-        readonly property bool swapActionAvailable: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount && walletStore.overview.canSend && !d.hideCollectibleTransferActions
+        readonly property bool swapActionAvailable: Global.featureFlags.swapEnabled
+                                                    && !walletStore.overview.isWatchOnlyAccount
+                                                    && walletStore.overview.canSend
+                                                    && !d.isCollectibleViewed
+                                                    && !d.isCommunityAsset
 
         function getFirstUserOwnedAddress(ownershipModel, accountsModel) {
             if (!ownershipModel) return ""
@@ -144,9 +152,9 @@ Rectangle {
         StatusFlatButton {
             id: swap
 
-            interactive: !d.isCollectibleViewed && networkConnectionStore.sendBuyBridgeEnabled
+            interactive: networkConnectionStore.sendBuyBridgeEnabled
             visible: d.swapActionAvailable
-            tooltip.text: d.isCollectibleViewed ? qsTr("Collectibles cannot be swapped") : networkConnectionStore.sendBuyBridgeToolTipText
+            tooltip.text: networkConnectionStore.sendBuyBridgeToolTipText
             icon.name: "swap"
             text: qsTr("Swap")
             onClicked: root.launchSwapModal()

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -177,19 +177,22 @@ QtObject {
     function resetCurrentViewedHolding(type) {
         currentViewedHoldingTokensKey = ""
         currentViewedHoldingID = ""
+        currentViewedHoldingCommunityId = ""
         currentViewedHoldingType = type
     }
 
     function setCurrentViewedHoldingType(type) {
         currentViewedHoldingTokensKey = ""
         currentViewedHoldingID = ""
+        currentViewedHoldingCommunityId = ""
         currentViewedHoldingType = type
     }
 
-    function setCurrentViewedHolding(id, tokensKey, type) {
+    function setCurrentViewedHolding(id, tokensKey, type, communityId) {
         currentViewedHoldingTokensKey = tokensKey
         currentViewedHoldingID = id
         currentViewedHoldingType = type
+        currentViewedHoldingCommunityId = communityId
     }
 
     property string currentViewedHoldingTokensKey: ""
@@ -197,6 +200,7 @@ QtObject {
     everywhere. Adding a new one currentViewedHoldingTokensKey aboce to not impact send/bridge flows */
     property string currentViewedHoldingID: ""
     property int currentViewedHoldingType
+    property string currentViewedHoldingCommunityId: ""
     readonly property var currentViewedCollectible: collectiblesStore.detailedCollectible
 
     function canProfileProveOwnershipOfProvidedAddresses(addresses) {

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -38,7 +38,7 @@ ColumnLayout {
     property bool isUpdating: false // Indicates if the collectibles list is being updated
     property bool isError: false // Indicates an error occurred while updating/fetching the collectibles list
 
-    signal collectibleClicked(int chainId, string contractAddress, string tokenId, string uid, int tokenType)
+    signal collectibleClicked(int chainId, string contractAddress, string tokenId, string uid, int tokenType, string communityId)
     signal sendRequested(string symbol, int tokenType, string fromAddress)
     signal receiveRequested(string symbol)
     signal switchToCommunityRequested(string communityId)
@@ -476,7 +476,7 @@ ColumnLayout {
             communityImage: model.communityImage ?? ""
             balance: model.balance ?? 1
 
-            onClicked: root.collectibleClicked(model.chainId, model.contractAddress, model.tokenId, model.symbol, model.tokenType)
+            onClicked: root.collectibleClicked(model.chainId, model.contractAddress, model.tokenId, model.symbol, model.tokenType, model.communityId ?? "")
             onRightClicked: {
                 const userOwnedAddress = d.getFirstUserOwnedAddress(model.ownership)
                 Global.openMenu(tokenContextMenu, this,

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -225,6 +225,7 @@ RightTabBaseView {
 
                         sendEnabled: root.networkConnectionStore.sendBuyBridgeEnabled &&
                                      !RootStore.overview.isWatchOnlyAccount && RootStore.overview.canSend
+                        communitySendEnabled: RootStore.tokensStore.showCommunityAssetsInSend
                         swapEnabled: !RootStore.overview.isWatchOnlyAccount
                         swapVisible: Global.featureFlags.swapEnabled
 
@@ -266,7 +267,8 @@ RightTabBaseView {
                                         token.symbol, RootStore.currencyStore.currentCurrency)
 
                             assetDetailView.token = token
-                            RootStore.setCurrentViewedHolding(token.symbol, token.key, Constants.TokenType.ERC20)
+                            RootStore.setCurrentViewedHolding(
+                                                token.symbol, token.key, Constants.TokenType.ERC20, token.communityId ?? "")
                             stack.currentIndex = 2
                         }
                     }
@@ -283,7 +285,7 @@ RightTabBaseView {
                         filterVisible: filterButton.checked
                         onCollectibleClicked: {
                             RootStore.collectiblesStore.getDetailedCollectible(chainId, contractAddress, tokenId)
-                            RootStore.setCurrentViewedHolding(uid, uid, tokenType)
+                            RootStore.setCurrentViewedHolding(uid, uid, tokenType, communityId)
                             d.detailedCollectibleActivityController.resetFilter()
                             d.detailedCollectibleActivityController.setFilterAddressesJson(JSON.stringify(RootStore.addressFilters.split(":")))
                             d.detailedCollectibleActivityController.setFilterChainsJson(JSON.stringify([chainId]), false)

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -58,8 +58,10 @@ Control {
 
     // switches configuring right click menu
     property bool sendEnabled: true
+    property bool communitySendEnabled: false
     property bool swapEnabled: true
     property bool swapVisible: true
+    property bool communitySwapVisible: false
 
     property string balanceError
 
@@ -267,13 +269,16 @@ Control {
             readonly property string key: model.key
             readonly property string communityKey: model.communityId
 
+            readonly property bool isCommunity: !!model.isCommunity
+
             onClosed: destroy()
 
             sendEnabled: root.sendEnabled
+                         && (!isCommunity || root.communitySendEnabled)
             swapEnabled: root.swapEnabled
-            swapVisible: root.swapVisible
+            swapVisible: root.swapVisible && (!isCommunity || root.communitySwapVisible)
             hideVisible: model.canBeHidden
-            communityHideVisible: !!model.isCommunity
+            communityHideVisible: isCommunity
 
             onSendRequested: root.sendRequested(key)
             onReceiveRequested: root.receiveRequested(key)


### PR DESCRIPTION
### What does the PR do

- make `swap` and `bridge` buttons not visible in collectible details view
- make `swap` and `bridge` buttons not visible in community assets details view
- make `swap` action to available in context menu when right-clicking on community minted asset in wallet main view, assets tab

> [!NOTE]
> This pr is not fixing existing problems in the code related to storing UI's temporary state in stores. It's intended to be refactored as a separate ticket.

Closes: #15952
Closes: #15931

### Screenshot of functionality (including design for comparison)

[Screencast from 02.08.2024 11:49:55.webm](https://github.com/user-attachments/assets/b158fc1e-b888-4688-b7d5-3e920f0c2545)

