### PR TITLE
feat(Wallet): Display the "Buy" button everywhere

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -69,7 +69,7 @@ Rectangle {
                                                         && !root.walletStore.showAllAccounts
                                                         && !d.hideCollectibleTransferActions
 
-        readonly property bool buyActionAvailable: !root.isCommunityOwnershipTransfer && !root.walletStore.showAllAccounts
+        readonly property bool buyActionAvailable: !isCollectibleViewed
 
         readonly property bool swapActionAvailable: Global.featureFlags.swapEnabled && !walletStore.overview.isWatchOnlyAccount && walletStore.overview.canSend && !d.hideCollectibleTransferActions
 


### PR DESCRIPTION
### What does the PR do

- display the "Buy" button in every context in the wallet footer except when viewing a collectible's details

Fixes #15813

### Affected areas

Wallet/Footer

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2024-08-07 17-20-03](https://github.com/user-attachments/assets/f989d5b5-9042-4f82-a5e5-38a326db7684)
