### PR TITLE
tests: update existing test to open send modal from chat message

### DIFF
--- a/test/e2e/gui/objects_map/messaging_names.py
+++ b/test/e2e/gui/objects_map/messaging_names.py
@@ -72,6 +72,8 @@ groupUserListPanel_StatusMemberListItem = {"container": mainWindow_userListPanel
 # Message quick actions
 mainWindow_chatLogView_StatusListView = {"container":  statusDesktop_mainWindow, "objectName": "chatLogView", "type": "StatusListView", "visible": True}
 chatLogView_chatMessageViewDelegate_MessageView = {"container": mainWindow_chatLogView_StatusListView, "objectName": "chatMessageViewDelegate", "type": "MessageView", "visible": True}
+StatusTextMessage_chatTextMessage = {"container": chatLogView_chatMessageViewDelegate_MessageView, "objectName": "StatusTextMessage_chatText", "type": "TextEdit", "visible": True}
+
 chatMessageViewDelegate_deletedMessage_RowLayout = {"container": chatLogView_chatMessageViewDelegate_MessageView, "id": "deletedMessage", "type": "RowLayout", "unnamed": 1, "visible": True}
 chatMessageViewDelegate_StatusMessageQuickActions = {"container": chatLogView_chatMessageViewDelegate_MessageView, "type": "StatusMessageQuickActions", "unnamed": 1, "visible": True}
 chatMessageViewDelegate_pin_icon_StatusIcon = {"container": chatLogView_chatMessageViewDelegate_MessageView, "objectName": "pin-icon", "type": "StatusIcon", "visible": True}


### PR DESCRIPTION
### What does the PR do

Update existing test for 1x1 chat to cover sending transaction in chat. The test opens the link and verifies that send modal appears and has correct recipient address.

NOTE: i did not cover ENS here as it is covered in QML tests. 

https://github.com/status-im/status-desktop/blob/730fcef6dee30f5c502c23d401238a87a9a15b88/storybook/qmlTests/tests/tst_StatusMessage.qml#L46

NOTE: I also did not cover full sending flow here as there is a separate test for it.
