### PR TITLE
perf(admin): unload admin panel when leaving it to preserve performance

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -234,8 +234,7 @@ StackLayout {
     Loader {
         id: communitySettingsLoader
         active: root.rootStore.chatCommunitySectionModule.isCommunity() &&
-                root.isPrivilegedUser &&
-                (root.currentIndex === 1 || !!communitySettingsLoader.item) // lazy load and preserve state after loading
+                root.isPrivilegedUser &&  root.currentIndex === 1
         asynchronous: false // It's false on purpose. We want to load the component synchronously
         sourceComponent: CommunitySettingsView {
             id: communitySettingsView


### PR DESCRIPTION
### What does the PR do

Iterates #16043

By unloading the admin panel when leaving it, we can free the memory and also make sure that further updates to the community don't try to update the invisible models from the admins panels, some of which are very heavy.

The downside is that if you were in a particular screen in the admin panel, go back to the community to answer a message or retrieve an address, you will have lost your state.
However, I got Jen's blessing to do this change, as she is having a lot of issues with memory and performance currently.

Later, when we have upgraded all models and proxies, we might want to revert this change.

### Affected areas

Admin Panel (especially when leaving and going back)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Architecture guidelines](../architecture-guide.md)

### Impact on end user

better performance when the admin tab is closed with the tradeoff of losing the last state.

### How to test

1. Go to the admin panel
2. Go to a screen
3. Leave it
4. Go back to it
See that we are back at the Overview

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

No risk
