### PR TITLE
feat(metrics): add onboarding screen metrics and section navigation

### DIFF
--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -57,4 +57,4 @@ QtObject:
 
   proc showCommunityMemberUnbannedNotification*(self: GlobalEvents, sectionId: string, title: string, message: string) {.signal.}
 
-  proc addCentralizedMetric*(self: GlobalEvents, eventName: string, eventValueJson: string) {.signal.}
+  proc addCentralizedMetricIfEnabled*(self: GlobalEvents, eventName: string, eventValueJson: string) {.signal.}

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, browsers
+import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, browsers, strutils
 
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model
@@ -925,6 +925,15 @@ method activeSectionSet*[T](self: Module[T], sectionId: string, skipSavingInSett
       self.communitiesModule.onActivated()
     of conf.BROWSER_SECTION_ID:
       self.browserSectionModule.onActivated()
+
+  # If metrics are enabled, send a navigation event
+  var sectionIdToSend = sectionId
+  if sectionId == singletonInstance.userProfile.getPubKey():
+    sectionIdToSend = conf.CHAT_SECTION_NAME
+  elif sectionId.startsWith("0x"):
+    # This is a community
+    sectionIdToSend = "community"
+  singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", sectionIdToSend)
 
   self.view.model().setActiveSection(sectionId)
   self.view.activeSectionSet(item)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -933,7 +933,7 @@ method activeSectionSet*[T](self: Module[T], sectionId: string, skipSavingInSett
   elif sectionId.startsWith("0x"):
     # This is a community
     sectionIdToSend = "community"
-  singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", sectionIdToSend)
+  singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", $(%*{"viewId": sectionIdToSend}))
 
   self.view.model().setActiveSection(sectionId)
   self.view.activeSectionSet(item)

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -76,7 +76,7 @@ QtObject:
 
   proc setCurrentStartupState*(self: View, state: State) =
     # If metrics is enabled, we send a metric of the screen visited
-    singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", $(%*{"viewId": state.stateType}))
+    singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", $(%*{"viewId": state.stateType, "flowType": state.flowType}))
 
     self.currentStartupState.setStateObj(state)
   proc getCurrentStartupState(self: View): QVariant {.slot.} =

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -1,5 +1,6 @@
-import NimQml, chronicles
+import NimQml, chronicles, json
 import io_interface
+import ../../global/global_singleton
 import selected_login_account
 import internal/[state, state_wrapper]
 import models/login_account_model as login_acc_model
@@ -74,6 +75,9 @@ QtObject:
     return self.currentStartupState.getStateObj()
 
   proc setCurrentStartupState*(self: View, state: State) =
+    # If metrics is enabled, we send a metric of the screen visited
+    singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", $(%*{"viewId": state.stateType}))
+
     self.currentStartupState.setStateObj(state)
   proc getCurrentStartupState(self: View): QVariant {.slot.} =
     return self.currentStartupStateVariant

--- a/src/app_service/service/metrics/async_tasks.nim
+++ b/src/app_service/service/metrics/async_tasks.nim
@@ -2,13 +2,22 @@ include ../../common/json_utils
 include ../../../app/core/tasks/common
 
 type
-  AsyncAddCentralizedMetricTaskArg = ref object of QObjectTaskArg
+  AsyncAddCentralizedMetricIfEnabledTaskArg = ref object of QObjectTaskArg
     eventName: string
     eventValueJson: string
 
-proc asyncAddCentralizedMetricTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncAddCentralizedMetricTaskArg](argEncoded)
+proc asyncAddCentralizedMetricIfEnabledTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncAddCentralizedMetricIfEnabledTaskArg](argEncoded)
   try:
+    let metricsEnabled = getIsCentralizedMetricsEnabled()
+    if not metricsEnabled:
+      arg.finish(%* {
+        "metricId": "",
+        "metricsDisabled": true,
+        "error": "",
+      })
+      return
+
     var metric = CentralizedMetricDto()
     metric.eventName = arg.eventName
     metric.eventValue = if arg.eventValueJson.len > 0: parseJson(arg.eventValueJson) else: JsonNode()
@@ -21,6 +30,7 @@ proc asyncAddCentralizedMetricTask(argEncoded: string) {.gcsafe, nimcall.} =
       if jsonObj.hasKey("error"):
         arg.finish(%* {
           "metricId": "",
+          "metricsDisabled": false,
           "error": jsonObj{"error"}.getStr,
         })
         return
@@ -29,6 +39,7 @@ proc asyncAddCentralizedMetricTask(argEncoded: string) {.gcsafe, nimcall.} =
 
     arg.finish(%* {
       "metricId": response,
+      "metricsDisabled": false,
       "error": "",
     })
 

--- a/src/app_service/service/metrics/async_tasks.nim
+++ b/src/app_service/service/metrics/async_tasks.nim
@@ -18,6 +18,7 @@ proc asyncAddCentralizedMetricIfEnabledTask(argEncoded: string) {.gcsafe, nimcal
       })
       return
 
+    debug "Add metric for ", eventName =  arg.eventName, eventValueJson = arg.eventValueJson
     var metric = CentralizedMetricDto()
     metric.eventName = arg.eventName
     metric.eventValue = if arg.eventValueJson.len > 0: parseJson(arg.eventValueJson) else: JsonNode()

--- a/src/app_service/service/metrics/service.nim
+++ b/src/app_service/service/metrics/service.nim
@@ -43,7 +43,6 @@ QtObject:
 
   # eventValueJson is a json string
   proc addCentralizedMetricIfEnabled*(self: MetricsService, eventName: string, eventValueJson: string) {.slot.} =
-    debug "Add metric if enabled for ", eventName, eventValueJson
     let arg = AsyncAddCentralizedMetricIfEnabledTaskArg(
       tptr: asyncAddCentralizedMetricIfEnabledTask,
       vptr: cast[ByteAddress](self.vptr),
@@ -62,7 +61,6 @@ QtObject:
         return
       
       if responseObj{"metricsDisabled"}.getBool:
-        debug "metrics collection is turned off"
         return
 
       debug "onCentralizedMetricAddedIdEnabled", metricId=responseObj{"metricId"}.getStr()

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -35,6 +35,10 @@ OnboardingBasePage {
         id: loader
         anchors.fill: parent
         sourceComponent: {
+            // If metrics is enabled, we send a metric to the screen visited
+            // TODO check if enabled
+            Global.addCentralizedMetricIfEnabled(Constants.navigationMetric, {viewId: root.startupStore.currentStartupState.stateType})
+
             switch (root.startupStore.currentStartupState.stateType) {
             case Constants.startupState.allowNotifications:
                 return allowNotificationsViewComponent

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -35,10 +35,6 @@ OnboardingBasePage {
         id: loader
         anchors.fill: parent
         sourceComponent: {
-            // If metrics is enabled, we send a metric to the screen visited
-            // TODO check if enabled
-            Global.addCentralizedMetricIfEnabled(Constants.navigationMetric, {viewId: root.startupStore.currentStartupState.stateType})
-
             switch (root.startupStore.currentStartupState.stateType) {
             case Constants.startupState.allowNotifications:
                 return allowNotificationsViewComponent

--- a/ui/imports/shared/stores/MetricsStore.qml
+++ b/ui/imports/shared/stores/MetricsStore.qml
@@ -7,9 +7,9 @@ QtObject {
         metrics.toggleCentralizedMetrics(enabled)
     }
 
-    function addCentralizedMetric(eventName, eventValue = null) {
+    function addCentralizedMetricIfEnabled(eventName, eventValue = null) {
         let eventValueJsonStr = !!eventValue ? JSON.stringify(eventValue) : ""
-        metrics.addCentralizedMetric(eventName, eventValueJsonStr)
+        metrics.addCentralizedMetricIfEnabled(eventName, eventValueJsonStr)
     }
 
     readonly property bool isCentralizedMetricsEnabled : metrics.isCentralizedMetricsEnabled

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1473,4 +1473,6 @@ QtObject {
         LessThanFiveMins,
         MoreThanFiveMins
     }
+
+    readonly property string navigationMetric: "navigation"
 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -111,7 +111,7 @@ QtObject {
 
     // Metrics
     signal openMetricsEnablePopupRequested(string placement, var cb)
-    signal addCentralizedMetric(string eventName, var eventValue)
+    signal addCentralizedMetricIfEnabled(string eventName, var eventValue)
 
     signal openAddEditSavedAddressesPopup(var params)
     signal openDeleteSavedAddressesPopup(var params)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -291,7 +291,7 @@ StatusWindow {
         restoreAppState();
 
         Global.openMetricsEnablePopupRequested.connect(openMetricsEnablePopup)
-        Global.addCentralizedMetric.connect(metricsStore.addCentralizedMetric)
+        Global.addCentralizedMetricIfEnabled.connect(metricsStore.addCentralizedMetricIfEnabled)
     }
 
     signal navigateTo(string path)
@@ -383,8 +383,8 @@ StatusWindow {
             onClosed: metricsPopupLoader.active = false
             onToggleMetrics: {
                 applicationWindow.metricsStore.toggleCentralizedMetrics(enabled)
-                if(enabled) {
-                    Global.addCentralizedMetric("usage_data_shared", {placement: metricsPopupLoader.item.placement})
+                if (enabled) {
+                    Global.addCentralizedMetricIfEnabled("usage_data_shared", {placement: metricsPopupLoader.item.placement})
                 }
             }
         }


### PR DESCRIPTION
Fixes #16100

Adds metrics for navigating to the different screens of the onboarding and when navigating to a new section while logged in; only when enabled of course.

I refactored the code a little to make it simpler. I moved the check to see if the metrics collection is enabled in the async task itself, so we don't have to check it each time we add a new metric