### PR TITLE
Windows installer: remove bin dir as a first step of installation

### DIFF
--- a/status.iss
+++ b/status.iss
@@ -68,6 +68,9 @@ Name: "{userdesktop}\{#Name}"; Filename: "{app}\{#ExeName}"; IconFilename: "{app
 Filename: "{app}\vendor\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing VS2017 redistributable package (64 Bit)";
 Filename: "{app}\{#ExeName}"; Description: {cm:LaunchProgram,{#Name}}; Flags: nowait postinstall skipifsilent
 
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\bin"
+
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"
 Type: files; Name: "{userdesktop}\{#Name}"


### PR DESCRIPTION
### What does the PR do

It fixes problem with unwanted qmldir in 2.31 which is in `bin/StatusQ` when overriding 2.30.1 or older installation.

Closes: #16693

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Window's installer script (`status.iss`)

