### PR TITLE
feat(CommunitySettingsView): add "Invite people" button

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
@@ -28,6 +28,7 @@ SettingsPage {
     signal acceptRequestToJoin(string id)
     signal declineRequestToJoin(string id)
     signal viewMemberMessagesClicked(string pubKey, string displayName)
+    signal inviteNewPeopleClicked()
 
     function goTo(tab: int) {
         if(root.contentItem) {
@@ -36,6 +37,13 @@ SettingsPage {
     }
 
     title: qsTr("Members")
+
+    buttons: [
+        StatusButton {
+            text: qsTr("Invite people")
+            onClicked: root.inviteNewPeopleClicked()
+        }
+    ]
 
     contentItem: ColumnLayout {
 

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -74,7 +74,6 @@ StackLayout {
 
     signal edited(Item item) // item containing edited fields (name, description, logoImagePath, color, options, etc..)
 
-    signal inviteNewPeopleClicked
     signal airdropTokensClicked
     signal exportControlNodeClicked
     signal importControlNodeClicked
@@ -369,6 +368,7 @@ StackLayout {
         id: transferOwnershipAlertPopup
 
         TransferOwnershipAlertPopup {
+            destroyOnClose: true
             communityName: root.name
             communityLogo: root.logoImageData
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -248,12 +248,6 @@ StatusSectionLayout {
                     }
                 }
 
-                onInviteNewPeopleClicked: {
-                    Global.openInviteFriendsToCommunityPopup(root.community,
-                                                            root.chatCommunitySectionModule,
-                                                            null)
-                }
-
                 onAirdropTokensClicked: root.goTo(Constants.CommunitySettingsSections.Airdrops)
                 onExportControlNodeClicked: {
                     if(!root.isControlNode)
@@ -308,6 +302,7 @@ StatusSectionLayout {
                     root.rootStore.loadCommunityMemberMessages(root.community.id, pubKey)
                     Global.openCommunityMemberMessagesPopupRequested(root.rootStore, root.chatCommunitySectionModule, pubKey, displayName)
                 }
+                onInviteNewPeopleClicked: Global.openInviteFriendsToCommunityPopup(root.community, root.chatCommunitySectionModule, null)
             }
         }
 


### PR DESCRIPTION
### What does the PR do

- this adds direct access to sending invitations to new ppl (aka adding members), instead of going thru the secondary nav context menu
- the new community context menu will be tackled in a separate task/issue

Fixes #16597

### Affected areas

Community/Settings/Members

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/1d66b2e3-72e5-4255-97be-884ba0ba849f

