### PR TITLE
refactor(community_tokens): only fetch holders when going to the page

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -178,9 +178,3 @@ proc declineOwnership*(self: Controller, communityId: string) =
 
 proc asyncGetOwnerTokenOwnerAddress*(self: Controller, chainId: int, contractAddress: string) =
   self.communityTokensService.asyncGetOwnerTokenOwnerAddress(chainId, contractAddress)
-
-proc startTokenHoldersManagement*(self: Controller, chainId: int, contractAddress: string) =
-  self.communityTokensService.startTokenHoldersManagement(chainId, contractAddress)
-
-proc stopTokenHoldersManagement*(self: Controller) =
-  self.communityTokensService.stopTokenHoldersManagement()

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -119,9 +119,3 @@ method onOwnerTokenOwnerAddress*(self: AccessInterface, chainId: int, contractAd
 
 method asyncGetOwnerTokenDetails*(self: AccessInterface, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
-
-method startTokenHoldersManagement*(self: AccessInterface, chainId: int, contractAddress: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method stopTokenHoldersManagement*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/tokens/models/token_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_item.nim
@@ -20,6 +20,7 @@ type
     burnState*: ContractTransactionStatus
     remoteDestructedAddresses*: seq[string]
     tokenOwnersModel*: token_owners_model.TokenOwnersModel
+    tokenHoldersLoading*: bool
 
 proc initTokenItem*(
   tokenDto: CommunityTokenDto,
@@ -29,7 +30,7 @@ proc initTokenItem*(
   burnState: ContractTransactionStatus,
   remoteDestructedAddresses: seq[string],
   remainingSupply: Uint256,
-  destructedAmount: Uint256
+  destructedAmount: Uint256,
 ): TokenItem =
   result.tokenDto = tokenDto
   if network != nil:
@@ -45,6 +46,7 @@ proc initTokenItem*(
     # TODO: provide number of messages here
     result = initTokenOwnersItem(owner.contactId, owner.name, owner.imageSource, 0, owner.collectibleOwner, remoteDestructedAddresses)
   ))
+  result.tokenHoldersLoading = false
 
 proc `$`*(self: TokenItem): string =
   result = fmt"""TokenItem(
@@ -55,6 +57,7 @@ proc `$`*(self: TokenItem): string =
     destructedAmount: {self.destructedAmount},
     burnState: {self.burnState},
     tokenOwnersModel: {self.tokenOwnersModel},
+    tokenHoldersLoading: {self.tokenHoldersLoading},
     remoteDestructedAddresses: {self.remoteDestructedAddresses}
     ]"""
 

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -385,9 +385,3 @@ method onOwnerTokenOwnerAddress*(self: Module, chainId: int, contractAddress: st
     "contractAddress": contractAddress
   }
   self.view.setOwnerTokenDetails($jsonObj)
-
-method startTokenHoldersManagement*(self: Module, chainId: int, contractAddress: string) =
-  self.controller.startTokenHoldersManagement(chainId, contractAddress)
-
-method stopTokenHoldersManagement*(self: Module) =
-  self.controller.stopTokenHoldersManagement()

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -145,9 +145,3 @@ QtObject:
   QtProperty[string] ownerTokenDetails:
     read = getOwnerTokenDetails
     notify = ownerTokenDetailsChanged
-
-  proc startTokenHoldersManagement*(self: View, chainId: int, contractAddress: string) {.slot.} =
-    self.communityTokensModule.startTokenHoldersManagement(chainId, contractAddress)
-
-  proc stopTokenHoldersManagement*(self: View) {.slot.} =
-    self.communityTokensModule.stopTokenHoldersManagement()

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -392,6 +392,10 @@ proc init*(self: Controller) =
     let args = CommunityTokenOwnersArgs(e)
     self.delegate.onCommunityTokenOwnersFetched(args.communityId, args.chainId, args.contractAddress, args.owners)
 
+  self.events.on(SIGNAL_COMMUNITY_TOKEN_OWNERS_LOADING_FAILED) do(e: Args):
+    let args = CommunityTokenOwnersArgs(e)
+    self.delegate.errorLoadingTokenHolders(args.communityId, args.chainId, args.contractAddress, args.error)
+
   self.events.on(SIGNAL_ACCEPT_REQUEST_TO_JOIN_LOADING) do(e: Args):
     var args = CommunityMemberArgs(e)
     self.delegate.onAcceptRequestToJoinLoading(args.communityId, args.pubKey)
@@ -411,10 +415,6 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_COMMUNITY_MEMBER_STATUS_CHANGED) do(e: Args):
     let args = CommunityMemberStatusUpdatedArgs(e)
     self.delegate.onMembershipStateUpdated(args.communityId, args.memberPubkey, args.state)
-
-  self.events.on(SIGNAL_COMMUNITY_MEMBERS_CHANGED) do(e: Args):
-    let args = CommunityMembersArgs(e)
-    self.communityTokensService.fetchCommunityTokenOwners(args.communityId)
 
   self.events.on(SIGNAL_SHARED_KEYCARD_MODULE_FLOW_TERMINATED) do(e: Args):
     let args = SharedKeycarModuleFlowTerminatedArgs(e)
@@ -597,3 +597,9 @@ proc asyncGetRevealedAccountsForAllMembers*(self: Controller, communityId: strin
 
 proc asyncReevaluateCommunityMembersPermissions*(self: Controller, communityId: string) =
   self.communityService.asyncReevaluateCommunityMembersPermissions(communityId)
+
+proc startTokenHoldersManagement*(self: Controller, chainId: int, contractAddress: string) =
+  self.communityTokensService.startTokenHoldersManagement(chainId, contractAddress)
+
+proc stopTokenHoldersManagement*(self: Controller) =
+  self.communityTokensService.stopTokenHoldersManagement()

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -337,6 +337,9 @@ method onOwnerTokensDeploymentStarted*(self: AccessInterface, ownerToken: Commun
 method onCommunityTokenOwnersFetched*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method errorLoadingTokenHolders*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onCommunityTokenDeployStateChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, deployState: DeployState) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -419,6 +422,12 @@ method openSectionChatAndMessage*(self: AccessInterface, sectionId: string, chat
   raise newException(ValueError, "No implementation available")
 
 method updateRequestToJoinState*(self: AccessInterface, sectionId: string, requestToJoinState: RequestToJoinState) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method startTokenHoldersManagement*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method stopTokenHoldersManagement*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1213,6 +1213,20 @@ method onCommunityTokenRemoved*[T](self: Module[T], communityId: string, chainId
   if item.id != "":
     item.removeCommunityToken(chainId, address)
 
+method startTokenHoldersManagement*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string) =
+  self.controller.startTokenHoldersManagement(chainId, contractAddress)
+  let item = self.view.model().getItemById(communityId)
+  if item.id != "" and not item.communityTokens.hasTokenHolders(chainId, contractAddress):
+    item.setCommunityTokenHoldersLoading(chainId, contractAddress, value = true)
+
+method stopTokenHoldersManagement*[T](self: Module[T]) =
+  self.controller.stopTokenHoldersManagement()
+
+method errorLoadingTokenHolders*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string, error: string) =
+  let item = self.view.model().getItemById(communityId)
+  if item.id != "":
+    item.setCommunityTokenHoldersLoading(chainId, contractAddress, value = false)
+
 method onCommunityTokenOwnersFetched*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner]) =
   let item = self.view.model().getItemById(communityId)
   if item.id != "":

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -375,3 +375,9 @@ QtObject:
   proc emitCommunityMemberStatusEphemeralNotification*(self:View, communityName: string, memberName: string,
     membershipState: int) =
     self.communityMemberStatusEphemeralNotification(communityName, memberName, membershipState)
+
+  proc startTokenHoldersManagement*(self: View, communityId: string, chainId: int, contractAddress: string) {.slot.} =
+    self.delegate.startTokenHoldersManagement(communityId, chainId, contractAddress)
+
+  proc stopTokenHoldersManagement*(self: View) {.slot.} =
+    self.delegate.stopTokenHoldersManagement()

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -373,6 +373,9 @@ proc updateRemoteDestructedAddresses*(self: SectionItem, chainId: int, contractA
 proc setCommunityTokenOwners*(self: SectionItem, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner]) {.inline.} =
   self.communityTokensModel.setCommunityTokenOwners(chainId, contractAddress, owners)
 
+proc setCommunityTokenHoldersLoading*(self: SectionItem, chainId: int, contractAddress: string, value: bool) {.inline.} =
+  self.communityTokensModel.setCommunityTokenHoldersLoading(chainId, contractAddress, value)
+
 proc communityTokens*(self: SectionItem): community_tokens_model.TokenModel {.inline.} =
   self.communityTokensModel
 

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -1291,7 +1291,6 @@ QtObject:
       debug "Unable to fetch token hodlers for token type ", token=communityToken.tokenType
 
   proc onCommunityTokenOwnersFetched*(self:Service, response: string) {.slot.} =
-    # TODO add try
     let responseJson = response.parseJson()
     let chainId = responseJson{"chainId"}.getInt
     let contractAddress = responseJson{"contractAddress"}.getStr

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -156,6 +156,7 @@ type
     contractAddress*: string
     chainId*: int
     owners*: seq[CommunityCollectibleOwner]
+    error*: string
 
 type
   CommunityTokensDetailsArgs* =  ref object of Args
@@ -259,6 +260,7 @@ const SIGNAL_COMPUTE_SELF_DESTRUCT_FEE* = "communityTokens-computeSelfDestructFe
 const SIGNAL_COMPUTE_BURN_FEE* = "communityTokens-computeBurnFee"
 const SIGNAL_COMPUTE_AIRDROP_FEE* = "communityTokens-computeAirdropFee"
 const SIGNAL_COMMUNITY_TOKEN_OWNERS_FETCHED* = "communityTokens-communityTokenOwnersFetched"
+const SIGNAL_COMMUNITY_TOKEN_OWNERS_LOADING_FAILED* = "communityTokens-communityTokenOwnersLoadingFailed"
 const SIGNAL_REMOTE_DESTRUCT_STATUS* = "communityTokens-communityTokenRemoteDestructStatus"
 const SIGNAL_BURN_STATUS* = "communityTokens-communityTokenBurnStatus"
 const SIGNAL_BURN_ACTION_RECEIVED* = "communityTokens-communityTokenBurnActionReceived"
@@ -1289,18 +1291,30 @@ QtObject:
       debug "Unable to fetch token hodlers for token type ", token=communityToken.tokenType
 
   proc onCommunityTokenOwnersFetched*(self:Service, response: string) {.slot.} =
+    # TODO add try
     let responseJson = response.parseJson()
-    if responseJson{"error"}.kind != JNull and responseJson{"error"}.getStr != "":
-      let errorMessage = responseJson["error"].getStr
-      error "Can't fetch community token owners", chainId=responseJson{"chainId"}, contractAddress=responseJson{"contractAddress"}, errorMsg=errorMessage
-      return
     let chainId = responseJson{"chainId"}.getInt
     let contractAddress = responseJson{"contractAddress"}.getStr
     let communityId = responseJson{"communityId"}.getStr
-    let communityTokenOwners = toCommunityCollectibleOwners(responseJson{"result"})
-    self.tokenOwnersCache[(chainId, contractAddress)] = communityTokenOwners
-    let data = CommunityTokenOwnersArgs(chainId: chainId, contractAddress: contractAddress, communityId: communityId, owners: communityTokenOwners)
-    self.events.emit(SIGNAL_COMMUNITY_TOKEN_OWNERS_FETCHED, data)
+
+    try:
+      if responseJson{"error"}.kind != JNull and responseJson{"error"}.getStr != "":
+        raise newException(ValueError, responseJson["error"].getStr)
+
+      let communityTokenOwners = toCommunityCollectibleOwners(responseJson{"result"})
+      self.tokenOwnersCache[(chainId, contractAddress)] = communityTokenOwners
+      let data = CommunityTokenOwnersArgs(chainId: chainId, contractAddress: contractAddress, communityId: communityId, owners: communityTokenOwners)
+      self.events.emit(SIGNAL_COMMUNITY_TOKEN_OWNERS_FETCHED, data)
+    except Exception as e:
+      error "Can't fetch community token owners", chainId=responseJson{"chainId"}, contractAddress=responseJson{"contractAddress"}, errorMsg=e.msg
+
+      let data = CommunityTokenOwnersArgs(
+        chainId: chainId,
+        contractAddress: contractAddress,
+        communityId: communityId,
+        error: e.msg,
+      )
+      self.events.emit(SIGNAL_COMMUNITY_TOKEN_OWNERS_LOADING_FAILED, data)
 
     # restart token holders timer
     self.restartTokenHoldersTimer(chainId, contractAddress)
@@ -1312,14 +1326,6 @@ QtObject:
   proc iAmCommunityPrivilegedUser(self:Service, communityId: string): bool =
     let community = self.communityService.getCommunityById(communityId)
     return community.isPrivilegedUser()
-
-  # used when community members changed
-  proc fetchCommunityTokenOwners*(self: Service, communityId: string) =
-    if not self.iAmCommunityPrivilegedUser(communityId):
-      return
-    let tokens = self.getCommunityTokens(communityId)
-    for token in tokens:
-      self.fetchCommunityOwners(token)
 
   proc getOwnerToken*(self: Service, communityId: string): CommunityTokenDto =
     let communityTokens = self.getCommunityTokens(communityId)

--- a/storybook/pages/CommunityTokenViewPage.qml
+++ b/storybook/pages/CommunityTokenViewPage.qml
@@ -41,6 +41,7 @@ SplitView {
                 chainName: networksGroup.checkedButton.text
                 chainIcon: networksGroup.checkedButton.chainIcon
                 accountName: "helloworld"
+                tokenHoldersLoading: loadingTokenHolders.checked
 
                 // collectible-specific properties
                 remotelyDestructState: remotelyDestructStateBox.checked
@@ -138,6 +139,16 @@ SplitView {
                         id: previewBox
                         text: "Preview"
                         checked: true
+                    }
+                }
+
+                GroupBox {
+                    Layout.fillWidth: true
+
+                    CheckBox {
+                        id: loadingTokenHolders
+                        text: "Loading Token Holders"
+                        checked: false
                     }
                 }
 

--- a/ui/app/AppLayouts/Communities/helpers/TokenObject.qml
+++ b/ui/app/AppLayouts/Communities/helpers/TokenObject.qml
@@ -51,4 +51,7 @@ QtObject {
 
     // Asset-specific properties:
     property int decimals: 2
+
+    // Loading indicators
+    property bool tokenHoldersLoading: false
 }

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -1005,6 +1005,7 @@ StackView {
                     token.accountAddress: model.accountAddress
                     token.multiplierIndex: model.multiplierIndex
                     token.tokenAddress: model.tokenAddress
+                    token.tokenHoldersLoading: model.tokenHoldersLoading
                 }
 
                 onCountChanged: {

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -375,7 +375,7 @@ StatusSectionLayout {
 
             onRegisterBurnTokenFeesSubscriber: d.feesBroker.registerBurnFeesSubscriber(feeSubscriber)
 
-            onStartTokenHoldersManagement: communityTokensStore.startTokenHoldersManagement(chainId, address)
+            onStartTokenHoldersManagement: communityTokensStore.startTokenHoldersManagement(root.community.id, chainId, address)
 
             onStopTokenHoldersManagement: communityTokensStore.stopTokenHoldersManagement()
 

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -96,6 +96,7 @@ StatusScrollView {
         id: d
 
         readonly property int iconSize: 20
+        property bool loadingTokenHolders: false
 
         readonly property var renamedTokenOwnersModel: RolesRenamingModel {
             sourceModel: root.tokenOwnersModel
@@ -172,7 +173,7 @@ StatusScrollView {
                 wrapMode: Text.Wrap
                 font.pixelSize: Style.current.primaryTextFontSize
                 color: Theme.palette.baseColor1
-                text: qsTr("Review token details before minting it as they can’t be edited later")
+                text: qsTr("Review token details before minting it as they can't be edited later")
             }
         }
 
@@ -228,7 +229,15 @@ StatusScrollView {
             id: tokenHolderLoader
 
             visible: !root.preview && root.deploymentCompleted
-            sourceComponent: isOwnerTokenItem ? tokenHolderContact : sortableTokenHolderPanel
+            sourceComponent: isOwnerTokenItem ? tokenHolderContact : (token.tokenHoldersLoading ? tokenHoldersLoadingComponent : sortableTokenHolderPanel)
+        }
+
+        Component {
+            id: tokenHoldersLoadingComponent
+
+            StatusBaseText {
+                text: qsTr("Loading token holders...")
+            }
         }
 
         Component {

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -7,6 +7,7 @@ QtObject {
     id: root
 
     property var communityTokensModuleInst: communityTokensModule ?? null
+    property var mainModuleInst: mainModule ?? null
 
     // Network selection properties:
     property var flatNetworks: networksModule.flatNetworks
@@ -231,11 +232,11 @@ QtObject {
         communityTokensModuleInst.asyncGetOwnerTokenDetails(communityId)
     }
 
-    function startTokenHoldersManagement(chainId, contractAddress) {
-        communityTokensModuleInst.startTokenHoldersManagement(chainId, contractAddress)
+    function startTokenHoldersManagement(communityId, chainId, contractAddress) {
+        mainModuleInst.startTokenHoldersManagement(communityId, chainId, contractAddress)
     }
 
     function stopTokenHoldersManagement() {
-        communityTokensModuleInst.stopTokenHoldersManagement()
+        mainModuleInst.stopTokenHoldersManagement()
     }
 }


### PR DESCRIPTION
### What does the PR do

Fixes #16307

Instead of fetching community token holders each time members change, we fetch when the page for the token is opened. It shows a small loading text then the resulting holders. If the list is already available (fetched previously, we show it directly). There is still the timer to refresh the list if you stay on the page.

### Affected areas

The community admin page where we show the list of holders for a token. That list is also shown in the remote destruct screen,

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality

[token-holders.webm](https://github.com/user-attachments/assets/9db839f2-aae2-4388-a0d9-5b6cad79e325)

### Impact on end user

There should be less background calls and less data loaded in the background, hopefully improving the performance and also reducing the RAM usage.
This affects only admins.

### How to test

Check the token holders and their functionalities (burn, self-destruct, airdrop)

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case scenario, the list doesn't update fast enough when something changes (new user, or burn), since it relies on the timer only now.
