### PR TITLE
fix(MembersTabPanel): Buttons in the Member tab do not work

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMemberListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMemberListItem.qml
@@ -170,6 +170,13 @@ ItemDelegate {
     background: Rectangle {
         color: root.color
         radius: 8
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: root.enabled && root.hoverEnabled && root.hovered ? Qt.PointingHandCursor : undefined
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: root.clicked(mouse)
+        }
     }
 
     contentItem: RowLayout {
@@ -266,13 +273,6 @@ ItemDelegate {
                 color: Theme.palette.directColor1
             }
         }
-    }
-
-    MouseArea {
-        anchors.fill: parent
-        cursorShape: root.enabled && root.hoverEnabled && root.hovered ? Qt.PointingHandCursor : undefined
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-        onClicked: root.clicked(mouse)
     }
 
     Component {

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -205,6 +205,7 @@ Item {
             onRemoveFromGroup: {
                 root.store.removeMemberFromGroupChat(profileContextMenu.publicKey)
             }
+            onClosed: destroy()
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
 
 import StatusQ 0.1
 import StatusQ.Core 0.1
@@ -68,7 +68,6 @@ Item {
             Layout.fillHeight: true
 
             model: SortFilterProxyModel {
-
                 sourceModel: root.model
 
                 sorters : [
@@ -234,7 +233,7 @@ Item {
                         text: qsTr("View Messages")
                         visible: viewMessagesButtonVisible
                         size: StatusBaseButton.Size.Small
-                        onClicked: root.viewMemberMessagesClicked(model.pubKey, model.displayName)
+                        onClicked: root.viewMemberMessagesClicked(model.pubKey, memberItem.title)
                     },
 
                     StatusButton {

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -371,6 +371,7 @@ Item {
                 const contactDetails = memberContextMenuView.publicKey === "" ? {} : Utils.getContactDetailsAsJson(memberContextMenuView.publicKey, true, true)
                 Global.blockContactRequested(memberContextMenuView.publicKey, contactDetails)
             }
+            onClosed: destroy()
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -89,6 +89,7 @@ SettingsContentBase {
                     const contactDetails = contactContextMenu.publicKey === "" ? {} : Utils.getContactDetailsAsJson(contactContextMenu.publicKey, true, true)
                     Global.blockContactRequested(contactContextMenu.publicKey, contactDetails)
                 }
+                onClosed: destroy()
             }
         }
         SearchBox {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1227,6 +1227,10 @@ Loader {
                 root.store.removeMemberFromGroupChat(profileContextMenu.publicKey)
             }
             onOpened: root.setMessageActive(root.messageId, true)
+            onClosed: {
+                root.setMessageActive(root.messageId, false)
+                destroy()
+            }
         }
     }
     Component {


### PR DESCRIPTION
### What does the PR do

- move the MouseArea into `background` so that it doesn't obscure the potential action buttons
- fixup SB page

- separate commit to fix ProfileContextMenu memory leaks

Fixes https://github.com/status-im/status-desktop/issues/16426

### Affected areas

MembersTabPanel

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/d51302ad-8c17-496c-85b2-94c420eba57e

