### PR TITLE
chore: group chat test is using newly created users to avoid potential waku issues

### DIFF
--- a/test/e2e/constants/user.py
+++ b/test/e2e/constants/user.py
@@ -15,7 +15,8 @@ user_account_three = UserAccount('nervous', '0000000000', [], '')
 
 # users for group chat test
 group_chat_user_1 = UserAccount('group_chat_user_1', '77_80Y+2Eh', [
-    'trophy', 'math', 'robust', 'lake', 'extend', 'cabbage', 'bicycle', 'begin', 'either', 'car', 'race', 'cousin'], '0xcd488381c1664c9585b7940f1c4b20f884b8b4a9')
+    'trophy', 'math', 'robust', 'lake', 'extend', 'cabbage', 'bicycle', 'begin', 'either', 'car', 'race', 'cousin'],
+                                '0xcd488381c1664c9585b7940f1c4b20f884b8b4a9')
 group_chat_user_2 = UserAccount('group_chat_user_2', '521/97Qv\:', [
     'opera', 'great', 'open', 'sight', 'still', 'quantum', 'flight', 'torch', 'mule', 'cage', 'noise', 'horn'
 
@@ -33,25 +34,36 @@ community_user_2 = UserAccount('community_user_2', 'vSq5T702_p', [
 ], '0x935034600f2ba486324cee6ae3f96ad8c8915ac6')
 
 user_with_random_attributes_1 = UserAccount(
-''.join((random.choice(
-            string.ascii_letters + string.digits + random.choice('_- '))
-                for i in range(5, 25))
-        ).strip(' '),
-        ''.join((random.choice(
-            string.ascii_letters + string.digits + string.punctuation)
-                for _ in range(10, 28))
-        ), [], ''
+    ''.join((random.choice(
+        string.ascii_letters + string.digits + random.choice('_- '))
+        for _ in range(5, 25))
+    ).strip(' '),
+    ''.join((random.choice(
+        string.ascii_letters + string.digits + string.punctuation)
+        for _ in range(10, 28))
+    ), [], ''
 )
 
 user_with_random_attributes_2 = UserAccount(
-''.join((random.choice(
-            string.ascii_letters + string.digits + random.choice('_- '))
-                for i in range(5, 25))
-        ).strip(' '),
-        ''.join((random.choice(
-            string.ascii_letters + string.digits + string.punctuation)
-                for _ in range(10, 28))
-        ), [], ''
+    ''.join((random.choice(
+        string.ascii_letters + string.digits + random.choice('_- '))
+        for _ in range(5, 25))
+    ).strip(' '),
+    ''.join((random.choice(
+        string.ascii_letters + string.digits + string.punctuation)
+        for _ in range(10, 28))
+    ), [], ''
+)
+
+user_with_random_attributes_3 = UserAccount(
+    ''.join((random.choice(
+        string.ascii_letters + string.digits + random.choice('_- '))
+        for _ in range(5, 25))
+    ).strip(' '),
+    ''.join((random.choice(
+        string.ascii_letters + string.digits + string.punctuation)
+        for _ in range(10, 28))
+    ), [], ''
 )
 
 user_account_one_changed_password = UserAccount('squisher', 'NewPassword@12345', [], '')
@@ -66,7 +78,7 @@ community_params = {
     'name': ''.join(random.choices(string.ascii_letters +
                                    string.digits, k=30)),
     'description': ''.join(random.choices(string.ascii_letters +
-                                    string.digits, k=140)),
+                                          string.digits, k=140)),
     'logo': {'fp': configs.testpath.TEST_IMAGES / 'comm_logo.jpeg', 'zoom': None, 'shift': None},
     'banner': {'fp': configs.testpath.TEST_IMAGES / 'comm_banner.jpeg', 'zoom': None, 'shift': None},
     'intro': ''.join(random.choices(string.ascii_letters +
@@ -93,4 +105,9 @@ token_list_item = namedtuple('TokenListItem', ['title', 'object'])
 ens_user_name = ''.join(
     random.choices(string.digits + string.ascii_lowercase, k=8))
 
-community_tags = ['Activism', 'Art', 'Blockchain', 'Books & blogs', 'Career', 'Collaboration', 'Commerce', 'Culture', 'DAO', 'DIY', 'DeFi', 'Design', 'Education', 'Entertainment', 'Environment', 'Ethereum', 'Event', 'Fantasy', 'Fashion', 'Food', 'Gaming', 'Global', 'Health', 'Hobby', 'Innovation', 'Language', 'Lifestyle', 'Local', 'Love', 'Markets', 'Movies & TV', 'Music', 'NFT', 'NSFW', 'News', 'Non-profit', 'Org', 'Pets', 'Play', 'Podcast', 'Politics', 'Privacy', 'Product', 'Psyche', 'Security', 'Social', 'Software dev', 'Sports', 'Tech', 'Travel', 'Vehicles', 'Web3']
+community_tags = ['Activism', 'Art', 'Blockchain', 'Books & blogs', 'Career', 'Collaboration', 'Commerce', 'Culture',
+                  'DAO', 'DIY', 'DeFi', 'Design', 'Education', 'Entertainment', 'Environment', 'Ethereum', 'Event',
+                  'Fantasy', 'Fashion', 'Food', 'Gaming', 'Global', 'Health', 'Hobby', 'Innovation', 'Language',
+                  'Lifestyle', 'Local', 'Love', 'Markets', 'Movies & TV', 'Music', 'NFT', 'NSFW', 'News', 'Non-profit',
+                  'Org', 'Pets', 'Play', 'Podcast', 'Politics', 'Privacy', 'Product', 'Psyche', 'Security', 'Social',
+                  'Software dev', 'Sports', 'Tech', 'Travel', 'Vehicles', 'Web3']

--- a/test/e2e/tests/messages/test_messaging_group_chat.py
+++ b/test/e2e/tests/messages/test_messaging_group_chat.py
@@ -1,6 +1,5 @@
 import random
 import string
-import time
 
 import allure
 import pytest
@@ -14,7 +13,7 @@ import constants
 from constants import UserAccount
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
-from gui.screens.messages import MessagesScreen
+from gui.screens.messages import MessagesScreen, ToolBar
 
 pytestmark = marks
 
@@ -22,27 +21,75 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703014', 'Create a group and send messages')
 @pytest.mark.case(703014)
 @pytest.mark.timeout(timeout=315)
-@pytest.mark.parametrize('user_data_one, user_data_two, user_data_three', [
-    (configs.testpath.TEST_USER_DATA / 'group_chat_user_1', configs.testpath.TEST_USER_DATA / 'group_chat_user_2',
-     configs.testpath.TEST_USER_DATA / 'group_chat_user_3')
-])
-def test_group_chat(multiple_instances, user_data_one, user_data_two, user_data_three):
-    user_one: UserAccount = constants.group_chat_user_1
-    user_two: UserAccount = constants.group_chat_user_2
-    user_three: UserAccount = constants.group_chat_user_3
+def test_group_chat(multiple_instances):
+    user_one: UserAccount = constants.user_with_random_attributes_1
+    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_three: UserAccount = constants.user_with_random_attributes_3
     members = [user_two.name, user_three.name]
     main_window = MainWindow()
     messages_screen = MessagesScreen()
+    timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
 
-    with multiple_instances(user_data=user_data_one) as aut_one, multiple_instances(
-            user_data=user_data_two) as aut_two, multiple_instances(
-        user_data=user_data_three) as aut_three:
+    with \
+            multiple_instances(user_data=None) as aut_one, \
+            multiple_instances(user_data=None) as aut_two, \
+            multiple_instances(user_data=None) as aut_three:
         with step(f'Launch multiple instances with authorized users {user_one.name}, {user_two.name}, {user_three}'):
             for aut, account in zip([aut_one, aut_two, aut_three], [user_one, user_two, user_three]):
                 aut.attach()
                 main_window.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
                 main_window.authorize_user(account)
                 main_window.hide()
+
+        with step(f'User {user_two.name}, get chat key'):
+            aut_two.attach()
+            main_window.prepare()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
+            user_2_chat_key = profile_popup.copy_chat_key
+            profile_popup.close()
+            main_window.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            contact_request_form = settings.left_panel.open_messaging_settings().open_contacts_settings().open_contact_request_form()
+            contact_request_form.send(user_2_chat_key, f'Hello {user_two.name}')
+
+        with step(f'User {user_two.name}, accept contact request from {user_one.name} via activity center'):
+            aut_two.attach()
+            main_window.prepare()
+            activity_center = ToolBar().open_activity_center()
+            request = activity_center.find_contact_request_in_list(user_one.name, timeout)
+            activity_center.click_activity_center_button(
+                'Contact requests').accept_contact_request(request)
+            activity_center.click()
+            main_window.hide()
+
+        with step(f'User {user_three.name}, get chat key'):
+            aut_three.attach()
+            main_window.prepare()
+            profile_popup = main_window.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
+            user_3_chat_key = profile_popup.copy_chat_key
+            profile_popup.close()
+            main_window.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_three.name}'):
+            aut_one.attach()
+            main_window.prepare()
+            settings = main_window.left_panel.open_settings()
+            contact_request_form = settings.left_panel.open_messaging_settings().open_contacts_settings().open_contact_request_form()
+            contact_request_form.send(user_3_chat_key, f'Hello {user_three.name}')
+
+        with step(f'User {user_three.name}, accept contact request from {user_one.name} via activity center'):
+            aut_three.attach()
+            main_window.prepare()
+            activity_center = ToolBar().open_activity_center()
+            request = activity_center.find_contact_request_in_list(user_one.name, timeout)
+            activity_center.click_activity_center_button(
+                'Contact requests').accept_contact_request(request)
+            activity_center.click()
+            main_window.hide()
 
         with step(f'User {user_one.name}, start chat and add {members}'):
             aut_one.attach()
@@ -99,6 +146,7 @@ def test_group_chat(multiple_instances, user_data_one, user_data_two, user_data_
         with step(f'Check group members and message for {user_two.name}'):
             aut_two.attach()
             main_window.prepare()
+
             assert driver.waitFor(lambda: group_chat_new_name in messages_screen.left_panel.get_chats_names,
                                   10000), f'{group_chat_new_name} is not present in chats list for {aut_two}'
             messages_screen.left_panel.click_chat_by_name(group_chat_new_name)


### PR DESCRIPTION
### What does the PR do

Group chat test was using predefined user data (when all 3 users are already in contacts of each other to speed up things). However, it might be issue for waku so i decided to change the test using newly created accounts each time to be on the safe side. If the test fails (no contact requests received, etc) then we could be more confident that it is somewhat real issue in waku / messaging rather than in test itself

https://ci.status.im/job/status-desktop/job/e2e/job/manual/2454/allure/#suites/dd016288b8f9f39d70dd9d9176bfc098

<img width="1840" alt="Screenshot 2024-08-09 at 15 44 43" src="https://github.com/user-attachments/assets/9b709b85-b80d-4686-85f9-1f0a284cb1ce">


### Affected areas

UI tests
