### PR TITLE
fix(wallet): Fill bridge tx type

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -383,6 +383,8 @@ QtObject:
       return transactions.MultiTransactionType.MultiTransactionSwap
     of SendType.Approve:
       return transactions.MultiTransactionType.MultiTransactionApprove
+    of SendType.Bridge:
+      return transactions.MultiTransactionType.MultiTransactionBridge
     else:
       return transactions.MultiTransactionType.MultiTransactionSend
 

--- a/ui/app/AppLayouts/Wallet/popups/TransactionAddressMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/TransactionAddressMenu.qml
@@ -345,7 +345,6 @@ StatusMenu {
     StatusAction {
         id: sendToAddressAction
         enabled: false
-        visibleOnDisabled: true
         text: {
             switch(d.addressType) {
             case TransactionAddressMenu.AddressType.Sender:

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -101,7 +101,7 @@ Item {
             return outSymbol || !transaction.tokenOutAddress ? formatted : "%1 (%2)".arg(formatted).arg(Utils.compactAddress(transaction.tokenOutAddress, 4))
         }
         readonly property real feeEthValue: d.details ? RootStore.getFeeEthValue(d.details.totalFees) : 0
-        readonly property real feeFiatValue: d.isTransactionValid ? RootStore.getFiatValue(d.feeEthValue, Constants.ethToken) : 0
+        readonly property real feeFiatValue: RootStore.getFiatValue(d.feeEthValue, Constants.ethToken)
         readonly property int transactionType: d.isTransactionValid ? WalletStores.RootStore.transactionType(transaction) : Constants.TransactionType.Send
         readonly property bool isBridge: d.transactionType === Constants.TransactionType.Bridge
 
@@ -289,7 +289,7 @@ Item {
                                 case Constants.TransactionType.Swap:
                                     return Constants.tokenIcon(d.inSymbol)
                                 case Constants.TransactionType.Bridge:
-                                    return Style.svg(RootStore.Icon(d.transaction.chainIdIn)) ?? Style.svg("network/Network=Custom")
+                                    return Style.svg(ModelUtils.getByKey(RootStore.flatNetworks, "chainId", d.transaction.chainIdIn, "iconUrl")) ?? Style.svg("network/Network=Custom")
                                 default:
                                     return ""
                                 }

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -61,8 +61,6 @@ StatusListItem {
     readonly property double inFiatValue: isModelDataValid && isMultiTransaction ? rootStore.getFiatValue(inCryptoValue, modelData.inSymbol): 0.0
     readonly property double outCryptoValue: isModelDataValid ? modelData.outAmount : 0.0
     readonly property double outFiatValue: isModelDataValid && isMultiTransaction ? rootStore.getFiatValue(outCryptoValue, modelData.outSymbol): 0.0
-    readonly property double feeCryptoValue: 0.0 // TODO fill when bridge data is implemented
-    readonly property double feeFiatValue: 0.0 // TODO fill when bridge data is implemented
     readonly property string networkColor: isModelDataValid ? SQUtils.ModelUtils.getByKey(rootStore.flatNetworks, "chainId", modelData.chainId, "chainColor") : ""
     readonly property string networkName: isModelDataValid ? SQUtils.ModelUtils.getByKey(rootStore.flatNetworks, "chainId", modelData.chainId, "chainName") : ""
     readonly property string networkNameIn: isMultiTransaction ? SQUtils.ModelUtils.getByKey(rootStore.flatNetworks, "chainId", modelData.chainIdIn, "chainName") : ""
@@ -589,8 +587,8 @@ StatusListItem {
             return qsTr("%1 to %2 on %3").arg(outTransactionValue).arg(inTransactionValue).arg(networkName)
         case Constants.TransactionType.Bridge:
             if (allAccounts)
-                return qsTr("%1 from %2 to %3 in %4").arg(inTransactionValue).arg(networkNameOut).arg(networkNameIn).arg(fromAddress)
-            return qsTr("%1 from %2 to %3").arg(inTransactionValue).arg(networkNameOut).arg(networkNameIn)
+                return qsTr("%1 from %2 to %3 in %4").arg(outTransactionValue).arg(networkNameOut).arg(networkNameIn).arg(fromAddress)
+            return qsTr("%1 from %2 to %3").arg(outTransactionValue).arg(networkNameOut).arg(networkNameIn)
         case Constants.TransactionType.ContractDeployment:
             const name = addressNameTo || addressNameFrom
             return qsTr("Via %1 on %2").arg(name).arg(networkName)
@@ -807,7 +805,6 @@ StatusListItem {
                                           .arg(Theme.palette.successColor1)
                                           .arg(inValue)
                         case Constants.TransactionType.Bridge:
-                            return "−" + root.rootStore.formatCurrencyAmount(feeCryptoValue, modelData.symbol)
                         case Constants.TransactionType.Approve:
                         default:
                             return ""
@@ -853,7 +850,6 @@ StatusListItem {
                             return "-%1 / +%2".arg(root.rootStore.formatCurrencyAmount(root.outFiatValue, root.currentCurrency))
                                               .arg(root.rootStore.formatCurrencyAmount(root.inFiatValue, root.currentCurrency))
                         case Constants.TransactionType.Bridge:
-                            return "−" + root.rootStore.formatCurrencyAmount(root.feeFiatValue, root.currentCurrency)
                         case Constants.TransactionType.Approve:
                         default:
                             return ""


### PR DESCRIPTION
Task #16133

### What does the PR do

* Fill Bridge type for tx
* Use proper transaction value in transaction activity delegate
* Hide activity details menu option when disabled
* Show network icon for `to` network in tx details
* Remove right side info for Bridge transaction details. It was intended to show fees values, but fees are fetched from additional call for tx details. It's better to drop them at this.

### Affected areas

Wallet activity

### Screenshot of functionality (including design for comparison)

![image](https://github.com/user-attachments/assets/462e3b4e-130f-497f-9621-215f087f45e0)

![image](https://github.com/user-attachments/assets/76e83fac-44b4-4049-8238-0e46ed01a4f2)
