### PR TITLE
chore: add timeout for clicks

### DIFF
--- a/test/e2e/gui/components/settings/sign_out_popup.py
+++ b/test/e2e/gui/components/settings/sign_out_popup.py
@@ -14,7 +14,7 @@ class SignOutPopup(BasePopup):
     @allure.step('Click sign out and quit button')
     def sign_out_and_quit(self, attempts: int = 2):
         try:
-            self._sign_out_and_quit_button.click()
+            self._sign_out_and_quit_button.click(timeout=10)
         except Exception as ec:
             if attempts:
                 self.sign_out_and_quit(attempts-1)

--- a/test/e2e/gui/components/signing_phrase_popup.py
+++ b/test/e2e/gui/components/signing_phrase_popup.py
@@ -13,7 +13,7 @@ class SigningPhrasePopup(QObject):
 
     @allure.step('Confirm signing phrase in popup')
     def confirm_phrase(self):
-        self._ok_got_it_button.click()
+        self._ok_got_it_button.click(timeout=10)
         SigningPhrasePopup().wait_until_hidden()
 
     @allure.step('Verify if the signing phrase popup is visible')

--- a/test/e2e/gui/screens/community_settings.py
+++ b/test/e2e/gui/screens/community_settings.py
@@ -580,7 +580,7 @@ class PermissionsSettingsView(QObject):
 
     @allure.step('Click create permission')
     def create_permission(self):
-        self._create_permission_button.click()
+        self._create_permission_button.click(timeout=10)
         self._create_permission_button.wait_until_hidden()
 
     @allure.step('Open Who holds context menu')


### PR DESCRIPTION
### What does the PR do

We did not yet figure out https://github.com/status-im/status-desktop/issues/15345
However, this issue impacts autotests.

Main problem: when the application is stuck because of https://github.com/status-im/status-desktop/issues/15345, and then test is terminated (i kill the app process), then on a test retry (we have 1 retry for failed test) squish cant connect to the application for some reason, which is looking like this:

![image](https://github.com/user-attachments/assets/a93b5d53-11ce-4df4-91b3-a0730d36087c)

It just stares at the app window and then fails.

I am not entirely sure, where the problem lies, in `pytest-rerunfailures` plugin i use to retry failed test, or in Squish version, or there is some bug in the app (that makes app completely froxzen), or all three or none

