### PR TITLE
fix: Remove forced OpenGl context sharing

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -7,6 +7,9 @@ export GST_PLUGIN_SYSTEM_PATH="${APPDIR}/usr/lib/gstreamer-1.0"
 export GST_PLUGIN_SYSTEM_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"
 export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/nss:${LD_LIBRARY_PATH}"
 export QT_QPA_PLATFORM="xcb"
+# TODO: Remove once qt 5.15.2 support is dropped
+# Fixing bug: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1944468
+export QTWEBENGINE_CHROMIUM_FLAGS="--disable-seccomp-filter-sandbox"
 
 DEFAULT_LANG=en_US.UTF-8
 if [[ "$LANG" == "C.UTF-8" ]]

--- a/AppRun
+++ b/AppRun
@@ -9,7 +9,7 @@ export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/nss:${LD_LIBRARY_PA
 export QT_QPA_PLATFORM="xcb"
 # TODO: Remove once qt 5.15.2 support is dropped
 # Fixing bug: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1944468
-export QTWEBENGINE_CHROMIUM_FLAGS="--disable-seccomp-filter-sandbox"
+export QTWEBENGINE_CHROMIUM_FLAGS="${QTWEBENGINE_CHROMIUM_FLAGS} --disable-seccomp-filter-sandbox"
 
 DEFAULT_LANG=en_US.UTF-8
 if [[ "$LANG" == "C.UTF-8" ]]

--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,7 @@ statusq-tests:
 		--build $(STATUSQ_BUILD_PATH) \
 		$(HANDLE_OUTPUT)
 
+run-statusq-tests: export QTWEBENGINE_CHROMIUM_FLAGS := "${QTWEBENGINE_CHROMIUM_FLAGS} --disable-seccomp-filter-sandbox"
 run-statusq-tests: statusq-tests
 	echo -e "\033[92mRunning:\033[39m StatusQ Unit Tests"
 	ctest -V --test-dir $(STATUSQ_BUILD_PATH) ${ARGS}

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -160,9 +160,10 @@ proc mainProc() =
   let fleetConfig = readFile(joinPath(getAppDir(), fleetsPath))
   let statusFoundation = newStatusFoundation(fleetConfig)
   let uiScaleFilePath = joinPath(DATADIR, "ui-scale")
+  # Required by the WalletConnectSDK view right after creating the QGuiApplication instance
+  initializeWebView()
   enableHDPI(uiScaleFilePath)
   tryEnableThreadedRenderer()
-  initializeOpenGL()
 
   let imageCert = imageServerTLSCert()
   installSelfSignedCertificate(imageCert)
@@ -173,9 +174,6 @@ proc mainProc() =
   if not singletonInstance.localAppSettings.getTranslationsEnabled():
     if singletonInstance.localAppSettings.getLanguage() != DEFAULT_LAS_KEY_LANGUAGE:
       singletonInstance.localAppSettings.setLanguage(DEFAULT_LAS_KEY_LANGUAGE)
-
-  # Required by the WalletConnectSDK view right after creating the QGuiApplication instance
-  initializeWebView()
 
   let singleInstance = newSingleInstance($toMD5(DATADIR), openUri)
   let urlSchemeEvent = newStatusUrlSchemeEventObject()

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -40,7 +40,11 @@ int main(int argc, char *argv[])
     QGuiApplication::setApplicationName(QStringLiteral("Status Desktop Storybook"));
 
     qputenv("QT_QUICK_CONTROLS_HOVER_ENABLED", QByteArrayLiteral("1"));
-    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArrayLiteral("--disable-seccomp-filter-sandbox"));
+    auto chromiumFlags = qgetenv("QTWEBENGINE_CHROMIUM_FLAGS");
+    if(!chromiumFlags.contains("--disable-seccomp-filter-sandbox")) {
+        chromiumFlags +=" --disable-seccomp-filter-sandbox";
+    }
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", chromiumFlags);
 
     QQmlApplicationEngine engine;
 

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char *argv[])
     QGuiApplication::setApplicationName(QStringLiteral("Status Desktop Storybook"));
 
     qputenv("QT_QUICK_CONTROLS_HOVER_ENABLED", QByteArrayLiteral("1"));
+    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArrayLiteral("--disable-seccomp-filter-sandbox"));
 
     QQmlApplicationEngine engine;
 

--- a/ui/StatusQ/tests/TestComponents/tst_WebEngineLoader.qml
+++ b/ui/StatusQ/tests/TestComponents/tst_WebEngineLoader.qml
@@ -72,9 +72,6 @@ TestCase {
         webEngineLoadedSpy.wait(1000)
         verify(webEngine.instance !== null , "The WebEngineView should be available")
 
-        if (Qt.platform.os === "linux") {
-            skip("fails to load page on linux")
-        }
         pageLoadedSpy.wait(1000)
         webEngine.active = false
         engineUnloadedSpy.wait(1000);
@@ -85,10 +82,6 @@ TestCase {
     SignalSpy { id: wcInitOkSpy; target: testObject; signalName: "webChannelInitOk" }
     SignalSpy { id: wcInitErrorSpy; target: testObject; signalName: "webChannelError" }
     function test_executeCode() {
-        if (Qt.platform.os === "linux") {
-            skip("fails to load page on linux")
-        }
-
         const webEngine = loader.item
         webEngine.active = true
         pageLoadedSpy.wait(1000);


### PR DESCRIPTION
### What does the PR do

closes #16391

Remove the forced openGL context sharing. This will be done in the QtWebView::initialise by Qt if possible, depending on platform.

### Affected areas

WebEngineView
WalletConnect
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ x I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
