### PR TITLE
[CHERRY-PICK] Make the getENSName calls async

### DIFF
--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -257,3 +257,28 @@ proc getTokenBalanceHistoryDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
       "error": e.msg,
     }
     arg.finish(output)
+
+#################################################
+# Async get ENS names for account
+#################################################
+
+type
+  FetchENSNamesForAddressesTaskArg = ref object of QObjectTaskArg
+    chainId: int
+    addresses: seq[string]
+
+proc fetchENSNamesForAddressesTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[FetchENSNamesForAddressesTaskArg](argEncoded)
+  var response = %* {
+    "result": [],
+    "error": "",
+  }
+  try:
+    var result = newJobject()
+    for address in arg.addresses:
+      let name = getEnsName(address, arg.chainId)
+      result[address] = %name
+    response["result"] = result
+  except Exception as e:
+    response["error"] = %* e.msg
+  arg.finish(response)

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -56,6 +56,8 @@ QtObject:
   proc handleKeypair(self: Service, keypair: KeypairDto)
   proc updateAccountsPositions(self: Service)
   proc importPartiallyOperableAccounts(self: Service, keyUid: string, password: string)
+  proc parseCurrencyValueByTokensKey*(self: Service, tokensKey: string, amountInt: UInt256): float64
+  proc fetchENSNamesForAddressesAsync(self: Service, addresses: seq[string], chainId: int)
   # All slots defined in included files have to be forward declared
   proc onAllTokensBuilt*(self: Service, response: string) {.slot.}
   proc onDerivedAddressesFetched*(self: Service, jsonString: string) {.slot.}
@@ -66,7 +68,7 @@ QtObject:
   proc onFetchChainIdForUrl*(self: Service, jsonString: string) {.slot.}
   proc onNonProfileKeycardKeypairMigratedToApp*(self: Service, response: string) {.slot.}
   proc tokenBalanceHistoryDataResolved*(self: Service, response: string) {.slot.}
-  proc parseCurrencyValueByTokensKey*(self: Service, tokensKey: string, amountInt: UInt256): float64
+  proc onENSNamesFetched*(self: Service, response: string) {.slot.}
 
   proc delete*(self: Service) =
     self.closingApp = true


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/16099

* wip: make the getENSName calls async

* fix: login to the app takes forever

Resolving ens name sometimes, most likely due to network congestion can be really slow, that results in slow app loading, especially if user has more accounts, cause the app checks ens name existence for each account.

This PR does that check in an async way.

Fixes #16086

* chore: async check for ens name existence when adding new accounts

---------

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
