### PR TITLE
[CHERRY-PICK] chore(connector): disable connector flag and WS server by  default

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -3,9 +3,9 @@ import os
 
 const DEFAULT_FLAG_DAPPS_ENABLED = false
 const DEFAULT_FLAG_SWAP_ENABLED = true
-const DEFAULT_FLAG_CONNECTOR_ENABLED = true
+const DEFAULT_FLAG_CONNECTOR_ENABLED* = false
 
-proc boolToEnv(defaultValue: bool): string =
+proc boolToEnv*(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"
 
 QtObject:

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -1,5 +1,7 @@
 import os, sequtils, strutils, stew/shims/strformat, chronicles
 
+import app/global/feature_flags
+
 import # vendor libs
   confutils
 
@@ -261,12 +263,12 @@ type StatusDesktopConfig = object
     name: "USE_MOCKED_KEYCARD"
     abbr: "use-mocked-keycard" .}: bool
   httpApiEnabled* {.
-    defaultValue: true
+    defaultValue: getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
     desc: "Enable HTTP RPC API"
     name: "HTTP_API"
     abbr: "http-api" .}: bool
   wsApiEnabled* {.
-    defaultValue: true
+    defaultValue: getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
     desc: "Enable WebSocket RPC API"
     name: "WS_API"
     abbr: "ws-api" .}: bool


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/16139

Also includes the fix from [the comment](https://github.com/status-im/status-desktop/pull/16139#discussion_r1720716474) by @caybro 

Fixes #16101
