### PR TITLE
Fix some of the freezes experienced by the admins when the community updates

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -309,6 +309,10 @@ proc init*(self: Controller) =
     var args = CommunityRequestArgs(e)
     self.delegate.newCommunityMembershipRequestReceived(args.communityRequest)
 
+  self.events.on(SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY_ACCEPTED) do(e: Args):
+    var args = CommunityRequestArgs(e)
+    self.delegate.communityMemberRevealedAccountsAdded(args.communityRequest)
+
   self.events.on(SIGNAL_NETWORK_CONNECTED) do(e: Args):
     self.delegate.onNetworkConnected()
 
@@ -594,6 +598,9 @@ proc getColorId*(self: Controller, pubkey: string): int =
 
 proc asyncGetRevealedAccountsForAllMembers*(self: Controller, communityId: string) =
   self.communityService.asyncGetRevealedAccountsForAllMembers(communityId)
+
+proc asyncGetRevealedAccountsForMember*(self: Controller, communityId, memberPubkey: string) =
+  self.communityService.asyncGetRevealedAccountsForMember(communityId, memberPubkey)
 
 proc asyncReevaluateCommunityMembersPermissions*(self: Controller, communityId: string) =
   self.communityService.asyncReevaluateCommunityMembersPermissions(communityId)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -391,6 +391,9 @@ method windowDeactivated*(self: AccessInterface) {.base.} =
 method communityMembersRevealedAccountsLoaded*(self: AccessInterface, communityId: string, membersRevealedAccounts: MembersRevealedAccounts) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityMemberRevealedAccountsAdded*(self: AccessInterface, request: CommunityMembershipRequestDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 ## Used in test env only, for testing keycard flows
 method registerMockedKeycard*(self: AccessInterface, cardIndex: int, readerState: int, keycardState: int,
   mockedKeycard: string, mockedKeycardHelper: string) {.base.} =

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -396,6 +396,13 @@ QtObject:
       ModelRole.AirdropAddress.int
     ])
 
+  proc getAirdropAddressForMember*(self: Model, pubKey: string): string =
+    let idx = self.findIndexForMember(pubKey)
+    if idx == -1:
+      return ""
+
+    return self.items[idx].airdropAddress
+
 # TODO: rename me to removeItemByPubkey
   proc removeItemById*(self: Model, pubKey: string) =
     let ind = self.findIndexForMember(pubKey)
@@ -437,3 +444,13 @@ QtObject:
     self.dataChanged(index, index, @[
       ModelRole.MembershipRequestState.int
     ])
+
+  proc getNewMembers*(self: Model, pubkeys: seq[string]): seq[string] = 
+    for pubkey in pubkeys:
+      var found = false
+      for item in self.items:
+        if item.pubKey == pubkey:
+          found = true
+          break
+      if not found:
+        result.add(pubkey)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -473,8 +473,8 @@ QtObject:
     if (index == -1):
       return
 
-    for pubkey, revealedAccounts in communityMembersAirdropAddress.pairs:
-      self.items[index].members.setAirdropAddress(pubkey, revealedAccounts)
+    for pubkey, airdropAddress in communityMembersAirdropAddress.pairs:
+      self.items[index].members.setAirdropAddress(pubkey, airdropAddress)
 
   proc setTokenItems*(self: SectionModel, id: string, communityTokensItems: seq[TokenItem]) = 
     let index = self.getItemIndex(id)

--- a/ui/app/AppLayouts/Communities/popups/InDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/InDropdown.qml
@@ -53,8 +53,11 @@ StatusDropdown {
         listView.positionViewAtBeginning()
     }
 
-    onAboutToShow: listView.Layout.preferredHeight = Math.min(
+    onAboutToShow: {
+        searcher.input.edit.forceActiveFocus()
+        listView.Layout.preferredHeight = Math.min(
                        listView.implicitHeight, 420)
+    }
 
     // only channels (no entries representing categories), sorted according to
     // category position and position

--- a/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
@@ -67,6 +67,7 @@ StatusDropdown {
     onOpened: {
         listView.positionViewAtBeginning()
         filterInput.text = ""
+        filterInput.input.edit.forceActiveFocus()
     }
 
     QtObject {

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -512,6 +512,13 @@ StatusScrollView {
                 model: SortFilterProxyModel {
                     sourceModel: membersModel
 
+                    sorters : [
+                        StringSorter {
+                            roleName: "preferredDisplayName"
+                            caseSensitivity: Qt.CaseInsensitive
+                        }
+                    ]
+
                     filters: [
                         ExpressionFilter {
                             enabled: membersDropdown.searchText !== ""

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -524,13 +524,9 @@ StatusScrollView {
                         FastExpressionFilter {
                             enabled: membersDropdown.searchText !== ""
 
-                            function matchesAlias(name, filter) {
-                                return name.split(" ").some(p => p.startsWith(filter))
-                            }
-
                             expression: {
                                 const filter = membersDropdown.searchText.toLowerCase()
-                                return matchesAlias(model.alias.toLowerCase(), filter)
+                                return model.alias.toLowerCase().includes(filter)
                                          || model.displayName.toLowerCase().includes(filter)
                                          || model.ensName.toLowerCase().includes(filter)
                                          || model.localNickname.toLowerCase().includes(filter)
@@ -538,9 +534,10 @@ StatusScrollView {
                             }
                             expectedRoles: ["alias", "displayName", "ensName", "localNickname", "pubKey"]
                         },
-                        FastExpressionFilter {
-                            expression: !!model.airdropAddress
-                            expectedRoles: ["airdropAddress"]
+                        ValueFilter {
+                            roleName: "airdropAddress"
+                            value: ""
+                            inverted: true
                         }
                     ]
                 }

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
@@ -520,7 +521,7 @@ StatusScrollView {
                     ]
 
                     filters: [
-                        ExpressionFilter {
+                        FastExpressionFilter {
                             enabled: membersDropdown.searchText !== ""
 
                             function matchesAlias(name, filter) {
@@ -528,8 +529,6 @@ StatusScrollView {
                             }
 
                             expression: {
-                                membersDropdown.searchText
-
                                 const filter = membersDropdown.searchText.toLowerCase()
                                 return matchesAlias(model.alias.toLowerCase(), filter)
                                          || model.displayName.toLowerCase().includes(filter)
@@ -537,9 +536,11 @@ StatusScrollView {
                                          || model.localNickname.toLowerCase().includes(filter)
                                          || model.pubKey.toLowerCase().includes(filter)
                             }
+                            expectedRoles: ["alias", "displayName", "ensName", "localNickname", "pubKey"]
                         },
-                        ExpressionFilter {
+                        FastExpressionFilter {
                             expression: !!model.airdropAddress
+                            expectedRoles: ["airdropAddress"]
                         }
                     ]
                 }


### PR DESCRIPTION
### What does the PR do

Iterates https://github.com/status-im/status-desktop/issues/16043

When the community gets updated by any means, we reconstruct the section item, which is already bad, but we also re-fetch all tokens and all shared addresses, which in turn re-updates models for no reason.

Instead, I make sure to only fetch those on first section build, then, I get the new shared addresses when members join using the request to join response that comes from status-go

Status-go PR to fix the correct return of the shared addresses: https://github.com/status-im/status-go/pull/5867

A further improvement IMO would be to stop redoing the section when the community updates, but we'll need to be careful, because it might break a lot of places that would normally update automatically.

Also includes a commit that makes the input focus and fixes the order of members in the airdrop popups.

### Affected areas

- Members' shared addresses (for airdropping for example)
- List of tokens
- Airdrop popup (order and focus on input)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Impact on end user

The general responsiveness of the app when the community updates for admins should be better (no or less freezes)

### How to test

Update the community, make people join, check that you have their airdrop address in the airdrop popup.

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case is that some properties don't get updated until a restart (for example the airdrop addresses of members)
