### PR TITLE
fix(BC): Implementing the personal_sign

### DIFF
--- a/src/app/core/signals/remote_signals/connector.nim
+++ b/src/app/core/signals/remote_signals/connector.nim
@@ -29,6 +29,14 @@ type ConnectorRevokeDAppPermissionSignal* = ref object of Signal
   name*: string
   iconUrl*: string
 
+type ConnectorPersonalSignSignal* = ref object of Signal
+  url*: string
+  name*: string
+  iconUrl*: string
+  requestId*: string
+  challenge*: string
+  address*: string
+
 proc fromEvent*(T: type ConnectorSendRequestAccountsSignal, event: JsonNode): ConnectorSendRequestAccountsSignal =
   result = ConnectorSendRequestAccountsSignal()
   result.url = event["event"]{"url"}.getStr()
@@ -58,3 +66,12 @@ proc fromEvent*(T: type ConnectorRevokeDAppPermissionSignal, event: JsonNode): C
   result.url = event["event"]{"url"}.getStr()
   result.name = event["event"]{"name"}.getStr()
   result.iconUrl = event["event"]{"iconUrl"}.getStr()
+
+proc fromEvent*(T: type ConnectorPersonalSignSignal, event: JsonNode): ConnectorPersonalSignSignal =
+  result = ConnectorPersonalSignSignal()
+  result.url = event["event"]{"url"}.getStr()
+  result.name = event["event"]{"name"}.getStr()
+  result.iconUrl = event["event"]{"iconUrl"}.getStr()
+  result.requestId = event["event"]{"requestId"}.getStr()
+  result.challenge = event["event"]{"challenge"}.getStr()
+  result.address = event["event"]{"address"}.getStr()

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -74,6 +74,7 @@ type SignalType* {.pure.} = enum
   ConnectorSendTransaction = "connector.sendTransaction"
   ConnectorGrantDAppPermission = "connector.dAppPermissionGranted"
   ConnectorRevokeDAppPermission = "connector.dAppPermissionRevoked"
+  ConnectorPersonalSign = "connector.personalSign"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -140,10 +140,12 @@ QtObject:
       of SignalType.LocalPairing: LocalPairingSignal.fromEvent(jsonSignal)
       of SignalType.CommunityTokenTransactionStatusChanged: CommunityTokenTransactionStatusChangedSignal.fromEvent(jsonSignal)
       of SignalType.CommunityTokenAction: CommunityTokenActionSignal.fromEvent(jsonSignal)
+      # connector
       of SignalType.ConnectorSendRequestAccounts: ConnectorSendRequestAccountsSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorSendTransaction: ConnectorSendTransactionSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorGrantDAppPermission: ConnectorGrantDAppPermissionSignal.fromEvent(jsonSignal)
       of SignalType.ConnectorRevokeDAppPermission: ConnectorRevokeDAppPermissionSignal.fromEvent(jsonSignal)
+      of SignalType.ConnectorPersonalSign: ConnectorPersonalSignSignal.fromEvent(jsonSignal)
       else: Signal()
 
     result.signalType = signalType

--- a/src/app/modules/shared_modules/connector/controller.nim
+++ b/src/app/modules/shared_modules/connector/controller.nim
@@ -13,6 +13,7 @@ const SIGNAL_CONNECTOR_SEND_REQUEST_ACCOUNTS* = "ConnectorSendRequestAccounts"
 const SIGNAL_CONNECTOR_EVENT_CONNECTOR_SEND_TRANSACTION* = "ConnectorSendTransaction"
 const SIGNAL_CONNECTOR_GRANT_DAPP_PERMISSION* = "ConnectorGrantDAppPermission"
 const SIGNAL_CONNECTOR_REVOKE_DAPP_PERMISSION* = "ConnectorRevokeDAppPermission"
+const SIGNAL_CONNECTOR_PERSONAL_SIGN* = "ConnectorPersonalSign"
 
 logScope:
   topics = "connector-controller"
@@ -30,12 +31,15 @@ QtObject:
   proc connected*(self: Controller, payload: string) {.signal.}
   proc disconnected*(self: Controller, payload: string) {.signal.}
 
-  proc signRequested*(self: Controller, requestId: string, payload: string) {.signal.}
+  proc sendTransaction*(self: Controller, requestId: string, payload: string) {.signal.}
+  proc personalSign(self: Controller, requestId: string, payload: string) {.signal.}
   proc approveConnectResponse*(self: Controller, payload: string, error: bool) {.signal.}
   proc rejectConnectResponse*(self: Controller, payload: string, error: bool) {.signal.}
 
   proc approveTransactionResponse*(self: Controller, topic: string, requestId: string, error: bool) {.signal.}
   proc rejectTransactionResponse*(self: Controller, topic: string, requestId: string, error: bool) {.signal.}
+  proc approvePersonalSignResponse*(self: Controller, topic: string, requestId: string, error: bool) {.signal.}
+  proc rejectPersonalSignResponse*(self: Controller, topic: string, requestId: string, error: bool) {.signal.}
 
   proc newController*(service: connector_service.Service, events: EventEmitter): Controller =
     new(result, delete)
@@ -69,7 +73,7 @@ QtObject:
         "txArgs": params.txArgs,
       }
 
-      controller.signRequested(params.requestId, dappInfo.toJson())
+      controller.sendTransaction(params.requestId, dappInfo.toJson())
 
     result.events.on(SIGNAL_CONNECTOR_GRANT_DAPP_PERMISSION) do(e: Args):
       let params = ConnectorGrantDAppPermissionSignal(e)
@@ -92,6 +96,18 @@ QtObject:
       }
 
       controller.disconnected(dappInfo.toJson())
+
+    result.events.on(SIGNAL_CONNECTOR_PERSONAL_SIGN) do(e: Args):
+      let params = ConnectorPersonalSignSignal(e)
+      let dappInfo = %*{
+        "icon": params.iconUrl,
+        "name": params.name,
+        "url": params.url,
+        "challenge": params.challenge,
+        "address": params.address,
+      }
+
+      controller.personalSign(params.requestId, dappInfo.toJson())
 
     result.QObject.setup
 
@@ -129,3 +145,12 @@ QtObject:
 
   proc getDApps*(self: Controller): string {.slot.} =
     return self.service.getDApps()
+
+  proc approvePersonalSigning*(self: Controller, sessionTopic: string, requestId: string, signature: string): bool {.slot.} =
+    result = self.service.approvePersonalSignRequest(requestId, signature)
+    self.approvePersonalSignResponse(sessionTopic, requestId, not result)
+
+
+  proc rejectPersonalSigning*(self: Controller, sessionTopic: string, requestId: string): bool {.slot.} =
+    result = self.service.rejectPersonalSigning(requestId)
+    self.rejectPersonalSignResponse(sessionTopic, requestId, not result)

--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -16,6 +16,7 @@ const SIGNAL_CONNECTOR_SEND_REQUEST_ACCOUNTS* = "ConnectorSendRequestAccounts"
 const SIGNAL_CONNECTOR_EVENT_CONNECTOR_SEND_TRANSACTION* = "ConnectorSendTransaction"
 const SIGNAL_CONNECTOR_GRANT_DAPP_PERMISSION* = "ConnectorGrantDAppPermission"
 const SIGNAL_CONNECTOR_REVOKE_DAPP_PERMISSION* = "ConnectorRevokeDAppPermission"
+const SIGNAL_CONNECTOR_EVENT_CONNECTOR_PERSONAL_SIGN* = "ConnectorPersonalSign"
 
 # Enum with events
 type Event* = enum
@@ -82,6 +83,18 @@ QtObject:
       var data = ConnectorRevokeDAppPermissionSignal(e)
 
       self.events.emit(SIGNAL_CONNECTOR_REVOKE_DAPP_PERMISSION, data)
+    )
+    self.events.on(SignalType.ConnectorPersonalSign.event, proc(e: Args) =
+      if self.eventHandler == nil:
+        return
+
+      var data = ConnectorPersonalSignSignal(e)
+
+      if not data.requestId.len() == 0:
+        error "ConnectorPersonalSignSignal failed, requestId is empty"
+        return
+
+      self.events.emit(SIGNAL_CONNECTOR_EVENT_CONNECTOR_PERSONAL_SIGN, data)
     )
 
   proc registerEventsHandler*(self: Service, handler: EventHandlerFn) =
@@ -151,3 +164,18 @@ QtObject:
     except Exception as e:
       error "getDApps failed: ", err=e.msg
       return "[]"
+
+  proc approvePersonalSignRequest*(self: Service, requestId: string, signature: string): bool =
+    try:
+      var args = PersonalSignAcceptedArgs()
+      args.requestId = requestId
+      args.signature = signature
+
+      return status_go.sendPersonalSignAcceptedFinishedRpc(args)
+
+    except Exception as e:
+      error "sendPersonalSigAcceptedFinishedRpc failed: ", err=e.msg
+      return false
+
+  proc rejectPersonalSigning*(self: Service, requestId: string): bool =
+    rejectRequest(self, requestId, status_go.sendPersonalSignRejectedFinishedRpc, "sendPersonalSignRejectedFinishedRpc failed: ")

--- a/src/backend/connector.nim
+++ b/src/backend/connector.nim
@@ -23,6 +23,10 @@ type RejectedArgs* = ref object of RootObj
 type RecallDAppPermissionArgs* = ref object of RootObj
   dAppUrl* {.serializedFieldName("dAppUrl").}: string
 
+type PersonalSignAcceptedArgs* = ref object of RootObj
+  requestId* {.serializedFieldName("requestId").}: string
+  signature* {.serializedFieldName("signature").}: string
+
 rpc(requestAccountsAccepted, "connector"):
   args: RequestAccountsAcceptedArgs
 
@@ -41,6 +45,12 @@ rpc(recallDAppPermission, "connector"):
 rpc(getPermittedDAppsList, "connector"):
   discard
 
+rpc(personalSignAccepted, "connector"):
+  args: PersonalSignAcceptedArgs
+
+rpc(personalSignRejected, "connector"):
+  args: RejectedArgs
+
 proc isSuccessResponse(rpcResponse: RpcResponse[JsonNode]): bool =
   return rpcResponse.error.isNil
 
@@ -58,3 +68,9 @@ proc sendTransactionRejectedFinishedRpc*(args: RejectedArgs): bool =
 
 proc recallDAppPermissionFinishedRpc*(dAppUrl: string): bool =
   return isSuccessResponse(recallDAppPermission(dAppUrl))
+
+proc sendPersonalSignAcceptedFinishedRpc*(args: PersonalSignAcceptedArgs): bool =
+  return isSuccessResponse(personalSignAccepted(args))
+
+proc sendPersonalSignRejectedFinishedRpc*(args: RejectedArgs): bool =
+  return isSuccessResponse(personalSignRejected(args))

--- a/ui/app/AppLayouts/Wallet/services/dapps/plugins/SignRequestPlugin.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/plugins/SignRequestPlugin.qml
@@ -169,7 +169,8 @@ SQUtils.QObject {
 
             if (error) {
                 root.signCompleted(topic, id, accept, error)
-                console.error(`Error accepting session request for topic: ${topic}, id: ${id}, accept: ${accept}, error: ${error}`)
+                const action = accept ? "accepting" : "rejecting"
+                console.error(`Error ${action} session request for topic: ${topic}, id: ${id}, accept: ${accept}, error: ${error}`)
                 return
             }
 

--- a/ui/imports/shared/stores/BrowserConnectStore.qml
+++ b/ui/imports/shared/stores/BrowserConnectStore.qml
@@ -9,7 +9,8 @@ SQUtils.QObject {
     
     // Signals driven by the dApp
     signal connectRequested(string requestId, string dappJson)
-    signal signRequested(string requestId, string requestJson)
+    signal sendTransaction(string requestId, string requestJson)
+    signal personalSign(string requestId, string dappJson)
 
     signal connected(string dappJson)
     signal disconnected(string dappJson)
@@ -20,6 +21,8 @@ SQUtils.QObject {
 
     signal approveTransactionResponse(string topic, string requestId, bool error)
     signal rejectTransactionResponse(string topic, string requestId, bool error)
+    signal approvePersonalSignResponse(string topic, string requestId, bool error)
+    signal rejectPersonalSignResponse(string topic, string requestId, bool error)
 
     function approveConnection(id, account, chainId) {
         return controller.approveConnection(id, account, chainId)
@@ -45,6 +48,14 @@ SQUtils.QObject {
         return controller.getDApps()
     }
 
+    function approvePersonalSign(topic, requestId, signature) {
+        return controller.approvePersonalSigning(topic, requestId, signature)
+    }
+
+    function rejectPersonalSign(topic, requestId) {
+        return controller.rejectPersonalSigning(topic, requestId)
+    }
+
     Connections {
         target: controller
 
@@ -52,8 +63,12 @@ SQUtils.QObject {
             root.connectRequested(requestId, dappJson)
         }
 
-        function onSignRequested(requestId, requestJson) {
-            root.signRequested(requestId, requestJson)
+        function onSendTransaction(requestId, requestJson) {
+            root.sendTransaction(requestId, requestJson)
+        }
+
+        function onPersonalSign(requestId, dappJson) {
+            root.personalSign(requestId, dappJson)
         }
 
         function onConnected(dappJson) {
@@ -78,6 +93,14 @@ SQUtils.QObject {
 
         function onRejectTransactionResponse(topic, requestId, error) {
             root.rejectTransactionResponse(topic, requestId, error)
+        }
+
+        function onApprovePersonalSignResponse(topic, requestId, error) {
+            root.approvePersonalSignResponse(topic, requestId, error)
+        }
+
+        function onRejectPersonalSignResponse(topic, requestId, error) {
+            root.rejectPersonalSignResponse(topic, requestId, error)
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

Closes: #16015

Introducing personal_sign to Browser Connect.
https://docs.metamask.io/wallet/reference/json-rpc-methods/personal_sign/

#### Needs https://github.com/status-im/status-go/pull/6090

Adding the event handler for personal sign, accept/reject QML slots and accept/reject result signals.

+ Fixed the send transaction parsing. The parsing has been adding unnecessary arguments to the event even if the arguments had no value.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Browser Connect
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/c8e531e4-20f1-49d5-9b45-336a405039b3

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
