### PR TITLE
fix(WalletConnect): Fixing sign for uniswap and paraswap

### DIFF
--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -700,7 +700,7 @@ Item {
             verify(eip155.hasOwnProperty("methods"))
             verify(eip155.methods.length > 0)
             verify(eip155.hasOwnProperty("events"))
-            compare(eip155.events.length, 2)
+            compare(eip155.events.length, 5)
         }
 
         function test_getAccountsInSession() {

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -68,7 +68,7 @@ function buildSupportedNamespaces(chainIds, addresses, methods) {
         "eip155":{
             "chains": [${eipChainIds.join(',')}],
             "methods": [${methodsStr}],
-            "events": ["accountsChanged", "chainChanged"],
+            "events": ["chainChanged","accountsChanged","message","disconnect","connect"],
             "accounts": [${eipAddresses.join(',')}]
         }
     }`


### PR DESCRIPTION
### What does the PR do

There are two fixes needed here.
1. Status-go fix for unknown primitive when signing the message
2. Fix for Paraswap pairing failure due to required namespaces mismatch

Needs for: https://github.com/status-im/status-go/pull/5755

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Wallet Connect
Message signing

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Impact on end user

Before:
The user could not use Paraswap services
The user could not sign messages using uint160 type

After:
The user can use Paraswap services
The user can sign messages using all types
### How to test

Case 1:
Connect to Paraswap (make sure the events in requiredNamespaces.eip155.events is not empty in the pairing message)

Case 2:
Try to swap more than USDC to DAI using Uniswap. Not sure of the repro steps. Probably can be reproduced when connecting new accounts because it would reproduce while signing the authorisation request. The message needs to contain a value of `uint160`. This can be seen in the message we're showing in the sign dialog.

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
