### PR TITLE
Fix slow chat switching 2: Electric Boogaloo

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -114,6 +114,8 @@ QtObject:
     notify = nameChanged
 
   proc setName*(self: ChatDetails, value: string) = # this is not a slot
+    if self.name == value:
+      return
     self.name = value
     self.nameChanged()
 
@@ -125,6 +127,8 @@ QtObject:
     notify = iconChanged
 
   proc setIcon*(self: ChatDetails, icon: string) = # this is not a slot
+    if self.icon == icon:
+      return
     self.icon = icon
     self.iconChanged()
 
@@ -136,6 +140,8 @@ QtObject:
     notify = colorChanged
 
   proc setColor*(self: ChatDetails, value: string) = # this is not a slot
+    if self.color == value:
+      return
     self.color = value
     self.colorChanged()
 
@@ -147,6 +153,8 @@ QtObject:
     notify = emojiChanged
 
   proc setEmoji*(self: ChatDetails, value: string) = # this is not a slot
+    if self.emoji == value:
+      return
     self.emoji = value
     self.emojiChanged()
 
@@ -158,6 +166,8 @@ QtObject:
     notify = descriptionChanged
 
   proc setDescription*(self: ChatDetails, value: string) = # this is not a slot
+    if self.description == value:
+      return
     self.description = value
     self.descriptionChanged()
 
@@ -169,6 +179,8 @@ QtObject:
     notify = hasUnreadMessages
 
   proc setHasUnreadMessages*(self: ChatDetails, value: bool) = # this is not a slot
+    if self.hasUnreadMessages == value:
+      return
     self.hasUnreadMessages = value
     self.hasUnreadMessagesChanged()
 
@@ -180,6 +192,8 @@ QtObject:
     notify = notificationCountChanged
 
   proc setNotificationCount*(self: ChatDetails, value: int) = # this is not a slot
+    if self.notificationsCount == value:
+      return
     self.notificationsCount = value
     self.notificationCountChanged()
 
@@ -191,6 +205,8 @@ QtObject:
     notify = highlightChanged
 
   proc setHighlight*(self: ChatDetails, value: bool) = # this is not a slot
+    if self.highlight == value:
+      return
     self.highlight = value
     self.highlightChanged()
 
@@ -202,6 +218,8 @@ QtObject:
     notify = mutedChanged
 
   proc setMuted*(self: ChatDetails, value: bool) = # this is not a slot
+    if self.muted == value:
+      return
     self.muted = value
     self.mutedChanged()
 
@@ -213,6 +231,8 @@ QtObject:
     notify = positionChanged
 
   proc setPotion*(self: ChatDetails, value: int) = # this is not a slot
+    if self.position == value:
+      return
     self.position = value
     self.positionChanged()
 
@@ -224,6 +244,8 @@ QtObject:
     notify = isMutualContactChanged
 
   proc setIsMutualContact*(self: ChatDetails, value: bool) = # this is not a slot
+    if self.isContact == value:
+      return
     self.isContact = value
     self.isMutualContactChanged()
 
@@ -235,6 +257,8 @@ QtObject:
     notify = isUntrustworthyChanged
 
   proc setIsUntrustworthy*(self: ChatDetails, value: bool) = # this is not a slot
+    if self.isUntrustworthy == value:
+      return
     self.isUntrustworthy = value
     self.isUntrustworthyChanged()
 
@@ -246,6 +270,8 @@ QtObject:
     notify = activeChanged
 
   proc setActive*(self: ChatDetails, value: bool) =
+    if self.active == value:
+      return
     self.active = value
     self.activeChanged()
 
@@ -257,6 +283,8 @@ QtObject:
     notify = blockedChanged
 
   proc setBlocked*(self: ChatDetails, value: bool) =
+    if self.blocked == value:
+      return
     self.blocked = value
     self.blockedChanged()
 
@@ -268,6 +296,8 @@ QtObject:
     notify = canPostChanged
 
   proc setCanPost*(self: ChatDetails, value: bool) =
+    if self.canPost == value:
+      return
     self.canPost = value
     self.canPostChanged()
 
@@ -279,6 +309,8 @@ QtObject:
     notify = canViewChanged
 
   proc setCanView*(self: ChatDetails, value: bool) =
+    if self.canView == value:
+      return
     self.canView = value
     self.canViewChanged()
 
@@ -290,6 +322,8 @@ QtObject:
     notify = canPostReactionsChanged
 
   proc setCanPostReactions*(self: ChatDetails, value: bool) =
+    if self.canPostReactions == value:
+      return
     self.canPostReactions = value
     self.canPostReactionsChanged()
   
@@ -301,6 +335,8 @@ QtObject:
     notify = hideIfPermissionsNotMetChanged
 
   proc setHideIfPermissionsNotMet*(self: ChatDetails, value: bool) =
+    if self.hideIfPermissionsNotMet == value:
+      return
     self.hideIfPermissionsNotMet = value
     self.hideIfPermissionsNotMetChanged()
 
@@ -312,6 +348,8 @@ QtObject:
     notify = missingEncryptionKeyChanged
 
   proc setMissingEncryptionKey*(self: ChatDetails, value: bool) =
+    if self.missingEncryptionKey == value:
+      return
     self.missingEncryptionKey = value
     self.missingEncryptionKeyChanged()
 
@@ -323,5 +361,7 @@ QtObject:
     notify = requiresPermissionsChanged
 
   proc setRequiresPermissions*(self: ChatDetails, value: bool) =
+    if self.requiresPermissions == value:
+      return
     self.requiresPermissions = value
     self.requiresPermissionsChanged()

--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -28,6 +28,7 @@ QtObject:
     canPostReactions: bool
     hideIfPermissionsNotMet: bool
     missingEncryptionKey: bool
+    requiresPermissions: bool
 
   proc delete*(self: ChatDetails) =
     self.QObject.delete
@@ -58,6 +59,7 @@ QtObject:
       canPostReactions: bool = true,
       hideIfPermissionsNotMet: bool,
       missingEncryptionKey: bool,
+      requiresPermissions: bool,
     ) =
     self.id = id
     self.`type` = `type`
@@ -82,6 +84,7 @@ QtObject:
     self.canPostReactions = canPostReactions
     self.hideIfPermissionsNotMet = hideIfPermissionsNotMet
     self.missingEncryptionKey = missingEncryptionKey
+    self.requiresPermissions = requiresPermissions
 
   proc getId(self: ChatDetails): string {.slot.} =
     return self.id
@@ -311,3 +314,14 @@ QtObject:
   proc setMissingEncryptionKey*(self: ChatDetails, value: bool) =
     self.missingEncryptionKey = value
     self.missingEncryptionKeyChanged()
+
+  proc requiresPermissionsChanged(self: ChatDetails) {.signal.}
+  proc getRequiresPermissions(self: ChatDetails): bool {.slot.} =
+    return self.requiresPermissions
+  QtProperty[bool] requiresPermissions:
+    read = getRequiresPermissions
+    notify = requiresPermissionsChanged
+
+  proc setRequiresPermissions*(self: ChatDetails, value: bool) =
+    self.requiresPermissions = value
+    self.requiresPermissionsChanged()

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -97,7 +97,7 @@ method load*(self: Module, chatItem: chat_item.Item) =
     chatItem.color, chatItem.description, chatItem.emoji, chatItem.hasUnreadMessages, chatItem.notificationsCount,
     chatItem.highlight, chatItem.muted, chatItem.position, isUntrustworthy = trustStatus == TrustStatus.Untrustworthy,
     isContact, chatItem.blocked, chatItem.canPost, chatItem.canView, chatItem.canPostReactions,
-    chatItem.hideIfPermissionsNotMet, chatItem.missingEncryptionKey)
+    chatItem.hideIfPermissionsNotMet, chatItem.missingEncryptionKey, chatItem.requiresPermissions)
   
   self.view.chatDetailsChanged()
 

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -383,6 +383,7 @@ method onChatUpdated*(self: Module, chatItem: chat_item.Item) =
   self.view.chatDetails.setCanPostReactions(chatItem.canPostReactions)
   self.view.chatDetails.setHideIfPermissionsNotMet(chat_item.hideIfPermissionsNotMet)
   self.view.chatDetails.setMissingEncryptionKey(chat_item.missingEncryptionKey)
+  self.view.chatDetails.setRequiresPermissions(chat_item.requiresPermissions)
 
   self.messagesModule.updateChatFetchMoreMessages()
   self.messagesModule.updateChatIdentifier()
@@ -400,6 +401,7 @@ method onCommunityChannelEdited*(self: Module, chatDto: ChatDto) =
   self.view.chatDetails.setName(chatDto.name)
   self.view.chatDetails.setIcon(chatDto.icon)
   self.view.chatDetails.setMissingEncryptionKey(chatDto.missingEncryptionKey)
+  self.view.chatDetails.setRequiresPermissions(chatDto.tokenGated)
 
   self.messagesModule.updateChatFetchMoreMessages()
   self.messagesModule.updateChatIdentifier()

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -179,6 +179,9 @@ QtObject:
     self.countChanged()
 
   proc addItems*(self: Model, items: seq[MemberItem]) =
+    if items.len == 0:
+      return
+
     let modelIndex = newQModelIndex()
     defer: modelIndex.delete
 
@@ -272,16 +275,21 @@ QtObject:
 
     var roles: seq[int] = @[]
 
+    var preferredNameMightHaveChanged = false
+
     if self.items[ind].displayName != displayName:
       self.items[ind].displayName = displayName
+      preferredNameMightHaveChanged = true
       roles.add(ModelRole.DisplayName.int)
 
     if self.items[ind].ensName != ensName:
       self.items[ind].ensName = ensName
+      preferredNameMightHaveChanged = true
       roles.add(ModelRole.EnsName.int)
 
     if self.items[ind].localNickname != localNickname:
       self.items[ind].localNickname = localNickname
+      preferredNameMightHaveChanged = true
       roles.add(ModelRole.LocalNickname.int)
 
     if self.items[ind].isEnsVerified != isEnsVerified:
@@ -290,6 +298,7 @@ QtObject:
 
     if self.items[ind].alias != alias:
       self.items[ind].alias = alias
+      preferredNameMightHaveChanged = true
       roles.add(ModelRole.Alias.int)
 
     if self.items[ind].icon != icon:
@@ -316,10 +325,11 @@ QtObject:
       self.items[ind].isUntrustworthy = isUntrustworthy
       roles.add(ModelRole.IsUntrustworthy.int)
 
+    if preferredNameMightHaveChanged:
+      roles.add(ModelRole.PreferredDisplayName.int)
+
     if roles.len == 0:
       return
-
-    roles.add(ModelRole.PreferredDisplayName.int)
 
     let index = self.createIndex(ind, 0, nil)
     defer: index.delete

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -179,6 +179,18 @@ QtObject:
     self.endInsertRows()
     self.countChanged()
 
+  proc addItems*(self: Model, items: seq[MemberItem]) =
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+
+    let first = self.items.len
+    let last = first + items.len - 1
+
+    self.beginInsertRows(modelIndex, first, last)
+    self.items.add(items)
+    self.endInsertRows()
+    self.countChanged()
+
   proc findIndexForMember(self: Model, pubKey: string): int =
     for i in 0 ..< self.items.len:
       if(self.items[i].pubKey == pubKey):

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -10,6 +10,7 @@ type
   ModelRole {.pure.} = enum
     PubKey = UserRole + 1
     DisplayName
+    PreferredDisplayName
     EnsName
     IsEnsVerified
     LocalNickname
@@ -79,6 +80,7 @@ QtObject:
     {
       ModelRole.PubKey.int: "pubKey",
       ModelRole.DisplayName.int: "displayName",
+      ModelRole.PreferredDisplayName.int: "preferredDisplayName",
       ModelRole.EnsName.int: "ensName",
       ModelRole.IsEnsVerified.int: "isEnsVerified",
       ModelRole.LocalNickname.int: "localNickname",
@@ -117,6 +119,15 @@ QtObject:
       result = newQVariant(item.pubKey)
     of ModelRole.DisplayName:
       result = newQVariant(item.displayName)
+    of ModelRole.PreferredDisplayName:
+      # ["localNickname", "ensName", "displayName", "alias"]
+      if item.localNickname != "":
+        return newQVariant(item.localNickname)
+      if item.ensName != "":
+        return newQVariant(item.ensName)
+      if item.displayName != "":
+        return newQVariant(item.displayName)
+      return newQVariant(item.alias)
     of ModelRole.EnsName:
       result = newQVariant(item.ensName)
     of ModelRole.IsEnsVerified:

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -120,7 +120,6 @@ QtObject:
     of ModelRole.DisplayName:
       result = newQVariant(item.displayName)
     of ModelRole.PreferredDisplayName:
-      # ["localNickname", "ensName", "displayName", "alias"]
       if item.localNickname != "":
         return newQVariant(item.localNickname)
       if item.ensName != "":
@@ -210,27 +209,40 @@ QtObject:
   proc isContactWithIdAdded*(self: Model, id: string): bool =
     return self.findIndexForMember(id) != -1
 
-  proc setName*(self: Model, pubKey: string, displayName: string,
-      ensName: string, localNickname: string) =
+  proc setName*(self: Model, pubKey: string, displayName: string, ensName: string, localNickname: string) =
     let ind = self.findIndexForMember(pubKey)
-    if(ind == -1):
+    if ind == -1:
       return
 
-    self.items[ind].displayName = displayName
-    self.items[ind].ensName = ensName
-    self.items[ind].localNickname = localNickname
+    var roles: seq[int] = @[]
+
+    if self.items[ind].displayName != displayName:
+      self.items[ind].displayName = displayName
+      roles.add(ModelRole.DisplayName.int)
+
+    if self.items[ind].ensName != ensName:
+      self.items[ind].ensName = ensName
+      roles.add(ModelRole.EnsName.int)
+
+    if self.items[ind].localNickname != localNickname:
+      self.items[ind].localNickname = localNickname
+      roles.add(ModelRole.LocalNickname.int)
+
+    if roles.len == 0:
+      return
+
+    roles.add(ModelRole.PreferredDisplayName.int)
 
     let index = self.createIndex(ind, 0, nil)
     defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.DisplayName.int,
-      ModelRole.EnsName.int,
-      ModelRole.LocalNickname.int,
-      ])
+    self.dataChanged(index, index, roles)
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
     let ind = self.findIndexForMember(pubKey)
-    if(ind == -1):
+    if ind == -1:
+      return
+
+    if self.items[ind].icon == icon:
       return
 
     self.items[ind].icon = icon
@@ -255,36 +267,63 @@ QtObject:
       isUntrustworthy: bool,
       ) =
     let ind = self.findIndexForMember(pubKey)
-    if(ind == -1):
+    if ind == -1:
       return
 
-    self.items[ind].displayName = displayName
-    self.items[ind].ensName = ensName
-    self.items[ind].isEnsVerified = isEnsVerified
-    self.items[ind].localNickname = localNickname
-    self.items[ind].alias = alias
-    self.items[ind].icon = icon
-    self.items[ind].isContact = isContact
-    self.items[ind].isVerified = isVerified
-    self.items[ind].memberRole = memberRole
-    self.items[ind].joined = joined
-    self.items[ind].isUntrustworthy = isUntrustworthy
+    var roles: seq[int] = @[]
+
+    if self.items[ind].displayName != displayName:
+      self.items[ind].displayName = displayName
+      roles.add(ModelRole.DisplayName.int)
+
+    if self.items[ind].ensName != ensName:
+      self.items[ind].ensName = ensName
+      roles.add(ModelRole.EnsName.int)
+
+    if self.items[ind].localNickname != localNickname:
+      self.items[ind].localNickname = localNickname
+      roles.add(ModelRole.LocalNickname.int)
+
+    if self.items[ind].isEnsVerified != isEnsVerified:
+      self.items[ind].isEnsVerified = isEnsVerified
+      roles.add(ModelRole.IsEnsVerified.int)
+
+    if self.items[ind].alias != alias:
+      self.items[ind].alias = alias
+      roles.add(ModelRole.Alias.int)
+
+    if self.items[ind].icon != icon:
+      self.items[ind].icon = icon
+      roles.add(ModelRole.Icon.int)
+
+    if self.items[ind].isContact != isContact:
+      self.items[ind].isContact = isContact
+      roles.add(ModelRole.IsContact.int)
+
+    if self.items[ind].isVerified != isVerified:
+      self.items[ind].isVerified = isVerified
+      roles.add(ModelRole.IsVerified.int)
+
+    if self.items[ind].memberRole != memberRole:
+      self.items[ind].memberRole = memberRole
+      roles.add(ModelRole.MemberRole.int)
+
+    if self.items[ind].joined != joined:
+      self.items[ind].joined = joined
+      roles.add(ModelRole.Joined.int)
+
+    if self.items[ind].isUntrustworthy != isUntrustworthy:
+      self.items[ind].isUntrustworthy = isUntrustworthy
+      roles.add(ModelRole.IsUntrustworthy.int)
+
+    if roles.len == 0:
+      return
+
+    roles.add(ModelRole.PreferredDisplayName.int)
 
     let index = self.createIndex(ind, 0, nil)
     defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.DisplayName.int,
-      ModelRole.IsEnsVerified.int,
-      ModelRole.EnsName.int,
-      ModelRole.LocalNickname.int,
-      ModelRole.Alias.int,
-      ModelRole.Icon.int,
-      ModelRole.IsContact.int,
-      ModelRole.IsVerified.int,
-      ModelRole.MemberRole.int,
-      ModelRole.Joined.int,
-      ModelRole.IsUntrustworthy.int,
-    ])
+    self.dataChanged(index, index, roles)
 
   proc updateItem*(
       self: Model,
@@ -300,39 +339,30 @@ QtObject:
       isUntrustworthy: bool,
       ) =
     let ind = self.findIndexForMember(pubKey)
-    if(ind == -1):
+    if ind == -1:
       return
 
-    self.items[ind].displayName = displayName
-    self.items[ind].ensName = ensName
-    self.items[ind].isEnsVerified = isEnsVerified
-    self.items[ind].localNickname = localNickname
-    self.items[ind].alias = alias
-    self.items[ind].icon = icon
-    self.items[ind].isContact = isContact
-    self.items[ind].isVerified = isVerified
-    self.items[ind].isUntrustworthy = isUntrustworthy
-
-    let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
-    self.dataChanged(index, index, @[
-      ModelRole.DisplayName.int,
-      ModelRole.EnsName.int,
-      ModelRole.IsEnsVerified.int,
-      ModelRole.LocalNickname.int,
-      ModelRole.Alias.int,
-      ModelRole.Icon.int,
-      ModelRole.IsContact.int,
-      ModelRole.IsVerified.int,
-      ModelRole.IsUntrustworthy.int,
-    ])
+    self.updateItem(
+      pubKey,
+      displayName,
+      ensName,
+      isEnsVerified,
+      localNickname,
+      alias,
+      icon,
+      isContact,
+      isVerified,
+      memberRole = self.items[ind].memberRole,
+      joined = self.items[ind].joined,
+      isUntrustworthy,
+    )
 
   proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =
     let idx = self.findIndexForMember(pubKey)
-    if(idx == -1):
+    if idx == -1:
       return
 
-    if(self.items[idx].onlineStatus == onlineStatus):
+    if self.items[idx].onlineStatus == onlineStatus:
       return
 
     self.items[idx].onlineStatus = onlineStatus
@@ -344,10 +374,10 @@ QtObject:
 
   proc setAirdropAddress*(self: Model, pubKey: string, airdropAddress: string) =
     let idx = self.findIndexForMember(pubKey)
-    if(idx == -1):
+    if idx == -1:
       return
 
-    if(self.items[idx].airdropAddress == airdropAddress):
+    if self.items[idx].airdropAddress == airdropAddress:
       return
 
     self.items[idx].airdropAddress = airdropAddress
@@ -360,7 +390,7 @@ QtObject:
 # TODO: rename me to removeItemByPubkey
   proc removeItemById*(self: Model, pubKey: string) =
     let ind = self.findIndexForMember(pubKey)
-    if(ind == -1):
+    if ind == -1:
       return
 
     self.removeItemWithIndex(ind)
@@ -371,7 +401,10 @@ QtObject:
 
   proc updateLoadingState*(self: Model, memberKey: string, requestToJoinLoading: bool) =
     let idx = self.findIndexForMember(memberKey)
-    if(idx == -1):
+    if idx == -1:
+      return
+
+    if self.items[idx].requestToJoinLoading == requestToJoinLoading:
       return
 
     self.items[idx].requestToJoinLoading = requestToJoinLoading
@@ -381,12 +414,15 @@ QtObject:
       ModelRole.RequestToJoinLoading.int
     ])
 
-  proc updateMembershipStatus*(self: Model, memberKey: string, status: MembershipRequestState) {.inline.} =
+  proc updateMembershipStatus*(self: Model, memberKey: string, membershipRequestState: MembershipRequestState) {.inline.} =
     let idx = self.findIndexForMember(memberKey)
-    if(idx == -1):
+    if idx == -1:
       return
 
-    self.items[idx].membershipRequestState = status
+    if self.items[idx].membershipRequestState == membershipRequestState:
+      return
+
+    self.items[idx].membershipRequestState = membershipRequestState
     let index = self.createIndex(idx, 0, nil)
     defer: index.delete
     self.dataChanged(index, index, @[

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -105,7 +105,8 @@ Item {
             section.delegate: (root.width > 58) ? sectionDelegateComponent : null
             delegate: StatusMemberListItem {
                 width: ListView.view.width
-                userName: model.preferredDisplayName
+                nickName: model.localNickname
+                userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
                 pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
                 isContact: model.isContact
                 isVerified: model.isVerified

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -90,15 +90,6 @@ Item {
             model: SortFilterProxyModel {
                 sourceModel: root.usersModel
 
-                proxyRoles: FastExpressionRole {
-                    function displayNameProxy(nickname, ensName, displayName, aliasName) {
-                        return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
-                    }
-                    name: "preferredDisplayName"
-                    expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
-                    expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
-                }
-
                 sorters: [
                     RoleSorter {
                         roleName: "onlineStatus"
@@ -114,8 +105,7 @@ Item {
             section.delegate: (root.width > 58) ? sectionDelegateComponent : null
             delegate: StatusMemberListItem {
                 width: ListView.view.width
-                nickName: model.localNickname
-                userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
+                userName: model.preferredDisplayName
                 pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
                 isContact: model.isContact
                 isVerified: model.isVerified

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -320,29 +320,6 @@ QtObject {
         return userProfileInst.pubKey
     }
 
-    function getCommunity(communityId) {
-        // Not Refactored Yet
-//        try {
-//            const communityJson = chatsModelInst.communities.list.getCommunityByIdJson(communityId);
-//            if (!communityJson) {
-//                return null;
-//            }
-
-//            let community = JSON.parse(communityJson);
-//            if (community) {
-//                community.nbMembers = community.members.length;
-//            }
-//            return community
-//        } catch (e) {
-//            console.error("Error parsing community", e);
-//        }
-
-       return null;
-    }
-
-    // Not Refactored Yet
-    property var activeCommunityChatsModel: "" //chatsModelInst.communities.activeCommunity.chats
-
     function createCommunity(args = {
                                 name: "",
                                 description: "",
@@ -436,11 +413,6 @@ QtObject {
 
     function declineRequestToJoinCommunity(requestId, communityId) {
         chatCommunitySectionModule.declineRequestToJoinCommunity(requestId, communityId)
-    }
-
-    function userNameOrAlias(pk) {
-        // Not Refactored Yet
-//        return chatsModelInst.userNameOrAlias(pk);
     }
 
     function generateAlias(pk) {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -173,19 +173,19 @@ StatusSectionLayout {
         id: userListComponent
         UserListPanel {
             id: userListPanel
-            readonly property bool isFullCommunityList: !root.chatContentModule || !root.chatContentModule.chatDetails || !root.chatContentModule.chatDetails.requiresPermissions
             property bool wasFullCommunityList: false
 
             Connections {
                 target: root
                 onChatContentModuleChanged: {
+                    let isFullCommunityList = !root.chatContentModule || !root.chatContentModule.chatDetails || !root.chatContentModule.chatDetails.requiresPermissions
                     if (!root.chatContentModule ||
-                        (userListPanel.usersModel != null && root.chatContentModule.chatDetails.belongsToCommunity && userListPanel.wasFullCommunityList && userListPanel.isFullCommunityList)) {
+                        (userListPanel.usersModel != null && root.chatContentModule.chatDetails.belongsToCommunity && userListPanel.wasFullCommunityList && isFullCommunityList)) {
                         // If the previous channel had the full community list already, and we still need the whole list, just keep the old model
                         return
                     }
                     userListPanel.usersModel = root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
-                    userListPanel.wasFullCommunityList = userListPanel.isFullCommunityList
+                    userListPanel.wasFullCommunityList = isFullCommunityList
                 }
             }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -162,12 +162,11 @@ StatusSectionLayout {
             return false
         }
 
-        let chatContentModule = root.rootStore.currentChatContentModule()
-        if (!chatContentModule) {
+        if (!root.chatContentModule) {
             return false
         }
         // Check if user list is available as an option for particular chat content module
-        return chatContentModule.chatDetails.isUsersListAvailable
+        return root.chatContentModule.chatDetails.isUsersListAvailable
     }
 
     rightPanel: Component {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -173,22 +173,6 @@ StatusSectionLayout {
         id: userListComponent
         UserListPanel {
             id: userListPanel
-            property bool wasFullCommunityList: false
-
-            Connections {
-                target: root
-                onChatContentModuleChanged: {
-                    let isFullCommunityList = !root.chatContentModule || !root.chatContentModule.chatDetails || !root.chatContentModule.chatDetails.requiresPermissions
-                    if (!root.chatContentModule ||
-                        (userListPanel.usersModel != null && root.chatContentModule.chatDetails.belongsToCommunity && userListPanel.wasFullCommunityList && isFullCommunityList)) {
-                        // If the previous channel had the full community list already, and we still need the whole list, just keep the old model
-                        return
-                    }
-                    userListPanel.usersModel = root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
-                    userListPanel.wasFullCommunityList = isFullCommunityList
-                }
-            }
-
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -179,11 +179,12 @@ StatusSectionLayout {
             Connections {
                 target: root
                 onChatContentModuleChanged: {
-                    if (userListPanel.usersModel != null && userListPanel.wasFullCommunityList && userListPanel.isFullCommunityList) {
+                    if (!root.chatContentModule ||
+                        (userListPanel.usersModel != null && root.chatContentModule.chatDetails.belongsToCommunity && userListPanel.wasFullCommunityList && userListPanel.isFullCommunityList)) {
                         // If the previous channel had the full community list already, and we still need the whole list, just keep the old model
                         return
                     }
-                    userListPanel.usersModel = root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
+                    userListPanel.usersModel = root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
                     userListPanel.wasFullCommunityList = userListPanel.isFullCommunityList
                 }
             }
@@ -192,6 +193,7 @@ StatusSectionLayout {
             store: root.rootStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
+            usersModel: root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -172,7 +172,6 @@ StatusSectionLayout {
     rightPanel: Component {
         id: userListComponent
         UserListPanel {
-            id: userListPanel
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -173,11 +173,26 @@ StatusSectionLayout {
     rightPanel: Component {
         id: userListComponent
         UserListPanel {
+            id: userListPanel
+            readonly property bool isFullCommunityList: !root.chatContentModule || !root.chatContentModule.chatDetails || !root.chatContentModule.chatDetails.requiresPermissions
+            property bool wasFullCommunityList: false
+
+            Connections {
+                target: root
+                onChatContentModuleChanged: {
+                    if (userListPanel.usersModel != null && userListPanel.wasFullCommunityList && userListPanel.isFullCommunityList) {
+                        // If the previous channel had the full community list already, and we still need the whole list, just keep the old model
+                        return
+                    }
+                    userListPanel.usersModel = root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
+                    userListPanel.wasFullCommunityList = userListPanel.isFullCommunityList
+                }
+            }
+
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
-            usersModel: root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
         }
     }
 

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -149,21 +149,13 @@ QtObject {
         mainModuleInst.switchTo(sectionId, chatId)
     }
 
-    // Not Refactored Yet
-//    property var chatsModelInst: chatsModel
-    // Not Refactored Yet
-//    property var walletModelInst: walletModel
     property var userProfileInst: userProfile
     readonly property var accounts: walletSectionAccounts.accounts
-    // Not Refactored Yet
-//    property var profileModelInst: profileModel
 
     property ProfileStores.ContactsStore contactStore: profileSectionStore.contactsStore
     property ProfileStores.PrivacyStore privacyStore: profileSectionStore.privacyStore
     property ProfileStores.MessagingStore messagingStore: profileSectionStore.messagingStore
     property bool hasAddedContacts: contactStore.myContactsModel.count > 0
-
-//    property MessageStore messageStore: MessageStore { }
 
     property real volume: !!appSettings ? appSettings.volume * 0.01 : 0.5
     property bool notificationSoundsEnabled: !!appSettings ? appSettings.notificationSoundsEnabled : true


### PR DESCRIPTION
Redo of https://github.com/status-im/status-desktop/pull/16178

Fixes https://github.com/status-im/status-desktop/issues/16132

In the previous PR, I was improving the slow chat switching by delaying the loading of the member list and the nkeeping it in memory.

After discussing with @micieslak , we agreed that it was making the code harder to understand and also didn't fix the root cause.

Turns out, the root cause is the SortFilterProxyModel and the `preferredDisplayName` property. 

@caybro already has [a PR](https://github.com/status-im/status-desktop/pull/16277) improving it, but I pushed it one step further (sorry)

In my PR, I moved the `preferredDisplayName` property to the Nim side (this is the biggest speed up).

I also made it so that we populate the models in one go instead of one entry at a time (saves just a little bit on start, but it's something)

Finally, I made it so that we don't update the user model if not needed.
Basically, when a community channel is not encrypted is when we put **all** the members of the community in the member list. Those are the channels that are the slowest to switch to.
To help that, I made it so that if we are switching from an unencrypted channel to another unencrypted channel, we just don't update the member list.
This makes the channel switching instantaneous.

The only caveat of that approach is that we are putting a little bit of app logic in the QML. If that's a problem, I can move it to a property in the model.

[fast-switching.webm](https://github.com/user-attachments/assets/73372237-60f6-409e-92ef-55dbc6a78571)
