### PR TITLE
fix(SwapModal): Max slippage value remains as set even the custom field is erased

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -355,7 +355,8 @@ StatusDialog {
                 RowLayout {
                     StatusBaseText {
                         objectName: "maxSlippageValue"
-                        text: "%1%".arg(LocaleUtils.numberToLocaleString(root.swapInputParamsForm.selectedSlippage))
+                        text: editSlippagePanel.valid ? "%1%".arg(LocaleUtils.numberToLocaleString(root.swapInputParamsForm.selectedSlippage))
+                                                      : qsTr("N/A")
                         color: Theme.palette.directColor4
                         font.weight: Font.Medium
                     }


### PR DESCRIPTION
### What does the PR do

- if the slippage value is invalid, display a "N/A" text in the footer instead of a partial value

Fixes #16395

### Affected areas

SwapModal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
![image](https://github.com/user-attachments/assets/2b6874b3-46f8-4034-ae4c-d089f84d2076)
