### PR TITLE
fix(ProfileContextMenu): excessive separators for a bridged profile

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -70,9 +70,9 @@ Menu {
 
     dim: false
     closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
-    topPadding: 8
-    bottomPadding: 8
-    margins: 16
+    topPadding: Theme.halfPadding
+    bottomPadding: Theme.halfPadding
+    margins: Theme.padding
 
     onOpened: {
         if (typeof openHandler === "function") {
@@ -92,6 +92,7 @@ Menu {
     }
 
     contentItem: StatusScrollView {
+        id: scrollView
         padding: 0
 
         ColumnLayout {
@@ -101,6 +102,7 @@ Menu {
 
                 onItemAdded: {
                     item.Layout.fillWidth = true
+                    item.Layout.minimumWidth = scrollView.width
                     item.Layout.maximumWidth = root.maxImplicitWidth
                 }
             }
@@ -111,7 +113,7 @@ Menu {
         id: backgroundContent
         implicitWidth: 176
         color: Theme.palette.statusMenu.backgroundColor
-        radius: 8
+        radius: Theme.radius
         layer.enabled: true
         layer.effect: DropShadow {
             width: backgroundContent.width

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuSeparator.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuSeparator.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core.Theme 0.1
 

--- a/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/ShowcaseDelegate.qml
@@ -103,11 +103,6 @@ StatusDraggableListItem {
                     onClosed: menuLoader.active = false
                     StatusMenuHeadline { text: qsTr("Show to") }
 
-                    Binding on width {
-                        value: Math.max(implicitWidth, everyoneAction.implicitWidth, contactsAction.implicitWidth, idVerifiedContactsAction.implicitWidth) + margins * 2
-                        delayed: true
-                    }
-
                     ShowcaseVisibilityAction {
                         id: everyoneAction
                         showcaseVisibility: Constants.ShowcaseVisibility.Everyone

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -284,6 +284,7 @@ Item {
         id: editImageMenuComponent
 
         StatusMenu {
+            onClosed: destroy()
             StatusAction {
                 text: !!root.icon ? qsTr("Select different image") : qsTr("Select image")
                 assetSettings.name: "image"

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -58,7 +58,7 @@ StatusMenu {
     }
 
     StatusMenuSeparator {
-        visible: emojiRow.visible
+        visible: emojiRow.visible && !root.disabledForChat
     }
 
     StatusAction {

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -38,9 +38,6 @@ StatusMenu {
     signal removeFromGroup
 
     ProfileHeader {
-        width: parent.width
-        height: visible ? implicitHeight : 0
-
         displayNameVisible: false
         displayNamePlusIconsVisible: true
         editButtonVisible: false
@@ -60,6 +57,7 @@ StatusMenu {
     }
 
     StatusMenuSeparator {
+        visible: root.profileType !== Constants.profileType.bridged
         topPadding: root.topPadding
     }
 
@@ -113,7 +111,8 @@ StatusMenu {
 
     StatusMenuSeparator {
         topPadding: root.topPadding
-        enabled: removeNicknameAction.enabled || unblockAction.enabled || markUntrustworthyMenuItem.enabled || removeUntrustworthyMarkMenuItem.enabled || removeContactAction.enabled || blockMenuItem.enabled
+        visible: root.profileType !== Constants.profileType.bridged &&
+                 (removeNicknameAction.enabled || unblockAction.enabled || markUntrustworthyMenuItem.enabled || removeUntrustworthyMarkMenuItem.enabled || removeContactAction.enabled || blockMenuItem.enabled)
     }
 
     // Remove Nickname


### PR DESCRIPTION
### What does the PR do

- hide the separators when showing a bridged profile
- fix calculating the menu item widths

Fixes #16593

### Affected areas

ProfileContextMenu

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Bridged profile:
![image](https://github.com/user-attachments/assets/58f93f5e-baf3-4102-899b-8ebff19b5139)

Regular profile:
![image](https://github.com/user-attachments/assets/ef15d1a5-d803-4a87-a971-f6cf3584dd6f)

