### PR TITLE
fix(notifs): only fetch notification exemptions when going to the page

### DIFF
--- a/src/app/modules/main/profile_section/notifications/controller.nim
+++ b/src/app/modules/main/profile_section/notifications/controller.nim
@@ -42,16 +42,6 @@ proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
-  self.events.on(SIGNAL_ACTIVE_CHATS_LOADED) do(e:Args):
-    self.chatsLoaded = true
-    if self.communitiesLoaded:
-      self.delegate.initModel()
-
-  self.events.on(SIGNAL_COMMUNITY_DATA_LOADED) do(e:Args):
-    self.communitiesLoaded = true
-    if self.chatsLoaded:
-      self.delegate.initModel()
-
   self.events.on(SIGNAL_COMMUNITY_JOINED) do(e:Args):
     let args = CommunityArgs(e)
     if(args.error.len > 0):

--- a/src/app/modules/main/profile_section/notifications/view.nim
+++ b/src/app/modules/main/profile_section/notifications/view.nim
@@ -5,6 +5,7 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
+      exemptionsLoaded: bool
       exemptionsModel: Model
       exemptionsModelVariant: QVariant
       
@@ -17,11 +18,18 @@ QtObject:
     new(result, delete)
     result.QObject.setup
     result.delegate = delegate
+    result.exemptionsLoaded = false
     result.exemptionsModel = newModel()
     result.exemptionsModelVariant = newQVariant(result.exemptionsModel)
     
   proc load*(self: View) =
     self.delegate.viewDidLoad()
+    
+  proc loadExemptions*(self: View) {.slot.} =
+    if self.exemptionsLoaded:
+      return
+    self.delegate.initModel()
+    self.exemptionsLoaded = true
 
   proc sendTestNotification*(self: View, title: string, message: string) {.slot.} =
     self.delegate.sendTestNotification(title, message)

--- a/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
@@ -8,6 +8,10 @@ QtObject {
 
     property var exemptionsModel: notificationsModule.exemptionsModel
 
+    function loadExemptions() {
+        root.notificationsModule.loadExemptions()
+    }
+
     function sendTestNotification(title, message) {
         root.notificationsModule.sendTestNotification(title, message)
     }

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -22,6 +22,8 @@ SettingsContentBase {
 
     property NotificationsStore notificationsStore
 
+    Component.onCompleted: root.notificationsStore.loadExemptions()
+
     content: ColumnLayout {
         id: contentColumn
 


### PR DESCRIPTION
Fixes #16165

All the logs about `settings_notificationsGetExPersonalMentions` are only to populate the model in the Notifications settings view, so it was pointless to load them on app start. Now we lazy load them on loading that page.

An additional improvement that could be done later is to make it async and/or create a new API that gets all the DB info in one shot, because calling 4 APIs for each chat and community is a bit useless.
(the calls to all those APIs is about 0.02 seconds on my machine)