### PR TITLE
[BC] Fixing the transaction hash forwarded to the dApp

### DIFF
--- a/src/app/modules/shared_modules/connector/controller.nim
+++ b/src/app/modules/shared_modules/connector/controller.nim
@@ -7,8 +7,6 @@ import app/core/signals/types
 
 import app_service/service/connector/service as connector_service
 
-import app_service/common/utils
-
 const SIGNAL_CONNECTOR_SEND_REQUEST_ACCOUNTS* = "ConnectorSendRequestAccounts"
 const SIGNAL_CONNECTOR_EVENT_CONNECTOR_SEND_TRANSACTION* = "ConnectorSendTransaction"
 const SIGNAL_CONNECTOR_GRANT_DAPP_PERMISSION* = "ConnectorGrantDAppPermission"
@@ -131,9 +129,7 @@ QtObject:
     self.rejectConnectResponse(requestId, not result)
 
   proc approveTransaction*(self: Controller, sessionTopic: string, requestId: string, signature: string): bool {.slot.} =
-    let hash = utils.createHash(signature)
-
-    result = self.service.approveTransactionRequest(requestId, hash)
+    result = self.service.approveTransactionRequest(requestId, signature)
     self.approveTransactionResponse(sessionTopic, requestId, not result)
 
   proc rejectTransaction*(self: Controller, sessionTopic: string, requestId: string): bool {.slot.} =


### PR DESCRIPTION
### What does the PR do

Iterates https://github.com/status-im/status-desktop/pull/16767

The send transaction was successful, but the transaction hash is not recognized by the dApp because it was being hashed again.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Browser connect
<!-- List the affected areas (e.g wallet, browser, etc..) -->


https://github.com/user-attachments/assets/474fa2f4-0cbe-4d08-bbb4-9584b4b3d30f


