### PR TITLE
fix(nim-tests): split tests into individual targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -851,9 +851,12 @@ run-windows: compile_windows_resources nim_status_client $(NIM_WINDOWS_PREBUILT_
 	./bin/nim_status_client.exe $(ARGS)
 
 NIM_TEST_FILES := $(wildcard test/nim/*.nim)
+NIM_TESTS := $(foreach test_file,$(NIM_TEST_FILES),nim-test-run/$(test_file))
 
-tests-nim-linux: | dotherside
-	LD_LIBRARY_PATH="$(QT5_LIBDIR):$(LD_LIBRARY_PATH)" \
-	$(foreach nimfile,$(NIM_TEST_FILES),$(ENV_SCRIPT) nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) -r $(nimfile);)
+nim-test-run/%: | dotherside
+	LD_LIBRARY_PATH="$(QT5_LIBDIR):$(LD_LIBRARY_PATH)" $(ENV_SCRIPT) \
+	nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) -r $(subst nim-test-run/,,$@)
+
+tests-nim-linux: $(NIM_TESTS)
 
 endif # "variables.mk" was not included

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -44,7 +44,7 @@ pipeline {
   environment {
     PLATFORM = 'tests/nim'
     /* Improve make performance */
-    MAKEFLAGS = "-j4 V=${params.VERBOSE}"
+    MAKEFLAGS = "-j${utils.getProcCount()} V=${params.VERBOSE}"
     /* Makefile assumes the compiler folder is included */
     QTDIR = "/opt/qt/5.15.2/gcc_64"
     /* Avoid weird bugs caused by stale cache. */
@@ -62,7 +62,9 @@ pipeline {
     }
 
     stage('Tests') {
-      steps { sh 'make tests-nim-linux' }
+      steps {
+        sh 'make tests-nim-linux V=1'
+      }
     }
   }
 

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -396,7 +396,7 @@ QtObject:
     result.extradata = extradata
     result.generatedId = result.id.toString()
     result.generatedCollectionId = result.id.contractID.toString()
-    result.tokenType = contractTypeToTokenType(data.contractType.get())
+    result.tokenType = contractTypeToTokenType(data.contractType.get(ContractType.ContractTypeUnknown))
     result.setup()
 
   proc newCollectibleDetailsBasicEntry*(id: backend.CollectibleUniqueID, extradata: ExtraData): CollectiblesEntry =

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -12,6 +12,7 @@ proc createTestMessageItem(id: string, clock: int64): Item =
   return initItem(
     id = id,
     communityId = "",
+    chatId = "",
     responseToMessageWithId = "",
     senderId = "",
     senderDisplayName = "",
@@ -60,6 +61,7 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     albumMessageIds = @[],
     albumImagesCount = 0,
     bridgeMessage = BridgeMessage(),
+    quotedBridgeMessage = BridgeMessage(),
   )
 
 let message0_chatIdentifier = createTestMessageItem("chat-identifier", -2)

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -204,7 +204,7 @@ RightTabBaseView {
                             settings.category = settingsCategoryName
                             walletSettings.sync()
                             settings.sync()
-                            let value = SortOrderComboBox.TokenOrderAlpha
+                            let value = SortOrderComboBox.TokenOrderBalance
                             if (walletSettings.assetsViewCustomOrderApplyTimestamp > settings.sortOrderUpdateTimestamp && customOrderAvailable) {
                                 value = SortOrderComboBox.TokenOrderCustom
                             } else {
@@ -326,7 +326,7 @@ RightTabBaseView {
                             settings.category = settingsCategoryName
                             walletSettings.sync()
                             settings.sync()
-                            let value = SortOrderComboBox.TokenOrderAlpha
+                            let value = SortOrderComboBox.TokenOrderBalance
                             if (walletSettings.collectiblesViewCustomOrderApplyTimestamp > settings.sortOrderUpdateTimestamp && customOrderAvailable) {
                                 value = SortOrderComboBox.TokenOrderCustom
                             } else {


### PR DESCRIPTION
Otherwise combining separate `nim` calls with `;` results in only the last one informing `make` call what exit code the whole target had.

Resolves:
- https://github.com/status-im/status-desktop/issues/16545