### PR TITLE
fix(wallet): Don't reset wallet view after filter change

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -45,14 +45,6 @@ RightTabBaseView {
         id: stack
         anchors.fill: parent
 
-        Connections {
-            target: walletSection
-
-            function onFilterChanged() {
-                root.resetView()
-            }
-        }
-
         onCurrentIndexChanged: {
             RootStore.backButtonName = d.getBackButtonText(currentIndex)
         }


### PR DESCRIPTION
Fixes #15857 

### What does the PR do

* Don't reset view back to Assets View when filter is changed (e.g. network selection is changed)
* Disable sorting of collectibles model used for function aggregation. Sorting and aggregation would cause the crash. Unfortunately I couldn't pinpoint the exact issue.

### Affected areas

Wallet
