### PR TITLE
fix: Update account only when networks did change

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -257,6 +257,8 @@ ColumnLayout {
                 flatNetworks: root.walletStore.filteredFlatModel
                 multiSelection: true
                 selection: d.preferredSharingNetworksArray
+
+                property string initialSelection
                 
                 onSelectionChanged: {
                     if (selection !== d.preferredSharingNetworksArray) {
@@ -264,8 +266,10 @@ ColumnLayout {
                     }
                 }
 
+                control.popup.onOpened: initialSelection = JSON.stringify(selection)
+
                 control.popup.onClosed: {
-                    if (!!root.account) {
+                    if (!!root.account && initialSelection !== JSON.stringify(selection)) {
                         root.walletStore.updateWalletAccountPreferredChains(root.account.address, d.preferredSharingNetworksArray.join(":"))
                     }
                 }

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -307,6 +307,8 @@ StatusModal {
                 NetworkSelectPopup {
                     id: selectPopup
 
+                    property string initialSelection
+
                     x: editButton.width - width
                     y: editButton.height + 2
 
@@ -323,8 +325,10 @@ StatusModal {
                             d.preferredChainIdsArray = selection
                     }
 
+                    onOpened: initialSelection = JSON.stringify(selection)
                     onClosed: {
-                        root.updatePreferredChains(root.selectedAccount.address, d.preferredChainIds)
+                        if (initialSelection !== JSON.stringify(selection))
+                            root.updatePreferredChains(root.selectedAccount.address, d.preferredChainIds)
                     }
                 }
             }


### PR DESCRIPTION
Task #15880

### What does the PR do

Update account only when networks did change

### Affected areas

* Receive modal
* Account preferred netwoks in settings