### PR TITLE
fix(AddAccount): Derivation path drop down is empty

### DIFF
--- a/storybook/pages/DerivationPathInputPage.qml
+++ b/storybook/pages/DerivationPathInputPage.qml
@@ -11,6 +11,32 @@ import utils 1.0
 import shared.popups.addaccount.panels 1.0
 
 SplitView {
+    id: root
+
+    QtObject {
+        id: d
+
+        function translation(key, isTitle) {
+            if (!isTitle) {
+                if (key === Constants.addAccountPopup.predefinedPaths.custom)
+                    return qsTr("Type your own derivation path")
+                return key
+            }
+            switch(key) {
+            case Constants.addAccountPopup.predefinedPaths.custom:
+                return qsTr("Custom")
+            case Constants.addAccountPopup.predefinedPaths.ethereum:
+                return qsTr("Ethereum")
+            case Constants.addAccountPopup.predefinedPaths.ethereumRopsten:
+                return qsTr("Ethereum Testnet (Ropsten)")
+            case Constants.addAccountPopup.predefinedPaths.ethereumLedger:
+                return qsTr("Ethereum (Ledger)")
+            case Constants.addAccountPopup.predefinedPaths.ethereumLedgerLive:
+                return qsTr("Ethereum (Ledger Live/KeepKey)")
+            }
+        }
+    }
+
     Pane {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
@@ -41,19 +67,19 @@ SplitView {
                     }
                 }
 
-                StatusMenu {
+                DerivationPathSelection {
                     id: derivationPathSelection
 
-                    ColumnLayout {
-                        StatusBaseText {
-                            text: "Test Popup"
-                            Layout.margins: 10
-                        }
-                        StatusBaseText {
-                            text: "Some more content here"
-                            Layout.margins: 10
-                        }
-                    }
+                    roots: [Constants.addAccountPopup.predefinedPaths.custom,
+                        Constants.addAccountPopup.predefinedPaths.ethereum,
+                        Constants.addAccountPopup.predefinedPaths.ethereumRopsten,
+                        Constants.addAccountPopup.predefinedPaths.ethereumLedger,
+                        Constants.addAccountPopup.predefinedPaths.ethereumLedgerLive
+                    ]
+                    translation: d.translation
+                    selectedRootPath: Constants.addAccountPopup.predefinedPaths.ethereum
+
+                    onSelected: (rootPath) => console.warn("!!! SELECTED PATH:", rootPath)
                 }
             }
 

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPathInput.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPathInput.qml
@@ -107,7 +107,7 @@ Item {
         readonly property var passthroughKeys: [Qt.Key_Left, Qt.Key_Right, Qt.Key_Escape]
 
         Shortcut {
-            sequence: StandardKey.Copy
+            sequences: [StandardKey.Copy]
             enabled: d.selectionIsActive
             onActivated: input.copy()
         }

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPathSelection.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPathSelection.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -12,37 +12,34 @@ StatusMenu {
     id: root
 
     implicitWidth: 285
+    padding: 0
 
     property string selectedRootPath
     property var roots: []
-    property var translation: function (key, isTitle) {}
+    property var translation: (key, isTitle) => console.error("Must provide implementation")
 
     signal selected(string rootPath)
 
-    contentItem: Column {
-        width: root.width
+    contentItem: StatusListView {
+        model: root.roots.length
+        implicitHeight: contentHeight
+        delegate: StatusListItem {
+            objectName: "AddAccountPopup-PreDefinedDerivationPath-%1".arg(title)
+            width: parent.width
+            title: root.translation(root.roots[index], true)
+            subTitle: root.translation(root.roots[index], false)
 
-        Repeater {
-            model: root.roots.length
-
-            StatusListItem {
-                objectName: "AddAccountPopup-PreDefinedDerivationPath-%1".arg(title)
-                width: parent.width
-                title: root.translation(root.roots[index], true)
-                subTitle: root.translation(root.roots[index], false)
-
-                components: [
-                    StatusIcon {
-                        visible: root.selectedRootPath === root.roots[index]
-                        icon: "checkmark"
-                        color: Theme.palette.primaryColor1
-                    }
-                ]
-
-                onClicked: {
-                    root.selected(root.roots[index])
-                    root.close()
+            components: [
+                StatusIcon {
+                    visible: root.selectedRootPath === root.roots[index]
+                    icon: "checkmark"
+                    color: Theme.palette.primaryColor1
                 }
+            ]
+
+            onClicked: {
+                root.selected(root.roots[index])
+                root.close()
             }
         }
     }

--- a/ui/imports/shared/popups/addaccount/panels/qmldir
+++ b/ui/imports/shared/popups/addaccount/panels/qmldir
@@ -1,1 +1,2 @@
 DerivationPathInput 1.0 DerivationPathInput.qml
+DerivationPathSelection 1.0 DerivationPathSelection.qml

--- a/ui/imports/shared/popups/common/BasePopupStore.qml
+++ b/ui/imports/shared/popups/common/BasePopupStore.qml
@@ -1,5 +1,4 @@
-import QtQuick 2.13
-import utils 1.0
+import QtQml 2.15
 
 QtObject {
     id: root


### PR DESCRIPTION
### What does the PR do

- use `StatusListView` for the popup/menu contentItem
- add the menu to SB too

Fixes #16635

### Affected areas

DerivationInput

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/3151eca5-513d-475e-8035-4a72d48131ac
