### PR TITLE
[CHERRY-PICK] fix(dApps): improved logic for the connected dApps list to always display as many dApps as possible

### DIFF
--- a/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
@@ -105,7 +105,15 @@ Popup {
             id: listViewWrapper
             Layout.fillWidth: true
             Layout.preferredHeight: listView.contentHeight
-            Layout.maximumHeight: 290
+
+            // TODO: uncomment maximumHeight: 290 and remove fillHeight: true
+            // after status app upgrades to
+            // a Qt version that has ListView scrolling with mouse wheel and
+            // touchpad fixed.
+            // https://github.com/status-im/status-desktop/issues/15595
+            // Layout.maximumHeight: 290
+            Layout.fillHeight: true
+
             visible: !listPlaceholder.visible
 
             Rectangle {


### PR DESCRIPTION
cherry-pick of (#15837)

Fixes: #15595.

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->

### Cool Spaceship Picture

<!-- optional but cool -->
