### PR TITLE
fix: DAppsWorkflow flaky test

### DIFF
--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -1129,6 +1129,12 @@ Item {
             waitForRendering(controlUnderTest)
             const popup = findChild(controlUnderTest, "dappsRequestModal")
             verify(popup.opened)
+
+            const acceptButton = findChild(popup, "signButton")
+            const rejectButton = findChild(popup, "rejectButton")
+            // Workaround for the buttons not being aligned yet
+            // Removing this could cause the wrong button to be clicked
+            tryVerify(() => acceptButton.x > rejectButton.x + rejectButton.width)
             return popup
         }
 
@@ -1136,11 +1142,10 @@ Item {
             const topic = "abcd"
             const requestId = "12345"
             let popup = showRequestModal(topic, requestId)
-
             let rejectButton = findChild(popup, "rejectButton")
 
+            verify(!!rejectButton)
             mouseClick(rejectButton)
-            waitForRendering(controlUnderTest)
             compare(signRequestRejectedSpy.count, 1, "expected signRequestRejected signal to be emitted")
             compare(signRequestAcceptedSpy.count, 0, "expected signRequestAccepted signal to not be emitted")
             compare(signRequestRejectedSpy.signalArguments[0][0], topic, "expected id to be set")

--- a/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DAppsWorkflow.qml
@@ -294,7 +294,6 @@ DappsComboBox {
                     return
                 }
                 requestHandled = true
-                let userRejected = true
                 root.signRequestRejected(request.topic, request.id)
             }
 


### PR DESCRIPTION
### What does the PR do

Fixing flaky qml test. The `Sign` and `Reject` buttons would sometimes overlap at the moment of mouseClick. This results in the wrong button to be clicked.

To fix this I'm waiting for the buttons to be aligned before doing any action.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
