### PR TITLE
Add remove user groups option to group chat context menu

### DIFF
--- a/storybook/pages/ProfileContextMenuPage.qml
+++ b/storybook/pages/ProfileContextMenuPage.qml
@@ -62,6 +62,8 @@ SplitView {
                     ensVerified: ensVerifiedCheckBox.checked
                     onlineStatus: onlineStatusSelector.currentValue
                     hasLocalNickname: hasLocalNicknameCheckBox.checked
+                    chatType: chatTypeSelector.currentValue
+                    isAdmin: isAdminCheckBox.checked
                     publicKey: publicKeyInput.text
 
                     onOpenProfileClicked: () => {
@@ -96,6 +98,9 @@ SplitView {
                     }
                     onBlockContact: () => {
                         logs.logEvent("Block contact:", profileContextMenu.publicKey)
+                    }
+                    onRemoveFromGroup: (publicKey) => {
+                        logs.logEvent("Remove from group:", publicKey)
                     }
                     onClosed: {
                         destroy()
@@ -115,6 +120,8 @@ SplitView {
                     ensVerified: ensVerifiedCheckBox.checked
                     onlineStatus: onlineStatusSelector.currentValue
                     hasLocalNickname: hasLocalNicknameCheckBox.checked
+                    chatType: chatTypeSelector.currentValue
+                    isAdmin: isAdminCheckBox.checked
                     publicKey: publicKeyInput.text
 
                     onOpenProfileClicked: () => {
@@ -150,7 +157,9 @@ SplitView {
                     onBlockContact: () => {
                         logs.logEvent("Block contact:", profileContextMenu.publicKey)
                     }
-
+                    onRemoveFromGroup: (publicKey) => {
+                        logs.logEvent("Remove from group:", publicKey)
+                    }
                     onClosed: {
                         destroy()
                     }
@@ -273,6 +282,39 @@ SplitView {
                 Layout.fillWidth: true
                 text: "Has Local Nickname: " + (hasLocalNicknameCheckBox.checked ? "Yes" : "No")
             }
+
+            ComboBox {
+                id: chatTypeSelector
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Unknown", value: Constants.chatType.unknown },
+                    { text: "Category", value: Constants.chatType.category },
+                    { text: "One-to-One", value: Constants.chatType.oneToOne },
+                    { text: "Public Chat", value: Constants.chatType.publicChat },
+                    { text: "Private Group Chat", value: Constants.chatType.privateGroupChat },
+                    { text: "Profile", value: Constants.chatType.profile },
+                    { text: "Community Chat", value: Constants.chatType.communityChat }
+                ]
+                currentIndex: 0
+            }
+
+            CheckBox {
+                id: isAdminCheckBox
+                text: "Is Admin"
+                checked: false
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: "Is Admin: " + (isAdminCheckBox.checked ? "Yes" : "No")
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: "Chat type: " + chatTypeSelector.currentText
+            }
+
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -128,9 +128,11 @@ Item {
                 onClicked: {
                     if (mouse.button === Qt.RightButton) {
                         const { profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname } = root.store.contactsStore.getProfileContext(model.pubKey, userProfile.pubKey)
+                        const chatType = chatContentModule.chatDetails.type
+                        const isAdmin = chatContentModule.amIChatAdmin()
 
                         Global.openMenu(profileContextMenuComponent, this, {
-                                            profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname,
+                                            profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname, chatType, isAdmin,
                                             publicKey: model.pubKey,
                                             displayName: nickName || userName,
                                             userIcon: model.icon,
@@ -208,6 +210,9 @@ Item {
             onBlockContact: {
                 const contactDetails = profileContextMenu.publicKey === "" ? {} : Utils.getContactDetailsAsJson(profileContextMenu.publicKey, true, true)
                 Global.blockContactRequested(profileContextMenu.publicKey, contactDetails)
+            }
+            onRemoveFromGroup: {
+                root.store.removeMemberFromGroupChat(profileContextMenu.publicKey)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -761,4 +761,9 @@ QtObject {
     function updatePermissionsModel(communityId, sharedAddresses) {
         communitiesModuleInst.checkPermissions(communityId, JSON.stringify(sharedAddresses))
     }
+
+    function removeMemberFromGroupChat(publicKey) {
+        const chatId = chatCommunitySectionModule.activeItem.id
+        chatCommunitySectionModule.removeMemberFromGroupChat("", chatId, publicKey)
+    }
 }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -157,8 +157,11 @@ Loader {
         const publicKey = isReply ? quotedMessageFrom : root.senderId
         const isBridgedAccount = isReply ? (quotedMessageContentType === Constants.messageContentType.bridgeMessageType) : root.isBridgeMessage
         const { profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname } = root.contactsStore.getProfileContext(publicKey, root.rootStore.contactsStore.myPublicKey, isBridgedAccount)
+        const chatType = chatContentModule.chatDetails.type
+        // set false for now, because the remove from group option is still available after member is removed
+        const isAdmin = false // chatContentModule.amIChatAdmin()
 
-        const params = { profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname,
+        const params = { profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname, chatType, isAdmin,
             publicKey: isReply ? quotedMessageFrom : root.senderId,
             displayName: isReply ? quotedMessageAuthorDetailsDisplayName : root.senderDisplayName,
             userIcon: isReply ? quotedMessageAuthorDetailsThumbnailImage : root.senderIcon,
@@ -1219,10 +1222,12 @@ Loader {
                 const contactDetails = profileContextMenu.publicKey === "" ? {} : Utils.getContactDetailsAsJson(profileContextMenu.publicKey, true, true)
                 Global.blockContactRequested(profileContextMenu.publicKey, contactDetails)
             }
+            onRemoveFromGroup: () => {
+                root.store.removeMemberFromGroupChat(profileContextMenu.publicKey)
+            }
             onOpened: root.setMessageActive(root.messageId, true)
         }
     }
-
     Component {
         id: messageContextMenuComponent
 

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -21,6 +21,8 @@ StatusMenu {
     property int profileType: Constants.profileType.regular
     property bool ensVerified: false
     property bool hasLocalNickname: false
+    property int chatType: Constants.chatType.unknown
+    property bool isAdmin: false
 
     signal openProfileClicked
     signal createOneToOneChat
@@ -33,6 +35,7 @@ StatusMenu {
     signal removeTrustStatus
     signal removeContact
     signal blockContact
+    signal removeFromGroup
 
     ProfileHeader {
         width: parent.width
@@ -132,6 +135,15 @@ StatusMenu {
         icon.name: "cancel"
         type: StatusAction.Type.Danger
         onTriggered: root.unblockContact()
+    }
+
+    StatusAction {
+        text: qsTr("Remove from group")
+        objectName: "removeFromGroup_StatusItem"
+        icon.name: "remove-contact"
+        type: StatusAction.Type.Danger
+        enabled: root.isAdmin && root.profileType !== Constants.profileType.self && root.chatType === Constants.chatType.privateGroupChat
+        onTriggered: root.removeFromGroup()
     }
 
     // Mark as Untrusted


### PR DESCRIPTION
closes #16130

requires https://github.com/status-im/status-desktop/pull/16334

### What does the PR do

Adds "Remove from group" to context menu in group chats

### Affected areas

Should only affect group chats

### Screenshot of functionality (including design for comparison)

### How to test

1. create or use an existing group chat
2. right click on the user list and click 'remove from group'
OR
2. right on a message from that user and click "remove from group'
expected: user is removed from the group and the message "user has left the group" is displayed for everyone

> - What kind of user flows should be checked?

- this option should NOT be available for self (i.e a user cannot remove himself from the group)
- this option should NOT be available if the user is not the group admin
- this option should only be available in group chats, e.g going to the community member list and right clicking should not have this option

### Risk 

Worst case scenario this option appears somewhere it shouldn't (like community member list) and clicking it has unknown behaviour (probably not happens)
