### PR TITLE
fix: Slippage Selector Issues

### DIFF
--- a/storybook/pages/SlippageSelectorPage.qml
+++ b/storybook/pages/SlippageSelectorPage.qml
@@ -45,6 +45,12 @@ SplitView {
                 text: "Valid: %1".arg(slippageSelector.valid ? "true" : "false")
             }
 
+            Label {
+                Layout.fillWidth: true
+                font.weight: Font.Medium
+                text: "Edited: %1".arg(slippageSelector.isEdited ? "true" : "false")
+            }
+
             ColumnLayout {
                 Repeater {
                     model: [0, 0.1, 0.5, 0.24, 0.8, 120.84]

--- a/ui/StatusQ/src/StatusQ/Controls/StatusButtonRow.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusButtonRow.qml
@@ -16,6 +16,8 @@ RowLayout {
 
     spacing: 8
 
+    signal buttonClicked()
+
     Repeater {
         id: repeater
 
@@ -34,7 +36,10 @@ RowLayout {
             checked: value === root.value
             text: model[root.textRole]
 
-            onClicked: root.value = value
+            onClicked: {
+                root.value = value
+                root.buttonClicked()
+            }
         }
     }
 }

--- a/ui/imports/shared/controls/CurrencyAmountInput.qml
+++ b/ui/imports/shared/controls/CurrencyAmountInput.qml
@@ -47,8 +47,10 @@ TextField {
     }
 
     Keys.onPressed: (event) => {
-                        // additionally accept dot (.) and convert it to the correct decimal point char
-                        if (event.key === Qt.Key_Period) {
+                        // reject group (thousands) separator
+                        if (event.text === Qt.locale(root.locale).groupSeparator) {
+                            event.accepted = true
+                        } else if (event.key === Qt.Key_Period) { // additionally accept dot (.) and convert it to the correct decimal point char
                             root.insert(root.cursorPosition, Qt.locale(root.locale).decimalPoint)
                             event.accepted = true
                         } else if (event.modifiers === Qt.NoModifier && event.key >= Qt.Key_A && event.key <= Qt.Key_Z) {


### PR DESCRIPTION
### What does the PR do

- add various error/warning messages according to Figma (where it makes sense)
- letters or more than 2 decimals are caught by the internal validator so those combinations are impossible to enter
- fix marking the custom value as (in)valid
- fix selecting "Use default" after typing a custom value
- fix resetting to predefined value after typing a custom value that matches one of the predefined ones
- add regression QML tests for the above fixes

Fixes #15017

### Affected areas

SlippageSelector, SwapModal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/dd09cf52-aef5-4246-ac32-56bc5e96ffc5
