### PR TITLE
`ModelEntryChangeTracker` introduced, removed dependency on contact model's `onItemChanged`

### DIFF
--- a/storybook/qmlTests/tests/tst_ModelEntryChangeTracker.qml
+++ b/storybook/qmlTests/tests/tst_ModelEntryChangeTracker.qml
@@ -1,0 +1,100 @@
+import QtQuick 2.15
+import QtTest 1.15
+
+import StatusQ.Core.Utils 0.1
+
+Item {
+    id: root
+
+    width: 600
+    height: 400
+
+    Component {
+        id: componentUnderTest
+
+        ModelEntryChangeTracker {
+            id: tracker
+
+            model: ListModel {
+                ListElement { key: "a"; name: "AA" }
+                ListElement { key: "b"; name: "BB" }
+                ListElement { key: "c"; name: "CC" }
+            }
+
+            role: "key"
+            key: "b"
+
+            readonly property SignalSpy itemChangedSpy: SignalSpy {
+                target: tracker
+                signalName: "itemChanged"
+            }
+        }
+    }
+
+    TestCase {
+        name: "ModelEntryChangeTracker"
+
+        function test_change() {
+            const tracker = createTemporaryObject(componentUnderTest, this)
+            compare(tracker.itemChangedSpy.count, 0)
+
+            tracker.model.setProperty(0, "name", "AAA")
+            compare(tracker.itemChangedSpy.count, 0)
+            compare(tracker.revision, 0)
+
+            tracker.model.setProperty(1, "name", "BBB")
+            compare(tracker.itemChangedSpy.count, 1)
+            compare(tracker.revision, 1)
+        }
+
+        function test_insertion() {
+            const tracker = createTemporaryObject(componentUnderTest, this,
+                                                  { key: "d" })
+            compare(tracker.itemChangedSpy.count, 0)
+
+            tracker.model.setProperty(0, "name", "AAA")
+            tracker.model.setProperty(1, "name", "BBB")
+            compare(tracker.itemChangedSpy.count, 0)
+            compare(tracker.revision, 0)
+
+            tracker.model.insert(1, { "key": "d", name: "DD" })
+            compare(tracker.itemChangedSpy.count, 0)
+            compare(tracker.revision, 0)
+
+            tracker.model.setProperty(1, "name", "DDD")
+            compare(tracker.itemChangedSpy.count, 1)
+            compare(tracker.revision, 1)
+        }
+
+        function test_reinitOnRemoval() {
+            const tracker = createTemporaryObject(componentUnderTest, this)
+            compare(tracker.itemChangedSpy.count, 0)
+
+            tracker.model.append({ "key": "b", name: "BB2" })
+            compare(tracker.itemChangedSpy.count, 0)
+            compare(tracker.revision, 0)
+
+            tracker.model.setProperty(3, "name", "BBB2")
+            compare(tracker.itemChangedSpy.count, 0)
+            compare(tracker.revision, 0)
+
+            tracker.model.remove(1)
+            compare(tracker.itemChangedSpy.count, 0)
+            compare(tracker.revision, 0)
+
+            tracker.model.setProperty(2, "name", "BBBB2")
+            compare(tracker.itemChangedSpy.count, 1)
+            compare(tracker.revision, 1)
+        }
+
+        function test_modelChanged() {
+            const tracker = createTemporaryObject(componentUnderTest, this)
+
+            const model = tracker.model
+            tracker.model = null
+
+            model.setProperty(1, "name", "BBB")
+            compare(tracker.itemChangedSpy.count, 0)
+        }
+    }
+}

--- a/storybook/stubs/shared/stores/ProfileStore.qml
+++ b/storybook/stubs/shared/stores/ProfileStore.qml
@@ -1,4 +1,0 @@
-import QtQuick 2.15
-
-QtObject {
-}

--- a/storybook/stubs/shared/stores/qmldir
+++ b/storybook/stubs/shared/stores/qmldir
@@ -5,6 +5,5 @@ DAppsStore 1.0 DAppsStore.qml
 GifStore 1.0 GifStore.qml
 NetworkConnectionStore 1.0 NetworkConnectionStore.qml
 PermissionsStore 1.0 PermissionsStore.qml
-ProfileStore 1.0 ProfileStore.qml
 RootStore 1.0 RootStore.qml
 UtilsStore 1.0 UtilsStore.qml

--- a/ui/StatusQ/include/StatusQ/modelutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/modelutilsinternal.h
@@ -35,6 +35,9 @@ public:
     Q_INVOKABLE int indexOf(QAbstractItemModel* model, const QString& roleName,
                             const QVariant& value);
 
+    Q_INVOKABLE QPersistentModelIndex persistentIndex(QAbstractItemModel* model,
+                                                      int index);
+
     Q_INVOKABLE bool contains(QAbstractItemModel *model, const QString &roleName,
                               const QVariant &value, int mode = Qt::CaseSensitive) const;
 

--- a/ui/StatusQ/include/StatusQ/modelutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/modelutilsinternal.h
@@ -32,7 +32,11 @@ public:
                                     const QString& filterRoleName,
                                     const QVariant& filterValue) const;
 
-    Q_INVOKABLE bool contains(QAbstractItemModel *model, const QString &roleName, const QVariant &value, int mode = Qt::CaseSensitive) const;
+    Q_INVOKABLE int indexOf(QAbstractItemModel* model, const QString& roleName,
+                            const QVariant& value);
+
+    Q_INVOKABLE bool contains(QAbstractItemModel *model, const QString &roleName,
+                              const QVariant &value, int mode = Qt::CaseSensitive) const;
 
     ///< performs a strict check whether @lhs and @rhs arrays (QList<T>) contain the same elements;
     /// eg. `["a", "c", "b"]` and `["b", "c", "a"]` are considered equal

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelEntryChangeTracker.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelEntryChangeTracker.qml
@@ -1,0 +1,77 @@
+import QtQml 2.15
+
+QObject {
+    id: root
+
+    property var model
+    property string role
+    property var key
+
+    readonly property alias revision: d.revision
+
+    signal itemChanged
+
+    onModelChanged: d.initPersistentIndex()
+    onRoleChanged: d.initPersistentIndex()
+    onKeyChanged: d.initPersistentIndex()
+
+    QtObject {
+        id: d
+
+        property var persistentIndex
+        property int revision: 0
+
+        function initPersistentIndex() {
+            d.persistentIndex = null
+
+            if (!model)
+                return
+
+            const idx = ModelUtils.indexOf(root.model, root.role, root.key)
+
+            if (idx === -1)
+                return
+
+            d.persistentIndex = ModelUtils.persistentIndex(root.model, idx)
+        }
+
+        Component.onCompleted: initPersistentIndex()
+    }
+
+    Connections {
+        target: root.model ?? null
+
+        function onDataChanged(topLeft, bottomRight) {
+            if (!d.persistentIndex || !d.persistentIndex.valid)
+                return
+
+            const row = d.persistentIndex.row
+
+            if (topLeft.row >= row && bottomRight.row <= row) {
+                d.revision++
+                root.itemChanged()
+            }
+        }
+
+        function onRowsInserted() {
+            if (d.persistentIndex && d.valid)
+                return
+
+            d.initPersistentIndex()
+        }
+
+        function onRowsRemoved() {
+            if (!!d.persistentIndex && !d.valid)
+                d.initPersistentIndex()
+        }
+
+        function onLayoutChanged() {
+            if (!!d.persistentIndex || !d.valid)
+                d.initPersistentIndex()
+        }
+
+        function onModelReset() {
+            d.initPersistentIndex()
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -61,16 +61,7 @@ QtObject {
     }
 
     function indexOf(model, role, key) {
-        if (!model)
-            return -1
-
-        const count = model.rowCount()
-
-        for (let i = 0; i < count; i++)
-            if (Internal.ModelUtils.get(model, i, role) === key)
-                return i
-
-        return -1
+        return Internal.ModelUtils.indexOf(model, role, key)
     }
 
     function contains(model, roleName, value, mode = Qt.CaseSensitive) {

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -64,6 +64,10 @@ QtObject {
         return Internal.ModelUtils.indexOf(model, role, key)
     }
 
+    function persistentIndex(model, index) {
+        return Internal.ModelUtils.persistentIndex(model, index)
+    }
+
     function contains(model, roleName, value, mode = Qt.CaseSensitive) {
         return Internal.ModelUtils.contains(model, roleName, value, mode)
     }

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -8,6 +8,7 @@ JSONListModel 0.1 JSONListModel.qml
 LazyStackLayout 0.1 LazyStackLayout.qml
 ModelChangeGuard 0.1 ModelChangeGuard.qml
 ModelChangeTracker 0.1 ModelChangeTracker.qml
+ModelEntryChangeTracker 0.1 ModelEntryChangeTracker.qml
 ModelsComparator 0.1 ModelsComparator.qml
 QObject 0.1 QObject.qml
 SearchFilter 0.1 SearchFilter.qml

--- a/ui/StatusQ/src/modelutilsinternal.cpp
+++ b/ui/StatusQ/src/modelutilsinternal.cpp
@@ -86,6 +86,31 @@ QVariantList ModelUtilsInternal::getAll(QAbstractItemModel* model,
     return result;
 }
 
+/*
+ * Finds the index of given value of given value in the model using
+ * QAbstractItemModel::match method with Qt::MatchExactly flag.
+ *
+ * Note: QAbstractItemModel::match Qt::MatchExactly flag performs QVariant-based
+ * matching internally. It means that types are not compared and e.g. 4 (int)
+ * compared to string "4" will give a positive result.
+ */
+int ModelUtilsInternal::indexOf(QAbstractItemModel* model,
+                                const QString& roleName, const QVariant& value)
+{
+    auto role = roleByName(model, roleName);
+
+    if (role == -1 || model->rowCount() == 0)
+        return -1;
+
+    QModelIndexList indexes = model->match(model->index(0, 0), role, value, 1,
+                                           Qt::MatchExactly);
+
+    if (indexes.isEmpty())
+        return -1;
+
+    return indexes.first().row();
+}
+
 bool ModelUtilsInternal::contains(QAbstractItemModel* model,
                                   const QString& roleName,
                                   const QVariant& value,

--- a/ui/StatusQ/src/modelutilsinternal.cpp
+++ b/ui/StatusQ/src/modelutilsinternal.cpp
@@ -111,6 +111,16 @@ int ModelUtilsInternal::indexOf(QAbstractItemModel* model,
     return indexes.first().row();
 }
 
+/*
+ * Provides the ability to obtain QPersistentModelIndex on the QML side from
+ * regular index fetched from the model via model.index(row, col) method.
+ */
+QPersistentModelIndex ModelUtilsInternal::persistentIndex(
+        QAbstractItemModel* model, int row)
+{
+    return QPersistentModelIndex(model->index(row, 0));
+}
+
 bool ModelUtilsInternal::contains(QAbstractItemModel* model,
                                   const QString& roleName,
                                   const QVariant& value,

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -199,6 +199,7 @@
         <file>StatusQ/Core/Utils/LazyStackLayout.qml</file>
         <file>StatusQ/Core/Utils/ModelChangeGuard.qml</file>
         <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
+        <file>StatusQ/Core/Utils/ModelEntryChangeTracker.qml</file>
         <file>StatusQ/Core/Utils/ModelUtils.qml</file>
         <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
         <file>StatusQ/Core/Utils/OperatorsUtils.qml</file>

--- a/ui/StatusQ/tests/CMakeLists.txt
+++ b/ui/StatusQ/tests/CMakeLists.txt
@@ -55,6 +55,10 @@ add_test(NAME QmlTests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 # C++ Tests
 ###########
 
+add_executable(ModelUtilsInternalTest tst_ModelUtilsInternal.cpp)
+target_link_libraries(ModelUtilsInternalTest PRIVATE StatusQ StatusQTestLib)
+add_test(NAME ModelUtilsInternalTest COMMAND ModelUtilsInternalTest)
+
 add_executable(RolesRenamingModelTest tst_RolesRenamingModel.cpp)
 target_link_libraries(RolesRenamingModelTest PRIVATE StatusQ StatusQTestLib)
 add_test(NAME RolesRenamingModelTest COMMAND RolesRenamingModelTest)

--- a/ui/StatusQ/tests/tst_ModelUtilsInternal.cpp
+++ b/ui/StatusQ/tests/tst_ModelUtilsInternal.cpp
@@ -1,0 +1,50 @@
+#include <QtTest>
+
+#include <QQmlEngine>
+
+#include <StatusQ/modelutilsinternal.h>
+#include <TestHelpers/listmodelwrapper.h>
+
+class TestModelUtilsInternal : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testIndexOf()
+    {
+        QQmlEngine engine;
+
+        ListModelWrapper model(engine, R"([
+            { name: "A", balance: 1, valid: true },
+            { name: "B", balance: 2, valid: false },
+            { name: "B", balance: 3, valid: false },
+            { name: "C", balance: 4, valid: false }
+        ])");
+
+        ModelUtilsInternal utils;
+
+        QCOMPARE(utils.indexOf(nullptr, "name", "A"), -1);
+        QCOMPARE(utils.indexOf(model, "notExisting", "A"), -1);
+
+        QCOMPARE(utils.indexOf(model, "name", "A"), 0);
+        QCOMPARE(utils.indexOf(model, "name", "B"), 1);
+        QCOMPARE(utils.indexOf(model, "name", "C"), 3);
+        QCOMPARE(utils.indexOf(model, "name", "D"), -1);
+
+        QCOMPARE(utils.indexOf(model, "valid", true), 0);
+        QCOMPARE(utils.indexOf(model, "valid", false), 1);
+        QCOMPARE(utils.indexOf(model, "valid", "true"), 0);
+        QCOMPARE(utils.indexOf(model, "valid", "false"), 1);
+        QCOMPARE(utils.indexOf(model, "valid", 1), 0);
+        QCOMPARE(utils.indexOf(model, "valid", 0), 1);
+
+        QCOMPARE(utils.indexOf(model, "balance", 1), 0);
+        QCOMPARE(utils.indexOf(model, "balance", 2), 1);
+        QCOMPARE(utils.indexOf(model, "balance", 3), 2);
+        QCOMPARE(utils.indexOf(model, "balance", 4), 3);
+        QCOMPARE(utils.indexOf(model, "balance", "4"), 3);
+    }
+};
+
+QTEST_MAIN(TestModelUtilsInternal)
+#include "tst_ModelUtilsInternal.moc"

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -677,29 +677,7 @@ QtObject {
 
         //Update oneToOneChatContact when the contact is updated
         readonly property var myContactsModelConnection: Connections {
-            target: root.contactsStore.myContactsModel ?? null
-            enabled: d.activeChatType === Constants.chatType.oneToOne
-
-            function onItemChanged(pubKey) {
-                if (pubKey === d.activeChatId) {
-                    d.oneToOneChatContact = Utils.getContactDetailsAsJson(pubKey, false)
-                }
-            }
-        }
-
-        readonly property var receivedContactsReqModelConnection: Connections {
-            target: root.contactsStore.receivedContactRequestsModel ?? null
-            enabled: d.activeChatType === Constants.chatType.oneToOne
-
-            function onItemChanged(pubKey) {
-                if (pubKey === d.activeChatId) {
-                    d.oneToOneChatContact = Utils.getContactDetailsAsJson(pubKey, false)
-                }
-            }
-        }
-
-        readonly property var sentContactReqModelConnection: Connections {
-            target: root.contactsStore.sentContactRequestsModel ?? null
+            target: root.contactsStore.contactsModel ?? null
             enabled: d.activeChatType === Constants.chatType.oneToOne
 
             function onItemChanged(pubKey) {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -640,7 +640,7 @@ QtObject {
         }
     }
 
-    readonly property QtObject _d: QtObject {
+    readonly property QtObject _d: StatusQUtils.QObject {
         id: d
 
         readonly property var userProfileInst: userProfile
@@ -675,16 +675,12 @@ QtObject {
                                                                                                     d.oneToOneChatContact.displayName,
                                                                                                     d.oneToOneChatContact.alias) : ""
 
-        //Update oneToOneChatContact when the contact is updated
-        readonly property var myContactsModelConnection: Connections {
-            target: root.contactsStore.contactsModel ?? null
-            enabled: d.activeChatType === Constants.chatType.oneToOne
+        StatusQUtils.ModelEntryChangeTracker {
+            model: root.contactsStore.contactsModel
+            role: "pubKey"
+            key: d.activeChatId
 
-            function onItemChanged(pubKey) {
-                if (pubKey === d.activeChatId) {
-                    d.oneToOneChatContact = Utils.getContactDetailsAsJson(pubKey, false)
-                }
-            }
+            onItemChanged: d.oneToOneChatContact = Utils.getContactDetailsAsJson(d.activeChatId, false)
         }
 
         readonly property bool isUserAllowedToSendMessage: {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -53,11 +53,7 @@ Item {
     property bool stickersLoaded: false
     property bool canPost: true
     property var viewAndPostHoldingsModel
-
-    readonly property var contactDetails: rootStore ? rootStore.oneToOneChatContact : null
-    readonly property bool isUserAdded: !!root.contactDetails && root.contactDetails.isContactRequestSent
     property bool amISectionAdmin: false
-
     property bool sendViaPersonalChatEnabled
 
     signal openStickerPackPopup(string stickerPackId)

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -45,8 +45,6 @@ QtObject {
 
     readonly property bool isFirstShowcaseInteraction: localAccountSettings.isFirstShowcaseInteraction
 
-    property var details: Utils.getContactDetailsAsJson(pubkey)
-
     // The following signals wrap the settings / preferences save request responses in one unique result (identity + preferences result)
     signal profileSettingsSaveSucceeded()
     signal profileSettingsSaveFailed()

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRemoved.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRemoved.qml
@@ -17,27 +17,6 @@ import "../stores"
 ActivityNotificationMessage {
     id: root
 
-    function checkAndUpdateContactDetails(pubKey) {
-        if (pubKey === root.contactId)
-            root.updateContactDetails()
-    }
-
-    Connections {
-        target: root.store.contactsStore.sentContactRequestsModel
-
-        function onItemChanged(pubKey) {
-            root.checkAndUpdateContactDetails(pubKey)
-        }
-    }
-
-    Connections {
-        target: root.store.contactsStore.receivedContactRequestsModel
-
-        function onItemChanged(pubKey) {
-            root.checkAndUpdateContactDetails(pubKey)
-        }
-    }
-
     messageSubheaderComponent: StatusBaseText {
         text: qsTr("Removed you as a contact")
         font.italic: true

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -22,16 +22,6 @@ ActivityNotificationMessage {
 
     readonly property string contactRequestId: notification && notification.message ? notification.message.id : ""
 
-    Connections {
-        target: root.isOutgoingMessage ? root.store.contactsStore.sentContactRequestsModel :
-                                         root.store.contactsStore.receivedContactRequestsModel
-
-        function onItemChanged(pubKey) {
-            if (pubKey === root.contactId)
-                root.updateContactDetails()
-        }
-    }
-
     maximumLineCount: 5
     messageDetails.messageText: !root.isOutgoingMessage && notification ? notification.message.messageText : ""
 

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -62,7 +62,7 @@ ActivityNotificationBase {
     onContactIdChanged: root.updateContactDetails()
 
     Connections {
-        target: root.store.contactsStore.myContactsModel
+        target: root.store.contactsStore.contactsModel
 
         function onItemChanged(pubKey) {
             if (pubKey === root.contactId)

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -61,13 +61,12 @@ ActivityNotificationBase {
 
     onContactIdChanged: root.updateContactDetails()
 
-    Connections {
-        target: root.store.contactsStore.contactsModel
+    CoreUtils.ModelEntryChangeTracker {
+        model: root.store.contactsStore.contactsModel
+        role: "pubKey"
+        key: root.contactId
 
-        function onItemChanged(pubKey) {
-            if (pubKey === root.contactId)
-                root.updateContactDetails()
-        }
+        onItemChanged: root.updateContactDetails()
     }
 
     bodyComponent: MouseArea {


### PR DESCRIPTION
### What does the PR do

- `ModelUtils`: optimize `indexOf` by moving implementation to C++
- `ModelUtils`: expose method `persistentIndex` giving possibility to obtain persistent index in QML
- Removes dependency on contact model's `onItemChanged`, unblocking https://github.com/status-im/status-desktop/pull/16667
- Fixes problems with updating activity view delegates after updating contact details (e.g. setting nickname)

Closes: #16754 

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`ModelUtils`, `ActivityNotificationMessage` with subclasses

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
