### PR TITLE
Exclude gifs handling to separate store, make shared/RootStore singleton smaller

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, uri, stew/shims/strformat, strutils, stint, re, httpclient
+import NimQml, strutils, uri, stew/shims/strformat, strutils, stint, httpclient
 import stew/byteutils
 import ./utils/qrcodegen
 import ./utils/time_utils
@@ -60,20 +60,8 @@ QtObject:
       add(str, "0")
     return str
 
-  proc hex2Eth*(self: Utils, value: string): string {.slot.} =
-    return stripTrailingZeroes(conversion.wei2Eth(stint.fromHex(StUint[256], value)))
-
-  proc hex2Gwei*(self: Utils, value: string): string {.slot.} =
-    return stripTrailingZeroes(conversion.wei2Eth(stint.fromHex(StUint[256], value)*1000000000))
-
   proc gwei2Hex*(self: Utils, gwei: float): string {.slot.} =
     return "0x" & conversion.gwei2Wei(gwei).toHex()
-
-  proc hex2Dec*(self: Utils, value: string): string {.slot.} =
-    # somehow this value crashes the app
-    if value.find(re("0x0+$")) >= 0:
-      return "0"
-    return $stint.fromHex(StUint[256], value)
 
   proc readTextFile*(self: Utils, filepath: string): string {.slot.} =
     try:

--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -7,7 +7,7 @@ import Models 1.0
 
 import utils 1.0
 import shared.status 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 import StatusQ.Core.Utils 0.1
 
@@ -37,21 +37,6 @@ SplitView {
         }
     }
 
-    QtObject {
-        id: rootStoreMock
-
-        property bool ready: false
-
-        readonly property ListModel gifColumnA: ListModel {}
-
-        Component.onCompleted: {
-            RootStore.isWalletEnabled = true
-            RootStore.gifUnfurlingEnabled = true
-            RootStore.gifColumnA = rootStoreMock.gifColumnA
-            rootStoreMock.ready = true
-        }
-    }
-
     UsersModel {
         id: fakeUsersModel
     }
@@ -71,7 +56,7 @@ SplitView {
 
         Loader {
             id: chatInputLoader
-            active: rootStoreMock.ready && globalUtilsMock.ready
+            active: globalUtilsMock.ready
             sourceComponent: StatusChatInput {
                 id: chatInput
                 property var globalUtils: globalUtilsMock.globalUtils
@@ -112,6 +97,16 @@ SplitView {
                 usersStore: ChatStores.UsersStore {
                     readonly property var usersModel: fakeUsersModel
                 }
+
+                sharedStore: SharedStores.RootStore {
+                    isWalletEnabled: true
+                    gifUnfurlingEnabled: true
+
+                    property var gifStore: SharedStores.GifStore {
+                        property var gifColumnA: ListModel {}
+                    }
+                }
+
                 onSendMessage: {
                     logs.logEvent("StatusChatInput::sendMessage", ["MessageWithPk"], [chatInput.getTextWithPublicKeys()])
                     logs.logEvent("StatusChatInput::sendMessage", ["PlainText"], [globalUtilsMock.globalUtils.plainText(chatInput.getTextWithPublicKeys())])

--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -44,31 +44,9 @@ SplitView {
 
         readonly property ListModel gifColumnA: ListModel {}
 
-        readonly property var formationChars: (["*", "`", "~"])
-
-        function getSelectedTextWithFormationChars(messageInputField) {
-            let i = 1
-            let text = ""
-            while (true) {
-                if (messageInputField.selectionStart - i < 0 && messageInputField.selectionEnd + i > messageInputField.length) {
-                    break
-                }
-
-                text = messageInputField.getText(messageInputField.selectionStart - i, messageInputField.selectionEnd + i)
-
-                if (!formationChars.includes(text.charAt(0)) ||
-                        !formationChars.includes(text.charAt(text.length - 1))) {
-                    break
-                }
-                i++
-            }
-            return text
-        }
-
         Component.onCompleted: {
             RootStore.isWalletEnabled = true
             RootStore.gifUnfurlingEnabled = true
-            RootStore.getSelectedTextWithFormationChars = rootStoreMock.getSelectedTextWithFormationChars
             RootStore.gifColumnA = rootStoreMock.gifColumnA
             rootStoreMock.ready = true
         }

--- a/storybook/pages/TransactionDetailViewPage.qml
+++ b/storybook/pages/TransactionDetailViewPage.qml
@@ -27,7 +27,6 @@ SplitView {
     Component.onCompleted: {
         RootStore.getFiatValue = (cryptoValue, symbol) => { return (cryptoValue * 1800).toPrecision(2) }
         RootStore.getLatestBlockNumber = () => { return 4 }
-        RootStore.hex2Dec = (number) => { return 10 }
         RootStore.formatCurrencyAmount = (value, symbol) => { return value + " " + symbol }
         RootStore.getNameForSavedWalletAddress = (address) => { return "Saved Wallet Name" }
         RootStore.getNameForAddress = (address) => { return "Address Name" }

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -7,7 +7,7 @@ import StatusQ 0.1 // https://github.com/status-im/status-desktop/issues/10218
 
 import utils 1.0
 import shared.status 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 import AppLayouts.Chat.stores 1.0 as ChatStores
 
@@ -28,6 +28,15 @@ Item {
             anchors.bottom: parent.bottom
             usersStore: ChatStores.UsersStore {
                 property var usersModel: ListModel {}
+            }
+
+            sharedStore: SharedStores.RootStore {
+                isWalletEnabled: true
+                gifUnfurlingEnabled: true
+
+                property var gifStore: SharedStores.GifStore {
+                    property var gifColumnA: ListModel {}
+                }
             }
         }
     }
@@ -696,20 +705,8 @@ Item {
         function isCompressedPubKey(publicKey) {
             return false
         }
-    }
-
-    QtObject {
-        id: rootStoreMock
-
-        property ListModel gifColumnA: ListModel {}
-
-        property bool gifUnfurlingEnabled: true
 
         Component.onCompleted: {
-            RootStore.isWalletEnabled = true
-            RootStore.gifUnfurlingEnabled = rootStoreMock.gifUnfurlingEnabled
-            RootStore.gifColumnA = rootStoreMock.gifColumnA
-
             Global.dragArea = root
         }
     }

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -703,31 +703,11 @@ Item {
 
         property ListModel gifColumnA: ListModel {}
 
-        readonly property var formationChars: (["*", "`", "~"])
         property bool gifUnfurlingEnabled: true
-        function getSelectedTextWithFormationChars(messageInputField) {
-            let i = 1
-            let text = ""
-            while (true) {
-                if (messageInputField.selectionStart - i < 0 && messageInputField.selectionEnd + i > messageInputField.length) {
-                    break
-                }
-
-                text = messageInputField.getText(messageInputField.selectionStart - i, messageInputField.selectionEnd + i)
-
-                if (!formationChars.includes(text.charAt(0)) ||
-                        !formationChars.includes(text.charAt(text.length - 1))) {
-                    break
-                }
-                i++
-            }
-            return text
-        }
 
         Component.onCompleted: {
             RootStore.isWalletEnabled = true
             RootStore.gifUnfurlingEnabled = rootStoreMock.gifUnfurlingEnabled
-            RootStore.getSelectedTextWithFormationChars = rootStoreMock.getSelectedTextWithFormationChars
             RootStore.gifColumnA = rootStoreMock.gifColumnA
 
             Global.dragArea = root

--- a/storybook/stubs/shared/stores/GifStore.qml
+++ b/storybook/stubs/shared/stores/GifStore.qml
@@ -1,0 +1,3 @@
+import QtQml 2.15
+
+QtObject {}

--- a/storybook/stubs/shared/stores/RootStore.qml
+++ b/storybook/stubs/shared/stores/RootStore.qml
@@ -4,7 +4,6 @@ QtObject {
     property var userProfileInst
     property bool gifUnfurlingEnabled
     property bool isWalletEnabled
-    property var gifColumnA
     property var currentCurrency
     property bool neverAskAboutUnfurlingAgain: false
 

--- a/storybook/stubs/shared/stores/RootStore.qml
+++ b/storybook/stubs/shared/stores/RootStore.qml
@@ -4,7 +4,6 @@ QtObject {
     property var userProfileInst
     property bool gifUnfurlingEnabled
     property bool isWalletEnabled
-    property var getSelectedTextWithFormationChars
     property var gifColumnA
     property var currentCurrency
     property bool neverAskAboutUnfurlingAgain: false

--- a/storybook/stubs/shared/stores/RootStore.qml
+++ b/storybook/stubs/shared/stores/RootStore.qml
@@ -14,7 +14,6 @@ QtObject {
 
     property var getFiatValue
     property var getLatestBlockNumber
-    property var hex2Dec
     property var formatCurrencyAmount
     property var getNameForSavedWalletAddress
     property var getNameForAddress

--- a/storybook/stubs/shared/stores/qmldir
+++ b/storybook/stubs/shared/stores/qmldir
@@ -1,10 +1,11 @@
+BIP39_en 1.0 BIP39_en.qml
 CommunityTokensStore 1.0 CommunityTokensStore.qml
 CurrenciesStore 1.0 CurrenciesStore.qml
+DAppsStore 1.0 DAppsStore.qml
+GifStore 1.0 GifStore.qml
 NetworkConnectionStore 1.0 NetworkConnectionStore.qml
+PermissionsStore 1.0 PermissionsStore.qml
+ProfileStore 1.0 ProfileStore.qml
 RootStore 1.0 RootStore.qml
 TokenBalanceHistoryStore 1.0 TokenBalanceHistoryStore.qml
-BIP39_en 1.0 BIP39_en.qml
-DAppsStore 1.0 DAppsStore.qml
-ProfileStore 1.0 ProfileStore.qml
-PermissionsStore 1.0 PermissionsStore.qml
 TokenMarketValuesStore 1.0 TokenMarketValuesStore.qml

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -625,10 +625,6 @@ QtObject {
         return profileSectionModule.ensUsernamesModule.getEtherscanLink()
     }
 
-    function hex2Eth(value) {
-        return globalUtilsInst.hex2Eth(value)
-    }
-
     function getLoginType() {
         if(!userProfileInst)
             return Constants.LoginType.Password

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -10,13 +10,15 @@ import StatusQ.Core.Backpressure 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
 
-import utils 1.0
 import shared 1.0
-import shared.popups 1.0
-import shared.status 1.0
 import shared.controls 1.0
-import shared.views.chat 1.0
+import shared.popups 1.0
 import shared.popups.send 1.0
+import shared.status 1.0
+import shared.stores 1.0 as SharedStores
+import shared.views.chat 1.0
+import utils 1.0
+
 import SortFilterProxyModel 0.2
 
 import AppLayouts.Communities.popups 1.0
@@ -270,7 +272,7 @@ Item {
                     id: chatInput
                     width: parent.width
                     visible: !!d.activeChatContentModule
-                    
+
                     // When `enabled` is switched true->false, `textInput.text` is cleared before d.activeChatContentModule updates.
                     // We delay the binding so that the `inputAreaModule.preservedProperties.text` doesn't get overriden with empty value.
                     Binding on enabled {
@@ -285,6 +287,9 @@ Item {
 
                     store: root.rootStore
                     usersStore: d.activeUsersStore
+
+                    sharedStore: SharedStores.RootStore
+
                     linkPreviewModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.linkPreviewModel : null
                     urlsList: d.urlsList
                     askToEnableLinkPreview: {
@@ -365,7 +370,7 @@ Item {
                     onKeyUpPress: {
                         d.activeMessagesStore.setEditModeOnLastMessage(root.rootStore.userProfileInst.pubKey)
                     }
-                    
+
                     onLinkPreviewReloaded: (link) => d.activeChatContentModule.inputAreaModule.reloadLinkPreview(link)
                     onEnableLinkPreview: () => {
                         d.activeChatContentModule.inputAreaModule.enableLinkPreview()

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -9,9 +9,10 @@ import StatusQ.Components 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
-import utils 1.0
-import shared.status 1.0
 import shared.controls.delegates 1.0
+import shared.status 1.0
+import shared.stores 1.0 as SharedStores
+import utils 1.0
 
 import AppLayouts.Chat.stores 1.0 as ChatStores
 
@@ -163,6 +164,7 @@ Page {
                 usersStore: ({
                     usersModel: membersSelector.model
                 })
+                sharedStore: SharedStores.RootStore
                 onStickerSelected: {
                     root.createChatPropertiesStore.createChatStickerHashId = hashId;
                     root.createChatPropertiesStore.createChatStickerPackId = packId;

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -218,10 +218,6 @@ QtObject {
         return profileSectionStore.ensUsernamesStore.getGasEthValue(gweiValue, gasLimit)
     }
 
-    function hex2Eth(value) {
-        return globalUtils.hex2Eth(value)
-    }
-
     function setCurrentUserStatus(newStatus) {
         if (userProfileInst && userProfileInst.currentUserStatus !== newStatus) {
             mainModuleInst.setCurrentUserStatus(newStatus)

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -9,7 +9,7 @@ import shared 1.0
 import shared.controls.chat 1.0
 import shared.panels 1.0
 import shared.popups 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 //TODO remove this dependency
 import AppLayouts.Chat.panels 1.0
@@ -38,6 +38,7 @@ Rectangle {
     
     property ChatStores.UsersStore usersStore
     property ChatStores.RootStore store
+    property SharedStores.RootStore sharedStore
 
     property var emojiPopup: null
     property var stickersPopup: null
@@ -1035,6 +1036,9 @@ Rectangle {
 
         StatusGifPopup {
             readonly property point relativePosition: d.getCommonPopupRelativePosition(this, parent)
+
+            gifStore: control.sharedStore.gifStore
+            gifUnfurlingEnabled: control.sharedStore.gifUnfurlingEnabled
 
             width: 360
             height: 440

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -295,6 +295,26 @@ Rectangle {
         function getMentionAtPosition(position: int) {
             return mentionsPos.find(mention => mention.leftIndex < position && mention.rightIndex > position)
         }
+
+        function getSelectedTextWithFormationChars(messageInputField) {
+            const formationChars = ["*", "`", "~"]
+            let i = 1
+            let text = ""
+            while (true) {
+                if (messageInputField.selectionStart - i < 0 && messageInputField.selectionEnd + i > messageInputField.length) {
+                    break
+                }
+
+                text = messageInputField.getText(messageInputField.selectionStart - i, messageInputField.selectionEnd + i)
+
+                if (!formationChars.includes(text.charAt(0)) ||
+                        !formationChars.includes(text.charAt(text.length - 1))) {
+                    break
+                }
+                i++
+            }
+            return text
+        }
     }
 
     function insertInTextInput(start, text) {
@@ -1089,37 +1109,37 @@ Rectangle {
                         wrapper: "**"
                         icon.name: "bold"
                         text: qsTr("Bold")
-                        selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                        selectedTextWithFormationChars: d.getSelectedTextWithFormationChars(messageInputField)
                         onActionTriggered: checked ?
-                                               unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                               unwrapSelection(wrapper, d.getSelectedTextWithFormationChars(messageInputField)) :
                                                wrapSelection(wrapper)
                     }
                     StatusChatInputTextFormationAction {
                         wrapper: "*"
                         icon.name: "italic"
                         text: qsTr("Italic")
-                        selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                        selectedTextWithFormationChars: d.getSelectedTextWithFormationChars(messageInputField)
                         checked: (surroundedBy("*") && !surroundedBy("**")) || surroundedBy("***")
                         onActionTriggered: checked ?
-                                               unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                               unwrapSelection(wrapper, d.getSelectedTextWithFormationChars(messageInputField)) :
                                                wrapSelection(wrapper)
                     }
                     StatusChatInputTextFormationAction {
                         wrapper: "~~"
                         icon.name: "strikethrough"
                         text: qsTr("Strikethrough")
-                        selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                        selectedTextWithFormationChars: d.getSelectedTextWithFormationChars(messageInputField)
                         onActionTriggered: checked ?
-                                               unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                               unwrapSelection(wrapper, d.getSelectedTextWithFormationChars(messageInputField)) :
                                                wrapSelection(wrapper)
                     }
                     StatusChatInputTextFormationAction {
                         wrapper: "`"
                         icon.name: "code"
                         text: qsTr("Code")
-                        selectedTextWithFormationChars: RootStore.getSelectedTextWithFormationChars(messageInputField)
+                        selectedTextWithFormationChars: d.getSelectedTextWithFormationChars(messageInputField)
                         onActionTriggered: checked ?
-                                               unwrapSelection(wrapper, RootStore.getSelectedTextWithFormationChars(messageInputField)) :
+                                               unwrapSelection(wrapper, d.getSelectedTextWithFormationChars(messageInputField)) :
                                                wrapSelection(wrapper)
                     }
                     StatusChatInputTextFormationAction {

--- a/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
@@ -13,6 +13,8 @@ import shared.controls 1.0
 Popup {
     id: root
 
+    signal enableGifsRequested
+
     anchors.centerIn: parent
     height: 278
     width: 291
@@ -79,8 +81,7 @@ Popup {
         size: StatusBaseButton.Size.Small
 
         onClicked: {
-            RootStore.setGifUnfurlingEnabled(true)
-            RootStore.getTrendingsGifs()
+            root.enableGifsRequested()
             root.close()
         }
     }

--- a/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
+++ b/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
@@ -13,9 +13,11 @@ import shared.stores 1.0
 Column {
     id: root
     spacing: 8
+
+    property GifStore gifStore
+
     property alias gifList: repeater
     property int gifWidth: 0
-    property RootStore store
     property var gifSelected: function () {}
     property var toggleFavorite: function () {}
     property string lastHoveredId
@@ -52,7 +54,7 @@ Column {
 
             StatusBaseButton {
                 id: starButton
-                property bool favorite: RootStore.isFavorite(model.id)
+                property bool favorite: root.gifStore.isFavorite(model.id)
 
                 type: StatusFlatRoundButton.Type.Secondary
                 textColor: hovered || favorite ? Style.current.yellow : Style.current.secondaryText
@@ -111,7 +113,7 @@ Column {
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: function (event) {
-                    root.store.addToRecentsGif(model.id)
+                    root.gifStore.addToRecentsGif(model.id)
                     root.gifSelected(event, model.url)
                 }
             }

--- a/ui/imports/shared/stores/GifStore.qml
+++ b/ui/imports/shared/stores/GifStore.qml
@@ -1,0 +1,48 @@
+import QtQuick 2.15
+
+QtObject {
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        readonly property var gifsModuleInst: typeof gifsModule !== "undefined"
+                                              ? gifsModule : null
+    }
+
+    property var gifColumnA: d.gifsModuleInst ? d.gifsModuleInst.gifColumnA : null
+    property var gifColumnB: d.gifsModuleInst ? d.gifsModuleInst.gifColumnB : null
+    property var gifColumnC: d.gifsModuleInst ? d.gifsModuleInst.gifColumnC : null
+    property bool gifLoading: d.gifsModuleInst ? d.gifsModuleInst.gifLoading : false
+
+    function searchGifs(query) {
+        if (d.gifsModuleInst)
+            d.gifsModuleInst.searchGifs(query)
+    }
+
+    function getTrendingsGifs() {
+        if (d.gifsModuleInst)
+            d.gifsModuleInst.getTrendingsGifs()
+    }
+
+    function getRecentsGifs() {
+        if (d.gifsModuleInst)
+            d.gifsModuleInst.getRecentsGifs()
+    }
+
+    function getFavoritesGifs() {
+        return d.gifsModuleInst ? d.gifsModuleInst.getFavoritesGifs() : null
+    }
+
+    function isFavorite(id) {
+        return d.gifsModuleInst ? d.gifsModuleInst.isFavorite(id) : null
+    }
+
+    function toggleFavoriteGif(id, reload) {
+        if (d.gifsModuleInst)
+            d.gifsModuleInst.toggleFavoriteGif(id, reload)
+    }
+
+    function addToRecentsGif(id) {
+        if (d.gifsModuleInst)
+            d.gifsModuleInst.addToRecentsGif(id)
+    }
+}

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -37,10 +37,6 @@ QtObject {
 
     property var flatNetworks: networksModule.flatNetworks
 
-    function hex2Dec(value) {
-        return globalUtils.hex2Dec(value)
-    }
-
     readonly property var formationChars: (["*", "`", "~"])
     function getSelectedTextWithFormationChars(messageInputField) {
         let i = 1
@@ -129,14 +125,6 @@ QtObject {
     function updateTransactionFilterIfDirty() {
         if (transactionActivityStatus.isFilterDirty)
             walletSectionInst.activityController.updateFilter()
-    }
-
-    function hex2Eth(value) {
-        return globalUtils.hex2Eth(value)
-    }
-
-    function hex2Gwei(value) {
-        return globalUtils.hex2Gwei(value)
     }
 
     function getCurrencyAmount(amount, symbol) {

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -1,10 +1,12 @@
 pragma Singleton
 
-import QtQuick 2.12
+import QtQuick 2.15
 import utils 1.0
 
 QtObject {
     id: root
+
+    readonly property GifStore gifStore: GifStore {}
 
     property var profileSectionModuleInst: profileSectionModule
     property var privacyModule: profileSectionModuleInst.privacyModule
@@ -43,51 +45,6 @@ QtObject {
 
     function setGifUnfurlingEnabled(value) {
         localAccountSensitiveSettings.gifUnfurlingEnabled = value
-    }
-
-    property var gifsModuleInst: typeof gifsModule !== "undefined" ? gifsModule : null
-    property var gifColumnA: gifsModuleInst ? gifsModuleInst.gifColumnA
-                                                                 : null
-    property var gifColumnB: gifsModuleInst ? gifsModuleInst.gifColumnB
-                                                                 : null
-    property var gifColumnC: gifsModuleInst ? gifsModuleInst.gifColumnC
-                                                                 : null
-    property bool gifLoading: gifsModuleInst ? gifsModuleInst.gifLoading
-                                                                 : false
-
-    function searchGifs(query) {
-        if (gifsModuleInst)
-            gifsModuleInst.searchGifs(query)
-    }
-
-    function getTrendingsGifs() {
-        if (gifsModuleInst)
-            gifsModuleInst.getTrendingsGifs()
-    }
-
-    function getRecentsGifs() {
-        if (gifsModuleInst)
-            gifsModuleInst.getRecentsGifs()
-    }
-
-    function getFavoritesGifs() {
-        return gifsModuleInst ? gifsModuleInst.getFavoritesGifs()
-                                                   : null
-    }
-
-    function isFavorite(id) {
-        return gifsModuleInst ? gifsModuleInst.isFavorite(id)
-                                                   : null
-    }
-
-    function toggleFavoriteGif(id, reload) {
-        if (gifsModuleInst)
-            gifsModuleInst.toggleFavoriteGif(id, reload)
-    }
-
-    function addToRecentsGif(id) {
-        if (gifsModuleInst)
-            gifsModuleInst.addToRecentsGif(id)
     }
 
     function getPasswordStrengthScore(password) {

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -37,26 +37,6 @@ QtObject {
 
     property var flatNetworks: networksModule.flatNetworks
 
-    readonly property var formationChars: (["*", "`", "~"])
-    function getSelectedTextWithFormationChars(messageInputField) {
-        let i = 1
-        let text = ""
-        while (true) {
-            if (messageInputField.selectionStart - i < 0 && messageInputField.selectionEnd + i > messageInputField.length) {
-                break
-            }
-
-            text = messageInputField.getText(messageInputField.selectionStart - i, messageInputField.selectionEnd + i)
-
-            if (!formationChars.includes(text.charAt(0)) ||
-                    !formationChars.includes(text.charAt(text.length - 1))) {
-                break
-            }
-            i++
-        }
-        return text
-    }
-
     function setNeverAskAboutUnfurlingAgain(value) {
         localAccountSensitiveSettings.neverAskAboutUnfurlingAgain = value;
     }

--- a/ui/imports/shared/stores/qmldir
+++ b/ui/imports/shared/stores/qmldir
@@ -1,11 +1,12 @@
-singleton RootStore 1.0 RootStore.qml
-CurrenciesStore 1.0 CurrenciesStore.qml
-CommunityTokensStore 1.0 CommunityTokensStore.qml
 BIP39_en 1.0 BIP39_en.qml
 ChartStoreBase 1.0 ChartStoreBase.qml
+CommunityTokensStore 1.0 CommunityTokensStore.qml
+CurrenciesStore 1.0 CurrenciesStore.qml
+DAppsStore 1.0 DAppsStore.qml
+GifStore 1.0 GifStore.qml
+MetricsStore 1.0 MetricsStore.qml
+NetworkConnectionStore 1.0 NetworkConnectionStore.qml
 PermissionsStore 1.0 PermissionsStore.qml
 TokenBalanceHistoryStore 1.0 TokenBalanceHistoryStore.qml
 TokenMarketValuesStore 1.0 TokenMarketValuesStore.qml
-MetricsStore 1.0 MetricsStore.qml
-NetworkConnectionStore 1.0 NetworkConnectionStore.qml
-DAppsStore 1.0 DAppsStore.qml
+singleton RootStore 1.0 RootStore.qml

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -8,7 +8,7 @@ import shared.controls 1.0
 import shared.popups 1.0
 import shared.views.chat 1.0
 import shared.controls.chat 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -916,6 +916,7 @@ Loader {
 
                         store: root.rootStore
                         usersStore: root.usersStore
+                        sharedStore: SharedStores.RootStore
                         emojiPopup: root.emojiPopup
                         stickersPopup: root.stickersPopup
 


### PR DESCRIPTION
### What does the PR do

This PR is very first step of bigger effort defined in https://github.com/status-im/status-desktop/issues/16246
It does initial cleanup in `shared/stores/RootStore` in order to make it non-singleton later.

- removes not used methods `hex2Dec`, `hex2Eth` and `hex2Gwei` from `nim` code and several stores where they were exposed
- moves `getSelectedTextWithFormationChars` from store to `Utils` because this method is stateless and fully backend-independent. It allowed the clean-up in `StatusChatInput`'s test and storybook page where this method was duplicated. It also reduced dependency of `StatusChatInput` on a singleton root store.
- dedicated `GifStore` excluded from shared `RootStore`
- direct usages of singleton `RootStore` removed from `StatusChatInput`, tests and sb page slightly simplified

Closes: https://github.com/status-im/status-desktop/issues/16253

### Affected areas
Mainly: `shared/stores/RootStore`, `StatusChatInput`

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)
