### PR TITLE
fix(perf): improve chat switching speed by delaying member list loading

### DIFF
--- a/storybook/pages/UserListPanelPage.qml
+++ b/storybook/pages/UserListPanelPage.qml
@@ -66,7 +66,6 @@ SplitView {
 
             sourceComponent: UserListPanel {
                 usersModel: model
-                label: "Some label"
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -20,184 +20,67 @@ import AppLayouts.Chat.stores 1.0 as ChatStores
 Item {
     id: root
 
-    property ChatStores.RootStore store
-    property var chatCommunitySectionModule
-    property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem.id
-    property string label
-    property int communityMemberReevaluationStatus: Constants.CommunityMemberReevaluationStatus.None
+    property var usersModel
+    signal openProfileContextMenu(string pubKey, string nickName, string userName, string icon)
 
-    StatusBaseText {
-        id: titleText
-        anchors.top: parent.top
-        anchors.topMargin: Style.current.padding
-        anchors.left: parent.left
-        anchors.leftMargin: Style.current.padding
-        opacity: (root.width > 58) ? 1.0 : 0.0
-        visible: (opacity > 0.1)
-        font.pixelSize: Style.current.primaryTextFontSize
-        font.weight: Font.Medium
-        color: Theme.palette.directColor1
-        text: root.label
-    }
+    StatusListView {
+        id: userListView
+        objectName: "userListPanel"
 
-    StatusBaseText {
-        id: communityMemberReevaluationInProgressText
-        visible: root.communityMemberReevaluationStatus === Constants.CommunityMemberReevaluationStatus.InProgress
-        height: visible ? implicitHeight : 0 
-        anchors.top: titleText.bottom
-        anchors.topMargin: visible ? Style.current.padding : 0
-        anchors.left: parent.left
-        anchors.leftMargin: Style.current.padding
-        anchors.right: parent.right
-        anchors.rightMargin: Style.current.padding
-        font.pixelSize: Style.current.secondaryTextFontSize
-        color: Theme.palette.directColor1
-        text: qsTr("Member re-evaluation in progress...")
-        wrapMode: Text.WordWrap
+        clip: false
 
-        StatusToolTip {
-            text: qsTr("Saving community edits might take longer than usual")
-            visible: hoverHandler.hovered
-        }
-        HoverHandler {
-            id: hoverHandler
-            enabled: communityMemberReevaluationInProgressText.visible
-        }
-    }
+        anchors.fill: parent
 
-    Item {
-        anchors {
-            top: communityMemberReevaluationInProgressText.bottom
-            topMargin: Style.current.padding
-            left: parent.left
-            leftMargin: Style.current.halfPadding
-            right: parent.right
-            rightMargin: Style.current.halfPadding
-            bottom: parent.bottom
-        }
+        model: SortFilterProxyModel {
+            sourceModel: usersModel
 
-        clip: true
-
-        Loader {
-            id: loadingUsersView
-
-            anchors.fill: parent
-
-            active: messageStore.loading
-            visible: active
-            sourceComponent: MessagesLoadingView {
-                isUserList: true
-                anchors.fill: parent
+            proxyRoles: FastExpressionRole {
+                function displayNameProxy(nickname, ensName, displayName, aliasName) {
+                    return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
+                }
+                name: "preferredDisplayName"
+                expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
+                expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
             }
+
+            sorters: [
+                RoleSorter {
+                    roleName: "onlineStatus"
+                    sortOrder: Qt.DescendingOrder
+                },
+                StringSorter {
+                    roleName: "preferredDisplayName"
+                    caseSensitivity: Qt.CaseInsensitive
+                }
+            ]
         }
-
-
-        Repeater {
-            id: chatRepeater
-            model: chatCommunitySectionModule && chatCommunitySectionModule.model
-
-            Loader {
-                id: listLoader
-
-                property bool makeActive: model.type !== Constants.chatType.category && model.type !== Constants.chatType.unknown && model.loaderActive
-                property string chatId: model.itemId
-
-                anchors.fill: parent
-                active: false
-                asynchronous: true
-
-                onMakeActiveChanged: {
-                    if (!listLoader.active && listLoader.makeActive) {
-                        loadingUsersView.active = true
-                        userListDelay.start()
-                    } else if (!listLoader.makeActive) {
-                        listLoader.active = false
-                    }
-                }
-
-                Timer {
-                    id: userListDelay
-                    repeat: false
-                    running: false
-                    interval: 500
-                    onTriggered: {
-                        listLoader.active = true
-                        loadingUsersView.active = false
-                    }
-                }
-
-                sourceComponent: StatusListView {
-                    id: userListView
-                    objectName: "userListPanel"
-
-                    clip: false
-
-                    visible: listLoader.chatId === root.activeChatId
-
-                    anchors.fill: parent
-                    anchors.bottomMargin: Style.current.bigPadding
-                    displayMarginEnd: anchors.bottomMargin
-
-                    model: SortFilterProxyModel {
-                        sourceModel: {
-                            root.chatCommunitySectionModule.prepareChatContentModuleForChatId(listLoader.chatId)
-                            const chatContentModule = root.chatCommunitySectionModule.getChatContentModule()
-                            if (!chatContentModule || !chatContentModule.usersModule) {
-                                return null
-                            }
-                            return chatContentModule.usersModule.model
-                        }
-
-                        proxyRoles: FastExpressionRole {
-                            function displayNameProxy(nickname, ensName, displayName, aliasName) {
-                                return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
-                            }
-                            name: "preferredDisplayName"
-                            expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
-                            expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
-                        }
-
-                        sorters: [
-                            RoleSorter {
-                                roleName: "onlineStatus"
-                                sortOrder: Qt.DescendingOrder
-                            },
-                            StringSorter {
-                                roleName: "preferredDisplayName"
-                                caseSensitivity: Qt.CaseInsensitive
-                            }
-                        ]
-                    }
-                    section.property: "onlineStatus"
-                    section.delegate: (root.width > 58) ? sectionDelegateComponent : null
-                    delegate: StatusMemberListItem {
-                        width: ListView.view.width
-                        nickName: model.localNickname
-                        userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                        pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
-                        isContact: model.isContact
-                        isVerified: model.isVerified
-                        isUntrustworthy: model.isUntrustworthy
-                        isAdmin: model.memberRole === Constants.memberRole.owner
-                        asset.name: model.icon
-                        asset.isImage: (asset.name !== "")
-                        asset.isLetterIdenticon: (asset.name === "")
-                        asset.color: Utils.colorForColorId(model.colorId)
-                        status: model.onlineStatus
-                        ringSettings.ringSpecModel: model.colorHash
-                        onClicked: {
-                            if (mouse.button === Qt.RightButton) {
-                                Global.openMenu(profileContextMenuComponent, this, {
-                                                    myPublicKey: userProfile.pubKey,
-                                                    selectedUserPublicKey: model.pubKey,
-                                                    selectedUserDisplayName: nickName || userName,
-                                                    selectedUserIcon: model.icon,
-                                                })
-                            } else if (mouse.button === Qt.LeftButton) {
-                                Global.openProfilePopup(model.pubKey);
-                            }
-                        }
-                    }
+        section.property: "onlineStatus"
+        section.delegate: (root.width > 58) ? sectionDelegateComponent : null
+        delegate: StatusMemberListItem {
+            width: ListView.view.width
+            nickName: model.localNickname
+            userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
+            pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+            isContact: model.isContact
+            isVerified: model.isVerified
+            isUntrustworthy: model.isUntrustworthy
+            isAdmin: model.memberRole === Constants.memberRole.owner
+            asset.name: model.icon
+            asset.isImage: (asset.name !== "")
+            asset.isLetterIdenticon: (asset.name === "")
+            asset.color: Utils.colorForColorId(model.colorId)
+            status: model.onlineStatus
+            ringSettings.ringSpecModel: model.colorHash
+            onClicked: {
+                if (mouse.button === Qt.RightButton) {
+                    root.openProfileContextMenu(
+                        model.pubKey,
+                        nickName,
+                        userName,
+                        model.icon
+                    )
+                } else if (mouse.button === Qt.LeftButton) {
+                    Global.openProfilePopup(model.pubKey);
                 }
             }
         }
@@ -222,25 +105,6 @@ Item {
                             return qsTr("Inactive")
                     }
                 }
-            }
-        }
-    }
-
-    Component {
-        id: profileContextMenuComponent
-
-        ProfileContextMenu {
-            store: root.store
-            margins: 8
-            onOpenProfileClicked: {
-                Global.openProfilePopup(publicKey, null)
-            }
-            onCreateOneToOneChat: {
-                Global.changeAppSectionBySectionType(Constants.appSection.chat)
-                root.store.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
-            }
-            onClosed: {
-                destroy()
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -21,7 +21,8 @@ Item {
     id: root
 
     property ChatStores.RootStore store
-    property var usersModel
+    property var chatCommunitySectionModule
+    property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem.id
     property string label
     property int communityMemberReevaluationStatus: Constants.CommunityMemberReevaluationStatus.None
 
@@ -77,66 +78,128 @@ Item {
 
         clip: true
 
-        StatusListView {
-            id: userListView
-            objectName: "userListPanel"
-
-            clip: false
+        Loader {
+            id: loadingUsersView
 
             anchors.fill: parent
-            anchors.bottomMargin: Style.current.bigPadding
-            displayMarginEnd: anchors.bottomMargin
 
-            model: SortFilterProxyModel {
-                sourceModel: root.usersModel
+            active: messageStore.loading
+            visible: active
+            sourceComponent: MessagesLoadingView {
+                // anchors.margins: 16
+                isUserList: true
+                anchors.fill: parent
+            }
+        }
 
-                proxyRoles: FastExpressionRole {
-                    function displayNameProxy(nickname, ensName, displayName, aliasName) {
-                        return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
+
+        Repeater {
+            id: chatRepeater
+            model: chatCommunitySectionModule && chatCommunitySectionModule.model
+
+            Loader {
+                id: listLoader
+
+                property bool makeActive: model.type !== Constants.chatType.category && model.type !== Constants.chatType.unknown && model.loaderActive
+                property string chatId: model.itemId
+
+                anchors.fill: parent
+                active: false
+                asynchronous: true
+
+                onMakeActiveChanged: {
+                    if (!listLoader.active && listLoader.makeActive) {
+                        loadingUsersView.active = true
+                        userListDelay.start()
+                    } else if (!listLoader.makeActive) {
+                        listLoader.active = false
                     }
-                    name: "preferredDisplayName"
-                    expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
-                    expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
                 }
 
-                sorters: [
-                    RoleSorter {
-                        roleName: "onlineStatus"
-                        sortOrder: Qt.DescendingOrder
-                    },
-                    StringSorter {
-                        roleName: "preferredDisplayName"
-                        caseSensitivity: Qt.CaseInsensitive
+                Timer {
+                    id: userListDelay
+                    repeat: false
+                    running: false
+                    interval: 500
+                    onTriggered: {
+                        listLoader.active = true
+                        loadingUsersView.active = false
                     }
-                ]
-            }
-            section.property: "onlineStatus"
-            section.delegate: (root.width > 58) ? sectionDelegateComponent : null
-            delegate: StatusMemberListItem {
-                width: ListView.view.width
-                nickName: model.localNickname
-                userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
-                isContact: model.isContact
-                isVerified: model.isVerified
-                isUntrustworthy: model.isUntrustworthy
-                isAdmin: model.memberRole === Constants.memberRole.owner
-                asset.name: model.icon
-                asset.isImage: (asset.name !== "")
-                asset.isLetterIdenticon: (asset.name === "")
-                asset.color: Utils.colorForColorId(model.colorId)
-                status: model.onlineStatus
-                ringSettings.ringSpecModel: model.colorHash
-                onClicked: {
-                    if (mouse.button === Qt.RightButton) {
-                        Global.openMenu(profileContextMenuComponent, this, {
-                                            myPublicKey: userProfile.pubKey,
-                                            selectedUserPublicKey: model.pubKey,
-                                            selectedUserDisplayName: nickName || userName,
-                                            selectedUserIcon: model.icon,
-                                        })
-                    } else if (mouse.button === Qt.LeftButton) {
-                        Global.openProfilePopup(model.pubKey);
+                }
+
+                sourceComponent: StatusListView {
+                    id: userListView
+                    objectName: "userListPanel"
+
+                    clip: false
+
+                    visible: listLoader.chatId === root.activeChatId
+
+                    anchors.fill: parent
+                    anchors.bottomMargin: Style.current.bigPadding
+                    displayMarginEnd: anchors.bottomMargin
+
+                    model: SortFilterProxyModel {
+                        sourceModel: {
+                            root.chatCommunitySectionModule.prepareChatContentModuleForChatId(listLoader.chatId)
+                            const chatContentModule = root.chatCommunitySectionModule.getChatContentModule()
+                            if (!chatContentModule || !chatContentModule.usersModule) {
+                                return null
+                            }
+                            return chatContentModule.usersModule.model
+                        }
+                        
+                        // sourceModel: root.usersModel
+
+                        proxyRoles: FastExpressionRole {
+                            function displayNameProxy(nickname, ensName, displayName, aliasName) {
+                                return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
+                            }
+                            name: "preferredDisplayName"
+                            expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
+                            expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
+                        }
+
+                        sorters: [
+                            RoleSorter {
+                                roleName: "onlineStatus"
+                                sortOrder: Qt.DescendingOrder
+                            },
+                            StringSorter {
+                                roleName: "preferredDisplayName"
+                                caseSensitivity: Qt.CaseInsensitive
+                            }
+                        ]
+                    }
+                    section.property: "onlineStatus"
+                    section.delegate: (root.width > 58) ? sectionDelegateComponent : null
+                    delegate: StatusMemberListItem {
+                        width: ListView.view.width
+                        nickName: model.localNickname
+                        userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
+                        pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+                        isContact: model.isContact
+                        isVerified: model.isVerified
+                        isUntrustworthy: model.isUntrustworthy
+                        isAdmin: model.memberRole === Constants.memberRole.owner
+                        asset.name: model.icon
+                        asset.isImage: (asset.name !== "")
+                        asset.isLetterIdenticon: (asset.name === "")
+                        asset.color: Utils.colorForColorId(model.colorId)
+                        status: model.onlineStatus
+                        ringSettings.ringSpecModel: model.colorHash
+                        onClicked: {
+                            if (mouse.button === Qt.RightButton) {
+                                Global.openMenu(profileContextMenuComponent, this, {
+                                                    myPublicKey: userProfile.pubKey,
+                                                    selectedUserPublicKey: model.pubKey,
+                                                    selectedUserDisplayName: nickName || userName,
+                                                    selectedUserIcon: model.icon,
+                                                })
+                            } else if (mouse.button === Qt.LeftButton) {
+                                Global.openProfilePopup(model.pubKey);
+                            }
+                        }
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -147,8 +147,6 @@ Item {
                             }
                             return chatContentModule.usersModule.model
                         }
-                        
-                        // sourceModel: root.usersModel
 
                         proxyRoles: FastExpressionRole {
                             function displayNameProxy(nickname, ensName, displayName, aliasName) {

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -86,7 +86,6 @@ Item {
             active: messageStore.loading
             visible: active
             sourceComponent: MessagesLoadingView {
-                // anchors.margins: 16
                 isUserList: true
                 anchors.fill: parent
             }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -174,7 +174,6 @@ StatusSectionLayout {
             store: root.rootStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
-            chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -169,7 +169,7 @@ StatusSectionLayout {
     }
 
     rightPanel: Component {
-        UserListPanel {
+        UserListsView {
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -161,21 +161,20 @@ StatusSectionLayout {
         }
 
         let chatContentModule = root.rootStore.currentChatContentModule()
-        if (!chatContentModule) {
+        if (!root.chatContentModule) {
             return false
         }
         // Check if user list is available as an option for particular chat content module
-        return chatContentModule.chatDetails.isUsersListAvailable
+        return root.chatContentModule.chatDetails.isUsersListAvailable
     }
 
     rightPanel: Component {
-        id: userListComponent
         UserListPanel {
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
-            usersModel: root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
+            chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/UserListsView.qml
+++ b/ui/app/AppLayouts/Chat/views/UserListsView.qml
@@ -1,0 +1,176 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import shared 1.0
+import shared.panels 1.0
+import shared.status 1.0
+import shared.views.chat 1.0
+import utils 1.0
+
+import "../panels"
+
+import AppLayouts.Chat.stores 1.0 as ChatStores
+
+Item {
+    id: root
+
+    property ChatStores.RootStore store
+    property var chatCommunitySectionModule
+    property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem.id
+    property string label
+    property int communityMemberReevaluationStatus: Constants.CommunityMemberReevaluationStatus.None
+
+    StatusBaseText {
+        id: titleText
+        anchors.top: parent.top
+        anchors.topMargin: Style.current.padding
+        anchors.left: parent.left
+        anchors.leftMargin: Style.current.padding
+        opacity: (root.width > 58) ? 1.0 : 0.0
+        visible: (opacity > 0.1)
+        font.pixelSize: Style.current.primaryTextFontSize
+        font.weight: Font.Medium
+        color: Theme.palette.directColor1
+        text: root.label
+    }
+
+    StatusBaseText {
+        id: communityMemberReevaluationInProgressText
+        visible: root.communityMemberReevaluationStatus === Constants.CommunityMemberReevaluationStatus.InProgress
+        height: visible ? implicitHeight : 0 
+        anchors.top: titleText.bottom
+        anchors.topMargin: visible ? Style.current.padding : 0
+        anchors.left: parent.left
+        anchors.leftMargin: Style.current.padding
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        font.pixelSize: Style.current.secondaryTextFontSize
+        color: Theme.palette.directColor1
+        text: qsTr("Member re-evaluation in progress...")
+        wrapMode: Text.WordWrap
+
+        StatusToolTip {
+            text: qsTr("Saving community edits might take longer than usual")
+            visible: hoverHandler.hovered
+        }
+        HoverHandler {
+            id: hoverHandler
+            enabled: communityMemberReevaluationInProgressText.visible
+        }
+    }
+
+    Item {
+        anchors {
+            top: communityMemberReevaluationInProgressText.bottom
+            topMargin: Style.current.padding
+            left: parent.left
+            leftMargin: Style.current.halfPadding
+            right: parent.right
+            rightMargin: Style.current.halfPadding
+            bottom: parent.bottom
+        }
+
+        clip: true
+
+        Loader {
+            id: loadingUsersView
+
+            anchors.fill: parent
+
+            active: messageStore.loading
+            visible: active
+            sourceComponent: MessagesLoadingView {
+                isUserList: true
+                anchors.fill: parent
+            }
+        }
+
+
+        Repeater {
+            id: chatRepeater
+            model: chatCommunitySectionModule && chatCommunitySectionModule.model
+
+            Loader {
+                id: listLoader
+
+                property bool makeActive: model.type !== Constants.chatType.category && model.type !== Constants.chatType.unknown && model.loaderActive
+                property string chatId: model.itemId
+
+                anchors.fill: parent
+                active: false
+                asynchronous: true
+
+                onMakeActiveChanged: {
+                    if (!listLoader.active && listLoader.makeActive) {
+                        loadingUsersView.active = true
+                        userListDelay.start()
+                    } else if (!listLoader.makeActive) {
+                        listLoader.active = false
+                    }
+                }
+
+                Timer {
+                    id: userListDelay
+                    repeat: false
+                    running: false
+                    interval: 500
+                    onTriggered: {
+                        listLoader.active = true
+                        loadingUsersView.active = false
+                    }
+                }
+
+                sourceComponent: UserListPanel {
+                    clip: false
+
+                    visible: listLoader.chatId === root.activeChatId
+
+                    anchors.fill: parent
+                    anchors.bottomMargin: Style.current.bigPadding
+
+                    usersModel: {
+                        root.chatCommunitySectionModule.prepareChatContentModuleForChatId(listLoader.chatId)
+                        const chatContentModule = root.chatCommunitySectionModule.getChatContentModule()
+                        if (!chatContentModule || !chatContentModule.usersModule) {
+                            return null
+                        }
+                        return chatContentModule.usersModule.model
+                    }
+                    onOpenProfileContextMenu: function (pubKey, nickName, userName, icon) {
+                        Global.openMenu(profileContextMenuComponent, this, {
+                                            myPublicKey: userProfile.pubKey,
+                                            selectedUserPublicKey: pubKey,
+                                            selectedUserDisplayName: nickName || userName,
+                                            selectedUserIcon: icon,
+                                        })
+                    }
+                } 
+            }
+        }
+
+        Component {
+            id: profileContextMenuComponent
+
+            ProfileContextMenu {
+                store: root.store
+                margins: 8
+                onOpenProfileClicked: {
+                    Global.openProfilePopup(publicKey, null)
+                }
+                onCreateOneToOneChat: {
+                    Global.changeAppSectionBySectionType(Constants.appSection.chat)
+                    root.store.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
+                }
+                onClosed: {
+                    destroy()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/views/UserListsView.qml
+++ b/ui/app/AppLayouts/Chat/views/UserListsView.qml
@@ -20,9 +20,7 @@ import AppLayouts.Chat.stores 1.0 as ChatStores
 Item {
     id: root
 
-    property ChatStores.RootStore store
-    property var chatCommunitySectionModule
-    property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem.id
+    required property ChatStores.RootStore store
     property string label
     property int communityMemberReevaluationStatus: Constants.CommunityMemberReevaluationStatus.None
 
@@ -94,7 +92,7 @@ Item {
 
         Repeater {
             id: chatRepeater
-            model: chatCommunitySectionModule && chatCommunitySectionModule.model
+            model: root.store.communityItemsModel
 
             Loader {
                 id: listLoader
@@ -129,14 +127,13 @@ Item {
                 sourceComponent: UserListPanel {
                     clip: false
 
-                    visible: listLoader.chatId === root.activeChatId
+                    visible: listLoader.chatId === root.store.activeChatId
 
                     anchors.fill: parent
                     anchors.bottomMargin: Style.current.bigPadding
 
                     usersModel: {
-                        root.chatCommunitySectionModule.prepareChatContentModuleForChatId(listLoader.chatId)
-                        const chatContentModule = root.chatCommunitySectionModule.getChatContentModule()
+                        const chatContentModule = root.store.getChatContentModule(listLoader.chatId)
                         if (!chatContentModule || !chatContentModule.usersModule) {
                             return null
                         }
@@ -165,7 +162,7 @@ Item {
                 }
                 onCreateOneToOneChat: {
                     Global.changeAppSectionBySectionType(Constants.appSection.chat)
-                    root.store.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
+                    root.store.createOneToOneChat(communityId, chatId, ensName)
                 }
                 onClosed: {
                     destroy()

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -149,21 +149,13 @@ QtObject {
         mainModuleInst.switchTo(sectionId, chatId)
     }
 
-    // Not Refactored Yet
-//    property var chatsModelInst: chatsModel
-    // Not Refactored Yet
-//    property var walletModelInst: walletModel
     property var userProfileInst: userProfile
     readonly property var accounts: walletSectionAccounts.accounts
-    // Not Refactored Yet
-//    property var profileModelInst: profileModel
 
     property ProfileStores.ContactsStore contactStore: profileSectionStore.contactsStore
     property ProfileStores.PrivacyStore privacyStore: profileSectionStore.privacyStore
     property ProfileStores.MessagingStore messagingStore: profileSectionStore.messagingStore
     property bool hasAddedContacts: contactStore.myContactsModel.count > 0
-
-//    property MessageStore messageStore: MessageStore { }
 
     property real volume: !!appSettings ? appSettings.volume * 0.01 : 0.5
     property bool notificationSoundsEnabled: !!appSettings ? appSettings.notificationSoundsEnabled : true

--- a/ui/imports/shared/views/chat/MessagesLoadingView.qml
+++ b/ui/imports/shared/views/chat/MessagesLoadingView.qml
@@ -5,6 +5,9 @@ import QtQuick.Layouts 1.15
 import StatusQ.Components 0.1
 
 ListView {
+    property bool isUserList: false
+
+    id: root
     spacing: 20
     interactive: false
     clip: true
@@ -13,6 +16,10 @@ ListView {
         Component.onCompleted: {
             var numElements = 20
             for (var i = 1; i < numElements; ++i) {
+                if (root.isUserList) {
+                    append({ "isImage": false, "thirdLine": false })
+                    continue
+                }
                 if (i % 5 === 0)
                     append({ "isImage": true, "thirdLine": false })
                 else if (i % 3 === 0)

--- a/ui/imports/shared/views/chat/qmldir
+++ b/ui/imports/shared/views/chat/qmldir
@@ -13,3 +13,4 @@ NewMessagesMarker 1.0 NewMessagesMarker.qml
 SimplifiedMessageView 1.0 SimplifiedMessageView.qml
 ProfileContextMenu 1.0 ProfileContextMenu.qml
 MessageAddReactionContextMenu 1.0 MessageAddReactionContextMenu.qml
+MessagesLoadingView 1.0 MessagesLoadingView.qml


### PR DESCRIPTION
Fixes #16132

It took a long time finding the culprit. I tried using Hotspot, but it wasn't giving me a clear answer. I had to add logs everywhere in the module to see what call was the slowest. Then comment out parts of the QML to see which component/Loader was causing the "hang".

The problem ended up being the member list (for communities). It takes a long time to load when you have hundreds of members, especially since it has multiple filters on the SortFilterProxy.

The solution I went with was to reuse the same method we have for message list, which is to keep 5 in memory. So we have multiple instances of the ListView and 5 max active at the same time. This uses the same model and property as the MessageView, so there is no code duplication. This makes sure that we don't have to reload and parse the member list each time we switch. So switching between the last 5 channels is instant like before.

The second solution is to had a fake delay on first load. I tried only using `asynchronous` on the Loader, but it didn't really give an improvement. By adding a Timer with a delay, we can feel the speed up. It switches rapidly to the channel and we can see the message loading skeleton (if needed).

The only missing part was to add a loader to fill the empty gap when delaying, so I reused the MessagesLoadingView and adapted it so it fits the MemberList format.

Later, we can even load the member list async in the backend and use that Loading animation and not rely on the timer.

In the end, with those solutions, I found that switching to a new channel is about 10 times faster, and switching to an already loaded channel is basically instant since we're not reloading it again.

~~I'll try to share a screencapture, but my recording app is not working anymore :skull:~~
Ok I fixed it. Enjoy (~~not sure why it's not unfurling though~~):

[chat-switch.webm](https://github.com/user-attachments/assets/4afac6b4-4553-407f-b3e2-9e493d282bba)


Old slow switch:

[slow-switch.webm](https://github.com/user-attachments/assets/ee3ad7b8-75d6-4b52-b6bb-121acbb1fe68)

You can see that before, it was laggy between switches.
Of course, it's not super bad, it was less than a second, but it just felt sluggish. Also, not having instant switched between channel you just looked at was not great