### PR TITLE
fix(ac): cache ac unread count and hasUnread in the view

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -71,6 +71,10 @@ proc init*(self: Controller) =
     self.delegate.onNotificationsCountMayHaveChanged()
     self.updateActivityGroupCounters()
 
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_UNSEEN_UPDATED) do(e: Args):
+    var evArgs = ActivityCenterNotificationHasUnseen(e)
+    self.delegate.onUnseenChanged(evArgs.hasUnseen)
+
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_REMOVED) do(e: Args):
     var evArgs = ActivityCenterNotificationIdsArgs(e)
     if (evArgs.notificationIds.len > 0):

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -24,10 +24,16 @@ method hasMoreToShow*(self: AccessInterface): bool {.base.} =
 method unreadActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method unreadActivityCenterNotificationsCountFromView*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method hasUnseenActivityCenterNotifications*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onNotificationsCountMayHaveChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onUnseenChanged*(self: AccessInterface, hasUnseen: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method hasUnseenActivityCenterNotificationsChanged*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -61,23 +61,30 @@ method load*(self: Module) =
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 
-method viewDidLoad*(self: Module) =
-  self.moduleLoaded = true
-  self.delegate.activityCenterDidLoad()
-
-method hasMoreToShow*(self: Module): bool =
-  self.controller.hasMoreToShow()
-
 method unreadActivityCenterNotificationsCount*(self: Module): int =
   self.controller.unreadActivityCenterNotificationsCount()
+
+method unreadActivityCenterNotificationsCountFromView*(self: Module): int =
+  self.view.unreadCount()
 
 method hasUnseenActivityCenterNotifications*(self: Module): bool =
   self.controller.hasUnseenActivityCenterNotifications()
 
+method viewDidLoad*(self: Module) =
+  self.moduleLoaded = true
+  self.delegate.activityCenterDidLoad()
+  self.view.setUnreadCount(self.unreadActivityCenterNotificationsCount())
+  self.view.setHasUnseen(self.hasUnseenActivityCenterNotifications())
+
+method hasMoreToShow*(self: Module): bool =
+  self.controller.hasMoreToShow()
+
 method onNotificationsCountMayHaveChanged*(self: Module) =
-  self.view.unreadActivityCenterNotificationsCountChanged()
-  self.view.hasUnseenActivityCenterNotificationsChanged()
+  self.view.setUnreadCount(self.unreadActivityCenterNotificationsCount())
   self.delegate.onActivityNotificationsUpdated()
+
+method onUnseenChanged*(self: Module, hasUnseen: bool) =
+  self.view.setHasUnseen(hasUnseen)
 
 proc createMessageItemFromDto(self: Module, message: MessageDto, communityId: string, albumMessages: seq[MessageDto]): MessageItem =
   let contactDetails = self.controller.getContactDetails(message.`from`)
@@ -221,7 +228,6 @@ method markAllActivityCenterNotificationsRead*(self: Module): string =
 
 method markAllActivityCenterNotificationsReadDone*(self: Module) =
   self.view.markAllActivityCenterNotificationsReadDone()
-  self.view.unreadActivityCenterNotificationsCountChanged()
 
 method markActivityCenterNotificationRead*(self: Module, notificationId: string) =
   self.controller.markActivityCenterNotificationRead(notificationId)
@@ -229,7 +235,6 @@ method markActivityCenterNotificationRead*(self: Module, notificationId: string)
 method markActivityCenterNotificationReadDone*(self: Module, notificationIds: seq[string]) =
   for notificationId in notificationIds:
     self.view.markActivityCenterNotificationReadDone(notificationId)
-  self.view.unreadActivityCenterNotificationsCountChanged()
 
 method markAsSeenActivityCenterNotifications*(self: Module) =
   self.controller.markAsSeenActivityCenterNotifications()
@@ -259,7 +264,6 @@ method dismissActivityCenterNotificationDone*(self: Module, notificationId: stri
 method markActivityCenterNotificationUnreadDone*(self: Module, notificationIds: seq[string]) =
   for notificationId in notificationIds:
     self.view.markActivityCenterNotificationUnreadDone(notificationId)
-  self.view.unreadActivityCenterNotificationsCountChanged()
 
 method removeActivityCenterNotifications*(self: Module, notificationIds: seq[string]) =
   self.view.removeActivityCenterNotifications(notificationIds)

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -12,6 +12,7 @@ QtObject:
       modelVariant: QVariant
       groupCounters: Table[ActivityCenterGroup, int]
       unreadCount: int
+      hasUnseen: bool
 
   proc delete*(self: View) =
     self.QObject.delete
@@ -24,6 +25,7 @@ QtObject:
     result.modelVariant = newQVariant(result.model)
     result.groupCounters = initTable[ActivityCenterGroup, int]()
     result.unreadCount = 0
+    result.hasUnseen = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -52,21 +54,32 @@ QtObject:
   proc unreadActivityCenterNotificationsCountChanged*(self: View) {.signal.}
 
   proc unreadActivityCenterNotificationsCount*(self: View): int {.slot.} =
-    self.unreadCount = self.delegate.unreadActivityCenterNotificationsCount()
     return self.unreadCount
 
   QtProperty[int] unreadActivityCenterNotificationsCount:
     read = unreadActivityCenterNotificationsCount
     notify = unreadActivityCenterNotificationsCountChanged
 
+  proc setUnreadCount*(self: View, count: int) =
+    if self.unreadCount == count:
+      return
+    self.unreadCount = count
+    self.unreadActivityCenterNotificationsCountChanged()
+
   proc hasUnseenActivityCenterNotificationsChanged*(self: View) {.signal.}
 
   proc hasUnseenActivityCenterNotifications*(self: View): bool {.slot.} =
-    self.delegate.hasUnseenActivityCenterNotifications()
+    return self.hasUnseen
 
   QtProperty[bool] hasUnseenActivityCenterNotifications:
     read = hasUnseenActivityCenterNotifications
     notify = hasUnseenActivityCenterNotificationsChanged
+
+  proc setHasUnseen*(self: View, hasUnseen: bool) =
+    if self.hasUnseen == hasUnseen:
+      return
+    self.hasUnseen = hasUnseen
+    self.hasUnseenActivityCenterNotificationsChanged()
 
   proc fetchActivityCenterNotifications(self: View) {.slot.} =
     self.delegate.fetchActivityCenterNotifications()

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -972,7 +972,7 @@ method onChatLeft*[T](self: Module[T], chatId: string) =
 
 proc checkIfWeHaveNotifications[T](self: Module[T]) =
   let sectionWithUnread = self.view.model().isThereASectionWithUnreadMessages()
-  let activtyCenterNotifications = self.activityCenterModule.unreadActivityCenterNotificationsCount() > 0
+  let activtyCenterNotifications = self.activityCenterModule.unreadActivityCenterNotificationsCountFromView() > 0
   self.view.setNotificationAvailable(sectionWithUnread or activtyCenterNotifications)
 
 method onActivityNotificationsUpdated[T](self: Module[T]) =


### PR DESCRIPTION
Fixes #16023

Caches the values of the number of notifications and hasUnseen in the view so that we access status-go only when there is an update or on app start. Also, uses the response value from user actions in the AC to retrieve the hasUnseen value directly instead of re-fetching. Finally, fixes an issue where marking notifs as read/unread wouldn't update the count

[ac-count.webm](https://github.com/user-attachments/assets/b6d14b4a-5b61-4890-b800-a476112a970a)
