### PR TITLE
fix(StatusChatInput): set max number of images to 6 to align with mobile

### DIFF
--- a/ui/imports/shared/status/StatusChatImageExtensionValidator.qml
+++ b/ui/imports/shared/status/StatusChatImageExtensionValidator.qml
@@ -1,10 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtGraphicalEffects 1.0
+import QtQuick 2.15
 
 import utils 1.0
-import ".."
 
 StatusChatImageValidator {
     id: root

--- a/ui/imports/shared/status/StatusChatImageQtyValidator.qml
+++ b/ui/imports/shared/status/StatusChatImageQtyValidator.qml
@@ -1,10 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtGraphicalEffects 1.0
+import QtQuick 2.15
 
 import utils 1.0
-import ".."
 
 StatusChatImageValidator {
     id: root

--- a/ui/imports/shared/status/StatusChatImageSizeValidator.qml
+++ b/ui/imports/shared/status/StatusChatImageSizeValidator.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 import utils 1.0
 

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -70,7 +70,7 @@ Rectangle {
 
     property bool askToEnableLinkPreview: false
 
-    property var imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Top // TODO: Remove this property?
+    property int imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Top // TODO: Remove this property?
 
     property alias suggestions: suggestionsBox
 
@@ -880,10 +880,7 @@ Rectangle {
         resetReplyArea()
     }
 
-    function validateImages(imagePaths) {
-        if (!imagePaths || !imagePaths.length) {
-            return []
-        }
+    function validateImages(imagePaths = []) {
         // needed because control.fileUrlsAndSources is not a normal js array
         const existing = (control.fileUrlsAndSources || []).map(x => x.toString())
         let validImages = Utils.deduplicate(existing.concat(imagePaths))
@@ -1144,13 +1141,23 @@ Rectangle {
                 z: 1
 
                 StatusChatImageExtensionValidator {
+                    id: imageExtValidator
                     Layout.alignment: Qt.AlignHCenter
                 }
                 StatusChatImageSizeValidator {
+                    id: imageSizeValidator
                     Layout.alignment: Qt.AlignHCenter
                 }
                 StatusChatImageQtyValidator {
+                    id: imageQtyValidator
                     Layout.alignment: Qt.AlignHCenter
+                }
+
+                Timer {
+                    interval: 3000
+                    repeat: true
+                    running: !imageQtyValidator.isValid || !imageSizeValidator.isValid || !imageExtValidator.isValid
+                    onTriggered: validateImages(control.fileUrlsAndSources)
                 }
             }
 
@@ -1195,6 +1202,7 @@ Rectangle {
                             urls.splice(index, 1)
                         }
                         control.fileUrlsAndSources = urls
+                        validateImages(control.fileUrlsAndSources)
                     }
                     onImageClicked: (chatImage) => Global.openImagePopup(chatImage, "", false)
                     onLinkReload: (link) => control.linkPreviewReloaded(link)

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -988,7 +988,7 @@ QtObject {
     readonly property string statusHelpLinkPrefix: `https://status.app/help/`
     readonly property string downloadLink: "https://status.im/get"
 
-    readonly property int maxUploadFiles: 5
+    readonly property int maxUploadFiles: 6
     readonly property double maxUploadFilesizeMB: 10
 
     readonly property int maxNumberOfPins: 3


### PR DESCRIPTION
### What does the PR do

- re-evaluate the validators to be able to hide the warning after 3 seconds (the validators won't let the user select/paste an invalid image; it's just the warning bubble that persisted)
- some small cleanups

Fixes #16210

### Affected areas

StatusChatInput

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/f09bc5b0-d65f-4409-9b8d-b3df3fc63bd7
