### PR TITLE
fix(ci): add hash algoritm for Sectigo TS server

### DIFF
--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -37,9 +37,9 @@ pipeline {
       name: 'WINDOWS_CODESIGN_TIMESTAMP_URL',
       description: 'Time Stamp Authority (TSA) server for signing binaries.',
       choices: [
-        'http://timestamp.digicert.com',
-        'http://timestamp.sectigo.com',
         'http://timestamp.apple.com/ts01',
+        'http://timestamp.digicert.com', /* Known to cause 0x80096005, 0x800700e1 errors. */
+        'http://timestamp.sectigo.com?td=sha256',
         'http://time.certum.pl',
         'https://freetsa.org',
       ]


### PR DESCRIPTION
Otherwise signing fails with:
```
Error: SignerSign() failed." (-2146869243/0x80096005)
```
See:
- https://stackoverflow.com/questions/62161135/signersign-failed-2146869243-0x80096005
- https://github.com/electron-userland/electron-builder/issues/5166#issuecomment-663568037