### PR TITLE
fix(red-dot): fix getting the real state of the AC notification count

### DIFF
--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -21,9 +21,6 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method hasMoreToShow*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method unreadActivityCenterNotificationsCountFromView*(self: AccessInterface): int {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method unreadActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -68,9 +68,6 @@ method viewDidLoad*(self: Module) =
 method hasMoreToShow*(self: Module): bool =
   self.controller.hasMoreToShow()
 
-method unreadActivityCenterNotificationsCountFromView*(self: Module): int =
-  self.view.unreadCount()
-
 method unreadActivityCenterNotificationsCount*(self: Module): int =
   self.controller.unreadActivityCenterNotificationsCount()
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -963,7 +963,7 @@ method onChatLeft*[T](self: Module[T], chatId: string) =
 
 proc checkIfWeHaveNotifications[T](self: Module[T]) =
   let sectionWithUnread = self.view.model().isThereASectionWithUnreadMessages()
-  let activtyCenterNotifications = self.activityCenterModule.unreadActivityCenterNotificationsCountFromView() > 0
+  let activtyCenterNotifications = self.activityCenterModule.unreadActivityCenterNotificationsCount() > 0
   self.view.setNotificationAvailable(sectionWithUnread or activtyCenterNotifications)
 
 method onActivityNotificationsUpdated[T](self: Module[T]) =


### PR DESCRIPTION
Fixes #16021

The problem was that the view doesn't update in a sync way, so getting the count from the view might be wrong.

This fix makes it so we have to get the count from status-go twice, which is not ideal, but to fix it, we'd need a refactor of the AC view count mechanism

I opened a refactor issue to address it at some point: https://github.com/status-im/status-desktop/issues/16023

[red-dot-ac.webm](https://github.com/user-attachments/assets/4fb00501-fb24-426a-babc-be284f213239)
