### PR TITLE
fix(requests): fix member requests not showing in list

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -410,7 +410,7 @@ proc init*(self: Controller) =
       self.delegate.updateRequestToJoinState(RequestToJoinState.Requested)
 
   self.events.on(SIGNAL_REQUEST_TO_JOIN_COMMUNITY_CANCELED) do(e:Args):
-    let args = community_service.CommunityIdArgs(e)
+    let args = community_service.CanceledCommunityRequestArgs(e)
     if args.communityId == self.sectionId:
       self.delegate.updateRequestToJoinState(RequestToJoinState.None)
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -309,6 +309,10 @@ proc init*(self: Controller) =
     var args = CommunityRequestArgs(e)
     self.delegate.newCommunityMembershipRequestReceived(args.communityRequest)
 
+  self.events.on(SIGNAL_REQUEST_TO_JOIN_COMMUNITY_CANCELED) do(e:Args):
+    let args = community_service.CanceledCommunityRequestArgs(e)
+    self.delegate.communityMembershipRequestCanceled(args.communityId, args.requestId, args.pubKey)
+
   self.events.on(SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY_ACCEPTED) do(e: Args):
     var args = CommunityRequestArgs(e)
     self.delegate.communityMemberRevealedAccountsAdded(args.communityRequest)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -219,6 +219,9 @@ method newCommunityMembershipRequestReceived*(self: AccessInterface, membershipR
   {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityMembershipRequestCanceled*(self: AccessInterface, communityId: string, requestId: string, pubKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method meMentionedCountChanged*(self: AccessInterface, allMentions: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1367,7 +1367,17 @@ method newCommunityMembershipRequestReceived*[T](self: Module[T], membershipRequ
   let (contactName, _, _) = self.controller.getContactNameAndImage(membershipRequest.publicKey)
   let community =  self.controller.getCommunityById(membershipRequest.communityId)
   singletonInstance.globalEvents.newCommunityMembershipRequestNotification("New membership request",
-  fmt "{contactName} asks to join {community.name}", community.id)
+    fmt "{contactName} asks to join {community.name}", community.id)
+
+  self.view.model().addPendingMember(membershipRequest.communityId, self.createMemberItem(
+    membershipRequest.publicKey,
+    membershipRequest.id,
+    MembershipRequestState(membershipRequest.state),
+    MemberRole.None,
+  ))
+  
+method communityMembershipRequestCanceled*[T](self: Module[T], communityId: string, requestId: string, pubKey: string) =
+  self.view.model().removePendingMember(communityId, pubKey)
 
 method meMentionedCountChanged*[T](self: Module[T], allMentions: int) =
   singletonInstance.globalEvents.meMentionedIconBadgeNotification(allMentions)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -2,7 +2,7 @@ import NimQml, Tables, strutils, stew/shims/strformat
 
 import json
 
-import section_item, member_model
+import section_item, member_model, member_item
 import ../main/communities/tokens/models/[token_item, token_model]
 
 type
@@ -468,7 +468,7 @@ QtObject:
         }
         return $jsonObj
 
-  proc setMembersAirdropAddress*(self: SectionModel, id: string, communityMembersAirdropAddress: Table[string, string]) = 
+  proc setMembersAirdropAddress*(self: SectionModel, id: string, communityMembersAirdropAddress: Table[string, string]) =
     let index = self.getItemIndex(id)
     if (index == -1):
       return
@@ -482,3 +482,15 @@ QtObject:
       return
 
     self.items[index].communityTokens.setItems(communityTokensItems)
+
+  proc addPendingMember*(self: SectionModel, communityId: string, memberItem: MemberItem) =
+    let i = self.getItemIndex(communityId)
+    if i == -1:
+      return
+    self.items[i].pendingMemberRequests.addItem(memberItem)
+
+  proc removePendingMember*(self: SectionModel, communityId: string, memberId: string) =
+    let i = self.getItemIndex(communityId)
+    if i == -1:
+      return
+    self.items[i].pendingMemberRequests.removeItemById(memberId)


### PR DESCRIPTION
Fixes #16600

There was no update to the model when we get a signal that a membership request is received. We also didn't send an event when one is canceled.

These changes were part of the [Improve performance by only updating the properties that changed in the model instead of reseting](https://github.com/status-im/status-desktop/pull/16436) PR I did, but that only landed in master because it's a bit too big or risky to put in the release so late.
I only selected the needed changes from that big PR.

Once this is merged, it shouldn't be necessary to cherry-pick it.

[requests-pending.webm](https://github.com/user-attachments/assets/0fa84e3f-1d1c-4cc1-a16f-70545813213f)

