### PR TITLE
Refactor various popups

### DIFF
--- a/storybook/pages/BlockContactConfirmationDialogPage.qml
+++ b/storybook/pages/BlockContactConfirmationDialogPage.qml
@@ -1,0 +1,165 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Block Contact Confirmation Dialog"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: blockContactDialog.open()
+            }
+
+            Item {
+                Layout.preferredWidth: blockContactDialog.implicitWidth
+                Layout.preferredHeight: blockContactDialog.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                BlockContactConfirmationDialog {
+                    id: blockContactDialog
+                    visible: false
+                    // mainDisplayName: nameInput.text
+                    isContact: isContactCheckBox.checked
+                    outgoingVerificationStatus: outgoingVerificationStatusSelector.currentValue
+                    incomingVerificationStatus: incomingVerificationStatusSelector.currentValue
+                    trustStatus: trustStatusSelector.currentValue
+                    onAccepted: {
+                        blockContactDialog.close()
+                        log("Contact blocked: " + nameInput.text)
+                        log("Remove Contact: " + blockContactDialog.removeContact)
+                        log("Remove ID Verification: " + blockContactDialog.removeIDVerification)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Block Contact Dialog Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter name"
+            }
+
+            CheckBox {
+                id: isContactCheckBox
+                text: "Is Contact"
+            }
+
+            Label { text: "Outgoing Verification Status" }
+            ComboBox {
+                id: outgoingVerificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            Label { text: "Incoming Verification Status" }
+            ComboBox {
+                id: incomingVerificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            Label { text: "Trust Status" }
+            ComboBox {
+                id: trustStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Untrusted", value: Constants.trustStatus.untrusted },
+                    { text: "Trusted", value: Constants.trustStatus.trusted }
+                ]
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/BlockContactConfirmationDialogPage.qml
+++ b/storybook/pages/BlockContactConfirmationDialogPage.qml
@@ -42,7 +42,6 @@ SplitView {
                 BlockContactConfirmationDialog {
                     id: blockContactDialog
                     visible: false
-                    // mainDisplayName: nameInput.text
                     isContact: isContactCheckBox.checked
                     outgoingVerificationStatus: outgoingVerificationStatusSelector.currentValue
                     incomingVerificationStatus: incomingVerificationStatusSelector.currentValue
@@ -125,7 +124,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -157,7 +155,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/ContactVerificationRequestPopupPage.qml
+++ b/storybook/pages/ContactVerificationRequestPopupPage.qml
@@ -1,0 +1,138 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Contact Verification Request Popup"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: contactVerificationRequestPopup.open()
+            }
+
+            Item {
+                Layout.preferredWidth: contactVerificationRequestPopup.implicitWidth
+                Layout.preferredHeight: contactVerificationRequestPopup.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                ContactVerificationRequestPopup {
+                    id: contactVerificationRequestPopup
+                    visible: false
+                    senderPublicKey: senderPublicKeyInput.text
+                    challengeText: challengeTextInput.text
+                    messageTimestamp: messageTimestampInput.value
+                    onVerificationRefused: {
+                        log("Verification request declined")
+                    }
+                    onResponseSent: {
+                        log("Response sent: " + response)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Contact Verification Request Popup Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Sender Public Key" }
+            TextField {
+                id: senderPublicKeyInput
+                Layout.fillWidth: true
+                placeholderText: "Enter sender's public key"
+            }
+
+            Label { text: "Challenge Text" }
+            TextArea {
+                id: challengeTextInput
+                Layout.fillWidth: true
+                placeholderText: "Enter challenge text"
+            }
+
+            Label { text: "Message Timestamp" }
+            SpinBox {
+                id: messageTimestampInput
+                Layout.fillWidth: true
+                from: 0
+                to: 2147483647  // Max 32-bit integer
+                value: Date.now()
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/ContactVerificationRequestPopupPage.qml
+++ b/storybook/pages/ContactVerificationRequestPopupPage.qml
@@ -98,7 +98,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -130,7 +129,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/MarkAsIDVerifiedDialogPage.qml
+++ b/storybook/pages/MarkAsIDVerifiedDialogPage.qml
@@ -1,0 +1,118 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Mark as ID Verified Dialog"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: markAsIDVerifiedDialog.open()
+            }
+
+            Item {
+                Layout.preferredWidth: markAsIDVerifiedDialog.implicitWidth
+                Layout.preferredHeight: markAsIDVerifiedDialog.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                MarkAsIDVerifiedDialog {
+                    id: markAsIDVerifiedDialog
+                    visible: false
+                    // mainDisplayName: nameInput.text
+                    onAccepted: {
+                        markAsIDVerifiedDialog.close()
+                        log("User marked as ID verified: " + nameInput.text)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Mark as ID Verified Dialog Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter name"
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/MarkAsIDVerifiedDialogPage.qml
+++ b/storybook/pages/MarkAsIDVerifiedDialogPage.qml
@@ -42,7 +42,6 @@ SplitView {
                 MarkAsIDVerifiedDialog {
                     id: markAsIDVerifiedDialog
                     visible: false
-                    // mainDisplayName: nameInput.text
                     onAccepted: {
                         markAsIDVerifiedDialog.close()
                         log("User marked as ID verified: " + nameInput.text)
@@ -78,7 +77,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -110,7 +108,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/MarkAsUntrustedPopupPage.qml
+++ b/storybook/pages/MarkAsUntrustedPopupPage.qml
@@ -1,0 +1,167 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Mark as Untrusted Popup"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: markAsUntrustedPopup.open()
+            }
+
+            Item {
+                Layout.preferredWidth: markAsUntrustedPopup.implicitWidth
+                Layout.preferredHeight: markAsUntrustedPopup.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                MarkAsUntrustedPopup {
+                    id: markAsUntrustedPopup
+                    visible: false
+                    // mainDisplayName: nameInput.text
+                    verificationStatus: verificationStatusSelector.currentValue
+                    incomingVerificationStatus: incomingVerificationStatusSelector.currentValue
+                    isContact: isContactCheckBox.checked
+                    trustStatus: trustStatusSelector.currentValue
+                    onAccepted: {
+                        markAsUntrustedPopup.close()
+                        log("Marked as untrusted: " + nameInput.text)
+                        log("Remove ID Verification: " + markAsUntrustedPopup.removeIDVerification)
+                        log("Remove Contact: " + markAsUntrustedPopup.removeContact)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Mark as Untrusted Popup Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter name"
+            }
+
+            Label { text: "Verification Status" }
+            ComboBox {
+                id: verificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Unverified", value: Constants.verificationStatus.unverified },
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            Label { text: "Incoming Verification Status" }
+            ComboBox {
+                id: incomingVerificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Unverified", value: Constants.verificationStatus.unverified },
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            CheckBox {
+                id: isContactCheckBox
+                text: "Is Contact"
+            }
+
+            Label { text: "Trust Status" }
+            ComboBox {
+                id: trustStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Untrusted", value: Constants.trustStatus.untrusted },
+                    { text: "Trusted", value: Constants.trustStatus.trusted }
+                ]
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/MarkAsUntrustedPopupPage.qml
+++ b/storybook/pages/MarkAsUntrustedPopupPage.qml
@@ -42,7 +42,6 @@ SplitView {
                 MarkAsUntrustedPopup {
                     id: markAsUntrustedPopup
                     visible: false
-                    // mainDisplayName: nameInput.text
                     verificationStatus: verificationStatusSelector.currentValue
                     incomingVerificationStatus: incomingVerificationStatusSelector.currentValue
                     isContact: isContactCheckBox.checked
@@ -127,7 +126,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -159,7 +157,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/NicknamePopupPage.qml
+++ b/storybook/pages/NicknamePopupPage.qml
@@ -1,0 +1,236 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.views.chat 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignHCenter
+
+                Button {
+                    text: "Open Add Nickname Popup"
+                    onClicked: {
+                        nicknamePopup.nickname = ""
+                        nicknamePopup.open()
+                    }
+                }
+
+                Button {
+                    text: "Open Edit Nickname Popup"
+                    onClicked: {
+                        nicknamePopup.nickname = nicknameInput.text
+                        nicknamePopup.open()
+                    }
+                }
+            }
+
+            Item {
+                Layout.preferredWidth: nicknamePopup.implicitWidth
+                Layout.preferredHeight: nicknamePopup.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                NicknamePopup {
+                    id: nicknamePopup
+                    visible: false
+                    nickname: nicknameInput.text
+                    publicKey: publicKeyInput.text
+                    localNickname: localNicknameInput.text
+                    name: nameInput.text
+                    displayName: displayNameInput.text
+                    alias: aliasInput.text
+                    ensVerified: ensVerifiedCheckBox.checked
+                    onlineStatus: onlineStatusSelector.currentValue
+                    largeImage: largeImageInput.text
+                    isContact: isContactCheckBox.checked
+                    trustStatus: trustStatusSelector.currentValue
+                    isBlocked: isBlockedCheckBox.checked
+                    onEditDone: function(newNickname) {
+                        nicknamePopup.close()
+                        log("Nickname edited: " + newNickname)
+                    }
+                    onRemoveNicknameRequested: {
+                        nicknamePopup.close()
+                        log("Nickname removed")
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Nickname Popup Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Nickname" }
+            TextField {
+                id: nicknameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter nickname"
+                text: nicknamePopup.nickname
+                onTextChanged: {
+                    nicknamePopup.nickname = text
+                }
+            }
+
+            Label { text: "Public Key" }
+            TextField {
+                id: publicKeyInput
+                Layout.fillWidth: true
+                placeholderText: "Enter public key"
+            }
+
+            Label { text: "Local Nickname" }
+            TextField {
+                id: localNicknameInput
+                Layout.fillWidth: true
+                placeholderText: "Local Nickname"
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Name"
+            }
+
+            Label { text: "Display Name" }
+            TextField {
+                id: displayNameInput
+                Layout.fillWidth: true
+                placeholderText: "Display Name"
+            }
+
+            Label { text: "Alias" }
+            TextField {
+                id: aliasInput
+                Layout.fillWidth: true
+                placeholderText: "Alias"
+            }
+
+            CheckBox {
+                id: ensVerifiedCheckBox
+                text: "ENS Verified"
+            }
+
+            Label { text: "Online Status" }
+            ComboBox {
+                id: onlineStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Offline", value: Constants.onlineStatus.inactive },
+                    { text: "Online", value: Constants.onlineStatus.online },
+                    { text: "Away", value: Constants.onlineStatus.away },
+                    { text: "Busy", value: Constants.onlineStatus.busy }
+                ]
+            }
+
+            Label { text: "Large Image URL" }
+            TextField {
+                id: largeImageInput
+                Layout.fillWidth: true
+                placeholderText: "Large Image URL"
+            }
+
+            CheckBox {
+                id: isContactCheckBox
+                text: "Is Contact"
+            }
+
+            Label { text: "Trust Status" }
+            ComboBox {
+                id: trustStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Untrusted", value: Constants.trustStatus.unknown },
+                    { text: "Trusted", value: Constants.trustStatus.trusted },
+                    { text: "Verified", value: Constants.trustStatus.verifiedTrusted }
+                ]
+            }
+
+            CheckBox {
+                id: isBlockedCheckBox
+                text: "Is Blocked"
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/NicknamePopupPage.qml
+++ b/storybook/pages/NicknamePopupPage.qml
@@ -196,7 +196,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -228,7 +227,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/OutgoingContactVerificationRequestPopupPage.qml
+++ b/storybook/pages/OutgoingContactVerificationRequestPopupPage.qml
@@ -45,11 +45,15 @@ SplitView {
                     verificationStatus: verificationStatusSelector.currentValue
                     verificationChallenge: challengeInput.text
                     verificationResponse: responseInput.text
-                    verificationResponseDisplayName: nameInput.text
-                    verificationResponseIcon: iconInput.text
+                    verificationResponseDisplayName: verificationResponseNameInput.text
+                    verificationResponseIcon: verificationResponseIconInput.text
                     verificationRequestedAt: requestedAtInput.text
                     verificationRepliedAt: repliedAtInput.text
                     ensVerified: ensVerifiedCheckBox.checked
+                    pubKey: pubKeyInput.text
+                    preferredName: preferredNameInput.text
+                    name: nameInput.text
+                    icon: iconInput.text
                     onVerificationRequestCanceled: {
                         log("Verification request canceled")
                     }
@@ -122,6 +126,20 @@ SplitView {
                 placeholderText: "Enter response"
             }
 
+            Label { text: "Verification Response Display Name" }
+            TextField {
+                id: verificationResponseNameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter verification response display name"
+            }
+
+            Label { text: "Verification Response Icon" }
+            TextField {
+                id: verificationResponseIconInput
+                Layout.fillWidth: true
+                placeholderText: "Enter verification response icon"
+            }
+
             Label { text: "Requested At" }
             TextField {
                 id: requestedAtInput
@@ -134,6 +152,20 @@ SplitView {
                 id: repliedAtInput
                 Layout.fillWidth: true
                 placeholderText: "Enter replied time"
+            }
+
+            Label { text: "Public Key" }
+            TextField {
+                id: pubKeyInput
+                Layout.fillWidth: true
+                placeholderText: "Enter public key"
+            }
+
+            Label { text: "Preferred Name" }
+            TextField {
+                id: preferredNameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter preferred name"
             }
 
             CheckBox {

--- a/storybook/pages/OutgoingContactVerificationRequestPopupPage.qml
+++ b/storybook/pages/OutgoingContactVerificationRequestPopupPage.qml
@@ -177,7 +177,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -209,7 +208,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/OutgoingContactVerificationRequestPopupPage.qml
+++ b/storybook/pages/OutgoingContactVerificationRequestPopupPage.qml
@@ -1,0 +1,185 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Outgoing Contact Verification Request Popup"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: verificationRequestPopup.open()
+            }
+
+            Item {
+                Layout.preferredWidth: verificationRequestPopup.implicitWidth
+                Layout.preferredHeight: verificationRequestPopup.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                OutgoingContactVerificationRequestPopup {
+                    id: verificationRequestPopup
+                    visible: false
+                    verificationStatus: verificationStatusSelector.currentValue
+                    verificationChallenge: challengeInput.text
+                    verificationResponse: responseInput.text
+                    verificationResponseDisplayName: nameInput.text
+                    verificationResponseIcon: iconInput.text
+                    verificationRequestedAt: requestedAtInput.text
+                    verificationRepliedAt: repliedAtInput.text
+                    ensVerified: ensVerifiedCheckBox.checked
+                    onVerificationRequestCanceled: {
+                        log("Verification request canceled")
+                    }
+                    onUntrustworthyVerified: {
+                        log("Marked as untrusted")
+                    }
+                    onTrustedVerified: {
+                        log("Marked as verified")
+                    }
+                    onOnLinkActivated: {
+                        log("Link activated")
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Verification Request Popup Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter name"
+            }
+
+            Label { text: "Icon" }
+            TextField {
+                id: iconInput
+                Layout.fillWidth: true
+                placeholderText: "Enter icon"
+            }
+
+            Label { text: "Verification Status" }
+            ComboBox {
+                id: verificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            Label { text: "Challenge" }
+            TextField {
+                id: challengeInput
+                Layout.fillWidth: true
+                placeholderText: "Enter challenge"
+            }
+
+            Label { text: "Response" }
+            TextField {
+                id: responseInput
+                Layout.fillWidth: true
+                placeholderText: "Enter response"
+            }
+
+            Label { text: "Requested At" }
+            TextField {
+                id: requestedAtInput
+                Layout.fillWidth: true
+                placeholderText: "Enter requested time"
+            }
+
+            Label { text: "Replied At" }
+            TextField {
+                id: repliedAtInput
+                Layout.fillWidth: true
+                placeholderText: "Enter replied time"
+            }
+
+            CheckBox {
+                id: ensVerifiedCheckBox
+                text: "ENS Verified"
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/RemoveContactPopupPage.qml
+++ b/storybook/pages/RemoveContactPopupPage.qml
@@ -42,7 +42,6 @@ SplitView {
                 RemoveContactPopup {
                     id: removeContactPopup
                     visible: false
-                    // mainDisplayName: nameInput.text
                     outgoingVerificationStatus: outgoingVerificationStatusSelector.currentValue
                     incomingVerificationStatus: incomingVerificationStatusSelector.currentValue
                     trustStatus: trustStatusSelector.currentValue
@@ -122,7 +121,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -154,7 +152,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/RemoveContactPopupPage.qml
+++ b/storybook/pages/RemoveContactPopupPage.qml
@@ -1,0 +1,162 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Remove Contact Popup"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: removeContactPopup.open()
+            }
+
+            Item {
+                Layout.preferredWidth: removeContactPopup.implicitWidth
+                Layout.preferredHeight: removeContactPopup.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                RemoveContactPopup {
+                    id: removeContactPopup
+                    visible: false
+                    // mainDisplayName: nameInput.text
+                    outgoingVerificationStatus: outgoingVerificationStatusSelector.currentValue
+                    incomingVerificationStatus: incomingVerificationStatusSelector.currentValue
+                    trustStatus: trustStatusSelector.currentValue
+                    onAccepted: {
+                        removeContactPopup.close()
+                        log("Contact removed: " + nameInput.text)
+                        log("Remove ID Verification: " + removeContactPopup.removeIDVerification)
+                        log("Mark as Untrusted: " + removeContactPopup.markAsUntrusted)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Remove Contact Popup Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter name"
+            }
+
+            Label { text: "Outgoing Verification Status" }
+            ComboBox {
+                id: outgoingVerificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Unverified", value: Constants.verificationStatus.unverified },
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            Label { text: "Incoming Verification Status" }
+            ComboBox {
+                id: incomingVerificationStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Unverified", value: Constants.verificationStatus.unverified },
+                    { text: "Untrustworthy", value: Constants.verificationStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.verificationStatus.trusted }
+                ]
+            }
+
+            Label { text: "Trust Status" }
+            ComboBox {
+                id: trustStatusSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "None", value: Constants.trustStatus.none },
+                    { text: "Untrusted", value: Constants.trustStatus.untrustworthy },
+                    { text: "Trusted", value: Constants.trustStatus.trusted }
+                ]
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/RemoveIDVerificationDialogPage.qml
+++ b/storybook/pages/RemoveIDVerificationDialogPage.qml
@@ -42,7 +42,6 @@ SplitView {
                 RemoveIDVerificationDialog {
                     id: removeIDVerificationDialog
                     visible: false
-                    // mainDisplayName: nameInput.text
                     onAccepted: {
                         removeIDVerificationDialog.close()
                         log("ID Verification removed for: " + nameInput.text)
@@ -80,7 +79,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -112,7 +110,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/RemoveIDVerificationDialogPage.qml
+++ b/storybook/pages/RemoveIDVerificationDialogPage.qml
@@ -1,0 +1,120 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Remove ID Verification Dialog"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: removeIDVerificationDialog.open()
+            }
+
+            Item {
+                Layout.preferredWidth: removeIDVerificationDialog.implicitWidth
+                Layout.preferredHeight: removeIDVerificationDialog.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                RemoveIDVerificationDialog {
+                    id: removeIDVerificationDialog
+                    visible: false
+                    // mainDisplayName: nameInput.text
+                    onAccepted: {
+                        removeIDVerificationDialog.close()
+                        log("ID Verification removed for: " + nameInput.text)
+                        log("Mark as Untrusted: " + removeIDVerificationDialog.markAsUntrusted)
+                        log("Remove Contact: " + removeIDVerificationDialog.removeContact)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Remove ID Verification Dialog Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Name" }
+            TextField {
+                id: nameInput
+                Layout.fillWidth: true
+                placeholderText: "Enter name"
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/ReviewContactRequestPopupPage.qml
+++ b/storybook/pages/ReviewContactRequestPopupPage.qml
@@ -121,7 +121,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -153,7 +152,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/storybook/pages/ReviewContactRequestPopupPage.qml
+++ b/storybook/pages/ReviewContactRequestPopupPage.qml
@@ -1,0 +1,161 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Review Contact Request Popup"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: reviewContactRequestPopup.open()
+            }
+
+            Item {
+                Layout.preferredWidth: reviewContactRequestPopup.implicitWidth
+                Layout.preferredHeight: reviewContactRequestPopup.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                ReviewContactRequestPopup {
+                    id: reviewContactRequestPopup
+                    visible: false
+                    contactRequestId: contactRequestIdInput.text
+                    fromAddress: fromAddressInput.text
+                    clock: clockInput.value
+                    text: messageInput.text
+                    contactRequestState: contactRequestStateSelector.currentValue
+                    onAccepted: {
+                        reviewContactRequestPopup.close()
+                        log("Contact request accepted")
+                    }
+                    onDiscarded: {
+                        reviewContactRequestPopup.close()
+                        log("Contact request ignored")
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Review Contact Request Popup Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Contact Request ID" }
+            TextField {
+                id: contactRequestIdInput
+                Layout.fillWidth: true
+                placeholderText: "Enter contact request ID"
+            }
+
+            Label { text: "From Address" }
+            TextField {
+                id: fromAddressInput
+                Layout.fillWidth: true
+                placeholderText: "Enter from address"
+            }
+
+            Label { text: "Clock" }
+            SpinBox {
+                id: clockInput
+                Layout.fillWidth: true
+                from: 0
+                to: 2147483647  // Max 32-bit integer
+            }
+
+            Label { text: "Message" }
+            TextArea {
+                id: messageInput
+                Layout.fillWidth: true
+                placeholderText: "Enter contact request message"
+            }
+
+            Label { text: "Contact Request State" }
+            ComboBox {
+                id: contactRequestStateSelector
+                Layout.fillWidth: true
+                textRole: "text"
+                valueRole: "value"
+                model: [
+                    { text: "Pending", value: 0 },
+                    { text: "Accepted", value: 1 },
+                    { text: "Declined", value: 2 }
+                ]
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/SendContactRequestModalPage.qml
+++ b/storybook/pages/SendContactRequestModalPage.qml
@@ -1,0 +1,136 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import shared.popups 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    id: root
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 20
+
+            Item {
+                Layout.preferredHeight: 50
+            }
+
+            Button {
+                text: "Open Send Contact Request Modal"
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: sendContactRequestModal.open()
+            }
+
+            Item {
+                Layout.preferredWidth: sendContactRequestModal.implicitWidth
+                Layout.preferredHeight: sendContactRequestModal.implicitHeight
+                Layout.alignment: Qt.AlignHCenter
+
+                SendContactRequestModal {
+                    id: sendContactRequestModal
+                    visible: false
+                    labelText: labelTextInput.text
+                    challengeText: challengeTextInput.text
+                    buttonText: buttonTextInput.text
+                    onAccepted: function(message) {
+                        log("Contact request sent with message: " + message)
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 400
+        SplitView.fillHeight: true
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 16
+
+            Label {
+                text: "Send Contact Request Modal Settings"
+                font.bold: true
+                font.pixelSize: 16
+            }
+
+            Label { text: "Label Text" }
+            TextField {
+                id: labelTextInput
+                Layout.fillWidth: true
+                text: qsTr("Why should they accept your contact request?")
+                placeholderText: "Enter label text"
+            }
+
+            Label { text: "Challenge Text" }
+            TextField {
+                id: challengeTextInput
+                Layout.fillWidth: true
+                text: qsTr("Write a short message telling them who you are...")
+                placeholderText: "Enter challenge text"
+            }
+
+            Label { text: "Button Text" }
+            TextField {
+                id: buttonTextInput
+                Layout.fillWidth: true
+                text: qsTr("Send contact request")
+                placeholderText: "Enter button text"
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+
+            // Add logs section
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 8
+
+                Label {
+                    text: "Logs"
+                    font.bold: true
+                    font.pixelSize: 16
+                }
+
+                ScrollView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 150
+                    clip: true
+
+                    TextArea {
+                        id: logsTextArea
+                        readOnly: true
+                        wrapMode: TextEdit.Wrap
+                        selectByMouse: true
+                    }
+                }
+
+                Button {
+                    text: "Clear Logs"
+                    onClicked: logsTextArea.clear()
+                }
+            }
+        }
+    }
+
+    // Add log function
+    function log(message) {
+        var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
+        logsTextArea.append(timestamp + ": " + message)
+    }
+}

--- a/storybook/pages/SendContactRequestModalPage.qml
+++ b/storybook/pages/SendContactRequestModalPage.qml
@@ -96,7 +96,6 @@ SplitView {
                 Layout.fillHeight: true
             }
 
-            // Add logs section
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: 8
@@ -128,7 +127,6 @@ SplitView {
         }
     }
 
-    // Add log function
     function log(message) {
         var timestamp = new Date().toLocaleTimeString(Qt.locale(), "HH:mm:ss")
         logsTextArea.append(timestamp + ": " + message)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -151,15 +151,51 @@ QtObject {
     }
 
     function openNicknamePopup(publicKey: string, contactDetails, cb) {
-        openPopup(nicknamePopupComponent, {publicKey, contactDetails}, cb)
+        openPopup(nicknamePopupComponent, {
+            publicKey: publicKey,
+            localNickname: contactDetails.localNickname,
+            name: contactDetails.name,
+            displayName: contactDetails.displayName,
+            alias: contactDetails.alias,
+            ensVerified: contactDetails.ensVerified,
+            onlineStatus: contactDetails.onlineStatus,
+            largeImage: contactDetails.largeImage,
+            isContact: contactDetails.isContact,
+            trustStatus: contactDetails.trustStatus,
+            isBlocked: contactDetails.isBlocked
+        }, cb)
     }
 
     function openMarkAsUntrustedPopup(publicKey: string, contactDetails) {
-        openPopup(markAsUntrustedComponent, {publicKey, contactDetails})
+        openPopup(markAsUntrustedComponent, {
+            publicKey: publicKey,
+            localNickname: contactDetails.localNickname,
+            name: contactDetails.name,
+            displayName: contactDetails.displayName,
+            alias: contactDetails.alias,
+            ensVerified: contactDetails.ensVerified,
+            onlineStatus: contactDetails.onlineStatus,
+            largeImage: contactDetails.largeImage,
+            isContact: contactDetails.isContact,
+            trustStatus: contactDetails.trustStatus,
+            isBlocked: contactDetails.isBlocked
+        })
     }
 
     function openBlockContactPopup(publicKey: string, contactDetails) {
-        openPopup(blockContactConfirmationComponent, {publicKey, contactDetails})
+        openPopup(blockContactConfirmationComponent, {
+            publicKey: publicKey,
+            localNickname: contactDetails.localNickname,
+            name: contactDetails.name,
+            displayName: contactDetails.displayName,
+            alias: contactDetails.alias,
+            ensVerified: contactDetails.ensVerified,
+            onlineStatus: contactDetails.onlineStatus,
+            largeImage: contactDetails.largeImage,
+            isContact: contactDetails.isContact,
+            trustStatus: contactDetails.trustStatus,
+            isBlocked: contactDetails.isBlocked
+        })
     }
 
     function openUnblockContactPopup(publicKey: string, contactDetails) {
@@ -191,11 +227,35 @@ QtObject {
     }
 
     function openMarkAsIDVerifiedPopup(publicKey, contactDetails, cb) {
-        openPopup(markAsIDVerifiedPopupComponent, {publicKey, contactDetails}, cb)
+        openPopup(markAsIDVerifiedPopupComponent, {
+            publicKey: publicKey,
+            localNickname: contactDetails.localNickname,
+            name: contactDetails.name,
+            displayName: contactDetails.displayName,
+            alias: contactDetails.alias,
+            ensVerified: contactDetails.ensVerified,
+            onlineStatus: contactDetails.onlineStatus,
+            largeImage: contactDetails.largeImage,
+            isContact: contactDetails.isContact,
+            trustStatus: contactDetails.trustStatus,
+            isBlocked: contactDetails.isBlocked
+        }, cb)
     }
 
     function openRemoveIDVerificationDialog(publicKey, contactDetails, cb) {
-        openPopup(removeIDVerificationPopupComponent, {publicKey, contactDetails}, cb)
+        openPopup(removeIDVerificationPopupComponent, {
+            publicKey: publicKey,
+            localNickname: contactDetails.localNickname,
+            name: contactDetails.name,
+            displayName: contactDetails.displayName,
+            alias: contactDetails.alias,
+            ensVerified: contactDetails.ensVerified,
+            onlineStatus: contactDetails.onlineStatus,
+            largeImage: contactDetails.largeImage,
+            isContact: contactDetails.isContact,
+            trustStatus: contactDetails.trustStatus,
+            isBlocked: contactDetails.isBlocked
+        }, cb)
     }
 
     function openOutgoingIDRequestPopup(publicKey, contactDetails, cb) {
@@ -211,7 +271,17 @@ QtObject {
                 verificationResponseDisplayName: verificationDetails.displayName,
                 verificationResponseIcon: verificationDetails.icon,
                 verificationRequestedAt: verificationDetails.requestedAt,
-                verificationRepliedAt: verificationDetails.repliedAt
+                verificationRepliedAt: verificationDetails.repliedAt,
+                localNickname: contactDetails.localNickname,
+                name: contactDetails.name,
+                displayName: contactDetails.displayName,
+                alias: contactDetails.alias,
+                ensVerified: contactDetails.ensVerified,
+                onlineStatus: contactDetails.onlineStatus,
+                largeImage: contactDetails.largeImage,
+                isContact: contactDetails.isContact,
+                trustStatus: contactDetails.trustStatus,
+                isBlocked: contactDetails.isBlocked
             }
             openPopup(contactOutgoingVerificationRequestPopupComponent, popupProperties, cb)
         } catch (e) {
@@ -252,7 +322,7 @@ QtObject {
                 console.warn("Popups.openReviewContactRequestPopup: not matching publicKey:", publicKey)
                 return
             }
-            openPopup(reviewContactRequestPopupComponent, {publicKey, contactDetails, crDetails}, cb)
+            openPopup(reviewContactRequestPopupComponent, {publicKey, contactDetails, ...crDetails}, cb)
         } catch (e) {
             console.error("Popups.openReviewContactRequestPopup: error getting or parsing contact request data", e)
         }
@@ -315,7 +385,21 @@ QtObject {
     }
 
     function openRemoveContactConfirmationPopup(publicKey, contactDetails) {
-        openPopup(removeContactConfirmationDialog, {publicKey, contactDetails})
+        openPopup(removeContactConfirmationDialog, {
+            publicKey: publicKey,
+            localNickname: contactDetails.localNickname,
+            name: contactDetails.name,
+            displayName: contactDetails.displayName,
+            alias: contactDetails.alias,
+            ensVerified: contactDetails.ensVerified,
+            onlineStatus: contactDetails.onlineStatus,
+            largeImage: contactDetails.largeImage,
+            isContact: contactDetails.isContact,
+            trustStatus: contactDetails.trustStatus,
+            isBlocked: contactDetails.isBlocked,
+            outgoingVerificationStatus: contactDetails.outgoingVerificationStatus,
+            incomingVerificationStatus: contactDetails.incomingVerificationStatus,
+        })
     }
 
     function openDeleteMessagePopup(messageId, messageStore) {
@@ -409,15 +493,16 @@ QtObject {
         Component {
             id: removeContactConfirmationDialog
             RemoveContactPopup {
+                id: removeContactPopup
                 onAccepted: {
-                    rootStore.contactStore.removeContact(publicKey)
-                    if (removeIDVerification)
-                        rootStore.contactStore.removeTrustVerificationStatus(publicKey)
-                    if (markAsUntrusted) {
-                        rootStore.contactStore.markUntrustworthy(publicKey)
-                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts and marked as untrusted").arg(mainDisplayName))
+                    rootStore.contactStore.removeContact(removeContactPopup.publicKey)
+                    if (removeContactPopup.removeIDVerification)
+                        rootStore.contactStore.removeTrustVerificationStatus(removeContactPopup.publicKey)
+                    if (removeContactPopup.markAsUntrusted) {
+                        rootStore.contactStore.markUntrustworthy(removeContactPopup.publicKey)
+                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts and marked as untrusted").arg(removeContactPopup.mainDisplayName))
                     } else {
-                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts").arg(mainDisplayName))
+                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts").arg(removeContactPopup.mainDisplayName))
                     }
                     close()
                 }
@@ -443,16 +528,21 @@ QtObject {
         Component {
             id: contactOutgoingVerificationRequestPopupComponent
             OutgoingContactVerificationRequestPopup {
-                onVerificationRequestCanceled: {
-                    rootStore.contactStore.cancelVerificationRequest(publicKey)
-                }
+                id: outgoingContactVerificationRequestPopup
+                onVerificationRequestCanceled: rootStore.contactStore.cancelVerificationRequest(outgoingContactVerificationRequestPopup.publicKey)
                 onUntrustworthyVerified: {
-                    rootStore.contactStore.verifiedUntrustworthy(publicKey)
-                    Global.displaySuccessToastMessage(qsTr("%1 marked as untrusted").arg(mainDisplayName))
+                    rootStore.contactStore.verifiedUntrustworthy(outgoingContactVerificationRequestPopup.publicKey)
+                    Global.displaySuccessToastMessage(qsTr("%1 marked as untrusted").arg(outgoingContactVerificationRequestPopup.mainDisplayName))
                 }
                 onTrustedVerified: {
-                    rootStore.contactStore.verifiedTrusted(publicKey)
-                    Global.displaySuccessToastMessage(qsTr("%1 ID verified").arg(mainDisplayName))
+                    rootStore.contactStore.verifiedTrusted(outgoingContactVerificationRequestPopup.publicKey)
+                    Global.displaySuccessToastMessage(qsTr("%1 ID verified").arg(outgoingContactVerificationRequestPopup.mainDisplayName))
+                }
+                onLinkActivated: {
+                    rootStore.contactStore.cancelVerificationRequest(outgoingContactVerificationRequestPopup.publicKey)
+                    outgoingContactVerificationRequestPopup.close()
+                    const contactDetails = Utils.getContactDetailsAsJson(outgoingContactVerificationRequestPopup.publicKey)
+                    Global.openSendIDRequestPopup(outgoingContactVerificationRequestPopup.publicKey, contactDetails, null)
                 }
                 onClosed: destroy()
             }
@@ -470,9 +560,10 @@ QtObject {
         Component {
             id: markAsIDVerifiedPopupComponent
             MarkAsIDVerifiedDialog {
+                id: markAsIDVerifiedPopupView
                 onAccepted: {
-                    rootStore.contactStore.markAsTrusted(publicKey)
-                    Global.displaySuccessToastMessage(qsTr("%1 ID verified").arg(mainDisplayName))
+                    rootStore.contactStore.markAsTrusted(markAsIDVerifiedPopupView.publicKey)
+                    Global.displaySuccessToastMessage(qsTr("%1 ID verified").arg(markAsIDVerifiedPopupView.mainDisplayName))
                     close()
                 }
                 onClosed: destroy()
@@ -482,21 +573,22 @@ QtObject {
         Component {
             id: removeIDVerificationPopupComponent
             RemoveIDVerificationDialog {
+                id: removeIDVerificationPopup
                 onAccepted: {
-                    rootStore.contactStore.removeTrustVerificationStatus(publicKey)
+                    rootStore.contactStore.removeTrustVerificationStatus(removeIDVerificationPopup.publicKey)
 
-                    if (markAsUntrusted && removeContact) {
-                        rootStore.contactStore.markUntrustworthy(publicKey)
-                        rootStore.contactStore.removeContact(publicKey)
-                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed, removed from contacts and marked as untrusted").arg(mainDisplayName))
-                    } else if (markAsUntrusted) {
-                        rootStore.contactStore.markUntrustworthy(publicKey)
-                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed and marked as untrusted").arg(mainDisplayName))
-                    } else if (removeContact) {
-                        rootStore.contactStore.removeContact(publicKey)
-                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed and removed from contacts").arg(mainDisplayName))
+                    if (removeIDVerificationPopup.markAsUntrusted && removeIDVerificationPopup.removeContact) {
+                        rootStore.contactStore.markUntrustworthy(removeIDVerificationPopup.publicKey)
+                        rootStore.contactStore.removeContact(removeIDVerificationPopup.publicKey)
+                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed, removed from contacts and marked as untrusted").arg(removeIDVerificationPopup.mainDisplayName))
+                    } else if (removeIDVerificationPopup.markAsUntrusted) {
+                        rootStore.contactStore.markUntrustworthy(removeIDVerificationPopup.publicKey)
+                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed and marked as untrusted").arg(removeIDVerificationPopup.mainDisplayName))
+                    } else if (removeIDVerificationPopup.removeContact) {
+                        rootStore.contactStore.removeContact(removeIDVerificationPopup.publicKey)
+                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed and removed from contacts").arg(removeIDVerificationPopup.mainDisplayName))
                     } else {
-                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed").arg(mainDisplayName))
+                        Global.displaySuccessToastMessage(qsTr("%1 ID verification removed").arg(removeIDVerificationPopup.mainDisplayName))
                     }
                     close()
                 }
@@ -526,13 +618,14 @@ QtObject {
         Component {
             id: reviewContactRequestPopupComponent
             ReviewContactRequestPopup {
+                id: reviewContactRequestPopup
                 onAccepted: {
-                    rootStore.contactStore.acceptContactRequest(publicKey, contactRequestId)
+                    rootStore.contactStore.acceptContactRequest(reviewContactRequestPopup.publicKey, reviewContactRequestPopup.contactRequestId)
                     Global.displaySuccessToastMessage(qsTr("Contact request accepted"))
                     close()
                 }
                 onDiscarded: {
-                    rootStore.contactStore.dismissContactRequest(publicKey, contactRequestId)
+                    rootStore.contactStore.dismissContactRequest(reviewContactRequestPopup.publicKey, reviewContactRequestPopup.contactRequestId)
                     Global.displaySuccessToastMessage(qsTr("Contact request ignored"))
                     close()
                 }
@@ -648,14 +741,15 @@ QtObject {
         Component {
             id: nicknamePopupComponent
             NicknamePopup {
-                onEditDone: {
-                    if (nickname !== newNickname) {
-                        rootStore.contactStore.changeContactNickname(publicKey, newNickname, optionalDisplayName, !!nickname)
+                id: nicknamePopup
+                onEditDone: function(newNickname) {
+                    if (nicknamePopup.nickname !== newNickname) {
+                        rootStore.contactStore.changeContactNickname(nicknamePopup.publicKey, newNickname, nicknamePopup.optionalDisplayName, !!nicknamePopup.nickname)
                     }
                     close()
                 }
                 onRemoveNicknameRequested: {
-                    rootStore.contactStore.changeContactNickname(publicKey, "", optionalDisplayName, true)
+                    rootStore.contactStore.changeContactNickname(nicknamePopup.publicKey, "", nicknamePopup.optionalDisplayName, true)
                     close()
                 }
                 onClosed: destroy()
@@ -665,13 +759,14 @@ QtObject {
         Component {
             id: markAsUntrustedComponent
             MarkAsUntrustedPopup {
+                id: markAsUntrustedPopup
                 onAccepted: {
-                    rootStore.contactStore.markUntrustworthy(publicKey)
-                    if (removeContact) {
-                        rootStore.contactStore.removeContact(publicKey)
-                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts and marked as untrusted").arg(mainDisplayName))
+                    rootStore.contactStore.markUntrustworthy(markAsUntrustedPopup.publicKey)
+                    if (markAsUntrustedPopup.removeContact) {
+                        rootStore.contactStore.removeContact(markAsUntrustedPopup.publicKey)
+                        Global.displaySuccessToastMessage(qsTr("%1 removed from contacts and marked as untrusted").arg(markAsUntrustedPopup.mainDisplayName))
                     } else {
-                        Global.displaySuccessToastMessage(qsTr("%1 marked as untrusted").arg(mainDisplayName))
+                        Global.displaySuccessToastMessage(qsTr("%1 marked as untrusted").arg(markAsUntrustedPopup.mainDisplayName))
                     }
                     close()
                 }
@@ -694,13 +789,14 @@ QtObject {
         Component {
             id: blockContactConfirmationComponent
             BlockContactConfirmationDialog {
+                id: blockContactConfirmationComponentView
                 onAccepted: {
-                    rootStore.contactStore.blockContact(publicKey)
-                    if (removeIDVerification)
-                        rootStore.contactStore.removeTrustVerificationStatus(publicKey)
-                    if (removeContact)
-                        rootStore.contactStore.removeContact(publicKey)
-                    Global.displaySuccessToastMessage(qsTr("%1 blocked").arg(mainDisplayName))
+                    rootStore.contactStore.blockContact(blockContactConfirmationComponentView.publicKey)
+                    if (blockContactConfirmationComponentView.removeIDVerification)
+                        rootStore.contactStore.removeTrustVerificationStatus(blockContactConfirmationComponentView.publicKey)
+                    if (blockContactConfirmationComponentView.removeContact)
+                        rootStore.contactStore.removeContact(blockContactConfirmationComponentView.publicKey)
+                    Global.displaySuccessToastMessage(qsTr("%1 blocked").arg(blockContactConfirmationComponentView.mainDisplayName))
                     close()
                 }
                 onClosed: destroy()

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -269,7 +269,6 @@ QtObject {
         let details = contactDetails ?? Utils.getContactDetailsAsJson(publicKey, false)
         const popupProperties = {
             publicKey: publicKey,
-            // contactDetails: details
             localNickname: details.localNickname,
             name: details.name,
             displayName: details.displayName,

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -504,7 +504,7 @@ QtObject {
             id: sendIDRequestPopupComponent
             SendContactRequestModal {
                 id: sendIDRequestPopup
-                onAccepted: rootStore.contactStore.sendVerificationRequest(sendIDRequestPopup.publicKey, sendIDRequestPopup.message)
+                onAccepted: rootStore.contactStore.sendVerificationRequest(sendIDRequestPopup.publicKey, message)
                 onClosed: destroy()
             }
         },
@@ -562,7 +562,7 @@ QtObject {
 
             SendContactRequestModal {
                 id: sendContactRequestPopup
-                onAccepted: rootStore.contactStore.sendContactRequest(sendContactRequestPopup.publicKey, sendContactRequestPopup.message)
+                onAccepted: rootStore.contactStore.sendContactRequest(sendContactRequestPopup.publicKey, message)
                 onClosed: destroy()
             }
         },

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -152,19 +152,8 @@ QtObject {
 
     function getContactDetails(publicKey) {
         const details = Utils.getContactDetailsAsJson(publicKey)
-        return {
-            publicKey: publicKey,
-            localNickname: details.localNickname,
-            name: details.name,
-            displayName: details.displayName,
-            alias: details.alias,
-            ensVerified: details.ensVerified,
-            onlineStatus: details.onlineStatus,
-            largeImage: details.largeImage,
-            isContact: details.isContact,
-            trustStatus: details.trustStatus,
-            isBlocked: details.isBlocked
-        }
+        details.publicKey = publicKey
+        return details
     }
 
     function openNicknamePopup(publicKey: string, contactDetails, cb) {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -150,56 +150,41 @@ QtObject {
         openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup}, cb)
     }
 
-    function openNicknamePopup(publicKey: string, contactDetails, cb) {
-        openPopup(nicknamePopupComponent, {
+    function getContactDetails(publicKey) {
+        const details = Utils.getContactDetailsAsJson(publicKey)
+        return {
             publicKey: publicKey,
-            localNickname: contactDetails.localNickname,
-            name: contactDetails.name,
-            displayName: contactDetails.displayName,
-            alias: contactDetails.alias,
-            ensVerified: contactDetails.ensVerified,
-            onlineStatus: contactDetails.onlineStatus,
-            largeImage: contactDetails.largeImage,
-            isContact: contactDetails.isContact,
-            trustStatus: contactDetails.trustStatus,
-            isBlocked: contactDetails.isBlocked
-        }, cb)
+            localNickname: details.localNickname,
+            name: details.name,
+            displayName: details.displayName,
+            alias: details.alias,
+            ensVerified: details.ensVerified,
+            onlineStatus: details.onlineStatus,
+            largeImage: details.largeImage,
+            isContact: details.isContact,
+            trustStatus: details.trustStatus,
+            isBlocked: details.isBlocked
+        }
+    }
+
+    function openNicknamePopup(publicKey: string, contactDetails, cb) {
+        const details = getContactDetails(publicKey)
+        openPopup(nicknamePopupComponent, details, cb)
     }
 
     function openMarkAsUntrustedPopup(publicKey: string, contactDetails) {
-        openPopup(markAsUntrustedComponent, {
-            publicKey: publicKey,
-            localNickname: contactDetails.localNickname,
-            name: contactDetails.name,
-            displayName: contactDetails.displayName,
-            alias: contactDetails.alias,
-            ensVerified: contactDetails.ensVerified,
-            onlineStatus: contactDetails.onlineStatus,
-            largeImage: contactDetails.largeImage,
-            isContact: contactDetails.isContact,
-            trustStatus: contactDetails.trustStatus,
-            isBlocked: contactDetails.isBlocked
-        })
+        const details = getContactDetails(publicKey)
+        openPopup(markAsUntrustedComponent, details)
     }
 
     function openBlockContactPopup(publicKey: string, contactDetails) {
-        openPopup(blockContactConfirmationComponent, {
-            publicKey: publicKey,
-            localNickname: contactDetails.localNickname,
-            name: contactDetails.name,
-            displayName: contactDetails.displayName,
-            alias: contactDetails.alias,
-            ensVerified: contactDetails.ensVerified,
-            onlineStatus: contactDetails.onlineStatus,
-            largeImage: contactDetails.largeImage,
-            isContact: contactDetails.isContact,
-            trustStatus: contactDetails.trustStatus,
-            isBlocked: contactDetails.isBlocked
-        })
+        const details = getContactDetails(publicKey)
+        openPopup(blockContactConfirmationComponent, details)
     }
 
     function openUnblockContactPopup(publicKey: string, contactDetails) {
-        openPopup(unblockContactConfirmationComponent, {publicKey, contactDetails})
+        const details = getContactDetails(publicKey)
+        openPopup(unblockContactConfirmationComponent, details)
     }
 
     function openChangeProfilePicPopup(cb) {
@@ -216,78 +201,40 @@ QtObject {
     }
 
     function openSendIDRequestPopup(publicKey, contactDetails, cb) {
-        openPopup(sendIDRequestPopupComponent, {
-            publicKey: publicKey,
-            contactDetails: contactDetails,
-            title: qsTr("Request ID verification"),
-            labelText: qsTr("Ask a question only they can answer"),
-            challengeText: qsTr("Ask your question..."),
-            buttonText: qsTr("Request ID verification")
-        }, cb)
+        const details = getContactDetails(publicKey)
+        details.title = qsTr("Request ID verification")
+        details.labelText = qsTr("Ask a question only they can answer")
+        details.challengeText = qsTr("Ask your question...")
+        details.buttonText = qsTr("Request ID verification")
+        openPopup(sendIDRequestPopupComponent, details, cb)
     }
 
-    function openMarkAsIDVerifiedPopup(publicKey, contactDetails, cb) {
-        openPopup(markAsIDVerifiedPopupComponent, {
-            publicKey: publicKey,
-            localNickname: contactDetails.localNickname,
-            name: contactDetails.name,
-            displayName: contactDetails.displayName,
-            alias: contactDetails.alias,
-            ensVerified: contactDetails.ensVerified,
-            onlineStatus: contactDetails.onlineStatus,
-            largeImage: contactDetails.largeImage,
-            isContact: contactDetails.isContact,
-            trustStatus: contactDetails.trustStatus,
-            isBlocked: contactDetails.isBlocked
-        }, cb)
+    function openMarkAsIDVerifiedPopup(publicKey: string, contactDetails, cb) {
+        const details = getContactDetails(publicKey)
+        openPopup(markAsIDVerifiedPopupComponent, details, cb)
     }
 
-    function openRemoveIDVerificationDialog(publicKey, contactDetails, cb) {
-        openPopup(removeIDVerificationPopupComponent, {
-            publicKey: publicKey,
-            localNickname: contactDetails.localNickname,
-            name: contactDetails.name,
-            displayName: contactDetails.displayName,
-            alias: contactDetails.alias,
-            ensVerified: contactDetails.ensVerified,
-            onlineStatus: contactDetails.onlineStatus,
-            largeImage: contactDetails.largeImage,
-            isContact: contactDetails.isContact,
-            trustStatus: contactDetails.trustStatus,
-            isBlocked: contactDetails.isBlocked
-        }, cb)
+    function openRemoveIDVerificationDialog(publicKey: string, contactDetails, cb) {
+        const details = getContactDetails(publicKey)
+        openPopup(removeIDVerificationPopupComponent, details, cb)
     }
 
-    function openOutgoingIDRequestPopup(publicKey, contactDetails, cb) {
-        let details = contactDetails ?? Utils.getContactDetailsAsJson(publicKey)
+    function openOutgoingIDRequestPopup(publicKey: string, contactDetails, cb) {
+        let details = getContactDetails(publicKey)
         try {
             const verificationDetails = rootStore.contactStore.getSentVerificationDetailsAsJson(publicKey)
-            const popupProperties = {
-                publicKey: publicKey,
-                contactDetails: details,
-                verificationStatus: verificationDetails.requestStatus,
-                verificationChallenge: verificationDetails.challenge,
-                verificationResponse: verificationDetails.response,
-                verificationResponseDisplayName: verificationDetails.displayName,
-                verificationResponseIcon: verificationDetails.icon,
-                verificationRequestedAt: verificationDetails.requestedAt,
-                verificationRepliedAt: verificationDetails.repliedAt,
-                localNickname: contactDetails.localNickname,
-                name: contactDetails.name,
-                displayName: contactDetails.displayName,
-                alias: contactDetails.alias,
-                ensVerified: contactDetails.ensVerified,
-                onlineStatus: contactDetails.onlineStatus,
-                largeImage: contactDetails.largeImage,
-                isContact: contactDetails.isContact,
-                trustStatus: contactDetails.trustStatus,
-                isBlocked: contactDetails.isBlocked,
-                pubKey: Global.userProfile.pubKey,
-                preferredName: Global.userProfile.preferredName,
-                name: Global.userProfile.name,
-                icon: Global.userProfile.icon
-            }
-            openPopup(contactOutgoingVerificationRequestPopupComponent, popupProperties, cb)
+            details.verificationStatus = verificationDetails.requestStatus
+            details.verificationChallenge = verificationDetails.challenge
+            details.verificationResponse = verificationDetails.response
+            details.verificationResponseDisplayName = verificationDetails.displayName
+            details.verificationResponseIcon = verificationDetails.icon
+            details.verificationRequestedAt = verificationDetails.requestedAt
+            details.verificationRepliedAt = verificationDetails.repliedAt
+            details.pubKey = Global.userProfile.pubKey
+            details.preferredName = Global.userProfile.preferredName
+            details.name = Global.userProfile.name
+            details.icon = Global.userProfile.icon
+            openPopup(contactOutgoingVerificationRequestPopupComponent, details, cb)
         } catch (e) {
             console.error("Error getting or parsing verification data", e)
         }
@@ -413,21 +360,10 @@ QtObject {
     }
 
     function openRemoveContactConfirmationPopup(publicKey, contactDetails) {
-        openPopup(removeContactConfirmationDialog, {
-            publicKey: publicKey,
-            localNickname: contactDetails.localNickname,
-            name: contactDetails.name,
-            displayName: contactDetails.displayName,
-            alias: contactDetails.alias,
-            ensVerified: contactDetails.ensVerified,
-            onlineStatus: contactDetails.onlineStatus,
-            largeImage: contactDetails.largeImage,
-            isContact: contactDetails.isContact,
-            trustStatus: contactDetails.trustStatus,
-            isBlocked: contactDetails.isBlocked,
-            outgoingVerificationStatus: contactDetails.outgoingVerificationStatus,
-            incomingVerificationStatus: contactDetails.incomingVerificationStatus,
-        })
+        const details = getContactDetails(publicKey)
+        details.outgoingVerificationStatus = contactDetails.outgoingVerificationStatus
+        details.incomingVerificationStatus = contactDetails.incomingVerificationStatus
+        openPopup(removeContactConfirmationDialog, details)
     }
 
     function openDeleteMessagePopup(messageId, messageStore) {

--- a/ui/imports/shared/popups/BlockContactConfirmationDialog.qml
+++ b/ui/imports/shared/popups/BlockContactConfirmationDialog.qml
@@ -15,7 +15,6 @@ CommonContactDialog {
     readonly property bool removeIDVerification: ctrlRemoveIDVerification.checked
     readonly property bool removeContact: ctrlRemoveContact.checked
 
-    // New properties to replace contactDetails
     property bool isContact: false
     property int outgoingVerificationStatus: Constants.verificationStatus.untrustworthy
     property int incomingVerificationStatus: Constants.verificationStatus.untrustworthy

--- a/ui/imports/shared/popups/BlockContactConfirmationDialog.qml
+++ b/ui/imports/shared/popups/BlockContactConfirmationDialog.qml
@@ -15,12 +15,18 @@ CommonContactDialog {
     readonly property bool removeIDVerification: ctrlRemoveIDVerification.checked
     readonly property bool removeContact: ctrlRemoveContact.checked
 
+    // New properties to replace contactDetails
+    property bool isContact: false
+    property int outgoingVerificationStatus: Constants.verificationStatus.untrustworthy
+    property int incomingVerificationStatus: Constants.verificationStatus.untrustworthy
+    property int trustStatus: Constants.trustStatus.untrusted
+
     title: qsTr("Block user")
 
     readonly property var d: QtObject {
         id: d
-        readonly property bool isTrusted: contactDetails.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
-                                          contactDetails.incomingVerificationStatus === Constants.verificationStatus.trusted
+        readonly property bool isTrusted: root.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
+                                          root.incomingVerificationStatus === Constants.verificationStatus.trusted
     }
 
     StatusBaseText {
@@ -49,7 +55,7 @@ CommonContactDialog {
         Layout.topMargin: Style.current.halfPadding
         objectName: "removeContactCheckbox"
         id: ctrlRemoveContact
-        visible: contactDetails.isContact
+        visible: root.isContact
         checked: visible
         enabled: false
         text: qsTr("Remove contact")
@@ -57,7 +63,7 @@ CommonContactDialog {
 
     StatusCheckBox {
         id: ctrlRemoveIDVerification
-        visible: (contactDetails.isContact && d.isTrusted) || contactDetails.trustStatus === Constants.trustStatus.trusted
+        visible: (root.isContact && d.isTrusted) || root.trustStatus === Constants.trustStatus.trusted
         checked: visible
         enabled: false
         text: qsTr("Remove ID verification")

--- a/ui/imports/shared/popups/CommonContactDialog.qml
+++ b/ui/imports/shared/popups/CommonContactDialog.qml
@@ -16,19 +16,32 @@ import shared.controls.chat 1.0
 StatusDialog {
     id: root
 
-    required property string publicKey
-    required property var contactDetails
-    property bool loadingContactDetails
+    property string publicKey: ""
+    // Remove the contactDetails object
+    // required property var contactDetails
+    property bool loadingContactDetails: false
+
+    // Add individual required properties
+    property string localNickname
+    property string name
+    property string displayName
+    property string alias
+    property bool ensVerified
+    property int onlineStatus
+    property string largeImage
+    property bool isContact
+    property int trustStatus
+    property bool isBlocked
 
     default property alias content: contentLayout.children
 
     property ObjectModel rightButtons
 
     readonly property string mainDisplayName: StatusQUtils.Emoji.parse(
-                                                  ProfileUtils.displayName(contactDetails.localNickname, contactDetails.name,
-                                                                           contactDetails.displayName, contactDetails.alias))
+                                                  ProfileUtils.displayName(localNickname, name,
+                                                                           displayName, alias))
     readonly property string optionalDisplayName: StatusQUtils.Emoji.parse(
-                                                      ProfileUtils.displayName("", contactDetails.name, contactDetails.displayName, contactDetails.alias))
+                                                      ProfileUtils.displayName("", name, displayName, alias))
 
     width: Math.max(implicitWidth, 480)
     horizontalPadding: 0
@@ -45,12 +58,12 @@ StatusDialog {
             UserImage {
                 name: root.mainDisplayName
                 pubkey: root.publicKey
-                image: Utils.addTimestampToURL(contactDetails.largeImage)
+                image: Utils.addTimestampToURL(root.largeImage)
                 interactive: false
                 imageWidth: 60
                 imageHeight: 60
-                ensVerified: contactDetails.ensVerified
-                onlineStatus: contactDetails.onlineStatus
+                ensVerified: root.ensVerified
+                onlineStatus: root.onlineStatus
                 loading: root.loadingContactDetails
             }
 
@@ -77,9 +90,9 @@ StatusDialog {
                         anchors.left: contactName.right
                         anchors.leftMargin: Style.current.halfPadding
                         anchors.verticalCenter: contactName.verticalCenter
-                        isContact: contactDetails.isContact
-                        trustIndicator: contactDetails.trustStatus
-                        isBlocked: contactDetails.isBlocked
+                        isContact: root.isContact
+                        trustIndicator: root.trustStatus
+                        isBlocked: root.isBlocked
                         tiny: false
                     }
                 }
@@ -90,7 +103,7 @@ StatusDialog {
                         color: Theme.palette.baseColor1
                         font.pixelSize: 13
                         text: root.optionalDisplayName
-                        visible: !!contactDetails.localNickname
+                        visible: !!root.localNickname
                     }
                     Rectangle {
                         Layout.preferredWidth: 4

--- a/ui/imports/shared/popups/CommonContactDialog.qml
+++ b/ui/imports/shared/popups/CommonContactDialog.qml
@@ -17,11 +17,7 @@ StatusDialog {
     id: root
 
     property string publicKey: ""
-    // Remove the contactDetails object
-    // required property var contactDetails
     property bool loadingContactDetails: false
-
-    // Add individual required properties
     property string localNickname
     property string name
     property string displayName

--- a/ui/imports/shared/popups/MarkAsIDVerifiedDialog.qml
+++ b/ui/imports/shared/popups/MarkAsIDVerifiedDialog.qml
@@ -15,7 +15,7 @@ CommonContactDialog {
     StatusBaseText {
         Layout.fillWidth: true
         wrapMode: Text.WordWrap
-        text: qsTr("Mark users as ID verified only if you’re 100% sure who they are. Otherwise, it’s safer to send %1 an ID verification request.").arg(mainDisplayName)
+        text: qsTr("Mark users as ID verified only if you’re 100% sure who they are. Otherwise, it’s safer to send %1 an ID verification request.").arg(root.mainDisplayName)
     }
 
     rightButtons: ObjectModel {

--- a/ui/imports/shared/popups/MarkAsUntrustedPopup.qml
+++ b/ui/imports/shared/popups/MarkAsUntrustedPopup.qml
@@ -12,6 +12,12 @@ import utils 1.0
 CommonContactDialog {
     id: root
 
+    // New properties to replace contactDetails, with default values
+    property int verificationStatus: Constants.verificationStatus.unverified
+    property int incomingVerificationStatus: Constants.verificationStatus.unverified
+    property bool isContact: false
+    property int trustStatus: Constants.trustStatus.untrusted
+
     readonly property bool removeIDVerification: ctrlRemoveIDVerification.checked
     readonly property bool removeContact: ctrlRemoveContact.checked
 
@@ -19,8 +25,8 @@ CommonContactDialog {
 
     readonly property var d: QtObject {
         id: d
-        readonly property int outgoingVerificationStatus: contactDetails.verificationStatus
-        readonly property int incomingVerificationStatus: contactDetails.incomingVerificationStatus
+        readonly property int outgoingVerificationStatus: root.verificationStatus
+        readonly property int incomingVerificationStatus: root.incomingVerificationStatus
         readonly property bool isTrusted: outgoingVerificationStatus === Constants.verificationStatus.trusted ||
                                           incomingVerificationStatus === Constants.verificationStatus.trusted
     }
@@ -34,7 +40,7 @@ CommonContactDialog {
 
     StatusCheckBox {
         id: ctrlRemoveIDVerification
-        visible: (contactDetails.isContact && d.isTrusted) || contactDetails.trustStatus === Constants.trustStatus.trusted
+        visible: (root.isContact && d.isTrusted) || root.trustStatus === Constants.trustStatus.trusted
         checked: visible
         enabled: false
         text: qsTr("Remove ID verification")
@@ -42,7 +48,7 @@ CommonContactDialog {
 
     StatusCheckBox {
         id: ctrlRemoveContact
-        visible: contactDetails.isContact
+        visible: root.isContact
         text: qsTr("Remove contact")
     }
 

--- a/ui/imports/shared/popups/MarkAsUntrustedPopup.qml
+++ b/ui/imports/shared/popups/MarkAsUntrustedPopup.qml
@@ -12,7 +12,6 @@ import utils 1.0
 CommonContactDialog {
     id: root
 
-    // New properties to replace contactDetails, with default values
     property int verificationStatus: Constants.verificationStatus.unverified
     property int incomingVerificationStatus: Constants.verificationStatus.unverified
     property bool isContact: false

--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -15,7 +15,6 @@ import utils 1.0
 CommonContactDialog {
     id: root
 
-    property string publicKey: ""
     property string nickname: ""
 
     signal editDone(string newNickname)

--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -15,7 +15,8 @@ import utils 1.0
 CommonContactDialog {
     id: root
 
-    readonly property string nickname: contactDetails.localNickname
+    property string publicKey: ""
+    property string nickname: ""
 
     signal editDone(string newNickname)
     signal removeNicknameRequested()

--- a/ui/imports/shared/popups/OutgoingContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/OutgoingContactVerificationRequestPopup.qml
@@ -20,12 +20,14 @@ CommonContactDialog {
     property string verificationResponseIcon
     property string verificationRequestedAt
     property string verificationRepliedAt
+    property bool ensVerified
 
     readonly property bool hasReply: root.verificationResponse !== ""
 
-    signal verificationRequestCanceled(string publicKey)
-    signal untrustworthyVerified(string publicKey)
-    signal trustedVerified(string publicKey)
+    signal verificationRequestCanceled()
+    signal untrustworthyVerified()
+    signal trustedVerified()
+    signal onLinkActivated()
 
     title: !hasReply ? qsTr("ID verification pending") : qsTr("Review ID verification reply")
 
@@ -36,7 +38,7 @@ CommonContactDialog {
             borderColor: "transparent"
             visible: !root.hasReply
             onClicked: {
-                root.verificationRequestCanceled(root.publicKey)
+                root.verificationRequestCanceled()
                 root.close()
             }
         }
@@ -51,7 +53,7 @@ CommonContactDialog {
             visible: root.hasReply
             type: StatusBaseButton.Type.Danger
             onClicked: {
-                root.untrustworthyVerified(root.publicKey)
+                root.untrustworthyVerified()
                 root.close()
             }
         }
@@ -60,7 +62,7 @@ CommonContactDialog {
             visible: root.hasReply
             type: StatusBaseButton.Type.Success
             onClicked: {
-                root.trustedVerified(root.publicKey)
+                root.trustedVerified()
                 root.close()
             }
         }
@@ -91,7 +93,7 @@ CommonContactDialog {
         messageDetails.sender.profileImage.assetSettings.isImage: true
         messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(root.publicKey)
         messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(root.publicKey)
-        messageDetails.sender.isEnsVerified: contactDetails.ensVerified
+        messageDetails.sender.isEnsVerified: root.ensVerified
         Layout.fillWidth: true
     }
 
@@ -105,10 +107,6 @@ CommonContactDialog {
         wrapMode: Text.WordWrap
         textFormat: Text.RichText
         color: root.hasReply ? Theme.palette.directColor1 : Theme.palette.baseColor1
-        onLinkActivated: {
-            root.verificationRequestCanceled(root.publicKey)
-            root.close()
-            Global.openSendIDRequestPopup(root.publicKey, root.contactDetails, null)
-        }
+        onLinkActivated: root.onLinkActivated()
     }
 }

--- a/ui/imports/shared/popups/OutgoingContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/OutgoingContactVerificationRequestPopup.qml
@@ -21,13 +21,17 @@ CommonContactDialog {
     property string verificationRequestedAt
     property string verificationRepliedAt
     property bool ensVerified
+    property string pubKey
+    property string preferredName
+    property string name
+    property string icon
 
     readonly property bool hasReply: root.verificationResponse !== ""
 
     signal verificationRequestCanceled()
     signal untrustworthyVerified()
     signal trustedVerified()
-    signal onLinkActivated()
+    signal linkActivated()
 
     title: !hasReply ? qsTr("ID verification pending") : qsTr("Review ID verification reply")
 
@@ -72,11 +76,11 @@ CommonContactDialog {
         id: challengeMessage
         timestamp: root.verificationRequestedAt
         messageDetails.messageText: root.verificationChallenge
-        messageDetails.sender.id: Global.userProfile.pubKey
-        messageDetails.sender.displayName: Global.userProfile.name
-        messageDetails.sender.profileImage.name: Global.userProfile.icon
+        messageDetails.sender.id: root.pubKey
+        messageDetails.sender.displayName: root.name
+        messageDetails.sender.profileImage.name: root.icon
         messageDetails.sender.profileImage.assetSettings.isImage: true
-        messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(Global.userProfile.pubKey)
+        messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(root.pubKey)
         messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(Global.userProfile.pubKey, !!Global.userProfile.preferredName)
         messageDetails.sender.isEnsVerified: !!Global.userProfile.preferredName
         Layout.fillWidth: true
@@ -107,6 +111,6 @@ CommonContactDialog {
         wrapMode: Text.WordWrap
         textFormat: Text.RichText
         color: root.hasReply ? Theme.palette.directColor1 : Theme.palette.baseColor1
-        onLinkActivated: root.onLinkActivated()
+        onLinkActivated: root.linkActivated()
     }
 }

--- a/ui/imports/shared/popups/RemoveContactPopup.qml
+++ b/ui/imports/shared/popups/RemoveContactPopup.qml
@@ -12,6 +12,10 @@ import utils 1.0
 CommonContactDialog {
     id: root
 
+    property int outgoingVerificationStatus: Constants.verificationStatus.unverified
+    property int incomingVerificationStatus: Constants.verificationStatus.unverified
+    property int trustStatus: Constants.trustStatus.none
+
     readonly property bool removeIDVerification: ctrlRemoveIDVerification.checked
     readonly property bool markAsUntrusted: ctrlMarkAsUntrusted.checked
 
@@ -19,8 +23,8 @@ CommonContactDialog {
 
     readonly property var d: QtObject {
         id: d
-        readonly property bool isTrusted: contactDetails.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
-                                          contactDetails.incomingVerificationStatus === Constants.verificationStatus.trusted
+        readonly property bool isTrusted: root.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
+                                          root.incomingVerificationStatus === Constants.verificationStatus.trusted
     }
 
     StatusBaseText {
@@ -32,7 +36,7 @@ CommonContactDialog {
 
     StatusCheckBox {
         id: ctrlRemoveIDVerification
-        visible: d.isTrusted || contactDetails.trustStatus === Constants.trustStatus.trusted
+        visible: d.isTrusted || root.trustStatus === Constants.trustStatus.trusted
         checked: visible
         enabled: false
         text: qsTr("Remove ID verification")
@@ -40,7 +44,7 @@ CommonContactDialog {
 
     StatusCheckBox {
         id: ctrlMarkAsUntrusted
-        visible: contactDetails.trustStatus !== Constants.trustStatus.untrustworthy
+        visible: root.trustStatus !== Constants.trustStatus.untrustworthy
         text: qsTr("Mark %1 as untrusted").arg(mainDisplayName)
     }
 

--- a/ui/imports/shared/popups/RemoveIDVerificationDialog.qml
+++ b/ui/imports/shared/popups/RemoveIDVerificationDialog.qml
@@ -19,12 +19,12 @@ CommonContactDialog {
         Layout.fillWidth: true
         Layout.bottomMargin: Style.current.halfPadding
         wrapMode: Text.WordWrap
-        text: qsTr("%1’s identity will no longer be verified. This is only visible to you.").arg(mainDisplayName)
+        text: qsTr("%1’s identity will no longer be verified. This is only visible to you.").arg(root.mainDisplayName)
     }
 
     StatusCheckBox {
         id: ctrlMarkAsUntrusted
-        text: qsTr("Mark %1 as untrusted").arg(mainDisplayName)
+        text: qsTr("Mark %1 as untrusted").arg(root.mainDisplayName)
     }
 
     StatusCheckBox {

--- a/ui/imports/shared/popups/ReviewContactRequestPopup.qml
+++ b/ui/imports/shared/popups/ReviewContactRequestPopup.qml
@@ -12,11 +12,14 @@ import utils 1.0
 CommonContactDialog {
     id: root
 
-    // expected roles: id, from, clock, text, contactRequestState
-    required property var crDetails
+    property string contactRequestId: ""
+    property string fromAddress: ""
+    property int clock: 0
+    property string text: ""
+    property int contactRequestState: 0
 
-    signal accepted(string contactRequestId)
-    signal discarded(string contactRequestId)
+    signal accepted()
+    signal discarded()
 
     title: qsTr("Review contact request")
 
@@ -35,12 +38,12 @@ CommonContactDialog {
 
             StatusTimeStampLabel {
                 Layout.maximumWidth: parent.width
-                timestamp: crDetails.clock
+                timestamp: root.clock
             }
             StatusBaseText {
                 Layout.fillWidth: true
                 wrapMode: Text.WordWrap
-                text: crDetails.text
+                text: root.text
             }
         }
     }
@@ -49,13 +52,13 @@ CommonContactDialog {
         StatusFlatButton {
             text: qsTr("Ignore")
             objectName: "ignoreButton"
-            onClicked: root.discarded(crDetails.id ?? "")
+            onClicked: root.discarded()
         }
         StatusButton {
             text: qsTr("Accept")
             type: StatusBaseButton.Type.Success
             objectName: "acceptButton"
-            onClicked: root.accepted(crDetails.id ?? "")
+            onClicked: root.accepted()
         }
     }
 }

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -15,8 +15,6 @@ import AppLayouts.stores 1.0 as AppLayoutStores
 CommonContactDialog {
     id: root
 
-    property AppLayoutStores.RootStore rootStore
-
     property string labelText: qsTr("Why should they accept your contact request?")
     property string challengeText: qsTr("Write a short message telling them who you are...")
     property string buttonText: qsTr("Send contact request")
@@ -25,49 +23,23 @@ CommonContactDialog {
 
     title: qsTr("Send contact request")
 
-    onAboutToShow: {
-        messageInput.input.edit.forceActiveFocus()
-
-        // (request) update from mailserver
-        if (d.userDisplayName === "") {
-            root.rootStore.contactStore.requestContactInfo(root.publicKey)
-            root.loadingContactDetails = true
-        }
-    }
-
-    readonly property var d: QtObject {
-        id: d
-
-        readonly property int maxMsgLength: 280
-        readonly property int minMsgLength: 1
-        readonly property int msgHeight: 152
-    }
-
-    readonly property var _conn: Connections {
-        target: root.rootStore.contactStore.contactsModule
-
-        function onContactInfoRequestFinished(publicKey, ok) {
-            if (publicKey !== root.publicKey)
-                return
-            if (ok)
-                root.contactDetails = Utils.getContactDetailsAsJson(root.publicKey, false)
-            root.loadingContactDetails = false
-        }
-    }
+    readonly property int maxMsgLength: 280
+    readonly property int minMsgLength: 1
+    readonly property int msgHeight: 152
 
     StatusInput {
         id: messageInput
         input.edit.objectName: "ProfileSendContactRequestModal_sayWhoYouAreInput"
         Layout.fillWidth: true
         label: root.labelText
-        charLimit: d.maxMsgLength
+        charLimit: root.maxMsgLength
         placeholderText: root.challengeText
         input.multiline: true
-        minimumHeight: d.msgHeight
-        maximumHeight: d.msgHeight
+        minimumHeight: root.msgHeight
+        maximumHeight: root.msgHeight
         input.verticalAlignment: TextEdit.AlignTop
         validators: StatusMinLengthValidator {
-            minLength: d.minMsgLength
+            minLength: root.minMsgLength
             errorMessage: Utils.getErrorMessage(messageInput.errors, qsTr("who are you"))
         }
     }

--- a/ui/imports/shared/popups/UnblockContactConfirmationDialog.qml
+++ b/ui/imports/shared/popups/UnblockContactConfirmationDialog.qml
@@ -17,7 +17,7 @@ CommonContactDialog {
         objectName: "unblockingText"
         Layout.fillWidth: true
         wrapMode: Text.WordWrap
-        text: qsTr("Unblocking %1 will allow new messages you receive from %1 to reach you.").arg(mainDisplayName)
+        text: qsTr("Unblocking %1 will allow new messages you receive from %1 to reach you.").arg(root.mainDisplayName)
     }
 
     rightButtons: ObjectModel {


### PR DESCRIPTION
### What does the PR do

Refactors the various popups to remove logic, make them functional and simplifies the code. Also added storybook pages for each of these components.

### Affected areas

Popups affected:
- Send Contact Request Popup
- Review Contact Request Popup
- Remove Contact Popup
- Mark as Untrusted Popup
- Add Nickname Popup
- Block Contact popup
- Unblock Contact popup

Also affected but not testable right now because this feature is disabled (and likely will be removed):
- Contact Verification Popup
- Mark as ID Verified Popup
- Remove ID verification Popup
- Outgoing Contact Verification Request Popup

### Impact on end user

The behaviour of these popups should remain the same

### How to test

Generally, right clicking on the user profile and select the menu item, then test if the functionality still works.

example:
1. right click on a profile that is already a contact
2. click remove contact

expectation: the popup should contain the correct data about the user

3. click remove contact

expectation: contact should be removed

ID verification is less of a concern as this feature is disabled, no testing of this is expected.

### Risk 

Main risk is one of the popups listed in "Popups affected" no longer working.
