### PR TITLE
fix: logs in utc time

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -37,7 +37,8 @@ else:
   # don't link libraries we're not actually using
   switch("passL", "-Wl,-as-needed")
 
---define:chronicles_line_numbers # useful when debugging
+--define:chronicles_line_numbers # useful when debugging=
+switch("define", "chronicles_timestamps=RfcUtcTime")
 
 # The compiler doth protest too much, methinks, about all these cases where it can't
 # do its (N)RVO pass: https://github.com/nim-lang/RFCs/issues/230


### PR DESCRIPTION
### What does the PR do

Closes https://github.com/status-im/status-desktop/issues/15198

- Updated nim-chronicles to the latest version including https://github.com/status-im/nim-chronicles/pull/152
- Defined `chronicles_timestamps=RfcUtcTime`

### Screenshot of functionality (including design for comparison)

<img width="1131" alt="Screenshot 2024-09-20 at 15 52 02" src="https://github.com/user-attachments/assets/25a56287-1303-4794-a95e-186e9999c63b">


### Impact on end user

Less identity disclusure.

### How to test

Start app
Check logs are in UTC time and not in local time

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.