### PR TITLE
fix(PermissionsSettingsPanel): fix initial view being too wide

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
@@ -87,7 +87,7 @@ StackView {
     // Community Permissions possible view contents:
     initialItem: SettingsPage {
         id: initialItem
-        implicitWidth: 0
+        width: root.viewWidth + leftPadding
 
         title: qsTr("Permissions")
 


### PR DESCRIPTION
### What does the PR do

- fixup the initial item width

Fixes #16617

### Affected areas
PermissionsSettingsPanel

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

App:
![Snímek obrazovky z 2024-10-25 17-11-17](https://github.com/user-attachments/assets/26050f1f-51e3-4af5-8905-b8dd01d4d208)

SB:
![Snímek obrazovky z 2024-10-25 17-04-24](https://github.com/user-attachments/assets/5d5e9968-8ed5-4772-b417-0fef86b2991c)
