### PR TITLE
chore: remove `settingsSubsection`/`settingsSubSubsection` props (state in singleton) from `Global`

### DIFF
--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -34,6 +34,8 @@ import AppLayouts.Communities.stores 1.0 as CommunitiesStore
 StatusSectionLayout {
     id: root
 
+    property alias settingsSubsection: profileContainer.currentIndex
+
     objectName: "profileStatusSectionLayout"
 
     property SharedStores.RootStore sharedRootStore
@@ -56,7 +58,7 @@ StatusSectionLayout {
 
     onNotificationButtonClicked: Global.openActivityCenterPopup()
     onBackButtonClicked: {
-        switch (Global.settingsSubsection) {
+        switch (root.settingsSubsection) {
         case Constants.settingsSubsection.contacts:
             Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.messaging)
             break;
@@ -75,8 +77,7 @@ StatusSectionLayout {
     }
 
     Component.onCompleted: {
-        profileContainer.currentIndex = -1
-        profileContainer.currentIndex = Qt.binding(() => Global.settingsSubsection)
+        profileContainer.currentIndexChanged()
         root.store.devicesStore.loadDevices() // Load devices to get non-paired number for badge
     }
 
@@ -109,6 +110,12 @@ StatusSectionLayout {
                 profileContainer.currentItem.notifyDirty();
             }
         }
+
+        onSettingsSubsectionChanged: root.settingsSubsection = settingsSubsection
+
+        Binding on settingsSubsection {
+            value: root.settingsSubsection
+        }
     }
 
     centerPanel: StackLayout {
@@ -118,8 +125,6 @@ StatusSectionLayout {
 
         anchors.fill: parent
         anchors.leftMargin: Constants.settingsSection.leftMargin
-
-        currentIndex: Global.settingsSubsection
 
         onCurrentIndexChanged: {
             if (!!children[currentIndex] && !children[currentIndex].active)

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -35,6 +35,7 @@ StatusSectionLayout {
     id: root
 
     property alias settingsSubsection: profileContainer.currentIndex
+    property int settingsSubSubsection
 
     objectName: "profileStatusSectionLayout"
 
@@ -73,7 +74,8 @@ StatusSectionLayout {
             keycardView.item.handleBackAction()
             break;
         }
-        Global.settingsSubSubsection = -1
+
+        root.settingsSubSubsection = -1
     }
 
     Component.onCompleted: {
@@ -257,6 +259,8 @@ StatusSectionLayout {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
                 contentWidth: d.contentWidth
+
+                settingsSubSubsection: root.settingsSubSubsection
 
                 rootStore: root.store
                 tokensStore: root.tokensStore

--- a/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
@@ -22,6 +22,8 @@ Column {
 
     property bool walletMenuItemEnabled: false
 
+    property int settingsSubsection
+
     signal menuItemClicked(var menu_item)
 
     Repeater {
@@ -33,7 +35,7 @@ Column {
             itemId: model.subsection
             title: model.text
             asset.name: model.icon
-            selected: Global.settingsSubsection === model.subsection
+            selected: root.settingsSubsection === model.subsection
             highlighted: !!betaTagLoader.item && betaTagLoader.item.hovered
             onClicked: root.menuItemClicked(model)
             badge.value: {
@@ -85,7 +87,7 @@ Column {
             itemId: model.subsection
             title: model.text
             asset.name: model.icon
-            selected: Global.settingsSubsection === model.subsection
+            selected: root.settingsSubsection === model.subsection
             onClicked: root.menuItemClicked(model)
             visible: {
                 (model.subsection !== Constants.settingsSubsection.wallet) ||
@@ -116,7 +118,7 @@ Column {
             itemId: model.subsection
             title: model.text
             asset.name: model.icon
-            selected: Global.settingsSubsection === model.subsection
+            selected: root.settingsSubsection === model.subsection
             onClicked: root.menuItemClicked(model)
         }
     }
@@ -134,7 +136,7 @@ Column {
             itemId: model.subsection
             title: model.text
             asset.name: model.icon
-            selected: Global.settingsSubsection === model.subsection
+            selected: root.settingsSubsection === model.subsection
             onClicked: root.menuItemClicked(model)
         }
     }

--- a/ui/app/AppLayouts/Profile/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/LeftTabView.qml
@@ -18,6 +18,8 @@ Item {
 
     signal menuItemClicked(var event)
 
+    property alias settingsSubsection: profileMenu.settingsSubsection
+
     StatusNavigationPanelHeadline {
         id: title
         text: qsTr("Settings")
@@ -68,7 +70,7 @@ Item {
                 if (menu_item.subsection === Constants.settingsSubsection.signout)
                     return confirmDialog.open()
 
-                Global.settingsSubsection = menu_item.subsection
+                profileMenu.settingsSubsection = menu_item.subsection
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -34,6 +34,8 @@ SettingsContentBase {
     property string myPublicKey: ""
     property alias currencySymbol: manageTokensView.currencySymbol
 
+    property int settingsSubSubsection
+
     property ProfileSectionStore rootStore
     property WalletStore walletStore: rootStore.walletStore
     required property TokensStore tokensStore
@@ -112,10 +114,10 @@ SettingsContentBase {
 
     readonly property var priv: QtObject {
         id: priv
-        readonly property bool isManageTokensSubsection: Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets ||
-                                                         Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles ||
-                                                         Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageHidden ||
-                                                         Global.settingsSubSubsection === Constants.walletSettingsSubsection.manageAdvanced
+        readonly property bool isManageTokensSubsection: root.settingsSubSubsection === Constants.walletSettingsSubsection.manageAssets ||
+                                                         root.settingsSubSubsection === Constants.walletSettingsSubsection.manageCollectibles ||
+                                                         root.settingsSubSubsection === Constants.walletSettingsSubsection.manageHidden ||
+                                                         root.settingsSubSubsection === Constants.walletSettingsSubsection.manageAdvanced
 
         readonly property var walletSettings: Settings {
             category: "walletSettings-" + root.myPublicKey
@@ -349,7 +351,7 @@ SettingsContentBase {
 
             Binding on currentIndex {
                 value: {
-                    switch (Global.settingsSubSubsection) {
+                    switch (root.settingsSubSubsection) {
                     case Constants.walletSettingsSubsection.manageAssets:
                         return 0
                     case Constants.walletSettingsSubsection.manageCollectibles:

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -501,7 +501,7 @@ Item {
             appMain.rootStore.mainModuleInst.setActiveSectionBySectionType(sectionType)
 
             if (sectionType === Constants.appSection.profile) {
-                Global.settingsSubsection = subsection;
+                profileLoader.settingsSubsection = subsection
                 Global.settingsSubSubsection = subSubsection;
             } else if (sectionType === Constants.appSection.wallet) {
                 appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
@@ -1432,6 +1432,10 @@ Item {
                     }
 
                     Loader {
+                        id: profileLoader
+
+                        property int settingsSubsection: Constants.settingsSubsection.profile
+
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
                         asynchronous: true
                         sourceComponent: ProfileLayout {
@@ -1448,6 +1452,12 @@ Item {
                             collectiblesStore: appMain.walletCollectiblesStore
                             currencyStore: appMain.currencyStore
                             isCentralizedMetricsEnabled: appMain.isCentralizedMetricsEnabled
+
+                            Binding on settingsSubsection {
+                                value: profileLoader.settingsSubsection
+                            }
+
+                            onSettingsSubsectionChanged: profileLoader.settingsSubsection = settingsSubsection
                         }
                     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -147,7 +147,7 @@ Item {
 
         function onActiveSectionChanged() {
             createChatView.opened = false
-            Global.settingsSubSubsection = -1
+            profileLoader.settingsSubSubsection = -1
         }
 
         function onOpenActivityCenter() {
@@ -502,7 +502,7 @@ Item {
 
             if (sectionType === Constants.appSection.profile) {
                 profileLoader.settingsSubsection = subsection
-                Global.settingsSubSubsection = subSubsection;
+                profileLoader.settingsSubSubsection = subSubsection;
             } else if (sectionType === Constants.appSection.wallet) {
                 appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
             }
@@ -1435,6 +1435,7 @@ Item {
                         id: profileLoader
 
                         property int settingsSubsection: Constants.settingsSubsection.profile
+                        property int settingsSubSubsection: -1
 
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
                         asynchronous: true
@@ -1452,6 +1453,7 @@ Item {
                             collectiblesStore: appMain.walletCollectiblesStore
                             currencyStore: appMain.currencyStore
                             isCentralizedMetricsEnabled: appMain.isCentralizedMetricsEnabled
+                            settingsSubSubsection: profileLoader.settingsSubSubsection
 
                             Binding on settingsSubsection {
                                 value: profileLoader.settingsSubsection

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -6,7 +6,6 @@ QtObject {
     id: root
 
     property bool activityPopupOpened: false
-    property int settingsSubsection: Constants.settingsSubsection.profile
     property int settingsSubSubsection: -1
 
     property bool appIsReady: false

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -6,7 +6,6 @@ QtObject {
     id: root
 
     property bool activityPopupOpened: false
-    property int settingsSubSubsection: -1
 
     property bool appIsReady: false
 


### PR DESCRIPTION
### What does the PR do

This PR is a next step towards making `Global` and other singletons stateless.

Closes: #16457

### Affected areas
`Global`, `ProfileLayout` and related subcomponents


### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

