### PR TITLE
SendContactRequestModal: fetching contact info fixed 

### DIFF
--- a/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
@@ -139,6 +139,9 @@ SortFilterProxyModel {
 
     // Update model after retranslation
     onEntriesChanged: {
+        if (baseModel.count === 0)
+            return
+
         entries.forEach((elem, index) => {
             baseModel.setProperty(index, "text", elem.text)
 

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -29,7 +29,7 @@ CommonContactDialog {
         messageInput.input.edit.forceActiveFocus()
 
         // (request) update from mailserver
-        if (d.userDisplayName === "") {
+        if (root.contactDetails.displayName === "") {
             root.rootStore.contactStore.requestContactInfo(root.publicKey)
             root.loadingContactDetails = true
         }


### PR DESCRIPTION
### What does the PR do

- fixes contact info loading in `SendContactRequestModal`
- fixes qml warnings from `SettingsEntriesModel`

Closes: #16774


### Affected areas
`SendContactRequestModal`, `SettingsEntriesModel`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[Screencast from 14.11.2024 13:47:56.webm](https://github.com/user-attachments/assets/375b4b13-a138-480a-a7d2-cb8126a5dd7b)


