### PR TITLE
fix(StatusBaseButton): correct radius and icon size for `isRoundIcon` mode

### DIFF
--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -203,7 +203,6 @@ SplitView {
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         isRoundIcon: true
-                        radius: height/2
                         textFillWidth: ctrlFillWidth.checked
                     }
                 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBackButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBackButton.qml
@@ -3,6 +3,5 @@ import StatusQ.Controls 0.1
 
 StatusButton {
     isRoundIcon: true
-    radius: height/2
     icon.name: "arrow-left"
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -50,7 +50,7 @@ Button {
     property int borderWidth: 0
     property bool textFillWidth: false
 
-    property int radius: isRoundIcon ? height/2 : size === StatusBaseButton.Size.Tiny ? 6 : 8
+    property int radius: isRoundIcon && d.iconOnly ? height/2 : size === StatusBaseButton.Size.Tiny ? 6 : 8
 
     property int size: StatusBaseButton.Size.Large
     property int type: StatusBaseButton.Type.Normal
@@ -241,8 +241,8 @@ Button {
 
         StatusRoundIcon {
             asset.name: root.icon.name
-            asset.width: root.icon.width
-            asset.height: root.icon.height
+            asset.width: d.iconSize
+            asset.height: d.iconSize
             asset.color: root.icon.color
             asset.bgColor: root.asset.bgColor
         }

--- a/ui/app/AppLayouts/Wallet/controls/SwapExchangeButton.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SwapExchangeButton.qml
@@ -13,7 +13,6 @@ StatusButton {
 
     focusPolicy: Qt.NoFocus
     isRoundIcon: true
-    radius: height/2
     normalColor: Theme.palette.indirectColor3
     disabledColor: normalColor
     opacity: enabled ? 1 : 0.4


### PR DESCRIPTION
### What does the PR do

- this fixes 2 small regressions, namely in how we calculate the background corner radius and icon size when in the mode of `isRoundIcon`
- the "Saved addresses" button in wallet's left view is very special on its own; overall we have only 3 instances of this "round" icon buttons in the whole app (only the first was affected)

Fixes #16156

### Affected areas

StatusBaseButton

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Wallet left view (Saved addresses):
![image](https://github.com/user-attachments/assets/6a84a99e-3e69-42ac-b154-2e373bfff0c3)

Swap exchange button:
![image](https://github.com/user-attachments/assets/48b66cc8-8e8d-4000-98d1-62ffc455307d)

Sticker back button:
![image](https://github.com/user-attachments/assets/aec72674-0955-4871-a112-38ce7e8b13db)
