### PR TITLE
chore: remove protoc-gen-go scripts

### DIFF
--- a/scripts/macos_build_setup.sh
+++ b/scripts/macos_build_setup.sh
@@ -15,7 +15,7 @@ function check_version {
 
 function install_build_dependencies {
   echo "Install build dependencies"
-  brew install cmake pkg-config libtool jq node@18 yarn protoc-gen-go
+  brew install cmake pkg-config libtool jq node@18 yarn
 }
 
 function install_qt {

--- a/scripts/ubuntu_build_setup.sh
+++ b/scripts/ubuntu_build_setup.sh
@@ -16,7 +16,7 @@ function install_build_dependencies {
   echo "Install build dependencies"
   apt update
   apt install -yq git wget build-essential \
-    cmake extra-cmake-modules pkg-config protoc-gen-go \
+    cmake extra-cmake-modules pkg-config \
     mesa-common-dev unixodbc-dev libpq-dev libglu1-mesa-dev libpcsclite-dev \
     libpcre3-dev libssl-dev libpulse-mainloop-glib0 libxkbcommon-x11-dev
 }

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -12,20 +12,6 @@ function Install-Scoop {
     }
 }
 
-# Install Protobuf tool necessary to generate status-go files.
-function Install-Protobuf-Go {
-    $ProtocGenVersion = "v1.34.1"
-    $ProtocGenZIP = "protoc-gen-go.$ProtocGenVersion.windows.amd64.zip"
-    $ProtocGenURL = "https://github.com/protocolbuffers/protobuf-go/releases/download/$ProtocGenVersion/$ProtocGenZIP"
-    $ProtocGenSHA256 = "403a619c4698fe5c4162c7f855803de3e8d8e0c187d7d51cbeb8d599f7a5a073"
-    (New-Object System.Net.WebClient).DownloadFile($ProtocGenURL, "$env:USERPROFILE\$ProtocGenZIP")
-    $ProtocGenRealSHA256 = (Get-Filehash -algorithm SHA256 "$env:USERPROFILE\$ProtocGenZIP").Hash
-    if ($ProtocGenRealSHA256 -ne $ProtocGenSHA256) {
-        throw "SHA256 hash does not match for $ProtocGenZIP !"
-    }
-    New-Item "$env:USERPROFILE\go\bin" -ItemType Directory -ea 0
-    7z x -o="$env:USERPROFILE\go\bin" -y "$env:USERPROFILE\$ProtocGenZIP"
-}
 
 # Install Git and other dependencies
 function Install-Dependencies {
@@ -104,7 +90,6 @@ $QtVersion = "5.15.2"
 If ($MyInvocation.InvocationName -ne ".") {
     Install-Scoop
     Install-Dependencies
-    Install-Protobuf-Go
     Install-Qt-SDK
     Install-VC-BuildTools
     Show-Success-Message


### PR DESCRIPTION
## Summary

This PR removes `protoc-gen-go` installation scripts because in https://github.com/status-im/status-desktop/pull/16488 we install this via `status-go-deps` stage in the Makefile.