### PR TITLE
fix: Reset collectible details after exiting details page

### DIFF
--- a/src/app/modules/shared_modules/collectible_details/controller.nim
+++ b/src/app/modules/shared_modules/collectible_details/controller.nim
@@ -112,6 +112,10 @@ QtObject:
       error "error fetching collectible details: ", response.error
       return
 
+  proc resetDetailedCollectible*(self: Controller) {.slot.} =
+    self.detailedEntry = newCollectibleDetailsEmptyEntry()
+    self.detailedEntryChanged()
+
   proc setupEventHandlers(self: Controller) =
     self.eventsHandler.onGetCollectiblesDetailsDone(proc (jsonObj: JsonNode) =
       self.processGetCollectiblesDetailsResponse(jsonObj)

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -297,7 +297,12 @@ Item {
         footer: WalletFooter {
             id: footer
 
-            readonly property bool isHoldingSelected: !!walletStore.currentViewedCollectible && walletStore.currentViewedHoldingID !== ""
+            readonly property bool isHoldingSelected: {
+                if (!rightPanelStackView.currentItem || rightPanelStackView.currentItem.currentTabIndex !== WalletLayout.RightPanelSelection.Collectibles) {
+                    return false
+                }
+                return !!walletStore.currentViewedCollectible && walletStore.currentViewedHoldingID !== ""
+            }
             readonly property bool isCommunityCollectible: !!walletStore.currentViewedCollectible ? walletStore.currentViewedCollectible.communityId !== "" : false
             readonly property bool isOwnerCommunityCollectible: isCommunityCollectible ? (walletStore.currentViewedCollectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) : false
 

--- a/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CollectiblesStore.qml
@@ -109,6 +109,10 @@ QtObject {
         walletSection.collectibleDetailsController.getDetailedCollectible(chainId, contractAddress, tokenId)
     }
 
+    function resetDetailedCollectible() {
+        walletSection.collectibleDetailsController.resetDetailedCollectible()
+    }
+
     function hasNFT(ownerAddress, chainId, tokenId, tokenAddress) {
         const uid = getUidForData(tokenId, tokenAddress, chainId)
         ownerAddress = ownerAddress.toLowerCase()

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -356,6 +356,7 @@ RightTabBaseView {
             onVisibleChanged: {
                 if (!visible) {
                     RootStore.resetCurrentViewedHolding(Constants.TokenType.ERC721)
+                    RootStore.collectiblesStore.resetDetailedCollectible()
                 }
             }
 


### PR DESCRIPTION
Closes #16192

### What does the PR do

Reset collectible details entry when closing details view.
Collectible is fetched every time when entering details view anyway

### Affected areas

Collectibles view / Wallet footer