### PR TITLE
stores: shared/RootStore made not singleton

### DIFF
--- a/monitoring/MonitorEntryPoint.qml
+++ b/monitoring/MonitorEntryPoint.qml
@@ -6,7 +6,6 @@ import Monitoring 1.0
 import Qt.labs.settings 1.0
 
 import AppLayouts.Wallet.stores 1.0 as WalletStores
-import shared.stores 1.0 as SharedStores
 
 Component {
 
@@ -315,8 +314,7 @@ Component {
                             onClicked: {
                                 const roots = [
                                     applicationWindow,
-                                    WalletStores.RootStore,
-                                    SharedStores.RootStore
+                                    WalletStores.RootStore
                                 ]
 
                                 let obj = null

--- a/storybook/pages/ActivityNotificationCommunityTokenReceivedPage.qml
+++ b/storybook/pages/ActivityNotificationCommunityTokenReceivedPage.qml
@@ -9,7 +9,7 @@ import Storybook 1.0
 import Models 1.0
 
 import AppLayouts.stores 1.0 as AppLayoutStores
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -23,8 +23,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     QtObject {

--- a/storybook/pages/AssetsViewPage.qml
+++ b/storybook/pages/AssetsViewPage.qml
@@ -7,14 +7,9 @@ import utils 1.0
 
 import Storybook 1.0
 
-import Qt.labs.settings 1.1
-
-import Models 1.0
-
 import AppLayouts.Wallet.controls 1.0
-import AppLayouts.stores 1.0 as AppLayoutStores
-import AppLayouts.Wallet.views 1.0
-import AppLayouts.Wallet.stores 1.0
+
+import Qt.labs.settings 1.1
 
 SplitView {
     id: root

--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -17,7 +17,7 @@ import AppLayouts.Communities.stores 1.0 as CommunitiesStore
 import AppLayouts.Wallet.views 1.0
 import AppLayouts.Wallet.stores 1.0
 
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import shared.views 1.0
 
 import Storybook 1.0
@@ -50,8 +50,9 @@ SplitView {
 
     Popups {
         popupParent: root
-        rootStore: AppLayoutStores.RootStore
-        communityTokensStore: CommunityTokensStore {}
+        sharedRootStore: SharedStores.RootStore {}
+        rootStore: AppLayoutStores.RootStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
         walletCollectiblesStore: CollectiblesStore {
             collectiblesController: collectiblesView.controller
         }

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -13,7 +13,7 @@ import Models 1.0
 
 import utils 1.0
 import mainui 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -21,8 +21,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     SplitView {

--- a/storybook/pages/CommunitiesViewPage.qml
+++ b/storybook/pages/CommunitiesViewPage.qml
@@ -12,7 +12,7 @@ import utils 1.0
 
 import Storybook 1.0
 import Models 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -25,12 +25,13 @@ SplitView {
         assetsWithFilteredBalances: walletAssetStore.groupedAccountsAssetsModel
     }
 
-    readonly property var currencyStore: CurrenciesStore {}
+    readonly property var currencyStore: SharedStores.CurrenciesStore {}
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutsStores.RootStore
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     ListModel {

--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -29,7 +29,7 @@ import AppLayouts.Wallet.stores 1.0 as WalletStore
 import AppLayouts.stores 1.0 as AppLayoutStores
 
 import mainui 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import utils 1.0
 
 Item {
@@ -38,8 +38,9 @@ Item {
     // Needed for DAppsWorkflow->PairWCModal to open its instructions popup
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     SplitView {
@@ -303,7 +304,7 @@ Item {
             projectId: projectIdText.projectId
         }
 
-        store: DAppsStore {
+        store: SharedStores.DAppsStore {
             signal dappsListReceived(string dappsJson)
             signal userAuthenticated(string topic, string id, string password, string pin)
             signal userAuthenticationFailed(string topic, string id)
@@ -421,7 +422,7 @@ Item {
             function getNetworkShortNames(chainIds) {
                 return "eth:oeth:arb"
             }
-            readonly property CurrenciesStore currencyStore: CurrenciesStore {}
+            readonly property SharedStores.CurrenciesStore currencyStore: SharedStores.CurrenciesStore {}
             readonly property WalletStore.WalletAssetsStore walletAssetsStore: WalletStore.WalletAssetsStore {
                 // Silence warnings
                 assetsWithFilteredBalances: ListModel {}

--- a/storybook/pages/EditSettingsPanelPage.qml
+++ b/storybook/pages/EditSettingsPanelPage.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import mainui 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import AppLayouts.stores 1.0 as AppLayoutsStores
 import AppLayouts.Communities.panels 1.0
 
@@ -15,8 +15,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutsStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     EditSettingsPanel {

--- a/storybook/pages/LanguageViewPage.qml
+++ b/storybook/pages/LanguageViewPage.qml
@@ -11,7 +11,7 @@ import Storybook 1.0
 import utils 1.0
 import mainui 1.0
 
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -20,8 +20,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     SplitView {
@@ -70,7 +71,7 @@ SplitView {
                 }
             }
 
-            currencyStore: CurrenciesStore {
+            currencyStore: SharedStores.CurrenciesStore {
                 property string currentCurrency: "USD"
 
                 function updateCurrency(currencyKey) {

--- a/storybook/pages/LazyStackLayoutPage.qml
+++ b/storybook/pages/LazyStackLayoutPage.qml
@@ -1,0 +1,66 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core.Utils 0.1
+
+ColumnLayout {
+    anchors.fill: parent
+
+    LazyStackLayout {
+        id: lazyStackLayout
+
+        currentIndex: indicator.currentIndex
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.margins: 100
+
+        Component {
+            Rectangle {
+                color: "green"
+
+                Component.onCompleted: console.log("GREEN LOADED")
+            }
+        }
+
+        Component {
+            Rectangle {
+                color: "red"
+
+                Component.onCompleted: console.log("RED LOADED")
+            }
+        }
+
+        Component {
+            Rectangle {
+                color: "yellow"
+
+                Component.onCompleted: console.log("YELLOW LOADED")
+            }
+        }
+    }
+
+    PageIndicator {
+        id: indicator
+
+        Layout.alignment: Qt.AlignHCenter
+
+        count: lazyStackLayout.count
+        interactive: true
+
+        delegate: Rectangle {
+            width: 40
+            height: 40
+            radius: 20
+            border.width: 2
+
+            Text {
+                anchors.centerIn: parent
+                text: index
+            }
+        }
+    }
+}
+
+// category: Controls

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -6,7 +6,7 @@ import mainui 1.0
 import AppLayouts.stores 1.0 as AppLayoutStores
 import AppLayouts.Communities.panels 1.0
 
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -14,8 +14,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     OverviewSettingsPanel {

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts 1.14
 
 import utils 1.0
 import shared.views 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import mainui 1.0
 
 import StatusQ 0.1
@@ -172,6 +172,7 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {
             property var contactStore: QtObject {
                 property var contactsModule: null
@@ -304,7 +305,7 @@ SplitView {
                 }
             }
         }
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     WalletAssetsStore {

--- a/storybook/pages/ProfileSocialLinksPanelPage.qml
+++ b/storybook/pages/ProfileSocialLinksPanelPage.qml
@@ -7,7 +7,7 @@ import StatusQ.Core.Utils 0.1 as CoreUtils
 import mainui 1.0
 import AppLayouts.stores 1.0 as AppLayoutStores
 import AppLayouts.Profile.panels 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 import utils 1.0
 
@@ -22,8 +22,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     ListModel {

--- a/storybook/pages/SwapModalPage.qml
+++ b/storybook/pages/SwapModalPage.qml
@@ -18,7 +18,7 @@ import mainui 1.0
 import AppLayouts.Wallet.popups.swap 1.0
 import AppLayouts.Wallet.stores 1.0
 import AppLayouts.stores 1.0 as AppLayoutStores
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -50,8 +50,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     PopupBackground {
@@ -131,7 +132,7 @@ SplitView {
                 readonly property var baseGroupedAccountAssetModel: GroupedAccountsAssetsModel {}
                 assetsWithFilteredBalances: thisWalletAssetStore.groupedAccountsAssetsModel
             }
-            currencyStore: CurrenciesStore {
+            currencyStore: SharedStores.CurrenciesStore {
                 function formatBigNumber(number: string, symbol: string, noSymbolOption: bool) {
                     if (!number)
                         return "N/A"

--- a/storybook/pages/SyncingEnterCodePage.qml
+++ b/storybook/pages/SyncingEnterCodePage.qml
@@ -6,7 +6,7 @@ import Storybook 1.0
 
 import mainui 1.0
 import shared.views 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 import AppLayouts.stores 1.0 as AppLayoutStores
 
@@ -18,8 +18,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     Item {

--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -10,7 +10,7 @@ import utils 1.0
 import AppLayouts.stores 1.0 as AppLayoutStores
 import AppLayouts.Profile.views 1.0
 import AppLayouts.Profile.stores 1.0 as ProfileStores
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 SplitView {
     id: root
@@ -20,8 +20,9 @@ SplitView {
 
     Popups {
         popupParent: root
+        sharedRootStore: SharedStores.RootStore {}
         rootStore: AppLayoutStores.RootStore {}
-        communityTokensStore: CommunityTokensStore {}
+        communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 
     SyncingView {

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -4,8 +4,8 @@ import QtQuick.Layouts 1.14
 
 import utils 1.0
 import shared.popups 1.0
-import shared.stores 1.0
-import shared.stores.send 1.0
+import shared.stores 1.0 as SharedStores
+import shared.stores.send 1.0 as SendStores
 
 import "views"
 
@@ -14,8 +14,8 @@ import AppLayouts.Communities.popups 1.0
 import AppLayouts.Communities.helpers 1.0
 import AppLayouts.Communities.stores 1.0 as CommunitiesStores
 
-import AppLayouts.Chat.stores 1.0
-import AppLayouts.Profile.stores 1.0
+import AppLayouts.Chat.stores 1.0 as ChatStores
+import AppLayouts.Profile.stores 1.0 as ProfileStores
 import AppLayouts.Wallet.stores 1.0 as WalletStore
 
 import StatusQ.Core.Utils 0.1
@@ -23,15 +23,16 @@ import StatusQ.Core.Utils 0.1
 StackLayout {
     id: root
 
-    property RootStore rootStore
-    property CreateChatPropertiesStore createChatPropertiesStore
-    readonly property ContactsStore contactsStore: rootStore.contactsStore
-    readonly property PermissionsStore permissionsStore: rootStore.permissionsStore
+    property SharedStores.RootStore sharedRootStore
+    property ChatStores.RootStore rootStore
+    property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
+    readonly property ProfileStores.ContactsStore contactsStore: rootStore.contactsStore
+    readonly property SharedStores.PermissionsStore permissionsStore: rootStore.permissionsStore
     property CommunitiesStores.CommunitiesStore communitiesStore
     required property WalletStore.TokensStore tokensStore
-    required property TransactionStore transactionStore
+    required property SendStores.TransactionStore transactionStore
     required property WalletStore.WalletAssetsStore walletAssetsStore
-    required property CurrenciesStore currencyStore
+    required property SharedStores.CurrenciesStore currencyStore
 
     property var sectionItemModel
     property var sendModalPopup
@@ -148,6 +149,7 @@ StackLayout {
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             contactsStore: root.contactsStore
+            sharedRootStore: root.sharedRootStore
             rootStore: root.rootStore
             transactionStore: root.transactionStore
             createChatPropertiesStore: root.createChatPropertiesStore

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -12,12 +12,14 @@ import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared.views.chat 1.0
+import shared.stores 1.0 as SharedStores
 
 import AppLayouts.Chat.stores 1.0
 
 StatusDialog {
     id: root
 
+    property SharedStores.RootStore sharedStore
     property RootStore store
     property MessageStore messageStore
     property var pinnedMessagesModel //this doesn't belong to the messageStore, it is a part of the ChatContentStore, but we didn't introduce it yet.
@@ -77,6 +79,7 @@ StatusDialog {
 
                     width: parent.width
 
+                    sharedRootStore: root.sharedStore
                     rootStore: root.store
                     messageStore: root.messageStore
 

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -39,6 +39,7 @@ Item {
     // don't follow struct we have on the backend.
     property var parentModule
 
+    property SharedStores.RootStore sharedRootStore
     property RootStore rootStore
     property CreateChatPropertiesStore createChatPropertiesStore
     property ContactsStore contactsStore
@@ -234,6 +235,7 @@ Item {
                         chatId: model.itemId
                         chatType: model.type
                         chatMessagesLoader.active: model.loaderActive
+                        sharedRootStore: root.sharedRootStore
                         rootStore: root.rootStore
                         contactsStore: root.contactsStore
                         emojiPopup: root.emojiPopup
@@ -290,7 +292,7 @@ Item {
 
                     store: root.rootStore
                     usersModel: d.activeUsersStore.usersModel
-                    sharedStore: SharedStores.RootStore
+                    sharedStore: root.sharedRootStore
 
                     linkPreviewModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.linkPreviewModel : null
                     urlsList: d.urlsList

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -10,6 +10,7 @@ import StatusQ.Controls 0.1
 
 import utils 1.0
 import shared 1.0
+import shared.stores 1.0 as SharedStores
 import shared.popups 1.0
 import shared.status 1.0
 import shared.controls 1.0
@@ -30,6 +31,7 @@ ColumnLayout {
     // Important: each chat/channel has its own ChatContentModule
     property var chatContentModule
     property var chatSectionModule
+    property SharedStores.RootStore sharedRootStore
     property RootStore rootStore
     property ContactsStore contactsStore
     property string chatId
@@ -81,6 +83,8 @@ ColumnLayout {
 
         sourceComponent: ChatMessagesView {
             chatContentModule: root.chatContentModule
+
+            sharedRootStore: root.sharedRootStore
             rootStore: root.rootStore
             contactsStore: root.contactsStore
             messageStore: root.messageStore

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -12,6 +12,7 @@ import StatusQ.Core.Theme 0.1
 
 import utils 1.0
 import shared 1.0
+import shared.stores 1.0 as SharedStores
 import shared.views 1.0
 import shared.panels 1.0
 import shared.popups 1.0
@@ -29,6 +30,8 @@ Item {
     id: root
 
     property var chatContentModule
+
+    property SharedStores.RootStore sharedRootStore
     property RootStore rootStore
     property MessageStore messageStore
     property UsersStore usersStore
@@ -266,6 +269,8 @@ Item {
             width: ListView.view.width
 
             objectName: "chatMessageViewDelegate"
+
+            sharedRootStore: root.sharedRootStore
             rootStore: root.rootStore
             messageStore: root.messageStore
             usersStore: root.usersStore

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -7,9 +7,9 @@ import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import shared.views.chat 1.0
-import shared.stores.send 1.0
+import shared.stores.send 1.0 as SendStores
 import SortFilterProxyModel 0.2
 
 import StatusQ.Core 0.1
@@ -29,10 +29,12 @@ import AppLayouts.Communities.views 1.0
 
 import AppLayouts.Profile.stores 1.0
 import AppLayouts.Wallet.stores 1.0 as WalletStore
+
+import AppLayouts.Chat.stores 1.0 as ChatStores
+
 import "../popups"
 import "../helpers"
 import "../controls"
-import "../stores"
 
 StatusSectionLayout {
     id: root
@@ -40,12 +42,13 @@ StatusSectionLayout {
     property ContactsStore contactsStore
     property bool hasAddedContacts: contactsStore.myContactsModel.count > 0
 
-    property RootStore rootStore
-    required property TransactionStore transactionStore
-    property CreateChatPropertiesStore createChatPropertiesStore
+    property SharedStores.RootStore sharedRootStore
+    property ChatStores.RootStore rootStore
+    required property SendStores.TransactionStore transactionStore
+    property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
     property CommunitiesStores.CommunitiesStore communitiesStore
     required property WalletStore.WalletAssetsStore walletAssetsStore
-    required property CurrenciesStore currencyStore
+    required property SharedStores.CurrenciesStore currencyStore
     property var sectionItemModel
 
     property var emojiPopup
@@ -220,6 +223,7 @@ StatusSectionLayout {
 
         ChatColumnView {
             parentModule: root.rootStore.chatCommunitySectionModule
+            sharedRootStore: root.sharedRootStore
             rootStore: root.rootStore
             createChatPropertiesStore: root.createChatPropertiesStore
             contactsStore: root.contactsStore

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -19,6 +19,7 @@ import AppLayouts.Chat.stores 1.0 as ChatStores
 Page {
     id: root
 
+    property SharedStores.RootStore sharedRootStore
     property ChatStores.RootStore rootStore
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
     property var emojiPopup: null
@@ -162,7 +163,7 @@ Page {
                 stickersPopup: root.stickersPopup
                 closeGifPopupAfterSelection: true
                 usersModel: membersSelector.model
-                sharedStore: SharedStores.RootStore
+                sharedStore: root.sharedRootStore
                 onStickerSelected: {
                     root.createChatPropertiesStore.createChatStickerHashId = hashId;
                     root.createChatPropertiesStore.createChatStickerPackId = packId;

--- a/ui/app/AppLayouts/Communities/popups/CommunityMemberMessagesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityMemberMessagesPopup.qml
@@ -12,12 +12,14 @@ import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared.views.chat 1.0
+import shared.stores 1.0 as SharedStores
 
 import AppLayouts.Chat.stores 1.0 as ChatStores
 
 StatusDialog {
     id: root
 
+    property SharedStores.RootStore sharedRootStore
     property ChatStores.RootStore rootStore
     property var chatCommunitySectionModule
     property var memberMessagesModel: chatCommunitySectionModule.memberMessagesModel
@@ -62,6 +64,7 @@ StatusDialog {
 
                     width: parent.width
 
+                    sharedRootStore: root.sharedRootStore
                     rootStore: root.store
                     chatCommunitySectionModule: root.chatCommunitySectionModule
                     messageStore: root.memberMessagesModel

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -35,6 +35,7 @@ StatusSectionLayout {
 
     objectName: "profileStatusSectionLayout"
 
+    property SharedStores.RootStore sharedRootStore
     property ProfileSectionStore store
     property AppLayoutsStores.RootStore globalStore
     property var systemPalette
@@ -188,7 +189,7 @@ StatusSectionLayout {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
                 privacyStore: root.store.privacyStore
-                passwordStrengthScoreFunction: SharedStores.RootStore.getPasswordStrengthScore
+                passwordStrengthScoreFunction: root.sharedRootStore.getPasswordStrengthScore
                 contentWidth: d.contentWidth
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.password)
             }
@@ -247,6 +248,7 @@ StatusSectionLayout {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
                 myPublicKey: root.store.contactsStore.myPublicKey
+                currencySymbol: root.sharedRootStore.currencyStore.currentCurrency
                 rootStore: root.store
                 tokensStore: root.tokensStore
                 networkConnectionStore: root.networkConnectionStore

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -32,6 +32,8 @@ SettingsContentBase {
 
     property var emojiPopup
     property string myPublicKey: ""
+    property alias currencySymbol: manageTokensView.currencySymbol
+
     property ProfileSectionStore rootStore
     property WalletStore walletStore: rootStore.walletStore
     required property TokensStore tokensStore

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -34,6 +34,7 @@ Item {
     required property var baseWalletAssetsModel
     required property var baseWalletCollectiblesModel
 
+    property string currencySymbol: "USD"
     property var getCurrencyAmount: function (balance, symbol) {}
     property var getCurrentCurrencyAmount: function(balance){}
 
@@ -216,7 +217,7 @@ Item {
                         CurrencyAmountInput {
                             id: currencyAmount
                             enabled: displayThresholdSwitch.checked
-                            currencySymbol: SharedStores.RootStore.currencyStore.currentCurrency
+                            currencySymbol: root.currencySymbol
                             value: advancedSettings.getDisplayThresholdAmount()
                             onValueChanged: {
                                 if (!advancedSettings.dirty && advancedSettings.getDisplayThresholdAmount() === value) {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -10,7 +10,7 @@ import utils 1.0
 import shared.controls 1.0
 import shared.popups.keypairimport 1.0
 
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import shared.stores.send 1.0
 
 import AppLayouts.stores 1.0 as AppLayoutsStores
@@ -30,6 +30,7 @@ Item {
 
     property bool hideSignPhraseModal: false
 
+    property SharedStores.RootStore sharedRootStore
     property AppLayoutsStores.RootStore store
     property ProfileStores.ContactsStore contactsStore
     property CommunitiesStore communitiesStore
@@ -37,7 +38,7 @@ Item {
 
     property var emojiPopup: null
     property var sendModalPopup
-    property NetworkConnectionStore networkConnectionStore
+    property SharedStores.NetworkConnectionStore networkConnectionStore
     property bool appMainVisible
 
     property bool dappsEnabled
@@ -220,6 +221,7 @@ Item {
     Component {
         id: walletContainer
         RightTabView {
+            sharedRootStore: root.sharedRootStore
             store: root.store
             contactsStore: root.contactsStore
             communitiesStore: root.communitiesStore

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.13
-import QtQuick.Controls 2.14
-import QtQuick.Window 2.12
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import QtQuick.Window 2.15
 
 import StatusQ 0.1
 import StatusQ.Components 0.1
@@ -13,7 +13,7 @@ import StatusQ.Controls 0.1
 import utils 1.0
 import shared.views 1.0
 import shared.controls 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 
 import AppLayouts.Wallet.stores 1.0 as WalletStores
 
@@ -28,18 +28,19 @@ Item {
     id: root
 
     property var token: ({})
+    property SharedStores.RootStore sharedRootStore
     property WalletStores.TokensStore tokensStore
-    property CurrenciesStore currencyStore
-    property NetworkConnectionStore networkConnectionStore
+    property SharedStores.CurrenciesStore currencyStore
+    property SharedStores.NetworkConnectionStore networkConnectionStore
     property var allNetworksModel
     property var networkFilters
     onNetworkFiltersChanged: d.forceRefreshBalanceStore = true
     /*required*/ property string address: ""
-    property TokenBalanceHistoryStore balanceStore: TokenBalanceHistoryStore {}
+    property SharedStores.TokenBalanceHistoryStore balanceStore: SharedStores.TokenBalanceHistoryStore {}
 
     QtObject {
         id: d
-        property TokenMarketValuesStore marketValueStore : RootStore.marketValueStore
+        property SharedStores.TokenMarketValuesStore marketValueStore : root.sharedRootStore.marketValueStore
         readonly property string symbol: !!root.token? root.token.symbol?? "" : ""
         property bool marketDetailsLoading: !!root.token? root.token.marketDetailsLoading?? false : false
         property bool tokenDetailsLoading: !!root.token? root.token.detailsLoading?? false: false
@@ -136,7 +137,7 @@ Item {
                     id: graphDetail
 
                     property int selectedGraphType: AssetsDetailView.GraphType.Price
-                    property TokenMarketValuesStore selectedStore: d.marketValueStore
+                    property SharedStores.TokenMarketValuesStore selectedStore: d.marketValueStore
 
                     function dataReady() {
                         return typeof selectedStore != "undefined"
@@ -165,7 +166,7 @@ Item {
                         {text: qsTr("Price"), enabled: true, id: AssetsDetailView.GraphType.Price, visible: !d.isCommunityAsset},
                         {text: qsTr("Balance"), enabled: true, id: AssetsDetailView.GraphType.Balance, visible: true},
                     ]
-                    defaultTimeRangeIndexShown: ChartStoreBase.TimeRange.All
+                    defaultTimeRangeIndexShown: SharedStores.ChartStoreBase.TimeRange.All
                     timeRangeModel: dataReady() && selectedStore.timeRangeTabsModel
                     onHeaderTabClicked: (privateIdentifier, isTimeRange) => {
                                             if(!isTimeRange && graphDetail.selectedGraphType !== privateIdentifier) {
@@ -185,7 +186,7 @@ Item {
 
                     readonly property var dateToShortLabel: function (value) {
                         const range = balanceStore.timeRangeStrToEnum(graphDetail.selectedTimeRange)
-                        return range === ChartStoreBase.TimeRange.Weekly || range === ChartStoreBase.TimeRange.Monthly ?
+                        return range === SharedStores.ChartStoreBase.TimeRange.Weekly || range === SharedStores.ChartStoreBase.TimeRange.Monthly ?
                                     LocaleUtils.getDayMonth(value) :
                                     LocaleUtils.getMonthYear(value)
                     }
@@ -319,7 +320,7 @@ Item {
                     function updateBalanceStore() {
                         let selectedTimeRangeEnum = balanceStore.timeRangeStrToEnum(graphDetail.selectedTimeRange)
 
-                        let currencySymbol = RootStore.currencyStore.currentCurrency
+                        let currencySymbol = root.sharedRootStore.currencyStore.currentCurrency
                         if(!balanceStore.hasData(root.address, token.symbol, currencySymbol, selectedTimeRangeEnum) || d.forceRefreshBalanceStore) {
                             root.tokensStore.fetchHistoricalBalanceForTokenAsJson(root.address, token.symbol, currencySymbol, selectedTimeRangeEnum)
                         }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -24,6 +24,8 @@ import "../views/collectibles"
 RightTabBaseView {
     id: root
 
+    property SharedStores.RootStore sharedRootStore
+
     property alias currentTabIndex: walletTabBar.currentIndex
 
     signal launchShareAddressModal()
@@ -445,7 +447,7 @@ RightTabBaseView {
             isCollectibleLoading: RootStore.collectiblesStore.isDetailedCollectibleLoading
             activityModel: d.detailedCollectibleActivityController.model
             addressFilters: RootStore.addressFilters
-            rootStore: SharedStores.RootStore
+            rootStore: root.sharedRootStore
             walletRootStore: RootStore
             communitiesStore: root.communitiesStore
 
@@ -469,6 +471,7 @@ RightTabBaseView {
 
             visible: (stack.currentIndex === 2)
 
+            sharedRootStore: root.sharedRootStore
             tokensStore: RootStore.tokensStore
             allNetworksModel: RootStore.filteredFlatModel
             address: RootStore.overview.mixedcaseAddress
@@ -503,8 +506,8 @@ RightTabBaseView {
                 showAllAccounts: RootStore.showAllAccounts
                 communitiesStore: root.communitiesStore
                 sendModal: root.sendModal
-                rootStore: SharedStores.RootStore
-                currenciesStore: SharedStores.RootStore.currencyStore
+                rootStore: root.sharedRootStore
+                currenciesStore: root.sharedRootStore.currencyStore
                 contactsStore: root.contactsStore
                 networkConnectionStore: root.networkConnectionStore
                 visible: (stack.currentIndex === 3)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -408,6 +408,8 @@ Item {
 
     Popups {
         id: popups
+
+        sharedRootStore: RootStore
         popupParent: appMain
         rootStore: appMain.rootStore
         communityTokensStore: appMain.communityTokensStore
@@ -1350,6 +1352,7 @@ Item {
                                     restoreMode: Binding.RestoreBindingOrValue
                                 }
 
+                                sharedRootStore: RootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
                                     communityTokensStore: appMain.communityTokensStore
@@ -1397,6 +1400,7 @@ Item {
                         asynchronous: true
                         sourceComponent: WalletLayout {
                             objectName: "walletLayoutReal"
+                            sharedRootStore: RootStore
                             store: appMain.rootStore
                             contactsStore: appMain.rootStore.profileSectionStore.contactsStore
                             communitiesStore: appMain.communitiesStore
@@ -1417,6 +1421,7 @@ Item {
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
                         asynchronous: true
                         sourceComponent: ProfileLayout {
+                            sharedRootStore: RootStore
                             store: appMain.rootStore.profileSectionStore
                             globalStore: appMain.rootStore
                             systemPalette: appMain.sysPalette
@@ -1506,6 +1511,7 @@ Item {
                                 communitiesStore: appMain.communitiesStore
                                 communitySettingsDisabled: !chatLayoutComponent.isManageCommunityEnabledInAdvanced &&
                                                            (production && appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled)
+                                sharedRootStore: RootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
                                     communityTokensStore: appMain.communityTokensStore
@@ -1550,6 +1556,7 @@ Item {
                             anchors.rightMargin - anchors.leftMargin : 0
 
                     sourceComponent: CreateChatView {
+                        sharedRootStore: RootStore
                         rootStore: ChatStores.RootStore {
                             contactsStore: appMain.rootStore.contactStore
                             communityTokensStore: appMain.communityTokensStore

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -23,7 +23,7 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.popups.keycard 1.0
 import shared.status 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import shared.popups.send 1.0 as SendPopups
 import shared.popups.send.views 1.0
 import shared.stores.send 1.0
@@ -55,6 +55,9 @@ Item {
     id: appMain
 
     property alias appLayout: appLayout
+
+    readonly property SharedStores.RootStore sharedRootStore: SharedStores.RootStore {}
+
     property AppStores.RootStore rootStore: AppStores.RootStore {
         profileSectionStore.sendModalPopup: sendModal
     }
@@ -67,13 +70,13 @@ Item {
     }
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore: ChatStores.CreateChatPropertiesStore {}
     property ActivityCenterStore activityCenterStore: ActivityCenterStore {}
-    property NetworkConnectionStore networkConnectionStore: NetworkConnectionStore {}
-    property CommunityTokensStore communityTokensStore: CommunityTokensStore {}
+    property SharedStores.NetworkConnectionStore networkConnectionStore: SharedStores.NetworkConnectionStore {}
+    property SharedStores.CommunityTokensStore communityTokensStore: SharedStores.CommunityTokensStore {}
     property CommunitiesStore communitiesStore: CommunitiesStore {}
     readonly property WalletStores.TokensStore tokensStore: WalletStores.RootStore.tokensStore
     readonly property WalletStores.WalletAssetsStore walletAssetsStore: WalletStores.RootStore.walletAssetsStore
     readonly property WalletStores.CollectiblesStore walletCollectiblesStore: WalletStores.RootStore.collectiblesStore
-    readonly property CurrenciesStore currencyStore: CurrenciesStore {}
+    readonly property SharedStores.CurrenciesStore currencyStore: SharedStores.CurrenciesStore {}
     readonly property TransactionStore transactionStore: TransactionStore {
         walletAssetStore: appMain.walletAssetsStore
         tokensStore: appMain.tokensStore
@@ -409,7 +412,7 @@ Item {
     Popups {
         id: popups
 
-        sharedRootStore: RootStore
+        sharedRootStore: appMain.sharedRootStore
         popupParent: appMain
         rootStore: appMain.rootStore
         communityTokensStore: appMain.communityTokensStore
@@ -1352,7 +1355,7 @@ Item {
                                     restoreMode: Binding.RestoreBindingOrValue
                                 }
 
-                                sharedRootStore: RootStore
+                                sharedRootStore: appMain.sharedRootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
                                     communityTokensStore: appMain.communityTokensStore
@@ -1400,7 +1403,7 @@ Item {
                         asynchronous: true
                         sourceComponent: WalletLayout {
                             objectName: "walletLayoutReal"
-                            sharedRootStore: RootStore
+                            sharedRootStore: appMain.sharedRootStore
                             store: appMain.rootStore
                             contactsStore: appMain.rootStore.profileSectionStore.contactsStore
                             communitiesStore: appMain.communitiesStore
@@ -1421,7 +1424,7 @@ Item {
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
                         asynchronous: true
                         sourceComponent: ProfileLayout {
-                            sharedRootStore: RootStore
+                            sharedRootStore: appMain.sharedRootStore
                             store: appMain.rootStore.profileSectionStore
                             globalStore: appMain.rootStore
                             systemPalette: appMain.sysPalette
@@ -1511,7 +1514,7 @@ Item {
                                 communitiesStore: appMain.communitiesStore
                                 communitySettingsDisabled: !chatLayoutComponent.isManageCommunityEnabledInAdvanced &&
                                                            (production && appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled)
-                                sharedRootStore: RootStore
+                                sharedRootStore: appMain.sharedRootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
                                     communityTokensStore: appMain.communityTokensStore
@@ -1556,7 +1559,7 @@ Item {
                             anchors.rightMargin - anchors.leftMargin : 0
 
                     sourceComponent: CreateChatView {
-                        sharedRootStore: RootStore
+                        sharedRootStore: appMain.sharedRootStore
                         rootStore: ChatStores.RootStore {
                             contactsStore: appMain.rootStore.contactStore
                             communityTokensStore: appMain.communityTokensStore
@@ -1882,7 +1885,7 @@ Item {
 
         sourceComponent: WalletPopups.AddEditSavedAddressPopup {
             store: WalletStores.RootStore
-            sharedRootStore: RootStore
+            sharedRootStore: appMain.sharedRootStore
             flatNetworks: WalletStores.RootStore.filteredFlatModel
 
             onClosed: {
@@ -2141,7 +2144,7 @@ Item {
             controller: WalletStores.RootStore.dappsConnectorController
             wcService: Global.walletConnectService
             walletStore: WalletStores.RootStore
-            store: DAppsStore {
+            store: SharedStores.DAppsStore {
                 controller: WalletStores.RootStore.walletConnectController
             }
             loginType: appMain.rootStore.loginType
@@ -2168,7 +2171,7 @@ Item {
                 userUID: appMain.rootStore.profileSectionStore.profileStore.pubkey
                 projectId: WalletStores.RootStore.appSettings.walletConnectProjectID
             }
-            store: DAppsStore {
+            store: SharedStores.DAppsStore {
                 controller: WalletStores.RootStore.walletConnectController
             }
             walletRootStore: WalletStores.RootStore

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -37,6 +37,8 @@ QtObject {
     id: root
 
     required property var popupParent
+
+    required property RootStore sharedRootStore
     required property AppLayoutStores.RootStore rootStore
     required property CommunityTokensStore communityTokensStore
     property CommunitiesStore communitiesStore
@@ -641,6 +643,7 @@ QtObject {
         Component {
             id: pinnedMessagesPopup
             PinnedMessagesPopup {
+                sharedStore: root.sharedRootStore
                 onClosed: destroy()
             }
         },
@@ -1230,6 +1233,7 @@ QtObject {
         Component {
             id: communityMemberMessagesPopup
             CommunityMemberMessagesPopup {
+                sharedRootStore: root.sharedRootStore
                 onClosed: destroy()
             }
         },

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -1,5 +1,3 @@
-pragma Singleton
-
 import QtQuick 2.15
 import utils 1.0
 

--- a/ui/imports/shared/stores/qmldir
+++ b/ui/imports/shared/stores/qmldir
@@ -7,6 +7,6 @@ GifStore 1.0 GifStore.qml
 MetricsStore 1.0 MetricsStore.qml
 NetworkConnectionStore 1.0 NetworkConnectionStore.qml
 PermissionsStore 1.0 PermissionsStore.qml
+RootStore 1.0 RootStore.qml
 TokenBalanceHistoryStore 1.0 TokenBalanceHistoryStore.qml
 TokenMarketValuesStore 1.0 TokenMarketValuesStore.qml
-singleton RootStore 1.0 RootStore.qml

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.15
-import QtQml 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
@@ -11,10 +10,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Wallet.controls 1.0
-import AppLayouts.Wallet.stores 1.0 as WalletStores
 import shared.controls 1.0
 import shared.popups 1.0
-import shared.stores 1.0
 import utils 1.0
 
 import SortFilterProxyModel 0.2

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -23,6 +23,7 @@ import AppLayouts.Profile.stores 1.0 as ProfileStores
 Loader {
     id: root
 
+    property SharedStores.RootStore sharedRootStore
     property ChatStores.RootStore rootStore
     property ChatStores.MessageStore messageStore
     property ChatStores.UsersStore usersStore
@@ -930,7 +931,7 @@ Loader {
 
                         store: root.rootStore
                         usersModel: root.usersStore.usersModel
-                        sharedStore: SharedStores.RootStore
+                        sharedStore: root.sharedRootStore
                         emojiPopup: root.emojiPopup
                         stickersPopup: root.stickersPopup
 
@@ -961,9 +962,9 @@ Loader {
                             Global.openMenu(imageContextMenuComponent, item, { url: url, domain: domain, requireConfirmationOnOpen: true })
                         }
                         onHoveredLinkChanged: delegate.highlightedLink = linksMessageView.hoveredLink
-                        gifUnfurlingEnabled: SharedStores.RootStore.gifUnfurlingEnabled
-                        canAskToUnfurlGifs: !SharedStores.RootStore.neverAskAboutUnfurlingAgain
-                        onSetNeverAskAboutUnfurlingAgain: SharedStores.RootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+                        gifUnfurlingEnabled: root.sharedRootStore.gifUnfurlingEnabled
+                        canAskToUnfurlGifs: !root.sharedRootStore.neverAskAboutUnfurlingAgain
+                        onSetNeverAskAboutUnfurlingAgain: root.sharedRootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
                         Component.onCompleted: {
                             root.messageStore.messageModule.forceLinkPreviewsLocalData(root.messageId)


### PR DESCRIPTION
### What does the PR do

- converts access to `shared/RootStore` via singleton to access via explicit input property
- converts `shared/RootStore`  to not-singleton type
- adds aliases to imports in various places to prevent name conflicts (like `RootStore` from multiple locations)
- adds storybook page for `LazyStackLayout` (accidentally omitted earlier)

Closes: https://github.com/status-im/status-desktop/issues/16247

### Affected areas
`shared/RootStore`, components using that store

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
