### PR TITLE
fix(wallet): Filter collectibles filter options

### DIFF
--- a/ui/StatusQ/src/wallet/managetokenscontroller.cpp
+++ b/ui/StatusQ/src/wallet/managetokenscontroller.cpp
@@ -494,9 +494,13 @@ void ManageTokensController::rebuildCommunityTokenGroupsModel()
         if (!communityIds.contains(communityId)) { // insert into groups
             communityIds.append(communityId);
 
+            const auto collectionName =
+                !communityToken.collectionName.isEmpty() ? communityToken.collectionName : communityToken.name;
+
             TokenData tokenGroup;
             tokenGroup.symbol = communityId;
             tokenGroup.communityId = communityId;
+            tokenGroup.collectionName = collectionName;
             tokenGroup.communityName = communityToken.communityName;
             tokenGroup.communityImage = communityToken.communityImage;
             tokenGroup.backgroundColor = communityToken.backgroundColor;
@@ -551,9 +555,13 @@ void ManageTokensController::rebuildHiddenCommunityTokenGroupsModel()
             m_hiddenCommunityGroups.contains(communityId)) { // insert into groups
             communityIds.append(communityId);
 
+            const auto collectionName =
+                !communityToken.collectionName.isEmpty() ? communityToken.collectionName : communityToken.name;
+
             TokenData tokenGroup;
             tokenGroup.symbol = communityId;
             tokenGroup.communityId = communityId;
+            tokenGroup.collectionName = collectionName;
             tokenGroup.communityName = communityToken.communityName;
             tokenGroup.communityImage = communityToken.communityImage;
             tokenGroup.backgroundColor = communityToken.backgroundColor;

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -234,9 +234,10 @@ ColumnLayout {
 
         sourceModel: d.sourceModel
         proxyRoles: [
-            JoinRole {
+            FastExpressionRole {
                 name: "groupName"
-                roleNames: ["collectionName", "communityName"]
+                expression: !!model.communityId ? model.communityName : model.collectionName
+                expectedRoles: ["communityId", "collectionName", "communityName"]
             },
             FastExpressionRole {
                 name: "balance"
@@ -306,7 +307,7 @@ ColumnLayout {
 
     Settings {
         id: settings
-        category: "CollectiblesViewSortSettings"
+        category: "CollectiblesViewSortSettings-" + root.addressFilters
         property int currentSortValue: SortOrderComboBox.TokenOrderDateAdded
         property alias currentSortOrder: cmbTokenOrder.currentSortOrder
         property alias selectedFilterGroupIds: cmbFilter.selectedFilterGroupIds
@@ -336,6 +337,33 @@ ColumnLayout {
 
             FilterComboBox {
                 id: cmbFilter
+                sourceModel: SortFilterProxyModel {
+                    sourceModel: d.sourceModel
+                    proxyRoles: [
+                        FastExpressionRole {
+                            name: "balance"
+                            expression: {
+                                d.addrFilters
+                                return d.getBalance(model.ownership, d.addrFilters)
+                            }
+                            expectedRoles: ["ownership"]
+                        }
+                    ]
+                    filters: [
+                        FastExpressionFilter {
+                            expression: {
+                                return d.nwFilters.includes(model.chainId+"")
+                            }
+                            expectedRoles: ["chainId"]
+                        },
+                        ValueFilter {
+                            roleName: "balance"
+                            value: 0
+                            inverted: true
+                        }
+                    ]
+                }
+
                 regularTokensModel: root.controller.regularTokensModel
                 collectionGroupsModel: root.controller.collectionGroupsModel
                 communityTokenGroupsModel: root.controller.communityTokenGroupsModel


### PR DESCRIPTION
Fixes #15805

### What does the PR do

* Filter collectibles filtering options to only show collectibles that are owned by specific account
* Save filtering options only for specific account
* Show collection name for community collectibles with unkown community name for more readability

### Affected areas

wallet collectible view

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/c5bc06b5-d8b5-41ce-ae1e-309522f7df4e

