### PR TITLE
feat(wallet): Recalculate specific entries in accounts model

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/controller.nim
+++ b/src/app/modules/main/wallet_section/accounts/controller.nim
@@ -32,6 +32,9 @@ proc init*(self: Controller) =
 proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAccountDto] =
   return self.walletAccountService.getWalletAccounts()
 
+proc getWalletAccountsByAddresses*(self: Controller, addresses: seq[string]): seq[wallet_account_service.WalletAccountDto] =
+  return self.walletAccountService.getAccountsByAddresses(addresses)
+
 proc isKeycardAccount*(self: Controller, account: WalletAccountDto): bool =
   return self.walletAccountService.isKeycardAccount(account)
 
@@ -73,6 +76,3 @@ proc updateWatchAccountHiddenFromTotalBalance*(self: Controller, address: string
 
 proc getTokensMarketValuesLoading*(self: Controller): bool =
   return self.walletAccountService.getTokensMarketValuesLoading()
-
-proc getChainIds*(self: Controller): seq[int] =
-  return self.networkService.getCurrentNetworksChainIds()

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -16,10 +16,10 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method deleteAccount*(self: AccessInterface, address: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method refreshWalletAccounts*(self: AccessInterface) {.base.} =
+method loadAllWalletAccounts*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int]) {.base.} =
+method filterChanged*(self: AccessInterface, chainIds: seq[int]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateAccount*(self: AccessInterface, address: string, accountName: string, colorId: string, emoji: string) {.base.} =

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -125,3 +125,13 @@ QtObject:
 
   proc canSend*(self: Item): bool =
     return self.canSend
+
+  proc setAssetsLoading*(self: Item, value: bool) =
+    self.assetsLoading = value
+
+  proc setBalance*(self: Item, value: CurrencyAmount) =
+    self.currencyBalance = value
+    self.currencyBalanceChanged()
+
+  proc setHideFromTotalBalance*(self: Item, value: bool) =
+    self.hideFromTotalBalance = value

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -1,12 +1,14 @@
-import NimQml, json, sequtils, sugar
+import NimQml, json, sequtils, sugar, tables
 
 import ./io_interface, ./view, ./controller
+import ./item as wallet_accounts_item
 import ../io_interface as delegate_interface
 import app/global/global_singleton
 import app/core/eventemitter
 import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/network/service as network_service
 import app_service/service/currency/service as currency_service
+import app_service/service/token/service as token_service
 import app/modules/shared/wallet_utils
 
 export io_interface
@@ -20,6 +22,7 @@ type
     controller: Controller
     moduleLoaded: bool
     walletAccountService: wallet_account_service.Service
+    filterChainIds: seq[int]
 
 proc newModule*(
   delegate: delegate_interface.AccessInterface,
@@ -42,28 +45,53 @@ method delete*(self: Module) =
   self.view.delete
   self.controller.delete
 
-method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) =
-  let walletAccounts = self.controller.getWalletAccounts()
+proc getWalletAccounts(self: Module, addresses: seq[string]): seq[wallet_account_service.WalletAccountDto] =
+  if addresses.len > 0:
+     return self.controller.getWalletAccountsByAddresses(addresses)
+  return self.controller.getWalletAccounts()
+
+proc refreshWalletAccountsBalances(self: Module, addresses: seq[string]) =
+  let walletAccounts = self.getWalletAccounts(addresses)
   let currency = self.controller.getCurrentCurrency()
-  let allChainIds = self.controller.getChainIds()
+  let currencyFormat = self.controller.getCurrencyFormat(currency)
+  let marketValuesLoading = self.controller.getTokensMarketValuesLoading()
+  for walletAccount in walletAccounts:
+    let currencyBalance = self.controller.getTotalCurrencyBalance(walletAccount.address, self.filterChainIds)
+    self.view.updateBalance(walletAccount.address, currencyAmountToItem(currencyBalance, currencyFormat), walletAccount.assetsLoading or marketValuesLoading)
+  
+proc refreshAllWalletAccountsBalances(self: Module) =
+  self.refreshWalletAccountsBalances(@[])
+
+proc getWalletItems(self: Module, addresses: seq[string]): seq[wallet_accounts_item.Item] =
+  let walletAccounts = self.getWalletAccounts(addresses)
+  let currency = self.controller.getCurrentCurrency()
   let currencyFormat = self.controller.getCurrencyFormat(currency)
   let areTestNetworksEnabled = self.controller.areTestNetworksEnabled()
 
-  let items = walletAccounts.map(w => (block:
-    let currencyBalance = self.controller.getTotalCurrencyBalance(w.address, chainIds)
-    let keycardAccount = self.controller.isKeycardAccount(w)
+  return walletAccounts.map(w => (block:
+    let currencyBalance = self.controller.getTotalCurrencyBalance(w.address, self.filterChainIds)
+    let isKeycardAccount = self.controller.isKeycardAccount(w)
     walletAccountToWalletAccountsItem(
       w,
-      keycardAccount,
-      allChainIds,
-      chainIds,
+      isKeycardAccount,
       currencyBalance,
       currencyFormat,
       areTestNetworksEnabled,
       self.controller.getTokensMarketValuesLoading()
     )
   ))
-  self.view.setItems(items)
+
+proc updateWalletAccounts(self: Module, addresses: seq[string]) =
+  self.view.updateItems(self.getWalletItems(addresses))
+
+method loadAllWalletAccounts*(self: Module) =
+  self.view.setItems(self.getWalletItems(@[]))
+
+method filterChanged*(self: Module, chainIds: seq[int]) =
+  if self.filterChainIds == chainIds:
+    return
+  self.filterChainIds = chainIds
+  self.refreshAllWalletAccountsBalances()
 
 method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("walletSectionAccounts", self.viewVariant)
@@ -73,6 +101,38 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e: Args):
     let args = AccountArgs(e)
     self.view.onPreferredSharingChainsUpdated(args.account.keyUid, args.account.address, args.account.prodPreferredChainIds, args.account.testPreferredChainIds)
+  self.events.on(SIGNAL_TOKENS_MARKET_VALUES_UPDATED) do(e:Args):
+    self.refreshAllWalletAccountsBalances()
+  self.events.on(SIGNAL_CURRENCY_FORMATS_UPDATED) do(e:Args):
+    self.refreshAllWalletAccountsBalances()
+  self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
+    self.refreshAllWalletAccountsBalances()
+  self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e:Args):
+    self.refreshAllWalletAccountsBalances()
+  self.events.on(SIGNAL_KEYPAIR_SYNCED) do(e: Args):
+    self.loadAllWalletAccounts()
+  self.events.on(SIGNAL_WALLET_ACCOUNT_UPDATED) do(e:Args):
+    let accountArgs = AccountArgs(e)
+    self.updateWalletAccounts(@[accountArgs.account.address])
+  self.events.on(SIGNAL_WALLET_ACCOUNT_SAVED) do(e:Args):
+    let accountArgs = AccountArgs(e)
+    self.updateWalletAccounts(@[accountArgs.account.address])
+  self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
+    let accountArgs = AccountArgs(e)
+    self.view.onAccountRemoved(accountArgs.account.address)
+  self.events.on(SIGNAL_NEW_KEYCARD_SET) do(e: Args):
+    self.loadAllWalletAccounts()
+  self.events.on(SIGNAL_ALL_KEYCARDS_DELETED) do(e: Args):
+    self.loadAllWalletAccounts()
+  self.events.on(SIGNAL_WALLET_ACCOUNT_POSITION_UPDATED) do(e: Args):
+    let walletAccounts = self.getWalletAccounts(@[])
+    var accountPositions = initTable[string, int]()
+    for walletAccount in walletAccounts.items:
+      accountPositions[walletAccount.address] = walletAccount.position
+    self.view.updateAccountsPositions(accountPositions)
+  self.events.on(SIGNAL_WALLET_ACCOUNT_HIDDEN_UPDATED) do(e: Args):
+    let accountArgs = AccountArgs(e)
+    self.view.updateAccountHiddenFromTotalBalance(accountArgs.account.address, accountArgs.account.hideFromTotalBalance)
 
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -1,6 +1,7 @@
-import NimQml, json, sequtils, strutils
+import NimQml, json, sequtils, strutils, tables
 
 import app_service/service/wallet_account/service as wallet_account_service
+import app/modules/shared_models/currency_amount
 
 import ./model
 import ./item
@@ -39,6 +40,21 @@ QtObject:
 
   proc setItems*(self: View, items: seq[Item]) =
     self.accounts.setItems(items)
+
+  proc updateItems*(self: View, items: seq[Item]) =
+    self.accounts.updateItems(items)
+
+  proc updateBalance*(self: View, address: string, balance: CurrencyAmount, assetsLoading: bool) =
+    self.accounts.updateBalance(address, balance, assetsLoading)
+    
+  proc onAccountRemoved*(self: View, address: string) =
+    self.accounts.deleteAccount(address)
+
+  proc updateAccountsPositions*(self: View, values: Table[string, int]) =
+    self.accounts.updateAccountsPositions(values)
+
+  proc updateAccountHiddenFromTotalBalance*(self: View, address: string, hideFromTotalBalance: bool) =
+    self.accounts.updateAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
 
   proc deleteAccount*(self: View, address: string) {.slot.} =
     self.delegate.deleteAccount(address)

--- a/src/app/modules/main/wallet_section/filter.nim
+++ b/src/app/modules/main/wallet_section/filter.nim
@@ -7,6 +7,7 @@ type Filter* = ref object
   addresses*: seq[string]
   chainIds*: seq[int]
   allChainsEnabled*: bool
+  isDirty*: bool
 
 proc initFilter*(
   controller: controller.Controller
@@ -16,6 +17,7 @@ proc initFilter*(
   result.addresses = @[]
   result.chainIds = @[]
   result.allChainsEnabled = true
+  result.isDirty = true
 
 proc `$`*(self: Filter): string =
   result = fmt"""WalletFilter(
@@ -25,14 +27,17 @@ proc `$`*(self: Filter): string =
 
 proc setAddresses*(self: Filter, addresses: seq[string]) =
   self.addresses = addresses
+  self.isDirty = true
 
 proc setAddress*(self: Filter, address: string) =
   self.setAddresses(@[address])
+  self.isDirty = true
 
 proc removeAddress*(self: Filter, address: string) =
   if len(self.addresses) == 1 and self.addresses[0] == address:
     let accounts = self.controller.getWalletAccounts()
     self.setAddresses(@[accounts[0].address])
+    self.isDirty = true
     return
 
   let ind = self.addresses.find(address)
@@ -42,6 +47,7 @@ proc removeAddress*(self: Filter, address: string) =
 proc updateNetworks*(self: Filter) =
   self.chainIds = self.controller.getEnabledChainIds()
   self.allChainsEnabled = (self.chainIds.len == self.controller.getCurrentNetworks().len)
+  self.isDirty = true
 
 proc load*(self: Filter) =
   self.updateNetworks()

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -65,7 +65,7 @@ method onUserAuthenticated*(self: AccessInterface, pin: string, password: string
 method setSelectedReceiveAccountIndex*(self: AccessInterface, index: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int]) {.base.} =
+method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int], isDirty: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getCollectiblesModel*(self: AccessInterface): collectibles.Model {.base.} =

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -351,8 +351,8 @@ method suggestedRoutes*(self: Module,
 method stopUpdatesForSuggestedRoute*(self: Module) =
   self.controller.stopSuggestedRoutesAsyncCalculation()
 
-method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) =
-  if addresses.len == 0:
+method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], isDirty: bool) =
+  if not isDirty or addresses.len == 0:
     return
   self.view.setSenderAccount(addresses[0])
   self.view.setReceiverAccount(addresses[0])

--- a/src/app/modules/shared/wallet_utils.nim
+++ b/src/app/modules/shared/wallet_utils.nim
@@ -33,8 +33,7 @@ proc walletAccountToWalletAccountItem*(w: WalletAccountDto, keycardAccount: bool
     w.hideFromTotalBalance
   )
 
-proc walletAccountToWalletAccountsItem*(w: WalletAccountDto, keycardAccount: bool,
-  chainIds: seq[int], enabledChainIds: seq[int], 
+proc walletAccountToWalletAccountsItem*(w: WalletAccountDto, isKeycardAccount: bool, 
   currencyBalance: float64, currencyFormat: CurrencyFormatDto, areTestNetworksEnabled: bool,
   marketValuesLoading: bool): wallet_accounts_item.Item =
   return wallet_accounts_item.newItem(
@@ -48,7 +47,7 @@ proc walletAccountToWalletAccountsItem*(w: WalletAccountDto, keycardAccount: boo
     w.keyUid,
     w.createdAt,
     w.position,
-    keycardAccount,
+    isKeycardAccount,
     w.assetsLoading or marketValuesLoading,
     w.isWallet,
     areTestNetworksEnabled,

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -219,3 +219,7 @@ QtObject:
   QtProperty[bool] hideFromTotalBalance:
     read = hideFromTotalBalance
     notify = hideFromTotalBalanceChanged
+
+  proc `hideFromTotalBalance=`*(self: WalletAccountItem, value: bool) {.inline.} =
+    self.hideFromTotalBalance = value
+    self.hideFromTotalBalanceChanged()


### PR DESCRIPTION
### What does the PR do

* Moved signal handling directly to wallet accounts module instead of wallet module
* Correctly update only. one account, if it's passed as argument. Sometimes signals do operation on all accounts so the signal itself would need refactor first. That's why some handlers refresh all accounts.
* For balance updates only balance is recalculated

### Affected areas

Wallet view

### Architecture compliance

- [X] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/9f03ce9b-1765-4899-896f-c0bdb99f23b7

### Impact on end user

Nothing should change from UI perspective.

### How to test

- How should one proceed with testing this PR.
Play around wallet accounts
- What kind of user flows should be checked?
Wallet accounts management

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [X] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
