### PR TITLE
[Cherry-pick] Fix/watch accounts removal master

### DIFF
--- a/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
@@ -24,6 +24,7 @@ pytestmark = marks
                              pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                                           'sunglasses', '1f60e', 'AccWatch1edited', '#216266', 'thumbsup', '1f44d')
                          ])
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15995')
 def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWindow, address: str, color: str, emoji: str,
                                                             emoji_unicode: str,
                                                             name: str, new_name: str, new_color: str, new_emoji: str,

--- a/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
+++ b/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
@@ -74,13 +74,19 @@ StatusMenu {
         }
     }
 
-    StatusAction {
-        objectName: "AccountMenu-AddWatchOnlyAccountAction-%1".arg(root.uniqueIdentifier)
-        text: qsTr("Add watched address")
-        enabled: !root.account
-        icon.name: "show"
-        onTriggered: {
-            root.addWatchOnlyAccountClicked()
+    Loader {
+        active: !production
+        sourceComponent: StatusAction {
+            objectName: "AccountMenu-AddWatchOnlyAccountAction-%1".arg(root.uniqueIdentifier)
+            text: qsTr("Add watched address")
+            enabled: !root.account
+            icon.name: "show"
+            onTriggered: {
+                root.addWatchOnlyAccountClicked()
+            }
+        }
+        onLoaded: {
+            root.addAction(item)
         }
     }
 }

--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -59,6 +59,7 @@ Item {
             readonly property string addWatchOnlyAccKeyUid: Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
             filters: [
                 FastExpressionFilter {
+                    enabled: production
                     expression: model.keyPair.keyUid !== originModelWithoutWatchOnlyAcc.addWatchOnlyAccKeyUid
                     expectedRoles: ["keyPair"]
                 }


### PR DESCRIPTION
### What does the PR do

Cherrypick 566a954935159caf17b1c89317f9534e84835015 and 5ac1f129e58d39dccf8e9e369402f5367bc7be4e

Closes https://github.com/status-im/status-desktop/issues/15979

Remove the possibility to add new watch accounts for production builds.
I've opted to allow watch accounts for dev purposes. We're actively using watch accounts to reproduce bugs and develop/test features on collectibles/assets we don't own.
