### PR TITLE
fix_: mailserver.not.working signal

### DIFF
--- a/src/app/core/signals/remote_signals/mailserver.nim
+++ b/src/app/core/signals/remote_signals/mailserver.nim
@@ -89,4 +89,4 @@ proc fromEvent*(T: type MailserverChangedSignal, jsonSignal: JsonNode): Mailserv
 
 proc fromEvent*(T: type MailserverNotWorkingSignal, jsonSignal: JsonNode): MailserverNotWorkingSignal =
   result = MailserverNotWorkingSignal()
-  result.signalType = SignalType.MailseverNotWorking
+  result.signalType = SignalType.MailserverNotWorking

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -103,6 +103,7 @@ QtObject:
       of SignalType.HistoryRequestFailed: HistoryRequestFailedSignal.fromEvent(jsonSignal)
       of SignalType.MailserverAvailable: MailserverAvailableSignal.fromEvent(jsonSignal)
       of SignalType.MailserverChanged: MailserverChangedSignal.fromEvent(jsonSignal)
+      of SignalType.MailserverNotWorking: MailserverNotWorkingSignal.fromEvent(jsonSignal)
       of SignalType.HistoryArchivesProtocolEnabled: HistoryArchivesSignal.historyArchivesProtocolEnabledFromEvent(jsonSignal)
       of SignalType.HistoryArchivesProtocolDisabled: HistoryArchivesSignal.historyArchivesProtocolDisabledFromEvent(jsonSignal)
       of SignalType.CreatingHistoryArchives: HistoryArchivesSignal.creatingHistoryArchivesFromEvent(jsonSignal)


### PR DESCRIPTION
Adds back the `can not connect to store node. Retrying automatically` banner.