### PR TITLE
Fix/reintroduce swap proposal autorefresh

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapInputParamsForm.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapInputParamsForm.qml
@@ -20,7 +20,7 @@ QtObject {
     // default token key
     property string defaultToTokenKey: ""
     // 15 seconds
-    property int autoRefreshTime: 15000
+    property int expirationTime: 15000
 
     onSelectedAccountAddressChanged: root.formValuesChanged()
     onSelectedNetworkChainIdChanged: root.formValuesChanged()


### PR DESCRIPTION
### What does the PR do
Fixes https://github.com/status-im/status-desktop/issues/16621

Re-introduces the missing Swap Proposal autorefresh logic.

A given "Swap Operation" begins when the user finishes entering the input parameters and a Swap Proposal is received. We consider the Proposal expired 15 seconds after it was received.
The Swap Proposal will be auto-refreshed after expiration unless:
- The Approve or Swap Tx review popup is visible.
- The user has placed an Approve Tx and is waiting to place the Swap Tx.

Changing any input parameter is considerered the beginning of a new "Swap Operation", so the prior logic is reset (i.e we forget about any placed Approve tx).

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
