### PR TITLE
fix: there are no options for remove and release ens username

### DIFF
--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -127,7 +127,7 @@ method connectOwnedUsername*(self: Module, ensUsername: string, isStatus: bool) 
 method ensTransactionSent*(self: Module, trxType: string, chainId: int, ensUsername: string, txHash: string, err: string) =
   var finalError = err
   defer:
-    self.view.emitTransactionWasSentSignal(chainId, txHash, finalError)
+    self.view.emitTransactionWasSentSignal(trxType, chainId, txHash, ensUsername, finalError)
   if (err.len != 0):
     error "sending ens tx failed", errMsg=err, methodName="ensTransactionSent"
     return

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -62,9 +62,9 @@ QtObject:
     self.loading(false)
     self.detailsObtained(chainId, ensUsername, address, pubkey, isStatus, expirationTime)
 
-  proc transactionWasSent(self: View, chainId: int, txHash: string, error: string) {.signal.}
-  proc emitTransactionWasSentSignal*(self: View, chainId: int, txHash: string, error: string) =
-    self.transactionWasSent(chainId, txHash, error)
+  proc transactionWasSent(self: View, trxType: string, chainId: int, txHash: string, username: string, error: string) {.signal.}
+  proc emitTransactionWasSentSignal*(self: View, trxType: string, chainId: int, txHash: string, username: string, error: string) =
+    self.transactionWasSent(trxType, chainId, txHash, username, error)
 
   proc getEtherscanLink*(self: View): string {.slot.} =
     return self.etherscanLink

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -47,6 +47,8 @@ const SIGNAL_OWNER_TOKEN_SENT* = "ownerTokenSent"
 const SIGNAL_TRANSACTION_SENDING_COMPLETE* = "transactionSendingComplete"
 const SIGNAL_TRANSACTION_STATUS_CHANGED* = "transactionStatusChanged"
 
+const InternalErrorCode = -1
+
 type TokenTransferMetadata* = object
   tokenName*: string
   isOwnerToken*: bool
@@ -428,6 +430,7 @@ QtObject:
         tokenIsOwnerToken, toToken, disabledFromChainIDs, disabledToChainIDs, lockedInAmounts, extraParamsTable)
     except CatchableError as e:
       error "suggestedRoutes", exception=e.msg
+      self.suggestedRoutesReady(uuid, @[], "", $InternalErrorCode, e.msg)
 
   proc stopSuggestedRoutesAsyncCalculation*(self: Service) =
     try:

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -151,11 +151,11 @@ StackLayout {
             contactsStore: root.contactsStore
             sharedRootStore: root.sharedRootStore
             rootStore: root.rootStore
-            transactionStore: root.transactionStore
             createChatPropertiesStore: root.createChatPropertiesStore
             communitiesStore: root.communitiesStore
             walletAssetsStore: root.walletAssetsStore
             currencyStore: root.currencyStore
+            sendModalPopup: root.sendModalPopup
             sectionItemModel: root.sectionItemModel
             amIMember: sectionItem.amIMember
             amISectionAdmin: root.sectionItemModel.memberRole === Constants.memberRole.owner ||

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -283,6 +283,8 @@ QtObject {
 
     property var mainModuleInst: mainModule
 
+    readonly property string appNetworkId: mainModuleInst.appNetworkId
+
     property var communitiesModuleInst: communitiesModule
     property var communitiesList: communitiesModuleInst.model
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -44,11 +44,11 @@ StatusSectionLayout {
 
     property SharedStores.RootStore sharedRootStore
     property ChatStores.RootStore rootStore
-    required property SendStores.TransactionStore transactionStore
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
     property CommunitiesStores.CommunitiesStore communitiesStore
     required property WalletStore.WalletAssetsStore walletAssetsStore
     required property SharedStores.CurrenciesStore currencyStore
+    required property var sendModalPopup
     property var sectionItemModel
 
     property var emojiPopup
@@ -307,8 +307,8 @@ StatusSectionLayout {
     Component {
         id: statusStickerPackClickPopup
         StatusStickerPackClickPopup{
-            transactionStore: root.transactionStore
             walletAssetsStore: root.walletAssetsStore
+            sendModalPopup: root.sendModalPopup
             onClosed: {
                 destroy();
             }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -38,11 +38,11 @@ StatusSectionLayout {
     property SharedStores.RootStore sharedRootStore
     property ProfileSectionStore store
     property AppLayoutsStores.RootStore globalStore
+    required property var sendModalPopup
     property var systemPalette
     property var emojiPopup
     property SharedStores.NetworkConnectionStore networkConnectionStore
     required property TokensStore tokensStore
-    required property TransactionStore transactionStore
     required property WalletAssetsStore walletAssetsStore
     required property CollectiblesStore collectiblesStore
     required property SharedStores.CurrenciesStore currencyStore
@@ -220,9 +220,9 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 ensUsernamesStore: root.store.ensUsernamesStore
                 walletAssetsStore: root.walletAssetsStore
+                sendModalPopup: root.sendModalPopup
                 contactsStore: root.store.contactsStore
                 networkConnectionStore: root.networkConnectionStore
-                transactionStore: root.transactionStore
                 profileContentWidth: d.contentWidth
             }
         }

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -19,15 +19,13 @@ import AppLayouts.Profile.stores 1.0
 Item {
     id: root
     property EnsUsernamesStore ensUsernamesStore
-    property ContactsStore contactsStore
-    required property TransactionStore transactionStore
     property string username: ""
     property string chainId: ""
     property string walletAddress: "-"
     property string key: "-"
 
-    signal backBtnClicked();
-    signal usernameReleased()
+    signal backBtnClicked()
+    signal releaseUsernameRequested()
 
     QtObject {
         id: d
@@ -117,38 +115,6 @@ Item {
         }
     }
 
-    Component {
-        id: transactionDialogComponent
-        SendModal {
-            id: releaseEnsModal
-            modalHeader: qsTr("Release your username")
-            interactive: false
-            store: root.transactionStore
-            preSelectedSendType: Constants.SendType.ENSRelease
-            preSelectedRecipient: root.ensUsernamesStore.getEnsRegisteredAddress()
-            preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0)
-            preSelectedHoldingID: Constants.ethToken
-            preSelectedHoldingType: Constants.TokenType.ERC20
-            publicKey: root.contactsStore.myPublicKey
-            ensName: root.username
-
-            Connections {
-                target: root.ensUsernamesStore.ensUsernamesModule
-                function onTransactionWasSent(chainId: int, txHash: string, error: string) {
-                    if (!!error) {
-                        if (error.includes(Constants.walletSection.cancelledMessage)) {
-                            return
-                        }
-                        releaseEnsModal.sendingError.text = error
-                        return releaseEnsModal.sendingError.open()
-                    }
-                    usernameReleased()
-                    releaseEnsModal.close()
-                }
-            }
-        }
-    }
-
     RowLayout {
         id: actionsLayout
 
@@ -174,7 +140,7 @@ Item {
             enabled: false
             text: qsTr("Release username")
             onClicked: {
-                Global.openPopup(transactionDialogComponent)
+                root.releaseUsernameRequested()
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -64,7 +64,7 @@ Item {
 
     Connections {
         target: root.ensUsernamesStore.ensUsernamesModule
-        function onDetailsObtained(ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {
+        function onDetailsObtained(chainId: int, ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {
             if(username != (isStatus ? ensName + ".stateofus.eth" : ensName))
                 return;
             walletAddressLbl.subTitle = address;

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -22,13 +22,10 @@ Item {
     id: root
 
     property EnsUsernamesStore ensUsernamesStore
-    property ContactsStore contactsStore
-    required property TransactionStore transactionStore
     property int profileContentWidth
 
+    signal connectUsername(string username)
     signal continueClicked(string output, string username)
-    signal usernameUpdated(username: string);
-
 
     property string validationMessage: ""
     property bool valid: false
@@ -60,39 +57,6 @@ Item {
         }
         loading = true;
         Qt.callLater(validateENS, ensUsername, isStatus)
-    }
-
-    Component {
-        id: transactionDialogComponent
-        SendModal {
-            id: connectEnsModal
-            modalHeader: qsTr("Connect username with your pubkey")
-            interactive: false
-            store: root.transactionStore
-            preSelectedSendType: Constants.SendType.ENSSetPubKey
-            preSelectedRecipient: root.ensUsernamesStore.getEnsRegisteredAddress()
-            preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0)
-            preSelectedHoldingID: Constants.ethToken
-            preSelectedHoldingType: Constants.TokenType.ERC20
-            publicKey: root.contactsStore.myPublicKey
-            ensName: ensUsername.text
-
-            Connections {
-                target: root.ensUsernamesStore.ensUsernamesModule
-                function onTransactionWasSent(chainId: int, txHash: string, error: string) {
-                    if (!!error) {
-                        if (error.includes(Constants.walletSection.cancelledMessage)) {
-                            return
-                        }
-                        connectEnsModal.sendingError.text = error
-                        return connectEnsModal.sendingError.open()
-                    }
-                    usernameUpdated(ensUsername.text);
-                    connectEnsModal.close()
-                }
-            }
-        }
-
     }
 
     Item {
@@ -206,8 +170,7 @@ Item {
                 }
 
                 if(ensStatus === Constants.ens_connected_dkey || ensStatus === Constants.ens_owned){
-                    Global.openPopup(transactionDialogComponent, {ensUsername: ensUsername.text})
-                    return;
+                    root.connectUsername(ensUsername.text)
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -139,6 +139,8 @@ QtObject {
         }
 
         switch(code) {
+        case Constants.routerErrorCodes.errInternal:
+            return qsTr("an internal error occurred")
         case Constants.routerErrorCodes.errGeneric:
             return qsTr("unknown error occurred, try again later")
         case Constants.routerErrorCodes.processor.errFailedToParseBaseFee:
@@ -225,6 +227,7 @@ QtObject {
         }
 
         switch(code) {
+        case Constants.routerErrorCodes.errInternal:
         case Constants.routerErrorCodes.errGeneric:
             return details
         case Constants.routerErrorCodes.processor.errFailedToParseBaseFee:

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -651,8 +651,8 @@ Item {
         active: appMain.rootStore.mainModuleInst.sectionsLoaded
         sourceComponent: StatusStickersPopup {
             store: appMain.rootChatStore
-            transactionStore: appMain.transactionStore
             walletAssetsStore: appMain.walletAssetsStore
+            sendModalPopup: sendModal
 
             isWalletEnabled: appMain.rootStore.profileSectionStore.profileStore.isWalletEnabled
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1434,11 +1434,11 @@ Item {
                             sharedRootStore: appMain.sharedRootStore
                             store: appMain.rootStore.profileSectionStore
                             globalStore: appMain.rootStore
+                            sendModalPopup: sendModal
                             systemPalette: appMain.sysPalette
                             emojiPopup: statusEmojiPopup.item
                             networkConnectionStore: appMain.networkConnectionStore
                             tokensStore: appMain.tokensStore
-                            transactionStore: appMain.transactionStore
                             walletAssetsStore: appMain.walletAssetsStore
                             collectiblesStore: appMain.walletCollectiblesStore
                             currencyStore: appMain.currencyStore
@@ -1625,6 +1625,8 @@ Item {
                 this.active = false
             }
 
+            property string modalHeaderText
+            property bool interactive: true
             property string preSelectedAccountAddress
             property var preSelectedRecipient
             property int preSelectedRecipientType
@@ -1635,7 +1637,12 @@ Item {
             property int preSelectedChainId: 0
             property bool onlyAssets: false
 
+            property string stickersPackId: ""
+            property string publicKey: ""
+            property string ensName: ""
+
             sourceComponent: SendPopups.SendModal {
+                interactive: sendModal.interactive
                 onlyAssets: sendModal.onlyAssets                
 
                 loginType: appMain.rootStore.loginType
@@ -1647,6 +1654,8 @@ Item {
 
                 onClosed: {
                     sendModal.closed()
+                    sendModal.modalHeaderText = ""
+                    sendModal.interactive = true
                     sendModal.preSelectedSendType = Constants.SendType.Unknown
                     sendModal.preSelectedHoldingID = ""
                     sendModal.preSelectedHoldingType = Constants.TokenType.Unknown
@@ -1654,6 +1663,10 @@ Item {
                     sendModal.preSelectedRecipient = undefined
                     sendModal.preDefinedAmountToSend = ""
                     sendModal.preSelectedChainId = 0
+
+                    sendModal.stickersPackId = ""
+                    sendModal.publicKey = ""
+                    sendModal.ensName = ""
                 }
             }
             onLoaded: {
@@ -1665,18 +1678,28 @@ Item {
                     item.preSelectedRecipientType = sendModal.preSelectedRecipientType
                     item.preSelectedRecipient = sendModal.preSelectedRecipient
                 }
-                if(sendModal.preSelectedSendType !== Constants.SendType.Unknown) {
+                if (sendModal.preSelectedSendType !== Constants.SendType.Unknown) {
                     item.preSelectedSendType = sendModal.preSelectedSendType
                 }
-                if(preSelectedHoldingType !== Constants.TokenType.Unknown) {
+                if (sendModal.preSelectedHoldingType !== Constants.TokenType.Unknown) {
                     item.preSelectedHoldingID = sendModal.preSelectedHoldingID
                     item.preSelectedHoldingType = sendModal.preSelectedHoldingType
                 }
-                if(preDefinedAmountToSend != "") {
-                    item.preDefinedAmountToSend = preDefinedAmountToSend
+                if (sendModal.preDefinedAmountToSend != "") {
+                    item.preDefinedAmountToSend = sendModal.preDefinedAmountToSend
                 }
-                if(!!sendModal.preSelectedChainId) {
+                if (!!sendModal.preSelectedChainId) {
                     item.preSelectedChainId = sendModal.preSelectedChainId
+                }
+
+                if (!!sendModal.stickersPackId) {
+                    item.stickersPackId = sendModal.stickersPackId
+                }
+                if (!!sendModal.publicKey) {
+                    item.publicKey = sendModal.publicKey
+                }
+                if (!!sendModal.ensName) {
+                    item.ensName = sendModal.ensName
                 }
             }
         }

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -19,8 +19,8 @@ Popup {
     id: root
 
     property ChatStores.RootStore store
-    required property TransactionStore transactionStore
     required property WalletAssetsStore walletAssetsStore
+    required property var sendModalPopup
 
     property alias isWalletEnabled: stickerMarket.isWalletEnabled
 
@@ -102,8 +102,8 @@ Popup {
             Layout.fillWidth: true
             Layout.fillHeight: true
             store: root.store
-            transactionStore: root.transactionStore
             walletAssetsStore: root.walletAssetsStore
+            sendModalPopup: root.sendModalPopup
             stickerPacks: d.stickerPackList
             packId: stickerPackListView.selectedPackId
             marketVisible: d.stickerPacksLoaded && d.online

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1075,6 +1075,7 @@ QtObject {
 
     readonly property QtObject routerErrorCodes: QtObject {
 
+        readonly property string errInternal: "-1" // comes from Nim side
         readonly property string errGeneric: "0"
 
         readonly property QtObject processor: QtObject {


### PR DESCRIPTION
Corresponding `statusgo` PR:
- https://github.com/status-im/status-go/pull/5910

Fixes #16452

This PR brings back "Remove username" and "Release username" options via the first commit.
The second commit improves all ens-related flows.
The third commit improves all buying stickers flows.

Affected flows:
- buying ens name
- connecting an existing ens name
- releasing ens name
- removing ens name
- buying stickers from the all stickers popup (bottom right corner of the chat view)
- buying stickers from the single stickers popup (bottom right corner of the chat view, click on the desired pack, then click buy for that popup)
- buying stickers from chat (click on the sticker in messages and buy it if you don't have it bought)

Old implementation had 6 usages of SendModal component:
<img width="1012" alt="image" src="https://github.com/user-attachments/assets/2d619d52-fe88-450e-bc28-d61efd560c16">

Now there is a single one only:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/92db8db9-ce3b-413e-a74d-8468f1da383f">
