### PR TITLE
fix: check for the route if 0 value is entered

### DIFF
--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -537,6 +537,11 @@ StatusDialog {
                         formatBalance: amount => d.currencyStore.formatCurrencyAmount(
                                            amount, selectedSymbol)
 
+                        onValidChanged: {
+                            d.sendError = ""
+                            popup.recalculateRoutesAndFees()
+                        }
+
                         onAmountChanged: {
                             d.sendError = ""
                             popup.recalculateRoutesAndFees()


### PR DESCRIPTION
When 0 value was entered checking for the best route was not done cause the amount change signal was not emitted.