### PR TITLE
fix(gifs): fix call to setGifUnfurlingEnabled using a bad store

### DIFF
--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -205,7 +205,7 @@ Popup {
             visible: true
 
             onEnableGifsRequested: {
-                RootStore.setGifUnfurlingEnabled(true)
+                root.gifStore.setGifUnfurlingEnabled(true)
                 root.gifStore.getTrendingsGifs()
             }
         }

--- a/ui/imports/shared/stores/GifStore.qml
+++ b/ui/imports/shared/stores/GifStore.qml
@@ -13,6 +13,10 @@ QtObject {
     property var gifColumnC: d.gifsModuleInst ? d.gifsModuleInst.gifColumnC : null
     property bool gifLoading: d.gifsModuleInst ? d.gifsModuleInst.gifLoading : false
 
+    function setGifUnfurlingEnabled(value) {
+        localAccountSensitiveSettings.gifUnfurlingEnabled = value
+    }
+
     function searchGifs(query) {
         if (d.gifsModuleInst)
             d.gifsModuleInst.searchGifs(query)

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -24,10 +24,6 @@ QtObject {
         localAccountSensitiveSettings.neverAskAboutUnfurlingAgain = value;
     }
 
-    function setGifUnfurlingEnabled(value) {
-        localAccountSensitiveSettings.gifUnfurlingEnabled = value
-    }
-
     function getPasswordStrengthScore(password) {
         return root.privacyModule.getPasswordStrengthScore(password);
     }


### PR DESCRIPTION
Fixes #16598

The gif popup was using the global RootStore, but it didn't work and it's also not a good practice.

I move the function to enable to the GifStore which is accessible as a reference instead.

[gif-enabling.webm](https://github.com/user-attachments/assets/0db23d3d-c4ca-4e19-8fec-79418b825827)
