### PR TITLE
StatusQ: ModelCount simplified and  property added

### DIFF
--- a/ui/StatusQ/include/StatusQ/modelcount.h
+++ b/ui/StatusQ/include/StatusQ/modelcount.h
@@ -8,6 +8,7 @@ class QAbstractItemModel;
 class ModelCount : public QObject {
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(bool empty READ empty NOTIFY emptyChanged)
 
 public:
     explicit ModelCount(QObject* parent = nullptr);
@@ -15,12 +16,14 @@ public:
     static ModelCount* qmlAttachedProperties(QObject* object);
 
     int count() const;
+    bool empty() const;
 
 signals:
     void countChanged();
+    void emptyChanged();
 
 private:
-    int m_intermediateCount = 0;
+    int m_count = 0;
 };
 
 QML_DECLARE_TYPEINFO(ModelCount, QML_HAS_ATTACHED_PROPERTIES)

--- a/ui/StatusQ/tests/tst_ModelCount.cpp
+++ b/ui/StatusQ/tests/tst_ModelCount.cpp
@@ -19,43 +19,59 @@ private slots:
         ModelCount modelCount(&model);
 
         QCOMPARE(modelCount.count(), 4);
+        QCOMPARE(modelCount.empty(), false);
 
-        QSignalSpy spy(&modelCount, &ModelCount::countChanged);
+        QSignalSpy countSpy(&modelCount, &ModelCount::countChanged);
+        QSignalSpy emptySpy(&modelCount, &ModelCount::emptyChanged);
 
         model.insert(1, { "e" });
 
-        QCOMPARE(spy.count(), 1);
+        QCOMPARE(countSpy.count(), 1);
+        QCOMPARE(emptySpy.count(), 0);
         QCOMPARE(modelCount.count(), 5);
+        QCOMPARE(modelCount.empty(), false);
 
         model.remove(0);
 
-        QCOMPARE(spy.count(), 2);
+        QCOMPARE(countSpy.count(), 2);
+        QCOMPARE(emptySpy.count(), 0);
         QCOMPARE(modelCount.count(), 4);
+        QCOMPARE(modelCount.empty(), false);
 
         model.update(0, 0, "aa");
 
-        QCOMPARE(spy.count(), 2);
+        QCOMPARE(countSpy.count(), 2);
+        QCOMPARE(emptySpy.count(), 0);
         QCOMPARE(modelCount.count(), 4);
+        QCOMPARE(modelCount.empty(), false);
 
         model.invert();
 
-        QCOMPARE(spy.count(), 2);
+        QCOMPARE(countSpy.count(), 2);
+        QCOMPARE(emptySpy.count(), 0);
         QCOMPARE(modelCount.count(), 4);
+        QCOMPARE(modelCount.empty(), false);
 
         model.removeEverySecond();
 
-        QCOMPARE(spy.count(), 3);
+        QCOMPARE(countSpy.count(), 3);
+        QCOMPARE(emptySpy.count(), 0);
         QCOMPARE(modelCount.count(), 2);
+        QCOMPARE(modelCount.empty(), false);
 
         model.reset();
 
-        QCOMPARE(spy.count(), 3);
+        QCOMPARE(countSpy.count(), 3);
+        QCOMPARE(emptySpy.count(), 0);
         QCOMPARE(modelCount.count(), 2);
+        QCOMPARE(modelCount.empty(), false);
 
         model.resetAndClear();
 
-        QCOMPARE(spy.count(), 4);
+        QCOMPARE(countSpy.count(), 4);
+        QCOMPARE(emptySpy.count(), 1);
         QCOMPARE(modelCount.count(), 0);
+        QCOMPARE(modelCount.empty(), true);
     }
 };
 

--- a/ui/imports/shared/views/AssetsViewAdaptor.qml
+++ b/ui/imports/shared/views/AssetsViewAdaptor.qml
@@ -116,7 +116,7 @@ QObject {
                 if (!model.visible)
                     return false
 
-                if (filteredBalances.ModelCount.count === 0)
+                if (filteredBalances.ModelCount.empty)
                     return false
 
                 if (hasCommunityId)


### PR DESCRIPTION
### What does the PR do

It adds `empty` property for convenience and simplifies the internal implementation of `ModelCount` attached property.

Closes: #15740

### Affected areas
`ModelCount`

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

