### PR TITLE
fix(SlippageSelector): cant do Swap with 100% slippage

### DIFF
--- a/storybook/qmlTests/tests/tst_SlippageSelector.qml
+++ b/storybook/qmlTests/tests/tst_SlippageSelector.qml
@@ -120,6 +120,7 @@ Item {
                 {tag: "valid", value: 1.42, valid: true, isDefault: false},
                 {tag: "default", value: 0.5, valid: true, isDefault: true},
                 {tag: "invalid", value: 111.42, valid: false, isDefault: false},
+                {tag: "hundred", value: 100, valid: false, isDefault: false},
             ]
         }
 

--- a/ui/imports/shared/controls/SlippageSelector.qml
+++ b/ui/imports/shared/controls/SlippageSelector.qml
@@ -102,7 +102,7 @@ Control {
 
                 visible: !customButton.visible
                 minValue: 0.01
-                maxValue: 100.0
+                maxValue: 99.99
                 maximumLength: 6 // 3 integral + separator + 2 decimals (e.g. "999.99")
                 currencySymbol: d.customSymbol
                 onValueChanged: d.update(value)


### PR DESCRIPTION
### What does the PR do

- set the max custom limit to < 100%
- add a regression test

Fixes #16394

### Affected areas

SlippageSelector, SwapModal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/a0d57cce-bcea-4aea-9f5b-e21241085192)

