### PR TITLE
Use a single member list for community public channels

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -354,7 +354,7 @@ QtObject:
     self.missingEncryptionKeyChanged()
 
   proc requiresPermissionsChanged(self: ChatDetails) {.signal.}
-  proc getRequiresPermissions(self: ChatDetails): bool {.slot.} =
+  proc getRequiresPermissions*(self: ChatDetails): bool {.slot.} =
     return self.requiresPermissions
   QtProperty[bool] requiresPermissions:
     read = getRequiresPermissions

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -401,7 +401,11 @@ method onCommunityChannelEdited*(self: Module, chatDto: ChatDto) =
   self.view.chatDetails.setName(chatDto.name)
   self.view.chatDetails.setIcon(chatDto.icon)
   self.view.chatDetails.setMissingEncryptionKey(chatDto.missingEncryptionKey)
-  self.view.chatDetails.setRequiresPermissions(chatDto.tokenGated)
+
+  if self.view.chatDetails.getRequiresPermissions() != chatDto.tokenGated:
+    # The channel permission status changed. Update the member list
+    self.view.chatDetails.setRequiresPermissions(chatDto.tokenGated)
+    self.usersModule.updateMembersList()
 
   self.messagesModule.updateChatFetchMoreMessages()
   self.messagesModule.updateChatIdentifier()

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -21,9 +21,6 @@ type
     communityService: community_service.Service
     messageService: message_service.Service
 
-# Forward declaration
-proc getChat*(self: Controller): ChatDto
-
 proc newController*(
   delegate: io_interface.AccessInterface, events: EventEmitter, sectionId: string, chatId: string,
   belongsToCommunity: bool, isUsersListAvailable: bool, contactService: contact_service.Service,
@@ -63,7 +60,7 @@ proc init*(self: Controller) =
     self.delegate.loggedInUserImageChanged()
 
   # Events only for the user list, so not needed in one to one chats
-  if(self.isUsersListAvailable):
+  if self.isUsersListAvailable:
     self.events.on(SIGNAL_CONTACT_UNTRUSTWORTHY) do(e: Args):
       var args = TrustArgs(e)
       self.delegate.contactUpdated(args.publicKey)
@@ -118,19 +115,11 @@ proc belongsToCommunity*(self: Controller): bool =
 proc getMyCommunity*(self: Controller): CommunityDto =
   return self.communityService.getCommunityById(self.sectionId)
 
-proc getChat*(self: Controller): ChatDto =
-  return self.chatService.getChatById(self.chatId)
+proc getMyChatId*(self: Controller): string =
+  return self.chatId
 
-proc getChatMembers*(self: Controller): seq[ChatMember] =
-  if self.belongsToCommunity:
-    let myCommunity = self.getMyCommunity()
-    # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
-    # see log here: https://github.com/status-im/status-desktop/issues/14442#issuecomment-2120756598
-    # should be resolved in https://github.com/status-im/status-desktop/issues/14219
-    let members = myCommunity.getCommunityChat(self.chatId).members
-    if members.len > 0:
-      return members
-  return self.chatService.getChatById(self.chatId).members
+proc getMyChat*(self: Controller): ChatDto =
+  return self.chatService.getChatById(self.chatId)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, largeImage: string] =

--- a/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
@@ -20,6 +20,9 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getUsersListVariant*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onNewMessagesLoaded*(self: AccessInterface, messages: seq[MessageDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -59,5 +62,5 @@ method addGroupMembers*(self: AccessInterface, pubKeys: seq[string]) {.base.} =
 method removeGroupMembers*(self: AccessInterface, pubKeys: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method updateMembersList*(self: AccessInterface) {.base.} =
+method updateMembersList*(self: AccessInterface, membersToReset: seq[ChatMember] = @[]) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -4,13 +4,13 @@ import view, controller
 import ../../../../shared_models/[member_model, member_item]
 import ../../../../../global/global_singleton
 import ../../../../../core/eventemitter
-import ../../../../../../app_service/common/conversion
 import ../../../../../../app_service/common/types
 import ../../../../../../app_service/service/contacts/dto/contacts
 import ../../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/community/service as community_service
 import ../../../../../../app_service/service/message/service as message_service
+from ../../../../../../app_service/common/conversion import intToEnum
 
 export io_interface
 
@@ -20,15 +20,17 @@ type
     viewVariant: QVariant
     controller: Controller
     moduleLoaded: bool
+    isPublicCommunityChannel: bool
+    isSectionMemberList: bool
 
 # Forward declaration
-proc processChatMember(self: Module,  member: ChatMember): MemberItem
+proc processChatMember(self: Module,  member: ChatMember, reset: bool = false): tuple[doAdd: bool, memberItem: MemberItem]
 
 proc newModule*(
   events: EventEmitter, sectionId: string, chatId: string,
   belongsToCommunity: bool, isUsersListAvailable: bool, contactService: contact_service.Service,
   chatService: chat_service.Service, communityService: community_service.Service,
-  messageService: message_service.Service,
+  messageService: message_service.Service, isSectionMemberList: bool = false,
 ): Module =
   result = Module()
   result.view = view.newView(result)
@@ -38,6 +40,8 @@ proc newModule*(
     contactService, chatService, communityService, messageService,
   )
   result.moduleLoaded = false
+  result.isPublicCommunityChannel = false
+  result.isSectionMemberList = isSectionMemberList
 
 method delete*(self: Module) =
   self.controller.delete
@@ -59,7 +63,12 @@ method viewDidLoad*(self: Module) =
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
+method getUsersListVariant*(self: Module): QVariant =
+  self.view.getModel()
+
 method contactNicknameChanged*(self: Module, publicKey: string) =
+  if self.isPublicCommunityChannel:
+    return
   let contactDetails = self.controller.getContactDetails(publicKey)
   self.view.model().setName(
     publicKey,
@@ -69,11 +78,15 @@ method contactNicknameChanged*(self: Module, publicKey: string) =
     )
 
 method contactsStatusUpdated*(self: Module, statusUpdates: seq[StatusUpdateDto]) =
+  if self.isPublicCommunityChannel:
+    return
   for s in statusUpdates:
     var status = toOnlineStatus(s.statusType)
     self.view.model().setOnlineStatus(s.publicKey, status)
 
 method contactUpdated*(self: Module, publicKey: string) =
+  if self.isPublicCommunityChannel:
+    return
   let contactDetails = self.controller.getContactDetails(publicKey)
   let isMe = publicKey == singletonInstance.userProfile.getPubKey()
   self.view.model().updateItem(
@@ -90,37 +103,43 @@ method contactUpdated*(self: Module, publicKey: string) =
   )
 
 method userProfileUpdated*(self: Module) =
+  if self.isPublicCommunityChannel:
+    return
   self.contactUpdated(singletonInstance.userProfile.getPubKey())
 
 method loggedInUserImageChanged*(self: Module) =
+  if self.isPublicCommunityChannel:
+    return
   self.view.model().setIcon(singletonInstance.userProfile.getPubKey(), singletonInstance.userProfile.getIcon())
 
 # This function either removes the member if it is no longer part of the community,
 # does nothing if the member is already in the model or creates the MemberItem
-proc processChatMember(self: Module,  member: ChatMember): MemberItem =
+proc processChatMember(self: Module,  member: ChatMember, reset: bool = false): tuple[doAdd: bool, memberItem: MemberItem] =
+  result.doAdd = false
   if member.id == "":
     return
 
-  if not self.controller.belongsToCommunity() and not member.joined:
+  if not reset and not self.controller.belongsToCommunity() and not member.joined:
     if self.view.model().isContactWithIdAdded(member.id):
       # Member is no longer joined
       self.view.model().removeItemById(member.id)
     return
 
-  if self.view.model().isContactWithIdAdded(member.id):
+  if not reset and self.view.model().isContactWithIdAdded(member.id):
     return
 
   let isMe = member.id == singletonInstance.userProfile.getPubKey()
   let contactDetails = self.controller.getContactDetails(member.id)
   var status = OnlineStatus.Online
-  if (isMe):
+  if isMe:
     let currentUserStatus = intToEnum(singletonInstance.userProfile.getCurrentUserStatus(), StatusType.Unknown)
     status = toOnlineStatus(currentUserStatus)
   else:
     let statusUpdateDto = self.controller.getStatusForContact(member.id)
     status = toOnlineStatus(statusUpdateDto.statusType)
 
-  return initMemberItem(
+  result.doAdd = true
+  result.memberItem = initMemberItem(
     pubKey = member.id,
     displayName = contactDetails.dto.displayName,
     ensName = contactDetails.dto.name,
@@ -136,38 +155,45 @@ proc processChatMember(self: Module,  member: ChatMember): MemberItem =
     memberRole = member.role,
     joined = member.joined,
     isUntrustworthy = contactDetails.dto.trustStatus == TrustStatus.Untrustworthy,
-    )
+  )
 
 method onChatMembersAdded*(self: Module, ids: seq[string]) =
+  if self.isPublicCommunityChannel:
+    return
   var memberItems: seq[MemberItem] = @[]
 
   for memberId in ids:
-    let item = self.processChatMember(ChatMember(id: memberId, role: MemberRole.None, joined: true))
-    if item.pubKey != "":
+    let (doAdd, item) = self.processChatMember(ChatMember(id: memberId, role: MemberRole.None, joined: true))
+    if doAdd:
       memberItems.add(item)
 
   self.view.model().addItems(memberItems)
 
 method onChatMemberRemoved*(self: Module, id: string) =
+  if self.isPublicCommunityChannel:
+    return
   self.view.model().removeItemById(id)
 
 method onMembersChanged*(self: Module,  members: seq[ChatMember]) =
+  if self.isPublicCommunityChannel:
+    return
   let modelIDs = self.view.model().getItemIds()
   let membersAdded = filter(members, member => not modelIDs.contains(member.id))
   let membersRemoved = filter(modelIDs, id => not members.any(member => member.id == id))
 
   var memberItems: seq[MemberItem] = @[]
   for member in membersAdded:
-    let item = self.processChatMember(member)
-    if item.pubKey != "":
+    let (doAdd, item) = self.processChatMember(member)
+    if doAdd:
       memberItems.add(item)
   self.view.model().addItems(memberItems)
 
   for id in membersRemoved:
     self.onChatMemberRemoved(id)
 
-
 method onChatMemberUpdated*(self: Module, publicKey: string, memberRole: MemberRole, joined: bool) =
+  if self.isPublicCommunityChannel:
+    return
   let contactDetails = self.controller.getContactDetails(publicKey)
   let isMe = publicKey == singletonInstance.userProfile.getPubKey()
   self.view.model().updateItem(
@@ -191,13 +217,45 @@ method addGroupMembers*(self: Module, pubKeys: seq[string]) =
 method removeGroupMembers*(self: Module, pubKeys: seq[string]) =
   self.controller.removeGroupMembers(pubKeys)
 
-method updateMembersList*(self: Module) =
-  let members = self.controller.getChatMembers()
+method updateMembersList*(self: Module, membersToReset: seq[ChatMember] = @[]) =
+  let reset = membersToReset.len > 0
+  var members: seq[ChatMember]
+  if reset:
+    members = membersToReset
+  else:
+    if self.controller.belongsToCommunity():
+      let myCommunity = self.controller.getMyCommunity()
+
+      if self.isSectionMemberList:
+        members = myCommunity.members
+      else:
+        # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
+        # see log here: https://github.com/status-im/status-desktop/issues/14442#issuecomment-2120756598
+        # should be resolved in https://github.com/status-im/status-desktop/issues/11694
+        let myChatId = self.controller.getMyChatId()
+        let chat = myCommunity.getCommunityChat(myChatId)
+        if not chat.tokenGated:
+          # No need to get the members, this channel is not encrypted and can use the section member list
+          self.isPublicCommunityChannel = true
+          return
+        self.isPublicCommunityChannel = false
+        if chat.members.len > 0:
+          members = chat.members
+        else:
+          # The channel now has a permisison, but the re-eval wasn't performed yet. Show all members for now
+          members = myCommunity.members
+
+    if members.len == 0:
+      members = self.controller.getMyChat().members
+
   var memberItems: seq[MemberItem] = @[]
 
   for member in members:
-    let item = self.processChatMember(member)
-    if item.pubKey != "":
+    let (doAdd, item) = self.processChatMember(member, reset)
+    if doAdd:
       memberItems.add(item)
 
-  self.view.model().addItems(memberItems)
+  if reset:
+    self.view.model().setItems(memberItems)
+  else:
+    self.view.model().addItems(memberItems)

--- a/src/app/modules/main/chat_section/chat_content/users/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/view.nim
@@ -33,10 +33,10 @@ QtObject:
 
   proc modelChanged*(self: View) {.signal.}
 
-  proc getModel(self: View): QVariant {.slot.} =
+  proc getModel*(self: View): QVariant {.slot.} =
     return self.modelVariant
 
-  QtProperty[QVariant]model:
+  QtProperty[QVariant] model:
     read = getModel
     notify = modelChanged
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -342,6 +342,11 @@ proc init*(self: Controller) =
       if args.communityId == self.sectionId:
         self.delegate.onSectionMutedChanged()
 
+    self.events.on(SIGNAL_COMMUNITY_MEMBERS_CHANGED) do(e: Args):
+      let args = CommunityMembersArgs(e)
+      if args.communityId == self.sectionId:
+        self.delegate.updateCommunityMemberList(args.members)
+
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.onContactDetailsUpdated(args.contactId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -46,6 +46,12 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method updateCommunityMemberList*(self: AccessInterface, members: seq[ChatMember]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getSectionMemberList*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onActiveSectionChange*(self: AccessInterface, sectionId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -573,3 +573,11 @@ QtObject:
       return
     self.communityMemberReevaluationStatus = value
     self.communityMemberReevaluationStatusChanged()
+
+  proc membersModelChanged*(self: View) {.signal.}
+  proc getMembersModel(self: View): QVariant {.slot.} =
+    return self.delegate.getSectionMemberList()
+
+  QtProperty[QVariant] membersModel:
+    read = getMembersModel
+    notify = membersModelChanged

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -68,7 +68,7 @@ proc `$`(self: Images): string =
     ]"""
 
 proc `$`*(self: ContactsDto): string =
-  result = fmt"""ContactDto(
+  result = fmt"""ContactsDto(
     id: {self.id},
     name: {self.name},
     ensVerified: {self.ensVerified},

--- a/src/app_service/service/ens/dto/ens_username_dto.nim
+++ b/src/app_service/service/ens/dto/ens_username_dto.nim
@@ -15,7 +15,7 @@ proc `==`*(l, r: EnsUsernameDto): bool =
     return l.chainId == r.chainid and l.username == r.username
 
 proc `$`*(self: EnsUsernameDto): string =
-  result = fmt"""ContactDto(
+  result = fmt"""EnsUsernameDto(
     chainId: {self.chainId},
     username: {self.username},
     txType: {self.txType},

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -179,7 +179,17 @@ StatusSectionLayout {
             store: root.rootStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
-            usersModel: root.chatContentModule && root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
+            usersModel: {
+                if (!root.chatContentModule || !root.chatContentModule.chatDetails) {
+                    return null
+                }
+                let isFullCommunityList = !root.chatContentModule.chatDetails.requiresPermissions
+                if (root.chatContentModule.chatDetails.belongsToCommunity && isFullCommunityList) {
+                    // Community channel with no permisisons. We can use the section's membersModel
+                    return root.rootStore.chatCommunitySectionModule.membersModel
+                }
+                return root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
+            }
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/16288

Follow up of https://github.com/status-im/status-desktop/pull/16279

In the base PR, I introduced the idea of reusing the same user model when we have the same full model.

However, as @alexjba pointed out, this was dangerous, since if a channel is deleted, the model should be deleted too and then we could have a crash.

This is remedied in this PR, by introducing a new instance of the users module, but managed by the section module.
This user module is managing the "public" community members list. Meaning that everytime we have a public channel in a community, we use that module instead.

The channel's user module is empty for public channels to reduce the amount of processing and memory used.

If the channel becomes private, we update the member list and populate it.

#### Very non-scientific stats:

Methodology: I started the app once on the master commit before the changes, then on top of my changes :+1: 
The time to start doesn't include all the login stuff, it's just the time to build the chat sections (`onChatsLoaded`) and having the Status community selected by default

1. Before the member list changes:
    - Memory on start: 860MB
    - Start time: 2.818s
2. After both PRs:
    - Memory on start: 834MB
    - Start time: 1.993s

### Affected areas

All the member lists!
Even though the work targets public channels for communities, the code affects all types of channels and their members list.

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

[user-list-upgraded.webm](https://github.com/user-attachments/assets/ae9027a7-4201-487a-aaa9-f25e2752f78a)


### Impact on end user

- Switching channels should be faster, because all the channels that used to be slow were the public channels (they contain the whole community list).
- The community/app loading will be a bit faster, since we don't have to build the member list for all channels
- Memory usage should be a little bit lower, since we don't store the user model for all channels

### How to test

- Test group chat member list
- Test public community channel member list
  - Test switching between public channels. It should use the same member list (you can even scroll it and it will stay at the same spot)
  - Switching between public channels should be instant
- Test private channels
- Test making a channel private and vice versa and see the member list update
  - Do note that there might be a 5 minute delay for the re-eval. It's better to test with another member to see when the re-eval happened. The user list should never become blank though
  - There is a small bug on master with the lock icon: https://github.com/status-im/status-desktop/issues/16300
- Test renaming users and having users leave and join the community to make sure it updates correctly.

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case scenario, the member list becomes blank for some reason. That would be a bug obviously. Without the member list, you can't mention.
