### PR TITLE
Feat/update launch send modal mechanism

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -6,6 +6,7 @@ const DEFAULT_FLAG_SWAP_ENABLED = true
 const DEFAULT_FLAG_CONNECTOR_ENABLED* = true
 const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED = true
 const DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED = true
+const DEFAULT_FLAG_SIMPLE_SEND_ENABLED = false
 
 proc boolToEnv*(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"
@@ -17,6 +18,7 @@ QtObject:
     connectorEnabled: bool
     sendViaPersonalChatEnabled: bool
     paymentRequestEnabled: bool
+    simpleSendEnabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
@@ -25,6 +27,7 @@ QtObject:
     self.connectorEnabled = getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
     self.sendViaPersonalChatEnabled = getEnv("FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED", boolToEnv(DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED)) != "0"
     self.paymentRequestEnabled = getEnv("FLAG_PAYMENT_REQUEST_ENABLED", boolToEnv(DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED)) != "0"
+    self.simpleSendEnabled = getEnv("FLAG_SIMPLE_SEND_ENABLED", boolToEnv(DEFAULT_FLAG_SIMPLE_SEND_ENABLED)) != "0"
 
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
@@ -62,3 +65,9 @@ QtObject:
 
   QtProperty[bool] paymentRequestEnabled:
     read = getPaymentRequestEnabled
+
+  proc getSimpleSendEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.simpleSendEnabled
+
+  QtProperty[bool] simpleSendEnabled:
+    read = getSimpleSendEnabled

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -1,0 +1,52 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import AppLayouts.Wallet.popups.simpleSend 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Horizontal
+
+    function launchPopup() {
+        simpleSend.createObject(root)
+    }
+
+    PopupBackground {
+        id: popupBg
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Button {
+            id: reopenButton
+            anchors.centerIn: parent
+            text: "Reopen"
+            enabled: !simpleSend.visible
+
+            onClicked: launchPopup()
+        }
+
+        Component.onCompleted: launchPopup()
+    }
+
+    Component {
+        id: simpleSend
+        SimpleSendModal {
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 100
+
+    }
+}
+
+// category: Popups

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -47,8 +47,6 @@ StackLayout {
         allMembers: !!sectionItemModel ? sectionItemModel.allMembers : null
     }
 
-    property var sendModalPopup
-
     readonly property bool isOwner: sectionItemModel.memberRole === Constants.memberRole.owner
     readonly property bool isAdmin: sectionItemModel.memberRole === Constants.memberRole.admin
     readonly property bool isTokenMasterOwner: sectionItemModel.memberRole === Constants.memberRole.tokenMaster
@@ -170,7 +168,6 @@ StackLayout {
 
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
-            sendModalPopup: root.sendModalPopup
             sectionItemModel: root.sectionItemModel
             joinedMembersCount: membersModelAdaptor.joinedMembers.ModelCount.count
             areTestNetworksEnabled: root.areTestNetworksEnabled
@@ -265,7 +262,6 @@ StackLayout {
             enabledChainIds: WalletStore.RootStore.networkFilters
             onEnableNetwork: WalletStore.RootStore.enableNetwork(chainId)
             tokensStore: root.tokensStore
-            sendModalPopup: root.sendModalPopup
             transactionStore: root.transactionStore
 
             isPendingOwnershipRequest: root.isPendingOwnershipRequest

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -60,8 +60,10 @@ StackLayout {
 
     property var emojiPopup
     property var stickersPopup
+
     signal profileButtonClicked()
     signal openAppSearch()
+    signal buyStickerPackRequested(string packId, int price)
 
     // Community transfer ownership related props/signals:
     property bool isPendingOwnershipRequest: sectionItemModel.isPendingOwnershipRequest
@@ -243,6 +245,8 @@ StackLayout {
                 Global.communityIntroPopupRequested(communityId, root.sectionItemModel.name, root.sectionItemModel.introMessage,
                                                     root.sectionItemModel.image, root.isInvitationPending)
             }
+
+            onBuyStickerPackRequested: root.buyStickerPackRequested(packId, price)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -383,6 +383,10 @@ Item {
 
             stickersLoaded: root.stickersLoaded
 
+            onSendViaPersonalChatRequested: {
+                Global.sendToRecipientRequested(recipientAddress)
+            }
+
             onVisibleChanged: {
                 if(!visible && model.editMode)
                     messageStore.setEditModeOff(model.id)

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -119,6 +119,8 @@ StatusSectionLayout {
     signal requestToJoinClicked
     signal invitationPendingClicked
 
+    signal buyStickerPackRequested(string packId, int price)
+
     Connections {
         target: root.rootStore.stickersStore.stickersModule
 
@@ -361,9 +363,7 @@ StatusSectionLayout {
     Component {
         id: statusStickerPackClickPopup
         StatusStickerPackClickPopup{
-            onBuyClicked: {
-                Global.buyStickerPackRequested(packId, price)
-            }
+            onBuyClicked: root.buyStickerPackRequested(packId, price)
             onClosed: destroy()
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -51,7 +51,6 @@ StatusSectionLayout {
 
     property var mutualContactsModel
 
-    required property var sendModalPopup
     property var sectionItemModel
     property int joinedMembersCount
     property bool areTestNetworksEnabled
@@ -362,11 +361,10 @@ StatusSectionLayout {
     Component {
         id: statusStickerPackClickPopup
         StatusStickerPackClickPopup{
-            walletAssetsStore: root.walletAssetsStore
-            sendModalPopup: root.sendModalPopup
-            onClosed: {
-                destroy();
+            onBuyClicked: {
+                Global.buyStickerPackRequested(packId, price)
             }
+            onClosed: destroy()
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -31,7 +31,6 @@ StackView {
     required property string communityName
     required property string communityLogo
     required property color communityColor
-    property var sendModalPopup
 
     // User profile props:
     required property bool isOwner
@@ -786,8 +785,7 @@ StackView {
             onSendOwnershipClicked: Global.openTransferOwnershipPopup(root.communityId,
                                                                       root.communityName,
                                                                       root.communityLogo,
-                                                                      tokenViewPage.token,
-                                                                      root.sendModalPopup)
+                                                                      tokenViewPage.token)
 
             // helper properties to pass data through popups
             property var walletsAndAmounts

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -40,7 +40,6 @@ StackLayout {
     property bool requestToJoinEnabled
     property bool pinMessagesEnabled
     property string previousPageName: (currentIndex === 1) ? qsTr("Overview") : ""
-    property var sendModalPopup
 
     property bool archiveSupporVisible: true
     property bool editable: false
@@ -134,8 +133,15 @@ StackLayout {
                             Global.openTransferOwnershipPopup(root.communityId,
                                                               root.name,
                                                               root.logoImageData,
-                                                              root.ownerToken,
-                                                              root.sendModalPopup)
+                                                              {
+                                                                  key: "0",
+                                                                  privilegesLevel: root.ownerToken.privilegesLevel,
+                                                                  chainId: root.ownerToken.chainId,
+                                                                  name: root.ownerToken.name,
+                                                                  artworkSource: root.ownerToken.image,
+                                                                  accountAddress: root.ownerToken.accountAddress.toLowerCase(),
+                                                                  tokenAddress: root.ownerToken.tokenAddress.toLowerCase()
+                                                              })
                         } else {
                             Global.openPopup(transferOwnershipAlertPopup, { mode: TransferOwnershipAlertPopup.Mode.TransferOwnership })
                         }

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
@@ -26,9 +26,9 @@ StatusDialog {
 
     // Transaction related props:
     property var token // Expected roles: accountAddress, key, chainId, name, artworkSource
-    property var sendModalPopup
 
     signal cancelClicked
+    signal transferOwnershipRequested(string tokenId, string senderAddress)
 
     width: 640 // by design
     padding: Theme.padding
@@ -109,13 +109,9 @@ StatusDialog {
 
                 onClicked: {
                     // Pre-populated dialog with the relevant Owner token info:
-                    root.sendModalPopup.preSelectedSendType = Constants.SendType.ERC721Transfer
-                    root.sendModalPopup.preSelectedAccountAddress = token.accountAddress
                     const store = WalletStores.RootStore.currentActivityFiltersStore
                     const uid = store.collectiblesList.getUidForData(token.key, token.tokenAddress, token.chainId);
-                    root.sendModalPopup.preSelectedHoldingID = uid
-                    root.sendModalPopup.preSelectedHoldingType = Constants.TokenType.ERC721
-                    root.sendModalPopup.open()
+                    root.transferOwnershipRequested(uid, token.accountAddress)
                     close()
                 }
             }

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -46,7 +46,6 @@ StatusSectionLayout {
     required property var declinedMembers
     required property TransactionStore transactionStore
     property bool communitySettingsDisabled
-    property var sendModalPopup
 
     required property string enabledChainIds
 
@@ -221,7 +220,6 @@ StatusSectionLayout {
                 pubsubTopic: root.community.pubsubTopic
                 pubsubTopicKey: root.community.pubsubTopicKey
 
-                sendModalPopup: root.sendModalPopup
                 ownerToken: tokensModelChangesTracker.ownerToken
 
                 isPendingOwnershipRequest: root.isPendingOwnershipRequest
@@ -380,7 +378,6 @@ StatusSectionLayout {
                 communityName: root.community.name
                 communityLogo: root.community.image
                 communityColor: root.community.color
-                sendModalPopup: root.sendModalPopup
 
                 // User profile props
                 isOwner: root.isOwner

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -45,7 +45,6 @@ StatusSectionLayout {
     property ProfileStores.ProfileSectionStore store
     property AppLayoutsStores.RootStore globalStore
     property CommunitiesStore.CommunitiesStore communitiesStore
-    required property var sendModalPopup
     property var systemPalette
     property var emojiPopup
     property SharedStores.NetworkConnectionStore networkConnectionStore
@@ -259,10 +258,12 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 ensUsernamesStore: root.store.ensUsernamesStore
                 walletAssetsStore: root.walletAssetsStore
-                sendModalPopup: root.sendModalPopup
                 contactsStore: root.store.contactsStore
                 networkConnectionStore: root.networkConnectionStore
                 profileContentWidth: d.contentWidth
+                onConnectUsernameRequested: Global.connectUsernameRequested(ensName)
+                onRegisterUsernameRequested: Global.registerUsernameRequested(ensName)
+                onReleaseUsernameRequested: Global.releaseUsernameRequested(ensName, senderAddress, chainId)
             }
         }
 
@@ -300,7 +301,6 @@ StatusSectionLayout {
                 myPublicKey: root.store.contactsStore.myPublicKey
                 currencySymbol: root.sharedRootStore.currencyStore.currentCurrency
                 emojiPopup: root.emojiPopup
-                sendModalPopup: root.sendModalPopup
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.wallet)
             }
             onLoaded: root.store.backButtonName = ""

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -60,6 +60,10 @@ StatusSectionLayout {
 
     required property bool isCentralizedMetricsEnabled
 
+    signal connectUsernameRequested(string ensName)
+    signal registerUsernameRequested(string ensName)
+    signal releaseUsernameRequested(string ensName, string senderAddress, int chainId)
+
     backButtonName: root.store.backButtonName
     notificationCount: activityCenterStore.unreadNotificationsCount
     hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
@@ -261,9 +265,9 @@ StatusSectionLayout {
                 contactsStore: root.store.contactsStore
                 networkConnectionStore: root.networkConnectionStore
                 profileContentWidth: d.contentWidth
-                onConnectUsernameRequested: Global.connectUsernameRequested(ensName)
-                onRegisterUsernameRequested: Global.registerUsernameRequested(ensName)
-                onReleaseUsernameRequested: Global.releaseUsernameRequested(ensName, senderAddress, chainId)
+                onConnectUsernameRequested: root.connectUsernameRequested(ensName)
+                onRegisterUsernameRequested: root.registerUsernameRequested(ensName)
+                onReleaseUsernameRequested: root.releaseUsernameRequested(ensName, senderAddress, chainId)
             }
         }
 

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -20,7 +20,7 @@ Item {
     id: root
     property EnsUsernamesStore ensUsernamesStore
     property string username: ""
-    property string chainId: ""
+    property int chainId: -1
 
     signal backBtnClicked()
     signal releaseUsernameRequested(string senderAddress)

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -25,7 +25,7 @@ Item {
     property int profileContentWidth
 
     signal addBtnClicked()
-    signal selectEns(string username, string chainId)
+    signal selectEns(string username, int chainId)
 
     Component.onCompleted: {
         d.updateNumberOfPendingEnsUsernames()

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -24,8 +24,21 @@ Item {
     property EnsUsernamesStore ensUsernamesStore
     property string username: ""
 
+    required property var assetsModel
+
     signal backBtnClicked()
     signal registerUsername()
+
+    QtObject {
+        id: d
+
+        readonly property var sntToken: statusTokenEntry.item
+        readonly property SumAggregator aggregator: SumAggregator {
+            model: !!d.sntToken && !!d.sntToken.balances ? d.sntToken.balances: null
+            roleName: "balance"
+        }
+        property real sntBalance: !!sntToken && !!sntToken.decimals ? aggregator.value/(10 ** sntToken.decimals): 0
+    }
 
     StatusBaseText {
         id: sectionTitle
@@ -345,5 +358,12 @@ Item {
           qsTr("Register")
         enabled: d.sntBalance >= 10 && termsAndConditionsCheckbox.checked
         onClicked: root.registerUsername(root.username)
+    }
+
+    ModelEntry {
+        id: statusTokenEntry
+        sourceModel: root.assetsModel
+        key: "tokensKey"
+        value: root.ensUsernamesStore.getStatusTokenKey()
     }
 }

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -44,8 +44,6 @@ SettingsContentBase {
     required property WalletAssetsStore assetsStore
     required property CollectiblesStore collectiblesStore
 
-    required property var sendModalPopup
-
     readonly property int mainViewIndex: 0
     readonly property int networksViewIndex: 1
     readonly property int editNetworksViewIndex: 2
@@ -372,7 +370,10 @@ SettingsContentBase {
             id: savedAddressesView
             contactsStore: root.rootStore.contactsStore
             networkConnectionStore: root.networkConnectionStore
-            sendModal: root.sendModalPopup
+
+            onSendToAddressRequested: {
+                Global.sendToRecipientRequested(address)
+            }
         }
 
         Component {

--- a/ui/app/AppLayouts/Profile/views/wallet/SavedAddressesView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/SavedAddressesView.qml
@@ -12,11 +12,13 @@ ColumnLayout {
 
     property ContactsStore contactsStore
     property SharedStores.NetworkConnectionStore networkConnectionStore
-    property var sendModal
+
+    signal sendToAddressRequested(string address)
 
     SavedAddresses {
-        sendModal: root.sendModal
         contactsStore: root.contactsStore
         networkConnectionStore: root.networkConnectionStore
+
+        onSendToAddressRequested: root.sendToAddressRequested(address)
     }
 }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -37,7 +37,6 @@ Item {
     required property TransactionStore transactionStore
 
     property var emojiPopup: null
-    property var sendModalPopup
     property SharedStores.NetworkConnectionStore networkConnectionStore
     property bool appMainVisible
 
@@ -219,12 +218,15 @@ Item {
             store: root.store
             contactsStore: root.contactsStore
             networkConnectionStore: root.networkConnectionStore
-            sendModal: root.sendModalPopup
 
             networkFilter.visible: false
             headerButton.text: qsTr("Add new address")
             headerButton.onClicked: {
                 Global.openAddEditSavedAddressesPopup({})
+            }
+
+            onSendToAddressRequested: {
+                Global.sendToRecipientRequested(address)
             }
         }
     }
@@ -236,7 +238,6 @@ Item {
             store: root.store
             contactsStore: root.contactsStore
             communitiesStore: root.communitiesStore
-            sendModal: root.sendModalPopup
             networkConnectionStore: root.networkConnectionStore
 
             swapEnabled: root.swapEnabled
@@ -346,40 +347,33 @@ Item {
                                                                   hasFloatingButtons: true
                                                               })
             onLaunchSendModal: (fromAddress) => {
-                if(isCommunityOwnershipTransfer) {
-                    const tokenItem = walletStore.currentViewedCollectible
-                    const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
+                                   if(isCommunityOwnershipTransfer) {
+                                       const tokenItem = walletStore.currentViewedCollectible
+                                       const ownership = StatusQUtils.ModelUtils.get(tokenItem.ownership, 0)
 
-                    Global.openTransferOwnershipPopup(tokenItem.communityId,
-                                                      footer.communityName,
-                                                      tokenItem.communityImage,
-                                                      {
-                                                          key: tokenItem.tokenId,
-                                                          privilegesLevel: tokenItem.communityPrivilegesLevel,
-                                                          chainId: tokenItem.chainId,
-                                                          name: tokenItem.name,
-                                                          artworkSource: tokenItem.artworkSource,
-                                                          accountAddress: fromAddress,
-                                                          tokenAddress: tokenItem.contractAddress
-                                                      },
-                                                      root.sendModalPopup)
-                    return
-                }
+                                       Global.openTransferOwnershipPopup(tokenItem.communityId,
+                                                                         footer.communityName,
+                                                                         tokenItem.communityImage,
+                                                                         {
+                                                                             key: tokenItem.tokenId,
+                                                                             privilegesLevel: tokenItem.communityPrivilegesLevel,
+                                                                             chainId: tokenItem.chainId,
+                                                                             name: tokenItem.name,
+                                                                             artworkSource: tokenItem.artworkSource,
+                                                                             accountAddress: fromAddress,
+                                                                             tokenAddress: tokenItem.contractAddress
+                                                                         })
+                                       return
+                                   }
 
-                // Common send modal popup:
-                root.sendModalPopup.preSelectedAccountAddress = fromAddress
-                root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
-                root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingTokensKey
-                root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
-                root.sendModalPopup.onlyAssets = false
-                root.sendModalPopup.open()
-            }
+                                   // Common send modal popup:
+                                   Global.sendTokenRequested(fromAddress,
+                                                             walletStore.currentViewedHoldingTokensKey,
+                                                             walletStore.currentViewedHoldingType)
+                               }
             onLaunchBridgeModal: {
-                root.sendModalPopup.preSelectedSendType = Constants.SendType.Bridge
-                root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
-                root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
-                root.sendModalPopup.onlyAssets = true
-                root.sendModalPopup.open()
+                Global.bridgeTokenRequested(walletStore.currentViewedHoldingID,
+                                            walletStore.currentViewedHoldingType)
             }
             onLaunchSwapModal: {
                 d.swapFormData.fromTokensKey =  ""

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -50,6 +50,10 @@ Item {
     signal dappPairRequested()
     signal dappDisconnectRequested(string dappUrl)
 
+    // TODO: remove tokenType parameter from signals below
+    signal sendTokenRequested(string senderAddress, string tokenId, int tokenType)
+    signal bridgeTokenRequested(string tokenId, int tokenType)
+
     onAppMainVisibleChanged: {
         resetView()
     }
@@ -263,6 +267,8 @@ Item {
             onDappPairRequested: root.dappPairRequested()
             onDappDisconnectRequested: (dappUrl) => root.dappDisconnectRequested(dappUrl)
             onLaunchBuyCryptoModal: d.launchBuyCryptoModal()
+
+            onSendTokenRequested: root.sendTokenRequested(senderAddress, tokenId, tokenType)
         }
     }
 
@@ -367,13 +373,13 @@ Item {
                                    }
 
                                    // Common send modal popup:
-                                   Global.sendTokenRequested(fromAddress,
+                                   root.sendTokenRequested(fromAddress,
                                                              walletStore.currentViewedHoldingTokensKey,
                                                              walletStore.currentViewedHoldingType)
                                }
             onLaunchBridgeModal: {
-                Global.bridgeTokenRequested(walletStore.currentViewedHoldingID,
-                                            walletStore.currentViewedHoldingType)
+                root.bridgeTokenRequested(walletStore.currentViewedHoldingID,
+                                          walletStore.currentViewedHoldingType)
             }
             onLaunchSwapModal: {
                 d.swapFormData.fromTokensKey =  ""

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -122,7 +122,7 @@ Rectangle {
             interactive: !d.isCollectibleSoulbound && networkConnectionStore.sendBuyBridgeEnabled
             onClicked: {
                 root.transactionStore.setSenderAccount(root.walletStore.selectedAddress)
-                root.launchSendModal(d.userOwnedAddressForCollectible)
+                root.launchSendModal(d.isCollectibleViewed ? d.userOwnedAddressForCollectible: root.walletStore.selectedAddress)
             }
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be sent to another wallet") : networkConnectionStore.sendBuyBridgeToolTipText
             visible: d.sendActionAvailable

--- a/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
@@ -14,6 +14,7 @@ import AppLayouts.Wallet.stores 1.0 as WalletStore
 
 import utils 1.0
 import shared.views 1.0
+import shared.popups.send 1.0
 import shared.stores 1.0 as SharedStores
 
 import "../controls"
@@ -24,7 +25,8 @@ StatusModal {
 
     property SharedStores.NetworkConnectionStore networkConnectionStore
     property ProfileStores.ContactsStore contactsStore
-    property var sendModalPopup
+
+    signal sendToAddressRequested(string address)
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
     hasCloseButton: false
@@ -162,8 +164,8 @@ StatusModal {
                         root.close()
                     }
                     onOpenSendModal: {
-                        root.close()
-                        root.sendModalPopup.open(recipient)
+                        root.sendToAddressRequested(recipient)
+                        root.close()  
                     }
                 }
 
@@ -240,8 +242,8 @@ StatusModal {
                     icon.name: "send"
                     enabled: root.networkConnectionStore.sendBuyBridgeEnabled
                     onClicked: {
+                        root.sendToAddressRequested(d.visibleAddress)
                         root.close()
-                        root.sendModalPopup.open(d.visibleAddress)
                     }
                 }
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.15
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    id: popup
+
+    title: qsTr("Send")
+
+    padding: 0
+    background: StatusDialogBackground {
+        implicitHeight: 846
+        implicitWidth: 556
+        color: Theme.palette.baseColor3
+    }
+}

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/qmldir
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/qmldir
@@ -1,0 +1,1 @@
+SimpleSendModal 1.0 SimpleSendModal.qml

--- a/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
@@ -26,8 +26,6 @@ FocusScope {
 
     property var dAppsModel
 
-    property var sendModal
-
     property alias header: header
     property alias headerButton: header.headerButton
     property alias networkFilter: header.networkFilter

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -309,13 +309,8 @@ RightTabBaseView {
                         swapVisible: root.swapEnabled
 
                         onSendRequested: {
-                            const modal = root.sendModal
-
-                            modal.preSelectedSendType = Constants.SendType.Transfer
-                            modal.preSelectedHoldingID = key
-                            modal.preSelectedHoldingType = Constants.TokenType.ERC20
-                            modal.onlyAssets = true
-                            modal.open()
+                            Global.sendTokenRequested(RootStore.overview.mixedcaseAddress.toLowerCase(),
+                                                      key, Constants.TokenType.ERC20)
                         }
 
                         onSwapRequested: root.launchSwapModal(key)
@@ -415,33 +410,27 @@ RightTabBaseView {
                             stack.currentIndex = 1
                         }
                         onSendRequested: (symbol, tokenType, fromAddress) => {
-                            const collectible = ModelUtils.getByKey(controller.sourceModel, "symbol", symbol)
-                            if (!!collectible && collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) {
-                                Global.openTransferOwnershipPopup(collectible.communityId,
-                                                                  collectible.communityName,
-                                                                  collectible.communityImage,
-                                                                  {
-                                                                      key: collectible.tokenId,
-                                                                      privilegesLevel: collectible.communityPrivilegesLevel,
-                                                                      chainId: collectible.chainId,
-                                                                      name: collectible.name,
-                                                                      artworkSource: collectible.communityImage,
-                                                                      accountAddress: fromAddress,
-                                                                      tokenAddress: collectible.contractAddress
-                                                                  },
-                                                                  root.sendModal)
-                                return
-                            }
-                        
-                            root.sendModal.preSelectedAccountAddress = fromAddress
-                            root.sendModal.preSelectedHoldingID = symbol
-                            root.sendModal.preSelectedHoldingType = tokenType
-                            root.sendModal.preSelectedSendType = tokenType === Constants.TokenType.ERC721 ?
-                                    Constants.SendType.ERC721Transfer:
-                                    Constants.SendType.ERC1155Transfer
-                            root.sendModal.onlyAssets = false
-                            root.sendModal.open()
-                        }
+                                             const collectible = ModelUtils.getByKey(controller.sourceModel, "symbol", symbol)
+                                             if (!!collectible && collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) {
+                                                 Global.openTransferOwnershipPopup(collectible.communityId,
+                                                                                   collectible.communityName,
+                                                                                   collectible.communityImage,
+                                                                                   {
+                                                                                       key: collectible.tokenId,
+                                                                                       privilegesLevel: collectible.communityPrivilegesLevel,
+                                                                                       chainId: collectible.chainId,
+                                                                                       name: collectible.name,
+                                                                                       artworkSource: collectible.communityImage,
+                                                                                       accountAddress: fromAddress,
+                                                                                       tokenAddress: collectible.contractAddress
+                                                                                   })
+                                                 return
+                                             }
+
+                                             Global.sendTokenRequested(fromAddress ,
+                                                                       symbol,
+                                                                       tokenType)
+                                         }
                         onReceiveRequested: (symbol) => root.launchShareAddressModal()
                         onSwitchToCommunityRequested: (communityId) => Global.switchToCommunity(communityId)
                         onManageTokensRequested: Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.wallet,

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -38,6 +38,8 @@ RightTabBaseView {
     signal launchShareAddressModal()
     signal launchBuyCryptoModal()
     signal launchSwapModal(string tokensKey)
+    signal sendTokenRequested(string senderAddress, string tokenId, int tokenType)
+
 
     function resetView() {
         resetStack()
@@ -309,8 +311,8 @@ RightTabBaseView {
                         swapVisible: root.swapEnabled
 
                         onSendRequested: {
-                            Global.sendTokenRequested(RootStore.overview.mixedcaseAddress.toLowerCase(),
-                                                      key, Constants.TokenType.ERC20)
+                            root.sendTokenRequested(RootStore.overview.mixedcaseAddress.toLowerCase(),
+                                                    key, Constants.TokenType.ERC20)
                         }
 
                         onSwapRequested: root.launchSwapModal(key)
@@ -427,9 +429,7 @@ RightTabBaseView {
                                                  return
                                              }
 
-                                             Global.sendTokenRequested(fromAddress ,
-                                                                       symbol,
-                                                                       tokenType)
+                                             root.sendTokenRequested(fromAddress, symbol, tokenType)
                                          }
                         onReceiveRequested: (symbol) => root.launchShareAddressModal()
                         onSwitchToCommunityRequested: (communityId) => Global.switchToCommunity(communityId)

--- a/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
@@ -20,9 +20,10 @@ import "../controls"
 ColumnLayout {
     id: root
 
-    property var sendModal
     property ProfileStores.ContactsStore contactsStore
     property SharedStores.NetworkConnectionStore networkConnectionStore
+
+    signal sendToAddressRequested(string address)
 
     QtObject {
         id: d
@@ -149,7 +150,7 @@ ColumnLayout {
             colorId: model.colorId
             networkConnectionStore: root.networkConnectionStore
             areTestNetworksEnabled: RootStore.areTestNetworksEnabled
-            onOpenSendModal: root.sendModal.open(recipient);
+            onOpenSendModal: root.sendToAddressRequested(recipient)
 
             states: [
                 State {

--- a/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
@@ -3,13 +3,16 @@ import QtQuick 2.13
 RightTabBaseView {
     id: root
 
+    signal sendToAddressRequested(string address)
+
     SavedAddresses {
         objectName: "savedAddressesArea"
         width: root.width
         height: root.height - header.height
 
-        sendModal: root.sendModal
         contactsStore: root.contactsStore
         networkConnectionStore: root.networkConnectionStore
+
+        onSendToAddressRequested: root.sendToAddressRequested(address)
     }
 }

--- a/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
@@ -6,4 +6,5 @@ QtObject {
     property bool swapEnabled
     property bool sendViaPersonalChatEnabled
     property bool paymentRequestEnabled
+    property bool simpleSendEnabled
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -100,6 +100,7 @@ Item {
         swapEnabled: featureFlags ? featureFlags.swapEnabled : false
         sendViaPersonalChatEnabled: featureFlags ? featureFlags.sendViaPersonalChatEnabled : false
         paymentRequestEnabled: featureFlags ? featureFlags.paymentRequestEnabled : false
+        simpleSendEnabled: featureFlags ? featureFlags.simpleSendEnabled : false
     }
 
     required property bool isCentralizedMetricsEnabled
@@ -656,6 +657,8 @@ Item {
         // for sticker flows
         stickersMarketAddress: appMain.rootChatStore.stickersStore.getStickersMarketAddress()
         stickersNetworkId: appMain.rootChatStore.appNetworkId
+
+        simpleSendEnabled: appMain.featureFlagsStore.simpleSendEnabled
 
         Component.onCompleted: {
             // It's requested from many nested places, so as a workaround we use

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -140,6 +140,8 @@ Item {
         rootChatStore: appMain.rootChatStore
         communityTokensStore: appMain.communityTokensStore
         profileStore: appMain.profileStore
+
+        onSendRequested: sendModalHandler.openSend()
     }
 
     Connections {
@@ -633,9 +635,12 @@ Item {
                 appMainLocalSettings.whitelistedUnfurledDomains = whitelistedHostnames
             }
         }
+        onTransferOwnershipRequested: sendModalHandler.transferOwnership(tokenId, senderAddress)
     }
 
     SendModalHandler {
+        id: sendModalHandler
+
         popupParent: appMain
         loginType: appMain.rootStore.loginType
         transactionStore: appMain.transactionStore
@@ -651,6 +656,12 @@ Item {
         // for sticker flows
         stickersMarketAddress: appMain.rootChatStore.stickersStore.getStickersMarketAddress()
         stickersNetworkId: appMain.rootChatStore.appNetworkId
+
+        Component.onCompleted: {
+            // It's requested from many nested places, so as a workaround we use
+            // Global to shorten the path via global signal.
+            Global.sendToRecipientRequested.connect(sendToRecipient)
+        }
     }
 
     Connections {
@@ -878,7 +889,7 @@ Item {
         sourceComponent: StatusStickersPopup {
             store: appMain.rootChatStore
             isWalletEnabled: appMain.profileStore.isWalletEnabled
-            onBuyClicked: Global.buyStickerPackRequested(packId, price)
+            onBuyClicked: sendModalHandler.buyStickerPack(packId, price)
         }
     }
 
@@ -1632,6 +1643,8 @@ Item {
                                 onOpenAppSearch: {
                                     appSearch.openSearchPopup()
                                 }
+
+                                onBuyStickerPackRequested: sendModalHandler.buyStickerPack(packId, price)
                             }
                         }
                     }
@@ -1672,6 +1685,9 @@ Item {
 
                             onDappPairRequested: dAppsServiceLoader.dappPairRequested()
                             onDappDisconnectRequested: (dappUrl) => dAppsServiceLoader.dappDisconnectRequested(dappUrl)
+			     onSendTokenRequested: sendModalHandler.sendToken(
+                                                      senderAddress, tokenId, tokenType)
+                            onBridgeTokenRequested: sendModalHandler.bridgeToken(tokenId, tokenType)
                         }
                         onLoaded: {
                             item.resetView()
@@ -1712,6 +1728,10 @@ Item {
                             }
 
                             onSettingsSubsectionChanged: profileLoader.settingsSubsection = settingsSubsection
+
+                            onConnectUsernameRequested: sendModalHandler.connectUsername(ensName)
+                            onRegisterUsernameRequested: sendModalHandler.registerUsername(ensName)
+                            onReleaseUsernameRequested: sendModalHandler.releaseUsername(ensName, senderAddress, chainId)
                         }
                     }
 
@@ -1810,6 +1830,8 @@ Item {
                                 onOpenAppSearch: {
                                     appSearch.openSearchPopup()
                                 }
+
+                                onBuyStickerPackRequested: sendModalHandler.buyStickerPack(packId, price)
                             }
                         }
                     }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -63,6 +63,7 @@ QtObject {
     signal openExternalLink(string link)
     signal saveDomainToUnfurledWhitelist(string domain)
     signal ownershipDeclined(string communityId, string communityName)
+    signal transferOwnershipRequested(string tokenId, string senderAddress)
 
     property var activePopupComponents: []
 
@@ -1064,9 +1065,8 @@ QtObject {
         Component {
             id: transferOwnershipPopup
             TransferOwnershipPopup {
-                onTransferOwnershipRequested: {
-                    Global.transferOwnershipRequested(tokenId, senderAddress)
-                }
+                onTransferOwnershipRequested: root.transferOwnershipRequested(
+                                                  tokenId, senderAddress)
                 onClosed: destroy()
             }
         },

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -353,8 +353,8 @@ QtObject {
         openPopup(importControlNodePopup, { community })
     }
 
-    function openTransferOwnershipPopup(communityId, communityName, communityLogo, token, sendModalPopup) {
-        openPopup(transferOwnershipPopup, { communityId, communityName, communityLogo, token, sendModalPopup })
+    function openTransferOwnershipPopup(communityId, communityName, communityLogo, token) {
+        openPopup(transferOwnershipPopup, { communityId, communityName, communityLogo, token })
     }
 
     function openConfirmExternalLinkPopup(link, domain) {
@@ -1064,6 +1064,9 @@ QtObject {
         Component {
             id: transferOwnershipPopup
             TransferOwnershipPopup {
+                onTransferOwnershipRequested: {
+                    Global.transferOwnershipRequested(tokenId, senderAddress)
+                }
                 onClosed: destroy()
             }
         },

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -1,0 +1,164 @@
+import QtQuick 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Wallet.stores 1.0 as WalletStores
+
+import shared.popups.send 1.0
+import shared.stores.send 1.0
+
+import utils 1.0
+
+QtObject {
+    id: root
+
+    required property var popupParent
+    required property int loginType
+    required property TransactionStore transactionStore
+    required property WalletStores.CollectiblesStore walletCollectiblesStore
+
+    // for ens flows
+    required property string myPublicKey
+    required property string ensRegisteredAddress
+    // TODO: This should probably be a property and not a function. Needs changes on  backend side
+    property var getStatusTokenKey: function() {}
+
+    // for sticker flows
+    required property string stickersMarketAddress
+    required property string stickersNetworkId
+
+    Component.onCompleted: {
+        Global.launchSendRequested.connect(openSend)
+        Global.connectUsernameRequested.connect(connectUsernameRequested)
+        Global.registerUsernameRequested.connect(registerUsernameRequested)
+        Global.releaseUsernameRequested.connect(releaseUsernameRequested)
+        Global.buyStickerPackRequested.connect(buyStickerPackRequested)
+        Global.transferOwnershipRequested.connect(transferOwnershipRequested)
+        Global.sendToRecipientRequested.connect(sendToRecipientRequested)
+        Global.bridgeTokenRequested.connect(bridgeTokenRequested)
+        Global.sendTokenRequested.connect(sendTokenRequested)
+    }
+
+    function openSend(params = {}) {
+        let sendModalInst = sendModalComponent.createObject(popupParent, params)
+        if (sendModalInst.opened) {
+            return
+        }
+        sendModalInst.open()
+    }
+
+    function connectUsernameRequested(ensName) {
+        let params = {
+            preSelectedSendType: Constants.SendType.ENSSetPubKey,
+            preSelectedHoldingID: Constants.ethToken ,
+            preSelectedHoldingType: Constants.TokenType.Native,
+            preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0),
+            preSelectedRecipient: root.ensRegisteredAddress,
+            interactive: false,
+            publicKey: root.myPublicKey,
+            ensName: ensName
+        }
+        openSend(params)
+    }
+
+    function registerUsernameRequested(ensName) {
+        let params = {
+            preSelectedSendType: Constants.SendType.ENSRegister,
+            preSelectedHoldingID: root.getStatusTokenKey(),
+            preSelectedHoldingType: Constants.TokenType.ERC20,
+            preDefinedAmountToSend: LocaleUtils.numberToLocaleString(10),
+            preSelectedRecipient: root.ensRegisteredAddress,
+            interactive: false,
+            publicKey: root.myPublicKey,
+            ensName: ensName
+        }
+        openSend(params)
+    }
+
+    function releaseUsernameRequested(ensName, senderAddress, chainId) {
+        let params = {
+            preSelectedSendType: Constants.SendType.ENSRelease,
+            preSelectedAccountAddress: senderAddress,
+            preSelectedHoldingID: Constants.ethToken ,
+            preSelectedHoldingType: Constants.TokenType.Native,
+            preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0),
+            preSelectedChainId: chainId,
+            preSelectedRecipient: root.ensRegisteredAddress,
+            interactive: false,
+            publicKey: root.myPublicKey,
+            ensName: ensName
+        }
+        openSend(params)
+    }
+
+    function buyStickerPackRequested(packId, price) {
+        let params = {
+            preSelectedSendType: Constants.SendType.StickersBuy,
+            preSelectedHoldingID: root.getStatusTokenKey(),
+            preSelectedHoldingType: Constants.TokenType.ERC20,
+            preDefinedAmountToSend: LocaleUtils.numberToLocaleString(price),
+            preSelectedChainId: root.stickersNetworkId,
+            preSelectedRecipient: root.stickersMarketAddress,
+            interactive: false,
+            stickersPackId: packId
+        }
+        openSend(params)
+    }
+
+    function transferOwnershipRequested(tokenId, senderAddress) {
+        let params = {
+            preSelectedSendType: Constants.SendType.ERC721Transfer,
+            preSelectedAccountAddress: senderAddress,
+            preSelectedHoldingID: tokenId,
+            preSelectedHoldingType:  Constants.TokenType.ERC721,
+        }
+        openSend(params)
+    }
+
+    function sendToRecipientRequested(recipientAddress) {
+        let params = {
+            preSelectedRecipient: recipientAddress
+        }
+        openSend(params)
+    }
+
+    function bridgeTokenRequested(tokenId, tokenType) {
+        let params = {
+            preSelectedSendType: Constants.SendType.Bridge,
+            preSelectedHoldingID: tokenId ,
+            preSelectedHoldingType: tokenType,
+            onlyAssets: true
+        }
+        openSend(params)
+    }
+
+    function sendTokenRequested(senderAddress, tokenId, tokenType) {
+        let sendType = Constants.SendType.Transfer
+        if (tokenType === Constants.TokenType.ERC721)  {
+            sendType = Constants.SendType.ERC721Transfer
+        } else if(tokenType === Constants.TokenType.ERC1155) {
+            sendType = Constants.SendType.ERC1155Transfer
+        }
+        let params = {
+            preSelectedSendType: sendType,
+            preSelectedAccountAddress: senderAddress,
+            preSelectedHoldingID: tokenId ,
+            preSelectedHoldingType: tokenType,
+        }
+        openSend(params)
+    }
+
+    readonly property Component sendModalComponent: Component {
+        SendModal {
+            loginType: root.loginType
+
+            store: root.transactionStore
+            collectiblesStore: root.walletCollectiblesStore
+
+            showCustomRoutingMode: !production
+
+            onClosed: destroy()
+        }
+    }
+}

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -28,27 +28,15 @@ QtObject {
     required property string stickersMarketAddress
     required property string stickersNetworkId
 
-    Component.onCompleted: {
-        Global.launchSendRequested.connect(openSend)
-        Global.connectUsernameRequested.connect(connectUsernameRequested)
-        Global.registerUsernameRequested.connect(registerUsernameRequested)
-        Global.releaseUsernameRequested.connect(releaseUsernameRequested)
-        Global.buyStickerPackRequested.connect(buyStickerPackRequested)
-        Global.transferOwnershipRequested.connect(transferOwnershipRequested)
-        Global.sendToRecipientRequested.connect(sendToRecipientRequested)
-        Global.bridgeTokenRequested.connect(bridgeTokenRequested)
-        Global.sendTokenRequested.connect(sendTokenRequested)
-    }
-
     function openSend(params = {}) {
-        let sendModalInst = sendModalComponent.createObject(popupParent, params)
-        if (sendModalInst.opened) {
+        if (!!root._sendModalInstance) {
             return
         }
-        sendModalInst.open()
+        _sendModalInstance = sendModalComponent.createObject(popupParent, params)
+        _sendModalInstance.open()
     }
 
-    function connectUsernameRequested(ensName) {
+    function connectUsername(ensName) {
         let params = {
             preSelectedSendType: Constants.SendType.ENSSetPubKey,
             preSelectedHoldingID: Constants.ethToken ,
@@ -62,7 +50,7 @@ QtObject {
         openSend(params)
     }
 
-    function registerUsernameRequested(ensName) {
+    function registerUsername(ensName) {
         let params = {
             preSelectedSendType: Constants.SendType.ENSRegister,
             preSelectedHoldingID: root.getStatusTokenKey(),
@@ -76,7 +64,7 @@ QtObject {
         openSend(params)
     }
 
-    function releaseUsernameRequested(ensName, senderAddress, chainId) {
+    function releaseUsername(ensName, senderAddress, chainId) {
         let params = {
             preSelectedSendType: Constants.SendType.ENSRelease,
             preSelectedAccountAddress: senderAddress,
@@ -92,7 +80,7 @@ QtObject {
         openSend(params)
     }
 
-    function buyStickerPackRequested(packId, price) {
+    function buyStickerPack(packId, price) {
         let params = {
             preSelectedSendType: Constants.SendType.StickersBuy,
             preSelectedHoldingID: root.getStatusTokenKey(),
@@ -106,7 +94,7 @@ QtObject {
         openSend(params)
     }
 
-    function transferOwnershipRequested(tokenId, senderAddress) {
+    function transferOwnership(tokenId, senderAddress) {
         let params = {
             preSelectedSendType: Constants.SendType.ERC721Transfer,
             preSelectedAccountAddress: senderAddress,
@@ -116,14 +104,14 @@ QtObject {
         openSend(params)
     }
 
-    function sendToRecipientRequested(recipientAddress) {
+    function sendToRecipient(recipientAddress) {
         let params = {
             preSelectedRecipient: recipientAddress
         }
         openSend(params)
     }
 
-    function bridgeTokenRequested(tokenId, tokenType) {
+    function bridgeToken(tokenId, tokenType) {
         let params = {
             preSelectedSendType: Constants.SendType.Bridge,
             preSelectedHoldingID: tokenId ,
@@ -133,7 +121,7 @@ QtObject {
         openSend(params)
     }
 
-    function sendTokenRequested(senderAddress, tokenId, tokenType) {
+    function sendToken(senderAddress, tokenId, tokenType) {
         let sendType = Constants.SendType.Transfer
         if (tokenType === Constants.TokenType.ERC721)  {
             sendType = Constants.SendType.ERC721Transfer
@@ -161,4 +149,7 @@ QtObject {
             onClosed: destroy()
         }
     }
+
+    // internally used to handle the instance thats launched
+    property var _sendModalInstance
 }

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -4,6 +4,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Wallet.stores 1.0 as WalletStores
+import AppLayouts.Wallet.popups.simpleSend 1.0
 
 import shared.popups.send 1.0
 import shared.stores.send 1.0
@@ -28,12 +29,14 @@ QtObject {
     required property string stickersMarketAddress
     required property string stickersNetworkId
 
+    // Feature flag for single network send until its feature complete
+    required property bool simpleSendEnabled
+
     function openSend(params = {}) {
-        if (!!root._sendModalInstance) {
-            return
-        }
-        _sendModalInstance = sendModalComponent.createObject(popupParent, params)
-        _sendModalInstance.open()
+        // TODO remove once simple send is feature complete
+        let sendModalCmp = root.simpleSendEnabled ? simpleSendModalComponent: sendModalComponent
+        let sendModalInst = sendModalCmp.createObject(popupParent, params)
+        sendModalInst.open()
     }
 
     function connectUsername(ensName) {
@@ -150,6 +153,9 @@ QtObject {
         }
     }
 
-    // internally used to handle the instance thats launched
-    property var _sendModalInstance
+    readonly property Component simpleSendModalComponent: Component {
+        SimpleSendModal {
+            onClosed: destroy()
+        }
+    }
 }

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -34,9 +34,6 @@ QtObject {
     required property SharedStores.CommunityTokensStore communityTokensStore
     required property ProfileStore profileStore
 
-    // Properties:
-    required property var sendModalPopup
-
     // Utils:
     readonly property string viewOptimismExplorerText: qsTr("View on Optimism Explorer")
     readonly property string checkmarkCircleAssetName: "checkmark-circle"
@@ -241,7 +238,7 @@ QtObject {
             Global.openFinaliseOwnershipPopup(actionData)
             return
         case ToastsManager.ActionType.OpenSendModalPopup:
-            root.sendModalPopup.open()
+            Global.launchSendRequested()
             return
         case ToastsManager.ActionType.ViewTransactionDetails:
             if(actionData) {

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -40,6 +40,8 @@ QtObject {
     readonly property string crownOffAssetName: "crown-off"
     readonly property string warningAssetName: "warning"
 
+    signal sendRequested
+
     // Community Transfer Ownership related toasts:
     readonly property Connections _communityTokensStoreConnections: Connections {
         target: root.communityTokensStore
@@ -238,7 +240,7 @@ QtObject {
             Global.openFinaliseOwnershipPopup(actionData)
             return
         case ToastsManager.ActionType.OpenSendModalPopup:
-            Global.launchSendRequested()
+            root.sendRequested()
             return
         case ToastsManager.ActionType.ViewTransactionDetails:
             if(actionData) {

--- a/ui/app/mainui/qmldir
+++ b/ui/app/mainui/qmldir
@@ -3,3 +3,4 @@ SplashScreen 1.0 SplashScreen.qml
 Popups 1.0 Popups.qml
 StatusTrayIcon 1.0 StatusTrayIcon.qml
 DropAreaPanel 1.0 panels/DropAreaPanel.qml
+SendModalHandler 1.0 SendModalHandler.qml

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -184,6 +184,20 @@ StatusDialog {
             d.routerErrorDetails = ""
             debounceRecalculateRoutesAndFees()
         }
+
+        function getTitleText() {
+            switch (store.sendType) {
+            case Constants.SendType.Bridge:
+                return qsTr("Bridge")
+            case Constants.SendType.ENSRegister:
+                return qsTr("Register Ens")
+            case Constants.SendType.ENSSetPubKey:
+                return qsTr("Connect username")
+            case Constants.SendType.ENSRelease:
+                return qsTr("Release username")
+            default: return qsTr("Send")
+            }
+        }
     }
 
     LeftJoinModel {
@@ -388,7 +402,7 @@ StatusDialog {
                         objectName: "modalHeader"
                         Layout.maximumWidth: contentWidth
                         Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-                        text: d.isBridgeTx ? qsTr("Bridge") : qsTr("Send")
+                        text: d.getTitleText()
                     }
 
                     TokenSelector {

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -26,8 +26,6 @@ Item {
 
     property ChatStores.RootStore store
     property var stickerPacks: ChatStores.StickerPackData {}
-    required property WalletAssetsStore walletAssetsStore
-    required property var sendModalPopup
     property string packId
     property bool marketVisible
     property bool isWalletEnabled
@@ -37,27 +35,7 @@ Item {
     signal installClicked(var stickers, string packId, int index)
     signal cancelClicked(string packId)
     signal updateClicked(string packId)
-    signal buyClicked(string packId)
-
-    QtObject {
-        id: d
-
-        function runSendModal(price, packId) {
-
-            const token = ModelUtils.getByKey(root.walletAssetsStore.groupedAccountAssetsModel, "tokensKey", root.store.stickersStore.getStatusTokenKey())
-
-            root.sendModalPopup.interactive = false
-            root.sendModalPopup.preSelectedRecipient = root.store.stickersStore.getStickersMarketAddress()
-            root.sendModalPopup.preSelectedRecipientType = Helpers.RecipientAddressObjectType.Address
-            root.sendModalPopup.preSelectedHoldingID = !!token && !!token.symbol ? token.symbol : ""
-            root.sendModalPopup.preSelectedHoldingType = Constants.TokenType.ERC20
-            root.sendModalPopup.preSelectedSendType = Constants.SendType.StickersBuy
-            root.sendModalPopup.preDefinedAmountToSend = LocaleUtils.numberToLocaleString(parseFloat(price))
-            root.sendModalPopup.preSelectedChainId = root.store.appNetworkId
-            root.sendModalPopup.stickersPackId = packId
-            root.sendModalPopup.open()
-        }
-    }
+    signal buyClicked(string packId, int price)
 
     StatusGridView {
         id: availableStickerPacks
@@ -174,10 +152,7 @@ Item {
                         onUninstallClicked: root.uninstallClicked(packId)
                         onCancelClicked: root.cancelClicked(packId)
                         onUpdateClicked: root.updateClicked(packId)
-                        onBuyClicked: {
-                            d.runSendModal(price, packId)
-                            root.buyClicked(packId)
-                        }
+                        onBuyClicked: root.buyClicked(packId, price)
                     }
                 }
 
@@ -207,10 +182,7 @@ Item {
                         onUninstallClicked: root.uninstallClicked(packId)
                         onCancelClicked: root.cancelClicked(packId)
                         onUpdateClicked: root.updateClicked(packId)
-                        onBuyClicked: {
-                            d.runSendModal(price, packId)
-                            root.buyClicked(packId)
-                        }
+                        onBuyClicked: root.buyClicked(packId, price)
                     }
                 }
             }

--- a/ui/imports/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/imports/shared/status/StatusStickerPackClickPopup.qml
@@ -5,6 +5,7 @@ import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1 as SQUtils
+import StatusQ.Core.Theme 0.1
 
 import utils 1.0
 import shared 1.0
@@ -16,17 +17,14 @@ import shared.stores.send 1.0
 
 //TODO remove this dependency!
 import AppLayouts.Chat.stores 1.0 as ChatStores
-import AppLayouts.Wallet.stores 1.0
 
 // TODO: replace with StatusModal
 ModalPopup {
-    id: stickerPackDetailsPopup
+    id: root
 
     property string packId
 
     property ChatStores.RootStore store
-    required property WalletAssetsStore walletAssetsStore
-    required property var sendModalPopup
     property string thumbnail: ""
     property string name: ""
     property string author: ""
@@ -35,7 +33,7 @@ ModalPopup {
     property bool bought: false
     property bool pending: false
     property var stickers
-    signal buyClicked(string packId)
+    signal buyClicked()
 
     onAboutToShow: {
         stickersModule.getInstalledStickerPacks()
@@ -71,7 +69,7 @@ ModalPopup {
         model: stickers
         anchors.fill: parent
         anchors.topMargin: Theme.padding
-        packId: stickerPackDetailsPopup.packId
+        packId: root.packId
     }
 
     footer: StatusStickerButton {
@@ -85,29 +83,14 @@ ModalPopup {
         tooltip.text: store.networkConnectionStore.stickersNetworkUnavailableText
         onInstallClicked: {
             stickersModule.install(packId)
-            stickerPackDetailsPopup.close()
+            root.close()
         }
         onUninstallClicked: {
             stickersModule.uninstall(packId);
-            stickerPackDetailsPopup.close();
+            root.close();
         }
         onCancelClicked: function(){}
         onUpdateClicked: function(){}
-        onBuyClicked: {
-            const token = SQUtils.ModelUtils.getByKey(stickerPackDetailsPopup.walletAssetsStore.groupedAccountAssetsModel, "tokensKey", stickerPackDetailsPopup.store.stickersStore.getStatusTokenKey())
-
-            stickerPackDetailsPopup.sendModalPopup.interactive = false
-            stickerPackDetailsPopup.sendModalPopup.preSelectedRecipient = stickerPackDetailsPopup.store.stickersStore.getStickersMarketAddress()
-            stickerPackDetailsPopup.sendModalPopup.preSelectedRecipientType = Helpers.RecipientAddressObjectType.Address
-            stickerPackDetailsPopup.sendModalPopup.preSelectedHoldingID = !!token && !!token.symbol ? token.symbol : ""
-            stickerPackDetailsPopup.sendModalPopup.preSelectedHoldingType = Constants.TokenType.ERC20
-            stickerPackDetailsPopup.sendModalPopup.preSelectedSendType = Constants.SendType.StickersBuy
-            stickerPackDetailsPopup.sendModalPopup.preDefinedAmountToSend = LocaleUtils.numberToLocaleString(parseFloat(stickerPackDetailsPopup.price))
-            stickerPackDetailsPopup.sendModalPopup.preSelectedChainId = stickerPackDetailsPopup.store.appNetworkId
-            stickerPackDetailsPopup.sendModalPopup.stickersPackId = stickerPackDetailsPopup.packId
-            stickerPackDetailsPopup.sendModalPopup.open()
-
-            stickerPackDetailsPopup.buyClicked(stickerPackDetailsPopup.packId)
-        }
+        onBuyClicked: root.buyClicked()
     }
 }

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -13,18 +13,16 @@ import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 //TODO improve this!
 import AppLayouts.Chat.stores 1.0 as ChatStores
-import AppLayouts.Wallet.stores 1.0
 
 Popup {
     id: root
 
     property ChatStores.RootStore store
-    required property WalletAssetsStore walletAssetsStore
-    required property var sendModalPopup
 
     property alias isWalletEnabled: stickerMarket.isWalletEnabled
 
     signal stickerSelected(string hashId, string packId, string url)
+    signal buyClicked(string packId, string price)
 
     QtObject {
         id: d
@@ -102,8 +100,6 @@ Popup {
             Layout.fillWidth: true
             Layout.fillHeight: true
             store: root.store
-            walletAssetsStore: root.walletAssetsStore
-            sendModalPopup: root.sendModalPopup
             stickerPacks: d.stickerPackList
             packId: stickerPackListView.selectedPackId
             marketVisible: d.stickerPacksLoaded && d.online
@@ -121,6 +117,7 @@ Popup {
                 footerContent.visible = true
                 stickersContainer.visible = true
             }
+            onBuyClicked: root.buyClicked(packId, price)
 
             Connections {
                 target: root.store.stickersModuleInst

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -17,7 +17,6 @@ import utils 1.0
 
 import "../panels"
 import "../popups"
-import "../popups/send"
 import "../stores"
 import "../controls"
 

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -529,6 +529,9 @@ Pane {
 
                     onCloseRequested: root.closeRequested()
                     onCopyToClipboard: ClipboardUtils.setText(text)
+                    onSendToAccountRequested: {
+                        Global.sendToRecipientRequested(recipientAddress)
+                    }
                 }
             }
         }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -10,6 +10,7 @@ import shared.popups 1.0
 import shared.views.chat 1.0
 import shared.controls.chat 1.0
 import shared.stores 1.0 as SharedStores
+import shared.popups.send 1.0
 
 import StatusQ 0.1
 import StatusQ.Core 0.1
@@ -244,6 +245,7 @@ Loader {
     }
 
     signal openStickerPackPopup(string stickerPackId)
+    signal sendViaPersonalChatRequested(string recipientAddress)
 
     z: (typeof chatLogView === "undefined") ? 1 : (chatLogView.count - index)
 
@@ -763,7 +765,7 @@ Loader {
                 onLinkActivated: {
                     if (link.startsWith(Constants.sendViaChatPrefix)) {
                         const addressOrEns = link.replace(Constants.sendViaChatPrefix, "");
-                        Global.openSendModal(addressOrEns)
+                        root.sendViaPersonalChatRequested(addressOrEns)
                         return
                     }
                     if (link.startsWith('//')) {

--- a/ui/imports/shared/views/profile/ProfileShowcaseAccountsView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseAccountsView.qml
@@ -25,6 +25,7 @@ Item {
     property alias cellHeight: accountsView.cellHeight
 
     signal copyToClipboard(string text)
+    signal sendToAccountRequested(string recipientAddress)
 
     StatusBaseText {
         anchors.centerIn: parent
@@ -68,9 +69,7 @@ Item {
                     icon.name: "send"
                     icon.color: !hovered ? Theme.palette.baseColor1 : Theme.palette.directColor1
                     enabled: root.sendToAccountEnabled
-                    onClicked: {
-                        Global.openSendModal(model.address)
-                    }
+                    onClicked: root.sendToAccountRequested(model.address)
                     onHoveredChanged: accountInfoDelegate.highlight = hovered
                 }
                 StatusFlatRoundButton {

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -41,6 +41,7 @@ Control {
 
     signal closeRequested()
     signal copyToClipboard(string text)
+    signal sendToAccountRequested(string recipientAddress)
 
     horizontalPadding: readOnly ? 20 : 40 // smaller in settings/preview
     topPadding: Theme.bigPadding
@@ -155,6 +156,7 @@ Control {
             cellHeight: d.delegateHeightM
 
             onCopyToClipboard: root.copyToClipboard(text)
+            onSendToAccountRequested: root.sendToAccountRequested(recipientAddress)
         }
 
         ProfileShowcaseCollectiblesView {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -107,15 +107,7 @@ QtObject {
     signal openCommunityMemberMessagesPopupRequested(var store, var chatCommunitySectionModule, var memberPubKey, var displayName)
 
     // Intent based launch send modal signals
-    signal launchSendRequested()
-    signal connectUsernameRequested(string ensName)
-    signal registerUsernameRequested(string ensName)
-    signal releaseUsernameRequested(string ensName, string senderAddress, int chainId)    
-    signal buyStickerPackRequested(string packId, int price)
-    signal transferOwnershipRequested(string tokenId, string senderAddress)
     signal sendToRecipientRequested(string recipientAddress)
-    signal bridgeTokenRequested(string tokenId, int tokenType)
-    signal sendTokenRequested(string senderAddress, string tokenId, int tokenType)
 
     function openProfilePopup(publicKey, parentPopup, cb) {
         root.openProfilePopupRequested(publicKey, parentPopup, cb)

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -47,8 +47,7 @@ QtObject {
     signal openTransferOwnershipPopup(string communityId,
                                       string communityName,
                                       string communityLogo,
-                                      var token,
-                                      var sendModalPopup)
+                                      var token)
     signal openFinaliseOwnershipPopup(string communityId)
     signal openDeclineOwnershipPopup(string communityId, string communityName)
     signal openFirstTokenReceivedPopup(string communityId,
@@ -69,7 +68,6 @@ QtObject {
     signal setNthEnabledSectionActive(int nthSection)
     signal appSectionBySectionTypeChanged(int sectionType, int subsection, int subSubsection, var data)
 
-    signal openSendModal(string address)
     signal paymentRequestClicked(string receiverAddress, string symbol, string amount, int chainId)
     signal switchToCommunity(string communityId)
     signal switchToCommunitySettings(string communityId)
@@ -107,6 +105,17 @@ QtObject {
     signal openShowQRPopup(var params)
     signal openSavedAddressActivityPopup(var params)
     signal openCommunityMemberMessagesPopupRequested(var store, var chatCommunitySectionModule, var memberPubKey, var displayName)
+
+    // Intent based launch send modal signals
+    signal launchSendRequested()
+    signal connectUsernameRequested(string ensName)
+    signal registerUsernameRequested(string ensName)
+    signal releaseUsernameRequested(string ensName, string senderAddress, int chainId)    
+    signal buyStickerPackRequested(string packId, int price)
+    signal transferOwnershipRequested(string tokenId, string senderAddress)
+    signal sendToRecipientRequested(string recipientAddress)
+    signal bridgeTokenRequested(string tokenId, int tokenType)
+    signal sendTokenRequested(string senderAddress, string tokenId, int tokenType)
 
     function openProfilePopup(publicKey, parentPopup, cb) {
         root.openProfilePopupRequested(publicKey, parentPopup, cb)


### PR DESCRIPTION
### What does the PR do

Changes the SendModal launching mechanish.

Update signals in Global for openSendModal to be parameterised, instead of having to pass sendModal instance across the app. 

### Affected areas

SendModal Invocations points from-
1. Wallet footer
2. Asset/Collectibles context menu
3. Asset/Collectibles details view
4. Send Via 1-1 chat
5. TokenOwnership flows
6. Profile showcase
7. Ens name
8. Stickers
9. Saved address (wallet + settings)
10. History view and Transaction details

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->


https://github.com/user-attachments/assets/e5d5b649-da9a-48cb-9038-008e5049d062


https://github.com/user-attachments/assets/68965750-5432-4d83-bb7b-8c1c30d2d975


https://github.com/user-attachments/assets/4876bc45-5d19-4462-a07f-14e16969614e


https://github.com/user-attachments/assets/ef66db58-c00f-4380-ac68-a1e793917e5e


https://github.com/user-attachments/assets/eb66f460-778e-4dbe-bfe8-703457193fe1


https://github.com/user-attachments/assets/f8e93c97-8cd6-46be-81c4-62186a88d124


https://github.com/user-attachments/assets/eb9a6931-3c6b-4dfa-a407-2cec18fff28b


https://github.com/user-attachments/assets/83a7c53d-af59-436c-9392-466bddc2db0d


https://github.com/user-attachments/assets/adcba85a-032d-433f-8142-b69c136eb305


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
