### PR TITLE
fix(curated): only load curated communities once

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -164,6 +164,8 @@ method communityDataLoaded*(self: Module) =
   self.buildTokensAndCollectiblesFromAllCommunities()
 
 method onActivated*(self: Module) =
+  if self.curatedCommunitiesLoaded:
+    return
   self.controller.asyncLoadCuratedCommunities()
 
 method curatedCommunitiesLoaded*(self: Module, curatedCommunities: seq[CommunityDto]) =


### PR DESCRIPTION
### What does the PR do

Found while debugging https://github.com/status-im/status-desktop/issues/16645

While this doesn't fix the issue, it removes useless calls to status-go.

### Affected areas

Curated communities

### Impact on end user

None. We only need to load once, so if they are already loaded, we don't need to call `load` each time we go there.

### How to test

Check the curated communities with an old and new account

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

I doubt anything can happen, but if the fetch fails, it won't retry
