### PR TITLE
fix: Share community link is gone

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
@@ -96,7 +96,7 @@ StatusStackModal {
         ProfilePopupInviteFriendsPanel {
             rootStore: root.rootStore
             contactsStore: root.contactsStore
-            communityId: root.communityId
+            communityId: root.community.id
             onPubKeysChanged: root.pubKeys = pubKeys
         },
 


### PR DESCRIPTION
### What does the PR do

- pass the correct community ID

Fixes #16637

### Affected areas

InviteFriendsToCommunityPopup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/160623d7-1ab5-49a9-b007-ba6e8e1cb41a)

