### PR TITLE
chore: add verifications when checking checkboxes on modal

### DIFF
--- a/test/e2e/gui/components/onboarding/before_started_popup.py
+++ b/test/e2e/gui/components/onboarding/before_started_popup.py
@@ -12,8 +12,8 @@ class BeforeStartedPopUp(BasePopup):
     def __init__(self):
         super(BeforeStartedPopUp, self).__init__()
         self._acknowledge_checkbox = CheckBox(names.acknowledge_checkbox)
-        self._acknowledgeIndicator = QObject(names.acknowledgeIndicator)
         self._terms_of_use_checkBox = CheckBox(names.termsOfUseCheckBox_StatusCheckBox)
+        self._acknowledgeIndicator = QObject(names.acknowledgeIndicator)
         self._termsOfUseIndicator = QObject(names.termsOfUseIndicator)
         self._get_started_button = Button(names.getStartedStatusButton_StatusButton)
         self._terms_of_use_link = QObject(names.termsOfUseLink_StatusBaseText)
@@ -27,7 +27,9 @@ class BeforeStartedPopUp(BasePopup):
     @allure.step('Allow all and get started')
     def get_started(self):
         self._acknowledgeIndicator.click()
+        assert self._acknowledge_checkbox.checkState != 0, f"Acknowledge checkbox is not checked"
         self._termsOfUseIndicator.click()
+        assert self._terms_of_use_checkBox.checkState != 0, f"ToU checkbox is not checked"
         assert self._terms_of_use_link.is_visible, f"Terms of use link is missing"
         assert self._privacy_policy_link.is_visible, f"Privacy Policy link is missing"
         self._get_started_button.click()


### PR DESCRIPTION
### What does the PR do

Sometimes tests fail on this screen being unable to check checkbox. In fact, i am not checking checkbox, but i am clicking indicator object that is inside of checkbox 

https://github.com/status-im/status-desktop/blob/de7872546ab2d91bb0b30f1c3c02578b08345717/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml#L46

Locators for the indicators i am clicking (as well as checkboxes) are as follows:

```
acknowledge_checkbox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "acknowledgeCheckBox", "type": "StatusCheckBox", "visible": True}
acknowledgeIndicator = {"container": acknowledge_checkbox, "objectName": "indicator", "type": "Item", "visible": True}
termsOfUseCheckBox_StatusCheckBox = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName":"termsOfUseCheckBox", "type": "StatusCheckBox", "visible": True}
termsOfUseIndicator = {"container": termsOfUseCheckBox_StatusCheckBox, "objectName": "indicator", "type": "Item", "visible": True}
```

I checked log and sometimes indeed test clicks the same object instead of clicking 2 different ones:

```
[2024-08-16 11:34:36,758] (         object.py:170) [INFO   ] --- <gui.main_window.MainWindow object at 0x7f67c0162440>: is visible
[2024-08-16 11:34:36,759] (         window.py:61 ) [INFO   ] --- Window Status Desktop appears
[2024-08-16 11:34:36,761] (         window.py:52 ) [INFO   ] --- <gui.main_window.MainWindow object at 0x7f67c0162440> is visible
[2024-08-16 11:34:36,763] (         window.py:27 ) [INFO   ] --- Window Status Desktop was maximized
[2024-08-16 11:34:36,764] (         window.py:42 ) [INFO   ] --- Window Status Desktop moved on top
[2024-08-16 11:34:36,876] (         object.py:111) [INFO   ] --- <gui.elements.object.QObject object at 0x7f67a46f3040>: is clicked with Qt.LeftButton
[2024-08-16 11:34:36,876] (         object.py:112) [INFO   ] --- Checking if application context is frozen
[2024-08-16 11:34:36,880] (         object.py:111) [INFO   ] --- <gui.elements.object.QObject object at 0x7f67a46f0cd0>: is clicked with Qt.LeftButton
[2024-08-16 11:34:36,880] (         object.py:112) [INFO   ] --- Checking if application context is frozen
```

I dont know why it happens (and only sometimes!) so i decided to add asserts in between , first to make sure checkboxes are checked before moving forward and second, it will add some time to test to not click that fast (maybe this is the reason)

Any ideas from QML experts are also welcomed!

![image](https://github.com/user-attachments/assets/95e2d170-cd8e-40b9-8d53-d3532203de7b)
