### PR TITLE
[CHERRY-PICK] Fix WC crash and dApp connected status

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsListProvider.qml
@@ -60,19 +60,15 @@ QObject {
                 let dappsList = JSON.parse(dappsJson);
                 for (let i = 0; i < dappsList.length; i++) {
                     const cachedEntry = dappsList[i];
-                    let accountAddresses = cachedEntry.accountAddresses
-                    if (!accountAddresses) {
-                        accountAddresses = [{address: ''}];
-                    }
-
+                    // TODO #15075: on SDK dApps refresh update the model that has data source from persistence instead of using reset
                     const dappEntryWithRequiredRoles = {
-                        description: cachedEntry.description,
+                        description: "",
                         url: cachedEntry.url,
                         name: cachedEntry.name,
-                        iconUrl: cachedEntry.url,
-                        accountAddresses: cachedEntry.accountAddresses
+                        iconUrl: cachedEntry.iconUrl,
+                        accountAddresses: [{address: ''}]
                     }
-                    dapps.append(dappsList[i]);
+                    dapps.append(dappEntryWithRequiredRoles);
                 }
             }
             root.store.dappsListReceived.connect(dappsListReceivedFn);
@@ -103,7 +99,7 @@ QObject {
                         if (existingDApp) {
                             // In Qt5.15.2 this is the way to make a "union" of two arrays
                             // more modern syntax (ES-6) is not available yet
-                            const combinedAddresses = new Set(existingDApp.accountAddresses.concat(dapp.accountAddresses));
+                            const combinedAddresses = new Set(existingDApp.accountAddresses.concat(accounts));
                             existingDApp.accountAddresses = Array.from(combinedAddresses);
                         } else {
                             dapp.accountAddresses = accounts

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -271,7 +271,20 @@ SQUtils.QObject {
             const account = SQUtils.ModelUtils.getFirstModelEntryIf(root.accountsModel, (account) => {
                 return account.address.toLowerCase() === address.toLowerCase();
             })
-            return { account, success: true }
+
+            if (!account) {
+                return { account: null, success: true }
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                const accountCopy = JSON.parse(JSON.stringify(account))
+                return { account: accountCopy, success: true }
+            }
+            catch (e) {
+                console.error("Error parsing account", e)
+                return { account: null, success: false }
+            }
         }
 
         /// Returns null if the network is not found
@@ -280,7 +293,19 @@ SQUtils.QObject {
                 return null
             }
             const chainId = DAppsHelpers.chainIdFromEip155(event.params.chainId)
-            return SQUtils.ModelUtils.getByKey(root.networksModel, "chainId", chainId)
+            const network = SQUtils.ModelUtils.getByKey(root.networksModel, "chainId", chainId)
+
+            if (!network) {
+                return null
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                return JSON.parse(JSON.stringify(network))
+            } catch (e) {
+                console.error("Error parsing network", network)
+                return null
+            }
         }
 
         /// Returns null if the network is not found

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -148,9 +148,22 @@ WalletConnectSDKBase {
                 }
                 address = event.params.request.params[0]
             }
-            return SQUtils.ModelUtils.getFirstModelEntryIf(root.wcService.validAccounts, (account) => {
+            const account = SQUtils.ModelUtils.getFirstModelEntryIf(root.wcService.validAccounts, (account) => {
                 return account.address.toLowerCase() === address.toLowerCase();
             })
+
+            if (!account) {
+                return null
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                return JSON.parse(JSON.stringify(account))
+            }
+            catch (e) {
+                console.error("Error parsing account", e.message)
+                return null
+            }
         }
 
         /// Returns null if the network is not found
@@ -159,7 +172,20 @@ WalletConnectSDKBase {
                 return null
             }
             const chainId = DAppsHelpers.chainIdFromEip155(event.params.chainId)
-            return SQUtils.ModelUtils.getByKey(networksModule.flatNetworks, "chainId", chainId)
+            const network = SQUtils.ModelUtils.getByKey(networksModule.flatNetworks, "chainId", chainId)
+
+            if (!network) {
+                return null
+            }
+
+            // deep copy to avoid operations on the original object
+            try {
+                return JSON.parse(JSON.stringify(network))
+            }
+            catch (e) {
+                console.error("Error parsing network", e)
+                return null
+            }
         }
 
         function extractMethodData(event, method) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -503,7 +503,6 @@ WalletConnectSDKBase {
             controller.recallDAppPermission(dAppUrl)
             const session = { url: dAppUrl, name: "", icon: "" }
             root.wcService.connectorDAppsProvider.revokeSession(JSON.stringify(session))
-            root.wcService.displayToastMessage(qsTr("Disconnected from %1").arg(dAppUrl), false)
         }
     }
 


### PR DESCRIPTION
### What does the PR do

closes #16032

Cherry-pick #16050

There are two issues fixed by this PR:
1. Crashing on authentication while signing dapp messages. In this case the root cause was the usage of model data items stored in js. When the modal changes, the underlying data changes as well and the app would crash in the JS execution.

- The quick fix is to create deep copies for the model data to be stored in JS.

2. Fixing the desynchronisation of the dapp connection status. This issue had lots of apparently random symptoms that could have been wrongly attributed to the shared cookies!

-    The DAppsListProvider needs to receive all the user accounts so that it can process all dapps the user is connected to (the dapps filtering based on selected account is an internal impl. detail)
- Call `revokeSession` on disconnect only if the dapp cannot be found in the WC active sessions. There is some overlapping between Browser connector and Wallet connect because both operate on the same data stored in the DB. If Browser connector controller removes WC data, the WC disconnect flows cannot be successfully completed.
- Reuse the same notification flow for Browser connector as it's used for WC
- Fix dapp filtering when processing the dapps that will be displayed in the UI.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

