### PR TITLE
test: set screen 2560x1440x24

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -154,7 +154,7 @@ pipeline {
           $class:            'Xvfb',
           autoDisplayName:   true,
           parallelBuild:     true,
-          screen:            '1920x1080x24',
+          screen:            '2560x1440x24',
           additionalOptions: '-dpi 1'
         ]) {
           sh 'fluxbox &'


### PR DESCRIPTION
### What does the PR do

aligned CI resolution with development environments
fix for resolution mismatch related issues, e.g. 

[test_settings_networks_edit_restore_defaults](https://ci.status.im/job/status-desktop/job/systems/job/linux/job/x86_64/job/tests-e2e-new/488/allure/#suites/c6abfc71b8927eeb22d04f5e7f84bb0e/d8a027187b077a1b/)
![Screenshot 2024-08-05 at 12 31 37](https://github.com/user-attachments/assets/ddbebc79-6d09-443c-b670-27f91446f47a)

CI run with fixed tests https://ci.status.im/job/status-desktop/job/e2e/job/manual/2449/