### PR TITLE
[Cherry-pick ]fix(WalletConnect): Fixing fees parsing when provided by the dApp

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -432,10 +432,11 @@ SQUtils.QObject {
             // Beware, the tx values are standard blockchain hex big number values; the fees values are nim's float64 values, hence the complex conversions
             if (!!tx.maxFeePerGas && !!tx.maxPriorityFeePerGas) {
                 let maxFeePerGasDec = root.store.hexToDec(tx.maxFeePerGas)
-                gasPrice = BigOps.fromString(maxFeePerGasDec)
+                const gasPriceInWei = BigOps.fromString(maxFeePerGasDec)
+                gasPrice = hexToGwei(tx.maxFeePerGas)
                 // Source fees info from the incoming transaction for when we process it
-                maxFeePerGas = maxFeePerGasDec
-                let maxPriorityFeePerGasDec = root.store.hexToDec(tx.maxPriorityFeePerGas)
+                maxFeePerGas = root.store.hexToDec(tx.maxFeePerGas)
+                let maxPriorityFeePerGasDec = hexToGwei(tx.maxPriorityFeePerGas)
                 maxPriorityFeePerGas = maxPriorityFeePerGasDec
             } else {
                 let fees = root.store.getSuggestedFees(chainId)


### PR DESCRIPTION
#### Description

Closes https://github.com/status-im/status-desktop/issues/15898

The disconnect notifications were operating on WalletConnectService.currentSessionProposal. This object stores the current session object on connect, but it's not necessarily the same session the user wants to disconnect.
To fix this I'm getting the active sessions from status-go when the disconnect request is received (from Status or dapp). If the topic matches to any connection topic owned by the users accounts we'll show a notification.

(cherry picked from commit f73356e2e8f2c6569ea58b8ead5bb469b24c7cf0)
