### PR TITLE
chore_: allow disabling http/ws api from cli

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -69,6 +69,10 @@ pipeline {
     SQUISH_DIR = '/opt/squish-runner-7.2.1'
     PYTHONPATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/lib/python:${PYTHONPATH}"
     LD_LIBRARY_PATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/python3/lib:${LD_LIBRARY_PATH}"
+    
+    /* To stop e2e tests using port 8545 */
+    STATUS_RUNTIME_HTTP_API = 'False'
+    STATUS_RUNTIME_WS_API = 'False'
 
     /* Avoid race conditions with other builds using virtualenv. */
     VIRTUAL_ENV = "${WORKSPACE_TMP}/venv"

--- a/src/app_service/service/accounts/dto/api_config.nim
+++ b/src/app_service/service/accounts/dto/api_config.nim
@@ -1,6 +1,7 @@
-import json
+import json, net
 
-include ../../../common/net_utils
+import ../../../common/net_utils
+import ../../../../constants as main_constants
 
 type APIConfig* = object
   apiModules*: string
@@ -12,21 +13,15 @@ type APIConfig* = object
   wsHost*: string
   wsPort*: int
 
-proc checkAndSetPort(port: Port, isEnabled: var bool) =
-  if isPortBusy(port):
-    isEnabled = false
-
 proc defaultAPIConfig*(): APIConfig =
   result.apiModules = "connector"
   result.connectorEnabled = true
 
-  result.httpEnabled = true
-  checkAndSetPort(Port(8545), result.httpEnabled)
+  result.httpEnabled = main_constants.HTTP_API_ENABLED and not isPortBusy(Port(8545))
   result.httpHost = "127.0.0.1"
   result.httpPort = 8545
 
-  result.wsEnabled = true
-  checkAndSetPort(Port(8586), result.wsEnabled)
+  result.wsEnabled = main_constants.WS_API_ENABLED and not isPortBusy(Port(8586))
   result.wsHost = "127.0.0.1"
   result.wsPort = 8586
 

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -70,6 +70,8 @@ let
   MIXPANEL_APP_ID* = desktopConfig.mixpanelAppId
   MIXPANEL_TOKEN* = desktopConfig.mixpanelToken
   BUILD_MODE* = if defined(production): "prod" else: "test"
+  HTTP_API_ENABLED* = desktopConfig.httpApiEnabled
+  WS_API_ENABLED* = desktopConfig.wsApiEnabled
 
 proc hasLogLevelOption*(): bool =
   for p in cliParams:

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -270,7 +270,16 @@ type StatusDesktopConfig = object
     desc: "Determines if the app should use mocked keycard"
     name: "USE_MOCKED_KEYCARD"
     abbr: "use-mocked-keycard" .}: bool
-
+  httpApiEnabled* {.
+    defaultValue: true
+    desc: "Enable HTTP RPC API"
+    name: "HTTP_API"
+    abbr: "http-api" .}: bool
+  wsApiEnabled* {.
+    defaultValue: true
+    desc: "Enable WebSocket RPC API"
+    name: "WS_API"
+    abbr: "ws-api" .}: bool
 
 # On macOS the first time when a user gets the "App downloaded from the
 # internet" warning, and clicks the Open button, the OS passes a unique process

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
@@ -38,7 +38,7 @@ def test_wallet_settings_add_saved_address(main_screen: MainWindow, address: str
     with step('Verify recently added saved address is present in the list'):
         assert driver.waitFor(
             lambda: name in settings_saved_addresses.get_saved_address_names_list(),
-            configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {name} not found'
+            configs.timeouts.APP_LOAD_TIMEOUT_MSEC), f'Address: {name} not found'
 
     with step('Verify toast message when adding saved address'):
         messages = main_screen.wait_for_notification()

--- a/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
@@ -65,6 +65,6 @@ def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, 
             f"Toast message about deleting saved address is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that saved address with new name is not in the list of saved addresses'):
-        assert not driver.waitFor(
-            lambda: new_name in wallet.left_panel.open_saved_addresses().get_saved_addresses_list(),
-            configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {new_name} is still present'
+       assert not driver.waitFor(
+           lambda: new_name in wallet.left_panel.open_saved_addresses().get_saved_addresses_list(),
+           configs.timeouts.APP_LOAD_TIMEOUT_MSEC), f'Address: {new_name} is still present'


### PR DESCRIPTION
First step to fix https://github.com/status-im/status-desktop/issues/15846

### What does the PR do

Added 2 new CLI options: `--http-api` and `--ws-api`.
The main use case is e2e tests, which for some reason frequently fail acuirng port 8545.