### PR TITLE
fix: fill missing fees in tx object received from dApp

### DIFF
--- a/src/app/modules/shared_modules/wallet_connect/helpers.nim
+++ b/src/app/modules/shared_modules/wallet_connect/helpers.nim
@@ -26,7 +26,6 @@ proc convertFeesInfoToHex*(feesInfoJson: string): string =
       parsedJson = parseJson(feesInfoJson)
 
       maxFeePerGasFloat = getFloatFromJson(parsedJson, "maxFeePerGas")
-      a = maxFeePerGasFloat * 1e9
       maxFeePerGasWei = uint64(maxFeePerGasFloat * 1e9)
 
       maxPriorityFeePerGasFloat = getFloatFromJson(parsedJson, "maxPriorityFeePerGas")

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -165,6 +165,7 @@ Item {
                 onConnectionDeclined: (pairingId) => wcService.rejectPairSession(pairingId)
                 onSignRequestAccepted: (connectionId, requestId) => wcService.sign(connectionId, requestId)
                 onSignRequestRejected: (connectionId, requestId) => wcService.rejectSign(connectionId, requestId, false /*hasError*/)
+                onSubscribeForFeeUpdates: (connectionId, requestId) => wcService.subscribeForFeeUpdates(connectionId, requestId)
 
                 Connections {
                     target: dappsWorkflow.wcService

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectService.qml
@@ -63,6 +63,10 @@ QObject {
         requestHandler.rejectSessionRequest(topic, id, hasError)
     }
 
+    function subscribeForFeeUpdates(topic, id) {
+        requestHandler.subscribeForFeeUpdates(topic, id)
+    }
+
     /// Validates the pairing URI
     function validatePairingUri(uri) {
         d.validatePairingUri(uri)

--- a/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppSignRequestModal.qml
@@ -11,6 +11,7 @@ import AppLayouts.Wallet.popups 1.0
 import AppLayouts.Wallet.panels 1.0
 
 import shared.popups.walletconnect.panels 1.0
+import shared.panels 1.0
 
 import utils 1.0
 
@@ -93,6 +94,7 @@ SignTransactionModalBase {
                     font.pixelSize: Theme.additionalTextSize
                 }
                 StatusTextWithLoadingState {
+                    id: maxFees
                     Layout.fillWidth: true
                     objectName: "footerFiatFeesText"
                     text: formatBigNumber(root.fiatFees, root.currentCurrency)
@@ -102,6 +104,18 @@ SignTransactionModalBase {
                     Binding on text {
                         when: !root.hasFees
                         value: qsTr("No fees")
+                    }
+
+                    onTextChanged: {
+                        if (text === "") {
+                            return
+                        }
+                        maxFeesAnimation.restart()
+                    }
+
+                    AnimatedText {
+                        id: maxFeesAnimation
+                        target: maxFees
                     }
                 }
             }
@@ -114,9 +128,22 @@ SignTransactionModalBase {
                     font.pixelSize: Theme.additionalTextSize
                 }
                 StatusTextWithLoadingState {
+                    id: estimatedTime
                     objectName: "footerEstimatedTime"
                     text: root.estimatedTime
                     loading: root.feesLoading
+
+                    onTextChanged: {
+                        if (text === "") {
+                            return
+                        }
+                        estimatedTimeAnimation.restart()
+                    }
+
+                    AnimatedText {
+                        id: estimatedTimeAnimation
+                        target: estimatedTime
+                    }
                 }
             }
         }
@@ -169,6 +196,7 @@ SignTransactionModalBase {
             ColumnLayout {
                 spacing: 2
                 StatusTextWithLoadingState {
+                    id: fiatFees
                     objectName: "fiatFeesText"
                     Layout.alignment: Qt.AlignRight
                     text: formatBigNumber(root.fiatFees, root.currentCurrency)
@@ -176,8 +204,21 @@ SignTransactionModalBase {
                     font.pixelSize: Theme.additionalTextSize
                     loading: root.feesLoading
                     customColor: root.enoughFundsForFees ? Theme.palette.directColor1 : Theme.palette.dangerColor1
+
+                    onTextChanged: {
+                        if (text === "") {
+                            return
+                        }
+                        fiatFeesAnimation.restart()
+                    }
+
+                    AnimatedText {
+                        id: fiatFeesAnimation
+                        target: fiatFees
+                    }
                 }
                 StatusTextWithLoadingState {
+                    id: cryptoFees
                     objectName: "cryptoFeesText"
                     Layout.alignment: Qt.AlignRight
                     text: formatBigNumber(root.cryptoFees, Constants.ethToken)
@@ -185,6 +226,18 @@ SignTransactionModalBase {
                     font.pixelSize: Theme.additionalTextSize
                     customColor: root.enoughFundsForFees ? Theme.palette.baseColor1 : Theme.palette.dangerColor1
                     loading: root.feesLoading
+
+                    onTextChanged: {
+                        if (text === "") {
+                            return
+                        }
+                        cryptoFeesAnimation.restart()
+                    }
+
+                    AnimatedText {
+                        id: cryptoFeesAnimation
+                        target: cryptoFees
+                    }
                 }
             }
         ]

--- a/ui/imports/shared/popups/walletconnect/panels/ContentPanel.qml
+++ b/ui/imports/shared/popups/walletconnect/panels/ContentPanel.qml
@@ -33,7 +33,6 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: 20
 
-        text: root.payloadToDisplay
         font.pixelSize: Theme.additionalTextSize
         lineHeightMode: Text.FixedHeight
         lineHeight: 18

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1098,6 +1098,12 @@ QtObject {
         }
     }
 
+    enum FeesMode {
+        Low,
+        Medium,
+        High
+    }
+
     enum LoginType {
         Password,
         Biometrics,


### PR DESCRIPTION
- the following params were removed from the tx preview (cause they are dynamic and recalculate with base fee change):
  - `maxFeePerGas`
  - `maxPriorityFeePerGas`
  - `gasPrice`
- fees and estimated time are recalculated periodically

Fixes #16528


https://github.com/user-attachments/assets/9282d927-320b-4d84-9704-542faa5cc235

