### PR TITLE
tests: refactor user.py to reduce references to hardcoded account (create new account each time where necessary)

### DIFF
--- a/test/e2e/constants/user.py
+++ b/test/e2e/constants/user.py
@@ -1,10 +1,53 @@
 import random
 import string
 from collections import namedtuple
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
 
 import configs
+from scripts.utils.generators import random_name_string, random_password_string
 
-UserAccount = namedtuple('User', ['name', 'password', 'seed_phrase', 'status_address'])
+
+@dataclass
+class UserAccount:
+    name: str = None
+    password: str = None
+    seed_phrase: Optional[list] = None
+    status_address: Optional[str] = None
+
+
+class RandomUser(UserAccount):
+    def __init__(self):
+        self.name = random_name_string()
+        self.password = random_password_string()
+
+
+class ReturningUser(UserAccount):
+    def __init__(self, seed_phrase, status_address):
+        self.name = random_name_string()
+        self.password = random_password_string()
+        self.seed_phrase = seed_phrase
+        self.status_address = status_address
+
+
+class ReturningUsersData(Enum):
+
+    RETURNING_USER_ONE = (
+        [
+            'rail', 'witness', 'era', 'asthma', 'empty', 'cheap', 'shed', 'pond', 'skate', 'amount', 'invite', 'year'
+        ], '0x3286c371ef648fe6232324b27ee0515f4ded24d9')
+    RETURNING_USER_TWO = (
+        [
+    'measure', 'cube', 'cousin', 'debris', 'slam', 'ignore', 'seven', 'hat', 'satisfy', 'frown', 'casino', 'inflict'
+], '0x99C096bB5F12bDe37DE9dbee8257Ebe2a5667C46')
+    WALLET_USER = (
+        [
+            'vocal', 'fruit', 'ordinary', 'meadow', 'south', 'athlete', 'inherit', 'since', 'version', 'pitch',
+            'oppose', 'lonely'
+        ], '0x26d6e10a6af4eb4d12ff4cf133a843eb4fa88d0b')
+
+
 user_account_one = UserAccount('squisher', '0000000000', [
     'rail', 'witness', 'era', 'asthma', 'empty', 'cheap', 'shed', 'pond', 'skate', 'amount', 'invite', 'year'
 ], '0x3286c371ef648fe6232324b27ee0515f4ded24d9')
@@ -21,58 +64,6 @@ group_chat_user_2 = UserAccount('group_chat_user_2', '521/97Qv\:', [
     'opera', 'great', 'open', 'sight', 'still', 'quantum', 'flight', 'torch', 'mule', 'cage', 'noise', 'horn'
 
 ], '0x472078f0110d0bb0dfc73389ce89d8a83c8c0502')
-group_chat_user_3 = UserAccount('group_chat_user_3', '29T\I8Cv_G', [
-    'bless', 'enter', 'wet', 'foot', 'lazy', 'will', 'reform', 'enemy', 'rubber', 'void', 'journey', 'fence'
-], '0x4b04b8e22e8295d0ae3177774e4acfd0badacf09')
-
-# usernames and passwords for join community test
-community_user_1 = UserAccount('community_user_1', '|Br2w547YN', [
-    'skirt', 'tired', 'finger', 'dinosaur', 'equal', 'garlic', 'snap', 'tired', 'friend', 'rack', 'net', 'imitate'
-], '0x21371358f1ba09204475e87444962ea4519771e1')
-community_user_2 = UserAccount('community_user_2', 'vSq5T702_p', [
-    'will', 'horn', 'tail', 'stock', 'puzzle', 'warfare', 'pledge', 'uniform', 'ozone', 'taste', 'someone', 'silk'
-], '0x935034600f2ba486324cee6ae3f96ad8c8915ac6')
-
-user_with_random_attributes_1 = UserAccount(
-    ''.join((random.choice(
-        string.ascii_letters + string.digits + random.choice('_- '))
-        for _ in range(5, 25))
-    ).strip(' '),
-    ''.join((random.choice(
-        string.ascii_letters + string.digits + string.punctuation)
-        for _ in range(10, 28))
-    ), [], ''
-)
-
-user_with_random_attributes_2 = UserAccount(
-    ''.join((random.choice(
-        string.ascii_letters + string.digits + random.choice('_- '))
-        for _ in range(5, 25))
-    ).strip(' '),
-    ''.join((random.choice(
-        string.ascii_letters + string.digits + string.punctuation)
-        for _ in range(10, 28))
-    ), [], ''
-)
-
-user_with_random_attributes_3 = UserAccount(
-    ''.join((random.choice(
-        string.ascii_letters + string.digits + random.choice('_- '))
-        for _ in range(5, 25))
-    ).strip(' '),
-    ''.join((random.choice(
-        string.ascii_letters + string.digits + string.punctuation)
-        for _ in range(10, 28))
-    ), [], ''
-)
-
-user_account_one_changed_password = UserAccount('squisher', 'NewPassword@12345', [], '')
-user_account_one_changed_name = UserAccount('NewUserName', '0000000000', [], '')
-
-user_with_funds = UserAccount('User_with_funds', '0000000000', [
-    'vocal', 'fruit', 'ordinary', 'meadow', 'south', 'athlete', 'inherit', 'since', 'version', 'pitch', 'oppose',
-    'lonely'
-], '0x26d6e10a6af4eb4d12ff4cf133a843eb4fa88d0b')
 
 community_params = {
     'name': ''.join(random.choices(string.ascii_letters +
@@ -101,9 +92,6 @@ private_key_address_pair_1 = wallet_account('2daa36a3abe381a9c01610bf10fda272fbc
                                             '0xd89b48cbcb4244f84a4fb5d3369c120e8f8aa74e')
 
 token_list_item = namedtuple('TokenListItem', ['title', 'object'])
-
-ens_user_name = ''.join(
-    random.choices(string.digits + string.ascii_lowercase, k=8))
 
 community_tags = ['Activism', 'Art', 'Blockchain', 'Books & blogs', 'Career', 'Collaboration', 'Commerce', 'Culture',
                   'DAO', 'DIY', 'DeFi', 'Design', 'Education', 'Entertainment', 'Environment', 'Ethereum', 'Event',

--- a/test/e2e/driver/context.py
+++ b/test/e2e/driver/context.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import allure
 import squish

--- a/test/e2e/fixtures/aut.py
+++ b/test/e2e/fixtures/aut.py
@@ -3,10 +3,9 @@ import os
 
 import pytest
 import logging
-import configs
 import constants
 from configs import get_platform
-from constants import UserAccount
+from constants.user import *
 from driver.aut import AUT
 from gui.main_window import MainWindow
 from scripts.utils import system_path
@@ -22,10 +21,12 @@ def options(request):
         return request.param
     return ''
 
+
 @pytest.fixture
 def keycard_controller(request):
     if 'settings_keycard' in str(getattr(request, 'fspath')):
         os.environ['STATUS_RUNTIME_USE_MOCKED_KEYCARD'] = 'True'
+
 
 @pytest.fixture
 def application_logs():
@@ -82,7 +83,7 @@ def user_account(request) -> UserAccount:
         user_account = request.param
         assert isinstance(user_account, UserAccount)
     else:
-        user_account = constants.user.user_account_one
+        user_account = constants.user.RandomUser()
     yield user_account
 
 
@@ -90,6 +91,7 @@ def user_account(request) -> UserAccount:
 def main_screen(user_account: UserAccount, main_window: MainWindow) -> MainWindow:
     main_window.authorize_user(user_account)
     return main_window
+
 
 @pytest.fixture(scope="session")
 def close_apps_before_start():

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -7,7 +7,7 @@ import allure
 import configs
 import constants
 import driver
-from constants import UserAccount
+from constants import UserAccount, RandomUser
 from gui.components.community.invite_contacts import InviteContactsPopup
 from gui.components.context_menu import ContextMenu
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
@@ -174,7 +174,7 @@ class MainWindow(Window):
         return super().prepare()
 
     @allure.step('Sign Up user')
-    def sign_up(self, user_account: UserAccount = constants.user.user_account_one):
+    def sign_up(self, user_account: UserAccount = RandomUser()):
         share_updates_popup = ShareUsageDataPopup()
         BeforeStartedPopUp().get_started()
         welcome_screen = WelcomeToStatusView().wait_until_appears()

--- a/test/e2e/scripts/utils/generators.py
+++ b/test/e2e/scripts/utils/generators.py
@@ -1,0 +1,21 @@
+import random
+import string
+
+
+def random_name_string():
+    return ''.join((random.choice(
+        string.ascii_letters + string.digits + random.choice('_- '))
+        for _ in range(5, 25))
+    ).strip(' ')
+
+
+def random_password_string():
+    return ''.join((random.choice(
+        string.ascii_letters + string.digits + string.punctuation)
+        for _ in range(10, 28))
+    )
+
+
+def random_ens_string():
+    return ''.join(
+        random.choices(string.digits + string.ascii_lowercase, k=8))

--- a/test/e2e/tests/communities/test_block_unblock_user.py
+++ b/test/e2e/tests/communities/test_block_unblock_user.py
@@ -37,7 +37,8 @@ def test_block_and_unblock_user_from_settings_and_profile(multiple_instances, us
                 main_screen.hide()
 
         with step(
-                f'User {user_one.name}, block contact {user_two.name} from user profile and verify button Unblock appeared'):
+                f'User {user_one.name}, block contact {user_two.name} from user profile and verify button Unblock '
+                f'appeared'):
             aut_one.attach()
             main_screen.prepare()
             community_screen = main_screen.left_panel.select_community('Community with 2 users')

--- a/test/e2e/tests/communities/test_communities_categories.py
+++ b/test/e2e/tests/communities/test_communities_categories.py
@@ -19,6 +19,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703274', 'Member role cannot remove category')
 @pytest.mark.case(703272, 703273, 703274)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
+@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
         community_screen = main_screen.left_panel.select_community('Community with 2 users')
@@ -51,6 +52,7 @@ def test_member_role_cannot_add_edit_or_delete_category(main_screen: MainWindow)
 @pytest.mark.parametrize('category_name, general_checkbox',
                          [pytest.param('Category in general', True)])
 def test_clicking_community_category(main_screen: MainWindow, category_name, general_checkbox):
+
     with step('Enable creation of community option'):
         settings = main_screen.left_panel.open_settings()
         settings.left_panel.open_advanced_settings().enable_creation_of_communities()

--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -87,6 +87,7 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703271', 'Member role cannot delete channels')
 @pytest.mark.case(703269, 703270, 703271)
 @pytest.mark.parametrize('user_data', [configs.testpath.TEST_USER_DATA / 'squisher'])
+@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
 def test_member_role_cannot_add_edit_and_delete_channels(main_screen: MainWindow):
     with step('Choose community user is not owner of'):
         community_screen = main_screen.left_panel.select_community('Community with 2 users')
@@ -123,7 +124,7 @@ def test_member_role_cannot_add_edit_and_delete_channels(main_screen: MainWindow
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/edit/737079',
                  'Member not holding permission cannot see channel (view-only permission)')
-# @pytest.mark.case(737079) # FIXME need to migrate all references to new test rail project first
+@pytest.mark.case(737079)
 @pytest.mark.parametrize('user_data_one, user_data_two, asset, amount, channel_description', [
     (configs.testpath.TEST_USER_DATA / 'squisher', configs.testpath.TEST_USER_DATA / 'athletic', 'ETH', '10',
      'description')

--- a/test/e2e/tests/communities/test_communities_mint_owner_token.py
+++ b/test/e2e/tests/communities/test_communities_mint_owner_token.py
@@ -7,6 +7,7 @@ from allure_commons._allure import step
 import configs
 import constants
 import driver
+from constants import ReturningUser, ReturningUsersData
 from . import marks
 from constants.community_settings import MintOwnerTokensElements
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
@@ -28,7 +29,10 @@ def keys_screen(main_window) -> KeysView:
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727245', 'Mint owner token')
 @pytest.mark.case(727245)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
+@pytest.mark.parametrize('user_account', [ReturningUser(
+    seed_phrase=ReturningUsersData.WALLET_USER.value[0],
+    status_address=ReturningUsersData.WALLET_USER.value[1]
+)])
 @pytest.mark.transaction
 def test_mint_owner_token(keys_screen, main_window, user_account):
     with step('Open import seed phrase view and enter seed phrase'):

--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -12,7 +12,7 @@ from gui.main_window import MainWindow
 from . import marks
 import configs
 import constants
-from constants import ColorCodes, UserAccount
+from constants import ColorCodes, UserAccount, RandomUser
 from gui.screens.community_settings import CommunitySettingsScreen
 from gui.screens.messages import MessagesScreen
 
@@ -26,8 +26,8 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703510', 'Join community via owner invite')
 @pytest.mark.case(703255, 703256, 703510)
 def test_join_community_and_pin_unpin_message(multiple_instances):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
     community_params = deepcopy(constants.community_params)
     community_params['name'] = f'{datetime.now():%d%m%Y_%H%M%S}'
     main_screen = MainWindow()

--- a/test/e2e/tests/communities/test_communities_send_accept_decline_request_from_profile.py
+++ b/test/e2e/tests/communities/test_communities_send_accept_decline_request_from_profile.py
@@ -12,7 +12,7 @@ from gui.main_window import MainWindow
 from . import marks
 import configs
 import constants
-from constants import UserAccount
+from constants import UserAccount, RandomUser
 
 pytestmark = marks
 
@@ -20,15 +20,10 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/736170',
                  "Add a contact from community's member list")
 @pytest.mark.case(736170)
-@pytest.mark.parametrize('user_data_one, user_data_two, user_data_three', [
-    (configs.testpath.TEST_USER_DATA / 'squisher', configs.testpath.TEST_USER_DATA / 'athletic',
-     configs.testpath.TEST_USER_DATA / 'nervous')
-])
-def test_communities_send_accept_decline_request_remove_contact_from_profile(multiple_instances, user_data_one,
-                                                                             user_data_two, user_data_three):
-    user_one: UserAccount = constants.user_account_one
-    user_two: UserAccount = constants.user_account_two
-    user_three: UserAccount = constants.user_account_three
+def test_communities_send_accept_decline_request_remove_contact_from_profile(multiple_instances):
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
+    user_three: UserAccount = RandomUser()
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     main_screen = MainWindow()
     community_params = deepcopy(constants.community_params)

--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
@@ -12,8 +12,7 @@ from constants.images_paths import HEART_EMOJI_PATH, ANGRY_EMOJI_PATH, THUMBSUP_
 from gui.screens.messages import MessagesScreen, ToolBar
 
 import configs.testpath
-import constants
-from constants import UserAccount
+from constants import RandomUser, UserAccount
 from gui.main_window import MainWindow
 
 from tests.messages import marks
@@ -25,8 +24,8 @@ pytestmark = marks
 @pytest.mark.case(703087)
 @pytest.mark.critical
 def test_1x1_chat(multiple_instances):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
     main_window = MainWindow()
     messages_screen = MessagesScreen()
     emoji = 'sunglasses'

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
@@ -2,12 +2,12 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+from constants import ReturningUser, ReturningUsersData
 from constants.onboarding import KeysExistText
 from driver.aut import AUT
 from tests.onboarding import marks
 
 import configs.system
-import constants
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
 from gui.components.splash_screen import SplashScreen
@@ -29,7 +29,9 @@ def keys_screen(main_window) -> KeysView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703040', 'Import: 12 word seed phrase')
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/736372', 'Re-importing seed-phrase')
 @pytest.mark.case(703040, 736372)
-@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('user_account', [ReturningUser(
+    seed_phrase=ReturningUsersData.RETURNING_USER_ONE.value[0],
+    status_address=ReturningUsersData.RETURNING_USER_ONE.value[1])])
 @pytest.mark.parametrize('autocomplete, default_name', [
     pytest.param(True, 'Account 1', marks=pytest.mark.critical)
 ])

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
@@ -8,7 +8,7 @@ from . import marks
 import configs.testpath
 import constants
 import driver
-from constants import UserAccount
+from constants import UserAccount, RandomUser
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
 from gui.components.splash_screen import SplashScreen
@@ -23,7 +23,7 @@ pytestmark = marks
 @pytest.mark.case(703592)
 @pytest.mark.critical
 def test_sync_device_during_onboarding(multiple_instances):
-    user: UserAccount = constants.user_with_random_attributes_1
+    user: UserAccount = RandomUser()
     main_window = MainWindow()
 
     with multiple_instances(user_data=None) as aut_one, multiple_instances(user_data=None) as aut_two:

--- a/test/e2e/tests/crtitical_tests_prs/test_plus_button_add_account_after_restart.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_plus_button_add_account_after_restart.py
@@ -3,6 +3,8 @@ import time
 import allure
 import pytest
 from allure import step
+
+from constants import RandomUser
 from tests.wallet_main_screen import marks
 
 import constants
@@ -17,7 +19,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704459',
                  'User can add  one more account after restarting the app')
 @pytest.mark.case(704459)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode,',
                          [
                              pytest.param('GenAcc1', '#2a4af5', 'sunglasses', '1f60e')

--- a/test/e2e/tests/crtitical_tests_prs/test_wallet_settings_acct_interactions_delete_account.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_wallet_settings_acct_interactions_delete_account.py
@@ -4,6 +4,8 @@ import string
 import allure
 import pytest
 from allure_commons._allure import step
+
+from constants import RandomUser
 from tests.settings.settings_wallet import marks
 
 import constants
@@ -21,7 +23,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704454',
                  'Account view interactions: Delete generated account')
 @pytest.mark.case(704454)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('account_name, color, emoji, emoji_unicode',
                          [
                              pytest.param(''.join(random.choices(string.ascii_letters +

--- a/test/e2e/tests/messages/test_messaging_group_chat.py
+++ b/test/e2e/tests/messages/test_messaging_group_chat.py
@@ -10,7 +10,8 @@ from . import marks
 
 import configs.testpath
 import constants
-from constants import UserAccount
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
 from gui.screens.messages import MessagesScreen, ToolBar
@@ -22,9 +23,9 @@ pytestmark = marks
 @pytest.mark.case(703014)
 @pytest.mark.timeout(timeout=315)
 def test_group_chat(multiple_instances):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
-    user_three: UserAccount = constants.user_with_random_attributes_3
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
+    user_three: UserAccount = RandomUser()
     members = [user_two.name, user_three.name]
     main_window = MainWindow()
     messages_screen = MessagesScreen()

--- a/test/e2e/tests/messages/test_messaging_link_previews.py
+++ b/test/e2e/tests/messages/test_messaging_link_previews.py
@@ -3,9 +3,8 @@ import pytest
 from allure_commons._allure import step
 
 import configs.testpath
-import constants
 import driver
-from constants import UserAccount
+from constants import UserAccount, RandomUser
 from constants.links import external_link, link_to_status_community, status_user_profile_link
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
@@ -27,8 +26,8 @@ pytestmark = marks
                                        '0x04c1671d3659b92671cdac657a901e133ca1cfadddbb640db7dec342ee70c4142533cc03e89eff2bd09dd75aea71d45ab2b605bc7e1996c4a6a82d037f4070d13c')
                           ])
 def test_link_previews(multiple_instances, community_name, domain_link, user_name, domain_link_2, user_emoji_hash):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
     main_window = MainWindow()
     messages_screen = MessagesScreen()
     path = configs.testpath.TEST_IMAGES / 'comm_logo.jpeg'

--- a/test/e2e/tests/onboarding/test_password_strength.py
+++ b/test/e2e/tests/onboarding/test_password_strength.py
@@ -2,6 +2,8 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from . import marks
 
 import constants
@@ -24,7 +26,7 @@ def keys_screen(main_window) -> KeysView:
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/702989',
                  'Strength of the password')
 @pytest.mark.case(702989)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 def test_check_password_strength_and_login(keys_screen, main_window, user_account):
     values = [('abcdefghij', very_weak_lower_elements),
               ('ABCDEFGHIJ', very_weak_upper_elements),
@@ -59,15 +61,11 @@ def test_check_password_strength_and_login(keys_screen, main_window, user_accoun
         assert create_password_view.get_password_from_first_field() == expected_password
 
         create_password_view.click_hide_icon(0)
-        # we decided to comment it because this verification is not stable (always different format of dots)
-        # assert create_password_view.get_password_from_first_field() == '●●●●●●●●●●'
 
         create_password_view.click_show_icon(1)
         assert create_password_view.get_password_from_confirmation_field() == expected_password
 
         create_password_view.click_hide_icon(0)
-        # we decided to comment it because this verification is not stable (always different format of dots)
-        # assert create_password_view.get_password_from_confirmation_field() == '●●●●●●●●●●'
 
     with step('Confirm creation of password and set password in confirmation again field'):
         confirm_password_view = create_password_view.click_create_password()
@@ -82,5 +80,4 @@ def test_check_password_strength_and_login(keys_screen, main_window, user_accoun
 
     with step('Click show icon to hide password and check that there are dots instead'):
         create_password_view.click_hide_icon(0)
-        # we decided to comment it because this verification is not stable (always different format of dots)
-        # assert confirm_password_view.get_password_from_confirmation_again_field() == '●●●●●●●●●●'
+

--- a/test/e2e/tests/online_identifier/test_online_identifier.py
+++ b/test/e2e/tests/online_identifier/test_online_identifier.py
@@ -1,15 +1,14 @@
 import time
-from datetime import datetime
-from copy import deepcopy
 
 import allure
 import pytest
 from allure import step
 
 import configs
-import constants
 import driver
-from constants import UserAccount, ColorCodes
+from constants import UserAccount, ColorCodes, RandomUser
+from gui.screens.messages import ToolBar
+from scripts.utils.generators import random_name_string, random_password_string
 from gui.components.changes_detected_popup import ChangesDetectedToastMessage
 from gui.main_window import MainWindow
 from . import marks
@@ -20,58 +19,75 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703007',
                  'Change own display name from online identifier')
 @pytest.mark.case(703007)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
-@pytest.mark.parametrize('new_name', [pytest.param('NewUserName')])
-def test_change_own_display_name(main_screen: MainWindow, user_account, new_name):
+@pytest.mark.parametrize('user_account', [RandomUser()])
+def test_change_own_display_name(main_screen: MainWindow, user_account):
     with step('Open own profile popup and check name of user is correct'):
         profile = main_screen.left_panel.open_online_identifier()
         profile_popup = profile.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name
 
     with step('Go to edit profile settings and change the name of the user'):
-        profile_popup.edit_profile().set_name(new_name)
+        updated_name = random_name_string()
+        profile_popup.edit_profile().set_name(updated_name)
         ChangesDetectedToastMessage().click_save_changes_button()
-        assert ChangesDetectedToastMessage().is_visible is False, f'Changes detected popup is not hidden when save changes button clicked'
+        assert ChangesDetectedToastMessage().is_visible is False, \
+            f'Changes detected popup is not hidden when save changes button clicked'
 
     with step('Open own profile popup and check name of user is correct'):
-        assert main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name == new_name
+        assert main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name == updated_name
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703002', 'Switch state to offline')
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703003', 'Switch state to online')
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703004', 'Switch state to automatic')
 @pytest.mark.case(703002, 703003, 703004)
-@pytest.mark.parametrize('user_data_one, user_data_two', [
-    (configs.testpath.TEST_USER_DATA / 'squisher', configs.testpath.TEST_USER_DATA / 'athletic')
-])
-def test_switch_state_to_offline_online_automatic(multiple_instances, user_data_one, user_data_two):
-    user_one: UserAccount = constants.user_account_one
-    user_two: UserAccount = constants.user_account_two
+@pytest.mark.skip(reason='To review later, perhaps does not worth automating')
+def test_switch_state_to_offline_online_automatic(multiple_instances):
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
     main_screen = MainWindow()
 
-    with (multiple_instances(user_data=user_data_one) as aut_one, multiple_instances(
-            user_data=user_data_two) as aut_two):
-        with step(f'Launch multiple instances with authorized users {user_one.name} and {user_two.name}'):
+    with (multiple_instances(user_data=None) as aut_one, multiple_instances(
+            user_data=None) as aut_two):
+        with step(f'Launch multiple instances for {user_one.name} and {user_two.name}'):
             for aut, account in zip([aut_one, aut_two], [user_one, user_two]):
                 aut.attach()
                 main_screen.wait_until_appears(configs.timeouts.APP_LOAD_TIMEOUT_MSEC).prepare()
                 main_screen.authorize_user(account)
                 main_screen.hide()
 
-        with step(f'User {user_two.name}, switch state to offline'):
+        with step(f'User {user_two.name}, get chat key'):
             aut_two.attach()
             main_screen.prepare()
+            profile_popup = main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier()
+            chat_key = profile_popup.copy_chat_key
+            profile_popup.close()
+            main_screen.hide()
+
+        with step(f'User {user_one.name}, send contact request to {user_two.name}'):
+            aut_one.attach()
+            main_screen.prepare()
+            settings = main_screen.left_panel.open_settings()
+            contact_request_form = settings.left_panel.open_messaging_settings().open_contacts_settings().open_contact_request_form()
+            contact_request_form.send(chat_key, f'Hello {user_two.name}')
+
+        with step(f'User {user_two.name}, accept contact request from {user_one.name} via activity center'):
+            aut_two.attach()
+            main_screen.prepare()
+            activity_center = ToolBar().open_activity_center()
+            request = activity_center.find_contact_request_in_list(user_one.name, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            activity_center.click_activity_center_button(
+                'Contact requests').accept_contact_request(request)
+            activity_center.click()
+
+        with step(f'User {user_two.name}, switch state to offline'):
             main_screen.left_panel.set_user_to_offline()
             main_screen.hide()
 
         with step(f'User {user_one.name}, sees {user_two.name} as offline'):
             aut_one.attach()
             main_screen.prepare()
-            community_screen = main_screen.left_panel.select_community('Community with 2 users')
-            time.sleep(2)
-            assert driver.waitFor(
-                lambda: community_screen.right_panel.member_state(user_two.name) == ColorCodes.GRAY.value,
-                configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Actual state is {community_screen.right_panel.member_state(user_two.name)}'
+            assert settings.user_is_offline()
             main_screen.hide()
 
         with step(f'User {user_two.name}, switch state to online'):
@@ -80,29 +96,3 @@ def test_switch_state_to_offline_online_automatic(multiple_instances, user_data_
             main_screen.left_panel.set_user_to_online()
             main_screen.hide()
 
-        with step(f'User {user_one.name}, sees {user_two.name} as online'):
-            aut_one.attach()
-            main_screen.prepare()
-            time.sleep(2)
-            assert driver.waitFor(
-                lambda: community_screen.right_panel.member_state(user_two.name) == ColorCodes.GREEN.value,
-                configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Actual state is {community_screen.right_panel.member_state(user_two.name)}'
-            main_screen.hide()
-
-        with step(f'User {user_two.name}, switch state to automatic'):
-            aut_two.attach()
-            main_screen.prepare()
-            settings = main_screen.left_panel
-            settings.set_user_to_automatic()
-
-        with step('Verify user status set automatically to online'):
-            assert settings.user_is_online()
-            main_screen.hide()
-
-        with step(f'User {user_one.name}, sees {user_two.name} as online'):
-            aut_one.attach()
-            main_screen.prepare()
-            assert driver.waitFor(
-                lambda: community_screen.right_panel.member_state(user_two.name) == ColorCodes.GREEN.value,
-                configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Actual state is {community_screen.right_panel.member_state(user_two.name)}'
-            main_screen.hide()

--- a/test/e2e/tests/settings/settings_keycard/test_check_whats_on_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_check_whats_on_keycard.py
@@ -3,6 +3,8 @@ import time
 import allure
 import pytest
 from allure import step
+
+from constants import RandomUser
 from . import marks
 
 import configs
@@ -19,7 +21,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703627', 'Check whats on a Keycard')
 @pytest.mark.case(703627)
-@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_check_whats_on_keycard(main_screen: MainWindow, user_account):
     main_screen.prepare()

--- a/test/e2e/tests/settings/settings_keycard/test_factory_reset_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_factory_reset_keycard.py
@@ -1,6 +1,8 @@
 import allure
 import pytest
 from allure_commons._allure import step
+
+from constants import RandomUser
 from . import marks
 
 import configs
@@ -16,7 +18,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703628', 'Factory reset a Keycard')
 @pytest.mark.case(703628)
-@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_factory_reset_keycard(main_screen: MainWindow, user_account):
     main_screen.prepare()
@@ -70,7 +72,7 @@ def test_factory_reset_keycard(main_screen: MainWindow, user_account):
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704606',
                  'Factory reset a Keycard: incorrect PIN')
 @pytest.mark.case(704606)
-@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_factory_reset_keycard_incorrect_pin(main_screen: MainWindow, user_account):
     main_screen.prepare()

--- a/test/e2e/tests/settings/settings_keycard/test_import_restore_keycard_via_seed_phrase.py
+++ b/test/e2e/tests/settings/settings_keycard/test_import_restore_keycard_via_seed_phrase.py
@@ -8,7 +8,7 @@ from . import marks
 import configs
 import constants
 import driver
-from constants import ColorCodes
+from constants import ColorCodes, RandomUser
 from constants.images_paths import PLUG_IN_KEYCARD_IMAGE_PATH, INSERT_KEYCARD_IMAGE_PATH, KEYCARD_SUCCESS_IMAGE_PATH
 from constants.keycard import Keycard
 from gui.main_window import MainWindow
@@ -20,7 +20,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703625',
                  'Import or restore a Keycard via a seed phrase')
 @pytest.mark.case(703625)
-@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_import_restore_keycard_via_seed_phrase(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC

--- a/test/e2e/tests/settings/settings_keycard/test_setup_existing_account.py
+++ b/test/e2e/tests/settings/settings_keycard/test_setup_existing_account.py
@@ -9,7 +9,7 @@ from . import marks
 import configs
 import constants
 import driver
-from constants import ColorCodes
+from constants import ColorCodes, RandomUser
 from constants.images_paths import PLUG_IN_KEYCARD_IMAGE_PATH, CHOOSE_KEYCARD_PIN_IMAGE_PATH, \
     KEYCARD_SUCCESS_IMAGE_PATH
 from constants.keycard import Keycard
@@ -23,7 +23,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703623',
                  'Setup a keycard with an existing account')
 @pytest.mark.case(703623)
-@pytest.mark.parametrize('user_account', [constants.user.user_account_one])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('account_name', [pytest.param('Account 1')])
 @pytest.mark.timeout(timeout=210)
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')

--- a/test/e2e/tests/settings/settings_keycard/test_unlock_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_unlock_keycard.py
@@ -3,6 +3,9 @@ import time
 import allure
 import pytest
 from allure import step
+
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from . import marks
 
 import configs
@@ -17,7 +20,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704607', 'Unlock Keycard')
 @pytest.mark.case(704607)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_unlock_keycard_using_correct_puk(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
@@ -82,7 +85,7 @@ def test_unlock_keycard_using_correct_puk(main_screen: MainWindow, user_account)
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704608', 'Unlock Keycard: incorrect PUK')
 @pytest.mark.case(704608)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_unlock_keycard_using_incorrect_puk(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC

--- a/test/e2e/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
+++ b/test/e2e/tests/settings/settings_messaging/test_messaging_settings_accept_request.py
@@ -6,7 +6,8 @@ from . import marks
 
 import configs.testpath
 import constants
-from constants import UserAccount
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
 
@@ -17,8 +18,8 @@ pytestmark = marks
 @pytest.mark.case(703011)
 # TODO: reason='https://github.com/status-im/desktop-qa-automation/issues/346'
 def test_messaging_settings_accepting_request(multiple_instances):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
     main_window = MainWindow()
 
     with (multiple_instances(user_data=None) as aut_one, multiple_instances(user_data=None) as aut_two):

--- a/test/e2e/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
+++ b/test/e2e/tests/settings/settings_messaging/test_messaging_settings_identity_verification.py
@@ -7,7 +7,8 @@ from . import marks
 
 import configs.testpath
 import constants
-from constants import UserAccount
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
 
@@ -18,8 +19,8 @@ pytestmark = marks
 @pytest.mark.case(704611)
 @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14954")
 def test_messaging_settings_identity_verification(multiple_instances):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_one: RandomUser()
+    user_two: RandomUser()
     main_window = MainWindow()
 
     with multiple_instances(user_data=None) as aut_one, multiple_instances(user_data=None) as aut_two:

--- a/test/e2e/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
+++ b/test/e2e/tests/settings/settings_messaging/test_messaging_settings_reject_request.py
@@ -1,10 +1,9 @@
 import allure
 import configs.testpath
 import configs.timeouts
-import constants
 import pytest
 from allure_commons._allure import step
-from constants import UserAccount
+from constants import UserAccount, RandomUser
 from . import marks
 from constants.messaging import Messaging
 from gui.main_window import MainWindow
@@ -16,8 +15,8 @@ pytestmark = marks
                  'Reject a contact request with a chat key')
 @pytest.mark.case(704610)
 def test_messaging_settings_rejecting_request(multiple_instances):
-    user_one: UserAccount = constants.user_with_random_attributes_1
-    user_two: UserAccount = constants.user_with_random_attributes_2
+    user_one: UserAccount = RandomUser()
+    user_two: UserAccount = RandomUser()
     main_window = MainWindow()
 
     with multiple_instances(user_data=None) as aut_one, multiple_instances(user_data=None) as aut_two:

--- a/test/e2e/tests/settings/settings_password/test_settings_password_change_password.py
+++ b/test/e2e/tests/settings/settings_password/test_settings_password_change_password.py
@@ -3,6 +3,8 @@ import psutil
 import pytest
 from allure_commons._allure import step
 
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from gui.components.change_password_popup import ChangePasswordPopup
 from tests.settings.settings_profile import marks
 
@@ -17,13 +19,11 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')
 @pytest.mark.case(703005)
-@pytest.mark.parametrize('user_account, user_account_changed_password',
-                         [pytest.param(constants.user.user_account_one,
-                                       constants.user.user_account_one_changed_password)])
+@pytest.mark.parametrize('user_account',[RandomUser()])
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15178')
 # @pytest.mark.critical
 # TODO: follow up on https://github.com/status-im/status-desktop/issues/13013
-def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account, user_account_changed_password):
+def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account):
     with step('Open profile settings'):
         settings_scr = main_screen.left_panel.open_settings()
 
@@ -31,7 +31,8 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         password_view = settings_scr.left_panel.open_password_settings()
 
     with step('Fill in the change password form and submit'):
-        password_view.change_password(user_account.password, user_account_changed_password.password)
+        new_password = random_password_string()
+        password_view.change_password(user_account.password, new_password)
 
     with step('Click re-encrypt data button and then restart'):
         ChangePasswordPopup().click_re_encrypt_data_restart_button()
@@ -40,7 +41,8 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
         aut.restart()
 
     with step('Login with new password'):
-        main_screen.authorize_user(user_account_changed_password)
+        main_screen.authorize_user(user_account=UserAccount(name=user_account.name,
+                                                            password=new_password))
 
     with step('Verify that the user logged in correctly'):
         online_identifier = main_screen.left_panel.open_online_identifier()

--- a/test/e2e/tests/settings/settings_profile/test_settings_profile_edit.py
+++ b/test/e2e/tests/settings/settings_profile/test_settings_profile_edit.py
@@ -1,8 +1,9 @@
-
 import allure
 import pytest
 from allure_commons._allure import step
 
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from . import marks
 
 import constants
@@ -16,10 +17,13 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703006',
                  'Set display name, bio and social links')
 @pytest.mark.case(703006)
-@pytest.mark.parametrize('user_account, user_account_changed',
-                         [pytest.param(constants.user.user_account_one, constants.user.user_account_one_changed_name)])
+@pytest.mark.parametrize('user_account',
+                         [
+                             pytest.param(
+                                 RandomUser())
+                         ])
 @pytest.mark.parametrize('bio, links', [pytest.param('This is my bio', constants.social_links)])
-def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_account, user_account_changed, bio, links):
+def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_account, bio, links):
     with step('Open profile settings and check name, bio and links'):
         profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()
         assert profile_settings.get_display_name == user_account.name
@@ -27,14 +31,15 @@ def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_accou
         assert len(profile_settings.get_social_links) == 0
 
     with (step('Set new name, bio and links')):
-        profile_settings.set_name(user_account_changed.name)
+        new_user_name = random_name_string()
+        profile_settings.set_name(new_user_name)
         profile_settings.set_bio(bio)
         ChangesDetectedToastMessage().click_save_changes_button()
         assert ChangesDetectedToastMessage().is_visible is False, \
             f'Bottom floating buttons are not hidden'
         assert \
             main_screen.left_panel.open_online_identifier().open_profile_popup_from_online_identifier().user_name \
-            == user_account_changed.name, \
+            == new_user_name, \
             f'Display name was not applied after changing'
         main_screen.left_panel.click()
         profile_settings.set_social_links(links)
@@ -45,10 +50,10 @@ def test_set_name_bio_social_links(main_screen: MainWindow, aut: AUT, user_accou
 
     with step('Restart application'):
         aut.restart()
-        main_screen.authorize_user(user_account_changed)
+        main_screen.authorize_user(user_account=UserAccount(name=new_user_name, password=user_account.password))
 
     with step('Open profile settings and check new name, bio and links'):
-      profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()
-      assert profile_settings.get_display_name == user_account_changed.name
-      assert profile_settings.get_bio == bio
-      profile_settings.verify_social_links(links)
+        profile_settings = main_screen.left_panel.open_settings().left_panel.open_profile_settings()
+        assert profile_settings.get_display_name == new_user_name
+        assert profile_settings.get_bio == bio
+        profile_settings.verify_social_links(links)

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
@@ -1,11 +1,11 @@
 import random
 import string
-import time
 
 import allure
 import pytest
 from allure_commons._allure import step
 
+from constants import RandomUser
 from constants.wallet import WalletRenameKeypair, WalletAccountPopup
 from gui.components.authenticate_popup import AuthenticatePopup
 from tests.wallet_main_screen import marks
@@ -20,7 +20,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703420',
                  'Wallet -> Settings -> Keypair interactions: Rename keypair')
 @pytest.mark.case(703420)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize(
     'name, color, emoji, acc_emoji, second_name, third_name, new_name, new_name_1, seed_phrase',
     [pytest.param('Acc01', '#2a4af5', 'sunglasses', '😎 ',

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -6,6 +6,8 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from constants.wallet import WalletAccountPopup
 from . import marks
 
@@ -20,7 +22,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/edit/703598',
                  'Add new account from wallet settings screen')
 @pytest.mark.case(703598)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('account_name, color, emoji, emoji_unicode',
                          [
                              pytest.param(''.join(random.choices(string.ascii_letters +

--- a/test/e2e/tests/settings/test_ens_name_purchase.py
+++ b/test/e2e/tests/settings/test_ens_name_purchase.py
@@ -6,6 +6,8 @@ import configs
 import constants
 import driver
 from configs.timeouts import UI_LOAD_TIMEOUT_SEC
+from constants import ReturningUser, ReturningUsersData
+from scripts.utils.generators import random_ens_string
 from constants.wallet import WalletTransactions
 from . import marks
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
@@ -31,8 +33,11 @@ def keys_screen(main_window) -> KeysView:
                  'Settings -> ENS usernames: buy ENS name on testnet')
 @pytest.mark.case(704597)
 @pytest.mark.transaction
-@pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
-@pytest.mark.parametrize('ens_name', [pytest.param(constants.user.ens_user_name)])
+@pytest.mark.parametrize('user_account', [[ReturningUser(
+    seed_phrase=ReturningUsersData.WALLET_USER.value[0],
+    status_address=ReturningUsersData.WALLET_USER.value[1]
+)]])
+@pytest.mark.parametrize('ens_name', [pytest.param(random_ens_string())])
 @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")
 @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_ens_name_purchase(keys_screen, main_window, user_account, ens_name):

--- a/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_send.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_send.py
@@ -5,6 +5,7 @@ from allure_commons._allure import step
 import configs
 import constants
 import driver
+from constants import ReturningUser, ReturningUsersData
 from constants.wallet import WalletTransactions
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
@@ -26,9 +27,12 @@ def keys_screen(main_window) -> KeysView:
                  'Send: can send 0 ETH to address pasted into receiver field with Simple flow')
 @pytest.mark.case(704527)
 @pytest.mark.transaction
-@pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
+@pytest.mark.parametrize('user_account', [ReturningUser(
+    seed_phrase=ReturningUsersData.WALLET_USER.value[0],
+    status_address=ReturningUsersData.WALLET_USER.value[1]
+)])
 @pytest.mark.parametrize('receiver_account_address, amount, asset, tab', [
-    pytest.param(constants.user.user_account_one.status_address, 0, 'Ether', 'Assets')
+    pytest.param(ReturningUsersData.RETURNING_USER_ONE.value[1], 0, 'Ether', 'Assets')
 ])
 @pytest.mark.timeout(timeout=120)
 @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")

--- a/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_send_nft.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_send_nft.py
@@ -5,6 +5,7 @@ from allure_commons._allure import step
 import configs
 import constants
 import driver
+from constants import ReturningUser, ReturningUsersData
 from constants.wallet import WalletTransactions
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
@@ -26,9 +27,12 @@ def keys_screen(main_window) -> KeysView:
                  'Send: can send ERC 721 token (collectible) to address pasted into receiver field with Simple flow')
 @pytest.mark.case(704602)
 @pytest.mark.transaction
-@pytest.mark.parametrize('user_account', [constants.user.user_with_funds])
+@pytest.mark.parametrize('user_account', [[ReturningUser(
+    seed_phrase=ReturningUsersData.WALLET_USER.value[0],
+    status_address=ReturningUsersData.WALLET_USER.value[1]
+)]])
 @pytest.mark.parametrize('tab, receiver_account_address, amount, collectible', [
-    pytest.param('Collectibles', constants.user.user_with_funds.status_address, 1, 'Panda')
+    pytest.param('Collectibles', ReturningUsersData.WALLET_USER.value[1], 1, 'Panda')
 ])
 @pytest.mark.timeout(timeout=120)
 @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14862")

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
@@ -6,6 +6,8 @@ import allure
 import pytest
 from allure import step
 
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from constants.wallet import WalletAccountPopup
 from tests.wallet_main_screen import marks
 
@@ -21,7 +23,7 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703036',
                  'Manage an account created from the generated seed phrase')
 @pytest.mark.case(703036)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
                          'new_name, new_color, new_emoji, new_emoji_unicode, keypair_name', [
                              pytest.param('SPAcc', '#2a4af5', 'sunglasses', '1f60e',

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
@@ -3,6 +3,9 @@ import time
 import allure
 import pytest
 from allure_commons._allure import step
+
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_password_string
 from tests.wallet_main_screen import marks
 
 import constants
@@ -16,7 +19,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703029', 'Manage a private key imported account')
 @pytest.mark.case(703029)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('address_pair', [constants.user.private_key_address_pair_1])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
                          'new_name, new_color, new_emoji, new_emoji_unicode', [

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
@@ -4,6 +4,8 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_name_string, random_password_string
 from constants.wallet import WalletSeedPhrase
 from tests.wallet_main_screen import marks
 
@@ -18,7 +20,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703030', 'Manage a seed phrase imported account')
 @pytest.mark.case(703030)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
                          'new_name, new_color, new_emoji, new_emoji_unicode, seed_phrase', [
                              pytest.param('SPAcc24', '#2a4af5', 'sunglasses', '1f60e',
@@ -90,7 +92,7 @@ def test_plus_button_manage_account_from_seed_phrase(main_screen: MainWindow, us
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/736371',
                  "Can't import the same seed phrase when adding account")
 @pytest.mark.case(736371)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
                          'new_name, new_color, new_emoji, new_emoji_unicode, seed_phrase', [
                              pytest.param('SPAcc24', '#2a4af5', 'sunglasses', '1f60e',

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account.py
@@ -3,6 +3,9 @@ import time
 import allure
 import pytest
 from allure_commons._allure import step
+
+from constants import UserAccount, RandomUser
+from scripts.utils.generators import random_password_string
 from tests.wallet_main_screen import marks
 
 import constants
@@ -16,7 +19,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703033', 'Manage a generated account')
 @pytest.mark.case(703033)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
                          'new_name, new_color, new_emoji, new_emoji_unicode', [
                              pytest.param('GenAcc1', '#2a4af5', 'sunglasses', '1f60e',

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
@@ -3,6 +3,8 @@ import time
 import allure
 import pytest
 from allure_commons._allure import step
+
+from constants import RandomUser
 from tests.wallet_main_screen import marks
 
 import constants
@@ -15,7 +17,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703028', 'Manage a custom generated account')
 @pytest.mark.case(703028)
-@pytest.mark.parametrize('user_account', [constants.user.user_with_random_attributes_1])
+@pytest.mark.parametrize('user_account', [RandomUser()])
 @pytest.mark.parametrize('derivation_path, generated_address_index, name, color, emoji, emoji_unicode, new_name, new_color, new_emoji, new_emoji_unicode',
                          [
                             pytest.param('Ethereum', '5', 'Ethereum', '#216266', 'sunglasses', '1f60e', 'EthEdited', '#216266', 'thumbsup', '1f44d'),


### PR DESCRIPTION
### What does the PR do

- refactor user.py. Initial idea was to reduce the number of hardcoded lines where possible (references to hardcoded account, where it is not neccessary)

### Affected areas

tests

I ran the tests full run and it looks good https://ci.status.im/job/status-desktop/job/e2e/job/manual/2465/allure/#suites/772a2d7720a00e6a6a9a64c91dffa645/8ef5d8e0b1315a35/

the failures are not related to these changes, the problem is that we use parametrize in a bit awkward way. I will change that in future PRs