### PR TITLE
fix(PasswordView): Password instructions missing max length requirement

### DIFF
--- a/storybook/pages/PasswordViewPage.qml
+++ b/storybook/pages/PasswordViewPage.qml
@@ -53,6 +53,7 @@ SplitView {
             Switch {
                 id: createNewPassword
                 text: "Create new password"
+                checked: true
             }
 
             Switch {
@@ -63,9 +64,12 @@ SplitView {
             Switch {
                 id: titleVisibleSwitch
                 text: "Title visible"
+                checked: true
             }
         }
     }
 }
 
 // category: Views
+
+// https://www.figma.com/design/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=41014-22302&node-type=frame&t=0JUvGJPEhU9e9QB9-0

--- a/test/e2e/constants/onboarding.py
+++ b/test/e2e/constants/onboarding.py
@@ -5,7 +5,7 @@ from enum import Enum
 class OnboardingMessages(Enum):
     WRONG_LOGIN_LESS_LETTERS = 'Display Names must be at least 5 character(s) long'
     WRONG_LOGIN_SYMBOLS_NOT_ALLOWED = 'Invalid characters (use A-Z and 0-9, hyphens and underscores only)'
-    WRONG_PASSWORD = 'Password must be at least 10 characters long'
+    WRONG_PASSWORD = 'Minimum 10 character(s)'
     PASSWORDS_DONT_MATCH = "Passwords don't match"
     PASSWORD_INCORRECT = 'Password incorrect'
 

--- a/test/e2e/scripts/utils/generators.py
+++ b/test/e2e/scripts/utils/generators.py
@@ -15,7 +15,7 @@ def random_name_string():
 def random_password_string():
     return ''.join((random.choice(
         string.ascii_letters + string.digits + string.punctuation)
-        for _ in range(10, 65))
+        for _ in range(10, 101))
     )
 
 

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -18,8 +18,7 @@ pytestmark = marks
                  'Change the password and login with new password')
 @pytest.mark.case(703005)
 @pytest.mark.parametrize('user_account', [RandomUser()])
-# @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15178')
-# @pytest.mark.critical
+@pytest.mark.critical
 # TODO: follow up on https://github.com/status-im/status-desktop/issues/13013
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account):
     with step('Open change password view'):

--- a/test/e2e/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/test/e2e/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -116,7 +116,7 @@ def test_sign_up_with_wrong_password_length(user_account, error: str, aut: AUT, 
 
     with step('Verify that button Create password is disabled and correct error appears'):
         assert create_password_view.is_create_password_button_enabled is False
-        assert create_password_view.password_error_message == error
+        assert str(create_password_view.password_error_message) == error
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/702994',

--- a/test/e2e/tests/settings/settings_password/__init__.py
+++ b/test/e2e/tests/settings/settings_password/__init__.py
@@ -1,4 +1,0 @@
-import pytest
-from .. import marks
-
-marks = [pytest.mark.settings_password, marks]

--- a/ui/StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core 0.1
@@ -42,7 +42,7 @@ StatusProgressBar {
     id: control
 
     /*!
-       \qmlproperty string StatusPasswordStrengthIndicator::strength
+       \qmlproperty int StatusPasswordStrengthIndicator::strength
        This property holds the password strength value. Possible values are:
        \list
        \li StatusPasswordStrengthIndicator.Strength.None
@@ -53,7 +53,7 @@ StatusProgressBar {
        \li StatusPasswordStrengthIndicator.Strength.Great
        \endlist
     */
-    property var strength
+    property int strength
     /*!
        \qmlproperty string StatusPasswordStrengthIndicator::labelVeryWeak
        This property holds the text shown when the strength is StatusPasswordStrengthIndicator.Strength.VeryWeak.

--- a/ui/imports/shared/views/PasswordConfirmationView.qml
+++ b/ui/imports/shared/views/PasswordConfirmationView.qml
@@ -74,7 +74,8 @@ ColumnLayout {
         Layout.alignment: Qt.AlignHCenter
         placeholderText: qsTr("Confirm your password (again)")
         echoMode: showPassword ? TextInput.Normal : TextInput.Password
-        validator: RegExpValidator { regExp: /^[!-~]{0,64}$/ } // That incudes NOT extended ASCII printable characters less space and a maximum of 64 characters allowed
+        validator: RegExpValidator { regExp: /^[!-~]+$/ } // That includes NOT extended ASCII printable characters less space
+        maximumLength: Constants.maxPasswordLength // a maximum of 100 characters allowed
         rightPadding: showHideCurrentIcon.width + showHideCurrentIcon.anchors.rightMargin + Style.current.padding / 2
         onTextChanged: {
             errorTxt.text = ""

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1046,6 +1046,7 @@ QtObject {
     readonly property string wrongDerivationPathError: "error parsing derivation path"
 
     readonly property int minPasswordLength: 10
+    readonly property int maxPasswordLength: 100
 
     readonly property QtObject suggestedRoutesExtraParamsProperties: QtObject {
         readonly property string packId: "packID"


### PR DESCRIPTION
### What does the PR do

- set the pass max length to 100 (via `Constants`, not with a hardcoded regexp)
- delay the validation until the user hits the limit
- clear the categories (lower/upper/num/sym) info if the password is cleared too
- update the error messages according to latest Figma designs

Fixes #16239

### Affected areas

PasswordView

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Max length check (101 chars entered):
![image](https://github.com/user-attachments/assets/cbbc958f-c243-49dc-9040-b6714cc835f9)

Unsupported chars check:
![image](https://github.com/user-attachments/assets/7ff46475-9dee-40d0-9bc7-1a7addf7e21d)

Min length check:
![image](https://github.com/user-attachments/assets/ad57179b-ae0c-4844-8daf-908a89265a63)

