### PR TITLE
Fix/dapp crash on authenticate

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
@@ -60,19 +60,15 @@ QObject {
                 let dappsList = JSON.parse(dappsJson);
                 for (let i = 0; i < dappsList.length; i++) {
                     const cachedEntry = dappsList[i];
-                    let accountAddresses = cachedEntry.accountAddresses
-                    if (!accountAddresses) {
-                        accountAddresses = [{address: ''}];
-                    }
-
+                    // TODO #15075: on SDK dApps refresh update the model that has data source from persistence instead of using reset
                     const dappEntryWithRequiredRoles = {
-                        description: cachedEntry.description,
+                        description: "",
                         url: cachedEntry.url,
                         name: cachedEntry.name,
-                        iconUrl: cachedEntry.url,
-                        accountAddresses: cachedEntry.accountAddresses
+                        iconUrl: cachedEntry.iconUrl,
+                        accountAddresses: [{address: ''}]
                     }
-                    dapps.append(dappsList[i]);
+                    dapps.append(dappEntryWithRequiredRoles);
                 }
             }
             root.store.dappsListReceived.connect(dappsListReceivedFn);
@@ -103,7 +99,7 @@ QObject {
                         if (existingDApp) {
                             // In Qt5.15.2 this is the way to make a "union" of two arrays
                             // more modern syntax (ES-6) is not available yet
-                            const combinedAddresses = new Set(existingDApp.accountAddresses.concat(dapp.accountAddresses));
+                            const combinedAddresses = new Set(existingDApp.accountAddresses.concat(accounts));
                             existingDApp.accountAddresses = Array.from(combinedAddresses);
                         } else {
                             dapp.accountAddresses = accounts

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -255,7 +255,20 @@ SQUtils.QObject {
             const account = SQUtils.ModelUtils.getFirstModelEntryIf(root.accountsModel, (account) => {
                 return account.address.toLowerCase() === address.toLowerCase();
             })
-            return { account, success: true }
+
+            if (!account) {
+                return { account: null, success: true }
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                const accountCopy = JSON.parse(JSON.stringify(account))
+                return { account: accountCopy, success: true }
+            }
+            catch (e) {
+                console.error("Error parsing account", e)
+                return { account: null, success: false }
+            }
         }
 
         /// Returns null if the network is not found
@@ -264,7 +277,19 @@ SQUtils.QObject {
                 return null
             }
             const chainId = DAppsHelpers.chainIdFromEip155(event.params.chainId)
-            return SQUtils.ModelUtils.getByKey(root.networksModel, "chainId", chainId)
+            const network = SQUtils.ModelUtils.getByKey(root.networksModel, "chainId", chainId)
+
+            if (!network) {
+                return null
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                return JSON.parse(JSON.stringify(network))
+            } catch (e) {
+                console.error("Error parsing network", network)
+                return null
+            }
         }
 
         /// Returns null if the network is not found

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -148,9 +148,22 @@ WalletConnectSDKBase {
                 }
                 address = event.params.request.params[0]
             }
-            return SQUtils.ModelUtils.getFirstModelEntryIf(root.wcService.validAccounts, (account) => {
+            const account = SQUtils.ModelUtils.getFirstModelEntryIf(root.wcService.validAccounts, (account) => {
                 return account.address.toLowerCase() === address.toLowerCase();
             })
+
+            if (!account) {
+                return null
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                return JSON.parse(JSON.stringify(account))
+            }
+            catch (e) {
+                console.error("Error parsing account", e.message)
+                return null
+            }
         }
 
         /// Returns null if the network is not found
@@ -159,7 +172,20 @@ WalletConnectSDKBase {
                 return null
             }
             const chainId = DAppsHelpers.chainIdFromEip155(event.params.chainId)
-            return SQUtils.ModelUtils.getByKey(networksModule.flatNetworks, "chainId", chainId)
+            const network = SQUtils.ModelUtils.getByKey(networksModule.flatNetworks, "chainId", chainId)
+
+            if (!network) {
+                return null
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                return JSON.parse(JSON.stringify(network))
+            }
+            catch (e) {
+                console.error("Error parsing network", e)
+                return null
+            }
         }
 
         function extractMethodData(event, method) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -482,7 +482,6 @@ WalletConnectSDKBase {
             controller.recallDAppPermission(dAppUrl)
             const session = { url: dAppUrl, name: "", icon: "" }
             root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
-            root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dAppUrl), false)
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -128,6 +128,7 @@ QObject {
     function disconnectDapp(url) {
         wcSDK.getActiveSessions((allSessionsAllProfiles) => {
             const sessions = DAppsHelpers.filterActiveSessionsForKnownAccounts(allSessionsAllProfiles, validAccounts)
+            let dappFoundInWcSessions = false
             for (const sessionID in sessions) {
                 const session = sessions[sessionID]
                 const accountsInSession = DAppsHelpers.getAccountsInSession(session)
@@ -137,13 +138,19 @@ QObject {
                     if (!dappsProvider.selectedAddress ||
                         (accountsInSession.includes(dappsProvider.selectedAddress)))
                     {
+                        dappFoundInWcSessions = true
                         wcSDK.disconnectSession(topic)
                     }
                 }
             }
-        });
 
-        root.revokeSession(url)
+            // TODO: #16044 - Refactor Wallet connect service to handle multiple SDKs
+            if (!dappFoundInWcSessions) {
+                // Revoke browser plugin session
+                root.revokeSession(url)
+                d.notifyDappDisconnect(url, false)
+            }
+        });
     }
 
     function getDApp(dAppUrl) {
@@ -336,18 +343,7 @@ QObject {
 
         sdk: root.wcSDK
         store: root.store
-        supportedAccountsModel: SortFilterProxyModel {
-            objectName: "SelectedAddressModelForDAppsListProvider"
-            sourceModel: d.supportedAccountsModel
-            filters: FastExpressionFilter {
-                enabled: !root.walletRootStore.showAllAccounts
-
-                expression: root.walletRootStore.selectedAddress.toLowerCase() === model.address.toLowerCase()
-
-                expectedRoles: ["address"]
-            }
-        }
-
+        supportedAccountsModel: d.supportedAccountsModel
         selectedAddress: root.walletRootStore.selectedAddress
     }
 


### PR DESCRIPTION
### What does the PR do

Fixing #16032

There are two issues fixed by this PR:
1. Crashing on authentication while signing dapp messages. In this case the root cause was the usage of model data items stored in js. When the modal changes, the underlying data changes as well and the app would crash in the JS execution.

- The quick fix is to create deep copies for the model data to be stored in JS.

2. Fixing the desynchronisation of the dapp connection status. This issue had lots of apparently random symptoms that could have been wrongly attributed to the shared cookies!

-    The DAppsListProvider needs to receive all the user accounts so that it can process all dapps the user is connected to (the dapps filtering based on selected account is an internal impl. detail)
- Call `revokeSession` on disconnect only if the dapp cannot be found in the WC active sessions. There is some overlapping between Browser connector and Wallet connect because both operate on the same data stored in the DB. If Browser connector controller removes WC data, the WC disconnect flows cannot be successfully completed.
- Reuse the same notification flow for Browser connector as it's used for WC
- Fix dapp filtering when processing the dapps that will be displayed in the UI.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Wallet connect
Browser connect plugin
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### How to test

1. App desynchronisation:
        Connect multiple dapps to multiple accounts. Try to switch between accounts when connecting dapps and check for the connection status in the dapp list.
3. Crash
       Connect to a dapp and request a sign. Click sign a when the authentication dialog is prompted let the app sit in the background for a few minutes. After authenticating the app would crash.

### Risk 

It has an impact on disconnect feature for Browser plugin that I can't assess!

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

