### PR TITLE
tests: editing account with right click stabilised

### DIFF
--- a/test/e2e/gui/components/context_menu.py
+++ b/test/e2e/gui/components/context_menu.py
@@ -9,65 +9,25 @@ class ContextMenu(QObject):
 
     def __init__(self):
         super(ContextMenu, self).__init__(names.contextMenu_PopupItem)
-        self._menu_item = QObject(names.contextMenuItem)
-        self._context_add_watched_address_option = QObject(names.contextMenuItem_AddWatchOnly)
-        self._context_delete_account_option = QObject(names.contextMenuItem_Delete)
-        self._context_edit_account_option = QObject(names.contextMenuItem_Edit)
-        self._context_copy_address_option = QObject(names.contextMenuItem_Copy_Address)
-        self._context_hide_include_in_total_balance = QObject(names.contextMenuItem_HideInclude)
-        self._context_edit_saved_address_option = QObject(names.contextSavedAddressEdit)
-        self._context_delete_saved_address_option = QObject(names.contextSavedAddressDelete)
-        self._edit_channel_context_item = QObject(communities_names.edit_Channel_StatusMenuItem)
-        self._delete_channel_context_item = QObject(communities_names.delete_Channel_StatusMenuItem)
-        self._invite_people_item = QObject(communities_names.invite_People_StatusMenuItem)
-        self._mute_community_item = QObject(communities_names.mute_Community_StatusMenuItem)
-
-    @allure.step('Is edit channel option present in context menu')
-    def is_edit_channel_option_present(self):
-        return self._edit_channel_context_item.exists
-
-    @allure.step('Is delete channel option present in context menu')
-    def is_delete_channel_option_present(self):
-        return self._delete_channel_context_item.exists
+        self.menu_item = QObject(names.contextMenuItem)
+        self.add_watched_address_from_context = QObject(names.contextMenuItem_AddWatchOnly)
+        self.delete_from_context = QObject(names.contextMenuItem_Delete)
+        self.edit_from_context = QObject(names.contextMenuItem_Edit)
+        self.copy_address_from_context = QObject(names.contextMenuItem_Copy_Address)
+        self.hide_include_in_total_balance = QObject(names.contextMenuItem_HideInclude)
+        self.edit_saved_address_from_context = QObject(names.contextSavedAddressEdit)
+        self.delete_saved_address_from_context = QObject(names.contextSavedAddressDelete)
+        self.edit_channel_from_context = QObject(communities_names.edit_Channel_StatusMenuItem)
+        self.delete_channel_from_context = QObject(communities_names.delete_Channel_StatusMenuItem)
+        self.invite_from_context = QObject(communities_names.invite_People_StatusMenuItem)
+        self.mute_from_context = QObject(communities_names.mute_Community_StatusMenuItem)
 
     @allure.step('Select in context menu')
     def select(self, value: str):
-        self._menu_item.real_name['text'] = value
-        self._menu_item.click()
-
-    @allure.step('Click Edit saved address option')
-    def select_edit_saved_address(self):
-        self._context_edit_saved_address_option.click()
-
-    @allure.step('Click Delete saved address option')
-    def select_delete_saved_address(self):
-        self._context_delete_saved_address_option.click()
-
-    @allure.step('Select add watched address option from context menu')
-    def select_add_watched_address_from_context_menu(self):
-        self._context_add_watched_address_option.click()
-
-    @allure.step('Select delete account option from context menu')
-    def select_delete_account_from_context_menu(self):
-        self._context_delete_account_option.click()
-
-    @allure.step('Select Hide/Include in total balance option from context menu')
-    def select_hide_include_total_balance_from_context_menu(self):
-        self._context_hide_include_in_total_balance.click()
-
-    @allure.step('Select edit account option from context menu')
-    def select_edit_account_from_context_menu(self):
-        self._context_edit_account_option.click()
-
-    @allure.step('Select copy address from context menu')
-    def select_copy_address_from_context_menu(self):
-        self._context_copy_address_option.click()
-
-    @allure.step('Check delete option visibility in context menu')
-    def is_delete_account_option_present(self):
-        return self._context_delete_account_option.is_visible
+        self.menu_item.real_name['text'] = value
+        self.menu_item.click()
 
     @allure.step('Select invite people to community')
     def select_invite_people(self):
-        self._invite_people_item.click()
+        self.invite_from_context.click()
         return InviteContactsPopup()

--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -105,19 +105,19 @@ def test_member_role_cannot_add_edit_and_delete_channels(main_screen: MainWindow
         with step('Right-click on general channel in the left navigation bar'):
             general_channel_context_menu = community_screen.left_panel.open_general_channel_context_menu()
         with step('Verify that edit item is not present in channel context menu'):
-            assert general_channel_context_menu.is_edit_channel_option_present() is False, \
+            assert general_channel_context_menu.edit_channel_from_context.exists is False, \
                 f'Edit channel option is present when it should not'
         with step('Verify that delete item is not present in channel context menu'):
-            assert general_channel_context_menu.is_delete_channel_option_present() is False, \
+            assert general_channel_context_menu.delete_channel_from_context.exists is False, \
                 f'Delete channel option is present when it should not'
 
         with step('Open context menu from the tool bar'):
             more_options = community_screen.tool_bar.open_more_options_dropdown()
         with step('Verify that edit item is not present in context menu'):
-            assert more_options.is_edit_channel_option_present() is False, \
+            assert more_options.iedit_channel_from_context.exists is False, \
                 f'Edit channel option is present when it should not'
         with step('Verify that delete item is not present in context menu'):
-            assert more_options.is_delete_channel_option_present() is False, \
+            assert more_options.delete_channel_from_context.exists is False, \
                 f'Delete channel option is present when it should not'
 
 

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_add_edit_delete_generated_account.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_add_edit_delete_generated_account.py
@@ -4,8 +4,8 @@ import allure
 import pytest
 from allure_commons._allure import step
 
-from constants import UserAccount, RandomUser
-from scripts.utils.generators import random_password_string
+from constants import RandomUser
+from scripts.utils.generators import random_wallet_account_name
 from tests.wallet_main_screen import marks
 
 import constants
@@ -20,16 +20,17 @@ pytestmark = marks
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703033', 'Manage a generated account')
 @pytest.mark.case(703033)
 @pytest.mark.parametrize('user_account', [RandomUser()])
-@pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
-                         'new_name, new_color, new_emoji, new_emoji_unicode', [
-                             pytest.param('GenAcc1', '#2a4af5', 'sunglasses', '1f60e',
-                                          'GenAcc1edited', '#216266', 'thumbsup', '1f44d')
+@pytest.mark.parametrize('color, emoji, emoji_unicode, '
+                         'new_color, new_emoji, new_emoji_unicode', [
+                             pytest.param('#2a4af5', 'sunglasses', '1f60e',
+                                          '#216266', 'thumbsup', '1f44d')
                          ])
-def test_plus_button_manage_generated_account(main_screen: MainWindow, user_account,
-                                              color: str, emoji: str, emoji_unicode: str,
-                                              name: str, new_name: str, new_color: str, new_emoji: str,
-                                              new_emoji_unicode: str):
+def test_add_edit_delete_generated_account(main_screen: MainWindow, user_account,
+                                           color: str, emoji: str, emoji_unicode: str,
+                                           new_color: str, new_emoji: str,
+                                           new_emoji_unicode: str):
     with step('Create generated wallet account'):
+        name = random_wallet_account_name()
         wallet = main_screen.left_panel.open_wallet()
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
@@ -52,6 +53,7 @@ def test_plus_button_manage_generated_account(main_screen: MainWindow, user_acco
                 raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
 
     with step('Edit wallet account'):
+        new_name = random_wallet_account_name()
         account_popup = wallet.left_panel.open_edit_account_popup_from_context_menu(name)
         account_popup.set_name(new_name).set_emoji(new_emoji).set_color(new_color).save_changes()
 

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
@@ -1,18 +1,13 @@
-import random
-import string
 import time
 
 import allure
 import pytest
 from allure import step
 
-from constants import UserAccount, RandomUser
-from scripts.utils.generators import random_name_string, random_password_string
-from constants.wallet import WalletAccountPopup
+from constants import RandomUser
 from tests.wallet_main_screen import marks
 
 import constants
-import driver
 from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.authenticate_popup import AuthenticatePopup
 from gui.main_window import MainWindow
@@ -24,15 +19,12 @@ pytestmark = marks
                  'Manage an account created from the generated seed phrase')
 @pytest.mark.case(703036)
 @pytest.mark.parametrize('user_account', [RandomUser()])
-@pytest.mark.parametrize('name, color, emoji, emoji_unicode, '
-                         'new_name, new_color, new_emoji, new_emoji_unicode, keypair_name', [
+@pytest.mark.parametrize('name, color, emoji, emoji_unicode, keypair_name', [
                              pytest.param('SPAcc', '#2a4af5', 'sunglasses', '1f60e',
-                                          'SPAccedited', '#216266', 'thumbsup', '1f44d', 'SPKeyPair')])
+                                          'SPKeyPair')])
 def test_plus_button_manage_account_added_for_new_seed(main_screen: MainWindow, user_account,
                                                        name: str, color: str, emoji: str,
                                                        emoji_unicode: str,
-                                                       new_name: str, new_color: str, new_emoji: str,
-                                                       new_emoji_unicode: str,
                                                        keypair_name: str):
     with step('Create generated seed phrase wallet account'):
         wallet = main_screen.left_panel.open_wallet()
@@ -57,32 +49,3 @@ def test_plus_button_manage_account_added_for_new_seed(main_screen: MainWindow, 
             if time.monotonic() - started_at > 15:
                 raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
 
-    with step('Edit wallet account'):
-        account_popup = wallet.left_panel.open_edit_account_popup_from_context_menu(name)
-
-        with step('Verify that error appears when name consists of less then 5 characters'):
-            account_popup.set_name(''.join(random.choices(string.ascii_letters +
-                                                          string.digits, k=4)))
-            assert account_popup.get_error_message() == WalletAccountPopup.WALLET_ACCOUNT_NAME_MIN.value
-
-        account_popup.set_name(new_name).set_emoji(new_emoji).set_color(new_color).save_changes()
-
-    with step('Verify that the account is correctly displayed in accounts list'):
-        expected_account = constants.user.account_list_item(new_name, new_color.lower(), new_emoji_unicode)
-        started_at = time.monotonic()
-        while expected_account not in wallet.left_panel.accounts:
-            time.sleep(1)
-            if time.monotonic() - started_at > 15:
-                raise LookupError(f'Account {expected_account} not found in {wallet.left_panel.accounts}')
-
-    with step('Delete wallet account with agreement'):
-        wallet.left_panel.delete_account_from_context_menu(new_name).agree_and_confirm()
-
-    with step('Verify toast message notification when removing account'):
-        messages = main_screen.wait_for_notification()
-        assert f'"{new_name}" successfully removed' in messages, \
-            f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
-
-    with step('Verify that the account is not displayed in accounts list'):
-        assert driver.waitFor(lambda: new_name not in [account.name for account in wallet.left_panel.accounts], 10000), \
-            f'Account with {new_name} is still displayed even it should not be'

--- a/test/e2e/tests/wallet_main_screen/wallet - right click on account/test_context_menu_edit_default_account.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click on account/test_context_menu_edit_default_account.py
@@ -24,7 +24,7 @@ def test_context_menu_edit_default_account(main_screen: MainWindow, name: str, n
 
     with step("Verify default status account can't be deleted"):
         context_menu = wallet.left_panel._open_context_menu_for_account(name)
-        assert not context_menu.is_delete_account_option_present(), \
+        assert not context_menu.delete_from_context.is_visible, \
             f"Delete option should not be present for Status account"
 
     with step('Edit wallet account'):

--- a/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
@@ -33,7 +33,7 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
         SigningPhrasePopup().wait_until_appears().confirm_phrase()
 
     with step('Create watched address from context menu'):
-        account_popup = wallet.left_panel.select_add_watched_address_from_context_menu()
+        account_popup = wallet.left_panel.add_watched_address_from_context.click()
         account_popup.set_name(name).set_emoji(emoji).set_color(color).set_eth_address(address).save_changes()
         account_popup.wait_until_hidden()
 


### PR DESCRIPTION
### What does the PR do

1. now editing account in wallet with right click won't be flaky (as on the video below). It was clicking too fast, and accidentally closing context menu and ending up opening saved addresses instead 

https://github.com/user-attachments/assets/7a48cd31-847c-4b01-936d-41e782467e78

2. removed unnecessary encapsulation. Frankly speaking, having a separate method that will locate and click item is overhead. I simplified that (for now only for context menu class, but will do more later on, it is just less code which is great i think)

CI run, seem to be no retries https://ci.status.im/job/status-desktop/job/e2e/job/manual/2477/allure/#suites/1daca0bc81a20f2b3833d58fe035f048/a33e374caad4a93c/

<img width="1840" alt="Screenshot 2024-08-29 at 16 49 25" src="https://github.com/user-attachments/assets/4433cca7-b750-43ce-9cc0-6297cf1107fb">


### Affected areas

Tests