### PR TITLE
feat(ProfileContextMenu): Add "Mark as Trusted" and "Remove trusted mark"

### DIFF
--- a/storybook/pages/ProfileContextMenuPage.qml
+++ b/storybook/pages/ProfileContextMenuPage.qml
@@ -286,3 +286,4 @@ SplitView {
 
 // category: Views
 // status: good
+// https://www.figma.com/design/ibJOTPlNtIxESwS96vJb06/%F0%9F%91%A4-Profile-%7C-Desktop?node-id=7898-265693&node-type=canvas&m=dev

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -30,8 +30,10 @@ Item {
     signal removeNicknameRequested(string pubKey)
     signal blockContactRequested(string pubKey)
     signal unblockContactRequested(string pubKey)
+    signal markAsTrustedRequested(string pubKey)
     signal markAsUntrustedRequested(string pubKey)
     signal removeTrustStatusRequested(string pubKey)
+    signal removeTrustedMarkRequested(string pubKey)
     signal removeContactRequested(string pubKey)
     signal removeContactFromGroupRequested(string pubKey)
 
@@ -212,6 +214,8 @@ Item {
             onRemoveContact: root.removeContactRequested(pubKey)
             onBlockContact: root.blockContactRequested(pubKey)
             onRemoveFromGroup: root.removeContactFromGroupRequested(pubKey)
+            onMarkAsTrusted: root.markAsTrustedRequested(pubKey)
+            onRemoveTrustedMark: root.removeTrustedMarkRequested(pubKey)
 
             onClosed: destroy()
         }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -216,11 +216,14 @@ StatusSectionLayout {
 
             onCreateOneToOneChatRequested: {
                 Global.changeAppSectionBySectionType(Constants.appSection.chat)
-                root.rootStore.chatCommunitySectionModule.createOneToOneChat("", profileContextMenu.pubKey, "")
+                root.rootStore.chatCommunitySectionModule.createOneToOneChat("", pubKey, "")
             }
 
             onRemoveTrustStatusRequested: root.contactsStore.removeTrustStatus(pubKey)
             onRemoveContactFromGroupRequested: root.rootStore.removeMemberFromGroupChat(pubKey)
+
+            onMarkAsTrustedRequested: Global.openMarkAsIDVerifiedPopup(pubKey, null)
+            onRemoveTrustedMarkRequested: Global.openRemoveIDVerificationDialog(pubKey, null)
         }
     }
 

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -363,6 +363,8 @@ Item {
             onRemoveTrustStatus: root.rootStore.contactsStore.removeTrustStatus(memberContextMenuView.pubKey)
             onRemoveContact: Global.removeContactRequested(memberContextMenuView.pubKey)
             onBlockContact: Global.blockContactRequested(memberContextMenuView.pubKey)
+            onMarkAsTrusted: Global.openMarkAsIDVerifiedPopup(memberContextMenuView.pubKey, null)
+            onRemoveTrustedMark: Global.openRemoveIDVerificationDialog(memberContextMenuView.pubKey, null)
             onClosed: destroy()
         }
     }

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -87,6 +87,8 @@ SettingsContentBase {
                 onRemoveTrustStatus: root.contactsStore.removeTrustStatus(contactContextMenu.pubKey)
                 onRemoveNickname: root.contactsStore.changeContactNickname(contactContextMenu.pubKey, "",
                                                                            contactContextMenu.displayName, true)
+                onMarkAsTrusted: Global.openMarkAsIDVerifiedPopup(contactContextMenu.pubKey, null)
+                onRemoveTrustedMark: Global.openRemoveIDVerificationDialog(contactContextMenu.pubKey, null)
                 onClosed: destroy()
             }
         }

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -333,7 +333,7 @@ SettingsContentBase {
             inShowcaseModel: priv.showcaseModels.accountsVisibleModel
             hiddenModel: priv.showcaseModels.accountsHiddenModel
             showcaseLimit: root.profileStore.getProfileShowcaseEntriesLimit()
-            currentWallet: RootStore.overview.mixedcaseAddress
+            currentWallet: WalletStores.RootStore.overview.mixedcaseAddress
 
             onChangePositionRequested: function (from, to) {
                 priv.showcaseModels.changeAccountPosition(from, to)

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -200,7 +200,7 @@ QtObject {
 
     function openMarkAsIDVerifiedPopup(publicKey, cb) {
         const contactDetails = Utils.getContactDetailsAsJson(
-                                 publicKey, false, true, true)
+                                 publicKey, true, true, true)
         const properties = { publicKey, contactDetails }
 
         openPopup(markAsIDVerifiedPopupComponent, properties, cb)
@@ -208,7 +208,7 @@ QtObject {
 
     function openRemoveIDVerificationDialog(publicKey, cb) {
         const contactDetails = Utils.getContactDetailsAsJson(
-                                 publicKey, false, true, true)
+                                 publicKey, true, true, true)
         const properties = { publicKey, contactDetails }
 
         openPopup(removeIDVerificationPopupComponent, properties, cb)

--- a/ui/imports/shared/popups/RemoveIDVerificationDialog.qml
+++ b/ui/imports/shared/popups/RemoveIDVerificationDialog.qml
@@ -20,7 +20,7 @@ CommonContactDialog {
         Layout.fillWidth: true
         Layout.bottomMargin: Theme.halfPadding
         wrapMode: Text.WordWrap
-        text: qsTr("%1's identity will no longer be verified. This is only visible to you.").arg(mainDisplayName)
+        text: qsTr("%1 will no longer be marked as trusted. This is only visible to you.").arg(mainDisplayName)
     }
 
     StatusCheckBox {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1219,6 +1219,8 @@ Loader {
             onRemoveContact: Global.removeContactRequested(profileContextMenu.pubKey)
             onBlockContact: Global.blockContactRequested(profileContextMenu.pubKey)
             onRemoveFromGroup: root.store.removeMemberFromGroupChat(profileContextMenu.pubKey)
+            onMarkAsTrusted: Global.openMarkAsIDVerifiedPopup(profileContextMenu.pubKey, null)
+            onRemoveTrustedMark: Global.openRemoveIDVerificationDialog(profileContextMenu.pubKey, null)
 
             onOpened: root.setMessageActive(root.messageId, true)
             onClosed: {

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -35,6 +35,8 @@ StatusMenu {
     signal editNickname
     signal removeNickname
     signal unblockContact
+    signal markAsTrusted
+    signal removeTrustedMark
     signal markAsUntrusted
     signal removeTrustStatus
     signal removeContact
@@ -78,25 +80,6 @@ StatusMenu {
         }
     }
 
-    // Edit Nickname
-    StatusAction {
-        id: renameAction
-        objectName: "rename_StatusItem"
-        enabled: root.profileType === Constants.profileType.blocked || root.profileType === Constants.profileType.regular
-        text: root.hasLocalNickname ? qsTr("Edit nickname") : qsTr("Add nickname")
-        icon.name: "edit_pencil"
-        onTriggered: root.editNickname()
-    }
-
-    // Review Contact Request
-    StatusAction {
-        text: qsTr("Review contact request")
-        objectName: "reviewContactRequest_StatusItem"
-        icon.name: "add-contact"
-        enabled: root.profileType === Constants.profileType.regular && root.contactType === Constants.contactType.contactRequestReceived
-        onTriggered: root.reviewContactRequest()
-    }
-
     // Send Message
     SendMessageMenuItem {
         id: sendMessageMenuItem
@@ -108,12 +91,40 @@ StatusMenu {
         }
     }
 
+    // Mark as trusted
+    StatusAction {
+        objectName: "markAsTrusted_StatusItem"
+        enabled: root.profileType === Constants.profileType.regular && root.contactType === Constants.contactType.contact && root.trustStatus !== Constants.trustStatus.trusted
+        text: qsTr("Mark as trusted")
+        icon.name: "checkmark-circle"
+        onTriggered: root.markAsTrusted()
+    }
+
+    // Review Contact Request
+    StatusAction {
+        text: qsTr("Review contact request")
+        objectName: "reviewContactRequest_StatusItem"
+        icon.name: "add-contact"
+        enabled: root.profileType === Constants.profileType.regular && root.contactType === Constants.contactType.contactRequestReceived
+        onTriggered: root.reviewContactRequest()
+    }
+
     // Send Contact Request
     SendContactRequestMenuItem {
         id: sendContactRequestMenuItem
         objectName: "sendContactRequest_StatusItem"
         enabled: root.profileType === Constants.profileType.regular && root.contactType === Constants.contactType.nonContact
         onTriggered: root.sendContactRequest()
+    }
+
+    // Edit Nickname
+    StatusAction {
+        id: renameAction
+        objectName: "rename_StatusItem"
+        enabled: root.profileType === Constants.profileType.blocked || root.profileType === Constants.profileType.regular
+        text: root.hasLocalNickname ? qsTr("Edit nickname") : qsTr("Add nickname")
+        icon.name: "edit_pencil"
+        onTriggered: root.editNickname()
     }
 
     StatusMenuSeparator {
@@ -132,6 +143,16 @@ StatusMenu {
         onTriggered: root.removeNickname()
     }
 
+    // Remove trusted mark
+    StatusAction {
+        objectName: "removeTrustedMark_StatusItem"
+        enabled: root.profileType === Constants.profileType.regular && root.contactType === Constants.contactType.contact && root.trustStatus === Constants.trustStatus.trusted
+        text: qsTr("Remove trusted mark")
+        icon.name: "checkmark-circle"
+        type: StatusAction.Type.Danger
+        onTriggered: root.removeTrustedMark()
+    }
+
     // Unblock User
     StatusAction {
         id: unblockAction
@@ -148,7 +169,7 @@ StatusMenu {
         objectName: "removeFromGroup_StatusItem"
         icon.name: "remove-contact"
         type: StatusAction.Type.Danger
-        enabled: root.isAdmin && root.profileType !== Constants.profileType.self && root.chatType === Constants.chatType.privateGroupChat
+        enabled: root.isAdmin && root.profileType !== Constants.profileType.self && root.profileType !== Constants.profileType.bridged && root.chatType === Constants.chatType.privateGroupChat
         onTriggered: root.removeFromGroup()
     }
 


### PR DESCRIPTION
### What does the PR do

- enhance and fix the SB page to be able to show all the permutations, including profile image, emoji hash and ring

Fixes #16586

### Affected areas

ProfileContextMenu

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Mark as trusted:
![image](https://github.com/user-attachments/assets/61e2b9ee-56f1-4946-9afe-8ee03ade1a5d)

User marked as trusted:
![image](https://github.com/user-attachments/assets/2c234dd6-94ee-4b9b-bc61-a0c56878b663)

![image](https://github.com/user-attachments/assets/a4c920df-3600-4864-a9ed-3c3a45eaa1f3)

Removing the trusted mark:
![image](https://github.com/user-attachments/assets/fce0c53f-cad0-43b5-a8c2-3d9a0fdd91a2)

![image](https://github.com/user-attachments/assets/d65ea906-17b7-49c4-94ba-3bcdfcc97c52)

![image](https://github.com/user-attachments/assets/44efcec9-091b-461f-84c4-b08140a2dc7b)


Storybook:
![image](https://github.com/user-attachments/assets/f521773c-604c-466c-a282-6ebd716ca50f)

