### PR TITLE
fix(SendModal): hide the Custom network mode in `production`

### DIFF
--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -210,6 +210,7 @@ SplitView {
                 preSelectedSendType: loader.preSelectedSendType
                 preSelectedHoldingID: loader.preSelectedHoldingID
                 preSelectedHoldingType: loader.preSelectedHoldingType
+                showCustomRoutingMode: ctrlShowCustomMode.checked
             }
             Component.onCompleted: loader.active = true
         }
@@ -222,7 +223,7 @@ SplitView {
 
         ColumnLayout {
             width: parent.width
-            spacing: 20
+            spacing: 10
 
             ColumnLayout {
                 spacing: 0
@@ -344,6 +345,12 @@ SplitView {
                     loader.item.close()
                     loader.item.open()
                 }
+            }
+
+            CheckBox {
+                id: ctrlShowCustomMode
+                text: "Show custom network routing panel"
+                checked: true
             }
 
             CheckBox {

--- a/ui/StatusQ/src/StatusQ/Components/StatusBetaTag.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusBetaTag.qml
@@ -7,6 +7,7 @@ import StatusQ.Core.Theme 0.1
 Rectangle {
     id: root
 
+    property color fgColor: Theme.palette.baseColor1
     property alias tooltipText: tip.text
 
     implicitHeight: 20
@@ -14,13 +15,12 @@ Rectangle {
     radius: 4
     color: "transparent"
     border.width: 1
-    border.color: Theme.palette.baseColor1
+    border.color: root.fgColor
 
     StatusBaseText {
-        id: label
         font.pixelSize: 11
         font.weight: Font.Medium
-        color: Theme.palette.baseColor1
+        color: root.fgColor
         anchors.centerIn: parent
         text: "Beta"
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabBar.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabBar.qml
@@ -1,13 +1,14 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
 import StatusQ.Core.Theme 0.1
 
 TabBar {
-    id: statusSwitchTabBar
     padding: 1
 
+    implicitHeight: 36
+
     background: Rectangle {
-        implicitHeight: 36
         color: Theme.palette.statusSwitchTab.barBackgroundColor
         radius: 8
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
@@ -9,48 +9,39 @@ import StatusQ.Core.Theme 0.1
 TabButton {
     id: root
 
-    property int fontPixelSize: 15
     property bool showBetaTag: false
 
+    implicitHeight: 36
+    implicitWidth: 148
+
+    font.pixelSize: 15
+
     contentItem: Item {
-        height: 36
-        MouseArea {
-            id: sensor
-            hoverEnabled: true
-            anchors.fill: parent
+        Row {
+            anchors.centerIn: parent
+            spacing: 8
 
-            cursorShape: Qt.PointingHandCursor
-            onPressed: mouse.accepted = false
-            onReleased: mouse.accepted = false
+            StatusBaseText {
+                id: label
+                text: root.text
+                color: root.checked ?
+                           Theme.palette.statusSwitchTab.selectedTextColor :
+                           Theme.palette.statusSwitchTab.textColor
+                font.weight: Font.Medium
+                font.pixelSize: root.font.pixelSize
+            }
 
-            Row {
-                anchors.centerIn: parent
-                spacing: 8
-
-                StatusBaseText {
-                    id: label
-                    text: root.text
-                    color: root.checked ?
-                               Theme.palette.statusSwitchTab.selectedTextColor :
-                               Theme.palette.statusSwitchTab.textColor
-                    font.weight: Font.Medium
-                    font.pixelSize: root.fontPixelSize
-                }
-
-                StatusBetaTag {
-                    visible: root.showBetaTag
-                }
+            StatusBetaTag {
+                visible: root.showBetaTag
+                fgColor: root.checked ? Theme.palette.statusSwitchTab.selectedTextColor
+                                      : Theme.palette.baseColor1
             }
         }
     }
 
     background: Rectangle {
-        id: controlBackground
-        implicitHeight: 36
-        implicitWidth: 148
-        color: root.checked ?
-            Theme.palette.statusSwitchTab.buttonBackgroundColor :
-            "transparent"
+        color: root.checked ? Theme.palette.statusSwitchTab.buttonBackgroundColor
+                            : "transparent"
         radius: 8
         layer.enabled: true
         layer.effect: DropShadow {
@@ -60,6 +51,10 @@ TabButton {
             samples: 25
             spread: 0
             color: Theme.palette.dropShadow
+        }
+
+        HoverHandler {
+            cursorShape: hovered ? Qt.PointingHandCursor : undefined
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -238,7 +238,7 @@ StatusDropdown {
 
                 StatusSwitchTabButton {
                     text: modelData
-                    fontPixelSize: d.tabBarTextSize
+                    font.pixelSize: d.tabBarTextSize
                 }
             }
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1,10 +1,10 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtMultimedia 5.13
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtMultimedia 5.15
 import Qt.labs.platform 1.1
 import Qt.labs.settings 1.1
-import QtQml.Models 2.14
+import QtQml.Models 2.15
 import QtQml 2.15
 
 import AppLayouts.Wallet 1.0
@@ -1594,6 +1594,8 @@ Item {
 
                 store: appMain.transactionStore
                 collectiblesStore: appMain.walletCollectiblesStore
+
+                showCustomRoutingMode: !production
 
                 onClosed: {
                     sendModal.closed()

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -58,6 +58,7 @@ StatusDialog {
     property var bestRoutes
     property bool isLoading: false
     property int loginType
+    property bool showCustomRoutingMode
 
     property MessageDialog sendingError: MessageDialog {
         id: sendingError
@@ -657,6 +658,7 @@ StatusDialog {
                 totalFeesInFiat: d.totalFeesInFiat
                 fromNetworksList: fromNetworksRouteModel
                 toNetworksList: toNetworksRouteModel
+                showCustomRoutingMode: popup.showCustomRoutingMode
 
                 routerError: d.routerError
                 routerErrorDetails: d.routerErrorDetails

--- a/ui/imports/shared/popups/send/views/NetworkSelector.qml
+++ b/ui/imports/shared/popups/send/views/NetworkSelector.qml
@@ -36,6 +36,7 @@ Item {
     property int errorType: Constants.NoError
     property var bestRoutes
     property double totalFeesInFiat
+    property bool showCustomRoutingMode
 
     property string routerError: ""
     property string routerErrorDetails: ""
@@ -46,6 +47,9 @@ Item {
 
     QtObject {
         id: d
+
+        property var customButton
+
         readonly property int backgroundRectRadius: 13
         readonly property color backgroundRectColor: Theme.palette.indirectColor1
     }
@@ -62,9 +66,24 @@ Item {
             text: qsTr("Advanced")
             showBetaTag: true
         }
+    }
+
+    // not visible in `production` for now, see https://github.com/status-im/status-desktop/issues/16052
+    Component {
+        id: customButtonComponent
         StatusSwitchTabButton {
             text: qsTr("Custom")
-            enabled: false
+        }
+    }
+
+    onShowCustomRoutingModeChanged: {
+        if (root.showCustomRoutingMode) {
+            if (!!d.customButton)
+                d.customButton.destroy()
+            d.customButton = customButtonComponent.createObject(tabBar)
+            tabBar.addItem(d.customButton)
+        } else if (!!d.customButton) {
+            d.customButton.destroy()
         }
     }
 


### PR DESCRIPTION
### What does the PR do

In SendModal, hides the Custom network mode button in `production`

- manage the lifetime of the Custom tab button dynamically; setting the tab button to `visible: false` doesn't unfortunately remove it from the tab bar
- add the option to StoryBook too

2 separate commits to customize StatusBetaTag and StatusSwitchTab*

### Affected areas

SendModal (StatusBetaTag, StatusSwitchTab*)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2024-08-10 14-47-40.webm](https://github.com/user-attachments/assets/a6ad3bcd-e32e-4f9a-a438-46afbb17a026)



