### PR TITLE
[CHERRY-PICK] feat(metrics): add onboarding screen metrics and section navigation 

### DIFF
--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -57,4 +57,4 @@ QtObject:
 
   proc showCommunityMemberUnbannedNotification*(self: GlobalEvents, sectionId: string, title: string, message: string) {.signal.}
 
-  proc addCentralizedMetric*(self: GlobalEvents, eventName: string, eventValueJson: string) {.signal.}
+  proc addCentralizedMetricIfEnabled*(self: GlobalEvents, eventName: string, eventValueJson: string) {.signal.}

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, browsers
+import NimQml, tables, json, sugar, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, browsers, strutils
 
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model
@@ -883,6 +883,15 @@ method activeSectionSet*[T](self: Module[T], sectionId: string, skipSavingInSett
   case sectionId:
     of conf.COMMUNITIESPORTAL_SECTION_ID:
       self.communitiesModule.onActivated()
+
+  # If metrics are enabled, send a navigation event
+  var sectionIdToSend = sectionId
+  if sectionId == singletonInstance.userProfile.getPubKey():
+    sectionIdToSend = conf.CHAT_SECTION_NAME
+  elif sectionId.startsWith("0x"):
+    # This is a community
+    sectionIdToSend = "community"
+  singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", $(%*{"viewId": sectionIdToSend}))
 
   self.view.model().setActiveSection(sectionId)
   self.view.activeSectionSet(item)

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -1,5 +1,6 @@
-import NimQml, chronicles
+import NimQml, chronicles, json
 import io_interface
+import ../../global/global_singleton
 import selected_login_account
 import internal/[state, state_wrapper]
 import models/login_account_model as login_acc_model
@@ -74,6 +75,9 @@ QtObject:
     return self.currentStartupState.getStateObj()
 
   proc setCurrentStartupState*(self: View, state: State) =
+    # If metrics is enabled, we send a metric of the screen visited
+    singletonInstance.globalEvents.addCentralizedMetricIfEnabled("navigation", $(%*{"viewId": state.stateType, "flowType": state.flowType}))
+
     self.currentStartupState.setStateObj(state)
   proc getCurrentStartupState(self: View): QVariant {.slot.} =
     return self.currentStartupStateVariant

--- a/src/app_service/service/metrics/service.nim
+++ b/src/app_service/service/metrics/service.nim
@@ -8,6 +8,18 @@ import status_go
 import constants
 import ./dto
 
+proc getIsCentralizedMetricsEnabled*(): bool =
+  try:
+    let response = status_go.centralizedMetricsInfo()
+    let jsonObj = response.parseJson
+    if jsonObj.hasKey("error"):
+      error "isCentralizedMetricsEnabled", errorMsg=jsonObj["error"].getStr
+      return false
+    let metricsInfo = toCentralizedMetricsInfoDto(jsonObj)
+    return metricsInfo.enabled
+  except Exception:
+    return false
+
 include async_tasks
 
 logScope:
@@ -16,6 +28,7 @@ logScope:
 QtObject:
   type MetricsService* = ref object of QObject
     threadpool: ThreadPool
+    metricsEnabled: bool
 
   proc delete*(self: MetricsService) =
     self.QObject.delete
@@ -25,48 +38,42 @@ QtObject:
     result.QObject.setup
     result.threadpool = threadpool
 
-    signalConnect(singletonInstance.globalEvents, "addCentralizedMetric(QString, QString)",
-      result, "addCentralizedMetric(QString, QString)", 2)
+    signalConnect(singletonInstance.globalEvents, "addCentralizedMetricIfEnabled(QString, QString)",
+      result, "addCentralizedMetricIfEnabled(QString, QString)", 2)
 
   # eventValueJson is a json string
-  proc addCentralizedMetric*(self: MetricsService, eventName: string, eventValueJson: string) {.slot.} =
-    let arg = AsyncAddCentralizedMetricTaskArg(
-      tptr: asyncAddCentralizedMetricTask,
+  proc addCentralizedMetricIfEnabled*(self: MetricsService, eventName: string, eventValueJson: string) {.slot.} =
+    let arg = AsyncAddCentralizedMetricIfEnabledTaskArg(
+      tptr: asyncAddCentralizedMetricIfEnabledTask,
       vptr: cast[ByteAddress](self.vptr),
-      slot: "onCentralizedMetricAdded",
+      slot: "onCentralizedMetricAddedIdEnabled",
       eventName: eventName,
       eventValueJson: eventValueJson,
     )
     self.threadpool.start(arg)
 
-  proc onCentralizedMetricAdded*(self: MetricsService, response: string) {.slot.} =
+  proc onCentralizedMetricAddedIdEnabled*(self: MetricsService, response: string) {.slot.} =
     try:
       let responseObj = response.parseJson
       let errorString = responseObj{"error"}.getStr()
       if errorString != "":
-        error "onCentralizedMetricAdded", error=errorString
+        error "onCentralizedMetricAddedIdEnabled", error=errorString
+        return
+      
+      if responseObj{"metricsDisabled"}.getBool:
         return
 
-      debug "onCentralizedMetricAdded", metricId=responseObj{"metricId"}.getStr()
+      debug "onCentralizedMetricAddedIdEnabled", metricId=responseObj{"metricId"}.getStr()
     except Exception as e:
-      error "onCentralizedMetricAdded", exceptionMsg = e.msg
+      error "onCentralizedMetricAddedIdEnabled", exceptionMsg = e.msg
 
-  proc centralizedMetricsEnabledChaned*(self: MetricsService) {.signal.}
+  proc centralizedMetricsEnabledChanged*(self: MetricsService) {.signal.}
   proc isCentralizedMetricsEnabled*(self: MetricsService): bool {.slot.} =
-    try:
-      let response = status_go.centralizedMetricsInfo()
-      let jsonObj = response.parseJson
-      if jsonObj.hasKey("error"):
-        error "isCentralizedMetricsEnabled", errorMsg=jsonObj["error"].getStr
-        return false
-      let metricsInfo = toCentralizedMetricsInfoDto(jsonObj)
-      return metricsInfo.enabled
-    except Exception:
-      return false
+    return getIsCentralizedMetricsEnabled()
 
   QtProperty[bool] isCentralizedMetricsEnabled:
     read = isCentralizedMetricsEnabled
-    notify = centralizedMetricsEnabledChaned
+    notify = centralizedMetricsEnabledChanged
 
   proc toggleCentralizedMetrics*(self: MetricsService, enabled: bool) {.slot.} =
     try:
@@ -79,6 +86,6 @@ QtObject:
       if jsonObj{"error"}.getStr.len > 0:
         error "toggleCentralizedMetrics", errorMsg=jsonObj["error"].getStr
       else:
-        self.centralizedMetricsEnabledChaned()
+        self.centralizedMetricsEnabledChanged()
     except Exception as e:
       error "toggleCentralizedMetrics", exceptionMsg = e.msg

--- a/ui/imports/shared/stores/MetricsStore.qml
+++ b/ui/imports/shared/stores/MetricsStore.qml
@@ -7,9 +7,9 @@ QtObject {
         metrics.toggleCentralizedMetrics(enabled)
     }
 
-    function addCentralizedMetric(eventName, eventValue = null) {
+    function addCentralizedMetricIfEnabled(eventName, eventValue = null) {
         let eventValueJsonStr = !!eventValue ? JSON.stringify(eventValue) : ""
-        metrics.addCentralizedMetric(eventName, eventValueJsonStr)
+        metrics.addCentralizedMetricIfEnabled(eventName, eventValueJsonStr)
     }
 
     readonly property bool isCentralizedMetricsEnabled : metrics.isCentralizedMetricsEnabled

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1460,4 +1460,6 @@ QtObject {
         LessThanFiveMins,
         MoreThanFiveMins
     }
+
+    readonly property string navigationMetric: "navigation"
 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -106,7 +106,7 @@ QtObject {
 
     // Metrics
     signal openMetricsEnablePopupRequested(string placement, var cb)
-    signal addCentralizedMetric(string eventName, var eventValue)
+    signal addCentralizedMetricIfEnabled(string eventName, var eventValue)
 
     signal openAddEditSavedAddressesPopup(var params)
     signal openDeleteSavedAddressesPopup(var params)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -289,7 +289,7 @@ StatusWindow {
         restoreAppState();
 
         Global.openMetricsEnablePopupRequested.connect(openMetricsEnablePopup)
-        Global.addCentralizedMetric.connect(metricsStore.addCentralizedMetric)
+        Global.addCentralizedMetricIfEnabled.connect(metricsStore.addCentralizedMetricIfEnabled)
     }
 
     signal navigateTo(string path)
@@ -381,8 +381,8 @@ StatusWindow {
             onClosed: metricsPopupLoader.active = false
             onToggleMetrics: {
                 applicationWindow.metricsStore.toggleCentralizedMetrics(enabled)
-                if(enabled) {
-                    Global.addCentralizedMetric("usage_data_shared", {placement: metricsPopupLoader.item.placement})
+                if (enabled) {
+                    Global.addCentralizedMetricIfEnabled("usage_data_shared", {placement: metricsPopupLoader.item.placement})
                 }
             }
         }


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/16112

* feat(metrics): add onboarding screen metrics and section navigation

Fixes #16100

Adds metrics for navigating to the different screens of the onboarding and when navigating to a new section while logged in; only when enabled of course.

I refactored the code a little to make it simpler. I moved the check to see if the metrics collection is enabled in the async task itself, so we don't have to check it each time we add a new metric
