### PR TITLE
perf(chat_section): improve onChatsLoaded performance

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -437,7 +437,7 @@ proc getChatsAndBuildUI*(self: Controller) =
     community = self.getMyCommunity()
     let normalChats = self.chatService.getChatsForCommunity(community.id)
 
-    # TODO remove this once we do this refactor https://github.com/status-im/status-desktop/issues/14219
+    # TODO remove this once we do this refactor https://github.com/status-im/status-desktop/issues/11694
     var fullChats: seq[ChatDto] = @[]
     for communityChat in community.chats:
       for chat in normalChats:
@@ -713,12 +713,6 @@ proc getColorHash*(self: Controller, pubkey: string): ColorHashDto =
 
 proc getColorId*(self: Controller, pubkey: string): int =
   procs_from_visual_identity_service.colorIdOf(pubkey)
-
-proc checkChatHasPermissions*(self: Controller, communityId: string, chatId: string): bool =
-  return self.communityService.checkChatHasPermissions(communityId, chatId)
-
-proc checkChatIsLocked*(self: Controller, communityId: string, chatId: string): bool =
-  return self.communityService.checkChatIsLocked(communityId, chatId)
 
 proc createOrEditCommunityTokenPermission*(self: Controller, communityId: string, tokenPermission: CommunityTokenPermissionDto) =
   self.communityService.createOrEditCommunityTokenPermission(communityId, tokenPermission)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -80,7 +80,8 @@ method addOrUpdateChat*(self: AccessInterface,
     mailserversService: mailservers_service.Service,
     sharedUrlsService: shared_urls_service.Service,
     setChatAsActive: bool = true,
-    insertIntoModel: bool = true
+    insertIntoModel: bool = true,
+    isSectionBuild: bool = false,
   ): Item {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -323,7 +323,7 @@ proc `loaderActive=`*(self: var Item, value: bool) =
 proc isCategory*(self: Item): bool =
   self.`type` == CATEGORY_TYPE
 
-proc isLocked*(self: Item): bool =
+proc locked*(self: Item): bool =
   self.locked
 
 proc `locked=`*(self: Item, value: bool) =

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -210,7 +210,7 @@ QtObject:
     of ModelRole.LoaderActive:
       result = newQVariant(item.loaderActive)
     of ModelRole.Locked:
-      result = newQVariant(item.isLocked)
+      result = newQVariant(item.locked)
     of ModelRole.RequiresPermissions:
       result = newQVariant(item.requiresPermissions)
     of ModelRole.CanPost:
@@ -366,7 +366,7 @@ QtObject:
     if index == -1:
       return
 
-    if (self.items[index].isLocked == locked):
+    if (self.items[index].locked == locked):
       return
 
     self.items[index].locked = locked

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -656,6 +656,8 @@ method onChatsLoaded*[T](
     myPubKey,
     sectionIsMuted = false
   )
+  var items: seq[SectionItem] = @[]
+
   let personalChatSectionItem = initItem(
     myPubKey,
     sectionType = SectionType.Chat,
@@ -671,7 +673,7 @@ method onChatsLoaded*[T](
     isMember = true,
     muted = false,
   )
-  self.view.model().addItem(personalChatSectionItem)
+  items.add(personalChatSectionItem)
   if activeSectionId == personalChatSectionItem.id:
     activeSection = personalChatSectionItem
 
@@ -699,11 +701,13 @@ method onChatsLoaded*[T](
       networkService
     )
     let communitySectionItem = self.createCommunitySectionItem(community)
-    self.view.model().addItem(communitySectionItem)
+    items.add(communitySectionItem)
     if activeSectionId == communitySectionItem.id:
       activeSection = communitySectionItem
 
     self.chatSectionModules[community.id].load()
+
+  self.view.model().addItems(items)
 
   # Set active section if it is one of the channel sections
   if not activeSection.isEmpty():

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -224,7 +224,6 @@ QtObject:
         return true
     return false
 
-
   proc addItem*(self: SectionModel, item: SectionItem) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
@@ -246,6 +245,20 @@ QtObject:
       self.endInsertRows()
 
       self.countChanged()
+
+  proc addItems*(self: SectionModel, items: seq[SectionItem]) =
+    if items.len == 0:
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    let first = self.items.len
+    let last = first + items.len - 1
+    self.beginInsertRows(parentModelIndex, first, last)
+    self.items.add(items)
+    self.endInsertRows()
+    self.countChanged()
 
   proc getItemIndex*(self: SectionModel, id: string): int =
     var i = 0

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2247,22 +2247,6 @@ QtObject:
     else:
       return community.declinedRequestsToJoin[indexDeclined].publicKey
 
-  proc checkChatIsLocked*(self: Service, communityId: string, chatId: string): bool =
-    if not self.communities.hasKey(communityId):
-      return false
-
-    let community = self.getCommunityById(communityId)
-    return community.channelPermissions.channels.hasKey(chatId) and not community.channelPermissions.channels[chatId].viewAndPostPermissions.satisfied
-
-  proc checkChatHasPermissions*(self: Service, communityId: string, chatId: string): bool =
-    let community = self.getCommunityById(communityId)
-    for id, tokenPermission in community.tokenPermissions:
-      if TokenPermissionType(tokenPermission.`type`) == TokenPermissionType.View or TokenPermissionType(tokenPermission.`type`) == TokenPermissionType.ViewAndPost:
-        for id in tokenPermission.chatIds:
-          if id == chatId:
-            return true
-    return false
-
   proc shareCommunityUrlWithChatKey*(self: Service, communityId: string): string =
     try:
       let response = status_go.shareCommunityUrlWithChatKey(communityId)


### PR DESCRIPTION
Fixes #16181

This commit improves the time taken by onChatsLoaded that is called on login. The culprit is `buildChatSectionUI` in the chat_section module. There is no silver bullet here. It's slow because the community is big and has a lot of channels to load and generate.

This commit helps by removing some old code that was inefficient (calculating if a channel has a permission instead of just using the `tokenGated` property for example). It also adds all the section items in one go instead of one another.

There are some other small improvements, but again, no way to make it way faster. Thankfully, that time is spent with the loading spinner at the same time.

Some other improvements can be made for the login, but in other parts of the app.