### PR TITLE
fix: Apply custom asset / collectible order

### DIFF
--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -11,6 +11,7 @@ import Qt.labs.settings 1.1
 
 import Models 1.0
 
+import AppLayouts.Wallet.controls 1.0
 import AppLayouts.stores 1.0 as AppLayoutStores
 import AppLayouts.Wallet.views 1.0
 import AppLayouts.Wallet.stores 1.0
@@ -172,6 +173,7 @@ SplitView {
             SplitView.fillHeight: true
 
             AssetsView {
+                id: assetView
                 anchors.fill: parent
 
                 loading: loadingCheckBox.checked
@@ -264,6 +266,44 @@ SplitView {
                 id: marketDataErrorCheckBox
 
                 text: "market data error"
+            }
+            ColumnLayout {
+                spacing: 5
+                Button {
+                    text: "Sort desc"
+                    onClicked: assetView.setSortOrder(Qt.DescendingOrder)
+                }
+
+                Button {
+                    text: "Sort asc"
+                    onClicked: assetView.setSortOrder(Qt.AscendingOrder)
+                }
+            }
+            ColumnLayout {
+                spacing: 10
+                Layout.fillWidth: true
+                Label {
+                    text: "Sort by:"
+                }
+
+                ComboBox {
+                    id: sortValueComboBox
+                    Layout.fillWidth: true
+                    textRole: "text"
+                    valueRole: "value"
+                    displayText: currentText || ""
+                    currentIndex: 4
+                    model: [
+                        { value: SortOrderComboBox.TokenOrderCurrencyBalance, text: "TokenOrderCurrencyBalance" },
+                        { value: SortOrderComboBox.TokenOrderBalance, text: "TokenOrderBalance" },
+                        { value: SortOrderComboBox.TokenOrderCurrencyPrice, text: "TokenOrderCurrencyPrice" },
+                        { value: SortOrderComboBox.TokenOrder1DChange, text: "TokenOrder1DChange" },
+                        { value: SortOrderComboBox.TokenOrderAlpha, text: "TokenOrderAlpha" },
+                        { value: SortOrderComboBox.TokenOrderCustom, text: "TokenOrderCustom" }
+                    ]
+
+                    onCurrentValueChanged: assetView.sortByValue(currentValue)
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -246,6 +246,7 @@ StatusSectionLayout {
             sourceComponent: WalletView {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
+                myPublicKey: root.store.contactsStore.myPublicKey
                 rootStore: root.store
                 tokensStore: root.tokensStore
                 networkConnectionStore: root.networkConnectionStore

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -31,6 +31,7 @@ SettingsContentBase {
     id: root
 
     property var emojiPopup
+    property string myPublicKey: ""
     property ProfileSectionStore rootStore
     property WalletStore walletStore: rootStore.walletStore
     required property TokensStore tokensStore
@@ -81,15 +82,14 @@ SettingsContentBase {
         }
 
         let sectionLink = "%1/%2/".arg(Constants.appSection.wallet).arg(WalletLayout.LeftPanelSelection.AllAddresses)
-
-        if (Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets) {
+        if (manageTokensView.assetsPanelVisible) {
             sectionLink += WalletLayout.RightPanelSelection.Assets
-            priv.assetSettings.setValue("currentSortValue", SortOrderComboBox.TokenOrderCustom)
-            priv.assetSettings.sync()
-        } else if (Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles) {
+            priv.walletSettings.setValue("assetsViewCustomOrderApplyTimestamp", new Date().getTime())
+            priv.walletSettings.sync()
+        } else if (manageTokensView.collectiblesPanelVisible) {
             sectionLink += WalletLayout.RightPanelSelection.Collectibles
-            priv.collectiblesSettings.setValue("currentSortValue", SortOrderComboBox.TokenOrderCustom)
-            priv.collectiblesSettings.sync()
+            priv.walletSettings.setValue("collectiblesViewCustomOrderApplyTimestamp", new Date().getTime())
+            priv.walletSettings.sync()
         }
 
         Global.displayToastMessage(
@@ -113,14 +113,8 @@ SettingsContentBase {
                                                          Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageHidden ||
                                                          Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAdvanced
 
-        readonly property var assetSettings: Settings {
-            category: "AssetsViewSortSettings"
-            //property int currentSortValue
-        }
-
-        readonly property var collectiblesSettings: Settings {
-            category: "CollectiblesViewSortSettings"
-            //property int currentSortValue
+        readonly property var walletSettings: Settings {
+            category: "walletSettings-" + root.myPublicKey
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -50,6 +50,9 @@ Item {
         loader.item.resetChanges()
     }
 
+    readonly property bool assetsPanelVisible: tabBar.currentIndex === d.assetsTabIndex
+    readonly property bool collectiblesPanelVisible: tabBar.currentIndex === d.collectiblesTabIndex
+
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -1,11 +1,14 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import Qt.labs.settings 1.1
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
+
+import AppLayouts.Wallet.controls 1.0
 
 import utils 1.0
 import shared.controls 1.0
@@ -195,6 +198,52 @@ RightTabBaseView {
                             }
                         }
 
+                        function refreshSortSettings() {
+                            settings.category = settingsCategoryName
+                            walletSettings.sync()
+                            settings.sync()
+                            let value = SortOrderComboBox.TokenOrderAlpha
+                            if (walletSettings.assetsViewCustomOrderApplyTimestamp > settings.sortOrderUpdateTimestamp && customOrderAvailable) {
+                                value = SortOrderComboBox.TokenOrderCustom
+                            } else {
+                                value = settings.currentSortValue
+                            }
+                            sortByValue(value)
+                            setSortOrder(settings.currentSortOrder)
+                        }
+
+                        function saveSortSettings() {
+                            settings.currentSortValue = getSortValue()
+                            settings.currentSortOrder = getSortOrder()
+                            settings.sortOrderUpdateTimestamp = new Date().getTime()
+                            settings.sync()
+                        }
+
+                        readonly property string settingsCategoryName: {
+                            const addressFilters = RootStore.addressFilters
+                            return "AssetsViewSortSettings-" + (addressFilters.indexOf(':') > -1 ? "all" : addressFilters)
+                        }
+                        onSettingsCategoryNameChanged: {
+                            saveSortSettings()
+                            refreshSortSettings()
+                        }
+
+                        Component.onCompleted: refreshSortSettings()
+                        Component.onDestruction: saveSortSettings()
+
+                        readonly property Settings walletSettings: Settings {
+                            id: walletSettings
+                            category: "walletSettings-" + root.contactsStore.myPublicKey
+                            property var assetsViewCustomOrderApplyTimestamp
+                        }
+
+                        readonly property Settings settings: Settings {
+                            id: settings
+                            property int currentSortValue: SortOrderComboBox.TokenOrderDateAdded
+                            property var sortOrderUpdateTimestamp
+                            property int currentSortOrder: Qt.DescendingOrder
+                        }
+
                         loading: RootStore.overview.balanceLoading
                         sorterVisible: filterButton.checked
                         customOrderAvailable: RootStore.walletAssetsStore.assetsController.hasSettings
@@ -269,13 +318,59 @@ RightTabBaseView {
 
                 Component {
                     id: collectiblesView
-                    CollectiblesView {
+                    CollectiblesView { 
+                        id: collView
+                        function refreshSortSettings() {
+                            settings.category = settingsCategoryName
+                            walletSettings.sync()
+                            settings.sync()
+                            let value = SortOrderComboBox.TokenOrderAlpha
+                            if (walletSettings.collectiblesViewCustomOrderApplyTimestamp > settings.sortOrderUpdateTimestamp && customOrderAvailable) {
+                                value = SortOrderComboBox.TokenOrderCustom
+                            } else {
+                                value = settings.currentSortValue
+                            }
+                            sortByValue(value)
+                            setSortOrder(settings.currentSortOrder)
+                        }
+
+                        function saveSortSettings() {
+                            settings.currentSortValue = getSortValue()
+                            settings.currentSortOrder = getSortOrder()
+                            settings.sortOrderUpdateTimestamp = new Date().getTime()
+                            settings.sync()
+                        }
+
+                        readonly property string settingsCategoryName: "CollectiblesViewSortSettings-" + (addressFilters.indexOf(':') > -1 ? "all" : addressFilters)
+                        onSettingsCategoryNameChanged: {
+                            saveSortSettings()
+                            refreshSortSettings()
+                        }
+
+                        Component.onCompleted: refreshSortSettings()
+                        Component.onDestruction: saveSortSettings()
+
+                        readonly property Settings walletSettings: Settings {
+                            id: walletSettings
+                            category: "walletSettings-" + root.contactsStore.myPublicKey
+                            property real collectiblesViewCustomOrderApplyTimestamp: 0
+                        }
+
+                        readonly property Settings settings: Settings {
+                            id: settings
+                            property int currentSortValue: SortOrderComboBox.TokenOrderDateAdded
+                            property real sortOrderUpdateTimestamp: 0
+                            property alias selectedFilterGroupIds: collView.selectedFilterGroupIds
+                            property int currentSortOrder: Qt.DescendingOrder
+                        }
+
                         ownedAccountsModel: RootStore.nonWatchAccounts
                         controller: RootStore.collectiblesStore.collectiblesController
                         networkFilters: RootStore.networkFilters
                         addressFilters: RootStore.addressFilters
                         sendEnabled: root.networkConnectionStore.sendBuyBridgeEnabled && !RootStore.overview.isWatchOnlyAccount && RootStore.overview.canSend
                         filterVisible: filterButton.checked
+                        customOrderAvailable: controller.hasSettings
                         onCollectibleClicked: {
                             RootStore.collectiblesStore.getDetailedCollectible(chainId, contractAddress, tokenId)
                             RootStore.setCurrentViewedHolding(uid, uid, tokenType, communityId)

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import QtQml 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
@@ -82,10 +83,28 @@ Control {
     signal hideCommunityAssetsRequested(string communityKey)
     signal manageTokensRequested
 
+    function setSortOrder(order) {
+        d.sortOrder = order
+    }
+
+    function getSortOrder() {
+        return d.sortOrder
+    }
+
+    function getSortValue() {
+        return d.sortValue
+    }
+
+    function sortByValue(value) {
+        d.sortValue = value
+    }
+
     QtObject {
         id: d
 
         readonly property int loadingItemsCount: 25
+        property int sortOrder: Qt.DescendingOrder
+        property int sortValue: -1
     }
 
     SortFilterProxyModel {
@@ -159,7 +178,21 @@ Control {
 
                     objectName: "cmbTokenOrder"
                     hasCustomOrderDefined: root.customOrderAvailable
-
+                    Binding on currentIndex {
+                        value: {
+                            sortOrderComboBox.count
+                            let id = sortOrderComboBox.indexOfValue(d.sortValue)
+                            if (id === -1)
+                                id = sortOrderComboBox.indexOfValue(SortOrderComboBox.TokenOrderAlpha)
+                            return id
+                        }
+                        when: sortOrderComboBox.count > 0
+                    }
+                    onCurrentValueChanged: d.sortValue = sortOrderComboBox.currentValue
+                    Binding on currentSortOrder {
+                        value: d.sortOrder
+                    }
+                    onCurrentSortOrderChanged: d.sortOrder = sortOrderComboBox.currentSortOrder
                     model: [
                         { value: SortOrderComboBox.TokenOrderCurrencyBalance,
                             text: qsTr("Asset balance value"), icon: "", sortRoleName: "marketBalance" },


### PR DESCRIPTION
Closes #15368

### What does the PR do

* Use separate token management settings for each account. On the backend the order is stored separate to each account.
* Add settings for assets view to save last used sort
* Added timestamps for both wallet settings and specific (asset or collectibles) settings to be able to differentiate override with custom order

### Affected areas

Asset view
Collectibles view

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/53d5ca25-b16d-4f58-b353-c0ad94e6a40f

