### PR TITLE
fix(MembersTabPanel): unbreak context menu

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -285,6 +285,8 @@ Item {
                     }
                 ]
 
+                readonly property string title: model.preferredDisplayName
+
                 width: membersList.width
                 visible: memberSearch.text === "" || title.toLowerCase().includes(memberSearch.text.toLowerCase())
                 height: visible ? implicitHeight : 0


### PR DESCRIPTION
### What does the PR do

- restore backwards compatibility; a lot of the actions in the component relies on the old StatusListItem's `title` property to work correctly
- fixes the missing image and name in the profile context menu, among others

Fixes #16367

### Affected areas

Community/Settings/Members

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/15fe3901-3ee3-42f4-99e6-7708a07b8cb7)
