### PR TITLE
fix for issue breaking `make` on mac: Update macOS deployment target to 12.0 and bottle version to Monterey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ else
 endif
 
 ifeq ($(detected_OS),Darwin)
- CFLAGS := -mmacosx-version-min=11.0
+ CFLAGS := -mmacosx-version-min=12.0
  export CFLAGS
- CGO_CFLAGS := -mmacosx-version-min=11.0
+ CGO_CFLAGS := -mmacosx-version-min=12.0
  export CGO_CFLAGS
  LIBSTATUS_EXT := dylib
   # keep in sync with BOTTLE_MACOS_VERSION
- MACOSX_DEPLOYMENT_TARGET := 11.0
+ MACOSX_DEPLOYMENT_TARGET := 12.0
  export MACOSX_DEPLOYMENT_TARGET
  PKG_TARGET := pkg-macos
  RUN_TARGET := run-macos
@@ -129,9 +129,9 @@ BOTTLES_DIR := $(shell pwd)/bottles
 BOTTLES := $(addprefix $(BOTTLES_DIR)/,openssl@1.1 pcre)
 ifeq ($(QT_ARCH),arm64)
 # keep in sync with MACOSX_DEPLOYMENT_TARGET
-	BOTTLE_MACOS_VERSION := 'arm64_big_sur'
+	BOTTLE_MACOS_VERSION := 'arm64_monterey'
 else
-	BOTTLE_MACOS_VERSION := 'big_sur'
+	BOTTLE_MACOS_VERSION := 'monterey'
 endif
 $(BOTTLES): | $(BOTTLES_DIR)
 	echo -e "\033[92mFetching:\033[39m $(notdir $@) bottle arch $(QT_ARCH) $(BOTTLE_MACOS_VERSION)"

--- a/config.nims
+++ b/config.nims
@@ -23,8 +23,8 @@ if defined(macosx):
   switch("passL", "bottles/pcre/lib/libpcre.a")
   # https://code.videolan.org/videolan/VLCKit/-/issues/232
   switch("passL", "-Wl,-no_compact_unwind")
-  # set the minimum supported macOS version to 11.0
-  switch("passC", "-mmacosx-version-min=11.0")
+  # set the minimum supported macOS version to 12.0
+  switch("passC", "-mmacosx-version-min=12.0")
 elif defined(windows):
   --app:gui
   --tlsEmulation:off

--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -10,6 +10,7 @@ function get_gh_pkgs_token() {
 }
 
 function get_bottle_json() {
+    # echo "Getting bottle JSON for $1 $2"
     brew info --json=v1 "${1}" | jq ".[0].bottle.stable.files[\"${2}\"]"
 }
 
@@ -53,8 +54,8 @@ BOTTLE_JSON=$(get_bottle_json "${BOTTLE_NAME}" "${BOTTLE_FILTER}")
 BOTTLE_URL=$(echo "${BOTTLE_JSON}" | jq -r .url)
 BOTTLE_SHA=$(echo "${BOTTLE_JSON}" | jq -r .sha256)
 
-if [[ -z "${BOTTLE_URL}" ]] || [[ -z "${BOTTLE_SHA}" ]]; then
-    echo "Failed to identify bottle URL or SHA256!" >&2
+if [[ "${BOTTLE_URL}" == "null" ]] || [[ "${BOTTLE_SHA}" == "null" ]]; then
+    echo "Failed to identify bottle URL or SHA256! Bottle dropped from Homebrew?" >&2
     exit 1
 fi
 

--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -10,7 +10,6 @@ function get_gh_pkgs_token() {
 }
 
 function get_bottle_json() {
-    # echo "Getting bottle JSON for $1 $2"
     brew info --json=v1 "${1}" | jq ".[0].bottle.stable.files[\"${2}\"]"
 }
 

--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 if (APPLE)
-    set(MACOS_VERSION_MIN_FLAGS -mmacosx-version-min=10.14)
+    set(MACOS_VERSION_MIN_FLAGS -mmacosx-version-min=11.0)
 endif()
 
 find_package(


### PR DESCRIPTION
### What does the PR do

The openssl bigsur bottle has be dropped, this PR updates the Makefile so the minimum version is now Monterey