### PR TITLE
feature(connector)_:Update middleware to support personal sign

### DIFF
--- a/src/app/core/signals/remote_signals/connector.nim
+++ b/src/app/core/signals/remote_signals/connector.nim
@@ -27,6 +27,14 @@ type ConnectorRevokeDAppPermissionSignal* = ref object of Signal
   name*: string
   iconUrl*: string
 
+type ConnectorPersonalSignSignal* = ref object of Signal
+  url*: string
+  name*: string
+  iconUrl*: string
+  requestId*: string
+  challenge*: string
+  address*: string
+
 proc fromEvent*(T: type ConnectorSendRequestAccountsSignal, event: JsonNode): ConnectorSendRequestAccountsSignal =
   result = ConnectorSendRequestAccountsSignal()
   result.url = event["event"]{"url"}.getStr()
@@ -54,3 +62,12 @@ proc fromEvent*(T: type ConnectorRevokeDAppPermissionSignal, event: JsonNode): C
   result.url = event["event"]{"url"}.getStr()
   result.name = event["event"]{"name"}.getStr()
   result.iconUrl = event["event"]{"iconUrl"}.getStr()
+
+proc fromEvent*(T: type ConnectorPersonalSignSignal, event: JsonNode): ConnectorPersonalSignSignal =
+  result = ConnectorPersonalSignSignal()
+  result.url = event["event"]{"url"}.getStr()
+  result.name = event["event"]{"name"}.getStr()
+  result.iconUrl = event["event"]{"iconUrl"}.getStr()
+  result.requestId = event["event"]{"requestId"}.getStr()
+  result.challenge = event["event"]{"challenge"}.getStr()
+  result.address = event["event"]{"address"}.getStr()

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -70,6 +70,7 @@ type SignalType* {.pure.} = enum
   ConnectorSendTransaction = "connector.sendTransaction"
   ConnectorGrantDAppPermission = "connector.dAppPermissionGranted"
   ConnectorRevokeDAppPermission = "connector.dAppPermissionRevoked"
+  ConnectorPersonalSign = "connector.personalSign"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -135,10 +135,12 @@ QtObject:
       of SignalType.LocalPairing: LocalPairingSignal.fromEvent(jsonSignal)
       of SignalType.CommunityTokenTransactionStatusChanged: CommunityTokenTransactionStatusChangedSignal.fromEvent(jsonSignal)
       of SignalType.CommunityTokenAction: CommunityTokenActionSignal.fromEvent(jsonSignal)
+      # connector
       of SignalType.ConnectorSendRequestAccounts: ConnectorSendRequestAccountsSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorSendTransaction: ConnectorSendTransactionSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorGrantDAppPermission: ConnectorGrantDAppPermissionSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorRevokeDAppPermission: ConnectorRevokeDAppPermissionSignal.fromEvent(jsonSignal)
+      of SignalType.ConnectorPersonalSign: ConnectorPersonalSignSignal.fromEvent(jsonSignal)
       else: Signal()
 
     result.signalType = signalType

--- a/src/backend/connector.nim
+++ b/src/backend/connector.nim
@@ -23,6 +23,10 @@ type RejectedArgs* = ref object of RootObj
 type RecallDAppPermissionArgs* = ref object of RootObj
   dAppUrl* {.serializedFieldName("dAppUrl").}: string
 
+type PersonalSignAcceptedArgs* = ref object of RootObj
+  requestId* {.serializedFieldName("requestId").}: string
+  signature* {.serializedFieldName("signature").}: string
+
 rpc(requestAccountsAccepted, "connector"):
   args: RequestAccountsAcceptedArgs
 
@@ -37,6 +41,12 @@ rpc(requestAccountsRejected, "connector"):
 
 rpc(recallDAppPermission, "connector"):
   dAppUrl: string
+
+rpc(personalSignAccepted, "connector"):
+  args: PersonalSignAcceptedArgs
+
+rpc(personalSignRejected, "connector"):
+  args: RejectedArgs
 
 proc isSuccessResponse(rpcResponse: RpcResponse[JsonNode]): bool =
   return rpcResponse.error.isNil
@@ -55,3 +65,9 @@ proc sendTransactionRejectedFinishedRpc*(args: RejectedArgs): bool =
 
 proc recallDAppPermissionFinishedRpc*(dAppUrl: string): bool =
   return isSuccessResponse(recallDAppPermission(dAppUrl))
+
+proc sendPersonalSignAcceptedFinishedRpc*(args: PersonalSignAcceptedArgs): bool =
+  return isSuccessResponse(personalSignAccepted(args))
+
+proc sendPersonalSignRejectedFinishedRpc*(args: RejectedArgs): bool =
+  return isSuccessResponse(personalSignRejected(args))


### PR DESCRIPTION
Close #16015

### What does the PR do

This PR implements the personal_sign ui side of things completing [status-go pr](https://github.com/status-im/status-go/pull/5681)

### Affected areas

- Connector sign Popup

### Screenshot of functionality (including design for comparison)

`WIP`

### Impact on end user

The user will be able to : 

- sign request using the personal sign
- reject request by clicking on the reject in popup

### How to test

- Start status-desktop
- Use a DApps interface or Postman for testing
- Send a requestAccount request to connec the Dapp
- Send a personal sign to test the new popup

```bash
{
    "jsonrpc": "2.0",
    "id": 37,
    "method": "connector_callRPC",
    "params": [
        "{\"method\": \"personal_sign\", \"params\":[{\"challenge\": \"0x506c65617365207369676e2074686973206d65737361676520746f20636f6e6669726d20796f7572206964656e746974792e\",\"address\":\"0x6b133bd2fbf852dced491426bfe094b8f94d2dfd\"}], \"url\": \"https://www.status-im.ca\", \"name\": \"testDAppName\", \"iconUrl\": \"http://testDAppIconUrl\"}"
    ]
}
```

- Authenticate and perform the personal sign
- The personal sign should be successful with notification

### Risk 

No specific risk

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
