### PR TITLE
[CHERRYPICK]: Windows installer: remove bin dir as a first step of installation

### DIFF
--- a/status.iss
+++ b/status.iss
@@ -68,6 +68,9 @@ Name: "{userdesktop}\{#Name}"; Filename: "{app}\{#ExeName}"; IconFilename: "{app
 Filename: "{app}\vendor\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing VS2017 redistributable package (64 Bit)";
 Filename: "{app}\{#ExeName}"; Description: {cm:LaunchProgram,{#Name}}; Flags: nowait postinstall skipifsilent
 
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\bin"
+
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"
 Type: files; Name: "{userdesktop}\{#Name}"


### PR DESCRIPTION
### What does the PR do

Cherry-pick of https://github.com/status-im/status-desktop/pull/16698

It fixes problem with unwanted qmldir in 2.31 which is in `bin/StatusQ` when overriding 2.30.1 or older installation.

Closes: #16693

### Affected areas
Windows installer's script (`status.iss`)

### How to test

- install Status Desktop on windows using 2.30 or earlier
- install Status Desktop 2.31 on top

Check if the app is running normally.

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

