### PR TITLE
chore: enable back test with context menu interactions

### DIFF
--- a/test/e2e/tests/crtitical_tests_prs/test_add_edit_delete_generated_account.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_edit_delete_generated_account.py
@@ -25,7 +25,7 @@ pytestmark = marks
                              pytest.param('#2a4af5', 'sunglasses', '1f60e',
                                           '#216266', 'thumbsup', '1f44d')
                          ])
-# @pytest.mark.critical TODO: https://github.com/status-im/status-desktop/issues/16236
+@pytest.mark.critical
 def test_add_edit_delete_generated_account(main_screen: MainWindow, user_account,
                                            color: str, emoji: str, emoji_unicode: str,
                                            new_color: str, new_emoji: str,


### PR DESCRIPTION
### What does the PR do

enable test back as the corresponding issue was fixed. Enabled for both nightly and PRs