### PR TITLE
fix(community): Owner token / Token Master token not visible in community settings

### DIFF
--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -378,16 +378,19 @@ proc getCommunityTokensDetailsTaskArg(argEncoded: string) {.gcsafe, nimcall.} =
         var destructedAmount = "0"
 
         if tokenDto.deployState == DeployState.Deployed:
-          remainingSupply =
-            if tokenDto.infiniteSupply:
-              "0"
-            else:
-              getRemainingSupply(tokenDto.chainId, tokenDto.address)
+          try:
+            remainingSupply =
+              if tokenDto.infiniteSupply:
+                "0"
+              else:
+                getRemainingSupply(tokenDto.chainId, tokenDto.address)
 
-          burnState = getCommunityTokenBurnState(tokenDto.chainId, tokenDto.address)
-          remoteDestructedAddresses = getRemoteDestructedAddresses(tokenDto.chainId, tokenDto.address)
+            burnState = getCommunityTokenBurnState(tokenDto.chainId, tokenDto.address)
+            remoteDestructedAddresses = getRemoteDestructedAddresses(tokenDto.chainId, tokenDto.address)
 
-          destructedAmount = getRemoteDestructedAmount(communityTokens, tokenDto.chainId, tokenDto.address)
+            destructedAmount = getRemoteDestructedAmount(communityTokens, tokenDto.chainId, tokenDto.address)
+          except Exception as e:
+            error "Remote token state retrieval error", message = getCurrentExceptionMsg()
 
         return %* {
           "address": tokenDto.address,


### PR DESCRIPTION
Fixes #15830

### What does the PR do

Ignore network errors, when loading community tokens 

### Affected areas

communities 

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/243acffd-97e2-48c3-989b-cb25593383bb

### Impact on end user

The user should always be able to see community collectibles, even when the app is offline.
### How to test

- Turn off internet
- Launch the app, check the tokens tab in the community settings

### Follow up task
#15981 - reload tokens when app comes back online

### Cool Spaceship Picture

<details>
  <summary>Spoiler warning</summary>
  
![image](https://github.com/user-attachments/assets/ee55952a-d32e-47c9-a3f8-d7c4ac7111f8)

  
</details>
