### PR TITLE
ci: move stage env variable setup to jenkins-lib

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -74,7 +74,6 @@ pipeline {
     /* Control output the filename */
     STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'AppImage', arch: getArch())}"
     STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'tar.gz', arch: getArch())}"
-    STATUS_BUILD_PROXY_STAGE_NAME = "${utils.isReleaseBuild() ? 'prod' : 'test'}"
   }
 
   stages {

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -63,7 +63,6 @@ pipeline {
     /* Control output the filename */
     STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'nix.AppImage', arch: getArch())}"
     STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'nix.tar.gz', arch: getArch())}"
-    STATUS_BUILD_PROXY_STAGE_NAME = "${utils.isReleaseBuild() ? 'prod' : 'test'}"
   }
 
   stages {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -75,7 +75,6 @@ pipeline {
     STATUS_CLIENT_DMG = "pkg/${utils.pkgFilename(ext: 'dmg', arch: getArch())}"
     /* Apple Team ID for Notarization */
     MACOS_NOTARIZE_TEAM_ID = "8B5X2M6H2Y"
-    STATUS_BUILD_PROXY_STAGE_NAME = "${utils.isReleaseBuild() ? 'prod' : 'test'}"
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 pipeline {
 

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -77,7 +77,6 @@ pipeline {
     STATUS_CLIENT_EXE = "pkg/${utils.pkgFilename(ext: 'exe', arch: getArch())}"
     /* 7zip archive filename */
     STATUS_CLIENT_7Z = "pkg/${utils.pkgFilename(ext: '7z', arch: getArch())}"
-    STATUS_BUILD_PROXY_STAGE_NAME = "${utils.isReleaseBuild() ? 'prod' : 'test'}"
     /* Hack-fix for params not being set in env on first job run. */
     WINDOWS_CODESIGN_TIMESTAMP_URL = "${params.WINDOWS_CODESIGN_TIMESTAMP_URL}"
   }

--- a/ci/cpp/Jenkinsfile.linux
+++ b/ci/cpp/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.macos
+++ b/ci/cpp/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.windows
+++ b/ci/cpp/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.7'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
Related jenkins lib commit:
- [`status-jenkins-lib#9571602f`](https://github.com/status-im/status-jenkins-lib/commit/9571602f) - desktop,mobile: add proxy stage env variable

Update:
- [`status-jenkins-lib#242b8554`](https://github.com/status-im/status-jenkins-lib/commit/242b8554) - mobile: remove proxy stage env variable setup
- [`status-jenkins-lib#32dda2a7`](https://github.com/status-im/status-jenkins-lib/commit/32dda2a7) - desktop: refactor proxy stage setup