### PR TITLE
fix: cant fetch fees when releasing ens name, token is not set, as well as value

### DIFF
--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -21,16 +21,16 @@ Item {
     property EnsUsernamesStore ensUsernamesStore
     property string username: ""
     property string chainId: ""
-    property string walletAddress: "-"
-    property string key: "-"
 
     signal backBtnClicked()
-    signal releaseUsernameRequested()
+    signal releaseUsernameRequested(string senderAddress)
 
     QtObject {
         id: d
 
         property double expirationTimestamp: 0
+        property string walletAddress: "-"
+        property string key: "-"
     }
 
     StatusBaseText {
@@ -65,10 +65,14 @@ Item {
         function onDetailsObtained(chainId: int, ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {
             if(username != (isStatus ? ensName + ".stateofus.eth" : ensName))
                 return;
+            d.walletAddress = address
             walletAddressLbl.subTitle = address;
+            walletAddressLbl.visible = !!address;
+
+            d.key = pubkey
             keyLbl.subTitle = pubkey.substring(0, 20) + "..." + pubkey.substring(pubkey.length - 20);
-            walletAddressLbl.visible = true;
-            keyLbl.visible = true;
+            keyLbl.visible = !!pubkey;
+
             releaseBtn.visible = isStatus
             removeButton.visible = true
             releaseBtn.enabled = expirationTime > 0
@@ -140,7 +144,7 @@ Item {
             enabled: false
             text: qsTr("Release username")
             onClicked: {
-                root.releaseUsernameRequested()
+                root.releaseUsernameRequested(d.walletAddress)
             }
         }
     }
@@ -152,6 +156,8 @@ Item {
         anchors.left: parent.left
         anchors.leftMargin: 24
         text: {
+            if (d.expirationTimestamp === 0)
+                return ""
             const formattedDate = LocaleUtils.formatDate(d.expirationTimestamp, Locale.ShortFormat)
             return qsTr("Username locked. You won't be able to release it until %1").arg(formattedDate)
         }

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -6,6 +6,8 @@ import QtQml.StateMachine 1.14 as DSM
 import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
 
 import utils 1.0
 import shared 1.0
@@ -377,8 +379,15 @@ Item {
             onBackBtnClicked: back()
 
             onReleaseUsernameRequested: {
+                const name = RootStore.getNameForWalletAddress(senderAddress)
+                if (name === "") {
+                    Global.openPopup(noAccountPopupComponent)
+                    return
+                }
+
                 ensView.sendModalPopup.modalHeaderText = qsTr("Release your username")
                 ensView.sendModalPopup.interactive = false
+                ensView.sendModalPopup.preSelectedAccountAddress = senderAddress
                 ensView.sendModalPopup.preSelectedRecipient = ensView.ensUsernamesStore.getEnsRegisteredAddress()
                 ensView.sendModalPopup.preSelectedRecipientType = Helpers.RecipientAddressObjectType.Address
                 ensView.sendModalPopup.preSelectedHoldingID = Constants.ethToken
@@ -400,6 +409,22 @@ Item {
                     done(ensView.selectedUsername)
                 }
             }
+        }
+    }
+
+    Component {
+        id: noAccountPopupComponent
+        StatusDialog {
+            title: qsTr("Release username")
+
+            StatusBaseText {
+                anchors.fill: parent
+                font.pixelSize: Constants.keycard.general.fontSize2
+                color: Theme.palette.directColor1
+                text: qsTr("The account this username was bought with is no longer among active accounts.\nPlease add it and try again.")
+            }
+
+            standardButtons: Dialog.Ok
         }
     }
 

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -229,10 +229,11 @@ StatusDialog {
         }
 
         if (!!popup.preSelectedHoldingID
-                && popup.preSelectedHoldingType > Constants.TokenType.Native
+                && popup.preSelectedHoldingType >= Constants.TokenType.Native
                 && popup.preSelectedHoldingType < Constants.TokenType.Unknown) {
 
-            if (popup.preSelectedHoldingType === Constants.TokenType.ERC20) {
+            if (popup.preSelectedHoldingType === Constants.TokenType.Native
+                    || popup.preSelectedHoldingType === Constants.TokenType.ERC20) {
                 const entry = SQUtils.ModelUtils.getByKey(
                                 assetsAdaptor.outputAssetsModel, "tokensKey",
                                 popup.preSelectedHoldingID)

--- a/ui/imports/shared/popups/send/views/NetworkSelector.qml
+++ b/ui/imports/shared/popups/send/views/NetworkSelector.qml
@@ -129,7 +129,7 @@ Item {
                     root.reCalculateSuggestedRoute()
                 }
 
-                showBetaTag: root.bestRoutes.count > 1
+                showBetaTag: !!root.bestRoutes && root.bestRoutes.count > 1
             }
         }
 


### PR DESCRIPTION
There are a few things improved in this commit:
- the account the username was bought with is selected for releasing
- if the account was removed in meantime, we warn user displaying a popup message
- ETH token is selected
- 0 value is set

Fixes #16611

@benjthayer if you have a better suggestion for the message in the video below, in case when the address the username was bought with was removed, let me know to update it.

https://github.com/user-attachments/assets/a1a5a037-5f75-48a2-accb-615d95b554e9

