### PR TITLE
fix(nix): add missing nix.conf with our binary cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 
 .PHONY: \
 	all \
+	nix-shell \
 	bottles \
 	check-qt-dir \
 	check-pkg-target-linux \
@@ -64,6 +65,10 @@ else # "variables.mk" was included. Business as usual until the end of this file
 
 all: nim_status_client
 
+nix-shell: export NIX_USER_CONF_FILES := $(PWD)/nix/nix.conf
+nix-shell: 
+	nix-shell
+
 # must be included after the default target
 -include $(BUILD_SYSTEM_DIR)/makefiles/targets.mk
 
@@ -98,7 +103,6 @@ else
  PKG_TARGET := pkg-linux
  RUN_TARGET := run-linux
 endif
-
 
 check-qt-dir:
 ifeq ($(shell qmake -v 2>/dev/null),)

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,0 +1,17 @@
+# NOTE: If you are in Asia you might want to add https://nix-cache-cn.status.im/ to substituters.
+substituters = https://nix-cache.status.im/ https://cache.nixos.org/
+trusted-substituters = https://nix-cache.status.im/ https://cache.nixos.org/
+trusted-public-keys = nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+# Some downloads are multiple GB, default is 5 minutes
+stalled-download-timeout = 3600
+connect-timeout = 10
+max-jobs = auto
+# Build packages if fetching from cache fails.
+fallback = true
+# Helps avoid removing currently used dependencies via garbage collection
+keep-derivations = true
+keep-outputs = true
+# Some builds on MacOS have issue with sandbox so they are disabled with __noChroot.
+sandbox = relaxed
+# Enable Nix v2 interface.
+experimental-features = flakes nix-command


### PR DESCRIPTION
Because re-building QT that we already have in cache locally is dumb.

![image](https://github.com/user-attachments/assets/9dd86bd9-11e6-401a-a655-411eb3f9d2e5)