### PR TITLE
fix(wallet): debounce send modal route requests and assign new uuid o…

### DIFF
--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -212,12 +212,11 @@ SplitView {
                 preSelectedHoldingID: loader.preSelectedHoldingID
                 preSelectedHoldingType: loader.preSelectedHoldingType
                 showCustomRoutingMode: ctrlShowCustomMode.checked
-                generateUuid: () => { return "12345" }
                 sendTransaction: () => {
                                     if (!showSendErrorCheckBox.checked)
                                          return
 
-                                    txStore.walletSectionSendInst.transactionSent(1, "0x123", generateUuid(), "Send error, please ignore")
+                                    txStore.walletSectionSendInst.transactionSent(1, "0x123", uuid, "Send error, please ignore")
                                  }
             }
             Component.onCompleted: loader.active = true

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -72,17 +72,7 @@ StatusDialog {
         popup.store.authenticateAndTransfer(d.uuid)
     }
 
-    property var recalculateRoutesAndFees: Backpressure.debounce(popup, 600, function() {
-        if(!!popup.selectedAccount && !!popup.selectedAccount.address && !!holdingSelector.selectedItem
-                && recipientInputLoader.ready && (amountToSend.ready || d.isCollectiblesTransfer)) {
-            popup.isLoading = true
-            d.routerError = ""
-            d.routerErrorDetails = ""
-            popup.store.suggestedRoutes(d.uuid, d.isCollectiblesTransfer ? "1" : amountToSend.amount, "0", d.extraParamsJson)
-        }
-    })
-
-    property var generateUuid: () => { return Utils.uuid() }
+    readonly property string uuid: d.uuid
 
     QtObject {
         id: d
@@ -130,7 +120,7 @@ StatusDialog {
 
         property string sendError: ""
 
-        readonly property string uuid: popup.generateUuid()
+        property string uuid: Utils.uuid()
         property bool isPendingTx: false
         property string totalTimeEstimate
         property double totalFeesInFiat
@@ -170,6 +160,27 @@ StatusDialog {
 
         function addMetricsEvent(subEventName) {
             Global.addCentralizedMetricIfEnabled(d.isBridgeTx ? "bridge" : "send", {subEvent: subEventName})
+        }
+
+        function areInputParametersValid() {
+            return !!popup.selectedAccount && !!popup.selectedAccount.address && !!holdingSelector.selectedItem
+                && recipientInputLoader.ready && (amountToSend.ready || d.isCollectiblesTransfer)
+        }
+
+        property var debounceRecalculateRoutesAndFees: Backpressure.debounce(popup, 1000, function() {
+            if(d.areInputParametersValid()) {
+                popup.store.suggestedRoutes(d.uuid, d.isCollectiblesTransfer ? "1" : amountToSend.amount, "0", d.extraParamsJson)
+            }
+        })
+
+        function recalculateRoutesAndFees() {
+            if(d.areInputParametersValid()) {
+                popup.isLoading = true
+            }
+            d.uuid = Utils.uuid()
+            d.routerError = ""
+            d.routerErrorDetails = ""
+            debounceRecalculateRoutesAndFees()
         }
     }
 
@@ -314,7 +325,7 @@ StatusDialog {
                                 d.selectedHolding.tokensKey)
                 }
 
-                popup.recalculateRoutesAndFees()
+                d.recalculateRoutesAndFees()
             }
         }
     }
@@ -529,12 +540,12 @@ StatusDialog {
 
                         onValidChanged: {
                             d.sendError = ""
-                            popup.recalculateRoutesAndFees()
+                            d.recalculateRoutesAndFees()
                         }
 
                         onAmountChanged: {
                             d.sendError = ""
-                            popup.recalculateRoutesAndFees()
+                            d.recalculateRoutesAndFees()
                         }
                     }
 
@@ -583,7 +594,7 @@ StatusDialog {
                         onIsLoading: popup.isLoading = true
                         onRecalculateRoutesAndFees: {
                             d.sendError = ""
-                            popup.recalculateRoutesAndFees()
+                            d.recalculateRoutesAndFees()
                         }
                         onAddressTextChanged: store.setSelectedRecipient(addressText)
                     }
@@ -669,7 +680,7 @@ StatusDialog {
                 selectedAsset: d.selectedHolding
                 onReCalculateSuggestedRoute: {
                     d.sendError = ""
-                    popup.recalculateRoutesAndFees()
+                    d.recalculateRoutesAndFees()
                 }
                 errorType: d.errorType
                 isLoading: popup.isLoading
@@ -748,6 +759,11 @@ StatusDialog {
     Connections {
         target: popup.store.walletSectionSendInst
         function onSuggestedRoutesReady(txRoutes, errCode, errDescription) {
+            if (txRoutes.uuid !== d.uuid) {
+                // Suggested routes for a different fetch, ignore
+                return
+            }
+
             popup.bestRoutes =  txRoutes.suggestedRoutes
 
             d.routerError = WalletUtils.getRouterErrorBasedOnCode(errCode)


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/16565

A bunch of improvements are done on the Send Modal:

- On each Send Modal parameter change, we immediately switch to the loading state but wait 1 second before we make the actual suggested routes fetch. This should help prevent make a bunch of requests when entering the amount to send character by character. The debounce time is now in line with what we use for the Swap modal.
- Every time we change some of the parameters, we use a different UUID. This way we can link responses to the matching requests.
- We ignore route responses with UUIDs other than the latest one.

### Affected areas

Wallet -> Send modal

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://github.com/user-attachments/assets/6d65e353-e356-4976-95d0-be9e8369548e

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

Stuff didn't work properly (see issue description), now stuff works properly (see video).

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
