### PR TITLE
fix: use proper networks model for detection of offline chain providers

### DIFF
--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -23,7 +23,7 @@ QtObject {
                                                       }
 
     readonly property var blockchainNetworksDown: !!networkConnectionModule.blockchainNetworkConnection.chainIds ? networkConnectionModule.blockchainNetworkConnection.chainIds.split(";") : []
-    readonly property bool atleastOneBlockchainNetworkAvailable: blockchainNetworksDown.length < __filteredflatNetworks.count
+    readonly property bool atleastOneBlockchainNetworkAvailable: blockchainNetworksDown.length < filteredflatNetworks.count
 
     readonly property bool sendBuyBridgeEnabled: localAppSettings.testEnvironment || (isOnline &&
                                         (!networkConnectionModule.blockchainNetworkConnection.completelyDown && atleastOneBlockchainNetworkAvailable) &&


### PR DESCRIPTION
### What does the PR do

A bug was introduced in https://github.com/status-im/status-desktop/pull/16230
A variable name was changed at the definition but not where it is used in `ui/imports/shared/stores/NetworkConnectionStore.qml`. This PR fixes that.

### Affected areas

Wallet

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

Before:
![image](https://github.com/user-attachments/assets/4892d974-8bff-4ad9-afdc-807c9ac64741)

After:
![image](https://github.com/user-attachments/assets/2084284b-6d8f-4441-96d2-15dabab628d2)

### Impact on end user

Users can use wallet bottom bar actions again. 

### How to test

- Open app
- Go to wallet
- If online, Send and other bottom bar buttons should be enabled

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
