### PR TITLE
fix(members): fix member count not updating correctly on join

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -390,6 +390,12 @@ proc createCommunitySectionItem[T](self: Module[T], communityDetails: CommunityD
 
   memberItems = concat(memberItems, pendingMembers, declinedMemberItems, bannedMembers)
 
+  # Remove duplicates, this can happen when the requests to join have not updated in time
+  var finalMembers: Table[string, MemberItem]
+  for memberItem in memberItems:
+    if not finalMembers.contains(memberItem.pubKey):
+      finalMembers[memberItem.pubKey] = memberItem
+
   result = initItem(
     communityDetails.id,
     sectionType = SectionType.Community,
@@ -417,7 +423,7 @@ proc createCommunitySectionItem[T](self: Module[T], communityDetails: CommunityD
     communityDetails.permissions.access,
     communityDetails.permissions.ensOnly,
     communityDetails.muted,
-    memberItems,
+    finalMembers.values.toSeq(),
     communityDetails.settings.historyArchiveSupportEnabled,
     communityDetails.adminSettings.pinMessageAllMembersEnabled,
     communityDetails.encrypted,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -337,6 +337,10 @@ QtObject:
 
     self.events.on(SignalType.Message.event) do(e: Args):
       var receivedData = MessageSignal(e)
+      # Handling membership requests
+      if(receivedData.membershipRequests.len > 0):
+        self.handleCommunitiesRequestsToJoin(receivedData.membershipRequests)
+
       # Handling community updates
       if (receivedData.communities.len > 0):
         # Channel added removed is notified in the chats param
@@ -344,10 +348,6 @@ QtObject:
 
       if (receivedData.communitiesSettings.len > 0):
         self.handleCommunitiesSettingsUpdates(receivedData.communitiesSettings)
-
-      # Handling membership requests
-      if(receivedData.membershipRequests.len > 0):
-        self.handleCommunitiesRequestsToJoin(receivedData.membershipRequests)
 
     self.events.on(SignalType.DiscordCategoriesAndChannelsExtracted.event) do(e: Args):
       var receivedData = DiscordCategoriesAndChannelsExtractedSignal(e)
@@ -788,12 +788,12 @@ QtObject:
         # Request was accepted, update the member's airdrop address
         self.events.emit(SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY_ACCEPTED,
           CommunityRequestArgs(communityRequest: membershipRequest))
-      else:
-        try:
-          self.updateMembershipRequestToNewState(membershipRequest.communityId, membershipRequest.id, self.communities[membershipRequest.communityId],
-            requestToJoinState)
-        except Exception as e:
-          error "Unknown request", msg = e.msg
+
+      try:
+        self.updateMembershipRequestToNewState(membershipRequest.communityId, membershipRequest.id, self.communities[membershipRequest.communityId],
+          requestToJoinState)
+      except Exception as e:
+        error "Unknown request", msg = e.msg
 
   proc init*(self: Service) =
     self.doConnect()

--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -22,7 +22,6 @@ pytestmark = marks
                  'Edit chat - Remove pinned message (when any member can pin is disabled)')
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703510', 'Join community via owner invite')
 @pytest.mark.case(703255, 703256, 703510)
-@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/16672')
 def test_join_community_and_pin_unpin_message(multiple_instances):
     user_one: UserAccount = RandomUser()
     user_two: UserAccount = RandomUser()


### PR DESCRIPTION
### What does the PR do

Fixes #16672

The issue was that the requests to join were not handled in time for when the community update came in, so when we udpated the section, we got both the normal member and the pending member still and they clashed and the pending one came on top, meaning that the joined member was not counted. On a restart it would fix itself.
To fix it, I reordered the parsing of communities and requests, so that the request is updated first, ie deleted because it is now accepted. I also fixed the function that handles request to that the state gets updated at all times. Before, it would only get updated if it was not accepted, pending or waiting for address. Finally, there was a weird scenario where as a TM, I saw myself as pending even if I was joined, so I fixed it by removing duplicates.

### Affected areas

Member items in the sections (main module) and the order of parsing requests to join in the community service.


### Screenshot of functionality (including design for comparison)

[fix-members-count.webm](https://github.com/user-attachments/assets/a3d34d3c-87a7-4021-a8cf-c734543233e5)

### Impact on end user

Fixes the members count on the top of the community and the list of members in the admin tab

### How to test

- Join a community

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the bug still happens
