### PR TITLE
feat(@desktop/wallet): Adding feature flag for Simple Send until it is ready for release

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -5,6 +5,7 @@ const DEFAULT_FLAG_DAPPS_ENABLED = true
 const DEFAULT_FLAG_SWAP_ENABLED = true
 const DEFAULT_FLAG_CONNECTOR_ENABLED* = true
 const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED = true
+const DEFAULT_FLAG_SIMPLE_SEND_ENABLED = false
 
 proc boolToEnv*(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"
@@ -15,6 +16,7 @@ QtObject:
     swapEnabled: bool
     connectorEnabled: bool
     sendViaPersonalChatEnabled: bool
+    simpleSendEnabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
@@ -22,6 +24,7 @@ QtObject:
     self.swapEnabled = getEnv("FLAG_SWAP_ENABLED", boolToEnv(DEFAULT_FLAG_SWAP_ENABLED)) != "0"
     self.connectorEnabled = getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
     self.sendViaPersonalChatEnabled = getEnv("FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED", boolToEnv(DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED)) != "0"
+    self.simpleSendEnabled = getEnv("FLAG_SIMPLE_SEND_ENABLED", boolToEnv(DEFAULT_FLAG_SIMPLE_SEND_ENABLED)) != "0"
 
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
@@ -53,3 +56,9 @@ QtObject:
 
   QtProperty[bool] sendViaPersonalChatEnabled:
     read = getSendViaPersonalChatEnabled
+
+  proc getSimpleSendEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.simpleSendEnabled
+
+  QtProperty[bool] simpleSendEnabled:
+    read = getSimpleSendEnabled

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -1,0 +1,52 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import AppLayouts.Wallet.popups.simpleSend 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Horizontal
+
+    function launchPopup() {
+        simpleSend.createObject(root)
+    }
+
+    PopupBackground {
+        id: popupBg
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Button {
+            id: reopenButton
+            anchors.centerIn: parent
+            text: "Reopen"
+            enabled: !simpleSend.visible
+
+            onClicked: launchPopup()
+        }
+
+        Component.onCompleted: launchPopup()
+    }
+
+    Component {
+        id: simpleSend
+        SimpleSendModal {
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 100
+
+    }
+}
+
+// category: Popups

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.15
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    id: popup
+
+    title: qsTr("Send")
+
+    padding: 0
+    background: StatusDialogBackground {
+        implicitHeight: 846
+        implicitWidth: 556
+        color: Theme.palette.baseColor3
+    }
+}

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/qmldir
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/qmldir
@@ -1,0 +1,1 @@
+SimpleSendModal 1.0 SimpleSendModal.qml

--- a/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
@@ -5,4 +5,5 @@ QtObject {
     property bool dappsEnabled
     property bool swapEnabled
     property bool sendViaPersonalChatEnabled
+    property bool simpleSendEnabled
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -98,6 +98,7 @@ Item {
         dappsEnabled: featureFlags ? featureFlags.dappsEnabled : false
         swapEnabled: featureFlags ? featureFlags.swapEnabled : false
         sendViaPersonalChatEnabled: featureFlags ? featureFlags.sendViaPersonalChatEnabled : false
+        simpleSendEnabled: featureFlags ? featureFlags.simpleSendEnabled : false
     }
 
     required property bool isCentralizedMetricsEnabled
@@ -654,6 +655,8 @@ Item {
         // for sticker flows
         stickersMarketAddress: appMain.rootChatStore.stickersStore.getStickersMarketAddress()
         stickersNetworkId: appMain.rootChatStore.appNetworkId
+
+        simpleSendEnabled: appMain.featureFlagsStore.simpleSendEnabled
 
         Component.onCompleted: {
             // It's requested from many nested places, so as a workaround we use

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -4,6 +4,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Wallet.stores 1.0 as WalletStores
+import AppLayouts.Wallet.popups.simpleSend 1.0
 
 import shared.popups.send 1.0
 import shared.stores.send 1.0
@@ -28,11 +29,16 @@ QtObject {
     required property string stickersMarketAddress
     required property string stickersNetworkId
 
+    // Feature flag for single network send until its feature complete
+    required property bool simpleSendEnabled
+
     function openSend(params = {}) {
         if (!!root._sendModalInstance) {
             return
         }
-        _sendModalInstance = sendModalComponent.createObject(popupParent, params)
+        // TODO remove once simple send is feature complete
+        let sendModalCmp = root.simpleSendEnabled ? simpleSendModalComponent: sendModalComponent
+        _sendModalInstance = sendModalCmp.createObject(popupParent, params)
         _sendModalInstance.open()
     }
 
@@ -146,6 +152,12 @@ QtObject {
 
             showCustomRoutingMode: !production
 
+            onClosed: destroy()
+        }
+    }
+
+    readonly property Component simpleSendModalComponent: Component {
+        SimpleSendModal {
             onClosed: destroy()
         }
     }


### PR DESCRIPTION
fixes #16710

### What does the PR do

Adds new feature flag for Simple Send
Create a mechanism to launch Simple Send in case the flag `FLAG_SIMPLE_SEND_ENABLED` is set to true
Else it will launch normal send as usual.

### Affected areas

Simple Send 

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
