### PR TITLE
chore: Disable clicking on Betatag

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusBetaTag.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusBetaTag.qml
@@ -9,6 +9,9 @@ Rectangle {
 
     property color fgColor: Theme.palette.baseColor1
     property alias tooltipText: tip.text
+    property alias cursorShape: hoverHandler.cursorShape
+
+    readonly property bool hovered: hoverHandler.hovered
 
     implicitHeight: 20
     implicitWidth: 36
@@ -32,5 +35,6 @@ Rectangle {
 
     HoverHandler {
         id: hoverHandler
+        enabled: root.visible
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusNavigationListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusNavigationListItem.qml
@@ -21,11 +21,13 @@ StatusListItem {
 
     statusListItemIcon.anchors.topMargin: 14
 
+    highlighted: sensor.containsMouse
+
     color: {
         if (selected) {
             return Theme.palette.statusNavigationListItem.selectedBackgroundColor
         }
-        return sensor.containsMouse ? 
+        return highlighted ?
           Theme.palette.statusNavigationListItem.hoverBackgroundColor :
           Theme.palette.baseColor4
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
@@ -35,6 +35,7 @@ TabButton {
                 visible: root.showBetaTag
                 fgColor: root.checked ? Theme.palette.statusSwitchTab.selectedTextColor
                                       : Theme.palette.baseColor1
+                cursorShape: hovered ? Qt.PointingHandCursor : undefined
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
@@ -34,6 +34,7 @@ Column {
             title: model.text
             asset.name: model.icon
             selected: Global.settingsSubsection === model.subsection
+            highlighted: !!betaTagLoader.item && betaTagLoader.item.hovered
             onClicked: root.menuItemClicked(model)
             badge.value: {
                 switch (model.subsection) {
@@ -64,6 +65,7 @@ Column {
 
                 sourceComponent: StatusBetaTag {
                     tooltipText: betaTagLoader.experimentalTooltip
+                    cursorShape: Qt.PointingHandCursor
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -134,6 +134,7 @@ Column {
         title: qsTr("Account order")
         height: 64
         width: parent.width
+        highlighted: accountOrderBetaTag.hovered
         onClicked: goToAccountOrderView()
         components: [
             StatusIcon {
@@ -143,10 +144,12 @@ Column {
         ]
 
         StatusBetaTag {
+            id: accountOrderBetaTag
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: 125
             tooltipText: qsTr("Under construction, you might experience some minor issues")
+            cursorShape: Qt.PointingHandCursor
         }
     }
 
@@ -157,6 +160,7 @@ Column {
         title: qsTr("Manage Tokens")
         height: 64
         width: parent.width
+        highlighted: manageTokensBetaTag.hovered
         onClicked: goToManageTokensView()
         components: [
             StatusIcon {
@@ -166,10 +170,12 @@ Column {
         ]
 
         StatusBetaTag {
+            id: manageTokensBetaTag
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.left
             anchors.leftMargin: 135
             tooltipText: qsTr("Under construction, you might experience some minor issues")
+            cursorShape: Qt.PointingHandCursor
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -129,6 +129,7 @@ RightTabBaseView {
                             anchors.topMargin: 6
                             anchors.left: parent.right
                             anchors.leftMargin: 5
+                            cursorShape: Qt.PointingHandCursor
                         }
                     }
                     onCurrentIndexChanged: {


### PR DESCRIPTION
### What does the PR do

Update BetaTag to hide tooltip correctly.
Extend BetaTag so it can be customized and propagate hover state to parent.

### Affected areas

Whole app

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/d29d88f0-de26-489b-9537-13a995065c5d


