### PR TITLE
tests: rework e2e tests according to product changes

### DIFF
--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -100,7 +100,7 @@ class QObject:
             x: int = None,
             y: int = None,
             button=None,
-            timeout=1
+            timeout=5
     ):
         driver.mouseClick(
             self.object,

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -100,7 +100,7 @@ class QObject:
             x: int = None,
             y: int = None,
             button=None,
-            timeout=5
+            timeout=1
     ):
         driver.mouseClick(
             self.object,

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_add_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_add_watched_address.py
@@ -15,6 +15,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703026', 'Manage a watch-only account')
 @pytest.mark.case(703026)
+@pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/15933")
 @pytest.mark.parametrize('address, name, color, emoji, emoji_unicode', [
     pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                  'sunglasses', '1f60e')


### PR DESCRIPTION
### What does the PR do

reworks e2e tests according to product changes

- added more wait time in case if app is frozen
- https://github.com/status-im/status-desktop/issues/15933 removed "watch only accounts" as result:
  - `test_change_account_order_by_drag_and_drop` reworked to include only generated accounts
  - `test_plus_button_add_watched_address` skipped