### PR TITLE
Fix/16568: Swap transaction - Wrong copy on the tooltip of the 'Swap' button

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -407,9 +407,18 @@ StatusDialog {
                         }
                         return qsTr("Swap")
                     }
-                    tooltip.text: root.swapAdaptor.validSwapProposalReceived &&
-                                  root.swapAdaptor.swapOutputData.approvalNeeded ?
-                                      qsTr("Approve %1 spending cap to Swap").arg(fromTokenSymbol) : ""
+                    tooltip.text: {
+                        if(root.swapAdaptor.validSwapProposalReceived) {
+                            if(root.swapAdaptor.swapOutputData.approvalNeeded) {
+                                if (root.swapAdaptor.approvalPending) {
+                                    return qsTr("Approving %1 spending cap to Swap").arg(fromTokenSymbol)
+                                } else if(!root.swapAdaptor.approvalSuccessful) {
+                                    return qsTr("Approve %1 spending cap to Swap").arg(fromTokenSymbol)
+                                }
+                            }
+                        }
+                        return ""
+                    }
                     disabledColor: Theme.palette.directColor8
                     interactive: root.swapAdaptor.validSwapProposalReceived &&
                                  editSlippagePanel.valid &&


### PR DESCRIPTION
fixes #16568

### What does the PR do

Fixes the tooltip text in SwapModal, doesnt show any tooltip when Swap button is shown

### Affected areas

SwapModal

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://github.com/user-attachments/assets/a94417d8-fd65-4ac9-abb0-97facdf2e414

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
