### PR TITLE
chore: Set-up the initial codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# By default adding the desktop team to review any changes
+*           @status-im/desktop
+Makefile    @status-im/devops @status-im/desktop
+
+# Any change in the ci requires approval from DevOps team
+/ci/        @status-im/devops
+/nix/       @status-im/devops
+/scripts/   @status-im/devops
+# Default qml/js code reviewers
+*.qml       @micieslak @caybro @alexjba
+*.js        @micieslak @caybro @alexjba
+/storybook/ @micieslak @caybro @alexjba
+# Default squish tests owners
+/test/e2e/  @status-im/desktop-qa
+
+# Wallet - nim
+/src/app/modules/main/wallet_section/           @status-im/desktop-wallet
+/src/app_service/service/wallet_account/        @status-im/desktop-wallet
+/src/app_service/service/wallet_connect/        @status-im/desktop-wallet
+/src/app_service/service/transaction/           @status-im/desktop-wallet
+/src/app_service/service/saved_address/         @status-im/desktop-wallet
+/src/app_service/service/ramp/                  @status-im/desktop-wallet
+/src/app_service/service/network/               @status-im/desktop-wallet
+
+# Wallet - qml
+/ui/app/AppLayouts/Wallet/                      @status-im/desktop-wallet @micieslak


### PR DESCRIPTION
### What does the PR do

closes #16473

Setting-up the initial code owners in GH. The code owners will be automatically added to PR reviews.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Important

Any CC can change the `CODEOWNERS` file to add/remove himself as a default reviewer. `CODEOWNERS` file can work with specific files or folders (E.g. When developing a new feature, the dev can add himself as a default reviewer for the files involved in the feature)

I've took the freedom to add specific CCs to some domain that are clearly defined (CI, e2e, qml). Please feel free to propose changes if you'd like me to extend the ownership or remove your username completely.
CC. @jakubgs @yakimant @micieslak @caybro

@status-im/desktop is the default reviewer
@status-im/desktop-qa is the default reviewer for `/test/e2e/`

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->
