### PR TITLE
fix(StatusChatInfoButton): missing lock icon

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -15,7 +15,8 @@ Button {
     property string subTitle
     property bool muted
     property int pinnedMessagesCount
-
+    property bool requiresPermissions
+    property bool locked
     property bool forceHideTypeIcon: false
 
     property StatusAssetSettings asset: StatusAssetSettings {
@@ -108,8 +109,12 @@ Button {
                             return "tiny/public-chat"
                         case StatusChatInfoButton.Type.GroupChat:
                             return "tiny/group"
-                        case StatusChatInfoButton.Type.CommunityChat:
-                            return "tiny/channel"
+                        case StatusChatInfoButton.Type.CommunityChat: {
+                            var iconName = "tiny/channel"
+                            if (root.requiresPermissions)
+                                iconName = root.locked ? "tiny/channel-locked" : "tiny/channel-unlocked"
+                            return Theme.palette.name === "light" ? iconName : iconName+"-white"
+                        }
                         default:
                             return ""
                         }

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -270,7 +270,8 @@ Item {
 
             objectName: "chatInfoBtnInHeader"
             title: chatContentModule? chatContentModule.chatDetails.name : ""
-
+            requiresPermissions: chatContentModule ? chatContentModule.chatDetails.requiresPermissions : false
+            locked: requiresPermissions && (chatContentModule ? !chatContentModule.chatDetails.canPost : false)
             subTitle: {
                 if(!chatContentModule)
                     return ""

--- a/ui/app/AppLayouts/Communities/popups/CommunityMemberMessagesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityMemberMessagesPopup.qml
@@ -65,10 +65,9 @@ StatusDialog {
                     width: parent.width
 
                     sharedRootStore: root.sharedRootStore
-                    rootStore: root.store
+                    rootStore: root.rootStore
                     chatCommunitySectionModule: root.chatCommunitySectionModule
-                    messageStore: root.memberMessagesModel
-
+                    messageStore: root.rootStore.messageStore
                     messageId: model.id
                     chatId: model.chatId
                     responseToMessageWithId: model.responseToMessageWithId

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -391,7 +391,7 @@ QtObject {
 
     function openCommunityMemberMessagesPopup(store, chatCommunitySectionModule, memberPubKey, displayName) {
         openPopup(communityMemberMessagesPopup, {
-            store: store,
+            rootStore: store,
             chatCommunitySectionModule: chatCommunitySectionModule,
             memberPubKey: memberPubKey,
             displayName: displayName

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -152,6 +152,9 @@ Loader {
                              || messageContentType === Constants.messageContentType.communityInviteType || messageContentType === Constants.messageContentType.transactionType
 
     function openProfileContextMenu(sender, mouse, isReply = false) {
+        if (isViewMemberMessagesePopup)
+            return false
+
         if (isReply && !quotedMessageFrom) {
             // The responseTo message was deleted
             // so we don't enable to right click the unavailable profile
@@ -174,7 +177,7 @@ Loader {
     }
 
     function openMessageContextMenu() {
-        if (placeholderMessage || !root.rootStore.mainModuleInst.activeSection.joined)
+        if (isViewMemberMessagesePopup || placeholderMessage || !root.rootStore.mainModuleInst.activeSection.joined)
             return
 
         const params = {


### PR DESCRIPTION
### What does the PR do

- propagate and set `requiresPermissions` + `locked` from the `chatContentModule.chatDetails`
- set the icon accordingly for community chats
- separate commit to fix a store refactoring regression

Fixes #16502

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->
StatusChatInfoButton / ChatHeaderContentView

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/1eb03e12-07f0-4dfe-9395-d5a1ab0e40a0)
