### PR TITLE
chore(@e2e): mark test as xfail because of issue

### DIFF
--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
@@ -18,6 +18,7 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703028', 'Manage a custom generated account')
 @pytest.mark.case(703028)
+@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/16683")
 def test_plus_button_manage_generated_account_custom_derivation_path(main_screen: MainWindow, user_account):
     with step('Create generated wallet account'):
         name = random_wallet_acc_keypair_name()


### PR DESCRIPTION
### What does the PR do

Mark test for adding account with custom derivation path as expected to fail: https://github.com/status-im/status-desktop/issues/16683

