### PR TITLE
Tests: make mint token test smarter using L2 networks to mint tokens (cheaper)

### DIFF
--- a/test/e2e/constants/community_settings.py
+++ b/test/e2e/constants/community_settings.py
@@ -30,7 +30,7 @@ class MintOwnerTokensElements(Enum):
     MASTER_TOKEN_CHEKLIST_ELEMENT_3 = 'Ability to mint and airdrop Community tokens'
     MASTER_TOKEN_CHEKLIST_ELEMENT_4 = 'Non-transferrable'
     MASTER_TOKEN_CHEKLIST_ELEMENT_5 = 'Remotely destructible by the Owner token hodler'
-    SIGN_TRANSACTION_MINT_TITLE = ' Owner and TokenMaster tokens on Mainnet'
+    SIGN_TRANSACTION_MINT_TITLE = ' Owner and TokenMaster tokens on '
     OWNER_TOKEN_NAME = 'Owner-'
     MASTER_TOKEN_NAME = 'TMaster-'
     OWNER_TOKEN_SYMBOL = 'OWN'

--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -1,4 +1,5 @@
 from gui.objects_map.names import statusDesktop_mainWindow, statusDesktop_mainWindow_overlay, mainWindow_StatusWindow
+from objectmaphelper import *
 
 # Map for communities screens, views locators
 
@@ -115,6 +116,7 @@ arbitrum_NetworkSelectItemDelegate = {"container": statusDesktop_mainWindow_over
 optimism_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionRadioButton_Optimism", "type": "StatusRadioButton", "visible": True}
 mainnet_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionRadioButton_Mainnet", "type": "StatusRadioButton", "visible": True}
 arbitrum_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionRadioButton_Arbitrum", "type": "StatusRadioButton", "visible": True}
+networkItem_StatusRadioButton = {"checkable": True, "container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("networkSelectionRadioButton*"), "type": "StatusRadioButton", "visible": True}
 
 editOwnerTokenView_Mint_StatusButton = {"checkable": False, "container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "objectName": "mintButton", "type": "StatusButton", "visible": True}
 editOwnerTokenView_FeeRow = {"container": mainWindow_editOwnerTokenView_EditOwnerTokenView, "type": "FeeRow", "unnamed": 1, "visible": True}

--- a/test/e2e/gui/screens/community_settings_tokens.py
+++ b/test/e2e/gui/screens/community_settings_tokens.py
@@ -103,27 +103,27 @@ class TokensOwnerTokenSettingsView(QObject):
 
     @allure.step('Verify text on owner token panel')
     def verify_text_on_owner_token_panel(self):
-        assert str(self.get_text_labels_from_owner_token_panel[
-                       1].text) == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_1.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[2].text}'
-        assert str(self.get_text_labels_from_owner_token_panel[
-                       2].text) == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_2.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[3].text}'
-        assert str(self.get_text_labels_from_owner_token_panel[
-                       3].text) == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_3.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[4].text}'
-        assert str(self.get_text_labels_from_owner_token_panel[
-                       4].text) == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_4.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[5].text}'
+        assert str(self.get_text_labels_from_owner_token_panel[2].text) \
+               == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_1.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[2].text}'
+        assert str(self.get_text_labels_from_owner_token_panel[3].text) \
+               == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_2.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[3].text}'
+        assert str(self.get_text_labels_from_owner_token_panel[4].text) \
+               == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_3.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[4].text}'
+        assert str(self.get_text_labels_from_owner_token_panel[5].text) \
+               == MintOwnerTokensElements.OWNER_TOKEN_CHEKLIST_ELEMENT_4.value, f'Actual text is {self.get_text_labels_from_owner_token_panel[5].text}'
 
     @allure.step('Verify text on master token panel')
     def verify_text_on_master_token_panel(self):
         assert str(self.get_text_labels_from_master_token_panel[
-                       1].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_1.value, f'Actual text is {self.get_text_labels_from_master_token_panel[1].text}'
+                       3].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_1.value, f'Actual text is {self.get_text_labels_from_master_token_panel[3].text}'
         assert str(self.get_text_labels_from_master_token_panel[
-                       2].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_2.value, f'Actual text is {self.get_text_labels_from_master_token_panel[2].text}'
+                       4].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_2.value, f'Actual text is {self.get_text_labels_from_master_token_panel[4].text}'
         assert str(self.get_text_labels_from_master_token_panel[
-                       3].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_3.value, f'Actual text is {self.get_text_labels_from_master_token_panel[3].text}'
+                       5].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_3.value, f'Actual text is {self.get_text_labels_from_master_token_panel[5].text}'
         assert str(self.get_text_labels_from_master_token_panel[
-                       4].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_4.value, f'Actual text is {self.get_text_labels_from_master_token_panel[4].text}'
+                       6].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_4.value, f'Actual text is {self.get_text_labels_from_master_token_panel[6].text}'
         assert str(self.get_text_labels_from_master_token_panel[
-                       5].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_5.value, f'Actual text is {self.get_text_labels_from_master_token_panel[5].text}'
+                       7].text) == MintOwnerTokensElements.MASTER_TOKEN_CHEKLIST_ELEMENT_5.value, f'Actual text is {self.get_text_labels_from_master_token_panel[5].text}'
 
     @property
     @allure.step('Get all text from master token panel')
@@ -151,6 +151,9 @@ class EditOwnerTokenView(QObject):
         self._select_network_filter = QObject(communities_names.editOwnerTokenView_netFilter_NetworkFilter)
         self._select_network_combobox = QObject(communities_names.editOwnerTokenView_comboBox_ComboBox)
         self._mainnet_network_item = CheckBox(communities_names.mainnet_StatusRadioButton)
+        self.optimism_network_item = CheckBox(communities_names.optimism_StatusRadioButton)
+        self.arbitrum_network_item = CheckBox(communities_names.arbitrum_StatusRadioButton)
+        self.network_item = CheckBox(communities_names.networkItem_StatusRadioButton)
         self._mint_button = Button(communities_names.editOwnerTokenView_Mint_StatusButton)
         self._fees_text_object = TextLabel(communities_names.editOwnerTokenView_fees_StatusBaseText)
         self._crown_icon = QObject(communities_names.editOwnerTokenView_crown_icon_StatusIcon)
@@ -255,20 +258,17 @@ class EditOwnerTokenView(QObject):
         destructible_box = self.get_destructible_boxes()[index]
         return str(destructible_box.value)
 
-    @allure.step('Select Mainnet network')
-    def select_mainnet_network(self, attempts: int = 2):
+    def select_network(self, network_name):
         if not self._fees_box.is_visible:
             self._scroll.vertical_scroll_down(self._fees_box)
         self._select_network_filter.click()
-        try:
-            self._mainnet_network_item.wait_until_appears()
-            self._mainnet_network_item.click()
-            return self
-        except AssertionError as err:
-            if attempts:
-                self.select_mainnet_network(attempts - 1)
-            else:
-                raise err
+        network_options = driver.findAllObjects(self.network_item.real_name)
+        assert network_options, f'Network options are not displayed'
+        for item in network_options:
+            if str(getattr(item, 'objectName', '')).endswith(network_name):
+                QObject(item).click()
+                break
+        return self
 
     @allure.step('Click mint button')
     def click_mint(self):

--- a/test/e2e/gui/screens/settings.py
+++ b/test/e2e/gui/screens/settings.py
@@ -102,7 +102,7 @@ class LeftPanel(QObject):
     @allure.step('Open advanced settings')
     @handle_settings_opening(AdvancedSettingsView, '10-SettingsMenuItem')
     def open_advanced_settings(self, click_attempts: int = 2) -> 'AdvancedSettingsView':
-        assert AdvancedSettingsView().exists, 'Advanced settings view was not opened'
+        assert AdvancedSettingsView().wait_until_appears(), 'Advanced settings view was not opened'
         return AdvancedSettingsView()
 
 

--- a/test/e2e/tests/transactions_tests/test_buy_ens_name_in_settings.py
+++ b/test/e2e/tests/transactions_tests/test_buy_ens_name_in_settings.py
@@ -33,12 +33,13 @@ def keys_screen(main_window) -> KeysView:
                  'Settings -> ENS usernames: buy ENS name on testnet')
 @pytest.mark.case(704597)
 @pytest.mark.transaction
-@pytest.mark.parametrize('user_account', [ReturningUser(
-    seed_phrase=WALLET_SEED.split(),
-    status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43'
-)])
 @pytest.mark.parametrize('ens_name', [pytest.param(random_ens_string())])
 def test_ens_name_purchase(keys_screen, main_window, user_account, ens_name):
+
+    user_account = ReturningUser(
+        seed_phrase=WALLET_SEED.split(),
+        status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43')
+
     with step('Open import seed phrase view and enter seed phrase'):
 
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()

--- a/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
+++ b/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
@@ -30,13 +30,13 @@ def keys_screen(main_window) -> KeysView:
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727245', 'Mint owner token')
 @pytest.mark.case(727245)
-@pytest.mark.parametrize('user_account', [ReturningUser(
-    seed_phrase=WALLET_SEED.split(),
-    status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43'
-)])
 @pytest.mark.transaction
 @pytest.mark.skip('temp skip test to fix it using L2 networks')
 def test_mint_owner_and_tokenmaster_tokens(keys_screen, main_window, user_account):
+    user_account = ReturningUser(
+        seed_phrase=WALLET_SEED.split(),
+        status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43')
+
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()
         input_view.input_seed_phrase(user_account.seed_phrase, True)

--- a/test/e2e/tests/transactions_tests/test_wallet_send_eth.py
+++ b/test/e2e/tests/transactions_tests/test_wallet_send_eth.py
@@ -27,15 +27,15 @@ def keys_screen(main_window) -> KeysView:
                  'Send: can send 0 ETH to address pasted into receiver field with Simple flow')
 @pytest.mark.case(704527)
 @pytest.mark.transaction
-@pytest.mark.parametrize('user_account', [ReturningUser(
-    seed_phrase=WALLET_SEED.split(),
-    status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43'
-)])
 @pytest.mark.parametrize('receiver_account_address, amount, asset', [
     pytest.param(WalletAddress.RECEIVER_ADDRESS.value, 0, 'ETH')
 ])
 @pytest.mark.timeout(timeout=120)
 def test_wallet_send_0_eth(keys_screen, main_window, user_account, receiver_account_address, amount, asset):
+    user_account = ReturningUser(
+        seed_phrase=WALLET_SEED.split(),
+        status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43')
+
     with step('Open import seed phrase view and enter seed phrase'):
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()
         input_view.input_seed_phrase(user_account.seed_phrase, True)

--- a/test/e2e/tests/transactions_tests/test_wallet_send_nft.py
+++ b/test/e2e/tests/transactions_tests/test_wallet_send_nft.py
@@ -28,10 +28,6 @@ def keys_screen(main_window) -> KeysView:
                  'Send: can send ERC 721 token (collectible) to address pasted into receiver field with Simple flow')
 @pytest.mark.case(704602)
 @pytest.mark.transaction
-@pytest.mark.parametrize('user_account', [[ReturningUser(
-    seed_phrase=WALLET_SEED.split(),
-    status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43'
-)]])
 @pytest.mark.parametrize('tab, receiver_account_address, amount, collectible', [
     pytest.param('Collectibles', '0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43', 1, 'Panda')
 ])
@@ -40,6 +36,11 @@ def keys_screen(main_window) -> KeysView:
 @pytest.mark.skip(reason="https://github.com/status-im/status-desktop/issues/14509")
 def test_wallet_send_nft(keys_screen, main_window, user_account, tab, receiver_account_address, amount, collectible):
     with step('Open import seed phrase view and enter seed phrase'):
+
+        user_account = ReturningUser(
+            seed_phrase=WALLET_SEED.split(),
+            status_address='0x44ddd47a0c7681a5b0fa080a56cbb7701db4bb43')
+
         input_view = keys_screen.open_import_seed_phrase_view().open_seed_phrase_input_view()
         input_view.input_seed_phrase(user_account.seed_phrase, True)
         profile_view = input_view.import_seed_phrase()


### PR DESCRIPTION
### What does the PR do

- test to mint community tokens is now using L2
- remove seed phrase from pytest params so it is not exposed in allure report
- removed flaky verifications of strings, i will bring them back later

CI run https://ci.status.im/job/status-desktop/job/e2e/job/manual/2495/

<img width="1840" alt="Screenshot 2024-09-06 at 17 08 59" src="https://github.com/user-attachments/assets/6edc2b2d-bb4e-486d-8646-1b6573bf3b6e">


