### PR TITLE
refactor: make MessageContextMenu a functional component

### DIFF
--- a/storybook/pages/MessageContextMenuPage.qml
+++ b/storybook/pages/MessageContextMenuPage.qml
@@ -54,10 +54,39 @@ SplitView {
             Component {
                 id: menu1
                 MessageContextMenuView {
+                    id: messageContextMenuView
                     anchors.centerIn: parent
                     hideDisabledItems: false
+                    isDebugEnabled: isDebugEnabledCheckBox.checked
                     onClosed: {
                         destroy()
+                    }
+                    onPinMessage: () => {
+                        logs.logEvent("Pin message:", messageContextMenuView.messageId)
+                    }
+                    onUnpinMessage: () => {
+                        logs.logEvent("Unpin message:", messageContextMenuView.messageId)
+                    }
+                    onPinnedMessagesLimitReached: () => {
+                        logs.logEvent("Pinned messages limit reached:", messageContextMenuView.messageId)
+                    }
+                    onMarkMessageAsUnread: () => {
+                        logs.logEvent("Mark message as unread:", messageContextMenuView.messageId)
+                    }
+                    onToggleReaction: (emojiId) => {
+                        logs.logEvent("Toggle reaction:", messageContextMenuView.messageId, emojiId)
+                    }
+                    onDeleteMessage: () => {
+                        logs.logEvent("Delete message:", messageContextMenuView.messageId)
+                    }
+                    onEditClicked: () => {
+                        logs.logEvent("Edit message:", messageContextMenuView.messageId)
+                    }
+                    onShowReplyArea: (senderId) => {
+                        logs.logEvent("Show reply area:", messageContextMenuView.messageId, senderId)
+                    }
+                    onCopyToClipboard: (text) => {
+                        logs.logEvent("Copy to clipboard:", text)
                     }
                 }
             }
@@ -65,10 +94,39 @@ SplitView {
             Component {
                 id: menu2
                 MessageContextMenuView {
+                    id: messageContextMenuView
                     anchors.centerIn: parent
                     hideDisabledItems: true
+                    isDebugEnabled: isDebugEnabledCheckBox.checked
                     onClosed: {
                         destroy()
+                    }
+                    onPinMessage: () => {
+                        logs.logEvent("Pin message:", messageContextMenuView.messageId)
+                    }
+                    onUnpinMessage: () => {
+                        logs.logEvent("Unpin message:", messageContextMenuView.messageId)
+                    }
+                    onPinnedMessagesLimitReached: () => {
+                        logs.logEvent("Pinned messages limit reached:", messageContextMenuView.messageId)
+                    }
+                    onMarkMessageAsUnread: () => {
+                        logs.logEvent("Mark message as unread:", messageContextMenuView.messageId)
+                    }
+                    onToggleReaction: (emojiId) => {
+                        logs.logEvent("Toggle reaction:", messageContextMenuView.messageId, emojiId)
+                    }
+                    onDeleteMessage: () => {
+                        logs.logEvent("Delete message:", messageContextMenuView.messageId)
+                    }
+                    onEditClicked: () => {
+                        logs.logEvent("Edit message:", messageContextMenuView.messageId)
+                    }
+                    onShowReplyArea: (senderId) => {
+                        logs.logEvent("Show reply area:", messageContextMenuView.messageId, senderId)
+                    }
+                    onCopyToClipboard: (text) => {
+                        logs.logEvent("Copy to clipboard:", text)
                     }
                 }
             }
@@ -85,6 +143,12 @@ SplitView {
 
         controls: ColumnLayout {
             spacing: 16
+
+            CheckBox {
+                id: isDebugEnabledCheckBox
+                text: "Enable Debug"
+                checked: false
+            }
         }
     }
 

--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
@@ -146,7 +146,7 @@ def test_1x1_chat(multiple_instances):
         with step(f'User {user_one.name}, add reaction to the last message and verify it was added'):
             occurrence = random.randint(1, 6)
             message.open_context_menu_for_message().add_reaction_to_message(occurrence)
-            assert driver.waitFor(lambda: EMOJI_PATHES[occurrence - 1] == message.get_emoji_reactions_pathes()[0],
+            assert driver.waitFor(lambda: EMOJI_PATHES[occurrence - 1] == str(message.get_emoji_reactions_pathes()[0]),
                                   timeout),\
                 f"Emoji reaction is not correct"
             main_window.hide()
@@ -155,7 +155,7 @@ def test_1x1_chat(multiple_instances):
             aut_two.attach()
             main_window.prepare()
             message = chat.find_message_by_text(chat_message_reply, 0)
-            assert driver.waitFor(lambda: EMOJI_PATHES[occurrence - 1] == message.get_emoji_reactions_pathes()[0],
+            assert driver.waitFor(lambda: EMOJI_PATHES[occurrence - 1] == str(message.get_emoji_reactions_pathes()[0]),
                                   timeout),\
                 f"Emoji reaction is not correct"
             main_window.hide()

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -15,12 +15,9 @@ import shared.status 1.0
 import shared.controls.chat 1.0
 import shared.controls.chat.menuItems 1.0
 
-import AppLayouts.Chat.stores 1.0 as ChatStores
-
 StatusMenu {
     id: root
 
-    property ChatStores.RootStore store
     property var reactionModel: []
 
     property string myPublicKey: ""
@@ -35,7 +32,7 @@ StatusMenu {
     property int messageContentType: Constants.messageContentType.unknownContentType
 
     property bool pinMessageAllowedForMembers: false
-    property bool isDebugEnabled: store && store.isDebugEnabled
+    property bool isDebugEnabled: false
     property bool editRestricted: false
     property bool pinnedMessage: false
     property bool canPin: false
@@ -44,14 +41,15 @@ StatusMenu {
         return root.messageSenderId !== "" && root.messageSenderId === root.myPublicKey;
     }
 
-    signal pinMessage(string messageId)
-    signal unpinMessage(string messageId)
-    signal pinnedMessagesLimitReached(string messageId)
-    signal showReplyArea(string messageId, string messageSenderId)
-    signal toggleReaction(string messageId, int emojiId)
-    signal deleteMessage(string messageId)
-    signal editClicked(string messageId)
-    signal markMessageAsUnread(string messageId)
+    signal pinMessage()
+    signal unpinMessage()
+    signal pinnedMessagesLimitReached()
+    signal showReplyArea(string messageSenderId)
+    signal toggleReaction(int emojiId)
+    signal deleteMessage()
+    signal editClicked()
+    signal markMessageAsUnread()
+    signal copyToClipboard(string text)
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 230)
 
@@ -66,8 +64,8 @@ StatusMenu {
             reactionsModel: root.reactionModel
             bottomPadding: Style.current.padding
             onToggleReaction: {
-                root.toggleReaction(root.messageId, emojiId)
-                close()
+                root.toggleReaction(emojiId)
+                root.close()
             }
         }
     }
@@ -80,19 +78,14 @@ StatusMenu {
         id: replyToMenuItem
         text: qsTr("Reply to")
         icon.name: "chat"
-        onTriggered: {
-            root.showReplyArea(root.messageId, root.messageSenderId)
-            root.close()
-        }
+        onTriggered: root.showReplyArea(root.messageSenderId)
         enabled: !root.disabledForChat
     }
 
     StatusAction {
         id: editMessageAction
         text: qsTr("Edit message")
-        onTriggered: {
-            editClicked(messageId)
-        }
+        onTriggered: editClicked()
         icon.name: "edit"
         enabled: root.isMyMessage &&
                  !root.editRestricted &&
@@ -103,10 +96,7 @@ StatusMenu {
         id: copyMessageMenuItem
         text: qsTr("Copy message")
         icon.name: "copy"
-        onTriggered: {
-            ClipboardUtils.setText(root.unparsedText)
-            close()
-        }
+        onTriggered: root.copyToClipboard(root.unparsedText)
         enabled: root.messageContentType === Constants.messageContentType.messageType && replyToMenuItem.enabled
     }
 
@@ -115,10 +105,7 @@ StatusMenu {
         text: qsTr("Copy Message Id")
         icon.name: "copy"
         enabled: root.isDebugEnabled && replyToMenuItem.enabled
-        onTriggered: {
-            ClipboardUtils.setText(root.messageId)
-            close()
-        }
+        onTriggered: root.copyToClipboard(root.messageId)
     }
 
     StatusAction {
@@ -126,18 +113,9 @@ StatusMenu {
         text: root.pinnedMessage ? qsTr("Unpin") : qsTr("Pin")
         icon.name: root.pinnedMessage ? "unpin" : "pin"
         onTriggered: {
-            if (root.pinnedMessage) {
-                root.unpinMessage(root.messageId)
-                return
-            }
-
-            if (!root.canPin) {
-                root.pinnedMessagesLimitReached(root.messageId)
-                return
-            }
-
-            root.pinMessage(root.messageId)
-            root.close()
+            if (root.pinnedMessage) return root.unpinMessage()
+            if (!root.canPin) return root.pinnedMessagesLimitReached()
+            root.pinMessage()
         }
         enabled: {
             if (root.disabledForChat)
@@ -163,10 +141,7 @@ StatusMenu {
         text: qsTr("Mark as unread")
         icon.name: "hide"
         enabled: !root.disabledForChat
-        onTriggered: {
-            root.markMessageAsUnread(root.messageId)
-            root.close()
-        }
+        onTriggered: root.markMessageAsUnread()
     }
 
     StatusMenuSeparator {
@@ -191,8 +166,6 @@ StatusMenu {
         text: qsTr("Delete message")
         icon.name: "delete"
         type: StatusAction.Type.Danger
-        onTriggered: {
-            root.deleteMessage(messageId)
-        }
+        onTriggered: root.deleteMessage()
     }
 }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -10,6 +10,7 @@ import shared.views.chat 1.0
 import shared.controls.chat 1.0
 import shared.stores 1.0 as SharedStores
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
@@ -1227,20 +1228,14 @@ Loader {
         id: messageContextMenuComponent
 
         MessageContextMenuView {
-            store: root.rootStore
+            id: messageContextMenuView
             reactionModel: root.emojiReactionsModel
             disabledForChat: !root.rootStore.isUserAllowedToSendMessage
             forceEnableEmojiReactions: !root.rootStore.isUserAllowedToSendMessage && d.addReactionAllowed
-
-            onPinMessage: (messageId) => {
-                root.messageStore.pinMessage(messageId)
-            }
-
-            onUnpinMessage: (messageId) => {
-                root.messageStore.unpinMessage(messageId)
-            }
-
-            onPinnedMessagesLimitReached: (messageId) => {
+            isDebugEnabled: root.rootStore && root.rootStore.isDebugEnabled
+            onPinMessage: root.messageStore.pinMessage(messageContextMenuView.messageId)
+            onUnpinMessage: root.messageStore.unpinMessage(messageContextMenuView.messageId)
+            onPinnedMessagesLimitReached: () => {
                 if (!root.chatContentModule) {
                     console.warn("error on open pinned messages limit reached from message context menu - chat content module is not set")
                     return
@@ -1248,30 +1243,21 @@ Loader {
                 Global.openPinnedMessagesPopupRequested(root.rootStore,
                                                         root.messageStore,
                                                         root.chatContentModule.pinnedMessagesModel,
-                                                        messageId,
+                                                        messageContextMenuView.messageId,
                                                         root.chatId)
             }
-
-            onMarkMessageAsUnread: (messageId) => {
-                root.messageStore.markMessageAsUnread(messageId)
+            onMarkMessageAsUnread: root.messageStore.markMessageAsUnread(messageContextMenuView.messageId)
+            onToggleReaction: (emojiId) => {
+                root.messageStore.toggleReaction(messageContextMenuView.messageId, emojiId)
             }
-
-            onToggleReaction: (messageId, emojiId) => {
-                root.messageStore.toggleReaction(messageId, emojiId)
+            onDeleteMessage: root.messageStore.warnAndDeleteMessage(messageContextMenuView.messageId)
+            onEditClicked: root.messageStore.setEditModeOn(messageContextMenuView.messageId)
+            onShowReplyArea: (senderId) => {
+                root.showReplyArea(messageContextMenuView.messageId, senderId)
             }
-
-            onDeleteMessage: (messageId) => {
-                root.messageStore.warnAndDeleteMessage(messageId)
+            onCopyToClipboard: (text) => {
+                ClipboardUtils.setText(text)
             }
-
-            onEditClicked: (messageId) => {
-                root.messageStore.setEditModeOn(messageId)
-            }
-
-            onShowReplyArea: (messageId, senderId) => {
-                root.showReplyArea(messageId, senderId)
-            }
-
             onOpened: {
                 root.setMessageActive(model.id, true)
             }


### PR DESCRIPTION
### What does the PR do

Removes logic and global calls from MessageContextMenu and simplifies some of it

### Affected areas

Anything with messages

### Impact on end user

Functionality should remain the same

### How to test

Right click on a message and test menu options, such as emoji reactions, copy message, reply to message

### Risk 

message context menu items not working as expected in some particular context