### PR TITLE
fix(StatusNavigationListItem): unbreak hovering over settings menu items

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusNavigationListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusNavigationListItem.qml
@@ -21,13 +21,11 @@ StatusListItem {
 
     statusListItemIcon.anchors.topMargin: 14
 
-    highlighted: sensor.containsMouse
-
     color: {
         if (selected) {
             return Theme.palette.statusNavigationListItem.selectedBackgroundColor
         }
-        return highlighted ?
+        return highlighted || sensor.containsMouse ?
           Theme.palette.statusNavigationListItem.hoverBackgroundColor :
           Theme.palette.baseColor4
     }


### PR DESCRIPTION
### What does the PR do

- fixes regression when hover wouldn't work if the menu item contained a beta tag

Fixes #16263

### Affected areas

Settings

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/fcd76ecd-c522-4c1f-9d2e-aa4272c0e05f
