### PR TITLE
refactor: Remove the business logic from UI components

### DIFF
--- a/storybook/qmlTests/tests/helpers/wallet_connect.js
+++ b/storybook/qmlTests/tests/helpers/wallet_connect.js
@@ -154,10 +154,11 @@ function formatApproveSessionResponse(networksArray, accountsArray, custom) {
     }`
 }
 
-function formatSessionRequest(chainId, method, params, topic) {
+function formatSessionRequest(chainId, method, params, topic, requestId) {
+    const reqId = requestId || 1717149885151715
     let paramsStr = params.map(param => `${param}`).join(',')
     return `{
-    "id": 1717149885151715,
+    "id": ${reqId},
     "params": {
         "chainId": "eip155:${chainId}",
         "request": {

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -157,4 +157,16 @@ QtObject {
 
         return null
     }
+
+    function forEach(model, callback) {
+        if (!model)
+            return
+
+        const count = model.rowCount()
+
+        for (let i = 0; i < count; i++) {
+            const modelItem = Internal.ModelUtils.get(model, i)
+            callback(modelItem)
+        }
+    }
 }

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -20,8 +20,44 @@ DappsComboBox {
 
     // Values mapped to Constants.LoginType
     required property int loginType
+    /*
+        Accounts model
+
+        Expected model structure:
+        name                    [string] - account name e.g. "Piggy Bank"
+        address                 [string] - wallet account address e.g. "0x1234567890"
+        colorizedChainPrefixes  [string] - chain prefixes with rich text colors e.g. "<font color=\"red\">eth:</font><font color=\"blue\">oeth:</font><font color=\"green\">arb:</font>"
+        emoji                   [string] - emoji for account e.g. "🐷"
+        colorId                 [string] - color id for account e.g. "1"
+        currencyBalance         [var]    - fiat currency balance
+            amount              [number] - amount of currency e.g. 1234
+            symbol              [string] - currency symbol e.g. "USD"
+            optDisplayDecimals  [number] - optional number of decimals to display
+            stripTrailingZeroes [bool]   - strip trailing zeroes
+        walletType              [string] - wallet type e.g. Constants.watchWalletType. See `Constants` for possible values
+        migratedToKeycard       [bool]   - whether account is migrated to keycard
+        accountBalance          [var]    - account balance for a specific network
+            formattedBalance    [string] - formatted balance e.g. "1234.56B"
+            balance             [string] - balance e.g. "123456000000"
+            iconUrl             [string] - icon url e.g. "network/Network=Hermez"
+            chainColor          [string] - chain color e.g. "#FF0000"
+    */
     property var accountsModel
+    /*
+      Networks model
+      Expected model structure:
+        chainName      [string]          - chain long name. e.g. "Ethereum" or "Optimism"
+        chainId        [int]             - chain unique identifier
+        iconUrl        [string]          - SVG icon name. e.g. "network/Network=Ethereum"
+        layer          [int]             - chain layer. e.g. 1 or 2
+        isTest         [bool]            - true if the chain is a testnet
+    */
     property var networksModel
+    /*
+      ObjectModel containig session requests
+        requestId     [string]                  - unique identifier for the request
+        requestItem   [SessionRequestResolved]  - request object
+    */ 
     property SessionRequestsModel sessionRequestsModel
     property string selectedAccountAddress
 
@@ -184,7 +220,7 @@ DappsComboBox {
 
         sourceComponent: ConnectDAppModal {
             visible: true
-            
+
             onClosed: connectDappLoader.active = false
             accounts: root.accountsModel
             flatNetworks: SortFilterProxyModel {

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
@@ -49,8 +49,8 @@ WalletConnectSDKBase {
         wcCalls.ping(topic)
     }
 
-    buildApprovedNamespaces: function(params, supportedNamespaces) {
-        wcCalls.buildApprovedNamespaces(params, supportedNamespaces)
+    buildApprovedNamespaces: function(id, params, supportedNamespaces) {
+        wcCalls.buildApprovedNamespaces(id, params, supportedNamespaces)
     }
 
     approveSession: function(sessionProposal, supportedNamespaces) {
@@ -134,16 +134,16 @@ WalletConnectSDKBase {
             )
         }
 
-        function buildApprovedNamespaces(params, supportedNamespaces) {
-            console.debug(`WC WalletConnectSDK.wcCall.buildApprovedNamespaces; params: ${JSON.stringify(params)}, supportedNamespaces: ${JSON.stringify(supportedNamespaces)}`)
+        function buildApprovedNamespaces(pairingId, params, supportedNamespaces) {
+            console.debug(`WC WalletConnectSDK.wcCall.buildApprovedNamespaces; id: ${pairingId}, params: ${JSON.stringify(params)}, supportedNamespaces: ${JSON.stringify(supportedNamespaces)}`)
 
             d.engine.runJavaScript(`
                                     wc.buildApprovedNamespaces(${JSON.stringify(params)}, ${JSON.stringify(supportedNamespaces)})
                                     .then((approvedNamespaces) => {
-                                        wc.statusObject.onBuildApprovedNamespacesResponse(approvedNamespaces, "")
+                                        wc.statusObject.onBuildApprovedNamespacesResponse(${pairingId}, approvedNamespaces, "")
                                     })
                                     .catch((e) => {
-                                        wc.statusObject.onBuildApprovedNamespacesResponse("", e.message)
+                                        wc.statusObject.onBuildApprovedNamespacesResponse(${pairingId}, "", e.message)
                                     })
                                    `
             )
@@ -155,10 +155,10 @@ WalletConnectSDKBase {
             d.engine.runJavaScript(`
                                     wc.approveSession(${JSON.stringify(sessionProposal)}, ${JSON.stringify(supportedNamespaces)})
                                     .then((session) => {
-                                        wc.statusObject.onApproveSessionResponse(session, "")
+                                        wc.statusObject.onApproveSessionResponse(${sessionProposal.id}, session, "")
                                     })
                                     .catch((e) => {
-                                        wc.statusObject.onApproveSessionResponse("", e.message)
+                                        wc.statusObject.onApproveSessionResponse(${sessionProposal.id}, "", e.message)
                                     })
                                    `
             )
@@ -170,10 +170,10 @@ WalletConnectSDKBase {
             d.engine.runJavaScript(`
                                     wc.rejectSession(${id})
                                     .then((value) => {
-                                        wc.statusObject.onRejectSessionResponse("")
+                                        wc.statusObject.onRejectSessionResponse(${id}, "")
                                     })
                                     .catch((e) => {
-                                        wc.statusObject.onRejectSessionResponse(e.message)
+                                        wc.statusObject.onRejectSessionResponse(${id}, e.message)
                                     })
                                    `
             )
@@ -296,19 +296,19 @@ WalletConnectSDKBase {
             console.debug(`WC WalletConnectSDK.onDisconnectPairingResponse; topic: ${topic}, error: ${error}`)
         }
 
-        function onBuildApprovedNamespacesResponse(approvedNamespaces, error) {
-            console.debug(`WC WalletConnectSDK.onBuildApprovedNamespacesResponse; approvedNamespaces: ${approvedNamespaces ? JSON.stringify(approvedNamespaces) : "-"}, error: ${error}`)
-            root.buildApprovedNamespacesResult(approvedNamespaces, error)
+        function onBuildApprovedNamespacesResponse(id, approvedNamespaces, error) {
+            console.debug(`WC WalletConnectSDK.onBuildApprovedNamespacesResponse; id: ${id}, approvedNamespaces: ${approvedNamespaces ? JSON.stringify(approvedNamespaces) : "-"}, error: ${error}`)
+            root.buildApprovedNamespacesResult(id, approvedNamespaces, error)
         }
 
-        function onApproveSessionResponse(session, error) {
-            console.debug(`WC WalletConnectSDK.onApproveSessionResponse; sessionTopic: ${JSON.stringify(session)}, error: ${error}`)
-            root.approveSessionResult(session, error)
+        function onApproveSessionResponse(proposalId, session, error) {
+            console.debug(`WC WalletConnectSDK.onApproveSessionResponse; proposalId: ${proposalId}, sessionTopic: ${JSON.stringify(session)}, error: ${error}`)
+            root.approveSessionResult(proposalId, session, error)
         }
 
-        function onRejectSessionResponse(error) {
-            console.debug(`WC WalletConnectSDK.onRejectSessionResponse; error: ${error}`)
-            root.rejectSessionResult(error)
+        function onRejectSessionResponse(proposalId, error) {
+            console.debug(`WC WalletConnectSDK.onRejectSessionResponse; proposalId: ${proposalId}, error: ${error}`)
+            root.rejectSessionResult(proposalId, error)
         }
 
         function onAcceptSessionRequestResponse(topic, id, error) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
@@ -9,9 +9,10 @@ Item {
     signal pairResponse(bool success)
     signal sessionProposal(var sessionProposal)
     signal sessionProposalExpired()
-    signal buildApprovedNamespacesResult(var session, string error)
-    signal approveSessionResult(var approvedNamespaces, string error)
-    signal rejectSessionResult(string error)
+    signal buildApprovedNamespacesResult(var id, var session, string error)
+    signal approveSessionResult(var proposalId, var approvedNamespaces, string error)
+    signal rejectSessionResult(var proposalId, string error)
+    signal sessionRequestExpired(var id)
     signal sessionRequestEvent(var sessionRequest)
     signal sessionRequestUserAnswerResult(string topic, string id, bool accept /* not reject */, string error)
 
@@ -41,7 +42,7 @@ Item {
         console.error("ping not implemented")
     }
 
-    property var buildApprovedNamespaces: function(params, supportedNamespaces) {
+    property var buildApprovedNamespaces: function(id, params, supportedNamespaces) {
         console.error("buildApprovedNamespaces not implemented")
     }
     property var approveSession: function(sessionProposal, supportedNamespaces) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -28,234 +28,228 @@ import "types"
 QObject {
     id: root
 
+    //input properties
     required property WalletConnectSDKBase wcSDK
     required property DAppsStore store
     required property var walletRootStore
 
-    readonly property var dappsModel: ConcatModel {
-        markerRoleName: "source"
-
-        sources: [
-            SourceModel {
-                model: dappsProvider.dappsModel
-                markerRoleValue: "walletConnect"
-            },
-            SourceModel {
-                model: connectorDAppsProvider.dappsModel
-                markerRoleValue: "connector"
-            }
-        ]
-    }
-    readonly property alias requestHandler: requestHandler
-
-    readonly property bool isServiceAvailableForAddressSelection: dappsProvider.supportedAccountsModel.ModelCount.count
-
+    //output properties
+    /// Model contaning all dApps available for the currently selected account
+    readonly property var dappsModel: d.filteredDappsModel
+    /// Model containig the dApps session requests to be resolved by the user
+    readonly property SessionRequestsModel sessionRequestsModel: requestHandler.requestsModel
+    /// Model containing the valid accounts a dApp can interact with
+    readonly property var validAccounts: d.validAccounts
+    /// Model containing the networks a dApp can interact with
+    readonly property var flatNetworks: root.walletRootStore.filteredFlatModel
+    /// Service can interact with the current address selection
+    /// Default value: true
+    readonly property bool serviceAvailableToCurrentAddress: !root.walletRootStore.selectedAddress ||
+                ModelUtils.contains(root.validAccounts, "address", root.walletRootStore.selectedAddress, Qt.CaseInsensitive)
+    /// TODO: refactor
     readonly property alias connectorDAppsProvider: connectorDAppsProvider
 
-    readonly property var validAccounts: SortFilterProxyModel {
-        sourceModel: d.supportedAccountsModel
-        proxyRoles: [
-            FastExpressionRole {
-                name: "colorizedChainPrefixes"
-                function getChainShortNames(chainIds) {
-                    const chainShortNames = root.walletRootStore.getNetworkShortNames(chainIds)
-                    return WalletUtils.colorizedChainPrefix(chainShortNames)
-                }
-                expression: getChainShortNames(model.preferredSharingChainIds)
-                expectedRoles: ["preferredSharingChainIds"]
-            }
-        ]
+    // methods
+    /// Triggers the signing process for the given session request
+    /// @param topic The topic of the session
+    /// @param id The id of the session request
+    function sign(topic, id) {
+        // The authentication triggers the signing process
+        // authenticate -> sign -> inform the dApp
+        d.authenticate(topic, id)
     }
-    readonly property var flatNetworks: root.walletRootStore.filteredFlatModel
 
+    function rejectSign(topic, id, hasError) {
+        requestHandler.rejectSessionRequest(topic, id, hasError)
+    }
+
+    /// Validates the pairing URI
     function validatePairingUri(uri) {
-        // Check if emoji inside the URI
-        if(Constants.regularExpressions.emoji.test(uri)) {
-            root.pairingValidated(Pairing.errors.tooCool)
-            return
-        } else if(!DAppsHelpers.validURI(uri)) {
-            root.pairingValidated(Pairing.errors.invalidUri)
-            return
-        }
-
-        const info = DAppsHelpers.extractInfoFromPairUri(uri)
-        wcSDK.getActiveSessions((sessions) => {
-            // Check if the URI is already paired
-            let validationState = Pairing.errors.uriOk
-            for (const key in sessions) {
-                if (sessions[key].pairingTopic === info.topic) {
-                    validationState = Pairing.errors.alreadyUsed
-                    break
-                }
-            }
-
-            // Check if expired
-            if (validationState === Pairing.errors.uriOk) {
-                const now = (new Date().getTime())/1000
-                if (info.expiry < now) {
-                    validationState = Pairing.errors.expired
-                }
-            }
-
-            root.pairingValidated(validationState)
-        });
+        d.validatePairingUri(uri)
     }
 
+    /// Initiates the pairing process with the given URI
     function pair(uri) {
-        d.acceptedSessionProposal = null
         timeoutTimer.start()
         wcSDK.pair(uri)
     }
+    
+    /// Approves or rejects the session proposal
+    function approvePairSession(key, approvedChainIds, accountAddress) {
+        if (!d.activeProposals.has(key)) {
+            console.error("No active proposal found for key: " + key)
+            return
+        }
 
-    function approvePairSession(sessionProposal, approvedChainIds, approvedAccount) {
-        d.acceptedSessionProposal = sessionProposal
+        const proposal = d.activeProposals.get(key)
+        d.acceptedSessionProposal = proposal
         const approvedNamespaces = JSON.parse(
             DAppsHelpers.buildSupportedNamespaces(approvedChainIds,
-                                             [approvedAccount.address],
+                                             [accountAddress],
                                              SessionRequest.getSupportedMethods())
         )
-        wcSDK.buildApprovedNamespaces(sessionProposal.params, approvedNamespaces)
+        wcSDK.buildApprovedNamespaces(key, proposal.params, approvedNamespaces)
     }
 
+    /// Rejects the session proposal
     function rejectPairSession(id) {
         wcSDK.rejectSession(id)
     }
 
-    function disconnectSession(sessionTopic) {
-        wcSDK.disconnectSession(sessionTopic)
+    /// Disconnects the dApp with the given topic
+    /// @param topic The topic of the dApp
+    /// @param source The source of the dApp; either "walletConnect" or "connector"
+    function disconnectDapp(topic) {
+        d.disconnectDapp(topic)
     }
 
-    function disconnectDapp(url) {
-        wcSDK.getActiveSessions((allSessionsAllProfiles) => {
-            const sessions = DAppsHelpers.filterActiveSessionsForKnownAccounts(allSessionsAllProfiles, validAccounts)
-            let dappFoundInWcSessions = false
-            for (const sessionID in sessions) {
-                const session = sessions[sessionID]
-                const accountsInSession = DAppsHelpers.getAccountsInSession(session)
-                const dapp = session.peer.metadata
-                const topic = session.topic
-                if (dapp.url === url) {
-                    if (!dappsProvider.selectedAddress ||
-                        (accountsInSession.includes(dappsProvider.selectedAddress)))
-                    {
-                        dappFoundInWcSessions = true
-                        wcSDK.disconnectSession(topic)
-                    }
-                }
-            }
-
-            // TODO: #16044 - Refactor Wallet connect service to handle multiple SDKs
-            if (!dappFoundInWcSessions) {
-                // Revoke browser plugin session
-                root.revokeSession(url)
-                d.notifyDappDisconnect(url, false)
-            }
-        });
-    }
-
-    function getDApp(dAppUrl) {
-        return ModelUtils.getByKey(dappsModel, "url", dAppUrl);
-    }
-
-    signal connectDApp(var dappChains, var sessionProposal, var approvedNamespaces)
-    signal approveSessionResult(var session, var error)
-    signal sessionRequest(SessionRequestResolved request)
+    // signals
+    signal connectDApp(var dappChains, url dappUrl, string dappName, url dappIcon, var key)
+    // Emitted as a response to WalletConnectService.approveSession
+    // @param key The key of the session proposal
+    // @param error The error message
+    // @param topic The new topic of the session
+    signal approveSessionResult(var key, var error, var topic)
+    // Emitted when a new session is requested by a dApp
+    signal sessionRequest(string id)
     signal displayToastMessage(string message, bool error)
     // Emitted as a response to WalletConnectService.validatePairingUri or other WalletConnectService.pair
     // and WalletConnectService.approvePair errors
     signal pairingValidated(int validationState)
-
-    signal revokeSession(string dAppUrl)
-
-    readonly property Connections sdkConnections: Connections {
-        target: wcSDK
-
-        function onPairResponse(ok) {
-            if (!ok) {
-                d.reportPairErrorState(Pairing.errors.unknownError)
-            } // else waiting for onSessionProposal
-        }
-
-        function onSessionProposal(sessionProposal) {
-            d.currentSessionProposal = sessionProposal
-
-            const supportedNamespacesStr = DAppsHelpers.buildSupportedNamespacesFromModels(
-                  root.flatNetworks, root.validAccounts, SessionRequest.getSupportedMethods())
-            wcSDK.buildApprovedNamespaces(sessionProposal.params, JSON.parse(supportedNamespacesStr))
-        }
-
-        function onBuildApprovedNamespacesResult(approvedNamespaces, error) {
-            if(error || !approvedNamespaces) {
-                // Check that it contains Non conforming namespaces"
-                if (error.includes("Non conforming namespaces")) {
-                    d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
-                } else {
-                    d.reportPairErrorState(Pairing.errors.unknownError)
-                }
-                return
-            }
-            const an = approvedNamespaces.eip155
-            if (!(an.accounts) || an.accounts.length === 0 || (!(an.chains) || an.chains.length === 0)) {
-                d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
-                return
-            }
-
-            if (d.acceptedSessionProposal) {
-                wcSDK.approveSession(d.acceptedSessionProposal, approvedNamespaces)
-            } else {
-                const res = DAppsHelpers.extractChainsAndAccountsFromApprovedNamespaces(approvedNamespaces)
-
-                root.connectDApp(res.chains, d.currentSessionProposal, approvedNamespaces)
-            }
-        }
-
-        function onApproveSessionResult(session, err) {
-            if (err) {
-                d.reportPairErrorState(Pairing.errors.unknownError)
-                return
-            }
-
-            // TODO #14754: implement custom dApp notification
-            const app_url = d.currentSessionProposal ? d.currentSessionProposal.params.proposer.metadata.url : "-"
-            const app_domain = StringUtils.extractDomainFromLink(app_url)
-            root.displayToastMessage(qsTr("Connected to %1 via WalletConnect").arg(app_domain), false)
-
-            // Persist session
-            if(!store.addWalletConnectSession(JSON.stringify(session))) {
-                console.error("Failed to persist session")
-            }
-
-            // Notify client
-            root.approveSessionResult(session, err)
-
-            dappsProvider.updateDapps()
-        }
-
-        function onRejectSessionResult(err) {
-            const app_url = d.currentSessionProposal ? d.currentSessionProposal.params.proposer.metadata.url : "-"
-            const app_domain = StringUtils.extractDomainFromLink(app_url)
-            if(err) {
-                d.reportPairErrorState(Pairing.errors.unknownError)
-                root.displayToastMessage(qsTr("Failed to reject connection request for %1").arg(app_domain), true)
-            } else {
-                root.displayToastMessage(qsTr("Connection request for %1 was rejected").arg(app_domain), false)
-            }
-        }
-
-        function onSessionDelete(topic, err) {
-            d.disconnectSessionRequested(topic, err)
-        }
-    }
+    signal revokeSession(string topic)
 
     QObject {
         id: d
 
-        readonly property var supportedAccountsModel: SortFilterProxyModel {
+        readonly property var validAccounts: SortFilterProxyModel {
             sourceModel: root.walletRootStore.nonWatchAccounts
+            proxyRoles: [
+                FastExpressionRole {
+                    name: "colorizedChainPrefixes"
+                    function getChainShortNames(chainIds) {
+                        const chainShortNames = root.walletRootStore.getNetworkShortNames(chainIds)
+                        return WalletUtils.colorizedChainPrefix(chainShortNames)
+                    }
+                    expression: getChainShortNames(model.preferredSharingChainIds)
+                    expectedRoles: ["preferredSharingChainIds"]
+                }
+            ]
         }
 
-        property var currentSessionProposal: null
+        readonly property var dappsModel: ConcatModel {
+            id: dappsModel
+            markerRoleName: "source"
+
+            sources: [
+                SourceModel {
+                    model: dappsProvider.dappsModel
+                    markerRoleValue: "walletConnect"
+                },
+                SourceModel {
+                    model: connectorDAppsProvider.dappsModel
+                    markerRoleValue: "statusConnect"
+                }
+            ]
+        }
+
+        readonly property var filteredDappsModel: SortFilterProxyModel {
+            id: dappsFilteredModel
+            objectName: "DAppsModelFiltered"
+            sourceModel: d.dappsModel
+            readonly property string selectedAddress: root.walletRootStore.selectedAddress
+
+            filters: FastExpressionFilter {
+                enabled: !!dappsFilteredModel.selectedAddress
+
+                function isAddressIncluded(accountAddressesSubModel, selectedAddress) {
+                    if (!accountAddressesSubModel) {
+                        return false
+                    }
+                    const addresses = ModelUtils.modelToFlatArray(accountAddressesSubModel, "address")
+                    return addresses.includes(selectedAddress)
+                }
+                expression: isAddressIncluded(model.accountAddresses, dappsFilteredModel.selectedAddress)
+
+                expectedRoles: "accountAddresses"
+            }
+        }
+
+        property var activeProposals: new Map() // key: proposalId, value: sessionProposal
         property var acceptedSessionProposal: null
+
+        /// Disconnects the WC session with the given topic
+        function disconnectSession(sessionTopic) {
+            wcSDK.disconnectSession(sessionTopic)
+        }   
+
+        function disconnectDapp(topic) {
+            const dApp = d.getDAppByTopic(topic)
+            if (!dApp) {
+                console.error("Disconnecting dApp: dApp not found")
+                return
+            }
+
+            if (!dApp.connectorId == undefined) {
+                console.error("Disconnecting dApp: connectorId not found")
+                return
+            }
+            
+            // TODO: refactor
+            if (dApp.connectorId === connectorDAppsProvider.connectorId) {
+                root.revokeSession(topic)
+                d.notifyDappDisconnect(dApp.url, false)
+                return
+            }
+            // TODO: refactor
+            if (dApp.connectorId === dappsProvider.connectorId) {
+                // Currently disconnect acts on all sessions!
+                for (let i = 0; i < dApp.sessions.ModelCount.count; i++) {
+                    d.disconnectSession(dApp.sessions.get(i).topic)
+                }
+            }
+        }
+
+        function validatePairingUri(uri) {
+            // Check if emoji inside the URI
+            if(Constants.regularExpressions.emoji.test(uri)) {
+                root.pairingValidated(Pairing.errors.tooCool)
+                return
+            } else if(!DAppsHelpers.validURI(uri)) {
+                root.pairingValidated(Pairing.errors.invalidUri)
+                return
+            }
+
+            const info = DAppsHelpers.extractInfoFromPairUri(uri)
+            wcSDK.getActiveSessions((sessions) => {
+                // Check if the URI is already paired
+                let validationState = Pairing.errors.uriOk
+                for (const key in sessions) {
+                    if (sessions[key].pairingTopic === info.topic) {
+                        validationState = Pairing.errors.alreadyUsed
+                        break
+                    }
+                }
+
+                // Check if expired
+                if (validationState === Pairing.errors.uriOk) {
+                    const now = (new Date().getTime())/1000
+                    if (info.expiry < now) {
+                        validationState = Pairing.errors.expired
+                    }
+                }
+
+                root.pairingValidated(validationState)
+            });
+        }
+        
+        function authenticate(topic, id) {
+            const request = sessionRequestsModel.findRequest(topic, id)
+            if (!request) {
+                console.error("Session request not found")
+                return
+            }
+            requestHandler.authenticate(topic, id, request.accountAddress, request.feesInfo)
+        }
 
         function reportPairErrorState(state) {
             timeoutTimer.stop()
@@ -309,6 +303,137 @@ QObject {
                 root.displayToastMessage(qsTr("Disconnected from %1").arg(appDomain), false)
             }
         }
+
+        function getDAppByTopic(topic) {
+            return ModelUtils.getFirstModelEntryIf(d.dappsModel, (modelItem) => {
+                if (modelItem.topic == topic) {
+                    return true
+                }
+                if (!modelItem.sessions) {
+                    return false
+                }
+                for (let i = 0; i < modelItem.sessions.ModelCount.count; i++) {
+                    if (modelItem.sessions.get(i).topic == topic) {
+                        return true
+                    }
+                }
+            })
+        }
+    }
+
+    Connections {
+        target: wcSDK
+
+        function onPairResponse(ok) {
+            if (!ok) {
+                d.reportPairErrorState(Pairing.errors.unknownError)
+            } // else waiting for onSessionProposal
+        }
+
+        function onSessionProposal(sessionProposal) {
+            const key = sessionProposal.id
+            d.activeProposals.set(key, sessionProposal)
+
+            const supportedNamespacesStr = DAppsHelpers.buildSupportedNamespacesFromModels(
+                  root.flatNetworks, root.validAccounts, SessionRequest.getSupportedMethods())
+            wcSDK.buildApprovedNamespaces(key, sessionProposal.params, JSON.parse(supportedNamespacesStr))
+        }
+
+        function onBuildApprovedNamespacesResult(key, approvedNamespaces, error) {
+            if (!d.activeProposals.has(key)) {
+                console.error("No active proposal found for key: " + key)
+                return
+            }
+
+            if(error || !approvedNamespaces) {
+                // Check that it contains Non conforming namespaces"
+                if (error.includes("Non conforming namespaces")) {
+                    d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
+                } else {
+                    d.reportPairErrorState(Pairing.errors.unknownError)
+                }
+                return
+            }
+            const an = approvedNamespaces.eip155
+            if (!(an.accounts) || an.accounts.length === 0 || (!(an.chains) || an.chains.length === 0)) {
+                d.reportPairErrorState(Pairing.errors.unsupportedNetwork)
+                return
+            }
+
+            if (d.acceptedSessionProposal) {
+                wcSDK.approveSession(d.acceptedSessionProposal, approvedNamespaces)
+            } else {
+                const proposal = d.activeProposals.get(key)
+                const res = DAppsHelpers.extractChainsAndAccountsFromApprovedNamespaces(approvedNamespaces)
+                const chains = res.chains
+                const dAppUrl = proposal.params.proposer.metadata.url
+                const dAppName = proposal.params.proposer.metadata.name
+                const dAppIcons = proposal.params.proposer.metadata.icons
+                const dAppIcon = dAppIcons && dAppIcons.length > 0 ? dAppIcons[0] : ""
+
+                root.connectDApp(chains, dAppUrl, dAppName, dAppIcon, key)
+            }
+        }
+
+        function onApproveSessionResult(proposalId, session, err) {
+            if (!d.activeProposals.has(proposalId)) {
+                console.error("No active proposal found for key: " + proposalId)
+                return
+            }
+
+            if (!d.acceptedSessionProposal || d.acceptedSessionProposal.id !== proposalId) {
+                console.error("No accepted proposal found for key: " + proposalId)
+                d.activeProposals.delete(proposalId)
+                return
+            }
+
+            const proposal = d.activeProposals.get(proposalId)
+            d.activeProposals.delete(proposalId)
+            d.acceptedSessionProposal = null
+            
+            if (err) {
+                d.reportPairErrorState(Pairing.errors.unknownError)
+                return
+            }
+
+            // TODO #14754: implement custom dApp notification
+            const app_url = proposal.params.proposer.metadata.url ?? "-"
+            const app_domain = StringUtils.extractDomainFromLink(app_url)
+            root.displayToastMessage(qsTr("Connected to %1 via WalletConnect").arg(app_domain), false)
+
+            // Persist session
+            if(!store.addWalletConnectSession(JSON.stringify(session))) {
+                console.error("Failed to persist session")
+            }
+
+            // Notify client
+            root.approveSessionResult(proposalId, err, session.topic)
+
+            dappsProvider.updateDapps()
+        }
+
+        function onRejectSessionResult(proposalId, err) {
+            if (!d.activeProposals.has(proposalId)) {
+                console.error("No active proposal found for key: " + proposalId)
+                return
+            }
+            
+            const proposal = d.activeProposals.get(proposalId)
+            d.activeProposals.delete(proposalId)
+
+            const app_url = proposal.params.proposer.metadata.url ?? "-"
+            const app_domain = StringUtils.extractDomainFromLink(app_url)
+            if(err) {
+                d.reportPairErrorState(Pairing.errors.unknownError)
+                root.displayToastMessage(qsTr("Failed to reject connection request for %1").arg(app_domain), true)
+            } else {
+                root.displayToastMessage(qsTr("Connection request for %1 was rejected").arg(app_domain), false)
+            }
+        }
+
+        function onSessionDelete(topic, err) {
+            d.disconnectSessionRequested(topic, err)
+        }
     }
 
     Component.onCompleted: {
@@ -325,9 +450,9 @@ QObject {
         currenciesStore: root.walletRootStore.currencyStore
         assetsStore: root.walletRootStore.walletAssetsStore
 
-        onSessionRequest: (request) => {
+        onSessionRequest: (id) => {
             timeoutTimer.stop()
-            root.sessionRequest(request)
+            root.sessionRequest(id)
         }
         onDisplayToastMessage: (message, error) => {
             root.displayToastMessage(message, error)
@@ -336,11 +461,9 @@ QObject {
 
     DAppsListProvider {
         id: dappsProvider
-
         sdk: root.wcSDK
         store: root.store
-        supportedAccountsModel: d.supportedAccountsModel
-        selectedAddress: root.walletRootStore.selectedAddress
+        supportedAccountsModel: root.walletRootStore.nonWatchAccounts
     }
 
     ConnectorDAppsListProvider {

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestResolved.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestResolved.qml
@@ -15,11 +15,14 @@ QObject {
     /// }
     required property var event
 
+    /// dApp request data
     required property string topic
     required property string id
     required property string method
     required property string accountAddress
     required property string chainId
+    // Maps to Constants.DAppConnectors values
+    required property int sourceId
 
     required property var data
     // Data prepared for display in a human readable format
@@ -29,9 +32,18 @@ QObject {
     readonly property alias dappUrl: d.dappUrl
     readonly property alias dappIcon: d.dappIcon
 
+    /// extra data resolved from wallet
     property string maxFeesText: ""
     property string maxFeesEthText: ""
-    property bool enoughFunds: false
+    property bool haveEnoughFunds: false
+    property bool haveEnoughFees: false
+
+    property var /* Big */ fiatMaxFees
+    property var /* Big */ ethMaxFees
+    property var feesInfo
+
+    /// maps to Constants.TransactionEstimatedTime values
+    property int estimatedTimeCategory: 0
 
     function resolveDappInfoFromSession(session) {
         let meta = session.peer.metadata

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestsModel.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestsModel.qml
@@ -5,14 +5,14 @@ ListModel {
     id: root
 
     function enqueue(request) {
-        root.append(request);
+        root.append({requestId: request.id, requestItem: request});
     }
 
     function dequeue() {
         if (root.count > 0) {
             var item = root.get(0);
             root.remove(0);
-            return item;
+            return item.requestItem;
         }
         return null;
     }
@@ -20,8 +20,19 @@ ListModel {
     /// returns null if not found
     function findRequest(topic, id) {
         for (var i = 0; i < root.count; i++) {
-            let entry = root.get(i)
-            if (entry.topic === topic && entry.id === id) {
+            let entry = root.get(i).requestItem
+            if (entry.topic == topic && entry.id == id) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    // returns null if not found
+    function findById(id) {
+        for (var i = 0; i < root.count; i++) {
+            let entry = root.get(i).requestItem
+            if (entry.id == id) {
                 return entry;
             }
         }

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/qmldir
@@ -1,3 +1,4 @@
 SessionRequestResolved 1.0 SessionRequestResolved.qml
+SessionRequestsModel 1.0 SessionRequestsModel.qml
 singleton SessionRequest 1.0 SessionRequest.qml
 singleton Pairing 1.0 Pairing.qml

--- a/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
+++ b/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
@@ -79,10 +79,10 @@ StatusDialog {
     readonly property int connectionSuccessfulStatus: 1
     readonly property int connectionFailedStatus: 2
 
-    function pairSuccessful(session) {
+    function pairSuccessful() {
         d.connectionStatus = root.connectionSuccessfulStatus
     }
-    function pairFailed(session, err) {
+    function pairFailed() {
         d.connectionStatus = root.connectionFailedStatus
     }
 

--- a/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
@@ -41,7 +41,7 @@ SignTransactionModalBase {
     property bool enoughFundsForTransaction: true
     property bool enoughFundsForFees: false
 
-    signButtonEnabled: enoughFundsForTransaction && enoughFundsForFees
+    signButtonEnabled: (!hasFees) || enoughFundsForTransaction && enoughFundsForFees
     title: qsTr("Sign Request")
     subtitle: SQUtils.StringUtils.extractDomainFromLink(root.dappUrl)
     headerIconComponent: RoundImageWithBadge {
@@ -68,7 +68,7 @@ SignTransactionModalBase {
     infoTag.states: [
         State {
             name: "insufficientFunds"
-            when: !root.enoughFundsForTransaction
+            when: root.hasFees && !root.enoughFundsForTransaction
             PropertyChanges {
                 target: infoTag
                 asset.color: Theme.palette.dangerColor1
@@ -96,8 +96,8 @@ SignTransactionModalBase {
                     Layout.fillWidth: true
                     objectName: "footerFiatFeesText"
                     text: formatBigNumber(root.fiatFees, root.currentCurrency)
-                    loading: root.feesLoading
-                    customColor: root.enoughFundsForFees ? Theme.palette.directColor1 : Theme.palette.dangerColor1
+                    loading: root.feesLoading && root.hasFees
+                    customColor: !root.hasFees || root.enoughFundsForFees ? Theme.palette.directColor1 : Theme.palette.dangerColor1
                     elide: Qt.ElideMiddle
                     Binding on text {
                         when: !root.hasFees

--- a/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal/WCUriInput.qml
@@ -22,11 +22,14 @@ ColumnLayout {
     StatusBaseInput {
         id: input
 
+        Component.onCompleted: {
+            forceActiveFocus()
+        }
+
         Layout.fillWidth: true
         Layout.preferredHeight: 132
 
         placeholderText: qsTr("Paste URI")
-
         verticalAlignment: TextInput.AlignTop
 
         valid: {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1464,4 +1464,9 @@ QtObject {
     }
 
     readonly property string navigationMetric: "navigation"
+
+    enum DAppConnectors {
+        WalletConnect = 1,
+        StatusConnect = 2
+    }
 }


### PR DESCRIPTION
### What does the PR do

closes https://github.com/status-im/status-desktop/issues/16463

**Separation of concerns**
1. **Issue**: The UI components depend on the `WalletConnectService` and also on its dependencies like `DAppsRequestHAndler`. As a result the UI components have a hard dependency on the WalletConnect specifics and are incompatible with BC. This results in duplication of logic.
2. **Issue**: The UI components operate on WalletConnect specific JSON object. E.g. session objects, session proposal etc. As a result the UI is built around the WalletConnect message format.
3. **Issue**: The UI components operate on ListModel items received through functions and stored internally. Any change in the model would result in a crash.

- **Solution**: Remove the WalletConnectService dependency from `DAppsWorkflow`. The `DAppsWorkflow` now operates with models, signals and functions. This is the first step in the broader refactoring. Moving the logic into the service itself will allow us to further refactor the WC and BC.

How does it work now:
1. Dependencies - The UI components have a dependency on models. `SessionRequestsModel` and `DAppsModel`.
2. Pairing - The pairing is initiated in the UI. On user input a `pairingValidationRequested` signal is emitted and the result is received as a function `pairingValidated`. If the url is valid the UI requests a `pairingRequested`. When the WalletConnectService is refactored we can go further and request only `pairingRequested` and to receive a `pairingResult` call as a function with the result. In the current implementation on `pairingRequested` we'll receive a `connectDApp` request.
2. Connecting dApps - The flow is initiated with `connectDApp` function. This call currently contains all the needed info as args. In the next step it could be replaced with a `ConnectionRequests` model. The `connectDApp` call triggered a connection popup if we're not currently showing one to the user. If we're currently showing one it will be queued (corner case). The connection can be accepted with `connectionAccepted` and rejected with `connectionDeclined`. Once the connection is accepted we're expecting a result `connectionSuccessful` or `connectionFailed`. The `connectionSuccessful` also expects a new id for the established connection.
3. Signing - The signing flow orbits around the `SessionRequestsModel`. Each item from the model will generate a popup showing the sign details to the user.  Sign can be accepted or rejected using `signRequestAccepted` or `signRequestRejected`. No response is currently expected. The model is expected to remove the sign request item.

**Next steps**: 
WC service refactoring to bring in a separation of concerns and to make it interoperable with WC and BC. This should result in flow simplification and remove the duplication of logic.

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
