### PR TITLE
fix(community): Missing community owner token image

### DIFF
--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -45,8 +45,7 @@ QtObject {
                                   string walletAddress)
 
     // Minting tokens:
-    function deployCollectible(communityId, collectibleItem)
-    {
+    function deployCollectible(communityId, collectibleItem) {
         if (collectibleItem.key !== "")
             deleteToken(communityId, collectibleItem.key)
 
@@ -57,8 +56,7 @@ QtObject {
                                                     collectibleItem.chainId, jsonArtworkFile)
     }
 
-    function deployAsset(communityId, assetItem)
-    {
+    function deployAsset(communityId, assetItem) {
         if (assetItem.key !== "")
             deleteToken(communityId, assetItem.key)
 
@@ -68,11 +66,23 @@ QtObject {
                                                assetItem.infiniteSupply, assetItem.decimals, assetItem.chainId, jsonArtworkFile)
     }
 
-    function deployOwnerToken(communityId, ownerToken, tMasterToken)
-    {
-        const jsonArtworkFile = Utils.getImageAndCropInfoJson(ownerToken.artworkSource, ownerToken.artworkCropRect)
-        communityTokensModuleInst.deployOwnerToken(communityId, ownerToken.accountAddress, ownerToken.name, ownerToken.symbol, ownerToken.description,
-                                                   tMasterToken.name, tMasterToken.symbol, tMasterToken.description, ownerToken.chainId, jsonArtworkFile)
+
+    function deployOwnerToken(communityId, ownerToken, tMasterToken) {
+        function deployOwnerTokenWithArtwork (communityId, artworkSource, ownerToken, tMasterToken) {
+            const jsonArtworkFile = Utils.getImageAndCropInfoJson(artworkSource, ownerToken.artworkCropRect)
+            communityTokensModuleInst.deployOwnerToken(communityId, ownerToken.accountAddress, ownerToken.name, ownerToken.symbol, ownerToken.description,
+                                                       tMasterToken.name, tMasterToken.symbol, tMasterToken.description, ownerToken.chainId, jsonArtworkFile)
+        }
+
+        if (String(ownerToken.artworkSource).startsWith("https://localhost:")) {
+            const ownerTokenCopy = Object.assign({}, ownerToken)
+            const tMasterTokenCopy = Object.assign({}, tMasterToken)
+            Utils.fetchImageBase64(ownerToken.artworkSource, (dataUrl) => {
+                deployOwnerTokenWithArtwork(communityId, dataUrl, ownerTokenCopy, tMasterTokenCopy)
+            })
+        } else {
+            deployOwnerTokenWithArtwork(communityId, ownerToken.artworkSource, ownerToken, tMasterToken);
+        }
     }
 
     function deleteToken(communityId, contractUniqueKey) {
@@ -90,9 +100,9 @@ QtObject {
     }
 
     function ownershipDeclined(communityId, communityName) {
-            communityTokensModuleInst.declineOwnership(communityId)
-            root.communityOwnershipDeclined(communityName)
-        }
+        communityTokensModuleInst.declineOwnership(communityId)
+        root.communityOwnershipDeclined(communityName)
+    }
 
     readonly property Connections connections: Connections {
         target: communityTokensModuleInst


### PR DESCRIPTION
### What does the PR do

(!) suboptimal solution

This issue is a regression after refactoring and sending images as localhost URLs instead of base64 (which is good)
We try to create a token and pass URL as base64 image, SaveCommunityToken(protocol/communities/manager.go) fails to read it.

To keep the old format, I'm fetching image dataUrl (base64) and passing it to the API in the expected format

### Affected areas
owner/master token

### Architecture compliance
I admit the solution is not perfect. Ideally we should update the approach and just pass the community ID and get the image from the database. Not sure how to crop it properly though. And also update status-go (DeploymentParameters and DeployOwnerToken API endpoint)

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/d5340f14-ea88-49ee-a69d-7f337608ed92


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Impact on end user
Should fix missing collectible image

### How to test
Create a community and mint an owner token, make sure the image is not empty

### Risk 

(since minting requires paying fees)
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

fixes #15855