### PR TITLE
stores: move wallet-related methods/properties from shared/stores/RootStore to dedicated stores

### DIFF
--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -96,7 +96,6 @@ SplitView {
                 usersModel: fakeUsersModel
 
                 sharedStore: SharedStores.RootStore {
-                    property bool isWalletEnabled: true
                     property bool gifUnfurlingEnabled: true
 
                     property var gifStore: SharedStores.GifStore {

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -29,7 +29,6 @@ Item {
             usersModel: ListModel {}
 
             sharedStore: SharedStores.RootStore {
-                property bool isWalletEnabled: true
                 property bool gifUnfurlingEnabled: true
 
                 property var gifStore: SharedStores.GifStore {

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -118,7 +118,7 @@ Item {
                                                                      RootStore.lastReloadTimestamp * 1000) : ""
                     tooltip.text: qsTr("Last refreshed %1").arg(lastReloadTimeFormated)
 
-                    onClicked: RootStore.walletSectionInst.reloadAccountTokens()
+                    onClicked: RootStore.reloadAccountTokens()
 
                     Timer {
                         id: throttleTimer

--- a/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
@@ -271,6 +271,7 @@ StatusModal {
                            isWatchOnlyAccount: false,
                            mixedcaseAddress: d.address
                        })
+            walletRootStore: WalletStore.RootStore
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -34,6 +34,8 @@ QtObject {
     readonly property string signingPhrase: walletSectionInst.signingPhrase
     readonly property string mnemonicBackedUp: walletSectionInst.isMnemonicBackedUp
 
+    readonly property var transactionActivityStatus: walletSectionInst.activityController.status
+
     /* This property holds networks currently selected in the Wallet Main layout  */
     readonly property var networkFilters: networksModule.enabledChainIds
     readonly property var networkFiltersArray: networkFilters.split(":").filter(Boolean).map(Number)
@@ -109,6 +111,11 @@ QtObject {
 
     readonly property bool isAccountTokensReloading: walletSectionInst.isAccountTokensReloading
     readonly property double lastReloadTimestamp: walletSectionInst.lastReloadTimestamp
+
+    readonly property var historyTransactions: walletSectionInst.activityController.model
+    readonly property bool loadingHistoryTransactions: walletSectionInst.activityController.status.loadingData
+    readonly property bool newDataAvailable: walletSectionInst.activityController.status.newDataAvailable
+    readonly property bool isNonArchivalNode: walletSectionInst.isNonArchivalNode
 
     signal savedAddressAddedOrUpdated(added: bool, name: string, address: string, errorMsg: string)
     signal savedAddressDeleted(name: string, address: string, errorMsg: string)
@@ -584,5 +591,39 @@ QtObject {
                 }
         }
         return undefined
+    }
+
+    function resetActivityData() {
+        root.walletSectionInst.activityController.resetActivityData()
+    }
+
+    function updateTransactionFilterIfDirty() {
+        if (root.transactionActivityStatus.isFilterDirty)
+            root.walletSectionInst.activityController.updateFilter()
+    }
+
+    function getTxDetails() {
+        return root.walletSectionInst.activityDetailsController.activityDetails
+    }
+
+    function fetchTxDetails(txID) {
+        root.walletSectionInst.activityController.fetchTxDetails(txID)
+        root.walletSectionInst.activityDetailsController.fetchExtraTxDetails()
+    }
+
+    function fetchDecodedTxData(txHash, input) {
+        root.walletSectionInst.fetchDecodedTxData(txHash, input)
+    }
+
+    function fetchMoreTransactions() {
+        if (root.historyTransactions.count === 0
+                || !root.historyTransactions.hasMore
+                || root.loadingHistoryTransactions)
+            return
+        root.walletSectionInst.activityController.loadMoreItems()
+    }
+
+    function reloadAccountTokens() {
+        root.walletSectionInst.reloadAccountTokens()
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -14,6 +14,9 @@ QtObject {
 
     readonly property double tokenListUpdatedAt: root._allTokensModule.tokenListUpdatedAt
 
+    readonly property bool marketHistoryIsLoading: Global.appIsReady ? walletSectionAllTokens.marketHistoryIsLoading : false
+    readonly property bool balanceHistoryIsLoading: Global.appIsReady ? walletSectionAllTokens.balanceHistoryIsLoading : false
+
     /* This contains the different sources for the tokens list
        ex. uniswap list, status tokens list */
     readonly property var sourcesOfTokensModel: SortFilterProxyModel {
@@ -114,6 +117,14 @@ QtObject {
     readonly property bool displayAssetsBelowBalance: root._allTokensModule.displayAssetsBelowBalance
 
     signal displayAssetsBelowBalanceThresholdChanged()
+
+    function getHistoricalDataForToken(symbol, currency) {
+        root._allTokensModule.getHistoricalDataForToken(symbol, currency)
+    }
+
+    function fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum) {
+        root._allTokensModule.fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum)
+    }
 
     function getDisplayAssetsBelowBalanceThresholdCurrency() {
         return root._allTokensModule.displayAssetsBelowBalanceThreshold

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -15,6 +15,8 @@ import shared.views 1.0
 import shared.controls 1.0
 import shared.stores 1.0
 
+import AppLayouts.Wallet.stores 1.0 as WalletStores
+
 import SortFilterProxyModel 0.2
 
 import "../controls"
@@ -26,6 +28,7 @@ Item {
     id: root
 
     property var token: ({})
+    property WalletStores.TokensStore tokensStore
     property CurrenciesStore currencyStore
     property NetworkConnectionStore networkConnectionStore
     property var allNetworksModel
@@ -187,7 +190,7 @@ Item {
                                     LocaleUtils.getMonthYear(value)
                     }
                     chart.type: 'line'
-                    chart.labels: RootStore.marketHistoryIsLoading ? [] : graphDetail.labelsData
+                    chart.labels: root.tokensStore.marketHistoryIsLoading ? [] : graphDetail.labelsData
                     chart.datasets: {
                         return [{
                             xAxisId: 'x-axis-1',
@@ -196,7 +199,7 @@ Item {
                             borderColor: (Theme.palette.name === "dark") ? 'rgba(136, 176, 255, 1)' : 'rgba(67, 96, 223, 1)',
                             borderWidth: graphDetail.selectedGraphType === AssetsDetailView.GraphType.Price ? 3 : 2,
                             pointRadius: 0,
-                            data: RootStore.marketHistoryIsLoading ? [] : graphDetail.dataRange,
+                            data: root.tokensStore.marketHistoryIsLoading ? [] : graphDetail.dataRange,
                             parsing: false,
                         }]
                     }
@@ -310,7 +313,7 @@ Item {
 
                     LoadingGraphView {
                         anchors.fill: chart
-                        active: RootStore.marketHistoryIsLoading
+                        active: root.tokensStore.marketHistoryIsLoading
                     }
 
                     function updateBalanceStore() {
@@ -318,7 +321,7 @@ Item {
 
                         let currencySymbol = RootStore.currencyStore.currentCurrency
                         if(!balanceStore.hasData(root.address, token.symbol, currencySymbol, selectedTimeRangeEnum) || d.forceRefreshBalanceStore) {
-                            RootStore.fetchHistoricalBalanceForTokenAsJson(root.address, token.symbol, currencySymbol, selectedTimeRangeEnum)
+                            root.tokensStore.fetchHistoricalBalanceForTokenAsJson(root.address, token.symbol, currencySymbol, selectedTimeRangeEnum)
                         }
                     }
 

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -305,8 +305,8 @@ RightTabBaseView {
                         onAssetClicked: (key) => {
                             const token = ModelUtils.getByKey(model, "key", key)
 
-                            SharedStores.RootStore.getHistoricalDataForToken(
-                                        token.symbol, RootStore.currencyStore.currentCurrency)
+                            RootStore.tokensStore.getHistoricalDataForToken(
+                                                token.symbol, RootStore.currencyStore.currentCurrency)
 
                             assetDetailView.token = token
                             RootStore.setCurrentViewedHolding(
@@ -468,6 +468,7 @@ RightTabBaseView {
 
             visible: (stack.currentIndex === 2)
 
+            tokensStore: RootStore.tokensStore
             allNetworksModel: RootStore.filteredFlatModel
             address: RootStore.overview.mixedcaseAddress
             currencyStore: RootStore.currencyStore

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -423,6 +423,7 @@ RightTabBaseView {
                     id: historyView
                     HistoryView {
                         overview: RootStore.overview
+                        walletRootStore: RootStore
                         communitiesStore: root.communitiesStore
                         showAllAccounts: RootStore.showAllAccounts
                         sendModal: root.sendModal

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -68,7 +68,7 @@ Item {
         onDetailsChanged: {
             if (!!d.details && !!d.details.input && d.details.input !== "0x") {
                 d.loadingInputDate = true
-                root.rootStore.fetchDecodedTxData(d.details.txHashOut, d.details.input)
+                WalletStores.RootStore.fetchDecodedTxData(d.details.txHashOut, d.details.input)
             }
         }
 
@@ -128,7 +128,7 @@ Item {
     }
 
     Connections {
-        target: root.rootStore.walletSectionInst
+        target: WalletStores.RootStore.walletSectionInst
         function onTxDecoded(txHash: string, dataDecoded: string) {
             if (!d.isTransactionValid || (d.isDetailsValid && txHash !== d.details.txHashOut))
                 return

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -631,6 +631,8 @@ Item {
             store: appMain.rootChatStore
             transactionStore: appMain.transactionStore
             walletAssetsStore: appMain.walletAssetsStore
+
+            isWalletEnabled: appMain.rootStore.profileSectionStore.profileStore.isWalletEnabled
         }
     }
 

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -13,7 +13,6 @@ import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
-import shared.stores 1.0 as SharedStores
 import shared.popups.send 1.0
 import shared.stores.send 1.0
 
@@ -30,6 +29,7 @@ Item {
     required property WalletAssetsStore walletAssetsStore
     property string packId
     property bool marketVisible
+    property bool isWalletEnabled
 
     signal backClicked
     signal uninstallClicked(string packId)
@@ -81,7 +81,7 @@ Item {
                 }
             }
 
-            readonly property bool walletEnabled: SharedStores.RootStore.isWalletEnabled
+            readonly property bool walletEnabled: root.isWalletEnabled
             onWalletEnabledChanged: {
                 update()
             }

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -22,6 +22,8 @@ Popup {
     required property TransactionStore transactionStore
     required property WalletAssetsStore walletAssetsStore
 
+    property alias isWalletEnabled: stickerMarket.isWalletEnabled
+
     signal stickerSelected(string hashId, string packId, string url)
 
     QtObject {
@@ -95,6 +97,7 @@ Popup {
 
         StatusStickerMarket {
             id: stickerMarket
+
             visible: false
             Layout.fillWidth: true
             Layout.fillHeight: true

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -63,11 +63,6 @@ QtObject {
             walletSectionInst.activityController.updateFilter()
     }
 
-    function getHistoricalDataForToken(symbol, currency) {
-        if (Global.appIsReady)
-            walletSectionAllTokens.getHistoricalDataForToken(symbol,currency)
-    }
-
     function fetchDecodedTxData(txHash, input) {
         walletSectionInst.fetchDecodedTxData(txHash, input)
     }
@@ -80,14 +75,4 @@ QtObject {
     function getTxDetails() {
         return walletSectionInst.activityDetailsController.activityDetails
     }
-
-    property bool marketHistoryIsLoading: Global.appIsReady? walletSectionAllTokens.marketHistoryIsLoading : false
-
-    function fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum) {
-        if (Global.appIsReady)
-            walletSectionAllTokens.fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum)
-    }
-
-    property bool balanceHistoryIsLoading: Global.appIsReady? walletSectionAllTokens.balanceHistoryIsLoading : false
-
 }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -24,8 +24,6 @@ QtObject {
 
     property TokenMarketValuesStore marketValueStore: TokenMarketValuesStore {}
 
-    property var flatNetworks: networksModule.flatNetworks
-
     function setNeverAskAboutUnfurlingAgain(value) {
         localAccountSensitiveSettings.neverAskAboutUnfurlingAgain = value;
     }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -11,7 +11,6 @@ QtObject {
     property var profileSectionModuleInst: profileSectionModule
     property var privacyModule: profileSectionModuleInst.privacyModule
     property var userProfileInst: !!Global.userProfile? Global.userProfile : null
-    property var walletSectionInst: Global.appIsReady && !!walletSection? walletSection : null
     property var appSettingsInst: Global.appIsReady && !!appSettings? appSettings : null
     property var accountSensitiveSettings: Global.appIsReady && !!localAccountSensitiveSettings? localAccountSensitiveSettings : null
     property real volume: !!appSettingsInst ? appSettingsInst.volume * 0.01 : 0.5
@@ -23,18 +22,7 @@ QtObject {
 
     property CurrenciesStore currencyStore: CurrenciesStore {}
 
-    readonly property var transactionActivityStatus: Global.appIsReady ? walletSectionInst.activityController.status : null
-
-    property var historyTransactions: Global.appIsReady? walletSectionInst.activityController.model : null
-    readonly property bool loadingHistoryTransactions: Global.appIsReady && walletSectionInst.activityController.status.loadingData
-    readonly property bool newDataAvailable: Global.appIsReady && walletSectionInst.activityController.status.newDataAvailable
-    property bool isNonArchivalNode: Global.appIsReady && walletSectionInst.isNonArchivalNode
-
-    property TokenMarketValuesStore marketValueStore: TokenMarketValuesStore{}
-
-    function resetActivityData() {
-        walletSectionInst.activityController.resetActivityData()
-    }
+    property TokenMarketValuesStore marketValueStore: TokenMarketValuesStore {}
 
     property var flatNetworks: networksModule.flatNetworks
 
@@ -48,31 +36,5 @@ QtObject {
 
     function getPasswordStrengthScore(password) {
         return root.privacyModule.getPasswordStrengthScore(password);
-    }
-
-    function fetchMoreTransactions() {
-        if (RootStore.historyTransactions.count === 0
-                || !RootStore.historyTransactions.hasMore
-                || loadingHistoryTransactions)
-            return
-        walletSectionInst.activityController.loadMoreItems()
-    }
-
-    function updateTransactionFilterIfDirty() {
-        if (transactionActivityStatus.isFilterDirty)
-            walletSectionInst.activityController.updateFilter()
-    }
-
-    function fetchDecodedTxData(txHash, input) {
-        walletSectionInst.fetchDecodedTxData(txHash, input)
-    }
-
-    function fetchTxDetails(txID) {
-        walletSectionInst.activityController.fetchTxDetails(txID)
-        walletSectionInst.activityDetailsController.fetchExtraTxDetails()
-    }
-
-    function getTxDetails() {
-        return walletSectionInst.activityDetailsController.activityDetails
     }
 }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -14,7 +14,6 @@ QtObject {
     property var appSettingsInst: Global.appIsReady && !!appSettings? appSettings : null
     property var accountSensitiveSettings: Global.appIsReady && !!localAccountSensitiveSettings? localAccountSensitiveSettings : null
     property real volume: !!appSettingsInst ? appSettingsInst.volume * 0.01 : 0.5
-    property bool isWalletEnabled: Global.appIsReady? mainModule.sectionsModel.getItemEnabledBySectionType(Constants.appSection.wallet) : true
 
     property bool notificationSoundsEnabled: !!appSettingsInst ? appSettingsInst.notificationSoundsEnabled : true
     property bool neverAskAboutUnfurlingAgain: !!accountSensitiveSettings ? accountSensitiveSettings.neverAskAboutUnfurlingAgain : false

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -489,7 +489,7 @@ ColumnLayout {
                 Layout.fillWidth: true
                 modelData: transactionDelegate.model.activityEntry
                 timeStampText: isModelDataValid ? LocaleUtils.formatRelativeTimestamp(modelData.timestamp * 1000, true) : ""
-                flatNetworks: RootStore.flatNetworks
+                flatNetworks: root.walletRootStore.flatNetworks
                 currenciesStore: RootStore.currencyStore
                 walletRootStore: root.walletRootStore
                 showAllAccounts: root.showAllAccounts
@@ -554,7 +554,7 @@ ColumnLayout {
                 TransactionDelegate {
                     Layout.fillWidth: true
 
-                    flatNetworks: RootStore.flatNetworks
+                    flatNetworks: root.walletRootStore.flatNetworks
                     currenciesStore: RootStore.currencyStore
                     walletRootStore: root.walletRootStore
                     loading: true

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -57,7 +57,7 @@ ColumnLayout {
     }
 
     Component.onCompleted: {
-        if (RootStore.transactionActivityStatus.isFilterDirty) {
+        if (root.walletRootStore.transactionActivityStatus.isFilterDirty) {
             root.walletRootStore.currentActivityFiltersStore.applyAllFilters()
         }
 
@@ -66,10 +66,10 @@ ColumnLayout {
     }
 
     Connections {
-        target: RootStore.transactionActivityStatus
+        target: root.walletRootStore.transactionActivityStatus
         enabled: root.visible
         function onIsFilterDirtyChanged() {
-            RootStore.updateTransactionFilterIfDirty()
+            root.walletRootStore.updateTransactionFilterIfDirty()
         }
         function onFilterChainsChanged() {
             root.walletRootStore.currentActivityFiltersStore.updateCollectiblesModel()
@@ -89,7 +89,7 @@ ColumnLayout {
 
     QtObject {
         id: d
-        readonly property bool isInitialLoading: RootStore.loadingHistoryTransactions && transactionListRoot.count === 0
+        readonly property bool isInitialLoading: root.walletRootStore.loadingHistoryTransactions && transactionListRoot.count === 0
 
         readonly property int loadingSectionWidth: 56
 
@@ -101,7 +101,7 @@ ColumnLayout {
 
         function openTxDetails(txID) {
             // Prevent opening details when loading, that will invalidate the model data
-            if (RootStore.loadingHistoryTransactions) {
+            if (root.walletRootStore.loadingHistoryTransactions) {
                 return false
             }
 
@@ -148,7 +148,7 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignTop
         Layout.topMargin: root.firstItemOffset
-        visible: RootStore.isNonArchivalNode
+        visible: root.walletRootStore.isNonArchivalNode
         text: qsTr("Status Desktop is connected to a non-archival node. Transaction history may be incomplete.")
         font.pixelSize: Style.current.primaryTextFontSize
         color: Style.current.danger
@@ -204,7 +204,7 @@ ColumnLayout {
                     if (d.openTxDetails(d.openTxDetailsHash)) {
                         d.openTxDetailsHash = ""
                     } else {
-                        RootStore.fetchMoreTransactions()
+                        root.walletRootStore.fetchMoreTransactions()
                     }
                 }
             }
@@ -212,7 +212,7 @@ ColumnLayout {
             model: SortFilterProxyModel {
                 id: txModel
 
-                sourceModel: RootStore.historyTransactions
+                sourceModel: root.walletRootStore.historyTransactions
 
                 // LocaleUtils is not accessable from inside expression, but local function works
                 property var daysTo: (d1, d2) => LocaleUtils.daysTo(d1, d2)
@@ -267,16 +267,17 @@ ColumnLayout {
             }
 
             Connections {
-                target: RootStore
+                target: root.walletRootStore
+
                 function onLoadingHistoryTransactionsChanged() {
                     // Calling timer instead directly to not cause binding loop
-                    if (!RootStore.loadingHistoryTransactions)
+                    if (!root.walletRootStore.loadingHistoryTransactions)
                         fetchMoreTimer.start()
                 }
             }
 
             function tryFetchMoreTransactions() {
-                if (d.isInitialLoading || !footerItem || !RootStore.historyTransactions.hasMore)
+                if (d.isInitialLoading || !footerItem || !root.walletRootStore.historyTransactions.hasMore)
                     return
                 const footerYPosition = footerItem.height / contentHeight
                 if (footerYPosition >= 1.0) {
@@ -285,7 +286,7 @@ ColumnLayout {
 
                 // On startup, first loaded ListView will have heightRatio equal 0
                 if (footerYPosition + visibleArea.yPosition + visibleArea.heightRatio > 1.0) {
-                    RootStore.fetchMoreTransactions()
+                    root.walletRootStore.fetchMoreTransactions()
                 }
             }
 
@@ -304,8 +305,8 @@ ColumnLayout {
 
             text: qsTr("New transactions")
 
-            visible: RootStore.newDataAvailable && !RootStore.loadingHistoryTransactions
-            onClicked: RootStore.resetActivityData()
+            visible: root.walletRootStore.newDataAvailable && !root.walletRootStore.loadingHistoryTransactions
+            onClicked: root.walletRootStore.resetActivityData()
 
             icon.name: "arrow-up"
 
@@ -389,8 +390,8 @@ ColumnLayout {
                     root.walletRootStore.addressWasShown(delegateMenu.transaction.recipient)
                 }
 
-                RootStore.fetchTxDetails(delegateMenu.transaction.id)
-                let detailsObj = RootStore.getTxDetails()
+                root.walletRootStore.fetchTxDetails(delegateMenu.transaction.id)
+                let detailsObj = root.walletRootStore.getTxDetails()
                 let detailsString = delegateMenu.transactionDelegate.getDetailsString(detailsObj)
                 ClipboardUtils.setText(detailsString)
             }
@@ -516,7 +517,7 @@ ColumnLayout {
         id: footerComp
         ColumnLayout {
             id: footerColumn
-            readonly property bool allActivityLoaded: !RootStore.historyTransactions.hasMore && transactionListRoot.count !== 0
+            readonly property bool allActivityLoaded: !root.walletRootStore.historyTransactions.hasMore && transactionListRoot.count !== 0
             width: root.width
             spacing: d.isInitialLoading ? 6 : 12
 
@@ -544,7 +545,7 @@ ColumnLayout {
                         const delegateHeight = 64 + footerColumn.spacing
                         if (d.isInitialLoading) {
                             return Math.floor(transactionListRoot.height / delegateHeight)
-                        } else if (RootStore.historyTransactions.hasMore) {
+                        } else if (root.walletRootStore.historyTransactions.hasMore) {
                             return Math.max(3, Math.floor(transactionListRoot.height / delegateHeight) - 3)
                         }
                     }


### PR DESCRIPTION
### What does the PR do

Makes the `shared/RootStore` singleton smaller by moving content to appropriate places. It's the next step towards making that store non-singleton.

- moves wallet-related content to `wallet/RootStore` and `wallet/TokensStore`
- changes dependency on stores from implicit (via singleton) to explicit (taken as a property) in various components (e.g. `HistoryView`)

Closes: https://github.com/status-im/status-desktop/issues/16254

### Affected areas

`shared/RootStore`, `wallet/RootStore`, several related ui components

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)