### PR TITLE
chore: sign the flow only once if approval and transaction need to be placed once after another (swap flow)

### DIFF
--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -44,7 +44,7 @@ method stopUpdatesForSuggestedRoute*(self: AccessInterface) {.base.} =
 method suggestedRoutesReady*(self: AccessInterface, uuid: string, suggestedRoutes: SuggestedRoutesDto, errCode: string, errDescription: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateAndTransferV2*(self: AccessInterface, fromAddr: string, uuid: string, slippagePercentage: float) {.base.} =
+method authenticateAndTransfer*(self: AccessInterface, fromAddr: string, uuid: string, slippagePercentage: float) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onUserAuthenticated*(self: AccessInterface, password: string, pin: string) {.base.} =

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -180,7 +180,7 @@ QtObject:
       slippagePercentage = slippagePercentageString.parseFloat()
     except:
       error "parsing slippage failed", slippage=slippagePercentageString
-    self.delegate.authenticateAndTransferV2(self.selectedSenderAccountAddress, uuid, slippagePercentage)
+    self.delegate.authenticateAndTransfer(self.selectedSenderAccountAddress, uuid, slippagePercentage)
 
   proc suggestedRoutesReady*(self: View, suggestedRoutes: QVariant, errCode: string, errDescription: string) {.signal.}
   proc setTransactionRoute*(self: View, routes: TransactionRoutes, errCode: string, errDescription: string) =

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -129,7 +129,6 @@ QtObject:
         break
 
     if ensDto.username.len == 0:
-      error "Error updating ens username status", message = "no ens username found for transactionHash: " & transactionHash
       return
 
     let key = makeKey(ensDto.username, chainId)

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -363,6 +363,8 @@ Item {
                 verify(!!headerContentItemEmoji)
                 compare(headerContentItemEmoji.asset.emoji, swapAdaptor.nonWatchAccounts.get(i).emoji)
 
+                waitForRendering(amountToSendInput)
+
                 verify(amountToSendInput.cursorVisible)
             }
             closeAndVerfyModal()
@@ -1399,6 +1401,7 @@ Item {
             launchAndVerfyModal()
             waitForRendering(payPanel)
             waitForRendering(receivePanel)
+            waitForRendering(payAmountToSendInput)
 
             let paytokenSelectorContentItemText = findChild(payPanel, "tokenSelectorContentItemText")
             verify(!!paytokenSelectorContentItemText)

--- a/storybook/qmlTests/tests/tst_SwapSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapSignModal.qml
@@ -99,8 +99,7 @@ Item {
             controlUnderTest.toTokenAmount = "1.42"
             controlUnderTest.toTokenContractAddress = "0xdeadcaff"
 
-            // title & subtitle
-            compare(controlUnderTest.title, qsTr("Sign Swap"))
+            // subtitle
             compare(controlUnderTest.subtitle, qsTr("%1 to %2").arg(controlUnderTest.formatBigNumber(controlUnderTest.fromTokenAmount, controlUnderTest.fromTokenSymbol))
                     .arg(controlUnderTest.formatBigNumber(controlUnderTest.toTokenAmount, controlUnderTest.toTokenSymbol)))
 

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -36,7 +36,11 @@ StatusDialog {
     property Component headerIconComponent
 
     property bool feesLoading
+
+    property string signButtonText: qsTr("Sign")
     property bool signButtonEnabled: true
+
+    property string closeButtonText: qsTr("Close")
 
     property date requestTimestamp: new Date()
     property int expirationSeconds
@@ -61,14 +65,14 @@ StatusDialog {
                 visible: !root.hasExpiryDate || !countdownPill.isExpired
                 icon.name: Constants.authenticationIconByType[root.loginType]
                 disabledColor: Theme.palette.directColor8
-                text: qsTr("Sign")
+                text: root.signButtonText
                 onClicked: root.accept() // close and emit accepted() signal
             }
             StatusButton {
                 objectName: "closeButton"
                 id: closeButton
                 visible: root.hasExpiryDate && countdownPill.isExpired
-                text: qsTr("Close")
+                text: root.closeButtonText
                 onClicked: root.close()
             }
         }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -397,10 +397,12 @@ StatusDialog {
                                                                                   : Constants.authenticationIconByType[root.loginType]
                     text: {
                         if(root.swapAdaptor.validSwapProposalReceived) {
-                            if (root.swapAdaptor.approvalPending) {
-                                return qsTr("Approving %1").arg(fromTokenSymbol)
-                            } else if(root.swapAdaptor.swapOutputData.approvalNeeded) {
-                                return qsTr("Approve %1").arg(fromTokenSymbol)
+                            if(root.swapAdaptor.swapOutputData.approvalNeeded) {
+                                if (root.swapAdaptor.approvalPending) {
+                                    return qsTr("Approving %1").arg(fromTokenSymbol)
+                                } else if(!root.swapAdaptor.approvalSuccessful) {
+                                    return qsTr("Approve %1").arg(fromTokenSymbol)
+                                }
                             }
                         }
                         return qsTr("Swap")
@@ -416,7 +418,7 @@ StatusDialog {
                     onClicked: {
                         if (root.swapAdaptor.validSwapProposalReceived) {
                             d.addMetricsEvent("next button pressed")
-                            if (root.swapAdaptor.swapOutputData.approvalNeeded)
+                            if (root.swapAdaptor.swapOutputData.approvalNeeded && !root.swapAdaptor.approvalSuccessful)
                                 Global.openPopup(swapApproveModalComponent)
                             else
                                 Global.openPopup(swapSignModalComponent)
@@ -482,6 +484,9 @@ StatusDialog {
         id: swapSignModalComponent
         SwapSignModal {
             destroyOnClose: true
+
+            title: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful? qsTr("Swap") : qsTr("Sign Swap")
+            signButtonText: root.swapAdaptor.swapOutputData.approvalNeeded && root.swapAdaptor.approvalSuccessful? qsTr("Swap") : qsTr("Sign")
 
             formatBigNumber: (number, symbol, noSymbolOption) => root.swapAdaptor.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -87,8 +87,6 @@ QObject {
     readonly property bool isEthBalanceInsufficient: d.isEthBalanceInsufficient
     readonly property bool isTokenBalanceInsufficient: d.isTokenBalanceInsufficient
 
-    signal suggestedRoutesReady()
-
     QtObject {
         id: d
 
@@ -252,11 +250,10 @@ QObject {
                 root.swapOutputData.hasError = true
             }
             root.swapOutputData.hasError = root.swapOutputData.hasError || root.swapOutputData.errCode !== ""
-            root.suggestedRoutesReady()
         }
 
         function onTransactionSent(uuid, chainId, approvalTx, txHash, error) {
-            if(root.swapOutputData.approvalNeeded) {
+            if(root.swapOutputData.approvalNeeded && !root.approvalSuccessful) {
                 if (uuid !== d.uuid || !!error) {
                     root.approvalPending = false
                     root.approvalSuccessful = false
@@ -272,10 +269,6 @@ QObject {
                 root.approvalPending = false
                 root.approvalSuccessful = status == "Success" // TODO: make a all tx statuses Constants (success, pending, failed)
                 d.txHash = ""
-
-                if (root.approvalSuccessful) {
-                    root.swapOutputData.approvalNeeded = false
-                }
             }
         }
     }
@@ -335,14 +328,10 @@ QObject {
 
     function sendApproveTx() {
         root.approvalPending = true
-        const accountAddress = root.swapFormData.selectedAccountAddress
-
         root.swapStore.authenticateAndTransfer(d.uuid, "")
     }
 
     function sendSwapTx() {
-        const accountAddress = root.swapFormData.selectedAccountAddress
-
         root.swapStore.authenticateAndTransfer(d.uuid, root.swapFormData.selectedSlippage)
     }
 }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapSignModal.qml
@@ -45,7 +45,6 @@ SignTransactionModalBase {
     required property string serviceProviderURL
     required property string serviceProviderTandCUrl
 
-    title: qsTr("Sign Swap")
     //: e.g. (swap) 100 DAI to 100 USDT
     subtitle: qsTr("%1 to %2").arg(formatBigNumber(fromTokenAmount, fromTokenSymbol)).arg(formatBigNumber(toTokenAmount, toTokenSymbol))
 


### PR DESCRIPTION
The Swap flow now:
1. if approval not needed (swapping ETH)
  - run swap flow
  - click "Swap" button
  - review "Sign Swap" popup
  - click "Sign"
  - authenticate
2. if approval needed (swapping any ERC20 token)
  - run swap flow
  - click "Approve TOKEN" button
  - review "Approve spending cap" popup
  - click "Sign"
  - authenticate
  - button is in the "Approving TOKEN" state
  - when approval is executed, and "Swap" button becomes available, click it
  - review "Swap" popup
  - click "Swap" button **(no need to sign again here)**

Updated the following User Stories:
- SD-28
- SD-36
- SD-89

Closes #16337 