### PR TITLE
fix(searchList): speed up ctrl-k search by using SPFM

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1740,43 +1740,21 @@ Item {
                 model: SortFilterProxyModel {
                     sourceModel: rootStore.chatSearchModel
 
-                    filters: [
-                        FastExpressionFilter {
-                            enabled: channelPickerLoader.searchText !== ""
-                            expression: {
-                                const lowerCaseSearchText = searchText.toLowerCase()
-                                return model.sectionName.toLowerCase().includes(lowerCaseSearchText) ||
-                                        model.name.toLowerCase().includes(lowerCaseSearchText)
-                            }
-                            expectedRoles: ["sectionName", "name"]
+                    filters: AnyOf {
+                        SQUtils.SearchFilter {
+                            roleName: "sectionName"
+                            searchPhrase: searchText
                         }
-                    ]
-                }
-                
-                delegate: StatusListItem {
-                    property var modelData
-                    property bool isCurrentItem: true
-
-                    title: modelData ? modelData.name : ""
-                    label: modelData? modelData.sectionName : ""
-                    highlighted: isCurrentItem
-                    sensor.hoverEnabled: false
-                    statusListItemIcon {
-                        name: modelData ? modelData.name : ""
-                        active: true
+                        SQUtils.SearchFilter {
+                            roleName: "name"
+                            searchPhrase: searchText
+                        }
                     }
-                    asset.width: 30
-                    asset.height: 30
-                    asset.color: modelData ? modelData.color ? modelData.color : Utils.colorForColorId(modelData.colorId) : ""
-                    asset.name: modelData ? modelData.icon : ""
-                    asset.charactersLen: 2
-                    asset.letterSize: asset._twoLettersSize
-                    ringSettings.ringSpecModel: modelData ? modelData.colorHash : undefined
                 }
 
                 onAboutToShow: rootStore.rebuildChatSearchModel()
                 onSelected: {
-                    rootStore.setActiveSectionChat(modelData.sectionId, modelData.chatId)
+                    rootStore.setActiveSectionChat(sectionId, chatId)
                     close()
                 }
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1737,20 +1737,7 @@ Item {
             asynchronous: true
             sourceComponent: StatusSearchListPopup {
                 searchBoxPlaceholder: qsTr("Where do you want to go?")
-                model: SortFilterProxyModel {
-                    sourceModel: rootStore.chatSearchModel
-
-                    filters: AnyOf {
-                        SQUtils.SearchFilter {
-                            roleName: "sectionName"
-                            searchPhrase: searchText
-                        }
-                        SQUtils.SearchFilter {
-                            roleName: "name"
-                            searchPhrase: searchText
-                        }
-                    }
-                }
+                model: rootStore.chatSearchModel
 
                 onAboutToShow: rootStore.rebuildChatSearchModel()
                 onSelected: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1737,14 +1737,25 @@ Item {
             asynchronous: true
             sourceComponent: StatusSearchListPopup {
                 searchBoxPlaceholder: qsTr("Where do you want to go?")
-                model: rootStore.chatSearchModel
+                model: SortFilterProxyModel {
+                    sourceModel: rootStore.chatSearchModel
+
+                    filters: [
+                        FastExpressionFilter {
+                            enabled: channelPickerLoader.searchText !== ""
+                            expression: {
+                                const lowerCaseSearchText = searchText.toLowerCase()
+                                return model.sectionName.toLowerCase().includes(lowerCaseSearchText) ||
+                                        model.name.toLowerCase().includes(lowerCaseSearchText)
+                            }
+                            expectedRoles: ["sectionName", "name"]
+                        }
+                    ]
+                }
+                
                 delegate: StatusListItem {
                     property var modelData
                     property bool isCurrentItem: true
-                    function filterAccepts(searchText) {
-                        const lowerCaseSearchText = searchText.toLowerCase()
-                        return title.toLowerCase().includes(lowerCaseSearchText) || label.toLowerCase().includes(lowerCaseSearchText)
-                    }
 
                     title: modelData ? modelData.name : ""
                     label: modelData? modelData.sectionName : ""

--- a/ui/imports/shared/status/StatusSearchListPopup.qml
+++ b/ui/imports/shared/status/StatusSearchListPopup.qml
@@ -7,7 +7,9 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1
 
+import SortFilterProxyModel 0.2
 import utils 1.0
 
 Popup {
@@ -18,8 +20,7 @@ Popup {
     width: 400
     height: 300
 
-    property alias model: listView.model
-    property alias searchText: searchBox.text
+    required property var model
 
     property string searchBoxPlaceholder: qsTr("Search...")
 
@@ -95,6 +96,21 @@ Popup {
             property bool selectByHover: false
 
             highlightMoveDuration: 200
+
+            model: SortFilterProxyModel {
+                sourceModel: root.model
+
+                filters: AnyOf {
+                    SearchFilter {
+                        roleName: "sectionName"
+                        searchPhrase: searchBox.text
+                    }
+                    SearchFilter {
+                        roleName: "name"
+                        searchPhrase: searchBox.text
+                    }
+                }
+            }
 
             delegate: StatusListItem {
                 id: listItem

--- a/ui/imports/shared/status/StatusSearchListPopup.qml
+++ b/ui/imports/shared/status/StatusSearchListPopup.qml
@@ -19,14 +19,12 @@ Popup {
     height: 300
 
     property alias model: listView.model
+    property alias searchText: searchBox.text
 
     // delegate interface has to be fulfilled
     property Component delegate: Item {
         property var modelData
         property bool isCurrentItem
-        function filterAccepts(searchText) {
-            return true
-        }
     }
     property string searchBoxPlaceholder: qsTr("Search...")
 
@@ -121,7 +119,6 @@ Popup {
                     onLoaded: {
                         item.modelData = delegateItem.myData
                         item.isCurrentItem = Qt.binding(() => delegateItem.ListView.isCurrentItem)
-                        delegateItem.visible = Qt.binding(() => item.filterAccepts(searchBox.text))
                     }
                 }
 


### PR DESCRIPTION
### What does the PR do

Speeds up the CTRL+K search popup search by using a SPFM instead of making objects invisible.

### Affected areas

The CTRL+K popup only

### Architecture compliance

- [C] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

[speed-ctrl-k.webm](https://github.com/user-attachments/assets/7f8e8931-5b16-4579-b531-3fce88aaee5d)

### Impact on end user

Makes using the ctrl-K menu way more snappy

### How to test

- Open tke ctrl-k popup and search channels

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worsct case scenario is the ctrl-K search doesn't work anymore
