### PR TITLE
fix(community): Token gating info when permission not met and set to private

### DIFF
--- a/storybook/pages/CommunitiesPortalDummyModel.qml
+++ b/storybook/pages/CommunitiesPortalDummyModel.qml
@@ -8,14 +8,14 @@ ListModel {
 
     Component.onCompleted: append([
         {
-            featured: true,
+            featured: false,
             id: "id1",
             loaded: true,
             icon: ModelsData.icons.status,
             banner: ModelsData.banners.status,
             color: "blue",
-            name: "Status.im",
-            description: "Your portal to Web3. Secure wallet. dApp browser. Private messaging. All-in-one.",
+            name: "Status.app",
+            description: "Your portal to Web3. Secure wallet. Private messaging. Requires secret tokens to join",
             members: 130,
             activeMembers: 61,
             popularity: 4,
@@ -42,8 +42,8 @@ ListModel {
                     "emoji": "💼",
                 },
             ]),
-            permissionsModel: PermissionsModel.shortPermissionsModel,
-            allTokenRequirementsMet: true
+            permissionsModel: PermissionsModel.privatePermissionsMemberNotMetModel,
+            allTokenRequirementsMet: false
         },
         {
             featured: true,
@@ -168,7 +168,7 @@ ListModel {
                 },
             ]),
             permissionsModel: PermissionsModel.threeShortPermissionsModel,
-            allTokenRequirementsMet: true
+            allTokenRequirementsMet: false
         },
         {
             featured: false,
@@ -218,7 +218,7 @@ ListModel {
                     "emoji": "💼",
                 },
             ]),
-            permissionsModel: PermissionsModel.longPermissionsModel,
+            permissionsModel: PermissionsModel.twoLongPermissionsModel,
             allTokenRequirementsMet: true
         },
         {
@@ -235,7 +235,8 @@ ListModel {
             popularity: 4,
             available: true,
             tags: JSON.stringify([]),
-            permissionsModel: emptyModel
+            permissionsModel: emptyModel,
+            allTokenRequirementsMet: false
         }
         ])
 }

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -22,7 +22,7 @@ SplitView {
     Popups {
         popupParent: root
         sharedRootStore: SharedStores.RootStore {}
-        rootStore: AppLayoutStores.RootStore
+        rootStore: AppLayoutStores.RootStore {}
         communityTokensStore: SharedStores.CommunityTokensStore {}
     }
 

--- a/storybook/pages/PermissionsRowPage.qml
+++ b/storybook/pages/PermissionsRowPage.qml
@@ -104,6 +104,22 @@ SplitView {
             Label {
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
 
+                text: "Private + unmet permissions:"
+            }
+
+            PermissionsRow {
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+                Layout.bottomMargin: spacing
+
+                assetsModel: root.assetsModel
+                collectiblesModel: root.collectiblesModel
+                model: PermissionsModel.privatePermissionsMemberNotMetModel
+                requirementsMet: false
+            }
+
+            Label {
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+
                 text: "5 permissions - long ones"
             }
 
@@ -139,7 +155,7 @@ SplitView {
             }
 
             Label {
-                text: "Row heigh:"
+                text: "Row height:"
             }
 
             Slider {

--- a/storybook/src/Models/CommunitiesModel.qml
+++ b/storybook/src/Models/CommunitiesModel.qml
@@ -115,7 +115,7 @@ ListModel {
                     members: [{ pubKey: "0xdeadbeef" }],
                     membersCount: 1,
                     loading: false,
-                    permissionsModel: null,
+                    permissionsModel: PermissionsModel.privatePermissionsMemberNotMetModel,
                     allTokenRequirementsMet: false
                 },
                 {

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -85,6 +85,24 @@ QtObject {
         }
     ]
 
+    readonly property var privatePermissionsMemberModelNotMetData: [
+        {
+            holdingsListModel: root.createHoldingsModel4(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Member,
+            permissionState: PermissionTypes.State.Approved,
+            isPrivate: true,
+            tokenCriteriaMet: false
+        },
+        {
+            holdingsListModel: root.createHoldingsModel2(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            permissionState: PermissionTypes.State.Approved,
+            isPrivate: true,
+            tokenCriteriaMet: false
+        }
+    ]
 
     readonly property var shortPermissionsModelData: [
         {
@@ -550,6 +568,17 @@ QtObject {
 
         Component.onCompleted: {
             append(privatePermissionsModelNotMetData)
+            guard.enabled = true
+        }
+    }
+
+    readonly property ListModel privatePermissionsMemberNotMetModel: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.privatePermissionsMemberNotMetModel
+        }
+
+        Component.onCompleted: {
+            append(privatePermissionsMemberModelNotMetData)
             guard.enabled = true
         }
     }

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -273,7 +273,7 @@ Rectangle {
         anchors.top: parent.top
         anchors.topMargin: (root.cardSize === StatusCommunityCard.Size.Big) ? 16 : 8
         anchors.left: parent.left
-        anchors.leftMargin: 12
+        anchors.leftMargin: d.margins
         width: root.asset.width + 4
         height: width
         radius: width / 2
@@ -313,15 +313,14 @@ Rectangle {
         // Community info
         ColumnLayout {
             anchors.top: parent.top
-            anchors.topMargin: (root.cardSize === StatusCommunityCard.Size.Big) ? 32 : 26
+            anchors.topMargin: (root.cardSize === StatusCommunityCard.Size.Big) ? 32 : 22
             anchors.left: parent.left
             anchors.leftMargin: d.margins
             anchors.right: parent.right
             anchors.rightMargin: d.margins
-            spacing: (root.cardSize === StatusCommunityCard.Size.Big) ? 6 : 0
+            spacing: (root.cardSize === StatusCommunityCard.Size.Big) ? 6 : 2
             StatusBaseText {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 22
                 text: root.name
                 font.weight: d.titleFontWeight
                 font.pixelSize: root.titleFontSize
@@ -345,8 +344,8 @@ Rectangle {
             anchors.leftMargin: d.margins
             anchors.right: parent.right
             anchors.rightMargin: d.margins
-            anchors.bottomMargin: d.margins
-            spacing: (root.cardSize === StatusCommunityCard.Size.Big) ? 18 : 0
+            anchors.bottomMargin: 8
+            spacing: (root.cardSize === StatusCommunityCard.Size.Big) ? 18 : 4
             Row {
                 spacing: 20
                 // Members
@@ -391,7 +390,8 @@ Rectangle {
             // Bottom Row extra info component
             Loader {
                 id: bottomRowLoader
-                Layout.fillWidth: true
+                Layout.maximumWidth: parent.width
+                Layout.alignment: Qt.AlignHCenter
                 Layout.preferredHeight: 24
                 active: ((root.categories.count > 0) || !!root.bottomRowComponent)
                 sourceComponent: tagsListComponent
@@ -400,6 +400,7 @@ Rectangle {
             Component {
                 id: tagsListComponent
                 StatusRollArea {
+                    implicitWidth: d.cardWidth
                     arrowsGradientColor: d.cardColor
 
                     // TODO: Replace by `StatusListItemTagRow` - To be done!

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -18,7 +18,7 @@ QtObject {
     property ContactsStore contactsStore
     property CommunityTokensStore communityTokensStore
     property WalletStore.RootStore walletStore
-
+    property CurrenciesStore currencyStore
     property NetworkConnectionStore networkConnectionStore
 
     readonly property PermissionsStore permissionsStore: PermissionsStore {
@@ -535,7 +535,6 @@ QtObject {
     // Needed for TX in chat for stickers and via contact
     readonly property var accounts: walletSectionAccounts.accounts
     property string currentCurrency: walletSection.currentCurrency
-    property CurrenciesStore currencyStore: CurrenciesStore {}
     property var savedAddressesModel: walletSectionSavedAddresses.model
 
     property var disabledChainIdsFromList: []

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -1,10 +1,10 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ 0.1
 import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Core.Theme 0.1
-import StatusQ.Core.Utils 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
@@ -71,21 +71,19 @@ StatusSectionLayout {
         sourceModel: root.communitiesStore.curatedCommunitiesModel
 
         filters: [
-            ExpressionFilter {
-                enabled: d.searchMode
-                expression: {
-                    searcher.text
-                    return name.toLowerCase().includes(searcher.text.toLowerCase())
-                }
+            SQUtils.SearchFilter {
+                roleName: "name"
+                searchPhrase: searcher.text
             },
-            ExpressionFilter {
+            FastExpressionFilter {
                 expression: {
                     return filteredCommunitiesModel.selectedTagsPredicate(communityTags.selectedTagsNames, model.tags)
                 }
+                expectedRoles: ["tags"]
             },
-            FastExpressionFilter {
-                expression: !model.amIBanned
-                expectedRoles: ["amIBanned"]
+            ValueFilter {
+                roleName: "amIBanned"
+                value: false
             }
         ]
     }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -432,7 +432,7 @@ QtObject {
         walletSectionAccounts.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
     }
 
-    property SharedStores.CurrenciesStore currencyStore: SharedStores.CurrenciesStore {}
+    property SharedStores.CurrenciesStore currencyStore: SharedStores.CurrenciesStore {} // FIXME pass it down from AppMain instead of recreating it here
 
     function addressWasShown(address) {
         return d.mainModuleInst.addressWasShown(address)

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -427,6 +427,7 @@ RightTabBaseView {
                         overview: RootStore.overview
                         walletRootStore: RootStore
                         communitiesStore: root.communitiesStore
+                        currencyStore: root.sharedRootStore.currencyStore
                         showAllAccounts: RootStore.showAllAccounts
                         sendModal: root.sendModal
                         filterVisible: filterButton.checked

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -56,13 +56,16 @@ Item {
 
     property alias appLayout: appLayout
 
-    readonly property SharedStores.RootStore sharedRootStore: SharedStores.RootStore {}
+    readonly property SharedStores.RootStore sharedRootStore: SharedStores.RootStore {
+        currencyStore: appMain.currencyStore
+    }
 
     property AppStores.RootStore rootStore: AppStores.RootStore {
         profileSectionStore.sendModalPopup: sendModal
     }
     property ChatStores.RootStore rootChatStore: ChatStores.RootStore {
         contactsStore: appMain.rootStore.contactStore
+        currencyStore: appMain.currencyStore
         communityTokensStore: appMain.communityTokensStore
         emojiReactionsModel: appMain.rootStore.emojiReactionsModel
         openCreateChat: createChatView.opened
@@ -1358,6 +1361,7 @@ Item {
                                 sharedRootStore: appMain.sharedRootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
+                                    currencyStore: appMain.currencyStore
                                     communityTokensStore: appMain.communityTokensStore
                                     emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                                     openCreateChat: createChatView.opened
@@ -1517,6 +1521,7 @@ Item {
                                 sharedRootStore: appMain.sharedRootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
+                                    currencyStore: appMain.currencyStore
                                     communityTokensStore: appMain.communityTokensStore
                                     emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                                     openCreateChat: createChatView.opened
@@ -1562,6 +1567,7 @@ Item {
                         sharedRootStore: appMain.sharedRootStore
                         rootStore: ChatStores.RootStore {
                             contactsStore: appMain.rootStore.contactStore
+                            currencyStore: appMain.currencyStore
                             communityTokensStore: appMain.communityTokensStore
                             emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                             openCreateChat: createChatView.opened
@@ -1586,6 +1592,7 @@ Item {
                 height: appView.height - _buttonSize * 2
                 store: ChatStores.RootStore {
                     contactsStore: appMain.rootStore.contactStore
+                    currencyStore: appMain.currencyStore
                     communityTokensStore: appMain.communityTokensStore
                     emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                     openCreateChat: createChatView.opened

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -17,7 +17,7 @@ QtObject {
     property bool neverAskAboutUnfurlingAgain: !!accountSensitiveSettings ? accountSensitiveSettings.neverAskAboutUnfurlingAgain : false
     property bool gifUnfurlingEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.gifUnfurlingEnabled : false
 
-    property CurrenciesStore currencyStore: CurrenciesStore {}
+    required property CurrenciesStore currencyStore
 
     property TokenMarketValuesStore marketValueStore: TokenMarketValuesStore {}
 

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -34,6 +34,7 @@ ColumnLayout {
 
     property WalletStores.RootStore walletRootStore
     property CommunitiesStore communitiesStore
+    property CurrenciesStore currencyStore
     property bool showAllAccounts: false
     property bool displayValues: true
     property var sendModal
@@ -490,7 +491,7 @@ ColumnLayout {
                 modelData: transactionDelegate.model.activityEntry
                 timeStampText: isModelDataValid ? LocaleUtils.formatRelativeTimestamp(modelData.timestamp * 1000, true) : ""
                 flatNetworks: root.walletRootStore.flatNetworks
-                currenciesStore: RootStore.currencyStore
+                currenciesStore: root.currencyStore
                 walletRootStore: root.walletRootStore
                 showAllAccounts: root.showAllAccounts
                 displayValues: root.displayValues
@@ -555,7 +556,7 @@ ColumnLayout {
                     Layout.fillWidth: true
 
                     flatNetworks: root.walletRootStore.flatNetworks
-                    currenciesStore: RootStore.currencyStore
+                    currenciesStore: root.currencyStore
                     walletRootStore: root.walletRootStore
                     loading: true
                 }


### PR DESCRIPTION
### What does the PR do

- hide the permission from the `PermissionsRow` when it's set to private and the conditions are not met
- display a tooltip "(Not) eligible to join" over the lock icon
- show the same info in both community portal and profile dialog's community showcase tab
- speedup searching/filtering in the community portal
- fixup and extend the SB pages to demonstrate the new behavior
- separate commit to fixup `StatusCommunityCard` layout

Fixes https://github.com/status-im/status-desktop/issues/14747

### Affected areas

Community Portal, Profile Dialog/Showcase/Communities

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

CommunitiesPortalLayout (Status community not showing the tokens due to restrictions):
![image](https://github.com/user-attachments/assets/9820ecd1-82ed-4d53-812c-819fb48b005e)

CommunitiesPortalLayout (before the fix, for comparison):
![image](https://github.com/user-attachments/assets/83b6b26d-9f00-459d-94d0-1be92350fabc)

ProfileDialogView with a restricted community:
![image](https://github.com/user-attachments/assets/0b2782cb-f536-4283-8ab2-a3f31b6377a9)

PermissionsRow:
![image](https://github.com/user-attachments/assets/e42b77e0-22e5-41ef-aae9-00d13d3ef4dd)

StatusCommunity card big:
![image](https://github.com/user-attachments/assets/c005948a-072e-42c1-b2ac-bdcd57959ca8)

StatusCommunity card small:
![image](https://github.com/user-attachments/assets/be390ee9-d110-4182-ab84-80bfedf2286a)

