### PR TITLE
tests: use own profile link in messages so the information is not gone after 30 days

### DIFF
--- a/test/e2e/gui/components/online_identifier.py
+++ b/test/e2e/gui/components/online_identifier.py
@@ -1,6 +1,7 @@
 import time
 
 import allure
+import pyperclip
 
 import configs
 import constants
@@ -20,6 +21,7 @@ class OnlineIdentifier(QObject):
         self._inactive_button = Button(names.userContextmenu_InActiveButton)
         self._automatic_button = Button(names.userContextmenu_AutomaticButton)
         self._view_my_profile_button = Button(names.userContextMenu_ViewMyProfileAction)
+        self._copy_link_to_profile = QObject(names.userContextMenu_CopyLinkToProfile)
         self._user_name_text_label = TextLabel(names.userLabel_StyledText)
         self._identicon_ring = QObject(names.o_StatusIdenticonRing)
 
@@ -27,11 +29,6 @@ class OnlineIdentifier(QObject):
     def wait_until_appears(self, timeout_msec: int = configs.timeouts.UI_LOAD_TIMEOUT_MSEC):
         driver.waitFor(lambda: self._view_my_profile_button.is_visible, timeout_msec)
         return self
-
-    @property
-    @allure.step('Check identicon ring visibility')
-    def is_identicon_ring_visible(self):
-        return self._identicon_ring.is_visible
 
     @property
     @allure.step('Get user name')
@@ -57,3 +54,9 @@ class OnlineIdentifier(QObject):
     def open_profile_popup_from_online_identifier(self) -> ProfilePopup:
         self._view_my_profile_button.click()
         return ProfilePopup().wait_until_appears()
+
+    @allure.step('Copy link to profile from online identifier')
+    def copy_link_to_profile(self) -> str:
+        self._copy_link_to_profile.click()
+        link = str(pyperclip.paste())
+        return link

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -87,6 +87,7 @@ userContextmenu_AlwaysActiveButton= {"container": o_StatusListView, "objectName"
 userContextmenu_InActiveButton= {"container": o_StatusListView, "objectName": "userStatusMenuInactiveAction", "type": "StatusMenuItem", "visible": True}
 userContextmenu_AutomaticButton= {"container": o_StatusListView, "objectName": "userStatusMenuAutomaticAction", "type": "StatusMenuItem", "visible": True}
 userContextMenu_ViewMyProfileAction = {"container": o_StatusListView, "objectName": "userStatusViewMyProfileAction", "type": "StatusMenuItem", "visible": True}
+userContextMenu_CopyLinkToProfile = {"container": statusDesktop_mainWindow_overlay, "objectName": "userStatusCopyLinkAction", "type": "StatusMenuItem", "visible": True}
 userLabel_StyledText = {"container": o_StatusListView, "type": "StyledText", "unnamed": 1, "visible": True}
 o_StatusIdenticonRing = {"container": o_StatusListView, "type": "StatusIdenticonRing", "unnamed": 1, "visible": True}
 

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -313,11 +313,6 @@ class YourProfileView(OnboardingView):
         return self._profile_image.image
 
     @property
-    @allure.step('Check identicon ring visibility')
-    def is_identicon_ring_visible(self):
-        return self._identicon_ring.is_visible
-
-    @property
     @allure.step('Get error messages')
     def get_error_message(self) -> str:
         return self._erros_text_label.text if self._erros_text_label.is_visible else ''
@@ -414,11 +409,6 @@ class YourEmojihashAndIdenticonRingView(OnboardingView):
     @allure.step('Get emoji hash image')
     def get_emoji_hash(self) -> str:
         return str(getattr(self._emoji_hash.object, 'publicKey'))
-
-    @property
-    @allure.step('Verify: Identicon ring visible')
-    def is_identicon_ring_visible(self):
-        return self._identicon_ring.is_visible
 
     @allure.step('Click next in your emojihash and identicon ring view')
     def next(self):

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_generate_new_keys.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_generate_new_keys.py
@@ -93,7 +93,7 @@ def test_generate_new_keys_sign_out_from_settings(aut, main_window, keys_screen,
         emoji_hash_identicon_view = YourEmojihashAndIdenticonRingView().verify_emojihash_view_present()
         chat_key = emoji_hash_identicon_view.get_chat_key
         emoji_hash_public_key = emoji_hash_identicon_view.get_emoji_hash
-        assert emoji_hash_identicon_view.is_identicon_ring_visible, f'Identicon ring is not present when it should'
+        assert emoji_hash_identicon_view._identicon_ring.is_visible, f'Identicon ring is not present when it should'
 
     with step('Click Start using Status'):
         next_view = emoji_hash_identicon_view.next()
@@ -112,7 +112,7 @@ def test_generate_new_keys_sign_out_from_settings(aut, main_window, keys_screen,
         online_identifier = main_window.left_panel.open_online_identifier()
         assert online_identifier.get_user_name == user_name, \
             f'Display name in online identifier is wrong, current: {online_identifier.get_user_name}, expected: {user_name}'
-        assert online_identifier.is_identicon_ring_visible, \
+        assert online_identifier._identicon_ring.is_visible, \
             f'Identicon ring is not present when it should'
         assert str(online_identifier.object.pubkey) is not None, \
             f'Public key is not present'

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -38,6 +38,7 @@ StatusMenu {
     }
 
     StatusAction {
+        objectName: "userStatusCopyLinkAction"
         text: qsTr("Copy link to profile")
         icon.name: "copy"
         onTriggered: {


### PR DESCRIPTION
### What does the PR do

Test logic is changed , instead of using pre-defined link to user profile, test now uses profile link of created account for the test. I am removing hardcoded values and improving test stability, because profile link is not unfurling (not showing display name and emoji hash) if user for this profile has not been online for 30 days (current threshold for storing info in waku)

So in short, test wont fail from now on at this screen being unable to get data from not resolved link 

![image](https://github.com/user-attachments/assets/5df94943-fa86-4197-835e-1766d194f628)

CI run:
<img width="1840" alt="Screenshot 2024-08-27 at 13 53 31" src="https://github.com/user-attachments/assets/96b497a0-700e-4065-973f-41762d77af8b">

