### PR TITLE
feat: Show send error message inside the SendModal

### DIFF
--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -211,6 +211,13 @@ SplitView {
                 preSelectedHoldingID: loader.preSelectedHoldingID
                 preSelectedHoldingType: loader.preSelectedHoldingType
                 showCustomRoutingMode: ctrlShowCustomMode.checked
+                generateUuid: () => { return "12345" }
+                sendTransaction: () => {
+                                    if (!showSendErrorCheckBox.checked)
+                                         return
+
+                                    txStore.walletSectionSendInst.transactionSent(1, "0x123", generateUuid(), "Send error, please ignore")
+                                 }
             }
             Component.onCompleted: loader.active = true
         }
@@ -351,6 +358,12 @@ SplitView {
                 id: ctrlShowCustomMode
                 text: "Show custom network routing panel"
                 checked: true
+            }
+
+            CheckBox {
+                id: showSendErrorCheckBox
+                text: "Show send error"
+                checked: false
             }
 
             CheckBox {


### PR DESCRIPTION
Closes #15828

### What does the PR do

Instead of native window error message, show error message inside the SendModal. 
It was based on similar router error visuals.
Additionally parsing was added so message is more clear, without obvious text that it is from status-go and createMultiTx API function.

**NOTE** this is not final product, just simple improvement over current really bad state. 
I'm more than happy to hear suggestions for improvements.

### Affected areas

Send Modal

### Screenshot of functionality (including design for comparison)

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/c457296a-5959-4055-8377-985787c2307f">
