### PR TITLE
fix(MessageView): unbreak GIF unfurling

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -947,9 +947,9 @@ Loader {
                             Global.openMenu(imageContextMenuComponent, item, { url: url, domain: domain, requireConfirmationOnOpen: true })
                         }
                         onHoveredLinkChanged: delegate.highlightedLink = linksMessageView.hoveredLink
-                        gifUnfurlingEnabled: RootStore.gifUnfurlingEnabled
-                        canAskToUnfurlGifs: !RootStore.neverAskAboutUnfurlingAgain
-                        onSetNeverAskAboutUnfurlingAgain: RootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+                        gifUnfurlingEnabled: SharedStores.RootStore.gifUnfurlingEnabled
+                        canAskToUnfurlGifs: !SharedStores.RootStore.neverAskAboutUnfurlingAgain
+                        onSetNeverAskAboutUnfurlingAgain: SharedStores.RootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
                         Component.onCompleted: {
                             root.messageStore.messageModule.forceLinkPreviewsLocalData(root.messageId)


### PR DESCRIPTION
### What does the PR do

- need to refer to the RootStore singleton under an alias now

Fixes #16368

### Affected areas

Chat (MessageView)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/c1af0b26-4a60-4517-9fce-0b5fa2836721)
