### PR TITLE
fix(AddAccountPopup): account list for address selection is empty

### DIFF
--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
@@ -18,7 +18,6 @@ pytestmark = marks
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703028', 'Manage a custom generated account')
 @pytest.mark.case(703028)
-@pytest.mark.xfail(reason="https://github.com/status-im/status-desktop/issues/16683")
 def test_plus_button_manage_generated_account_custom_derivation_path(main_screen: MainWindow, user_account):
     with step('Create generated wallet account'):
         name = random_wallet_acc_keypair_name()

--- a/ui/StatusQ/src/StatusQ/Components/StatusPageIndicator.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusPageIndicator.qml
@@ -118,7 +118,6 @@ Item {
         model: d.pages
         delegate: StatusBaseButton {
             objectName: "Page-%1".arg(itemText)
-            width: d.buttonWidth
             text: itemText
             size: StatusBaseButton.Size.Small
             normalColor: itemIndex === root.currentIndex? Theme.palette.primaryColor3 : "transparent"

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPath.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPath.qml
@@ -149,7 +149,7 @@ GridLayout {
                 return qsTr("Select address")
             }
 
-            return "0x0000000000000000000000000000000000000000"
+            return Constants.zeroAddress
         }
 
         components: [


### PR DESCRIPTION
### What does the PR do

- use a similar approach as in the DerivationPath popup; ListView instead of a Repeater
- some smaller fixes & speedups in the SFPM
- reenable the test
- separate commit to fix a small issue in StatusPageIndicator

Fixes https://github.com/status-im/status-desktop/issues/16683

### Affected areas

AddAccountPopup, StatusPageIndicator

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/0ae1589f-cc7d-4cbc-ad5a-6668ef218579

