### PR TITLE
fix: Sign transaction popup scroll when content changes height

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -120,10 +120,12 @@ StatusDialog {
         id: scrollView
         anchors.fill: parent
         contentWidth: availableWidth
+        contentHeight: content.implicitHeight
         topPadding: 0
         bottomPadding: countdownPill.height
 
         ColumnLayout {
+            id: content
             anchors.left: parent.left
             anchors.leftMargin: 4
             anchors.right: parent.right


### PR DESCRIPTION
### What does the PR do

Closes #16529

Fixing the scroll contentHeight whenever the content changes height.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Sign popup - Wallet connect and Swap, Swap cap approval
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/ce5956df-b05f-49cd-a410-0d622049110a

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
