### PR TITLE
fix(categories): make categories collapsing async to fix performance

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -173,12 +173,6 @@ proc init*(self: Controller) =
       self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
   if (self.isCommunitySection):
-    self.events.on(SIGNAL_COMMUNITY_CATEGORY_COLLAPSED_TOGGLED) do(e: Args):
-      let args = CommunityCategoryCollapsedArgs(e)
-
-      if (args.communityId == self.sectionId):
-        self.delegate.onToggleCollapsedCommunityCategory(args.categoryId, args.collapsed)
-
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
       let belongsToCommunity = args.chat.communityId.len > 0
@@ -699,8 +693,8 @@ proc shareCommunityToUsers*(self: Controller, pubKeys: string, inviteMessage: st
 proc reorderCommunityCategories*(self: Controller, categoryId: string, position: int) =
   self.communityService.reorderCommunityCategories(self.sectionId, categoryId, position)
 
-proc toggleCollapsedCommunityCategory*(self: Controller, categoryId: string, collapsed: bool) =
-  self.communityService.toggleCollapsedCommunityCategory(self.sectionId, categoryId, collapsed)
+proc toggleCollapsedCommunityCategoryAsync*(self: Controller, categoryId: string, collapsed: bool) =
+  self.communityService.toggleCollapsedCommunityCategoryAsync(self.sectionId, categoryId, collapsed)
 
 proc reorderCommunityChat*(self: Controller, categoryId: string, chatId: string, position: int) =
   self.communityService.reorderCommunityChat(self.sectionId, categoryId, chatId, position)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -318,10 +318,7 @@ method prepareEditCategoryModel*(self: AccessInterface, categoryId: string) {.ba
 method reorderCommunityCategories*(self: AccessInterface, categoryId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleCollapsedCommunityCategory*(self: AccessInterface, categoryId: string, collapsed: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onToggleCollapsedCommunityCategory*(self: AccessInterface, categoryId: string, collapsed: bool) {.base.} =
+method toggleCollapsedCommunityCategoryAsync*(self: AccessInterface, categoryId: string, collapsed: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method reorderCommunityChat*(self: AccessInterface, categoryId: string, chatId: string, position: int) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1427,11 +1427,8 @@ method reorderCommunityCategories*(self: Module, categoryId: string, categoryPos
 
   self.controller.reorderCommunityCategories(categoryId, finalPosition)
 
-method toggleCollapsedCommunityCategory*(self: Module, categoryId: string, collapsed: bool) =
-  self.controller.toggleCollapsedCommunityCategory(categoryId, collapsed)
-
-method onToggleCollapsedCommunityCategory*(self: Module, categoryId: string, collapsed: bool) =
-  self.view.chatsModel().changeCategoryOpened(categoryId, not collapsed)
+method toggleCollapsedCommunityCategoryAsync*(self: Module, categoryId: string, collapsed: bool) =
+  self.controller.toggleCollapsedCommunityCategoryAsync(categoryId, collapsed)
 
 method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, toPosition: int) =
   self.controller.reorderCommunityChat(categoryId, chatId, toPosition + 1)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -357,7 +357,8 @@ QtObject:
     self.delegate.reorderCommunityCategories(categoryId, categoryPosition)
 
   proc toggleCollapsedCommunityCategory*(self: View, categoryId: string, collapsed: bool) {.slot} =
-    self.delegate.toggleCollapsedCommunityCategory(categoryId, collapsed)
+    self.model.changeCategoryOpened(categoryId, not collapsed)
+    self.delegate.toggleCollapsedCommunityCategoryAsync(categoryId, collapsed)
 
   proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int) {.slot} =
     self.delegate.reorderCommunityChat(categoryId, chatId, position)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -119,9 +119,6 @@ method communityImported*(self: AccessInterface, community: CommunityDto) {.base
 method communityDataImported*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleCollapsedCommunityCategory*(self: AccessInterface, communityId:string, categoryId: string, collapsed: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method communityInfoRequestFailed*(self: AccessInterface, communityId: string, errorMsg: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -282,7 +282,6 @@ proc asyncReevaluateCommunityMembersPermissionsTask(argEncoded: string) {.gcsafe
       "error": e.msg,
     })
 
-
 type
   AsyncSetCommunityShardArg = ref object of QObjectTaskArg
     communityId: string
@@ -300,5 +299,28 @@ proc asyncSetCommunityShardTask(argEncoded: string) {.gcsafe, nimcall.} =
   except Exception as e:
     arg.finish(%* {
       "communityId": arg.communityId,
+      "error": e.msg,
+    })
+
+type
+  AsyncCollapseCategory = ref object of QObjectTaskArg
+    communityId: string
+    categoryId: string
+    collapsed: bool
+
+proc asyncCollapseCategoryTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncCollapseCategory](argEncoded)
+  try:
+    let response = status_go.toggleCollapsedCommunityCategory(
+      arg.communityId,
+      arg.categoryId,
+      arg.collapsed,
+    )
+    arg.finish(%* {
+      "response": response,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
       "error": e.msg,
     })


### PR DESCRIPTION
Fixes #16270

Makes the category collapsing and opening async, so UI feedback is immediate, while the actual save in the DB is done async in the background.

[async-category-collapse.webm](https://github.com/user-attachments/assets/cdf6a303-0755-41a3-a83c-3a63c73721a5)
