### PR TITLE
fix(chat): chat input accepts DnD for blocked users

### DIFF
--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -32,7 +32,6 @@ SplitView {
         }
         Component.onCompleted: {
             Utils.globalUtilsInst = globalUtilsMock.globalUtils
-            Global.dragArea = null
             globalUtilsMock.ready = true
         }
     }

--- a/storybook/qmlTests/tests/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/tests/tst_StatusChatInput.qml
@@ -702,9 +702,5 @@ Item {
         function isCompressedPubKey(publicKey) {
             return false
         }
-
-        Component.onCompleted: {
-            Global.dragArea = root
-        }
     }
 }

--- a/test/e2e/configs/__init__.py
+++ b/test/e2e/configs/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from os import path
 from scripts.utils.system_path import SystemPath

--- a/test/e2e/gui/components/back_up_your_seed_phrase_popup.py
+++ b/test/e2e/gui/components/back_up_your_seed_phrase_popup.py
@@ -111,4 +111,4 @@ class BackUpYourSeedPhrasePopUp(BasePopup):
         self.confirm_second_word(seed_phrases)
         self.continue_seed_phrase()
         self.set_acknowledge(True)
-        self.complete_and_delete_seed_phrase().wait_until_hidden()
+        self.complete_and_delete_seed_phrase()

--- a/test/e2e/gui/components/base_popup.py
+++ b/test/e2e/gui/components/base_popup.py
@@ -13,4 +13,3 @@ class BasePopup(QObject):
     @allure.step('Close')
     def close(self):
         driver.type(self.object, '<Escape>')
-        self.wait_until_hidden()

--- a/test/e2e/gui/components/community/community_category_popup.py
+++ b/test/e2e/gui/components/community/community_category_popup.py
@@ -1,7 +1,7 @@
 import allure
 
 import configs
-import driver.objects_access
+import driver
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
 from gui.elements.check_box import CheckBox
@@ -28,13 +28,15 @@ class CategoryPopup(BasePopup):
         self._name_text_edit.text = title
         return self
 
-    @allure.step('Click checkbox in category popup')
+    @allure.step('Click checkbox in edit category popup')
     def click_checkbox_by_index(self, index: int):
-        checkboxes = []
-        for child in driver.objects_access.walk_children(self._channels_view.object):
-            if child.id == 'channelItemCheckbox':
-                checkboxes.append(child)
-        driver.mouseClick(checkboxes[index])
+        checkboxes = driver.findAllObjects(self._channel_item_checkbox.real_name)
+        if len(checkboxes) > 0:
+            for _index, item in enumerate(checkboxes):
+                if index == _index:
+                    driver.mouseClick(item)
+        else:
+            raise AssertionError('Empty list of channels')
         return self
 
 
@@ -50,7 +52,6 @@ class NewCategoryPopup(CategoryPopup):
         if checkbox_state:
             self._channel_item_checkbox.click()
         self._create_button.click()
-        self.wait_until_hidden()
 
 
 class EditCategoryPopup(CategoryPopup):
@@ -63,4 +64,3 @@ class EditCategoryPopup(CategoryPopup):
     @allure.step('Click save in edit category popup')
     def save(self):
         self._save_button.click()
-        self.wait_until_hidden()

--- a/test/e2e/gui/components/community/create_community_popups.py
+++ b/test/e2e/gui/components/community/create_community_popups.py
@@ -238,5 +238,4 @@ class CreateCommunityPopup(BasePopup):
         self.set_intro(intro)
         self.set_outro(outro)
         self._create_community_button.click()
-        self.wait_until_hidden()
         return CommunityScreen().wait_until_appears()

--- a/test/e2e/gui/components/messaging/edit_group_name_and_image_popup.py
+++ b/test/e2e/gui/components/messaging/edit_group_name_and_image_popup.py
@@ -20,4 +20,3 @@ class EditGroupNameAndImagePopup(BasePopup):
     @allure.step('Save changes')
     def save_changes(self):
         self._save_changes_button.click()
-        self.wait_until_hidden()

--- a/test/e2e/gui/components/messaging/leave_group_popup.py
+++ b/test/e2e/gui/components/messaging/leave_group_popup.py
@@ -14,5 +14,4 @@ class LeaveGroupPopup(BasePopup):
     @allure.step("Confirm leaving group")
     def confirm_leaving(self):
         self._leave_button.click()
-        self.wait_until_hidden()
 

--- a/test/e2e/gui/components/settings/send_contact_request_popup.py
+++ b/test/e2e/gui/components/settings/send_contact_request_popup.py
@@ -20,7 +20,6 @@ class SendContactRequest(BasePopup):
         self._chat_key_text_edit.text = chat_key
         self._message_text_edit.text = message
         self._send_button.click()
-        self.wait_until_hidden()
 
 
 class SendContactRequestFromProfile(BasePopup):

--- a/test/e2e/gui/components/settings/sync_new_device_popup.py
+++ b/test/e2e/gui/components/settings/sync_new_device_popup.py
@@ -37,7 +37,6 @@ class SyncNewDevicePopup(BasePopup):
     @allure.step('Click done')
     def done(self):
         self._done_button.click()
-        self.wait_until_hidden()
 
     @allure.step('Click close')
     def close(self):

--- a/test/e2e/gui/components/wallet/add_saved_address_popup.py
+++ b/test/e2e/gui/components/wallet/add_saved_address_popup.py
@@ -90,7 +90,6 @@ class AddressPopup(AddSavedAddressPopup):
             self.verify_otimism_mainnet_network_tag_present()
             self.verify_arbitrum_mainnet_network_tag_present(),
         self._save_add_address_button.click()
-        self.wait_until_hidden()
 
 
 class EditSavedAddressPopup(AddSavedAddressPopup):

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -115,18 +115,20 @@ class QObject:
             button or driver.Qt.LeftButton
         )
         LOG.info('%s: is clicked with Qt.LeftButton', self)
-        LOG.info("Checking if application context is frozen")
+        # LOG.info("Checking if application context is frozen")
 
         if timeout is None:
             pass
 
         if timeout is not None:
-            if not isFrozen(timeout):
-                pass
+            pass
+            # TODO: enable after fixing https://github.com/status-im/status-desktop/issues/15345
+            # if not isFrozen(timeout):
+            #    pass
 
-            else:
-                LOG.info("Application context did not respond after click")
-                raise Exception(f'Application UI is not responding within {timeout} second(s)')
+            # else:
+            #    LOG.info("Application context did not respond after click")
+            #    raise Exception(f'Application UI is not responding within {timeout} second(s)')
 
     @allure.step('Native click {0}')
     def native_mouse_click(

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -12,7 +12,6 @@ from gui.components.community.invite_contacts import InviteContactsPopup
 from gui.components.context_menu import ContextMenu
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
-from gui.components.onboarding.share_usage_data_popup import ShareUsageDataPopup
 from gui.components.splash_screen import SplashScreen
 from gui.components.toast_message import ToastMessage
 from gui.components.online_identifier import OnlineIdentifier
@@ -176,7 +175,6 @@ class MainWindow(Window):
 
     @allure.step('Sign Up user')
     def sign_up(self, user_account: UserAccount = RandomUser()):
-        share_updates_popup = ShareUsageDataPopup()
         BeforeStartedPopUp().get_started()
         welcome_screen = WelcomeToStatusView().wait_until_appears()
         profile_view = welcome_screen.get_keys().generate_new_keys()
@@ -193,19 +191,14 @@ class MainWindow(Window):
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
-        if share_updates_popup.exists:
-            share_updates_popup.skip()
         return self
 
     @allure.step('Log in user')
     def log_in(self, user_account: UserAccount):
-        share_updates_popup = ShareUsageDataPopup()
         LoginView().log_in(user_account)
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
-        if share_updates_popup.exists:
-            share_updates_popup.skip()
         return self
 
     @allure.step('Authorize user')

--- a/test/e2e/tests/crtitical_tests_prs/test_add_account_after_restart.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_account_after_restart.py
@@ -40,7 +40,6 @@ def test_add_generated_account_restart_add_again(
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_emoji(emoji).set_color(color).save_changes()
         authenticate_with_password(user_account)
-        account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
         assert len(main_screen.wait_for_notification()) == 1, \
@@ -67,7 +66,6 @@ def test_add_generated_account_restart_add_again(
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name2).set_emoji(emoji2).set_color(color2).save_changes()
         authenticate_with_password(user_account)
-        account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
         assert len(main_screen.wait_for_notification()) == 1, \

--- a/test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
@@ -38,7 +38,6 @@ def test_delete_generated_account_from_wallet_settings(
     with step('Add a new generated account from wallet settings screen'):
         add_account_popup.set_name(account_name).set_emoji(emoji).set_color(color).save_changes()
         authenticate_with_password(user_account)
-        add_account_popup.wait_until_hidden()
 
     with step('Open account details view for the generated account'):
         account_index = 1

--- a/test/e2e/tests/crtitical_tests_prs/test_add_edit_delete_generated_account.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_edit_delete_generated_account.py
@@ -37,7 +37,6 @@ def test_add_edit_delete_generated_account(main_screen: MainWindow, user_account
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_emoji(emoji).set_color(color).save_changes()
         authenticate_with_password(user_account)
-        account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
         assert len(main_screen.wait_for_notification()) == 1, \

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -50,8 +50,6 @@ import mainui.activitycenter.popups 1.0
 
 import SortFilterProxyModel 0.2
 
-import "panels"
-
 Item {
     id: appMain
 
@@ -1353,14 +1351,6 @@ Item {
                             ChatLayout {
                                 id: chatLayoutContainer
 
-                                Binding {
-                                    target: rootDropAreaPanel
-                                    property: "enabled"
-                                    value: chatLayoutContainer.currentIndex === 0 // Meaning: Chats / channels view
-                                    when: visible
-                                    restoreMode: Binding.RestoreBindingOrValue
-                                }
-
                                 sharedRootStore: appMain.sharedRootStore
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
@@ -1486,14 +1476,6 @@ Item {
                                 id: chatLayoutComponent
 
                                 readonly property bool isManageCommunityEnabledInAdvanced: appMain.rootStore.profileSectionStore.advancedStore.isManageCommunityOnTestModeEnabled
-
-                                Binding {
-                                    target: rootDropAreaPanel
-                                    property: "enabled"
-                                    value: chatLayoutComponent.currentIndex === 0 // Meaning: Chats / channels view
-                                    when: visible
-                                    restoreMode: Binding.RestoreBindingOrValue
-                                }
 
                                 Connections {
                                     target: Global
@@ -2151,13 +2133,6 @@ Item {
                 savedAddressActivity.close()
             }
         }
-    }
-
-    DropAreaPanel {
-        id: rootDropAreaPanel
-
-        width: appMain.width
-        height: appMain.height
     }
 
     Loader {

--- a/ui/app/mainui/panels/DropAreaPanel.qml
+++ b/ui/app/mainui/panels/DropAreaPanel.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.14
+import QtQuick 2.15
+
 import utils 1.0
 
 DropArea {
@@ -11,10 +12,6 @@ DropArea {
 
     function cleanup() {
         rptDraggedPreviews.model = []
-    }
-
-    Component.onCompleted: {
-        Global.dragArea = this;
     }
 
     onDropped: (drop) => {
@@ -42,7 +39,7 @@ DropArea {
     onExited: cleanup()
 
     Loader {
-        active: root.containsDrag
+        active: root.containsDrag && root.enabled
         width: active ? parent.width : 0
         height: active ? parent.height : 0
         sourceComponent: Rectangle {

--- a/ui/app/mainui/qmldir
+++ b/ui/app/mainui/qmldir
@@ -2,3 +2,4 @@ AppMain 1.0 AppMain.qml
 SplashScreen 1.0 SplashScreen.qml
 Popups 1.0 Popups.qml
 StatusTrayIcon 1.0 StatusTrayIcon.qml
+DropAreaPanel 1.0 panels/DropAreaPanel.qml

--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -1,7 +1,10 @@
 import QtQuick 2.15
 import QtQuick.Window 2.15
 import QtGraphicalEffects 1.15
+
 import shared.panels 1.0
+
+import utils 1.0
 
 Item {
     id: root

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -11,6 +11,8 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.stores 1.0 as SharedStores
 
+import mainui 1.0
+
 //TODO remove this dependency
 import AppLayouts.Chat.panels 1.0
 import AppLayouts.Chat.stores 1.0 as ChatStores
@@ -948,11 +950,11 @@ Rectangle {
         messageInputField.forceActiveFocus();
     }
 
-    Connections {
-        target: Global.dragArea
-        enabled: control.visible
-        ignoreUnknownSignals: true
-        function onDroppedOnValidScreen(drop) {
+    DropAreaPanel {
+        enabled: control.visible && control.enabled
+        parent: Overlay.overlay
+        anchors.fill: parent
+        onDroppedOnValidScreen: (drop) => {
             let dropUrls = drop.urls
             if (!drop.hasUrls) {
                 console.warn("Trying to drop, list of URLs is empty tho; formats:", drop.formats)

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -5,7 +5,6 @@ import QtQml 2.15
 QtObject {
     id: root
 
-    property var dragArea
     property bool activityPopupOpened: false
     property int settingsSubsection: Constants.settingsSubsection.profile
     property int settingsSubSubsection: -1


### PR DESCRIPTION
### What does the PR do

- do not allow DND when the StatusChatInput is disabled
- remove `Global.dragArea` variable from the Global singleton

Fixes #16451

### Affected areas

Chat/Input

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/dbf0c944-d92f-4251-b89d-cb83fd9fda2f

