### PR TITLE
feat(StatusButton): Add support to show text when button is loading

### DIFF
--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -55,6 +55,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
@@ -73,6 +74,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
@@ -92,6 +94,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
@@ -111,10 +114,10 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         isRoundIcon: true
-                        radius: height/2
                         textFillWidth: ctrlFillWidth.checked
                     }
                 }
@@ -137,6 +140,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
@@ -155,6 +159,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
@@ -174,6 +179,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
@@ -193,6 +199,7 @@ SplitView {
                         textPosition: d.effectiveTextPosition
                         type: ctrlType.currentIndex
                         loading: ctrlLoading.checked
+                        loadingWithText: ctrlLoadingWithText.checked
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         isRoundIcon: true
@@ -283,6 +290,10 @@ SplitView {
                 Switch {
                     id: ctrlLoading
                     text: "Loading"
+                }
+                Switch {
+                    id: ctrlLoadingWithText
+                    text: "Loading with text"
                 }
                 Switch {
                     id: ctrlInteractive

--- a/storybook/qmlTests/tests/tst_StatusButton.qml
+++ b/storybook/qmlTests/tests/tst_StatusButton.qml
@@ -1,0 +1,259 @@
+import QtQuick 2.15
+import QtTest 1.15
+
+import StatusQ.Controls 0.1
+
+import Models 1.0
+
+Item {
+    id: root
+    width: 600
+    height: 400
+
+    Component {
+        id: componentUnderTest
+        StatusButton {
+            anchors.centerIn: parent
+        }
+    }
+
+    SignalSpy {
+        id: signalSpy
+        target: controlUnderTest
+        signalName: "clicked"
+    }
+
+    property StatusButton controlUnderTest: null
+
+    TestCase {
+        name: "StatusButton"
+        when: windowShown
+
+        function cleanup() {
+            if (!!controlUnderTest)
+                controlUnderTest.destroy()
+            signalSpy.clear()
+        }
+
+        function test_defaults() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: "Hello" })
+            verify(!!controlUnderTest)
+            verify(controlUnderTest.width > 0)
+            verify(controlUnderTest.height > 0)
+            verify(controlUnderTest.interactive)
+            verify(controlUnderTest.enabled)
+            verify(!controlUnderTest.loading)
+            verify(!controlUnderTest.loadingWithText)
+            verify(!controlUnderTest.isRoundIcon)
+        }
+
+        function test_text() {
+            const textToTest = "Hello"
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: textToTest })
+            verify(!!controlUnderTest)
+
+            const buttonText = findChild(controlUnderTest, "buttonText")
+            verify(!!buttonText)
+            verify(buttonText.visible)
+            compare(buttonText.text, textToTest)
+
+            // verify the icon is not visible
+            const buttonIcon = findChild(controlUnderTest, "buttonIcon")
+            verify(!!buttonIcon)
+            compare(buttonIcon.item, null)
+        }
+
+        function test_textLeftRight() {
+            const textToTest = "Hello"
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: textToTest, "icon.name": "gif" })
+            verify(!!controlUnderTest)
+            compare(controlUnderTest.textPosition, StatusBaseButton.TextPosition.Right)
+
+            const leftTextLoader = findChild(controlUnderTest, "leftTextLoader")
+            verify(!!leftTextLoader)
+            verify(!leftTextLoader.active)
+
+            const rightTextLoader = findChild(controlUnderTest, "rightTextLoader")
+            verify(!!rightTextLoader)
+            verify(rightTextLoader.active)
+
+            // set the text to appear on the right, verify the text position
+            controlUnderTest.textPosition = StatusBaseButton.TextPosition.Left
+            verify(leftTextLoader.active)
+            verify(!rightTextLoader.active)
+        }
+
+        function test_elideText() {
+            const textToTest = "This is a very long text that should be elided"
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: textToTest })
+            verify(!!controlUnderTest)
+            controlUnderTest.width = 100
+
+            // verify the text is visible and truncated (elided)
+            const buttonText = findChild(controlUnderTest, "buttonText")
+            verify(!!buttonText)
+            verify(buttonText.visible)
+            verify(buttonText.truncated)
+        }
+
+        function test_icon_data() {
+            return [
+                { tag: "empty", name: "", iconVisible: false },
+                { tag: "gif", name: "gif", iconVisible: true },
+                { tag: "invalid", name: "bflmpsvz", iconVisible: false },
+                { tag: "blob", name: ModelsData.icons.status, iconVisible: true },
+                { tag: "fileUrl", name: ModelsData.assets.snt, iconVisible: true },
+            ]
+        }
+
+        function test_icon(data) {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { "icon.name": data.name })
+            verify(!!controlUnderTest)
+
+            const buttonIcon = findChild(controlUnderTest, "buttonIcon")
+            verify(!!buttonIcon)
+
+            if (data.iconVisible)
+                verify(buttonIcon.item.visible)
+
+            // verify the button is square with rounded edges
+            compare(controlUnderTest.width, controlUnderTest.height)
+            verify(controlUnderTest.radius != controlUnderTest.width/2)
+
+            // verify the text is not visible
+            const buttonText = findChild(controlUnderTest, "buttonText")
+            compare(buttonText, null)
+        }
+
+        function test_roundIcon() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { "icon.name": "gif", "isRoundIcon": true })
+            verify(!!controlUnderTest)
+
+            const buttonIcon = findChild(controlUnderTest, "buttonIcon")
+            verify(!!buttonIcon)
+            verify(buttonIcon.item.visible)
+
+            // verify that the button is rounded
+            compare(controlUnderTest.width, controlUnderTest.height)
+            compare(controlUnderTest.radius, controlUnderTest.width/2)
+        }
+
+        function test_emoji() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: "Hello" })
+            verify(!!controlUnderTest)
+
+            const buttonEmoji = findChild(controlUnderTest, "buttonEmoji")
+            verify(!!buttonEmoji)
+            verify(!buttonEmoji.visible)
+
+            // set some emoji, verify it's visible
+            controlUnderTest.asset.emoji = "💩"
+            verify(buttonEmoji.visible)
+
+            // unset the emoji, verify it's not visible
+            controlUnderTest.asset.emoji = ""
+            verify(!buttonEmoji.visible)
+        }
+
+        function test_textAndIcon_data() {
+            return test_icon_data()
+        }
+
+        function test_textAndIcon(data) {
+            const textToTest = "Hello"
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: textToTest, "icon.name": data.name })
+            verify(!!controlUnderTest)
+
+            const buttonIcon = findChild(controlUnderTest, "buttonIcon")
+            verify(!!buttonIcon)
+
+            if (data.iconVisible)
+                verify(buttonIcon.item.visible)
+
+            // verify the button is not square/round
+            verify(controlUnderTest.width > controlUnderTest.height)
+
+            // verify the text is visible too
+            const buttonText = findChild(controlUnderTest, "buttonText")
+            verify(!!buttonText)
+            verify(buttonText.visible)
+            compare(buttonText.text, textToTest)
+        }
+
+        function test_interactiveAndEnabled_data() {
+            return [
+                { tag: "enabled", enabled: true, interactive: true, spyCount: 1, tooltip: true },
+                { tag: "not enabled + interactive", enabled: false, interactive: true, spyCount: 0, tooltip: false },
+                { tag: "enabled + not interactive", enabled: true, interactive: false, spyCount: 0, tooltip: true },
+                { tag: "not enabled + not interactive", enabled: false, interactive: false, spyCount: 0, tooltip: false },
+            ]
+        }
+
+        function test_interactiveAndEnabled(data) {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: "Hello", "tooltip.text": "This is a tooltip" })
+            verify(!!controlUnderTest)
+            controlUnderTest.enabled = data.enabled
+            controlUnderTest.interactive = data.interactive
+
+            // verify the tooltip is visible in interactive or enabled when hovered
+            const buttonTooltip = findChild(controlUnderTest, "buttonTooltip")
+            verify(!!buttonTooltip)
+            mouseMove(controlUnderTest, controlUnderTest.width/2, controlUnderTest.height/2)
+            waitForItemPolished(buttonTooltip.contentItem)
+            tryCompare(buttonTooltip, "opened", data.tooltip)
+
+            // verify the click goes thru (or not) as expected
+            mouseClick(controlUnderTest)
+            compare(signalSpy.count, data.spyCount)
+        }
+
+        function test_loadingIndicators() {
+            controlUnderTest =
+                    createTemporaryObject(componentUnderTest, root,
+                                          { text: "Hello", "icon.name": "gif", "asset.emoji": "💩", "tooltip.text": "This is a tooltip" })
+            verify(!!controlUnderTest)
+
+            const buttonIcon = findChild(controlUnderTest, "buttonIcon")
+            verify(!!buttonIcon)
+            compare(buttonIcon.visible, true)
+
+            const buttonText = findChild(controlUnderTest, "buttonText")
+            verify(!!buttonText)
+            compare(buttonText.visible, true)
+
+            const buttonEmoji = findChild(controlUnderTest, "buttonEmoji")
+            verify(!!buttonEmoji)
+            compare(buttonEmoji.visible, true)
+
+            const loadingIndicator = findChild(controlUnderTest, "loadingIndicator")
+            verify(!!loadingIndicator)
+            compare(loadingIndicator.visible, false)
+            compare(controlUnderTest.contentItem.opacity, 1)
+
+            // verify when the overall indicator is running, nothing else is visible
+            controlUnderTest.loading = true
+            compare(loadingIndicator.visible, true)
+            compare(controlUnderTest.contentItem.opacity, 0) // the loading indicator is above the contentItem
+
+            // stop the loadingIndicator, verify icon, emoji and text are visible again
+            controlUnderTest.loading = false
+            compare(loadingIndicator.visible, false)
+            compare(controlUnderTest.contentItem.opacity, 1)
+            compare(buttonIcon.visible, true)
+            compare(buttonText.visible, true)
+            compare(buttonEmoji.visible, true)
+
+            // start the loadingWithText indicator, verify it and text are visible, icon and emoji not
+            const loadingWithTextIndicator = findChild(controlUnderTest, "loadingWithTextIndicator")
+            verify(!!loadingWithTextIndicator)
+            verify(!controlUnderTest.loadingWithText)
+            compare(loadingWithTextIndicator.visible, false)
+
+            controlUnderTest.loadingWithText = true
+            compare(loadingWithTextIndicator.visible, true)
+            compare(buttonIcon.visible, false)
+            compare(buttonText.visible, true)
+            compare(buttonEmoji.visible, false)
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -570,7 +570,7 @@ Item {
             // Check max fees values and sign button state when nothing is set
             compare(maxFeesText.text, qsTr("Max fees:"))
             compare(maxFeesValue.text, "--")
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             verify(!errorTag.visible)
 
             // set input values in the form correctly
@@ -606,7 +606,7 @@ Item {
             compare(root.swapAdaptor.swapOutputData.hasError, true)
             verify(errorTag.visible)
             verify(errorTag.text, qsTr("An error has occured, please try again"))
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             compare(signButton.text, qsTr("Swap"))
 
             // verfy input and output panels
@@ -644,7 +644,7 @@ Item {
             compare(root.swapAdaptor.swapOutputData.hasError, true)
             verify(errorTag.visible)
             verify(errorTag.text, qsTr("Insufficient funds for swap"))
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             compare(signButton.text, qsTr("Swap"))
 
             // verfy input and output panels
@@ -682,7 +682,7 @@ Item {
             compare(root.swapAdaptor.swapOutputData.hasError, true)
             verify(errorTag.visible)
             verify(errorTag.text, qsTr("Insufficient funds to pay gas fees"))
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             compare(signButton.text, qsTr("Swap"))
 
             // verfy input and output panels
@@ -720,7 +720,7 @@ Item {
             compare(root.swapAdaptor.swapOutputData.hasError, true)
             verify(errorTag.visible)
             verify(errorTag.text, qsTr("Fetching the price took longer than expected. Please, try again later."))
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             compare(signButton.text, qsTr("Swap"))
 
             // verfy input and output panels
@@ -758,7 +758,7 @@ Item {
             compare(root.swapAdaptor.swapOutputData.hasError, true)
             verify(errorTag.visible)
             verify(errorTag.text, qsTr("Not enough liquidity. Lower token amount or try again later."))
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             compare(signButton.text, qsTr("Swap"))
 
             // verfy input and output panels
@@ -1487,7 +1487,7 @@ Item {
 
             // Check max fees values and sign button state when nothing is set
             compare(maxFeesValue.text, "--")
-            verify(!signButton.enabled)
+            verify(!signButton.interactive)
             verify(!errorTag.visible)
 
             // set input values in the form correctly
@@ -1536,7 +1536,7 @@ Item {
 
             verify(!errorTag.visible)
             verify(signButton.enabled)
-            verify(!signButton.loading)
+            verify(!signButton.loadingWithText)
             compare(signButton.text, qsTr("Approve %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
@@ -1549,8 +1549,8 @@ Item {
             verify(root.swapAdaptor.approvalPending)
             verify(!root.swapAdaptor.approvalSuccessful)
             verify(!errorTag.visible)
-            verify(!signButton.enabled)
-            verify(signButton.loading)
+            verify(!signButton.interactive)
+            verify(signButton.loadingWithText)
             compare(signButton.text, qsTr("Approving %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
@@ -1564,7 +1564,7 @@ Item {
             verify(!root.swapAdaptor.approvalSuccessful)
             verify(!errorTag.visible)
             verify(signButton.enabled)
-            verify(!signButton.loading)
+            verify(!signButton.loadingWithText)
             compare(signButton.text, qsTr("Approve %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
@@ -1578,8 +1578,8 @@ Item {
             verify(root.swapAdaptor.approvalPending)
             verify(!root.swapAdaptor.approvalSuccessful)
             verify(!errorTag.visible)
-            verify(!signButton.enabled)
-            verify(signButton.loading)
+            verify(!signButton.interactive)
+            verify(signButton.loadingWithText)
             compare(signButton.text, qsTr("Approving %1").arg(root.swapAdaptor.fromToken.symbol))
             // TODO: note that there is a loss of precision as the approvalGasFees is currently passes as float from the backend and not string.
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
@@ -1599,8 +1599,8 @@ Item {
             verify(!root.swapAdaptor.approvalPending)
             verify(!root.swapAdaptor.approvalSuccessful)
             verify(!errorTag.visible)
-            verify(!signButton.enabled)
-            verify(!signButton.loading)
+            verify(!signButton.interactive)
+            verify(!signButton.loadingWithText)
             compare(signButton.text, qsTr("Swap"))
             compare(maxFeesValue.text,  Constants.dummyText)
 
@@ -1612,7 +1612,7 @@ Item {
             verify(!root.swapAdaptor.approvalSuccessful)
             verify(!errorTag.visible)
             verify(signButton.enabled)
-            verify(!signButton.loading)
+            verify(!signButton.loadingWithText)
             compare(signButton.text, qsTr("Swap"))
             compare(maxFeesValue.text, root.swapAdaptor.currencyStore.formatCurrencyAmount(
                         root.swapAdaptor.swapOutputData.totalFees,

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -86,7 +86,6 @@ Item {
                 StatusButton {
                     id: reloadButton
                     size: StatusBaseButton.Size.Tiny
-                    loadingIndicatorSize: size
                     height: parent.height
                     width: height
                     borderColor: Theme.palette.directColor7

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -399,12 +399,10 @@ StatusDialog {
                         loading: root.swapAdaptor.swapProposalLoading
                     }
                 }
-                /* TODO: https://github.com/status-im/status-desktop/issues/15313
-                will introduce having loading button and showing text on the side*/
                 StatusButton {
                     objectName: "signButton"
                     readonly property string fromTokenSymbol: !!root.swapAdaptor.fromToken ? root.swapAdaptor.fromToken.symbol ?? "" : ""
-                    loading: root.swapAdaptor.approvalPending
+                    loadingWithText: root.swapAdaptor.approvalPending
                     icon.name: root.swapAdaptor.selectedAccount.migratedToKeycard ? Constants.authenticationIconByType[Constants.LoginType.Keycard]
                                                                                   : Constants.authenticationIconByType[root.loginType]
                     text: {
@@ -421,10 +419,10 @@ StatusDialog {
                                   root.swapAdaptor.swapOutputData.approvalNeeded ?
                                       qsTr("Approve %1 spending cap to Swap").arg(fromTokenSymbol) : ""
                     disabledColor: Theme.palette.directColor8
-                    enabled: root.swapAdaptor.validSwapProposalReceived &&
-                             editSlippagePanel.valid &&
-                             !d.isError &&
-                             !root.swapAdaptor.approvalPending
+                    interactive: root.swapAdaptor.validSwapProposalReceived &&
+                                 editSlippagePanel.valid &&
+                                 !d.isError &&
+                                 !root.swapAdaptor.approvalPending
                     onClicked: {
                         if (root.swapAdaptor.validSwapProposalReceived) {
                             if (root.swapAdaptor.swapOutputData.approvalNeeded)


### PR DESCRIPTION
### What does the PR do

- add a secondary "loading" state (`loadingWithText`), that is show the loading indicator next to the text
- simplify the StatusBaseButton layout (esp. handling the overall opacity/visibility)
- add a QML test suite; the code was becoming too complex and adding a simple boolean prop was getting "dangerous"
- port the SwapModal to use the new `loadingWithText` property

Fixes #15313

### Affected areas

Status(Base)Button

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

SwapModal approval pending:
![image](https://github.com/user-attachments/assets/cf187282-b519-4be3-90f8-0a65e6e38fb0)

Loading with text:
![image](https://github.com/user-attachments/assets/73aa057d-65bc-43f6-a0fa-0d7bf74bd651)

Loading:
![image](https://github.com/user-attachments/assets/09463975-369b-4d34-8ae3-8ffebe704228)
