### PR TITLE
chore(@e2e): allow account list to load before selecting

### DIFF
--- a/test/e2e/gui/components/wallet/wallet_account_popups.py
+++ b/test/e2e/gui/components/wallet/wallet_account_popups.py
@@ -1,3 +1,5 @@
+import time
+
 import configs.timeouts
 from constants.wallet import *
 from gui.screens.settings_keycard import KeycardSettingsView
@@ -353,3 +355,4 @@ class GeneratedAddressesList(QObject):
                 selected_page_number += 1
                 self._paginator_page.real_name['text'] = selected_page_number
                 self._paginator_page.click()
+                time.sleep(0.5)

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -328,7 +328,7 @@ sharedPopup_Primary_Button = {"container": statusDesktop_mainWindow, "objectName
 # Wallet Account Popup
 mainWallet_AddEditAccountPopup_derivationPath = {"container": statusDesktop_mainWindow, "objectName": RegularExpression("AddAccountPopup-PreDefinedDerivationPath*"), "type": "StatusListItem", "visible": True}
 mainWallet_Address_Panel = {"container": statusDesktop_mainWindow, "objectName": "addressPanel", "type": "StatusAddressPanel", "visible": True}
-addAccountPopup_GeneratedAddress = {"container": statusDesktop_mainWindow_overlay_popup2, "type": "Rectangle", "visible": True}
+addAccountPopup_GeneratedAddress = {"container": statusDesktop_mainWindow_overlay_popup2, "objectName": RegularExpression("AddAccountPopup-GeneratedAddress*"), "type": "Rectangle", "visible": True}
 address_0x_StatusBaseText = {"container": statusDesktop_mainWindow_overlay_popup2, "text": RegularExpression("0x*"), "type": "StatusBaseText", "unnamed": 1, "visible": True}
 addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator = {"container": statusDesktop_mainWindow_overlay_popup2, "objectName": "AddAccountPopup-GeneratedAddressesListPageIndicatior", "type": "StatusPageIndicator", "visible": True}
 page_StatusBaseButton = {"checkable": False, "container": addAccountPopup_GeneratedAddressesListPageIndicatior_StatusPageIndicator, "objectName": RegularExpression("Page-*"), "type": "StatusBaseButton", "visible": True}


### PR DESCRIPTION
### What does the PR do

Allow the list of addresses to load before trying to click them

https://ci.status.im/job/status-desktop/job/e2e/job/manual/2577/

<img width="1840" alt="Screenshot 2024-11-04 at 19 08 54" src="https://github.com/user-attachments/assets/d0896424-15c3-4c3b-89da-4382ba75debd">


