### PR TITLE
[CHERRY-PICK] fix(members): fix list showing all members when missing encryption keys (#16625)

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -242,6 +242,9 @@ method updateMembersList*(self: Module, membersToReset: seq[ChatMember] = @[]) =
         if chat.members.len > 0:
           members = chat.members
         else:
+          if chat.missingEncryptionKey:
+            # We don't have the enryption keys, so we can't show the members
+            return
           # The channel now has a permisison, but the re-eval wasn't performed yet. Show all members for now
           members = myCommunity.members
 


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/16625

Fixes #16614

The problem was that I was missing encryption keys for some channels, but since I'm an admin, I still have access, so I could see the member list and it was showing me all members because of a missing condition in the code
