### PR TITLE
fix(StatusSeedPhraseInput): accept a common prefix suggestion

### DIFF
--- a/storybook/stubs/shared/stores/BIP39_en.qml
+++ b/storybook/stubs/shared/stores/BIP39_en.qml
@@ -5,7 +5,7 @@ ListModel {
 
     Component.onCompleted: {
         var englishWords = [
-            "apple", "banana", "cat", "dog", "elephant", "fish", "grape", "horse", "ice cream", "jellyfish",
+            "apple", "banana", "cat", "cow", "catalog", "catch", "category", "cattle", "dog", "elephant", "fish", "grape", "horse", "ice cream", "jellyfish",
             "kiwi", "lemon", "mango", "nut", "orange", "pear", "quail", "rabbit", "strawberry", "turtle",
             "umbrella", "violet", "watermelon", "xylophone", "yogurt", "zebra"
             // Add more English words here...

--- a/ui/imports/shared/panels/EnterSeedPhrase.qml
+++ b/ui/imports/shared/panels/EnterSeedPhrase.qml
@@ -55,7 +55,6 @@ ColumnLayout {
             let mnemonicString = ""
 
             if (d.allEntriesValid) {
-
                 mnemonicString = buildMnemonicString()
                 if (!Utils.isMnemonic(mnemonicString) || !root.isSeedPhraseValid(mnemonicString)) {
                     root.setWrongSeedPhraseMessage(qsTr("Invalid seed phrase"))


### PR DESCRIPTION
### What does the PR do

- fix for a corner case prob when there was a valid seedphrase word (e.g. cat) that is at the same time a prefix for other valid suggestions (e.g. category, catalog, ...); it was imposible to select it using Enter key or mouse click from the suggestions popup at the last field
- add a QML regression test for this issue
- use standard subcomponents (StatusDropdown, StatusListView) reducing code duplication and unifying UI/UX

Fixes #16291

### Affected areas

StatusSeedPhraseInput

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/2e0f8888-aba2-4cf6-832e-7a01146c7de6

