### PR TITLE
feat: some limits for wallet section

### DIFF
--- a/src/app/modules/main/profile_section/keycard/controller.nim
+++ b/src/app/modules/main/profile_section/keycard/controller.nim
@@ -124,3 +124,9 @@ proc getKeypairs*(self: Controller): seq[wallet_account_service.KeypairDto] =
 
 proc getKeypairByKeyUid*(self: Controller, keyUid: string): wallet_account_service.KeypairDto =
   return self.walletAccountService.getKeypairByKeyUid(keyUid)
+
+proc remainingKeypairCapacity*(self: Controller): int =
+  return self.walletAccountService.remainingKeypairCapacity()
+
+proc remainingAccountCapacity*(self: Controller): int =
+  return self.walletAccountService.remainingAccountCapacity()

--- a/src/app/modules/main/profile_section/keycard/io_interface.nim
+++ b/src/app/modules/main/profile_section/keycard/io_interface.nim
@@ -100,6 +100,12 @@ method onKeycardUidUpdated*(self: AccessInterface, keycardUid: string, keycardNe
 method prepareKeycardDetailsModel*(self: AccessInterface, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method remainingKeypairCapacity*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method remainingAccountCapacity*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 
 # View Delegate Interface
 # Delegate for the view must be declared here due to use of QtObject and multi

--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -415,3 +415,9 @@ method prepareKeycardDetailsModel*(self: Module, keyUid: string) =
       continue
     items.add(item)
   self.view.createModelAndSetKeycardDetailsItems(items)
+
+method remainingKeypairCapacity*(self: Module): int =
+  return self.controller.remainingKeypairCapacity()
+
+method remainingAccountCapacity*(self: Module): int =
+  return self.controller.remainingAccountCapacity()

--- a/src/app/modules/main/profile_section/keycard/view.nim
+++ b/src/app/modules/main/profile_section/keycard/view.nim
@@ -131,3 +131,9 @@ QtObject:
 
   proc prepareKeycardDetailsModel*(self: View, keyUid: string) {.slot.} =
     self.delegate.prepareKeycardDetailsModel(keyUid)
+
+  proc remainingKeypairCapacity*(self: View): int {.slot.} =
+    return self.delegate.remainingKeypairCapacity()
+
+  proc remainingAccountCapacity*(self: View): int {.slot.} =
+    return self.delegate.remainingAccountCapacity()

--- a/src/app/modules/main/wallet_section/saved_addresses/controller.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/controller.nim
@@ -52,3 +52,6 @@ proc createOrUpdateSavedAddress*(self: Controller, name: string, address: string
 
 proc deleteSavedAddress*(self: Controller, address: string) =
   self.savedAddressService.deleteSavedAddress(address)
+
+proc remainingCapacityForSavedAddresses*(self: Controller): int =
+  return self.savedAddressService.remainingCapacityForSavedAddresses()

--- a/src/app/modules/main/wallet_section/saved_addresses/io_interface.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/io_interface.nim
@@ -39,6 +39,9 @@ method savedAddressNameExists*(self: AccessInterface, name: string): bool {.base
 method getSavedAddressAsJson*(self: AccessInterface, address: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method remainingCapacityForSavedAddresses*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   ## Abstract class (concept) which must be implemented by object/s used in this
   ## module.

--- a/src/app/modules/main/wallet_section/saved_addresses/module.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/module.nim
@@ -104,3 +104,6 @@ method getSavedAddressAsJson*(self: Module, address: string): string =
     "isTest": saDto.isTest,
   }
   return $jsonObj
+
+method remainingCapacityForSavedAddresses*(self: Module): int =
+  return self.controller.remainingCapacityForSavedAddresses()

--- a/src/app/modules/main/wallet_section/saved_addresses/view.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/view.nim
@@ -59,3 +59,6 @@ QtObject:
 
   proc getSavedAddressAsJson*(self: View, address: string): string {.slot.} =
     return self.delegate.getSavedAddressAsJson(address)
+
+  proc remainingCapacityForSavedAddresses*(self: View): int {.slot.} =
+    return self.delegate.remainingCapacityForSavedAddresses()

--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -254,3 +254,12 @@ proc resolveSuggestedPathForKeypair*(self: Controller, keyUid: string): string =
 
 proc isChecksumValidForAddress*(self: Controller, address: string): bool =
   return self.walletAccountService.isChecksumValidForAddress(address)
+
+proc remainingAccountCapacity*(self: Controller): int =
+  return self.walletAccountService.remainingAccountCapacity()
+
+proc remainingKeypairCapacity*(self: Controller): int =
+  return self.walletAccountService.remainingKeypairCapacity()
+
+proc remainingWatchOnlyAccountCapacity*(self: Controller): int =
+  return self.walletAccountService.remainingWatchOnlyAccountCapacity()

--- a/src/app/modules/shared_modules/add_account/io_interface.nim
+++ b/src/app/modules/shared_modules/add_account/io_interface.nim
@@ -110,6 +110,15 @@ method savedAddressDeleted*(self: AccessInterface, address: string, errorMsg: st
 method isChecksumValidForAddress*(self: AccessInterface, address: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method remainingAccountCapacity*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method remainingKeypairCapacity*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method remainingWatchOnlyAccountCapacity*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   DelegateInterface* = concept c
     c.onAddAccountModuleLoaded()

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -739,4 +739,13 @@ method buildNewSeedPhraseKeypairAndAddItToOrigin*[T](self: Module[T]) =
 method isChecksumValidForAddress*[T](self: Module[T], address: string): bool =
   return self.controller.isChecksumValidForAddress(address)
 
+method remainingAccountCapacity*[T](self: Module[T]): int =
+  return self.controller.remainingAccountCapacity()
+
+method remainingKeypairCapacity*[T](self: Module[T]): int =
+  return self.controller.remainingKeypairCapacity()
+
+method remainingWatchOnlyAccountCapacity*[T](self: Module[T]): int =
+  return self.controller.remainingWatchOnlyAccountCapacity()
+
 {.pop.}

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -366,3 +366,12 @@ QtObject:
 
   proc isChecksumValidForAddress*(self: View, address: string): bool {.slot.} =
     return self.delegate.isChecksumValidForAddress(address)
+
+  proc remainingAccountCapacity*(self: View): int {.slot.} =
+    return self.delegate.remainingAccountCapacity()
+
+  proc remainingKeypairCapacity*(self: View): int {.slot.} =
+    return self.delegate.remainingKeypairCapacity()
+
+  proc remainingWatchOnlyAccountCapacity*(self: View): int {.slot.} =
+    return self.delegate.remainingWatchOnlyAccountCapacity()

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -836,6 +836,9 @@ proc getTotalCurrencyBalance*(self: Controller, address: string, chainIds: seq[i
 proc parseCurrencyValueByTokensKey*(self: Controller, tokensKey: string, amountInt: UInt256): float64 =
   return self.walletAccountService.parseCurrencyValueByTokensKey(tokensKey, amountInt)
 
+proc remainingAccountCapacity*(self: Controller): int =
+  return self.walletAccountService.remainingAccountCapacity()
+
 # Keep this function at the end of the file.
 # There's a bug in Nim: https://github.com/nim-lang/Nim/issues/23002
 # that blocks us from enabling back the warning pragma.

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -239,5 +239,8 @@ method getPin*(self: AccessInterface): string {.base.} =
 method onTokensRebuilt*(self: AccessInterface, accountAddresses: seq[string], accountTokens: seq[GroupedTokenItem]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method remainingAccountCapacity*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   DelegateInterface* = concept c

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -799,4 +799,7 @@ method keychainObtainedDataSuccess*[T](self: Module[T], data: string) =
     else:
       self.view.setCurrentState(newBiometricsPinInvalidState(self.runningFlow, nil))
 
+method remainingAccountCapacity*[T](self: Module[T]): int =
+  return self.controller.remainingAccountCapacity()
+
 {.pop.}

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -248,3 +248,6 @@ QtObject:
 
   proc getSigningPhrase*(self: View): string {.slot.} =
     return self.delegate.getSigningPhrase()
+
+  proc remainingAccountCapacity*(self: View): int {.slot.} =
+    return self.delegate.remainingAccountCapacity()

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -172,3 +172,12 @@ QtObject:
       error "onDeleteSavedAddress", msg = e.msg
       arg.errorMsg = e.msg
     self.updateAddresses(SIGNAL_SAVED_ADDRESS_DELETED, arg)
+
+  proc remainingCapacityForSavedAddresses*(self: Service): int =
+    try:
+      let response = backend.remainingCapacityForSavedAddresses(self.areTestNetworksEnabled())
+      if not response.error.isNil:
+        raise newException(CatchableError, response.error.message)
+      return response.result.getInt
+    except Exception as e:
+      error "error: ", procName="remainingCapacityForSavedAddresses", errName=e.name, errDesription=e.msg

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -811,3 +811,30 @@ proc resolveSuggestedPathForKeypair*(self: Service, keyUid: string): string =
     return response.result.getStr
   except Exception as e:
     error "error: ", procName="resolveSuggestedPathForKeypair", errName=e.name, errDesription=e.msg
+
+proc remainingAccountCapacity*(self: Service): int =
+  try:
+    let response = status_go_accounts.remainingAccountCapacity()
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+    return response.result.getInt
+  except Exception as e:
+    error "error: ", procName="remainingAccountCapacity", errName=e.name, errDesription=e.msg
+
+proc remainingKeypairCapacity*(self: Service): int =
+  try:
+    let response = status_go_accounts.remainingKeypairCapacity()
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+    return response.result.getInt
+  except Exception as e:
+    error "error: ", procName="remainingKeypairCapacity", errName=e.name, errDesription=e.msg
+
+proc remainingWatchOnlyAccountCapacity*(self: Service): int =
+  try:
+    let response = status_go_accounts.remainingWatchOnlyAccountCapacity()
+    if not response.error.isNil:
+      raise newException(CatchableError, response.error.message)
+    return response.result.getInt
+  except Exception as e:
+    error "error: ", procName="remainingWatchOnlyAccountCapacity", errName=e.name, errDesription=e.msg

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -420,3 +420,15 @@ proc getNumOfAddressesToGenerateForKeypair*(keyUID: string): RpcResponse[JsonNod
 proc resolveSuggestedPathForKeypair*(keyUID: string): RpcResponse[JsonNode] =
   let payload = %* [keyUID]
   result = core.callPrivateRPC("accounts_resolveSuggestedPathForKeypair", payload)
+
+proc remainingAccountCapacity*(): RpcResponse[JsonNode] =
+  let payload = %* []
+  return core.callPrivateRPC("accounts_remainingAccountCapacity", payload)
+
+proc remainingKeypairCapacity*(): RpcResponse[JsonNode] =
+  let payload = %* []
+  return core.callPrivateRPC("accounts_remainingKeypairCapacity", payload)
+
+proc remainingWatchOnlyAccountCapacity*(): RpcResponse[JsonNode] =
+  let payload = %* []
+  return core.callPrivateRPC("accounts_remainingWatchOnlyAccountCapacity", payload)

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -76,6 +76,12 @@ rpc(deleteSavedAddress, "wakuext"):
 rpc(getSavedAddresses, "wakuext"):
   discard
 
+rpc(getSavedAddressesPerMode, "wakuext"):
+  isTest: bool
+
+rpc(remainingCapacityForSavedAddresses, "wakuext"):
+  isTest: bool
+
 rpc(checkConnected, "wallet"):
   discard
 

--- a/ui/app/AppLayouts/Profile/stores/KeycardStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/KeycardStore.qml
@@ -61,4 +61,12 @@ QtObject {
     function prepareKeycardDetailsModel(keyUid) {
         root.keycardModule.prepareKeycardDetailsModel(keyUid)
     }
+
+    function remainingKeypairCapacity() {
+        return root.keycardModule.remainingKeypairCapacity()
+    }
+
+    function remainingAccountCapacity() {
+        return root.keycardModule.remainingAccountCapacity()
+    }
 }

--- a/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
@@ -7,6 +7,7 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared.panels 1.0
@@ -128,6 +129,14 @@ ColumnLayout {
             }
         ]
         onClicked: {
+            if (root.keycardStore.remainingKeypairCapacity() === 0) {
+                Global.openPopup(limitWarningComponent)
+                return
+            }
+            if (root.keycardStore.remainingAccountCapacity() === 0) {
+                Global.openPopup(limitWarningComponent, {accountsWarning: true})
+                return
+            }
             root.keycardStore.runCreateNewKeycardWithNewSeedPhrasePopup()
         }
     }
@@ -143,6 +152,14 @@ ColumnLayout {
             }
         ]
         onClicked: {
+            if (root.keycardStore.remainingKeypairCapacity() === 0) {
+                Global.openPopup(limitWarningComponent)
+                return
+            }
+            if (root.keycardStore.remainingAccountCapacity() === 0) {
+                Global.openPopup(limitWarningComponent, {accountsWarning: true})
+                return
+            }
             root.keycardStore.runImportOrRestoreViaSeedPhrasePopup()
         }
     }
@@ -158,6 +175,14 @@ ColumnLayout {
             }
         ]
         onClicked: {
+            if (root.keycardStore.remainingKeypairCapacity() === 0) {
+                Global.openPopup(limitWarningComponent)
+                return
+            }
+            if (root.keycardStore.remainingAccountCapacity() === 0) {
+                Global.openPopup(limitWarningComponent, {accountsWarning: true})
+                return
+            }
             root.keycardStore.runImportFromKeycardToAppPopup()
         }
     }
@@ -196,6 +221,27 @@ ColumnLayout {
         ]
         onClicked: {
             root.keycardStore.runFactoryResetPopup()
+        }
+    }
+
+    Component {
+        id: limitWarningComponent
+
+        StatusDialog {
+            id: dialog
+
+            property bool accountsWarning: false
+
+            title: dialog.accountsWarning? Constants.walletConstants.maxNumberOfAccountsTitle : Constants.walletConstants.maxNumberOfKeypairsTitle
+
+            StatusBaseText {
+                anchors.fill: parent
+                font.pixelSize: Constants.keycard.general.fontSize2
+                color: Theme.palette.directColor1
+                text: dialog.accountsWarning? Constants.walletConstants.maxNumberOfAccountsContent : Constants.walletConstants.maxNumberOfKeypairsContent
+            }
+
+            standardButtons: Dialog.Ok
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -18,6 +18,7 @@ import StatusQ.Core.Backpressure 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import SortFilterProxyModel 0.2
 
@@ -283,6 +284,11 @@ StatusModal {
                     || event !== undefined && event.key !== Qt.Key_Return && event.key !== Qt.Key_Enter)
                 return
 
+            if (!d.editMode && root.store.remainingCapacityForSavedAddresses() === 0) {
+                limitPopup.active = true
+                return
+            }
+
             root.store.createOrUpdateSavedAddress(d.name, d.address, d.ens, d.colorId, d.chainShortNames)
             root.close()
         }
@@ -364,6 +370,34 @@ StatusModal {
             bottomPadding: 28
 
             spacing: Style.current.xlPadding
+
+            Loader {
+                id: limitPopup
+                active: false
+                asynchronous: true
+
+                sourceComponent: StatusDialog {
+                    width: root.width - 2*Style.current.padding
+
+                    title: Constants.walletConstants.maxNumberOfSavedAddressesTitle
+
+                    StatusBaseText {
+                        anchors.fill: parent
+                        text: Constants.walletConstants.maxNumberOfSavedAddressesContent
+                        wrapMode: Text.WordWrap
+                    }
+
+                    standardButtons: Dialog.Ok
+
+                    onClosed: {
+                        limitPopup.active = false
+                    }
+                }
+
+                onLoaded: {
+                    limitPopup.item.open()
+                }
+            }
 
             StatusInput {
                 id: nameInput

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -369,6 +369,10 @@ QtObject {
         return walletSectionSavedAddresses.savedAddressNameExists(name)
     }
 
+    function remainingCapacityForSavedAddresses() {
+        return walletSectionSavedAddresses.remainingCapacityForSavedAddresses()
+    }
+
     function toggleNetwork(chainId) {
         networksModule.toggleNetwork(chainId)
     }

--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -21,6 +21,9 @@ Item {
 
     property AddAccountStore store
 
+    signal watchOnlyAccountsLimitReached()
+    signal keypairLimitReached()
+
     implicitHeight: layout.implicitHeight
 
     Component.onCompleted: {
@@ -194,7 +197,17 @@ Item {
                 enabled: !root.store.editMode
 
                 onOriginSelected: {
+                    if (keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc) {
+                        if (root.store.remainingWatchOnlyAccountCapacity() === 0) {
+                            root.watchOnlyAccountsLimitReached()
+                            return
+                        }
+                    }
                     if (keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddNewMasterKey) {
+                        if (root.store.remainingKeypairCapacity() === 0) {
+                            root.keypairLimitReached()
+                            return
+                        }
                         root.store.currentState.doSecondaryAction()
                         return
                     }

--- a/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
+++ b/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
@@ -54,6 +54,8 @@ BasePopupStore {
         Constants.addAccountPopup.predefinedPaths.ethereumLedgerLive
     ]
 
+    signal showLimitPopup(int warningType)
+
     function resetStoreValues() {
         root.enteredSeedPhraseIsValid = false
         root.enteredPrivateKeyIsValid = false
@@ -91,10 +93,20 @@ BasePopupStore {
         }
 
         if(!event) {
+            if (!root.editMode && root.remainingAccountCapacity() === 0) {
+                root.showLimitPopup(0)
+                return
+            }
+
             root.currentState.doPrimaryAction()
         }
         else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             event.accepted = true
+            if (!root.editMode && root.remainingAccountCapacity() === 0) {
+                root.showLimitPopup(0)
+                return
+            }
+
             root.currentState.doPrimaryAction()
         }
     }
@@ -157,6 +169,18 @@ BasePopupStore {
 
     function isChecksumValidForAddress(address) {
         return root.addAccountModule.isChecksumValidForAddress(address)
+    }
+
+    function remainingAccountCapacity() {
+        return root.addAccountModule.remainingAccountCapacity()
+    }
+
+    function remainingKeypairCapacity() {
+        return root.addAccountModule.remainingKeypairCapacity()
+    }
+
+    function remainingWatchOnlyAccountCapacity() {
+        return root.addAccountModule.remainingWatchOnlyAccountCapacity()
     }
 
     validSeedPhrase: function(seedPhrase) {

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -2,7 +2,9 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 
 import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 
@@ -69,6 +71,9 @@ StatusModal {
         onCancelBtnClicked: {
             root.close();
         }
+        onAccountLimitWarning: {
+            limitPopup.active = true
+        }
     }
 
     onClosed: {
@@ -105,6 +110,30 @@ StatusModal {
             sharedKeycardModule: root.sharedKeycardModule
             emojiPopup: root.emojiPopup
             onPrimaryButtonEnabledChanged: d.primaryButtonEnabled = primaryButtonEnabled
+
+            Loader {
+                id: limitPopup
+                active: false
+                asynchronous: true
+
+                sourceComponent: StatusDialog {
+                    width: root.width - 2*Style.current.padding
+
+                    title: Constants.walletConstants.maxNumberOfAccountsTitle
+
+                    StatusBaseText {
+                        anchors.fill: parent
+                        text: Constants.walletConstants.maxNumberOfAccountsContent
+                        wrapMode: Text.WordWrap
+                    }
+
+                    standardButtons: Dialog.Ok
+
+                    onClosed: {
+                        limitPopup.active = false
+                    }
+                }
+            }
         }
     }
 

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -14,6 +14,7 @@ QtObject {
     property bool primaryButtonEnabled: false
 
     signal cancelBtnClicked()
+    signal accountLimitWarning()
 
     // disables action buttons (back, cancel, primary, secondary) and close button (upper right "X" button) as well
     readonly property bool disableActionPopupButtons: {
@@ -620,6 +621,17 @@ QtObject {
             }
 
             onClicked: {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.manageKeycardAccounts &&
+                            !!root.sharedKeycardModule.keyPairForProcessing &&
+                            root.sharedKeycardModule.remainingAccountCapacity() === root.sharedKeycardModule.keyPairForProcessing.accounts.count) {
+                        root.accountLimitWarning()
+                        return
+                    }
+                }
+
                 root.sharedKeycardModule.currentState.doSecondaryAction()
             }
         },
@@ -1259,6 +1271,9 @@ QtObject {
                 case Constants.keycardSharedFlow.importFromKeycard:
                     switch (root.sharedKeycardModule.currentState.stateType) {
 
+                    case Constants.keycardSharedState.keycardMetadataDisplay:
+                        return root.sharedKeycardModule.keyPairHelper.accounts.count <= root.sharedKeycardModule.remainingAccountCapacity()
+
                     case Constants.keycardSharedState.manageKeycardAccounts:
                         return root.primaryButtonEnabled
                     }
@@ -1423,6 +1438,16 @@ QtObject {
             }
 
             onClicked: {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.manageKeycardAccounts &&
+                            !!root.sharedKeycardModule.keyPairForProcessing &&
+                            root.sharedKeycardModule.remainingAccountCapacity() - root.sharedKeycardModule.keyPairForProcessing.accounts.count < 0) {
+                        root.accountLimitWarning()
+                        return
+                    }
+                }
                 root.sharedKeycardModule.currentState.doPrimaryAction()
             }
         }

--- a/ui/imports/shared/popups/keycard/states/KeycardInit.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardInit.qml
@@ -177,382 +177,379 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
         }
-    }
 
-    Loader {
-        id: loader
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.leftMargin: Style.current.xlPadding
-        anchors.rightMargin: Style.current.xlPadding
+        Loader {
+            id: loader
+            Layout.preferredWidth: parent.width - 2*Style.current.xlPadding
+            Layout.alignment: Qt.AlignHCenter
 
-        active: {
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
-                if((root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader && !d.hideKeyPair) ||
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard && !d.hideKeyPair) ||
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted && !d.hideKeyPair) ||
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard && !d.hideKeyPair) ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    return true
+            active: {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
+                    if((root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader && !d.hideKeyPair) ||
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard && !d.hideKeyPair) ||
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted && !d.hideKeyPair) ||
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard && !d.hideKeyPair) ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        return true
+                    }
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
+                        return true
+                    }
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
+                        return true
+                    }
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
+                        return true
+                    }
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        return true
+                    }
+                    if(!!root.sharedKeycardModule.keyPairForProcessing &&
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard))
+                        return true
                 }
-                if(!!root.sharedKeycardModule.keyPairForProcessing &&
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard))
-                    return true
-            }
-            if (d.authenticationOrSigning &&
-                    !!root.sharedKeycardModule.keyPairForProcessing &&
-                    root.sharedKeycardModule.keyPairForProcessing.name !== "") {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard) {
-                    return true
+                if (d.authenticationOrSigning &&
+                        !!root.sharedKeycardModule.keyPairForProcessing &&
+                        root.sharedKeycardModule.keyPairForProcessing.name !== "") {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard) {
+                        return true
+                    }
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        return true
+                    }
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.renameKeycard && !d.hideKeyPair) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameFailure)
-                    return true
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPin && !d.hideKeyPair) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return true
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPuk && !d.hideKeyPair) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return true
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changePairingCode && !d.hideKeyPair) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return true
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard && !d.hideKeyPair) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.removeKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardSuccess)
-                    return true
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromKeycardToApp) {
-                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToApp ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToApp ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.renameKeycard && !d.hideKeyPair) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameFailure)
+                        return true
                 }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromAppToKeycard) {
-                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
-                    return true
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPin && !d.hideKeyPair) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return true
                 }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPuk && !d.hideKeyPair) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return true
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changePairingCode && !d.hideKeyPair) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return true
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard && !d.hideKeyPair) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.removeKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardSuccess)
+                        return true
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromKeycardToApp) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToApp ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToApp ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
+                        return true
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromAppToKeycard) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
+                        return true
+                    }
+                }
+
+                return false
             }
 
-            return false
-        }
-
-        sourceComponent: {
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
-                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+            sourceComponent: {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+                    if ((root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader && !d.hideKeyPair) ||
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard && !d.hideKeyPair) ||
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted && !d.hideKeyPair) ||
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard && !d.hideKeyPair) ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
                         return keyPairForProcessingComponent
                     }
-                    return unknownKeyPairCompontnt
                 }
-                if ((root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader && !d.hideKeyPair) ||
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard && !d.hideKeyPair) ||
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted && !d.hideKeyPair) ||
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard && !d.hideKeyPair) ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
-                    return keyPairForProcessingComponent
-                }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
                         return keyPairForProcessingComponent
                     }
-                    return unknownKeyPairCompontnt
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
+                        return keyPairForProcessingComponent
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
+                        return keyPairForProcessingComponent
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+                    if(!!root.sharedKeycardModule.keyPairForProcessing &&
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard))
+                        return keyPairForProcessingComponent
+                }
+                if (d.authenticationOrSigning) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard) {
+                        return keyPairForProcessingComponent
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.renameKeycard) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameFailure) {
+                        return keyPairForProcessingComponent
+                    }
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return keyPairForProcessingComponent
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPin) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return keyPairForProcessingComponent
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPuk) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return keyPairForProcessingComponent
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changePairingCode) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
+                        return keyPairForProcessingComponent
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.removeKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyToKeycard) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardSuccess)
+                        return keyPairForProcessingComponent
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromKeycardToApp) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToApp ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToApp ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
+                        return keyPairForProcessingComponent
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromAppToKeycard) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
+                        return keyPairForProcessingComponent
+                    }
                 }
 
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
-                    return keyPairForProcessingComponent
-                }
+                return undefined
             }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
-                        return keyPairForProcessingComponent
-                    }
-                    return unknownKeyPairCompontnt
-                }
-
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
-                    return keyPairForProcessingComponent
-                }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
-                        return keyPairForProcessingComponent
-                    }
-                    return unknownKeyPairCompontnt
-                }
-
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycardFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
-                    return keyPairForProcessingComponent
-                }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
-                        return keyPairForProcessingComponent
-                    }
-                    return unknownKeyPairCompontnt
-                }
-                if(!!root.sharedKeycardModule.keyPairForProcessing &&
-                        (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard))
-                    return keyPairForProcessingComponent
-            }
-            if (d.authenticationOrSigning) {
-                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard) {
-                    return keyPairForProcessingComponent
-                }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
-                        return keyPairForProcessingComponent
-                    }
-                    return unknownKeyPairCompontnt
-                }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.renameKeycard) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameFailure) {
-                    return keyPairForProcessingComponent
-                }
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return keyPairForProcessingComponent
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPin) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return keyPairForProcessingComponent
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPuk) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return keyPairForProcessingComponent
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changePairingCode) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-                    return keyPairForProcessingComponent
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard) {
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.removeKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyToKeycard) {
-                    if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
-                        return keyPairForProcessingComponent
-                    }
-                    return unknownKeyPairCompontnt
-                }
-                if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardFailure ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycardSuccess)
-                    return keyPairForProcessingComponent
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromKeycardToApp) {
-                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToApp ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToApp ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
-                    return keyPairForProcessingComponent
-                }
-            }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.migrateFromAppToKeycard) {
-                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migrateKeypairToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeypairToKeycard ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
-                        root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure) {
-                    return keyPairForProcessingComponent
-                }
-            }
-
-            return undefined
         }
     }
 
@@ -1232,7 +1229,12 @@ Item {
             }
             PropertyChanges {
                 target: message
-                text: ""
+                text: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.importFromKeycard &&
+                        root.sharedKeycardModule.keyPairHelper.accounts.count > root.sharedKeycardModule.remainingAccountCapacity()?
+                          qsTr("Adding these accounts will exceed the limit of 20.\nRemove some already added accounts to be able to import a new ones.")
+                        : ""
+                font.pixelSize: Constants.keycard.general.fontSize2
+                color: Theme.palette.dangerColor1
             }
         },
         State {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -873,6 +873,20 @@ QtObject {
         readonly property string market: "market"
     }
 
+    readonly property QtObject walletConstants: QtObject {
+        readonly property string maxNumberOfAccountsTitle: qsTr("Limit of 20 accounts reached")
+        readonly property string maxNumberOfAccountsContent: qsTr("Remove any account to add a new one.")
+
+        readonly property string maxNumberOfKeypairsTitle: qsTr("Limit of 5 key pairs reached")
+        readonly property string maxNumberOfKeypairsContent: qsTr("Remove key pair to add a new one.")
+
+        readonly property string maxNumberOfWatchOnlyAccountsTitle: qsTr("Limit of 3 watched addresses reached")
+        readonly property string maxNumberOfWatchOnlyAccountsContent: qsTr("Remove a watched address to add a new one.")
+
+        readonly property string maxNumberOfSavedAddressesTitle: qsTr("Limit of 20 saved addresses reached")
+        readonly property string maxNumberOfSavedAddressesContent: qsTr("Remove a saved address to add a new one.")
+    }
+
     enum ConnectionStatus {
         Success = 0,
         Failure = 1,


### PR DESCRIPTION
Related `status-go` PR:
- https://github.com/status-im/status-go/pull/5645

Added limitations:
- allowed adding of max 20 accounts
- allowed adding of max 3 watch only accounts
- allowed adding of max 5 key pairs (including the profile key pair)
- allowed adding of max 20 saved addresses per mode

Limits applied when running keycard flows that add new key pairs/accounts

Closes #15934

Accounts/keypairs flow:


https://github.com/user-attachments/assets/70a6f0fb-2661-473d-9f5c-9979fad3a3de


Keycard flow:

https://github.com/user-attachments/assets/70da7cfb-461f-4918-ab18-c9f102def2e3

