### PR TITLE
fix: links do not work in the terms of name registration popup

### DIFF
--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -56,8 +56,9 @@ method delete*(self: Module) =
 method load*(self: Module) =
   self.controller.init()
 
-  let link = self.controller.getAppNetwork().blockExplorerUrl & "/tx/"
-  self.view.load(link)
+  let txLink = self.controller.getAppNetwork().blockExplorerUrl & EXPLORER_TX_PATH
+  let addressLink = self.controller.getAppNetwork().blockExplorerUrl & EXPLORER_ADDRESS_PATH
+  self.view.load(txLink, addressLink)
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e: Args):
     self.controller.fixPreferredName(true)

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -9,7 +9,8 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: Model
       modelVariant: QVariant
-      etherscanLink: string
+      etherscanTxLink: string
+      etherscanAddressLink: string
 
   proc delete*(self: View) =
     self.model.delete
@@ -23,8 +24,9 @@ QtObject:
     result.modelVariant = newQVariant(result.model)
     result.delegate = delegate
 
-  proc load*(self: View, link: string) =
-    self.etherscanLink = link
+  proc load*(self: View, txLink, addressLink: string) =
+    self.etherscanTxLink = txLink
+    self.etherscanAddressLink = addressLink
     self.delegate.viewDidLoad()
 
   proc model*(self: View): Model =
@@ -66,8 +68,11 @@ QtObject:
   proc emitTransactionWasSentSignal*(self: View, trxType: string, chainId: int, txHash: string, username: string, error: string) =
     self.transactionWasSent(trxType, chainId, txHash, username, error)
 
-  proc getEtherscanLink*(self: View): string {.slot.} =
-    return self.etherscanLink
+  proc getEtherscanTxLink*(self: View): string {.slot.} =
+    return self.etherscanTxLink
+
+  proc getEtherscanAddressLink*(self: View): string {.slot.} =
+    return self.etherscanAddressLink
 
   proc usernameConfirmed(self: View, username: string) {.signal.}
   proc emitUsernameConfirmedSignal*(self: View, ensUsername: string) =

--- a/src/app/modules/main/wallet_section/networks/model.nim
+++ b/src/app/modules/main/wallet_section/networks/model.nim
@@ -3,7 +3,7 @@ import NimQml, Tables, strutils, sequtils, sugar
 import app_service/service/network/dto
 import ./io_interface
 
-const EXPLORER_TX_PREFIX* = "/tx/"
+from app_service/service/network/service import EXPLORER_TX_PATH
 
 type
   ModelRole* {.pure.} = enum
@@ -125,10 +125,10 @@ QtObject:
     self.endResetModel()
     self.countChanged()
 
-  proc getBlockExplorerURL*(self: Model, chainId: int): string =
+  proc getBlockExplorerTxURL*(self: Model, chainId: int): string =
     for item in self.delegate.getFlatNetworksList():
       if(item.chainId == chainId):
-        return item.blockExplorerURL & EXPLORER_TX_PREFIX
+        return item.blockExplorerURL & EXPLORER_TX_PATH
     return ""
 
   proc getEnabledState*(self: Model, chainId: int): UxEnabledState =

--- a/src/app/modules/main/wallet_section/networks/view.nim
+++ b/src/app/modules/main/wallet_section/networks/view.nim
@@ -79,8 +79,8 @@ QtObject:
   proc enableNetwork*(self: View, chainId: int) {.slot.} =
     self.delegate.setNetworksState(@[chainId], enable = true)
 
-  proc getBlockExplorerURL*(self: View, chainId: int): string {.slot.} =
-    return self.flatNetworks.getBlockExplorerURL(chainId)
+  proc getBlockExplorerTxURL*(self: View, chainId: int): string {.slot.} =
+    return self.flatNetworks.getBlockExplorerTxURL(chainId)
 
   proc updateNetworkEndPointValues*(self: View, chainId: int, testNetwork: bool, newMainRpcInput: string, newFailoverRpcUrl: string, revertToDefault: bool) {.slot.} =
     self.delegate.updateNetworkEndPointValues(chainId, testNetwork, newMainRpcInput, newFailoverRpcUrl, revertToDefault)

--- a/src/app_service/service/network/service.nim
+++ b/src/app_service/service/network/service.nim
@@ -13,6 +13,8 @@ logScope:
   topics = "network-service"
 
 const SIGNAL_NETWORK_ENDPOINT_UPDATED* = "networkEndPointUpdated"
+const EXPLORER_TX_PATH* = "/tx"
+const EXPLORER_ADDRESS_PATH* = "/address"
 
 type NetworkEndpointUpdatedArgs* = ref object of Args
   isTest*: bool

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -599,8 +599,8 @@ QtObject {
         return globalUtilsInst.wei2Eth(wei,18)
     }
 
-    function getEtherscanLink() {
-        return profileSectionModule.ensUsernamesModule.getEtherscanLink()
+    function getEtherscanTxLink() {
+        return profileSectionModule.ensUsernamesModule.getEtherscanTxLink()
     }
 
     function getLoginType() {

--- a/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
@@ -49,10 +49,16 @@ QtObject {
     }
 
 
-    function getEtherscanLink() {
+    function getEtherscanTxLink() {
         if(!root.ensUsernamesModule)
             return ""
-        return ensUsernamesModule.getEtherscanLink()
+        return ensUsernamesModule.getEtherscanTxLink()
+    }
+
+    function getEtherscanAddressLink() {
+        if(!root.ensUsernamesModule)
+            return ""
+        return ensUsernamesModule.getEtherscanAddressLink()
     }
 
     function ensConnectOwnedUsername(name, isStatus) {

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -135,8 +135,8 @@ Item {
                 }
 
                 StatusBaseText {
-                    text: qsTr("<a href='%1%2'>Look up on Etherscan</a>")
-                    .arg(root.ensUsernamesStore.getEtherscanLink())
+                    text: qsTr("<a href='%1/%2'>Look up on Etherscan</a>")
+                    .arg(root.ensUsernamesStore.getEtherscanAddressLink())
                     .arg(root.ensUsernamesStore.getEnsRegisteredAddress())
                     anchors.left: parent.left
                     anchors.right: parent.right
@@ -159,8 +159,8 @@ Item {
                 }
 
                 StatusBaseText {
-                    text: qsTr("<a href='%1%2'>Look up on Etherscan</a>")
-                    .arg(root.ensUsernamesStore.getEtherscanLink())
+                    text: qsTr("<a href='%1/%2'>Look up on Etherscan</a>")
+                    .arg(root.ensUsernamesStore.getEtherscanAddressLink())
                     .arg(root.ensUsernamesStore.getEnsRegistry())
                     anchors.left: parent.left
                     anchors.right: parent.right

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -445,7 +445,7 @@ Item {
                 ephType = Constants.ephemeralNotificationType.success;
             }
 
-            let url = `${ensView.ensUsernamesStore.getEtherscanLink()}/${txHash}`;
+            let url = `${ensView.ensUsernamesStore.getEtherscanTxLink()}/${txHash}`;
             Global.displayToastMessage(qsTr("Transaction pending..."),
                                        qsTr("View on etherscan"),
                                        icon,

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -171,8 +171,8 @@ QtObject {
         readonly property var userProfileInst: userProfile
     }
 
-    function getEtherscanLink(chainID) {
-        return networksModule.getBlockExplorerURL(chainID)
+    function getEtherscanTxLink(chainID) {
+        return networksModule.getBlockExplorerTxURL(chainID)
     }
 
     function createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityTags,

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -249,7 +249,7 @@ Item {
                     const approvalAmount = currencyStore.formatCurrencyAmountFromBigInt(fromAmount, fromToken.symbol, fromToken.decimals)
                     let toastTitle = qsTr("Setting spending cap: %1 in %2 for %3 on %4").arg(approvalAmount).arg(fromAccountName).arg(Constants.swap.paraswapHostname).arg(networkName)
                     let toastSubtitle = qsTr("View on %1").arg(networkName)
-                    let urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanLink(chainId)).arg(txHash)
+                    let urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanTxLink(chainId)).arg(txHash)
                     let toastType = Constants.ephemeralNotificationType.normal
                     let icon = ""
                     if(error) {
@@ -273,7 +273,7 @@ Item {
                     const toSwapAmount = currencyStore.formatCurrencyAmountFromBigInt(toAmount, toToken.symbol, toToken.decimals)
                     let toastTitle = qsTr("Swapping %1 to %2 in %3 using %4 on %5").arg(fromSwapAmount).arg(toSwapAmount).arg(fromAccountName).arg(Constants.swap.paraswapHostname).arg(networkName)
                     let toastSubtitle = qsTr("View on %1").arg(networkName)
-                    let urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanLink(chainId)).arg(txHash)
+                    let urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanTxLink(chainId)).arg(txHash)
                     let toastType = Constants.ephemeralNotificationType.normal
                     let icon = ""
                     if(error) {
@@ -296,7 +296,7 @@ Item {
                                                    "",
                                                    true,
                                                    Constants.ephemeralNotificationType.normal,
-                                                   "%1/%2".arg(appMain.rootStore.getEtherscanLink(chainId)).arg(txHash))
+                                                   "%1/%2".arg(appMain.rootStore.getEtherscanTxLink(chainId)).arg(txHash))
                     }
                 }
                 break
@@ -316,7 +316,7 @@ Item {
                     const approvalAmount = currencyStore.formatCurrencyAmountFromBigInt(fromAmount, fromToken.symbol, fromToken.decimals)
                     let toastTitle = qsTr("Spending cap set: %1 in %2 for %3 on %4").arg(approvalAmount).arg(fromAccountName).arg(Constants.swap.paraswapHostname).arg(networkName)
                     const toastSubtitle =  qsTr("View on %1").arg(networkName)
-                    const urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanLink(chainId)).arg(txHash)
+                    const urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanTxLink(chainId)).arg(txHash)
                     let toastType = Constants.ephemeralNotificationType.success
                     let icon = "checkmark-circle"
                     if(!success) {
@@ -338,7 +338,7 @@ Item {
                     const toSwapAmount = currencyStore.formatCurrencyAmountFromBigInt(toAmount, toToken.symbol, toToken.decimals)
                     let toastTitle = qsTr("Swapped %1 to %2 in %3 using %4 on %5").arg(fromSwapAmount).arg(toSwapAmount).arg(fromAccountName).arg(Constants.swap.paraswapHostname).arg(networkName)
                     const toastSubtitle = qsTr("View on %1").arg(networkName)
-                    const urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanLink(chainId)).arg(txHash)
+                    const urlLink = "%1/%2".arg(appMain.rootStore.getEtherscanTxLink(chainId)).arg(txHash)
                     let toastType = Constants.ephemeralNotificationType.success
                     let icon = "checkmark-circle"
                     if(!success) {

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -54,8 +54,8 @@ QtObject {
         walletSectionSendInst.setSelectedRecipient(recipientAddress)
     }
 
-    function getEtherscanLink(chainID) {
-        return networksModule.getBlockExplorerURL(chainID)
+    function getEtherscanTxLink(chainID) {
+        return networksModule.getBlockExplorerTxURL(chainID)
     }
 
     function authenticateAndTransfer(uuid, slippagePercentage = "") {


### PR DESCRIPTION
Old `getEtherscanLink` is now `getEtherscanTxLink` and the new `getEtherscanAddressLink` method added.

Fixes #16658