### PR TITLE
ci: adding more output for pytest when running tests

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -171,7 +171,7 @@ pipeline {
           ]) {
             /* Keep the --reruns flag first, or it won't work */
             sh """
-              python3 -m pytest --reruns=1 --timeout=180 ${flags.join(" ")} \
+              python3 -m pytest -v --reruns=1 --timeout=180 ${flags.join(" ")} \
                 --disable-warnings \
                 --alluredir=./allure-results \
                 -o timeout_func_only=true


### PR DESCRIPTION
### What does the PR do

Adding more output during tests execution so it is more readable real time

<img width="1319" alt="Screenshot 2024-08-19 at 18 52 32" src="https://github.com/user-attachments/assets/eb6836b3-4e8e-4d9e-997a-5b85fdef7a12">


### Affected areas

Only tests
