### PR TITLE
fix(members): fix list showing all members when missing encryption keys

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -242,6 +242,9 @@ method updateMembersList*(self: Module, membersToReset: seq[ChatMember] = @[]) =
         if chat.members.len > 0:
           members = chat.members
         else:
+          if chat.missingEncryptionKey:
+            # We don't have the enryption keys, so we can't show the members
+            return
           # The channel now has a permisison, but the re-eval wasn't performed yet. Show all members for now
           members = myCommunity.members
 


### PR DESCRIPTION
### What does the PR do

Fixes #16614

The problem was that I was missing encryption keys for some channels, but since I'm an admin, I still have access, so I could see the member list and it was showing me all members because of a missing condition in the code

### Affected areas

Member list (user module to be exact)

### Screenshot of functionality (including design for comparison)

I couldn't reproduce the issue because I received the encryption keys, so I can't see the bug anymore. However, I'm positive this will fix it. I tested by hardcoding the conditions when testing.

### Impact on end user

The user should not be able to see the full member list in a private channel anymore.

### How to test

Test public and private channels in a community. Even better if you have one where you're missing encryption keys, but that is hard to reproduce.

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case is the bug isn't fixed
