### PR TITLE
fix(communities): fix missing members in community settings

### DIFF
--- a/ui/app/AppLayouts/Chat/views/qmldir
+++ b/ui/app/AppLayouts/Chat/views/qmldir
@@ -1,3 +1,4 @@
 CreateChatView 1.0 CreateChatView.qml
-MembersSelectorView 1.0 MembersSelectorView.qml
 MembersEditSelectorView 1.0 MembersEditSelectorView.qml
+MembersModelAdaptor 1.0 MembersModelAdaptor.qml
+MembersSelectorView 1.0 MembersSelectorView.qml

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
@@ -10,6 +11,7 @@ import StatusQ.Popups 0.1
 import utils 1.0
 import shared.controls.chat.menuItems 1.0
 import AppLayouts.stores 1.0 as AppLayoutsStores
+import AppLayouts.Chat.views 1.0
 
 StatusListView {
     id: root
@@ -32,6 +34,12 @@ StatusListView {
 
     delegate: StatusListItem {
         id: listItem
+
+        MembersModelAdaptor {
+            id: membersModelAdaptor
+            allMembers: model.allMembers
+        }
+
         width: ListView.view.width
         title: model.name
         statusListItemTitle.font.pixelSize: 17
@@ -39,7 +47,7 @@ StatusListView {
         statusListItemIcon.anchors.verticalCenter: undefined
         statusListItemIcon.anchors.top: statusListItemTitleArea.top
         subTitle: model.description
-        tertiaryTitle: qsTr("%n member(s)", "", model.members.count)
+        tertiaryTitle: qsTr("%n member(s)", "", membersModelAdaptor.joinedMembers.ModelCount.count)
         statusListItemTertiaryTitle.font.weight: Font.Medium
         asset.name: model.image
         asset.isLetterIdenticon: !model.image


### PR DESCRIPTION
### What does the PR do

Fixes #16627

I had missed that the community settings also used the members. Fixed by using the model adaptor and using the right property name

### Affected areas

Community settings (members only)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/20923f70-4884-4ad4-a813-5d82616b7044)

### Impact on end user

Goes back to expected behavior of seeing the members count in the settings

### How to test

- Be part of a community
- Check the community settings

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

