### PR TITLE
chore(UserListPanel): speed up sorting by removing ExpressionRole

### DIFF
--- a/storybook/pages/UserListPanelPage.qml
+++ b/storybook/pages/UserListPanelPage.qml
@@ -45,7 +45,7 @@ SplitView {
     // mainModuleInst mock
     QtObject {
         function getContactDetailsAsJson(publicKey, getVerificationRequest) {
-            return JSON.stringify({ ensVerified: false })
+            return JSON.stringify({ ensVerified: publicKey === "0x04d1bed192343f470f1255" }) // make Richard "ENS verified"
         }
         Component.onCompleted: {
             Utils.mainModuleInst = this
@@ -66,7 +66,7 @@ SplitView {
 
             sourceComponent: UserListPanel {
                 usersModel: model
-                label: "Some label"
+                label: "Members"
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -90,13 +90,10 @@ Item {
             model: SortFilterProxyModel {
                 sourceModel: root.usersModel
 
-                proxyRoles: FastExpressionRole {
-                    function displayNameProxy(nickname, ensName, displayName, aliasName) {
-                        return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
-                    }
+                proxyRoles: JoinRole {
                     name: "preferredDisplayName"
-                    expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
-                    expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
+                    roleNames: ["localNickname", "ensName", "displayName", "alias"]
+                    separator: ""
                 }
 
                 sorters: [


### PR DESCRIPTION
> michalc — today at 15:25
with sorting by online status and display name: 517ms
no sorting: 5ms
only sorting by online status, no proxy role: 21ms
with sorting by online status and display name with joined role: 130ms

### What does the PR do

- for sorting purposes, we can achieve the same effect with a simple `JoinRole` instead

Iterates: #11059

### Affected areas

UserListPanel

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Still works and sorts as before :)

![image](https://github.com/user-attachments/assets/7f28a99e-7fe1-43ac-b769-50e51a81671f)


