### PR TITLE
Refactor: move `Utils.getCompressedPk` to `UtilsStore` and backend models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -853,9 +853,9 @@ run-windows: compile_windows_resources nim_status_client $(NIM_WINDOWS_PREBUILT_
 NIM_TEST_FILES := $(wildcard test/nim/*.nim)
 NIM_TESTS := $(foreach test_file,$(NIM_TEST_FILES),nim-test-run/$(test_file))
 
-nim-test-run/%: | dotherside
-	LD_LIBRARY_PATH="$(QT5_LIBDIR):$(LD_LIBRARY_PATH)" $(ENV_SCRIPT) \
-	nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) -r $(subst nim-test-run/,,$@)
+nim-test-run/%: | dotherside $(STATUSGO)
+	LD_LIBRARY_PATH="$(QT5_LIBDIR)":"$(STATUSGO_LIBDIR)":"$(LD_LIBRARY_PATH)" $(ENV_SCRIPT) \
+	nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) --passL:"-L$(STATUSGO_LIBDIR)" --passL:"-lstatus" -r $(subst nim-test-run/,,$@)
 
 tests-nim-linux: $(NIM_TESTS)
 

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -8,7 +8,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.2.1-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.5.0-qt5.15.2'
     }
   }
 

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -3,6 +3,8 @@ import NimQml
 import ../../constants as main_constants
 import local_account_settings
 
+import ../../app_service/service/accounts/utils
+
 QtObject:
   type UserProfile* = ref object of QObject
     localAccountSettings: LocalAccountSettings
@@ -45,6 +47,11 @@ QtObject:
     self.pubKey
   QtProperty[string] pubKey:
     read = getPubKey
+
+  proc getCompressedPubKey*(self: UserProfile): string {.slot.} =
+    compressPk(self.pubKey)
+  QtProperty[string] compressedPubKey:
+    read = getCompressedPubKey
 
   proc getIsKeycardUser*(self: UserProfile): bool {.slot.} =
     self.isKeycardUser

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -43,6 +43,7 @@ import ../../../app_service/service/wallet_account/service as wallet_account_ser
 import ../../../app_service/service/provider/service as provider_service
 import ../../../app_service/service/profile/service as profile_service
 import ../../../app_service/service/accounts/service as accounts_service
+import ../../../app_service/service/accounts/utils as accounts_utils
 import ../../../app_service/service/settings/service as settings_service
 import ../../../app_service/service/contacts/service as contacts_service
 import ../../../app_service/service/about/service as about_service
@@ -1137,6 +1138,7 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string, getVerifi
     # contact dto props
     "displayName": contactDetails.dto.displayName,
     "publicKey": contactDetails.dto.id,
+    "compressedPublicKey": accounts_utils.compressPk(contactDetails.dto.id),
     "name": contactDetails.dto.name,
     "ensVerified": contactDetails.dto.ensVerified,
     "alias": contactDetails.dto.alias,

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -3,6 +3,7 @@ import NimQml, Tables, stew/shims/strformat, sequtils, sugar
 
 import ../../../app_service/common/types
 import ../../../app_service/service/contacts/dto/contacts
+import ../../../app_service/service/accounts/utils
 import member_item
 import contacts_utils
 import model_utils
@@ -10,6 +11,7 @@ import model_utils
 type
   ModelRole {.pure.} = enum
     PubKey = UserRole + 1
+    CompressedPubKey
     DisplayName
     PreferredDisplayName
     EnsName
@@ -79,6 +81,7 @@ QtObject:
   method roleNames(self: Model): Table[int, string] =
     {
       ModelRole.PubKey.int: "pubKey",
+      ModelRole.CompressedPubKey.int: "compressedPubKey",
       ModelRole.DisplayName.int: "displayName",
       ModelRole.PreferredDisplayName.int: "preferredDisplayName",
       ModelRole.EnsName.int: "ensName",
@@ -116,6 +119,8 @@ QtObject:
     case enumRole:
     of ModelRole.PubKey:
       result = newQVariant(item.pubKey)
+    of ModelRole.CompressedPubKey:
+      result = newQVariant(compressPk(item.pubKey))
     of ModelRole.DisplayName:
       result = newQVariant(item.displayName)
     of ModelRole.PreferredDisplayName:

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -2,12 +2,14 @@ import NimQml, Tables, stew/shims/strformat, sequtils, sugar
 import user_item
 
 import ../../../app_service/common/types
+import ../../../app_service/service/accounts/utils
 import contacts_utils
 import model_utils
 
 type
   ModelRole {.pure.} = enum
     PubKey = UserRole + 1
+    CompressedPubKey
     DisplayName
     PreferredDisplayName
     EnsName
@@ -83,6 +85,7 @@ QtObject:
   method roleNames(self: Model): Table[int, string] =
     {
       ModelRole.PubKey.int: "pubKey",
+      ModelRole.CompressedPubKey.int: "compressedPubKey",
       ModelRole.DisplayName.int: "displayName",
       ModelRole.PreferredDisplayName.int: "preferredDisplayName",
       ModelRole.EnsName.int: "ensName",
@@ -126,6 +129,8 @@ QtObject:
     case enumRole:
     of ModelRole.PubKey:
       result = newQVariant(item.pubKey)
+    of ModelRole.CompressedPubKey:
+      result = newQVariant(compressPk(item.pubKey))
     of ModelRole.DisplayName:
       result = newQVariant(item.displayName)
     of ModelRole.PreferredDisplayName:

--- a/storybook/pages/AirdropsSettingsPanelPage.qml
+++ b/storybook/pages/AirdropsSettingsPanelPage.qml
@@ -23,14 +23,6 @@ SplitView {
     Logs { id: logs }
 
     QtObject {
-        function isCompressedPubKey(publicKey) {
-            return true
-        }
-
-        function getCompressedPk(publicKey) {
-            return "compressed_" + publicKey
-        }
-
         function getColorId(publicKey) {
             return Math.floor(Math.random() * 10)
         }
@@ -103,6 +95,8 @@ SplitView {
                 // Models
                 assetsModel: AssetsModel {}
                 collectiblesModel: ListModel {}
+
+                enabledChainIds: "1"
 
                 CollectiblesModel {
                     id: collectiblesModel

--- a/storybook/pages/ImportCommunityPopupPage.qml
+++ b/storybook/pages/ImportCommunityPopupPage.qml
@@ -133,45 +133,7 @@ SplitView {
             timer.start()
         }
     }
-    QtObject {
-        id: utilsMock
-
-        function getContactDetailsAsJson(arg1, arg2) {
-            return JSON.stringify({
-                displayName: "Mock user",
-                displayIcon: Theme.png("tokens/AST"),
-                publicKey: 123456789,
-                name: "",
-                ensVerified: false,
-                alias: "",
-                lastUpdated: 0,
-                lastUpdatedLocally: 0,
-                localNickname: "",
-                thumbnailImage: "",
-                largeImage: "",
-                isContact: false,
-                isAdded: false,
-                isBlocked: false,
-                requestReceived: false,
-                isSyncing: false,
-                removed: false,
-                trustStatus: Constants.trustStatus.unknown,
-                verificationStatus: Constants.verificationStatus.unverified,
-            })
-        }
-
-        function getCommunityDataFromSharedLink(link) {
-            return d.knownCommunityDetails
-        }
-
-        function getCompressedPk(publicKey) {
-            return d.knownCommunityCompressedPublicKey
-        }
-
-        signal importingCommunityStateChanged(string communityId, int state, string errorMsg)
-
-        // sharedUrlsModuleInst
-
+    QtObject {        // sharedUrlsModuleInst
         function parseCommunitySharedUrl(link) {
             if (link === d.knownCommunityLink)
                 return JSON.stringify({ communityId: d.knownCommunityPublicKey })
@@ -182,13 +144,11 @@ SplitView {
 
         Component.onCompleted: {
             Utils.sharedUrlsModuleInst = this
-            Utils.globalUtilsInst = this
             d.utilsReady = true
         }
         Component.onDestruction: {
             d.utilsReady = false
             Utils.sharedUrlsModuleInst = {}
-            Utils.globalUtilsInst = {}
         }
     }
 

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -118,24 +118,22 @@ SplitView {
                     }
                 }
 
-                contactsStore: ProfileStores.ContactsStore {
-                    readonly property ListModel myContactsModel: ListModel {
-                        Component.onCompleted: {
-                            for (let i = 0; i < 20; i++) {
-                                const key = `pub_key_${i}`
+                contactsModel: ListModel {
+                    Component.onCompleted: {
+                        for (let i = 0; i < 20; i++) {
+                            const key = `pub_key_${i}`
 
-                                append({
-                                    alias: "",
-                                    colorId: "1",
-                                    displayName: `contact ${i}`,
-                                    ensName: "",
-                                    icon: "",
-                                    isContact: true,
-                                    localNickname: "",
-                                    onlineStatus: 1,
-                                    pubKey: key
-                                })
-                            }
+                            append({
+                                alias: "",
+                                colorId: "1",
+                                displayName: `contact ${i}`,
+                                ensName: "",
+                                icon: "",
+                                isContact: true,
+                                localNickname: "",
+                                onlineStatus: 1,
+                                pubKey: key
+                            })
                         }
                     }
                 }

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -13,12 +13,9 @@ SplitView {
 
     Logs { id: logs }
 
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
     property bool communitiesModuleReady: false
 
     Item {
-
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
@@ -31,46 +28,6 @@ SplitView {
             text: "Reopen"
 
             onClicked: loader.item.open()
-        }
-
-        QtObject {
-            function getCompressedPk(publicKey) {
-                return "compressed"
-            }
-
-            function isCompressedPubKey() {
-                return true
-            }
-
-            function getColorHashAsJson(publicKey) {
-                return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                       {colorId: 19, segmentLength: 2}])
-            }
-
-            Component.onCompleted: {
-                Utils.globalUtilsInst = this
-                globalUtilsReady = true
-
-            }
-            Component.onDestruction: {
-                globalUtilsReady = false
-                Utils.globalUtilsInst = {}
-            }
-        }
-
-        QtObject {
-            function getContactDetailsAsJson() {
-                return JSON.stringify({})
-            }
-
-            Component.onCompleted: {
-                mainModuleReady = true
-                Utils.mainModuleInst = this
-            }
-            Component.onDestruction: {
-                mainModuleReady = false
-                Utils.mainModuleInst = {}
-            }
         }
 
         QtObject {
@@ -90,7 +47,7 @@ SplitView {
 
         Loader {
             id: loader
-            active: globalUtilsReady && mainModuleReady && communitiesModuleReady
+            active: communitiesModuleReady
             anchors.fill: parent
 
             sourceComponent: InviteFriendsToCommunityPopup {
@@ -132,7 +89,13 @@ SplitView {
                                 isContact: true,
                                 localNickname: "",
                                 onlineStatus: 1,
-                                pubKey: key
+                                pubKey: key,
+                                compressedKey: "zx3sh" + key,
+                                colorHash: [
+                                    { colorId: i, segmentLength: i % 5 },
+                                    { colorId: i + 5, segmentLength: 3 },
+                                    { colorId: 19, segmentLength: 2 }
+                                ]
                             })
                         }
                     }

--- a/storybook/pages/LinkPreviewCardPage.qml
+++ b/storybook/pages/LinkPreviewCardPage.qml
@@ -23,14 +23,10 @@ SplitView {
     QtObject {
         function getColorId(publicKey) { return 4 }
 
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
-
         function getColorHashAsJson(publicKey) {
             return JSON.stringify([{4: 0, segmentLength: 1},
                                    {5: 19, segmentLength: 2}])
         }
-
-        function isCompressedPubKey(publicKey) { return true }
 
         Component.onCompleted: {
             Utils.globalUtilsInst = this
@@ -51,6 +47,10 @@ SplitView {
             id: previewCard
 
             utilsStore: UtilsStore {
+                function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
+
+                function isCompressedPubKey(publicKey) { return true }
+
                 function getEmojiHash(publicKey) {
                     return JSON.stringify(["👨🏻‍🍼", "🏃🏿‍♂️", "🌇", "🤶🏿", "🏮","🤷🏻‍♂️", "🤦🏻", "📣", "🤎", "👷🏽", "😺", "🥞", "🔃", "🧝🏽‍♂️"])
                 }

--- a/storybook/pages/MembersDropdownPage.qml
+++ b/storybook/pages/MembersDropdownPage.qml
@@ -5,7 +5,6 @@ import QtQml 2.15
 
 import AppLayouts.Communities.popups 1.0
 
-import utils 1.0
 import SortFilterProxyModel 0.2
 
 import Storybook 1.0
@@ -13,52 +12,9 @@ import Storybook 1.0
 SplitView {
     id: root
 
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
-
     orientation: Qt.Vertical
 
     Logs { id: logs }
-
-    QtObject {
-        function isCompressedPubKey(publicKey) {
-            return true
-        }
-
-        function getCompressedPk(publicKey) {
-            return "compressed_" + publicKey
-        }
-
-        function getColorId(publicKey) {
-            return Math.floor(Math.random() * 10)
-        }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            globalUtilsReady = true
-
-        }
-        Component.onDestruction: {
-            globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    QtObject {
-        function getContactDetailsAsJson() {
-            return JSON.stringify({ ensVerified: true })
-        }
-
-        Component.onCompleted: {
-            mainModuleReady = true
-            Utils.mainModuleInst = this
-        }
-        Component.onDestruction: {
-            mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
-
 
     ListModel {
         id: members
@@ -84,6 +40,7 @@ SplitView {
                 localNickname: "",
                 onlineStatus: 1,
                 pubKey: key,
+                compressedPubKey: "compressed_" + key,
                 isVerified: true,
                 isUntrustworthy: false,
                 airdropAddress: `0x${firstLetter}${i}`
@@ -126,57 +83,46 @@ SplitView {
             }
         }
 
-        Loader {
-            id: loader
+        MembersDropdown {
+            id: membersDropdown
 
-            anchors.centerIn: parent
-            active: globalUtilsReady && mainModuleReady
+            closePolicy: Popup.NoAutoClose
 
-            sourceComponent: MembersDropdown {
-                id: membersDropdown
+            model: SortFilterProxyModel {
+                sourceModel: members
 
-                closePolicy: Popup.NoAutoClose
+                filters: [
+                    ExpressionFilter {
+                        enabled: membersDropdown.searchText !== ""
 
-                model: SortFilterProxyModel {
-                    Binding on sourceModel {
-                        when: globalUtilsReady && mainModuleReady
-                        value: members
-                        restoreMode: Binding.RestoreBindingOrValue
-                    }
-
-                    filters: [
-                        ExpressionFilter {
-                            enabled: membersDropdown.searchText !== ""
-
-                            function matchesAlias(name, filter) {
-                                return name.split(" ").some(p => p.startsWith(filter))
-                            }
-
-                            expression: {
-                                membersDropdown.searchText
-
-                                const filter = membersDropdown.searchText.toLowerCase()
-                                return matchesAlias(model.alias.toLowerCase(), filter)
-                                         || model.displayName.toLowerCase().includes(filter)
-                                         || model.ensName.toLowerCase().includes(filter)
-                                         || model.localNickname.toLowerCase().includes(filter)
-                                         || model.pubKey.toLowerCase().includes(filter)
-                            }
+                        function matchesAlias(name, filter) {
+                            return name.split(" ").some(p => p.startsWith(filter))
                         }
-                    ]
-                }
 
-                onBackButtonClicked: {
-                    logs.logEvent("MembersDropdown::backButtonClicked")
-                }
+                        expression: {
+                            membersDropdown.searchText
 
-                onAddButtonClicked: {
-                    logs.logEvent("MembersDropdown::addButtonClicked, keys: "
-                                  + [...membersDropdown.selectedKeys])
-                }
-
-                Component.onCompleted: open()
+                            const filter = membersDropdown.searchText.toLowerCase()
+                            return matchesAlias(model.alias.toLowerCase(), filter)
+                                     || model.displayName.toLowerCase().includes(filter)
+                                     || model.ensName.toLowerCase().includes(filter)
+                                     || model.localNickname.toLowerCase().includes(filter)
+                                     || model.pubKey.toLowerCase().includes(filter)
+                        }
+                    }
+                ]
             }
+
+            onBackButtonClicked: {
+                logs.logEvent("MembersDropdown::backButtonClicked")
+            }
+
+            onAddButtonClicked: {
+                logs.logEvent("MembersDropdown::addButtonClicked, keys: "
+                              + [...membersDropdown.selectedKeys])
+            }
+
+            Component.onCompleted: open()
         }
     }
 
@@ -186,163 +132,157 @@ SplitView {
 
         logsView.logText: logs.logText
 
-        Loader {
-            active: loader.item
-
+        ColumnLayout {
             anchors.left: parent.left
             anchors.right: parent.right
 
-            sourceComponent: ColumnLayout {
-                readonly property MembersDropdown membersDropdown: loader.item
+            RowLayout {
+                RadioButton {
+                    id: addModeRadioButton
 
-                RowLayout {
-                    RadioButton {
-                        id: addModeRadioButton
-
-                        text: "add mode"
-                        checked: true
-
-                        Binding {
-                            target: membersDropdown
-                            property: "mode"
-                            value: addModeRadioButton.checked
-                                   ? MembersDropdown.Mode.Add
-                                   : MembersDropdown.Mode.Update
-                        }
-                    }
-
-                    RadioButton {
-                        text: "update mode"
-                    }
-
-                    CheckBox {
-                        id: forceButtonDisabledCheckBox
-
-                        text: "force button disabled"
-
-                        Binding {
-                            target: membersDropdown
-                            property: "forceButtonDisabled"
-                            value: forceButtonDisabledCheckBox.checked
-                        }
-                    }
-                }
-
-                RowLayout {
-                    Label {
-                        text: "maximum list height:"
-                    }
-
-                    Slider {
-                        id: maxListHeightSlider
-                        from: 100
-                        to: 500
-                        stepSize: 1
-
-                        Component.onCompleted: {
-                            value = membersDropdown.maximumListHeight
-                            membersDropdown.maximumListHeight
-                                    = Qt.binding(() => value)
-                        }
-                    }
-
-                    Label {
-                        text: maxListHeightSlider.value
-                    }
-                }
-
-                RowLayout {
-                    Label {
-                        text: "margins:"
-                    }
-
-                    Slider {
-                        id: marginsSlider
-                        from: -1
-                        to: 50
-                        stepSize: 1
-
-                        Component.onCompleted: {
-                            value = membersDropdown.margins
-                            membersDropdown.margins = Qt.binding(() => value)
-                        }
-                    }
-
-                    Label {
-                        text: marginsSlider.value
-                    }
-                }
-
-                RowLayout {
-                    Label {
-                        text: "bottom inset:"
-                    }
-
-                    Slider {
-                        id: bottomInsetSlider
-                        from: 0
-                        to: 50
-                        stepSize: 1
-
-                        Component.onCompleted: {
-                            value = membersDropdown.bottomInset
-                            membersDropdown.bottomInset = Qt.binding(() => value)
-                        }
-                    }
-
-                    Label {
-                        text: bottomInsetSlider.value
-                    }
-                }
-
-                RowLayout {
-                    RadioButton {
-                        id: anchorToItemRadioButton
-                        text: "anchor to item"
-
-                        checked: true
-                    }
-                    RadioButton {
-                        id: anchorToOverlayRadioButton
-                        text: "anchor to overlay"
-
-                    }
+                    text: "add mode"
+                    checked: true
 
                     Binding {
                         target: membersDropdown
-                        property: "parent"
-                        value: anchorToItemRadioButton.checked
-                               ? startRect : membersDropdown.Overlay.overlay
+                        property: "mode"
+                        value: addModeRadioButton.checked
+                               ? MembersDropdown.Mode.Add
+                               : MembersDropdown.Mode.Update
                     }
+                }
 
-                    Binding {
-                        target: membersDropdown.anchors
-                        when: anchorToOverlayRadioButton.checked
-                        property: "centerIn"
-                        value: membersDropdown.parent
-                        restoreMode: Binding.RestoreBindingOrValue
-                    }
+                RadioButton {
+                    text: "update mode"
+                }
 
-                    Binding {
-                        target: membersDropdown
-                        property: "x"
-                        value: anchorToItemRadioButton.checked
-                               ? startRect.width / 2 : 0
-                    }
+                CheckBox {
+                    id: forceButtonDisabledCheckBox
+
+                    text: "force button disabled"
 
                     Binding {
                         target: membersDropdown
-                        property: "y"
-                        value: anchorToItemRadioButton.checked
-                               ? startRect.height / 2 : 0
+                        property: "forceButtonDisabled"
+                        value: forceButtonDisabledCheckBox.checked
+                    }
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "maximum list height:"
+                }
+
+                Slider {
+                    id: maxListHeightSlider
+                    from: 100
+                    to: 500
+                    stepSize: 1
+
+                    Component.onCompleted: {
+                        value = membersDropdown.maximumListHeight
+                        membersDropdown.maximumListHeight
+                                = Qt.binding(() => value)
                     }
                 }
 
                 Label {
-                    Layout.fillWidth: true
-                    text: `selected members: ${[...membersDropdown.selectedKeys]}`
-                    wrapMode: Label.Wrap
+                    text: maxListHeightSlider.value
                 }
+            }
+
+            RowLayout {
+                Label {
+                    text: "margins:"
+                }
+
+                Slider {
+                    id: marginsSlider
+                    from: -1
+                    to: 50
+                    stepSize: 1
+
+                    Component.onCompleted: {
+                        value = membersDropdown.margins
+                        membersDropdown.margins = Qt.binding(() => value)
+                    }
+                }
+
+                Label {
+                    text: marginsSlider.value
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "bottom inset:"
+                }
+
+                Slider {
+                    id: bottomInsetSlider
+                    from: 0
+                    to: 50
+                    stepSize: 1
+
+                    Component.onCompleted: {
+                        value = membersDropdown.bottomInset
+                        membersDropdown.bottomInset = Qt.binding(() => value)
+                    }
+                }
+
+                Label {
+                    text: bottomInsetSlider.value
+                }
+            }
+
+            RowLayout {
+                RadioButton {
+                    id: anchorToItemRadioButton
+                    text: "anchor to item"
+
+                    checked: true
+                }
+                RadioButton {
+                    id: anchorToOverlayRadioButton
+                    text: "anchor to overlay"
+
+                }
+
+                Binding {
+                    target: membersDropdown
+                    property: "parent"
+                    value: anchorToItemRadioButton.checked
+                           ? startRect : membersDropdown.Overlay.overlay
+                }
+
+                Binding {
+                    target: membersDropdown.anchors
+                    when: anchorToOverlayRadioButton.checked
+                    property: "centerIn"
+                    value: membersDropdown.parent
+                    restoreMode: Binding.RestoreBindingOrValue
+                }
+
+                Binding {
+                    target: membersDropdown
+                    property: "x"
+                    value: anchorToItemRadioButton.checked
+                           ? startRect.width / 2 : 0
+                }
+
+                Binding {
+                    target: membersDropdown
+                    property: "y"
+                    value: anchorToItemRadioButton.checked
+                           ? startRect.height / 2 : 0
+                }
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: `selected members: ${[...membersDropdown.selectedKeys]}`
+                wrapMode: Label.Wrap
             }
         }
     }

--- a/storybook/pages/MembersSelectorPage.qml
+++ b/storybook/pages/MembersSelectorPage.qml
@@ -18,14 +18,6 @@ SplitView {
     property bool mainModuleReady: false
 
     QtObject {
-        function isCompressedPubKey(publicKey) {
-            return true
-        }
-
-        function getCompressedPk(publicKey) {
-            return "123456789"
-        }
-
         function getColorHashAsJson(publicKey) {
             return JSON.stringify([{colorId: 0, segmentLength: 1},
                                    {colorId: 19, segmentLength: 2}])
@@ -33,10 +25,6 @@ SplitView {
 
         function getColorId(publicKey) {
             return Math.floor(Math.random() * 10)
-        }
-
-        function isEnsVerified(publicKey)  {
-            return false
         }
 
         Component.onCompleted: {
@@ -132,6 +120,7 @@ SplitView {
                 const obj = temporaryModel.get(i)
                 users.push({
                                pubKey: obj.pubKey,
+                               compressedPubKey: "compressed_" + obj.pubKey,
                                displayName: obj.displayName,
                                localNickname: "",
                                alias: "three word name(%1)".arg(obj.pubKey),
@@ -191,6 +180,10 @@ SplitView {
                         rootStore: rootStoreMock
                         utilsStore: SharedStores.UtilsStore {
                             function isChatKey() {
+                                return true
+                            }
+
+                            function isCompressedPubKey(publicKey) {
                                 return true
                             }
                         }

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -26,12 +26,7 @@ SplitView {
 
     // globalUtilsInst mock
     QtObject {
-        function getEmojiHashAsJson(publicKey) {
-            return JSON.stringify(["👨🏻‍🍼", "🏃🏿‍♂️", "🌇", "🤶🏿", "🏮","🤷🏻‍♂️", "🤦🏻", "📣", "🤎", "👷🏽", "😺", "🥞", "🔃", "🧝🏽‍♂️"])
-        }
         function getColorId(publicKey) { return colorId.value }
-
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
 
         function getColorHashAsJson(publicKey, skipEnsVerification=false) {
             if (skipEnsVerification)
@@ -40,14 +35,8 @@ SplitView {
                                    {colorId: 19, segmentLength: 2}])
         }
 
-        function isCompressedPubKey(publicKey) { return true }
-
         function addTimestampToURL(url) {
             return url
-        }
-
-        function isAlias(name)  {
-            return false
         }
 
         Component.onCompleted: {
@@ -407,6 +396,24 @@ SplitView {
                             function requestProfileShowcase(publicKey) {
                                 logs.logEvent("contactsStore::requestProfileShowcase", ["publicKey"], arguments)
                             }
+                        }
+
+                        utilsStore: SharedStores.UtilsStore {
+                            function getEmojiHash(publicKey) {
+                                return ["👨🏻‍🍼", "🏃🏿‍♂️", "🌇", "🤶🏿", "🏮","🤷🏻‍♂️", "🤦🏻",
+                                        "📣", "🤎", "👷🏽", "😺", "🥞", "🔃", "🧝🏽‍♂️"]
+                            }
+
+                            function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
+
+
+                            function isCompressedPubKey(publicKey) { return true }
+
+                            function isAlias(name)  {
+                                return false
+                            }
+
+
                         }
                     }
                 }

--- a/storybook/pages/ProfilePopupInviteFriendsPanelPage.qml
+++ b/storybook/pages/ProfilePopupInviteFriendsPanelPage.qml
@@ -2,90 +2,45 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 import AppLayouts.Communities.panels 1.0
-import AppLayouts.Profile.stores 1.0 as ProfileStores
 import AppLayouts.stores 1.0 as AppLayoutStores
 
-import utils 1.0
-
 Item {
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
-
-    QtObject {
-        function isCompressedPubKey(publicKey) {
-            return true
-        }
-
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
-
-        function getColorHashAsJson(publicKey) {
-            return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                   {colorId: 19, segmentLength: 2}])
-        }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            globalUtilsReady = true
-
-        }
-        Component.onDestruction: {
-            globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    QtObject {
-        function getContactDetailsAsJson() {
-            return JSON.stringify({})
-        }
-
-        Component.onCompleted: {
-            mainModuleReady = true
-            Utils.mainModuleInst = this
-        }
-        Component.onDestruction: {
-            mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
-
     Frame {
         anchors.centerIn: parent
 
-        Loader {
-            active: globalUtilsReady && mainModuleReady
-            sourceComponent: ProfilePopupInviteFriendsPanel {
-                id: panel
+        ProfilePopupInviteFriendsPanel {
+            communityId: "communityId"
 
-                communityId: "communityId"
-
-                rootStore: AppLayoutStores.RootStore {
-                    function communityHasMember(communityId, pubKey) {
-                        return false
-                    }
+            rootStore: AppLayoutStores.RootStore {
+                function communityHasMember(communityId, pubKey) {
+                    return false
                 }
+            }
 
-                contactsStore: ProfileStores.ContactsStore {
-                    readonly property ListModel myContactsModel: ListModel {
-                        Component.onCompleted: {
-                            const keys = []
+            contactsModel: ListModel {
+                Component.onCompleted: {
+                    const keys = []
 
-                            for (let i = 0; i < 20; i++) {
-                                const key = `pub_key_${i}`
+                    for (let i = 0; i < 20; i++) {
+                        const key = `pub_key_${i}`
 
-                                append({
-                                    alias: "",
-                                    colorId: "1",
-                                    displayName: `contact ${i}`,
-                                    ensName: "",
-                                    icon: "",
-                                    isContact: true,
-                                    localNickname: "",
-                                    onlineStatus: 1,
-                                    pubKey: key
-                                })
-                            }
-                        }
+                        append({
+                            alias: "",
+                            colorId: "1",
+                            displayName: `contact ${i}`,
+                            ensName: "",
+                            icon: "",
+                            isContact: true,
+                            localNickname: "",
+                            onlineStatus: 1,
+                            pubKey: key,
+                            compressedKey: "zx3sh" + key,
+                            colorHash: [
+                                { colorId: i, segmentLength: i % 5 },
+                                { colorId: i + 5, segmentLength: 3 },
+                                { colorId: 19, segmentLength: 2 }
+                            ]
+                        })
                     }
                 }
             }

--- a/storybook/pages/ProfilePopupInviteMessagePanelPage.qml
+++ b/storybook/pages/ProfilePopupInviteMessagePanelPage.qml
@@ -1,91 +1,46 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import AppLayouts.Communities.panels 1.0
-import AppLayouts.Profile.stores 1.0 as ProfileStores
-
-import utils 1.0
 
 Item {
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
-
-    QtObject {
-        function getCompressedPk(publicKey) {
-            return "compressed"
-        }
-
-        function isCompressedPubKey() {
-            return true
-        }
-
-        function getColorHashAsJson(publicKey) {
-            return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                   {colorId: 19, segmentLength: 2}])
-        }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            globalUtilsReady = true
-        }
-
-        Component.onDestruction: {
-            globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    QtObject {
-        function getContactDetailsAsJson() {
-            return JSON.stringify({})
-        }
-
-        Component.onCompleted: {
-            Utils.mainModuleInst = this
-            mainModuleReady = true
-        }
-
-        Component.onDestruction: {
-            mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
-
     Frame {
         anchors.centerIn: parent
 
         height: parent.height * 0.8
         width: parent.width * 0.8
 
-        Loader {
-            active: globalUtilsReady && mainModuleReady
+        ProfilePopupInviteMessagePanel {
+            id: panel
 
             anchors.fill: parent
 
-            sourceComponent: ProfilePopupInviteMessagePanel {
-                id: panel
+            contactsModel: ListModel {
+                Component.onCompleted: {
+                    const keys = []
 
-                contactsModel: ListModel {
-                    Component.onCompleted: {
-                        const keys = []
+                    for (let i = 0; i < 20; i++) {
+                        const key = `pub_key_${i}`
 
-                        for (let i = 0; i < 20; i++) {
-                            const key = `pub_key_${i}`
+                        append({
+                            isContact: true,
+                            onlineStatus: 1,
+                            displayName: `contact ${i}`,
+                            icon: "",
+                            colorId: "1",
+                            pubKey: key,
+                            compressedKey: "zx3sh" + key,
+                            colorHash: [
+                                { colorId: i, segmentLength: i % 5 },
+                                { colorId: i + 5, segmentLength: 3 },
+                                { colorId: 19, segmentLength: 2 }
+                            ]
+                        })
 
-                            append({
-                                isContact: true,
-                                onlineStatus: 1,
-                                displayName: `contact ${i}`,
-                                icon: "",
-                                colorId: "1",
-                                pubKey: key
-                            })
-
-                            keys.push(key)
-                        }
-
-                        panel.pubKeys = keys
+                        keys.push(key)
                     }
+
+                    panel.pubKeys = keys
                 }
             }
         }

--- a/storybook/pages/ProfilePopupInviteMessagePanelPage.qml
+++ b/storybook/pages/ProfilePopupInviteMessagePanelPage.qml
@@ -65,28 +65,26 @@ Item {
             sourceComponent: ProfilePopupInviteMessagePanel {
                 id: panel
 
-                contactsStore: ProfileStores.ContactsStore {
-                    readonly property ListModel myContactsModel: ListModel {
-                        Component.onCompleted: {
-                            const keys = []
+                contactsModel: ListModel {
+                    Component.onCompleted: {
+                        const keys = []
 
-                            for (let i = 0; i < 20; i++) {
-                                const key = `pub_key_${i}`
+                        for (let i = 0; i < 20; i++) {
+                            const key = `pub_key_${i}`
 
-                                append({
-                                    isContact: true,
-                                    onlineStatus: 1,
-                                    displayName: `contact ${i}`,
-                                    icon: "",
-                                    colorId: "1",
-                                    pubKey: key
-                                })
+                            append({
+                                isContact: true,
+                                onlineStatus: 1,
+                                displayName: `contact ${i}`,
+                                icon: "",
+                                colorId: "1",
+                                pubKey: key
+                            })
 
-                                keys.push(key)
-                            }
-
-                            panel.pubKeys = keys
+                            keys.push(key)
                         }
+
+                        panel.pubKeys = keys
                     }
                 }
             }

--- a/storybook/pages/TransactionDetailViewPage.qml
+++ b/storybook/pages/TransactionDetailViewPage.qml
@@ -42,7 +42,6 @@ SplitView {
 
     // globalUtilsInst mock
     QtObject {
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
         function getColorHashAsJson(publicKey) {
             return JSON.stringify([{"segmentLength":1,"colorId":12},{"segmentLength":5,"colorId":18},
                                    {"segmentLength":3,"colorId":25},{"segmentLength":3,"colorId":23},
@@ -51,7 +50,6 @@ SplitView {
                                    {"segmentLength":4,"colorId":28},{"segmentLength":1,"colorId":17},
                                    {"segmentLength":2,"colorId":2}])
         }
-        function isCompressedPubKey(publicKey) { return true }
         function getColorId(publicKey) { return Math.floor(Math.random() * 10) }
 
         Component.onCompleted: {
@@ -71,6 +69,7 @@ SplitView {
                 displayName: "ArianaP",
                 displayIcon: "",
                 publicKey: publicKey,
+                compressedPublicKey: "compressed",
                 name: "",
                 alias: "",
                 localNickname: "",

--- a/storybook/pages/UserListPanelPage.qml
+++ b/storybook/pages/UserListPanelPage.qml
@@ -1,72 +1,35 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import AppLayouts.Chat.panels 1.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
-import utils 1.0
+import AppLayouts.Chat.panels 1.0
+import StatusQ 0.1
 
 import Storybook 1.0
 import Models 1.0
 
-SplitView {
-    id: root
+import SortFilterProxyModel 0.2
 
+SplitView {
     Logs { id: logs }
 
     orientation: Qt.Vertical
-
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
 
     UsersModel {
         id: model
     }
 
-    // globalUtilsInst mock
-    QtObject {
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
-
-        function getColorHashAsJson(publicKey) {
-            return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                   {colorId: 19, segmentLength: 2}])
-        }
-
-        function isCompressedPubKey(publicKey) { return true }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            root.globalUtilsReady = true
-        }
-        Component.onDestruction: {
-            root.globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    // mainModuleInst mock
-    QtObject {
-        function getContactDetailsAsJson(publicKey, getVerificationRequest) {
-            return JSON.stringify({ ensVerified: false })
-        }
-        Component.onCompleted: {
-            Utils.mainModuleInst = this
-            root.mainModuleReady = true
-        }
-        Component.onDestruction: {
-            root.mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
-    Item {
+    UserListPanel {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        Loader {
-            anchors.fill: parent
-            active: globalUtilsReady && mainModuleReady
+        label: "Some label"
 
-            sourceComponent: UserListPanel {
-                usersModel: model
-                label: "Some label"
+        usersModel: SortFilterProxyModel {
+            sourceModel: model
+
+            proxyRoles: FastExpressionRole {
+                name: "compressedKey"
+                expression: "compressed"
             }
         }
     }

--- a/storybook/pages/UsersModelEditor.qml
+++ b/storybook/pages/UsersModelEditor.qml
@@ -18,6 +18,7 @@ Item {
          const pubKey = "0x%1".arg(seed)
          return {
              pubKey: pubKey,
+             compressedPubKey: "compressed_" + pubKey,
              displayName: seed%8 ? "_user%1".arg(seed) : "",
              preferredDisplayName: "user%1".arg(seed),
              localNickname: seed%3 ? "" : "nickname%1".arg(seed),

--- a/ui/StatusQ/sandbox/demoapp/CreateChatView.qml
+++ b/ui/StatusQ/sandbox/demoapp/CreateChatView.qml
@@ -48,7 +48,7 @@ Page {
             }
             compressedKeyGetter: function(pubKey) {
                 //for simulation purposes only, in real app
-                //this would be Utils.getCompressedPk(pubKey);
+                //this would be utilsStore.getCompressedPk(pubKey);
                 var possibleCharacters = pubKey.split('');
                 var randomStringLength = 12; // assuming you want random strings of 12 characters
                 var randomString = [];

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageSenderDetails.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageSenderDetails.qml
@@ -5,6 +5,7 @@ QtObject {
     id: root
 
     property string id: ""
+    property string compressedPubKey: ""
     property string displayName: ""
     property string secondaryName: ""
 

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -12,7 +12,6 @@ import shared 1.0
 import shared.panels 1.0
 import shared.status 1.0
 import shared.views.chat 1.0
-import shared.stores 1.0 as SharedStores
 
 import utils 1.0
 
@@ -24,7 +23,6 @@ Item {
     id: root
 
     property ChatStores.RootStore store
-    property SharedStores.UtilsStore utilsStore
 
     property var usersModel
     property string label
@@ -112,7 +110,7 @@ Item {
                 width: ListView.view.width
                 nickName: model.localNickname
                 userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+                pubKey: model.isEnsVerified ? "" : model.compressedKey
                 isContact: model.isContact
                 isVerified: model.isVerified
                 isUntrustworthy: model.isUntrustworthy
@@ -130,9 +128,9 @@ Item {
                         Global.openMenu(profileContextMenuComponent, this, {
                                             profileType, trustStatus, contactType, ensVerified, onlineStatus, hasLocalNickname, chatType, isAdmin,
                                             publicKey: model.pubKey,
-                                            emojiHash: root.utilsStore.getEmojiHash(model.pubKey),
+                                            emojiHash: model.emojiHash,
                                             displayName: nickName || userName,
-                                            userIcon: model.icon,
+                                            userIcon: model.icon
                                         })
                     } else if (mouse.button === Qt.LeftButton) {
                         Global.openProfilePopup(model.pubKey)

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -110,7 +110,7 @@ Item {
                 width: ListView.view.width
                 nickName: model.localNickname
                 userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                pubKey: model.isEnsVerified ? "" : model.compressedKey
+                pubKey: model.isEnsVerified ? "" : model.compressedPubKey
                 isContact: model.isContact
                 isVerified: model.isVerified
                 isUntrustworthy: model.isUntrustworthy

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -40,8 +40,6 @@ StatusSectionLayout {
     id: root
 
     property ContactsStore contactsStore
-    property bool hasAddedContacts: contactsStore.myContactsModel.count > 0
-
     property SharedStores.RootStore sharedRootStore
     property SharedStores.UtilsStore utilsStore
     property ChatStores.RootStore rootStore
@@ -307,7 +305,6 @@ StatusSectionLayout {
             walletAssetsStore: root.walletAssetsStore
             currencyStore: root.currencyStore
             emojiPopup: root.emojiPopup
-            hasAddedContacts: root.hasAddedContacts
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
             onInfoButtonClicked: root.communityInfoButtonClicked()
             onManageButtonClicked: root.communityManageButtonClicked()

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -190,18 +190,11 @@ StatusSectionLayout {
             usersModel: SortFilterProxyModel {
                 sourceModel: usersStore.usersModel
 
-                proxyRoles: [
-                    FastExpressionRole {
-                        name: "emojiHash"
-                        expression: root.utilsStore.getEmojiHash(model.pubKey)
-                        expectedRoles: ["pubKey"]
-                    },
-                    FastExpressionRole {
-                        name: "compressedKey"
-                        expression: root.utilsStore.getCompressedPk(model.pubKey)
-                        expectedRoles: ["pubKey"]
-                    }
-                ]
+                proxyRoles: FastExpressionRole {
+                    name: "emojiHash"
+                    expression: root.utilsStore.getEmojiHash(model.pubKey)
+                    expectedRoles: ["pubKey"]
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -12,6 +12,7 @@ import shared.views.chat 1.0
 import shared.stores.send 1.0 as SendStores
 import SortFilterProxyModel 0.2
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Layout 0.1
@@ -183,10 +184,25 @@ StatusSectionLayout {
 
             anchors.fill: parent
             store: root.rootStore
-            utilsStore: root.utilsStore
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
-            usersModel: usersStore.usersModel
+
+            usersModel: SortFilterProxyModel {
+                sourceModel: usersStore.usersModel
+
+                proxyRoles: [
+                    FastExpressionRole {
+                        name: "emojiHash"
+                        expression: root.utilsStore.getEmojiHash(model.pubKey)
+                        expectedRoles: ["pubKey"]
+                    },
+                    FastExpressionRole {
+                        name: "compressedKey"
+                        expression: root.utilsStore.getCompressedPk(model.pubKey)
+                        expectedRoles: ["pubKey"]
+                    }
+                ]
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
@@ -106,7 +106,7 @@ ItemDelegate {
             hoverEnabled: false
             nickName: root.contactDetails.localNickname
             userName: ProfileUtils.displayName("", root.contactDetails.ensName, root.contactDetails.displayName, root.contactDetails.alias)
-            pubKey: root.contactDetails.isEnsVerified ? "" : Utils.getCompressedPk(root.contactId)
+            pubKey: root.contactDetails.isEnsVerified ? "" : root.contactDetails.compressedPublicKey
             isContact: root.contactDetails.isContact
             isVerified: root.contactDetails.trustStatus === Constants.trustStatus.trusted
             isUntrustworthy: root.contactDetails.trustStatus === Constants.trustStatus.untrustworthy

--- a/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
@@ -15,7 +15,6 @@ import shared.views 1.0
 import shared.status 1.0
 
 import AppLayouts.stores 1.0 as AppLayoutStores
-import AppLayouts.Profile.stores 1.0 as ProfileStores
 
 ColumnLayout {
     id: root
@@ -24,7 +23,8 @@ ColumnLayout {
     property string headerTitle: ""
 
     property AppLayoutStores.RootStore rootStore
-    property ProfileStores.ContactsStore contactsStore
+
+    property var contactsModel
     property string communityId
 
     property var pubKeys: ([])
@@ -57,7 +57,8 @@ ColumnLayout {
         id: existingContacts
 
         rootStore: root.rootStore
-        contactsStore: root.contactsStore
+
+        contactsModel: root.contactsModel
         communityId: root.communityId
 
         hideCommunityMembers: true

--- a/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteMessagePanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteMessagePanel.qml
@@ -13,15 +13,12 @@ import shared.panels 1.0
 import shared.views 1.0
 import shared.status 1.0
 
-import AppLayouts.Profile.stores 1.0 as ProfileStores
-
 ColumnLayout {
     id: root
     objectName: "CommunityProfilePopupInviteMessagePanel_ColumnLayout"
 
+    property var contactsModel
     property var pubKeys: ([])
-
-    property ProfileStores.ContactsStore contactsStore
 
     property alias inviteMessage: messageInput.text
 
@@ -62,7 +59,8 @@ ColumnLayout {
 
     PickedContacts {
         id: existingContacts
-        contactsStore: root.contactsStore
+
+        contactsModel: root.contactsModel
         pubKeys: root.pubKeys
         Layout.fillWidth: true
         Layout.fillHeight: true

--- a/ui/app/AppLayouts/Communities/panels/WelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/WelcomeBannerPanel.qml
@@ -17,7 +17,6 @@ Rectangle {
     property var activeCommunity
     property RootStore store
     property var communitySectionModule
-    property bool hasAddedContacts
 
     signal manageCommunityClicked()
 

--- a/ui/app/AppLayouts/Communities/popups/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityProfilePopup.qml
@@ -15,7 +15,6 @@ StatusModal {
     id: root
 
     property var community
-    property bool hasAddedContacts
     property var communitySectionModule
 
     onClosed: {

--- a/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
@@ -17,7 +17,8 @@ StatusStackModal {
     id: root
 
     property AppLayoutStores.RootStore rootStore
-    property ProfileStores.ContactsStore contactsStore
+
+    property var contactsModel
     property var community
     property var communitySectionModule
 
@@ -95,13 +96,15 @@ StatusStackModal {
     stackItems: [
         ProfilePopupInviteFriendsPanel {
             rootStore: root.rootStore
-            contactsStore: root.contactsStore
+
+            contactsModel: root.contactsModel
             communityId: root.community.id
+
             onPubKeysChanged: root.pubKeys = pubKeys
         },
 
         ProfilePopupInviteMessagePanel {
-            contactsStore: root.contactsStore
+            contactsModel: root.contactsModel
             pubKeys: root.pubKeys
             onInviteMessageChanged: root.inviteMessage = inviteMessage
         }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -42,7 +42,6 @@ Item {
     property CommunitiesStores.CommunitiesStore communitiesStore
     required property WalletStores.WalletAssetsStore walletAssetsStore
     required property CurrenciesStore currencyStore
-    property bool hasAddedContacts: false
     property var communityData
     property int joinedMembersCount
     property alias createChannelPopup: createChannelPopup
@@ -411,7 +410,6 @@ Item {
                     WelcomeBannerPanel {
                         activeCommunity: communityData
                         store: root.store
-                        hasAddedContacts: root.hasAddedContacts
                         communitySectionModule: root.communitySectionModule
                         onManageCommunityClicked: root.manageButtonClicked()
                     }

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -316,7 +316,7 @@ StatusScrollView {
 
                         nickName: model.localNickname
                         userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                        pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+                        pubKey: model.isEnsVerified ? "" : model.compressedPubKey
                         isContact: model.isContact
                         isVerified: model.trustStatus === Constants.trustStatus.trusted
                         isUntrustworthy: model.trustStatus === Constants.trustStatus.untrustworthy

--- a/ui/app/AppLayouts/Onboarding/views/ProfileChatKeyView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ProfileChatKeyView.qml
@@ -100,7 +100,7 @@ Item {
             objectName: "profileChatKeyViewChatKeyTxt"
             Layout.preferredHeight: 22
             color: Theme.palette.secondaryText
-            text: qsTr("Chatkey:") + " " + Utils.getCompressedPk(d.publicKey)
+            text: qsTr("Chatkey:") + " " + root.utilsStore.getCompressedPk(d.publicKey)
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -1,22 +1,11 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
 
-import StatusQ.Core 0.1
-import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
-import StatusQ.Popups 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 
 import utils 1.0
-import shared 1.0
-import shared.panels 1.0
-import shared.status 1.0
-import shared.views 1.0
-import shared.controls.chat 1.0
-import shared.controls.chat.menuItems 1.0
-
-import AppLayouts.Profile.stores 1.0
 
 StatusListItem {
     id: root
@@ -25,13 +14,12 @@ StatusListItem {
     height: visible ? implicitHeight : 0
     title: root.name
 
-    property ContactsStore contactsStore
-
     property string name
     property string publicKey
-    property string compressedPk // Needed for the tests + probably gonna be used more in the future
     property string iconSource
-    property bool ensVerified
+
+    property color pubKeyColor
+    property var colorHash
 
     property bool isContact: false
     property bool isBlocked: false
@@ -54,17 +42,15 @@ StatusListItem {
     signal rejectionRemoved(string publicKey)
     signal textClicked(string publicKey)
 
-    subTitle: root.ensVerified ? "" :  Utils.getElidedCompressedPk(root.publicKey)
-
     asset.width: 40
     asset.height: 40
-    asset.color: Utils.colorForPubkey(root.publicKey)
+    asset.color: root.pubKeyColor
     asset.letterSize: asset._twoLettersSize
     asset.charactersLen: 2
     asset.name: root.iconSource
     asset.isLetterIdenticon: root.iconSource.toString() === ""
     ringSettings {
-        ringSpecModel: Utils.getColorHashAsJson(root.publicKey, root.ensVerified)
+        ringSpecModel: root.colorHash
         ringPxSize: Math.max(asset.width / 24.0)
     }
 

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -15,32 +15,23 @@ StatusListItem {
     title: root.name
 
     property string name
-    property string publicKey
     property string iconSource
 
     property color pubKeyColor
     property var colorHash
-
-    property bool isContact: false
-    property bool isBlocked: false
-    property bool isVerified: false
-    property bool isUntrustworthy: false
-    property int verificationRequestStatus: 0
 
     property bool showSendMessageButton: false
     property bool showRejectContactRequestButton: false
     property bool showAcceptContactRequestButton: false
     property bool showRemoveRejectionButton: false
     property string contactText: ""
-    property bool contactTextClickable: false
 
-    signal openContactContextMenu(string publicKey, string name, string icon)
-    signal sendMessageActionTriggered(string publicKey)
-    signal showVerificationRequest(string publicKey)
-    signal contactRequestAccepted(string publicKey)
-    signal contactRequestRejected(string publicKey)
-    signal rejectionRemoved(string publicKey)
-    signal textClicked(string publicKey)
+    signal contextMenuRequested
+    signal sendMessageRequested
+    signal showVerificationRequestRequested
+    signal acceptContactRequested
+    signal rejectRequestRequested
+    signal removeRejectionRequested
 
     asset.width: 40
     asset.height: 40
@@ -62,7 +53,7 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "chat"
             icon.color: Theme.palette.directColor1
-            onClicked: root.sendMessageActionTriggered(root.publicKey)
+            onClicked: root.sendMessageRequested()
         },
         StatusFlatRoundButton {
             objectName: "declineBtn"
@@ -71,7 +62,7 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "close-circle"
             icon.color: Theme.palette.dangerColor1
-            onClicked: root.contactRequestRejected(root.publicKey)
+            onClicked: root.rejectRequestRequested()
         },
         StatusFlatRoundButton {
             objectName: "acceptBtn"
@@ -80,7 +71,7 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "checkmark-circle"
             icon.color: Theme.palette.successColor1
-            onClicked: root.contactRequestAccepted(root.publicKey)
+            onClicked: root.acceptContactRequested()
         },
         StatusFlatRoundButton {
             objectName: "removeRejectBtn"
@@ -89,22 +80,13 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "cancel"
             icon.color: Theme.palette.dangerColor1
-            onClicked: root.rejectionRemoved(root.publicKey)
+            onClicked: root.removeRejectionRequested()
         },
         StatusBaseText {
             text: root.contactText
             anchors.verticalCenter: parent.verticalCenter
-            color: root.contactTextClickable? Theme.palette.directColor1 : Theme.palette.baseColor1
 
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.contactTextClickable
-                cursorShape: sensor.enabled && containsMouse ? Qt.PointingHandCursor : Qt.ArrowCursor
-                hoverEnabled: true
-                onClicked: {
-                    root.textClicked(root.publicKey)
-                }
-            }
+            color: Theme.palette.baseColor1
         },
         StatusFlatRoundButton {
             objectName: "moreBtn"
@@ -113,9 +95,7 @@ StatusListItem {
             height: 32
             icon.name: "more"
             icon.color: Theme.palette.directColor1
-            onClicked: {
-                root.openContactContextMenu(root.publicKey, root.name, root.iconSource)
-            }
+            onClicked: root.contextMenuRequested()
         }
     ]
 }

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -13,15 +13,12 @@ import shared.panels 1.0
 
 import "../../Chat/popups"
 
-import AppLayouts.Profile.stores 1.0
-
 import SortFilterProxyModel 0.2
 
 Item {
     id: root
     implicitHeight: (title.height + contactsList.height)
 
-    property ContactsStore contactsStore
     property var contactsModel
 
     property int panelUsage: Constants.contactsPanelUsage.unknownPosition
@@ -104,16 +101,17 @@ Item {
             id: panelDelegate
 
             width: ListView.view.width
-            contactsStore: root.contactsStore
             name: model.preferredDisplayName
-            ensVerified: model.isEnsVerified
             publicKey: model.pubKey
-            compressedPk: Utils.getCompressedPk(model.pubKey)
             iconSource: model.icon
             isContact: model.isContact
             isBlocked: model.isBlocked
             isVerified: model.isVerified
             isUntrustworthy: model.isUntrustworthy
+
+            subTitle: model.ensVerified ? "" : Utils.getElidedCompressedPk(model.pubKey)
+            pubKeyColor: Utils.colorForPubkey(model.pubKey)
+            colorHash: Utils.getColorHashAsJson(model.pubKey, model.ensVerified)
 
             showSendMessageButton: isContact && !isBlocked
             onOpenContactContextMenu: function (publicKey, name, icon) {

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -11,8 +11,6 @@ import shared 1.0
 import shared.popups 1.0
 import shared.panels 1.0
 
-import "../../Chat/popups"
-
 import SortFilterProxyModel 0.2
 
 Item {
@@ -28,13 +26,11 @@ Item {
     readonly property int count: contactsList.count
 
     signal openContactContextMenu(string publicKey, string name, string icon)
-    signal contactClicked(string publicKey)
     signal sendMessageActionTriggered(string publicKey)
     signal showVerificationRequest(string publicKey)
     signal contactRequestAccepted(string publicKey)
     signal contactRequestRejected(string publicKey)
     signal rejectionRemoved(string publicKey)
-    signal textClicked(string publicKey)
 
     StyledText {
         id: title
@@ -102,63 +98,51 @@ Item {
 
             width: ListView.view.width
             name: model.preferredDisplayName
-            publicKey: model.pubKey
             iconSource: model.icon
-            isContact: model.isContact
-            isBlocked: model.isBlocked
-            isVerified: model.isVerified
-            isUntrustworthy: model.isUntrustworthy
 
             subTitle: model.ensVerified ? "" : Utils.getElidedCompressedPk(model.pubKey)
             pubKeyColor: Utils.colorForPubkey(model.pubKey)
             colorHash: Utils.getColorHashAsJson(model.pubKey, model.ensVerified)
 
-            showSendMessageButton: isContact && !isBlocked
-            onOpenContactContextMenu: function (publicKey, name, icon) {
-                root.openContactContextMenu(publicKey, name, icon)
-            }
+            showSendMessageButton: model.isContact && !model.isBlocked
             showRejectContactRequestButton: {
-                if (root.panelUsage === Constants.contactsPanelUsage.receivedContactRequest && !model.verificationRequestStatus) {
+                if (root.panelUsage === Constants.contactsPanelUsage.receivedContactRequest
+                        && !model.verificationRequestStatus)
                     return true
-                }
 
                 return false
             }
             showAcceptContactRequestButton: {
-                if (root.panelUsage === Constants.contactsPanelUsage.receivedContactRequest && !model.verificationRequestStatus) {
+                if (root.panelUsage === Constants.contactsPanelUsage.receivedContactRequest
+                        && !model.verificationRequestStatus)
                     return true
-                }
 
                 return false
             }
             showRemoveRejectionButton: {
-                if (root.panelUsage === Constants.contactsPanelUsage.rejectedReceivedContactRequest) {
+                if (root.panelUsage === Constants.contactsPanelUsage.rejectedReceivedContactRequest)
                     return true
-                }
 
                 return false
             }
             contactText: {
-                if (root.panelUsage === Constants.contactsPanelUsage.sentContactRequest) {
+                if (root.panelUsage === Constants.contactsPanelUsage.sentContactRequest)
                     return qsTr("Contact Request Sent")
-                }
-                else if (root.panelUsage === Constants.contactsPanelUsage.rejectedSentContactRequest) {
+
+                if (root.panelUsage === Constants.contactsPanelUsage.rejectedSentContactRequest)
                     return qsTr("Contact Request Rejected")
-                }
 
                 return ""
             }
-            contactTextClickable: {
-                return false
-            }
 
-            onClicked: root.contactClicked(model.pubKey)
-            onSendMessageActionTriggered: root.sendMessageActionTriggered(publicKey)
-            onContactRequestAccepted: root.contactRequestAccepted(publicKey)
-            onContactRequestRejected: root.contactRequestRejected(publicKey)
-            onRejectionRemoved: root.rejectionRemoved(publicKey)
-            onTextClicked: root.textClicked(publicKey)
-            onShowVerificationRequest: root.showVerificationRequest(publicKey)
+
+            onContextMenuRequested: root.openContactContextMenu(
+                                      model.pubKey, model.preferredDisplayName, model.icon)
+            onSendMessageRequested: root.sendMessageActionTriggered(model.pubKey)
+            onAcceptContactRequested: root.contactRequestAccepted(model.pubKey)
+            onRejectRequestRequested: root.contactRequestRejected(model.pubKey)
+            onRemoveRejectionRequested: root.rejectionRemoved(model.pubKey)
+            onShowVerificationRequestRequested: root.showVerificationRequest(model.pubKey)
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -10,7 +10,6 @@ import StatusQ.Core.Theme 0.1
 import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
-import shared.stores 1.0 as SharedStores
 import utils 1.0
 
 import SortFilterProxyModel 0.2
@@ -20,7 +19,6 @@ Item {
     implicitHeight: (title.height + contactsList.height)
 
     property var contactsModel
-    property SharedStores.UtilsStore utilsStore
 
     property int panelUsage: Constants.contactsPanelUsage.unknownPosition
 
@@ -71,13 +69,12 @@ Item {
                 return true
             }
 
-            function searchPredicate(name, pubkey) {
+            function searchPredicate(name, pubkey, compressedPubKey) {
                 const lowerCaseSearchString = root.searchString.toLowerCase()
-                const compressedPubkey = root.utilsStore.getCompressedPk(pubkey)
 
                 return name.toLowerCase().includes(lowerCaseSearchString) ||
                        pubkey.toLowerCase().includes(lowerCaseSearchString) ||
-                       compressedPubkey.toLowerCase().includes(lowerCaseSearchString)
+                       compressedPubKey.toLowerCase().includes(lowerCaseSearchString)
             }
 
             filters: [
@@ -85,12 +82,13 @@ Item {
                     expression: filteredModel.panelUsagePredicate(model.isVerified)
                     expectedRoles: ["isVerified"]
                 },
-                ExpressionFilter {
+                FastExpressionFilter {
                     enabled: root.searchString !== ""
                     expression: {
                         root.searchString // ensure expression is reevaluated when searchString changes
-                        return filteredModel.searchPredicate(model.displayName, model.pubKey)
+                        return filteredModel.searchPredicate(model.displayName, model.pubKey, model.compressedPubKey)
                     }
+                    expectedRoles: ["displayName", "pubKey", "compressedPubKey"]
                 }
             ]
 

--- a/ui/app/AppLayouts/Profile/panels/qmldir
+++ b/ui/app/AppLayouts/Profile/panels/qmldir
@@ -1,3 +1,4 @@
+ContactPanel 1.0 ContactPanel.qml
 ProfileDescriptionPanel 1.0 ProfileDescriptionPanel.qml
 ProfileShowcaseAccountsPanel 1.0 ProfileShowcaseAccountsPanel.qml
 ProfileShowcaseAssetsPanel 1.0 ProfileShowcaseAssetsPanel.qml

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -9,6 +9,7 @@ QtObject {
     property var profileModule
 
     property string pubkey: userProfile.pubKey
+    property string compressedPubKey: userProfile.compressedPubKey
     property string name: userProfile.name
     property string username: userProfile.username
     property string displayName: userProfile.displayName

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -168,6 +168,7 @@ SettingsContentBase {
                     title: qsTr("Trusted Contacts")
                     visible: !noFriendsItem.visible && count > 0
                     contactsModel: root.contactsStore.myContactsModel
+                    utilsStore: root.utilsStore
                     searchString: searchBox.text
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
@@ -184,6 +185,7 @@ SettingsContentBase {
                     visible: !noFriendsItem.visible && count > 0
                     title: qsTr("Contacts")
                     contactsModel: root.contactsStore.myContactsModel
+                    utilsStore: root.utilsStore
                     searchString: searchBox.text
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
@@ -230,6 +232,7 @@ SettingsContentBase {
                         root.openContextMenu(publicKey, name, icon)
                     }
                     contactsModel: root.contactsStore.receivedContactRequestsModel
+                    utilsStore: root.utilsStore
                     panelUsage: Constants.contactsPanelUsage.receivedContactRequest
 
                     onSendMessageActionTriggered: {
@@ -256,6 +259,7 @@ SettingsContentBase {
                         root.openContextMenu(publicKey, name, icon)
                     }
                     contactsModel: root.contactsStore.sentContactRequestsModel
+                    utilsStore: root.utilsStore
                     panelUsage: Constants.contactsPanelUsage.sentContactRequest
                 }
             }
@@ -314,6 +318,7 @@ SettingsContentBase {
                     root.openContextMenu(publicKey, name, icon)
                 }
                 contactsModel: root.contactsStore.blockedContactsModel
+                utilsStore: root.utilsStore
                 panelUsage: Constants.contactsPanelUsage.blockedContacts
                 visible: (stackLayout.currentIndex === 2)
                 onVisibleChanged: {

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -168,7 +168,6 @@ SettingsContentBase {
                     title: qsTr("Trusted Contacts")
                     visible: !noFriendsItem.visible && count > 0
                     contactsModel: root.contactsStore.myContactsModel
-                    utilsStore: root.utilsStore
                     searchString: searchBox.text
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
@@ -185,7 +184,6 @@ SettingsContentBase {
                     visible: !noFriendsItem.visible && count > 0
                     title: qsTr("Contacts")
                     contactsModel: root.contactsStore.myContactsModel
-                    utilsStore: root.utilsStore
                     searchString: searchBox.text
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
@@ -232,7 +230,6 @@ SettingsContentBase {
                         root.openContextMenu(publicKey, name, icon)
                     }
                     contactsModel: root.contactsStore.receivedContactRequestsModel
-                    utilsStore: root.utilsStore
                     panelUsage: Constants.contactsPanelUsage.receivedContactRequest
 
                     onSendMessageActionTriggered: {
@@ -259,7 +256,6 @@ SettingsContentBase {
                         root.openContextMenu(publicKey, name, icon)
                     }
                     contactsModel: root.contactsStore.sentContactRequestsModel
-                    utilsStore: root.utilsStore
                     panelUsage: Constants.contactsPanelUsage.sentContactRequest
                 }
             }
@@ -318,7 +314,6 @@ SettingsContentBase {
                     root.openContextMenu(publicKey, name, icon)
                 }
                 contactsModel: root.contactsStore.blockedContactsModel
-                utilsStore: root.utilsStore
                 panelUsage: Constants.contactsPanelUsage.blockedContacts
                 visible: (stackLayout.currentIndex === 2)
                 onVisibleChanged: {

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -126,14 +126,6 @@ SettingsContentBase {
                 text: qsTr("Pending Requests")
                 badge.value: root.contactsStore.receivedContactRequestsModel.count
             }
-            // Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
-            //            StatusTabButton {
-            //                id: rejectedRequestsBtn
-            //                width: implicitWidth
-            //                enabled: root.contactsStore.receivedButRejectedContactRequestsModel.count > 0 ||
-            //                         root.contactsStore.sentButRejectedContactRequestsModel.count > 0
-            //                btnText: qsTr("Rejected Requests")
-            //            }
             StatusTabButton {
                 id: blockedBtn
                 objectName: "ContactsView_Blocked_Button"
@@ -259,52 +251,6 @@ SettingsContentBase {
                     panelUsage: Constants.contactsPanelUsage.sentContactRequest
                 }
             }
-
-            // Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
-            //            // REJECTED REQUESTS
-            //            Item {
-            //                Layout.fillWidth: true
-            //                //Layout.fillHeight: true
-
-            //                ColumnLayout {
-            //                    //anchors.fill: parent
-
-            //                    ContactsListPanel {
-            //                        Layout.fillWidth: true
-            //                        Layout.preferredHeight: root.height * 0.5
-            //                        clip: true
-            //                        title: qsTr("Received")
-            //                        searchString: searchBox.text
-            //                        onOpenContactContextMenu: function (publicKey, name, icon) {
-            //                           root.openContextMenu(publicKey, name, icon)
-            //                        }
-            //                        contactsModel: root.contactsStore.receivedButRejectedContactRequestsModel
-            //                        panelUsage: Constants.contactsPanelUsage.rejectedReceivedContactRequest
-
-            //                        onRejectionRemoved: {
-            //                            root.contactsStore.removeContactRequestRejection(publicKey)
-            //                        }
-            //                    }
-
-            //                    ContactsListPanel {
-            //                        Layout.fillWidth: true
-            //                        Layout.preferredHeight: root.height * 0.5
-            //                        clip: true
-            //                        title: qsTr("Sent")
-            //                        searchString: searchBox.text
-            //                        onOpenContactContextMenu: function (publicKey, name, icon) {
-            //                             root.openContextMenu(publicKey, name, icon)
-            //                         }
-            //                        contactsModel: root.contactsStore.sentButRejectedContactRequestsModel
-            //                        panelUsage: Constants.contactsPanelUsage.rejectedSentContactRequest
-            //                    }
-
-            //                    Item {
-            //                        Layout.fillWidth: true
-            //                        Layout.fillHeight: true
-            //                    }
-            //                }
-            //            }
 
             // BLOCKED
             ContactsListPanel {

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -172,7 +172,6 @@ SettingsContentBase {
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
                     }
-                    contactsStore: root.contactsStore
                     panelUsage: Constants.contactsPanelUsage.verifiedMutualContacts
                     onSendMessageActionTriggered: {
                         root.contactsStore.joinPrivateChat(publicKey)
@@ -186,7 +185,6 @@ SettingsContentBase {
                     title: qsTr("Contacts")
                     contactsModel: root.contactsStore.myContactsModel
                     searchString: searchBox.text
-                    contactsStore: root.contactsStore
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
                     }
@@ -227,7 +225,6 @@ SettingsContentBase {
                     Layout.fillWidth: true
                     title: qsTr("Received")
                     searchString: searchBox.text
-                    contactsStore: root.contactsStore
                     visible: count > 0
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
@@ -254,7 +251,6 @@ SettingsContentBase {
                     Layout.fillWidth: true
                     title: qsTr("Sent")
                     searchString: searchBox.text
-                    contactsStore: root.contactsStore
                     visible: count > 0
                     onOpenContactContextMenu: function (publicKey, name, icon) {
                         root.openContextMenu(publicKey, name, icon)
@@ -279,7 +275,6 @@ SettingsContentBase {
             //                        clip: true
             //                        title: qsTr("Received")
             //                        searchString: searchBox.text
-            //                        contactsStore: root.contactsStore
             //                        onOpenContactContextMenu: function (publicKey, name, icon) {
             //                           root.openContextMenu(publicKey, name, icon)
             //                        }
@@ -297,7 +292,6 @@ SettingsContentBase {
             //                        clip: true
             //                        title: qsTr("Sent")
             //                        searchString: searchBox.text
-            //                        contactsStore: root.contactsStore
             //                        onOpenContactContextMenu: function (publicKey, name, icon) {
             //                             root.openContextMenu(publicKey, name, icon)
             //                         }
@@ -316,7 +310,6 @@ SettingsContentBase {
             ContactsListPanel {
                 Layout.fillWidth: true
                 searchString: searchBox.text
-                contactsStore: root.contactsStore
                 onOpenContactContextMenu: function (publicKey, name, icon) {
                     root.openContextMenu(publicKey, name, icon)
                 }

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -7,12 +7,11 @@ import utils 1.0
 import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
-import shared.stores 1.0
+import shared.stores 1.0 as SharedStores
 import shared.validators 1.0
 import shared.controls.chat 1.0
 
 import "../popups"
-import "../stores"
 import "../controls"
 import "./profile"
 
@@ -22,18 +21,19 @@ import StatusQ.Core.Utils 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
+import AppLayouts.Communities.stores 1.0 as CommunitiesStores
 import AppLayouts.Profile.helpers 1.0
 import AppLayouts.Profile.panels 1.0
-import AppLayouts.Wallet.stores 1.0
-import AppLayouts.Communities.stores 1.0
+import AppLayouts.Profile.stores 1.0 as ProfileStores
+import AppLayouts.Wallet.stores 1.0 as WalletStores
 
 SettingsContentBase {
     id: root
 
-    property ProfileStore profileStore
-    property ContactsStore contactsStore
-    property CommunitiesStore communitiesStore
-    property UtilsStore utilsStore
+    property ProfileStores.ProfileStore profileStore
+    property ProfileStores.ContactsStore contactsStore
+    property CommunitiesStores.CommunitiesStore communitiesStore
+    property SharedStores.UtilsStore utilsStore
 
     property bool sendToAccountEnabled: false
 
@@ -406,6 +406,7 @@ SettingsContentBase {
                 publicKey: root.contactsStore.myPublicKey
                 profileStore: root.profileStore
                 contactsStore: root.contactsStore
+                walletStore: WalletStores.RootStore
                 utilsStore: root.utilsStore
                 sendToAccountEnabled: root.sendToAccountEnabled
                 onClosed: destroy()

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfilePreview.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfilePreview.qml
@@ -2,11 +2,11 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.15
 
-import shared.views 1.0 as SharedViews
-
 import StatusQ.Core.Theme 0.1
 
+import AppLayouts.Wallet.stores 1.0 as WalletStores
 import shared.controls 1.0
+import shared.views 1.0 as SharedViews
 
 Item {
     property alias profileStore: profilePreview.profileStore
@@ -51,9 +51,13 @@ Item {
 
         SharedViews.ProfileDialogView {
             id: profilePreview
+
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.maximumHeight: implicitHeight
+
+            walletStore: WalletStores.RootStore
+
             readOnly: true
         }
         Item { Layout.fillHeight: true }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -154,7 +154,6 @@ QtObject {
     property ProfileStores.ContactsStore contactStore: profileSectionStore.contactsStore
     property ProfileStores.PrivacyStore privacyStore: profileSectionStore.privacyStore
     property ProfileStores.MessagingStore messagingStore: profileSectionStore.messagingStore
-    property bool hasAddedContacts: contactStore.myContactsModel.count > 0
 
     property real volume: !!appSettings ? appSettings.volume * 0.01 : 0.5
     property bool notificationSoundsEnabled: !!appSettings ? appSettings.notificationSoundsEnabled : true

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -5,7 +5,6 @@ import QtQuick.Dialogs 1.3
 import QtQml.Models 2.15
 import QtQml 2.15
 
-import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
@@ -32,8 +31,6 @@ import shared.popups 1.0
 import shared.status 1.0
 import shared.stores 1.0
 import shared.views 1.0
-
-import SortFilterProxyModel 0.2
 
 import utils 1.0
 
@@ -444,15 +441,7 @@ QtObject {
             InviteFriendsToCommunityPopup {
                 rootStore: root.rootStore
 
-                contactsModel: SortFilterProxyModel {
-                    sourceModel: root.rootStore.contactStore.myContactsModel
-
-                    proxyRoles: FastExpressionRole {
-                        name: "compressedKey"
-                        expression: root.utilsStore.getCompressedPk(model.pubKey)
-                        expectedRoles: ["pubKey"]
-                    }
-                }
+                contactsModel: root.rootStore.contactStore.myContactsModel
 
                 onClosed: destroy()
             }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -569,8 +569,6 @@ QtObject {
             id: communityProfilePopup
 
             CommunityProfilePopup {
-                hasAddedContacts: rootStore.hasAddedContacts
-
                 onClosed: destroy()
             }
         },

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -5,6 +5,7 @@ import QtQuick.Dialogs 1.3
 import QtQml.Models 2.15
 import QtQml 2.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
@@ -31,6 +32,8 @@ import shared.popups 1.0
 import shared.status 1.0
 import shared.stores 1.0
 import shared.views 1.0
+
+import SortFilterProxyModel 0.2
 
 import utils 1.0
 
@@ -440,7 +443,17 @@ QtObject {
 
             InviteFriendsToCommunityPopup {
                 rootStore: root.rootStore
-                contactsModel: root.rootStore.contactStore.myContactsModel
+
+                contactsModel: SortFilterProxyModel {
+                    sourceModel: root.rootStore.contactStore.myContactsModel
+
+                    proxyRoles: FastExpressionRole {
+                        name: "compressedKey"
+                        expression: root.utilsStore.getCompressedPk(model.pubKey)
+                        expectedRoles: ["pubKey"]
+                    }
+                }
+
                 onClosed: destroy()
             }
         },

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -25,7 +25,7 @@ import AppLayouts.Wallet.popups.buy 1.0
 import AppLayouts.Wallet.popups 1.0
 import AppLayouts.Communities.stores 1.0
 
-import AppLayouts.Wallet.stores 1.0 as WalletStore
+import AppLayouts.Wallet.stores 1.0 as WalletStores
 import AppLayouts.Chat.stores 1.0 as ChatStores
 
 import shared.popups 1.0
@@ -51,10 +51,10 @@ QtObject {
     property ProfileStores.ProfileStore profileStore
     property ProfileStores.DevicesStore devicesStore
     property CurrenciesStore currencyStore
-    property WalletStore.WalletAssetsStore walletAssetsStore
-    property WalletStore.CollectiblesStore walletCollectiblesStore
+    property WalletStores.WalletAssetsStore walletAssetsStore
+    property WalletStores.CollectiblesStore walletCollectiblesStore
     property NetworkConnectionStore networkConnectionStore
-    property WalletStore.BuyCryptoStore buyCryptoStore
+    property WalletStores.BuyCryptoStore buyCryptoStore
     property bool isDevBuild
 
     signal openExternalLink(string link)
@@ -528,6 +528,7 @@ QtObject {
 
                 profileStore: rootStore.profileSectionStore.profileStore
                 contactsStore: rootStore.profileSectionStore.contactsStore
+                walletStore: WalletStores.RootStore
                 utilsStore: root.utilsStore
 
                 sendToAccountEnabled: root.networkConnectionStore.sendBuyBridgeEnabled
@@ -695,9 +696,9 @@ QtObject {
                 joinPermissionsCheckCompletedWithoutErrors: root.rootStore.joinPermissionsCheckCompletedWithoutErrors
 
                 walletAccountsModel: root.rootStore.walletAccountsModel
-                walletCollectiblesModel: WalletStore.RootStore.collectiblesStore.allCollectiblesModel
+                walletCollectiblesModel: WalletStores.RootStore.collectiblesStore.allCollectiblesModel
 
-                canProfileProveOwnershipOfProvidedAddressesFn: WalletStore.RootStore.canProfileProveOwnershipOfProvidedAddresses
+                canProfileProveOwnershipOfProvidedAddressesFn: WalletStores.RootStore.canProfileProveOwnershipOfProvidedAddresses
 
                 walletAssetsModel: walletAssetsStore.groupedAccountAssetsModel
                 permissionsModel: {
@@ -947,12 +948,12 @@ QtObject {
 
                 introMessage: chatStore.sectionDetails.introMessage
 
-                canProfileProveOwnershipOfProvidedAddressesFn: WalletStore.RootStore.canProfileProveOwnershipOfProvidedAddresses
+                canProfileProveOwnershipOfProvidedAddressesFn: WalletStores.RootStore.canProfileProveOwnershipOfProvidedAddresses
 
                 walletAccountsModel: root.rootStore.walletAccountsModel
 
                 walletAssetsModel: walletAssetsStore.groupedAccountAssetsModel
-                walletCollectiblesModel: WalletStore.RootStore.collectiblesStore.allCollectiblesModel
+                walletCollectiblesModel: WalletStores.RootStore.collectiblesStore.allCollectiblesModel
 
                 permissionsModel: {
                     root.rootStore.prepareTokenModelForCommunity(editSharedAddressesPopup.communityId)
@@ -1054,7 +1055,7 @@ QtObject {
                 feeErrorText: feeSubscriber.feeErrorText
                 isFeeLoading: !feeSubscriber.feesResponse
 
-                accounts: WalletStore.RootStore.nonWatchAccounts
+                accounts: WalletStores.RootStore.nonWatchAccounts
 
                 destroyOnClose: true
 
@@ -1200,7 +1201,7 @@ QtObject {
             id: swapModal
             SwapModal {
                 swapAdaptor: SwapModalAdaptor {
-                    swapStore: WalletStore.SwapStore {}
+                    swapStore: WalletStores.SwapStore {}
                     walletAssetsStore: root.walletAssetsStore
                     currencyStore: root.currencyStore
                     swapFormData: swapInputParamsForm

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -440,7 +440,7 @@ QtObject {
 
             InviteFriendsToCommunityPopup {
                 rootStore: root.rootStore
-                contactsStore: root.rootStore.contactStore
+                contactsModel: root.rootStore.contactStore.myContactsModel
                 onClosed: destroy()
             }
         },

--- a/ui/app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml
@@ -17,6 +17,7 @@ StatusDialog {
     id: root
 
     property StatusMessageDetails messageDetails
+    property string compressedPubKey
     property double timestamp: 0
 
     signal accepted
@@ -56,7 +57,7 @@ StatusDialog {
                 sender: root.messageDetails.sender
                 amISender: root.messageDetails.amISender
                 messageOriginInfo: root.messageDetails.messageOriginInfo
-                tertiaryDetail: Utils.getCompressedPk(sender.id)
+                tertiaryDetail: root.compressedPubKey
                 timestamp: root.timestamp
             }
 

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -61,6 +61,7 @@ ActivityNotificationMessage {
         onDetailsClicked: {
             Global.openPopup(reviewContactRequestPopupComponent, {
                 messageDetails: root.messageDetails,
+                compressedPubKey: contactDetails ? contactDetails.compressedPublicKey : "",
                 timestamp: notification ? notification.timestamp : 0
             })
         }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -26,6 +26,7 @@ ActivityNotificationBase {
         messageText: notification && notification.message ? notification.message.messageText : ""
         amISender: false
         sender.id: contactId
+        sender.compressedPubKey: contactDetails ? contactDetails.compressedPublicKey : ""
         sender.displayName: contactName
         sender.secondaryName: contactDetails && contactDetails.localNickname ?
                                   ProfileUtils.displayName("", contactDetails.name, contactDetails.displayName, contactDetails.alias) : ""

--- a/ui/imports/shared/controls/delegates/ContactListItemDelegate.qml
+++ b/ui/imports/shared/controls/delegates/ContactListItemDelegate.qml
@@ -15,7 +15,7 @@ StatusMemberListItem {
 
     readonly property string _pubKey: model.pubKey // expose uncompressed pubkey
 
-    pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+    pubKey: model.isEnsVerified ? "" : model.compressedPubKey
     nickName: model.localNickname
     userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
     isVerified: model.isVerified

--- a/ui/imports/shared/popups/CommonContactDialog.qml
+++ b/ui/imports/shared/popups/CommonContactDialog.qml
@@ -110,7 +110,7 @@ StatusDialog {
                             id: keyHoverHandler
                         }
                         StatusToolTip {
-                            text: Utils.getCompressedPk(root.publicKey)
+                            text: root.utilsStore.getCompressedPk(root.publicKey)
                             visible: keyHoverHandler.hovered
                         }
                     }

--- a/ui/imports/shared/popups/ProfileDialog.qml
+++ b/ui/imports/shared/popups/ProfileDialog.qml
@@ -15,6 +15,7 @@ StatusDialog {
 
     property alias profileStore: profileView.profileStore
     property alias contactsStore: profileView.contactsStore
+    property alias walletStore: profileView.walletStore
     property alias utilsStore: profileView.utilsStore
 
     property alias sendToAccountEnabled: profileView.sendToAccountEnabled

--- a/ui/imports/shared/stores/UtilsStore.qml
+++ b/ui/imports/shared/stores/UtilsStore.qml
@@ -39,4 +39,13 @@ QtObject {
     function changeCommunityKeyCompression(communityKey) {
         return d.globalUtilsInst.changeCommunityKeyCompression(communityKey)
     }
+
+    function getCompressedPk(publicKey) {
+        if (publicKey === "") {
+            return ""
+        }
+        if (!isChatKey(publicKey))
+            return publicKey
+        return d.globalUtilsInst.getCompressedPk(publicKey)
+    }
 }

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -82,7 +82,7 @@ Item {
 
         delegate: StatusMemberListItem {
             width: contactListView.availableWidth
-            pubKey: model.isEnsVerified ? "" : model.compressedKey
+            pubKey: model.isEnsVerified ? "" : model.compressedPubKey
             isContact: model.isContact
             status: model.onlineStatus
             height: visible ? implicitHeight : 0

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -13,7 +13,6 @@ import shared.stores 1.0
 // TODO move Contact into shared to get rid of that import
 import AppLayouts.Chat.controls 1.0
 import AppLayouts.stores 1.0 as AppLayoutStores
-import AppLayouts.Profile.stores 1.0 as ProfileStores
 
 import SortFilterProxyModel 0.2
 
@@ -21,7 +20,8 @@ Item {
     id: root
 
     property AppLayoutStores.RootStore rootStore
-    property ProfileStores.ContactsStore contactsStore
+
+    property var contactsModel
     property string communityId
 
     property string filterText: ""
@@ -51,7 +51,7 @@ Item {
         spacing: Theme.padding
 
         model: SortFilterProxyModel {
-            sourceModel: root.contactsStore.myContactsModel
+            sourceModel: root.contactsModel
             filters: [
                 ExpressionFilter {
                     expression: {

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -82,7 +82,7 @@ Item {
 
         delegate: StatusMemberListItem {
             width: contactListView.availableWidth
-            pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+            pubKey: model.isEnsVerified ? "" : model.compressedKey
             isContact: model.isContact
             status: model.onlineStatus
             height: visible ? implicitHeight : 0

--- a/ui/imports/shared/views/PickedContacts.qml
+++ b/ui/imports/shared/views/PickedContacts.qml
@@ -35,7 +35,7 @@ Item {
 
         delegate: StatusMemberListItem {
             width: contactGridView.cellWidth
-            pubKey: model.isEnsVerified ? "" : model.compressedKey
+            pubKey: model.isEnsVerified ? "" : model.compressedPubKey
             isContact: model.isContact
             status: model.onlineStatus
             nickName: model.localNickname

--- a/ui/imports/shared/views/PickedContacts.qml
+++ b/ui/imports/shared/views/PickedContacts.qml
@@ -7,15 +7,13 @@ import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 
 import utils 1.0
-import AppLayouts.Profile.stores 1.0 as ProfileStores
 
 import SortFilterProxyModel 0.2
 
 Item {
     id: root
 
-    property ProfileStores.ContactsStore contactsStore
-
+    property var contactsModel
     property var pubKeys: ([])
 
     readonly property alias count: contactGridView.count
@@ -28,13 +26,11 @@ Item {
         cellHeight: 2 * Theme.xlPadding + Theme.halfPadding
 
         model: SortFilterProxyModel {
-            sourceModel: root.contactsStore.myContactsModel
-            filters: [
-                FastExpressionFilter {
-                    expression: root.pubKeys.indexOf(model.pubKey) > -1
-                    expectedRoles: ["pubKey"]
-                }
-            ]
+            sourceModel: root.contactsModel
+            filters: FastExpressionFilter {
+                expression: root.pubKeys.indexOf(model.pubKey) > -1
+                expectedRoles: ["pubKey"]
+            }
         }
 
         delegate: StatusMemberListItem {

--- a/ui/imports/shared/views/PickedContacts.qml
+++ b/ui/imports/shared/views/PickedContacts.qml
@@ -35,7 +35,7 @@ Item {
 
         delegate: StatusMemberListItem {
             width: contactGridView.cellWidth
-            pubKey: model.isEnsVerified ? "" : Utils.getCompressedPk(model.pubKey)
+            pubKey: model.isEnsVerified ? "" : model.compressedKey
             isContact: model.isContact
             status: model.onlineStatus
             nickName: model.localNickname

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -38,6 +38,7 @@ Pane {
     property ProfileStores.ProfileStore profileStore
     property ProfileStores.ContactsStore contactsStore
     property SharedStores.UtilsStore utilsStore
+    property WalletStores.RootStore walletStore
     
     property alias sendToAccountEnabled: showcaseView.sendToAccountEnabled
 
@@ -448,7 +449,7 @@ Pane {
                         id: keyHoverHandler
                     }
                     StatusToolTip {
-                        text: Utils.getCompressedPk(root.publicKey)
+                        text: root.utilsStore.getCompressedPk(root.publicKey)
                         visible: keyHoverHandler.hovered
                     }
                 }
@@ -456,7 +457,7 @@ Pane {
                     Layout.leftMargin: -4
                     Layout.preferredWidth: 16
                     Layout.preferredHeight: 16
-                    textToCopy: Utils.getCompressedPk(root.publicKey)
+                    textToCopy: root.utilsStore.getCompressedPk(root.publicKey)
                     StatusToolTip {
                         text: qsTr("Copy Chat Key")
                         visible: parent.hovered
@@ -549,7 +550,7 @@ Pane {
                     socialLinksModel: root.showcaseSocialLinksModel
                     // assetsModel: root.showcaseAssetsModel
 
-                    walletStore: WalletStores.RootStore
+                    walletStore: root.walletStore
 
                     onCloseRequested: root.closeRequested()
                     onCopyToClipboard: ClipboardUtils.setText(text)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -846,7 +846,7 @@ Loader {
                     albumCount: root.albumCount
 
                     amISender: root.amISender
-                    sender.id: root.senderIsEnsVerified ? "" :  Utils.getCompressedPk(root.senderId)
+                    sender.id: root.senderIsEnsVerified ? "" :  root.utilsStore.getCompressedPk(root.senderId)
                     sender.displayName: root.senderDisplayName
                     sender.secondaryName: root.senderOptionalName
                     sender.isEnsVerified: root.isBridgeMessage ? false : root.senderIsEnsVerified

--- a/ui/imports/shared/views/chat/SimplifiedMessageView.qml
+++ b/ui/imports/shared/views/chat/SimplifiedMessageView.qml
@@ -56,7 +56,7 @@ RowLayout {
             sender: root.messageDetails.sender
             amISender: root.messageDetails.amISender
             messageOriginInfo: root.messageDetails.messageOriginInfo
-            tertiaryDetail: sender.isEnsVerified ? "" : Utils.getCompressedPk(sender.id)
+            tertiaryDetail: sender.isEnsVerified ? "" : root.messageDetails.sender.compressedPubKey
             timestamp: root.timestamp
             onClicked: root.openProfilePopup()
         }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -723,6 +723,7 @@ QtObject {
             colorHash: "",
             displayName: "",
             publicKey: publicKey,
+            compressedPublicKey: "",
             name: "",
             ensVerified: false,
             alias: "",
@@ -824,7 +825,8 @@ QtObject {
         }
     }
 
-    function getCompressedPk(publicKey) {
+    // TODO: remove when getElidedCompressedPk moved to utilsStore
+    function _getCompressedPk(publicKey) {
         if (publicKey === "") {
             return ""
         }
@@ -837,7 +839,7 @@ QtObject {
         if (publicKey === "") {
             return ""
         }
-        let compressedPk = getCompressedPk(publicKey)
+        let compressedPk = _getCompressedPk(publicKey)
         return getElidedPk(compressedPk)
     }
 


### PR DESCRIPTION
### What does the PR do

This PR is a next step of a bigger effort of making singletons stateless and backend-independent. 

The top-level target of this pr was moving `Utils.getCompressedPk` to `UtilsStore`. Most other changes are a consequence of that change. In most cases it leads to simplifications, especially in storybook pages. However many workarounds in SB pages will be removed only when all singletons are done stateless finally.

Closes:  #16650

### Affected areas
Multiple components where backend was called via `Utils.getCompressedPk`


### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
