### PR TITLE
use preferredDisplayName and preferredPubKey from proxyRole

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -90,14 +90,24 @@ Item {
             model: SortFilterProxyModel {
                 sourceModel: root.usersModel
 
-                proxyRoles: FastExpressionRole {
-                    function displayNameProxy(nickname, ensName, displayName, aliasName) {
-                        return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
+                proxyRoles: [
+                    FastExpressionRole {
+                        function displayNameProxy(nickname, ensName, displayName, aliasName) {
+                            return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
+                        }
+                        name: "preferredDisplayName"
+                        expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
+                        expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
+                    },
+                    FastExpressionRole {
+                        function pubKeyProxy(ensVerified, pubKey) {
+                            return ensVerified ? "" : Utils.getCompressedPk(pubKey)
+                        }
+                        name: "preferredPubKey"
+                        expectedRoles: ["ensVerified", "pubKey"]
+                        expression: pubKeyProxy(model.ensVerified, model.pubKey)
                     }
-                    name: "preferredDisplayName"
-                    expectedRoles: ["localNickname", "ensName", "displayName", "alias"]
-                    expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
-                }
+                ]
 
                 sorters: [
                     RoleSorter {
@@ -115,8 +125,8 @@ Item {
             delegate: StatusMemberListItem {
                 width: ListView.view.width
                 nickName: model.localNickname
-                userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+                userName: model.preferredDisplayName
+                pubKey: model.preferredPubKey
                 isContact: model.isContact
                 isVerified: model.isVerified
                 isUntrustworthy: model.isUntrustworthy


### PR DESCRIPTION
This uses the existing preferredDisplayName in the proxy and adds a preferredPubKey to simplify the code. This should (might) be an intermediary step until these are moved to the backend itself, but the point is to avoid calling globals and helpers all over the place.

Doing this PR to confirm if there are concerns (for example performance?) before going further with it