### PR TITLE
fix: Wrap login error message in login view

### DIFF
--- a/storybook/pages/LoginViewPage.qml
+++ b/storybook/pages/LoginViewPage.qml
@@ -18,6 +18,7 @@ SplitView {
         SplitView.fillWidth: true
 
         LoginView {
+            id: loginView
             SplitView.fillWidth: true
             SplitView.fillHeight: true
 
@@ -25,7 +26,7 @@ SplitView {
                 readonly property QtObject startupModuleInst: QtObject {
                     readonly property int remainingAttempts: 5
 
-                    signal accountLoginError
+                    signal accountLoginError(string errorMessage)
                     signal obtainingPasswordSuccess
                     signal obtainingPasswordError
 
@@ -79,7 +80,7 @@ SplitView {
                 }
 
                 readonly property QtObject currentStartupState: QtObject {
-                    readonly property string stateType: Constants.startupState.welcome
+                    readonly property string stateType: Constants.startupState.loginKeycardEnterPassword
                 }
 
                 function setPassword(password) {
@@ -123,6 +124,12 @@ SplitView {
             SplitView.preferredHeight: 200
 
             logsView.logText: logs.logText
+
+            TextField {
+                id: error
+                placeholderText: "Error"
+                onAccepted: loginView.startupStore.startupModuleInst.accountLoginError(text)
+            }
         }
     }
 }

--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -184,6 +184,7 @@ Item {
         horizontalAlignment: Text.AlignRight
         font.pixelSize: 12
         height: 16
+        width: inputField.width
         color: validationErrorColor
         wrapMode: TextEdit.Wrap
     }


### PR DESCRIPTION
### What does the PR do

Fixing the login error wrapping issue on login view. Was missing the width.

<img width="982" alt="Screenshot 2024-10-25 at 17 31 56" src="https://github.com/user-attachments/assets/4c1c97dc-7e9a-4b9f-80c3-7c43b4606175">


### Affected areas

LoginView

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

<img width="641" alt="Screenshot 2024-10-25 at 15 17 57" src="https://github.com/user-attachments/assets/f1a0d60a-de51-482e-8d3e-fdcf53ac8f22">

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
