### PR TITLE
chore(E2E): Use `mouseWheel` method to scroll

### DIFF
--- a/test/e2e/driver/mouse.py
+++ b/test/e2e/driver/mouse.py
@@ -42,3 +42,16 @@ def press_and_move(
     move(obj, x, y, dx, dy, step, sleep)
     squish.mouseRelease(mouse)
     time.sleep(1)
+
+def scroll(
+        obj,
+        x: int,
+        y: int,
+        dx: int,
+        dy: int,
+        steps: int = 1,
+        sleep: float = 0
+):
+    for _ in range(steps):
+        squish.mouseWheel(obj, x, y, dx, dy, squish.Qt.NoModifier)
+        time.sleep(sleep)

--- a/test/e2e/gui/elements/scroll.py
+++ b/test/e2e/gui/elements/scroll.py
@@ -17,8 +17,7 @@ class Scroll(QObject):
     def vertical_scroll_down(self, element: QObject, timeout_sec: int = 5):
         started_at = time.monotonic()
         while not element.is_visible:
-            self.object.scrollPageDown()
-            time.sleep(0.1)
+            driver.mouse.scroll(self.object, self.object.width / 2, self.object.height / 2, 0, -30, 1, 0.1)
             if time.monotonic() - started_at > timeout_sec:
                 raise LookupError(f'Object not found: {element}')
 
@@ -26,39 +25,6 @@ class Scroll(QObject):
     def vertical_scroll_up(self, element: QObject, timeout_sec: int = 5):
         started_at = time.monotonic()
         while not element.is_visible:
-            self.object.scrollPageUp()
-            time.sleep(0.1)
+            driver.mouse.scroll(self.object, self.object.width / 2, self.object.height / 2, 0, 30, 1, 0.1)
             if time.monotonic() - started_at > timeout_sec:
                 raise LookupError(f'Object not found: {element}')
-
-    @allure.step('Scroll vertical to object {1}')
-    def old_vertical_scroll_to(self, element: QObject, timeout_sec: int = 5):
-        started_at = time.monotonic()
-        step = 10
-        direction = 1
-        while not element.is_visible:
-            step *= 2
-            direction *= -1
-            driver.flick(self.object, 0, step * direction)
-            time.sleep(0.1)
-            if time.monotonic() - started_at > timeout_sec:
-                raise LookupError(f'Object not found: {element}')
-        try:
-            if hasattr(element.object, 'y'):
-                y = int(element.object.y)
-                if hasattr(element.object, 'height'):
-                    y += int(element.object.height)
-                driver.flick(self.object, 0, y)
-                LOG.info('%s: scrolled to %s', self, element)
-        except LookupError as err:
-            LOG.error(err)
-
-    @allure.step('Scroll down to object')
-    def vertical_down_to(self, element: QObject, timeout_sec: int = 5):
-        started_at = time.monotonic()
-        step = 100
-        while not element.is_visible:
-            driver.flick(self.object, 0, step)
-            if time.monotonic() - started_at > timeout_sec:
-                raise LookupError(f'Object not found: {element}')
-            LOG.info('%s: scrolled down to %s', self, element)

--- a/test/e2e/gui/mocked_keycard_controller.py
+++ b/test/e2e/gui/mocked_keycard_controller.py
@@ -55,7 +55,7 @@ class MockedKeycardController(Window):
     @allure.step('Click Register keycard')
     def register_keycard(self):
         time.sleep(1)
-        self._scroll_flick.vertical_down_to(self._register_keycard_button)
+        self._scroll_flick.vertical_scroll_down(self._register_keycard_button)
         self._register_keycard_button.click()
         time.sleep(1)
         return self


### PR DESCRIPTION
### What does the PR do

Closes #16325 

This makes the scrolling work for any qml type where the child supports scrolling. By default the cursor is positioned in the middle of the scrollable item and scroll in steps of 30px.
This can be adjusted later on to better fit most of our use cases. It's a configuration we can tweak in an empirical way.
