### PR TITLE
fix: Update "Welcome to Status Beta" startup dialog

### DIFF
--- a/ui/imports/shared/popups/UserAgreementPopup.qml
+++ b/ui/imports/shared/popups/UserAgreementPopup.qml
@@ -72,7 +72,7 @@ StatusModal {
             }
 
             AgreementSection {
-                body: qsTr("We are working to fix all these issues ASAP, ahead of Status Desktop’s 1.0 release!")
+                body: qsTr("We are working to fix all these issues ASAP")
             }
 
             StatusCheckBox {


### PR DESCRIPTION
### What does the PR do

- reword the sentence, remove ref to 1.0 release

Fixes #16447

### Affected areas

UserAgreementPopup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/f342c5aa-7846-4aca-aa23-2c8312c64542)