### PR TITLE
fix(mentions): fix wrong user list given to mentions model

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/UsersStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/UsersStore.qml
@@ -3,9 +3,21 @@ import QtQuick 2.15
 QtObject {
     id: root
 
+    property var chatCommunitySectionModule
+    property var chatDetails
     property var usersModule
 
-    readonly property var usersModel: usersModule ? usersModule.model : null
+    readonly property var usersModel: {
+        if (!chatDetails && !chatCommunitySectionModule) {
+            return null
+        }
+        let isFullCommunityList = !chatDetails.requiresPermissions
+        if (chatDetails.belongsToCommunity && isFullCommunityList && !!chatCommunitySectionModule) {
+            // Community channel with no permisisons. We can use the section's membersModel
+            return chatCommunitySectionModule.membersModel
+        }
+        return usersModule ? usersModule.model : null
+    }
     readonly property var temporaryModel: usersModule ? usersModule.temporaryModel : null
 
     function appendTemporaryModel(pubKey, displayName) {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -103,6 +103,8 @@ Item {
 
         readonly property ChatStores.UsersStore activeUsersStore: ChatStores.UsersStore {
             usersModule: !!d.activeChatContentModule ? d.activeChatContentModule.usersModule : null
+            chatDetails: !!d.activeChatContentModule ? d.activeChatContentModule.chatDetails : null
+            chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
         }
 
         readonly property ChatStores.MessageStore activeMessagesStore: ChatStores.MessageStore {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -41,7 +41,9 @@ ColumnLayout {
 
     property var emojiPopup
     property var stickersPopup
-    property UsersStore usersStore: UsersStore {}
+    property UsersStore usersStore: UsersStore {
+        chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
+    }
 
     signal openStickerPackPopup(string stickerPackId)
 
@@ -63,6 +65,7 @@ ColumnLayout {
     spacing: 0
 
     onChatContentModuleChanged: if (!!chatContentModule) {
+        root.usersStore.chatDetails = root.chatContentModule.chatDetails
         root.usersStore.usersModule = root.chatContentModule.usersModule
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -175,21 +175,17 @@ StatusSectionLayout {
     rightPanel: Component {
         id: userListComponent
         UserListPanel {
+            readonly property var usersStore: ChatStores.UsersStore {
+                usersModule: !!root.chatContentModule ? root.chatContentModule.usersModule : null
+                chatDetails: !!root.chatContentModule ? root.chatContentModule.chatDetails : null
+                chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
+            }
+
             anchors.fill: parent
             store: root.rootStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
-            usersModel: {
-                if (!root.chatContentModule || !root.chatContentModule.chatDetails) {
-                    return null
-                }
-                let isFullCommunityList = !root.chatContentModule.chatDetails.requiresPermissions
-                if (root.chatContentModule.chatDetails.belongsToCommunity && isFullCommunityList) {
-                    // Community channel with no permisisons. We can use the section's membersModel
-                    return root.rootStore.chatCommunitySectionModule.membersModel
-                }
-                return root.chatContentModule.usersModule ? root.chatContentModule.usersModule.model : null
-            }
+            usersModel: usersStore.usersModel
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes #16602

This was broken when we refactored the members to use a single model for public channels. Those public channels then didn't have any members in their model they used for suggestions. This is fixed by putting the logic in the UsersStore and reusing that store whenever we need a list of the members.

### Affected areas

ChatColumnView and ChatView

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[mentions.webm](https://github.com/user-attachments/assets/45df2f1a-f768-47cc-bca1-282fce04da39)

I forgot to show in the video, but they work in the Edit message input too.

![image](https://github.com/user-attachments/assets/821e8999-a286-4e82-8c38-4e4c93fad7da)


### Impact on end user

Fixes the mentions

### How to test

Test the mentions in different types of chats and scenarios (1-1, group, community channel (public or not), edit message.

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the mentions are still missing in some context
