### PR TITLE
ci: add env vars to prevent autotests hitting 8545

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -69,6 +69,10 @@ pipeline {
     SQUISH_DIR = '/opt/squish-runner-7.2.1'
     PYTHONPATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/lib/python:${PYTHONPATH}"
     LD_LIBRARY_PATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/python3/lib:${LD_LIBRARY_PATH}"
+    
+    /* To stop e2e tests using port 8545 */
+    STATUS_RUNTIME_HTTP_API = 'False'
+    STATUS_RUNTIME_WS_API = 'False'
 
     /* Avoid race conditions with other builds using virtualenv. */
     VIRTUAL_ENV = "${WORKSPACE_TMP}/venv"

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_saved_addresses_add.py
@@ -38,7 +38,7 @@ def test_wallet_settings_add_saved_address(main_screen: MainWindow, address: str
     with step('Verify recently added saved address is present in the list'):
         assert driver.waitFor(
             lambda: name in settings_saved_addresses.get_saved_address_names_list(),
-            configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {name} not found'
+            configs.timeouts.APP_LOAD_TIMEOUT_MSEC), f'Address: {name} not found'
 
     with step('Verify toast message when adding saved address'):
         messages = main_screen.wait_for_notification()

--- a/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
@@ -65,6 +65,6 @@ def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, 
             f"Toast message about deleting saved address is not correct or not present. Current list of messages: {messages}"
 
     with step('Verify that saved address with new name is not in the list of saved addresses'):
-        assert not driver.waitFor(
-            lambda: new_name in wallet.left_panel.open_saved_addresses().get_saved_addresses_list(),
-            configs.timeouts.UI_LOAD_TIMEOUT_MSEC), f'Address: {new_name} is still present'
+       assert not driver.waitFor(
+           lambda: new_name in wallet.left_panel.open_saved_addresses().get_saved_addresses_list(),
+           configs.timeouts.APP_LOAD_TIMEOUT_MSEC), f'Address: {new_name} is still present'


### PR DESCRIPTION
### What does the PR do

Adding env vars to prevent tests hitting 8454
