### PR TITLE
fix(ci)_: move nim cache to workspace tmp folder

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -35,7 +35,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: '--colors:off'
+      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -27,7 +27,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: '--colors:off'
+      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -29,7 +29,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: '--colors:off'
+      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -26,7 +26,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: '--colors:off'
+      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',


### PR DESCRIPTION
An error has shown that Nim compilation uses cache folder in `jenkins` home:
```
clang: error: no such file or directory:
'/Users/jenkins/.cache/nim/nimsuggest_r/@m..@slib@swrappers@slinenoise@slinenoise.c.o'
```
This is a bad idea as parallel CI builds can result in very bizzarre bugs.