### PR TITLE
perf(contacts): make initial contacts fetching async

### DIFF
--- a/src/app/global/app_sections_config.nim
+++ b/src/app/global/app_sections_config.nim
@@ -2,6 +2,8 @@ const CHAT_SECTION_NAME* = "Messages"
 const CHAT_SECTION_ICON* = "chat"
 
 const LOADING_SECTION_ID* = "loadingSection"
+const LOADING_SECTION_NAME* = "Chat section loading..."
+const LOADING_SECTION_ICON* = "loading"
 
 const COMMUNITIESPORTAL_SECTION_ID* = "communitiesPortal"
 const COMMUNITIESPORTAL_SECTION_NAME* = "Communities Portal"

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -208,9 +208,6 @@ proc getMessageById*(self: Controller, messageId: string): GetMessageResult =
 proc isUsersListAvailable*(self: Controller): bool =
   return self.isUsersListAvailable
 
-proc getMyMutualContacts*(self: Controller): seq[ContactsDto] =
-  return self.contactService.getContactsByGroup(ContactsGroup.MyMutualContacts)
-
 proc muteChat*(self: Controller, interval: int) =
   self.chatService.muteChat(self.chatId, interval)
 

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -89,9 +89,6 @@ method unpinMessage*(self: AccessInterface, messageId: string) {.base.} =
 method getMyChatId*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method isMyContact*(self: AccessInterface, contactId: string): bool {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method muteChat*(self: AccessInterface, interval: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, sugar
+import NimQml, chronicles, sequtils
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller
@@ -272,9 +272,6 @@ method onPinMessage*(self: Module, messageId: string, actionInitiatedBy: string)
 
 method getMyChatId*(self: Module): string =
   self.controller.getMyChatId()
-
-method isMyContact*(self: Module, contactId: string): bool =
-  self.controller.getMyMutualContacts().filter(x => x.id == contactId).len > 0
 
 method muteChat*(self: Module, interval: int) =
   self.controller.muteChat(interval)

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -66,9 +66,6 @@ QtObject:
   proc getMyChatId*(self: View): string {.slot.} =
     return self.delegate.getMyChatId()
 
-  proc isMyContact*(self: View, contactId: string): bool {.slot.} =
-    return self.delegate.isMyContact(contactId)
-
   proc muteChat*(self: View, interval: int) {.slot.} =
     self.delegate.muteChat(interval)
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -263,12 +263,6 @@ method createGroupChat*(self: AccessInterface, groupName: string, pubKeys: seq[s
 method joinGroupChatFromInvitation*(self: AccessInterface, groupName: string, chatId: string, adminPK: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method initListOfMyContacts*(self: AccessInterface, pubKeys: string) {.base.}  =
-  raise newException(ValueError, "No implementation available")
-
-method clearListOfMyContacts*(self: AccessInterface) {.base.}  =
-  raise newException(ValueError, "No implementation available")
-
 method acceptRequestToJoinCommunity*(self: AccessInterface, requestId: string, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -413,18 +413,6 @@ proc convertPubKeysToJson(self: Module, pubKeys: string): seq[string] =
 proc showPermissionUpdateNotification(self: Module, community: CommunityDto, tokenPermission: CommunityTokenPermissionDto): bool =
   return tokenPermission.state == TokenPermissionState.Approved and (community.isControlNode or not tokenPermission.isPrivate) and community.isMember
 
-method initListOfMyContacts*(self: Module, pubKeys: string) =
-  var myContacts: seq[UserItem]
-  let contacts =  self.controller.getContacts(ContactsGroup.MyMutualContacts)
-  for c in contacts:
-    let item = self.createItemFromPublicKey(c.id)
-    myContacts.add(item)
-
-  self.view.listOfMyContacts().addItems(myContacts)
-
-method clearListOfMyContacts*(self: Module) =
-  self.view.listOfMyContacts().clear()
-
 method load*(self: Module) =
   self.controller.init()
   self.view.load()
@@ -452,7 +440,7 @@ method onChatsLoaded*(
   if self.membersListModule != nil:
     self.membersListModule.load()
 
-  if(not self.controller.isCommunity()):
+  if not self.controller.isCommunity():
     # we do this only in case of chat section (not in case of communities)
     self.initContactRequestsModel()
   else:

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -18,8 +18,6 @@ QtObject:
       tmpChatId: string # shouldn't be used anywhere except in prepareChatContentModuleForChatId/getChatContentModule procs
       contactRequestsModel: user_model.Model
       contactRequestsModelVariant: QVariant
-      listOfMyContacts: user_model.Model
-      listOfMyContactsVariant: QVariant
       editCategoryChannelsModel: chats_model.Model
       editCategoryChannelsVariant: QVariant
       loadingHistoryMessagesInProgress: bool
@@ -47,8 +45,6 @@ QtObject:
     self.activeItemVariant.delete
     self.contactRequestsModel.delete
     self.contactRequestsModelVariant.delete
-    self.listOfMyContacts.delete
-    self.listOfMyContactsVariant.delete
     self.editCategoryChannelsModel.delete
     self.editCategoryChannelsVariant.delete
     self.tokenPermissionsModel.delete
@@ -70,8 +66,6 @@ QtObject:
     result.activeItemVariant = newQVariant(result.activeItem)
     result.contactRequestsModel = user_model.newModel()
     result.contactRequestsModelVariant = newQVariant(result.contactRequestsModel)
-    result.listOfMyContacts = user_model.newModel()
-    result.listOfMyContactsVariant = newQVariant(result.listOfMyContacts)
     result.loadingHistoryMessagesInProgress = false
     result.tokenPermissionsModel = newTokenPermissionsModel()
     result.tokenPermissionsVariant = newQVariant(result.tokenPermissionsModel)
@@ -131,25 +125,6 @@ QtObject:
     return self.contactRequestsModelVariant
   QtProperty[QVariant] contactRequestsModel:
     read = getContactRequestsModel
-
-  proc listOfMyContactsChanged*(self: View) {.signal.}
-
-  proc populateMyContacts*(self: View, pubKeys: string) {.slot.} =
-    self.delegate.initListOfMyContacts(pubKeys)
-    self.listOfMyContactsChanged()
-
-  proc clearMyContacts*(self: View) {.slot.} =
-    self.delegate.clearListOfMyContacts()
-    self.listOfMyContactsChanged()
-
-  proc listOfMyContacts*(self: View): user_model.Model =
-    return self.listOfMyContacts
-
-  proc getListOfMyContacts(self: View): QVariant {.slot.} =
-    return self.listOfMyContactsVariant
-  QtProperty[QVariant] listOfMyContacts:
-    read = getListOfMyContacts
-    notify = listOfMyContactsChanged
 
   proc activeItemChanged*(self:View) {.signal.}
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -143,6 +143,23 @@ proc init*(self: Controller) =
       self.networksService,
     )
 
+  self.events.on(SIGNAL_CONTACTS_LOADED) do(e:Args):
+    self.delegate.onContactsLoaded(
+      self.events,
+      self.settingsService,
+      self.nodeConfigurationService,
+      self.contactsService,
+      self.chatService,
+      self.communityService,
+      self.messageService,
+      self.mailserversService,
+      self.walletAccountService,
+      self.tokenService,
+      self.communityTokensService,
+      self.sharedUrlsService,
+      self.networksService,
+    )
+
   self.events.on(SIGNAL_CHATS_LOADING_FAILED) do(e:Args):
     self.delegate.onChatsLoadingFailed()
 
@@ -532,9 +549,6 @@ proc setCurrentUserStatus*(self: Controller, status: StatusType) =
 
 proc getContact*(self: Controller, id: string): ContactsDto =
   return self.contactsService.getContactById(id)
-
-proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
-  return self.contactsService.getContactsByGroup(group)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, largeImage: string] =

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -117,6 +117,24 @@ method onCommunityDataLoaded*(
   ){.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onContactsLoaded*(
+    self: AccessInterface,
+    events: EventEmitter,
+    settingsService: settings_service.Service,
+    nodeConfigurationService: node_configuration_service.Service,
+    contactsService: contacts_service.Service,
+    chatService: chat_service.Service,
+    communityService: community_service.Service,
+    messageService: message_service.Service,
+    mailserversService: mailservers_service.Service,
+    walletAccountService: wallet_account_service.Service,
+    tokenService: token_service.Service,
+    communityTokensService: community_tokens_service.Service,
+    sharedUrlsService: urls_service.Service,
+    networkService: network_service.Service,
+  ){.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onChatsLoadingFailed*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -504,6 +504,22 @@ method load*[T](
   if (activeSectionId == ""):
     activeSectionId = singletonInstance.userProfile.getPubKey()
 
+  let loadingItem = initItem(
+    LOADING_SECTION_ID,
+    SectionType.LoadingSection,
+    conf.LOADING_SECTION_NAME,
+    memberRole = MemberRole.Owner,
+    description = "",
+    image = "",
+    icon = conf.LOADING_SECTION_ICON,
+    color = "",
+    hasNotification = false,
+    notificationsCount = 0,
+    active = false,
+    enabled = true,
+  )
+  self.view.model().addItem(loadingItem)
+
   # Communities Portal Section
   let communitiesPortalSectionItem = initItem(
     conf.COMMUNITIESPORTAL_SECTION_ID,
@@ -520,7 +536,7 @@ method load*[T](
     enabled = true,
   )
   self.view.model().addItem(communitiesPortalSectionItem)
-  if(activeSectionId == communitiesPortalSectionItem.id):
+  if activeSectionId == communitiesPortalSectionItem.id:
     activeSection = communitiesPortalSectionItem
 
   # Wallet Section
@@ -541,7 +557,7 @@ method load*[T](
     enabled = WALLET_ENABLED,
   )
   self.view.model().addItem(walletSectionItem)
-  if(activeSectionId == walletSectionItem.id):
+  if activeSectionId == walletSectionItem.id:
     activeSection = walletSectionItem
 
   # Node Management Section
@@ -562,7 +578,7 @@ method load*[T](
     enabled = singletonInstance.localAccountSensitiveSettings.getNodeManagementEnabled(),
   )
   self.view.model().addItem(nodeManagementSectionItem)
-  if(activeSectionId == nodeManagementSectionItem.id):
+  if activeSectionId == nodeManagementSectionItem.id:
     activeSection = nodeManagementSectionItem
 
   # Profile Section
@@ -583,7 +599,7 @@ method load*[T](
     enabled = true,
   )
   self.view.model().addItem(profileSettingsSectionItem)
-  if(activeSectionId == profileSettingsSectionItem.id):
+  if activeSectionId == profileSettingsSectionItem.id:
     activeSection = profileSettingsSectionItem
 
   self.profileSectionModule.load()
@@ -602,21 +618,6 @@ method load*[T](
   # If section is empty or profile then open the loading section until chats are loaded
   if activeSection.isEmpty() or activeSection.sectionType == SectionType.ProfileSettings:
     # Set bogus Item as active until the chat is loaded
-    let loadingItem = initItem(
-      LOADING_SECTION_ID,
-      SectionType.LoadingSection,
-      name = "",
-      memberRole = MemberRole.Owner,
-      description = "",
-      image = "",
-      icon = "",
-      color = "",
-      hasNotification = false,
-      notificationsCount = 0,
-      active = false,
-      enabled = true,
-    )
-    self.view.model().addItem(loadingItem)
     self.setActiveSection(loadingItem, skipSavingInSettings = true)
   else:
     self.setActiveSection(activeSection)

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -30,6 +30,9 @@ proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
+  self.events.on(SIGNAL_CONTACTS_LOADED) do(e:Args):
+    self.delegate.onContactsLoaded()
+
   self.events.on(SIGNAL_CONTACT_ADDED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.contactAdded(args.contactId)

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -27,6 +27,9 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onContactsLoaded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method switchToOrCreateOneToOneChat*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -118,6 +118,10 @@ method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 
 method viewDidLoad*(self: Module) =
+  self.moduleLoaded = true
+  self.delegate.contactsModuleDidLoad()
+
+method onContactsLoaded*(self: Module) =
   self.buildModel(self.view.contactsModel(), ContactsGroup.AllKnownContacts)
   self.buildModel(self.view.myMutualContactsModel(), ContactsGroup.MyMutualContacts)
   self.buildModel(self.view.blockedContactsModel(), ContactsGroup.BlockedContacts)
@@ -126,9 +130,6 @@ method viewDidLoad*(self: Module) =
   # Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
   # self.buildModel(self.view.receivedButRejectedContactRequestsModel(), ContactsGroup.IncomingRejectedContactRequests)
   # self.buildModel(self.view.sentButRejectedContactRequestsModel(), ContactsGroup.IncomingRejectedContactRequests)
-
-  self.moduleLoaded = true
-  self.delegate.contactsModuleDidLoad()
 
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -10,13 +10,13 @@ import ../../../app_service/service/community_tokens/community_collectible_owner
 
 type
   SectionType* {.pure.} = enum
-    LoadingSection = -1
     Chat = 0
     Community,
     Wallet,
     ProfileSettings,
     NodeManagement,
-    CommunitiesPortal
+    CommunitiesPortal,
+    LoadingSection,
 
 type
   SectionItem* = object

--- a/src/app_service/service/contacts/async_tasks.nim
+++ b/src/app_service/service/contacts/async_tasks.nim
@@ -53,9 +53,22 @@ proc lookupContactTask(argEncoded: string) {.gcsafe, nimcall.} =
     error "error lookupContactTask: ", message = e.msg
     arg.finish(output)
 
-#################################################
-# Async request contact info
-#################################################
+type
+  AsyncFetchContactsTaskArg = ref object of QObjectTaskArg
+    pubkey: string
+
+proc asyncFetchContactsTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncFetchContactsTaskArg](argEncoded)
+  try:
+    let response = status_contacts.getContacts()
+    arg.finish(%* {
+      "response": response,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })
 
 type
   AsyncRequestContactInfoTaskArg = ref object of QObjectTaskArg

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -83,10 +83,6 @@ proc removeTrustStatus*(pubkey: string): RpcResponse[JsonNode] =
   let payload = %* [pubkey]
   result = callPrivateRPC("removeTrustStatus".prefix, payload)
 
-proc getTrustStatus*(pubkey: string): RpcResponse[JsonNode] =
-  let payload = %* [pubkey]
-  result = callPrivateRPC("getTrustStatus".prefix, payload)
-
 proc retractContactRequest*(pubkey: string): RpcResponse[JsonNode] =
   let payload = %*[{
     "id": pubkey

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -8,10 +8,6 @@ proc getContacts*(): RpcResponse[JsonNode] =
   let payload = %* []
   result = callPrivateRPC("contacts".prefix, payload)
 
-proc getContactById*(id: string): RpcResponse[JsonNode] =
-  let payload = %* [id]
-  result = callPrivateRPC("getContactByID".prefix, payload)
-
 proc blockContact*(id: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("blockContactDesktop".prefix, %* [id])
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusIconTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusIconTabButton.qml
@@ -25,7 +25,8 @@ TabButton {
         StatusSmartIdenticon {
             id: identicon
             anchors.centerIn: parent
-            asset.isImage: (statusIconTabButton.icon.source.toString() !== "")
+            loading: statusIconTabButton.icon.name === "loading"
+            asset.isImage: loading || statusIconTabButton.icon.source.toString() !== ""
             asset.name: asset.isImage ?
                         statusIconTabButton.icon.source : statusIconTabButton.icon.name
             asset.width: asset.isImage ? 28 : statusIconTabButton.icon.width

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -815,7 +815,7 @@ Item {
                     RangeFilter {
                         roleName: "sectionType"
                         minimumValue: Constants.appSection.wallet
-                        maximumValue: Constants.appSection.communitiesPortal
+                        maximumValue: Constants.appSection.loadingSection
                     },
                     ValueFilter {
                         roleName: "enabled"

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -326,6 +326,7 @@ QtObject {
         readonly property int profile: 3
         readonly property int node: 4
         readonly property int communitiesPortal: 5
+        readonly property int loadingSection: 6
     }
 
     readonly property QtObject appViewStackIndex: QtObject {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -417,6 +417,8 @@ QtObject {
             return qsTr("Node Management")
         case Constants.appSection.communitiesPortal:
             return qsTr("Discover Communities")
+        case Constants.appSection.loadingSection:
+            return qsTr("Chat section loading...")
         default:
             return fallback
         }


### PR DESCRIPTION
### What does the PR do

Fixes #16509

Based on top of https://github.com/status-im/status-desktop/pull/16548

This PR makes the initial contacts fetching async. It delays the chat section showing until that is done.

It also removes the `trustStatus` fetch, since we get the `trustStatus` inside the `contact` already 

### Affected areas

Contacts and the chat sections construction

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[async-contacts.webm](https://github.com/user-attachments/assets/1e65aedf-0946-47c0-a20e-bbaca2ae8cd1)

### Impact on end user

It should make the app start faster. It could make it so that the "sections laoding" loader stays on longer, but the user could interact with the app already

### How to test

- Login to the app and check if contacts work in all contexts

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case, the contacts are no longer available in some context