### PR TITLE
Fix: Reject the sign request when cancelling the authentication method + fix cookies issue

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/WebEngineLoader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/WebEngineLoader.qml
@@ -23,6 +23,7 @@ Item {
 
     required property url url
     required property var webChannelObjects
+    property string profileName: "Default"
 
     // Used to control the loading of the web engine
     property bool active: false
@@ -48,6 +49,7 @@ Item {
 
             url: root.url
             webChannel: statusChannel
+            profile.storageName: root.profileName
 
             onLoadingChanged: function(loadRequest) {
                 switch(loadRequest.status) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsRequestHandler.qml
@@ -114,6 +114,7 @@ SQUtils.QObject {
                 if (session === null)
                     return
                 root.displayToastMessage(qsTr("Failed to authenticate %1 from %2").arg(methodStr).arg(session.peer.metadata.url), true)
+                root.sessionRequestResult(request, false /*isSuccessful*/)
             })
         }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
@@ -17,6 +17,7 @@ WalletConnectSDKBase {
 
     // Enable the WalletConnect SDK
     property alias enableSdk: loader.active
+    property alias userUID: loader.profileName
     readonly property alias url: loader.url
 
     implicitWidth: 1

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2162,7 +2162,7 @@ Item {
 
             wcSDK: WalletConnectSDK {
                 enableSdk: WalletStore.RootStore.walletSectionInst.walletReady
-
+                userUID: appMain.rootStore.profileSectionStore.profileStore.pubkey
                 projectId: WalletStore.RootStore.appSettings.walletConnectProjectID
             }
             store: DAppsStore {


### PR DESCRIPTION
### What does the PR do

closes #16088
+Fixing the shared cookies issues on WalletConnect
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

WalletConnect
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

The dApp flow is completed even when the authentication fails.
Each user profile will use its own cookies for WC

### How to test

1. Start a sign flow and reach the password input stage in Status
2. Hit cancel or X button.
3. The sign request should be explicitly rejected and the dApp is informed

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
