### PR TITLE
feat(WalletFirst): Rearrange left nav bar and open wallet section by default

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -501,8 +501,8 @@ method load*[T](
 
   var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
-  if (activeSectionId == ""):
-    activeSectionId = singletonInstance.userProfile.getPubKey()
+  if activeSectionId == "" or activeSectionId == conf.SETTINGS_SECTION_ID:
+    activeSectionId = conf.WALLET_SECTION_ID
 
   let loadingItem = initItem(
     LOADING_SECTION_ID,
@@ -647,8 +647,6 @@ method onChatsLoaded*[T](
   let myPubKey = singletonInstance.userProfile.getPubKey()
   var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
-  if activeSectionId == "" or activeSectionId == conf.SETTINGS_SECTION_ID:
-    activeSectionId = myPubKey
 
   # Create personal chat section
   self.chatSectionModules[myPubKey] = chat_section_module.newModule(

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -10,9 +10,9 @@ import ../../../app_service/service/community_tokens/community_collectible_owner
 
 type
   SectionType* {.pure.} = enum
-    Chat = 0
+    Wallet = 0,
+    Chat,
     Community,
-    Wallet,
     ProfileSettings,
     NodeManagement,
     CommunitiesPortal,

--- a/test/e2e/gui/components/onboarding/share_usage_data_popup.py
+++ b/test/e2e/gui/components/onboarding/share_usage_data_popup.py
@@ -2,13 +2,14 @@ import allure
 
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
+from gui.elements.object import QObject
 from gui.objects_map import names
 
 
-class ShareUsageDataPopup(BasePopup):
+class ShareUsageDataPopup(QObject):
 
     def __init__(self):
-        super().__init__()
+        super().__init__(names.share_usage_data_StatusButton)
         self._not_now_button = Button(names.not_now_StatusButton )
         self._share_usage_data_button = Button(names.share_usage_data_StatusButton)
 

--- a/test/e2e/gui/components/signing_phrase_popup.py
+++ b/test/e2e/gui/components/signing_phrase_popup.py
@@ -8,15 +8,11 @@ from gui.objects_map import names
 class SigningPhrasePopup(QObject):
 
     def __init__(self):
-        super(SigningPhrasePopup, self).__init__(names.signPhrase_Ok_Button)
-        self._ok_got_it_button = Button(names.signPhrase_Ok_Button)
+        super().__init__(names.signPhrase_Ok_Button)
+        self.ok_got_it_button = Button(names.signPhrase_Ok_Button)
 
     @allure.step('Confirm signing phrase in popup')
     def confirm_phrase(self):
-        # TODO https://github.com/status-im/status-desktop/issues/15345
-        self._ok_got_it_button.click(timeout=60)
+        self.ok_got_it_button.click()
         SigningPhrasePopup().wait_until_hidden()
 
-    @allure.step('Verify if the signing phrase popup is visible')
-    def is_ok_got_it_button_visible(self):
-        return self._ok_got_it_button.is_visible

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -12,6 +12,7 @@ from gui.components.onboarding.share_usage_data_popup import ShareUsageDataPopup
 from gui.components.context_menu import ContextMenu
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
+from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.splash_screen import SplashScreen
 from gui.components.toast_message import ToastMessage
 from gui.components.online_identifier import OnlineIdentifier
@@ -191,6 +192,8 @@ class MainWindow(Window):
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
+        assert SigningPhrasePopup().ok_got_it_button.is_visible
+        SigningPhrasePopup().confirm_phrase()
         return self
 
     @allure.step('Log in user')
@@ -200,6 +203,8 @@ class MainWindow(Window):
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
+        if SigningPhrasePopup().is_visible:
+            SigningPhrasePopup().confirm_phrase()
         if share_updates_popup.is_visible:
             share_updates_popup.skip()
         return self

--- a/test/e2e/helpers/OnboardingHelper.py
+++ b/test/e2e/helpers/OnboardingHelper.py
@@ -5,6 +5,7 @@ import configs.system
 
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
 from gui.components.onboarding.beta_consent_popup import BetaConsentPopup
+from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.components.splash_screen import SplashScreen
 from gui.screens.onboarding import WelcomeToStatusView, BiometricsView, YourEmojihashAndIdenticonRingView
 
@@ -38,4 +39,6 @@ with step('Finalize onboarding and open main screen'):
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
+        assert SigningPhrasePopup().ok_got_it_button.is_visible
+        SigningPhrasePopup().confirm_phrase()
 

--- a/test/e2e/helpers/WalletHelper.py
+++ b/test/e2e/helpers/WalletHelper.py
@@ -11,10 +11,9 @@ with step('Authenticate user action with password'):
         AuthenticatePopup().wait_until_appears().authenticate(user_account.password)
         AuthenticatePopup().wait_until_hidden()
 
-with step('Close signing phrase popup and open wallet send popup'):
+with step('Open wallet send popup'):
     def open_send_modal_for_account(main_window, account_name):
         wallet = main_window.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         assert \
             driver.waitFor(lambda: wallet.left_panel.is_total_balance_visible, configs.timeouts.UI_LOAD_TIMEOUT_SEC), \
             f"Total balance is not visible"

--- a/test/e2e/tests/crtitical_tests_prs/test_add_account_after_restart.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_account_after_restart.py
@@ -35,7 +35,6 @@ def test_add_generated_account_restart_add_again(
 ):
     with step('Add the first generated wallet account'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).save_changes()
         authenticate_with_password(user_account)
@@ -61,7 +60,7 @@ def test_add_generated_account_restart_add_again(
 
     with step('Add second generated wallet account'):
         wallet = main_screen.left_panel.open_wallet()
-        assert not SigningPhrasePopup().is_ok_got_it_button_visible(), \
+        assert not SigningPhrasePopup().ok_got_it_button.is_visible, \
             f"Signing phrase should not be present because it has been hidden in the first step"
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name2).save_changes()

--- a/test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
@@ -70,7 +70,6 @@ def test_delete_generated_account_from_wallet_settings(
 
     with step('Verify the removed account is not displayed in accounts list on main wallet screen'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         assert driver.waitFor(
             lambda: account_name not in [account.name for account in wallet.left_panel.accounts], 10000), \
             f'Account with {account_name} is still displayed even it should not be'

--- a/test/e2e/tests/crtitical_tests_prs/test_add_edit_delete_generated_account.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_edit_delete_generated_account.py
@@ -24,7 +24,6 @@ def test_add_edit_delete_generated_account(main_screen: MainWindow, user_account
     with step('Create generated wallet account'):
         name = random_wallet_acc_keypair_name()
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).save_changes()
         authenticate_with_password(user_account)

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_generate_account_back_up_seed.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_generate_account_back_up_seed.py
@@ -8,6 +8,7 @@ import constants
 import driver
 from constants import RandomUser
 from gui.components.back_up_your_seed_phrase_banner import BackUpSeedPhraseBanner
+from gui.components.signing_phrase_popup import SigningPhrasePopup
 from . import marks
 
 import configs.timeouts
@@ -92,6 +93,8 @@ def test_generate_account_back_up_seed_sign_out(aut, main_window, user_account,
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
+        assert SigningPhrasePopup().ok_got_it_button.is_visible
+        SigningPhrasePopup().confirm_phrase()
 
     with step('Verify that user avatar background color'):
         avatar_color = str(main_window.left_panel.profile_button.object.identicon.asset.color.name).upper()

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
@@ -3,6 +3,7 @@ import pyperclip
 import pytest
 from allure_commons._allure import step
 
+from gui.components.signing_phrase_popup import SigningPhrasePopup
 from . import marks
 
 import configs.testpath
@@ -79,6 +80,8 @@ def test_sync_device_during_onboarding(multiple_instances):
             SplashScreen().wait_until_appears().wait_until_hidden()
             if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
                 BetaConsentPopup().confirm()
+            assert SigningPhrasePopup().ok_got_it_button.is_visible
+            SigningPhrasePopup().confirm_phrase()
 
         with step('Verify user details are the same with user in first instance'):
             online_identifier = main_window.left_panel.open_online_identifier()

--- a/test/e2e/tests/onboarding/test_onboarding_negative_scenarios.py
+++ b/test/e2e/tests/onboarding/test_onboarding_negative_scenarios.py
@@ -6,6 +6,7 @@ import allure
 import pytest
 from allure_commons._allure import step
 
+from gui.components.signing_phrase_popup import SigningPhrasePopup
 from helpers.OnboardingHelper import open_generate_new_keys_view
 from . import marks
 
@@ -48,6 +49,8 @@ def test_login_with_wrong_password(aut: AUT, main_window, error: str):
         SplashScreen().wait_until_appears().wait_until_hidden()
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
             BetaConsentPopup().confirm()
+        if SigningPhrasePopup().is_visible:
+            SigningPhrasePopup().confirm_phrase()
 
     with step('Verify that the user logged in correctly'):
         user_image = main_window.left_panel.open_online_identifier()

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
@@ -32,7 +32,6 @@ def test_rename_keypair_test(main_screen: MainWindow, user_account, emoji: str, 
 
     with step('To import an account within private key open add account popup and set name, emoji and color'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(random_wallet_acc_keypair_name()).set_emoji(emoji)
 

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_account_order.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_account_order.py
@@ -44,7 +44,6 @@ def test_change_account_order_by_drag_and_drop(main_screen: MainWindow, user_acc
     name_2, emoji_2, acc_emoji_2 = 'Generated 2', 'thumbsup', '👍 '
 
     wallet = main_screen.left_panel.open_wallet()
-    SigningPhrasePopup().wait_until_appears().confirm_phrase()
 
     colors = []
 

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -6,7 +6,6 @@ import allure
 import pytest
 from allure_commons._allure import step
 
-from constants import RandomUser
 from helpers.WalletHelper import authenticate_with_password
 from constants.wallet import WalletAccountPopup
 from . import marks
@@ -53,7 +52,6 @@ def test_add_new_account_from_wallet_settings(
     with step('Verify that the account is correctly displayed in accounts list on main wallet screen'):
 
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         expected_account = constants.user.account_list_item(account_name, None, None)
         started_at = time.monotonic()
         while expected_account not in wallet.left_panel.accounts:

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_watched_addr_include_in_total_balance.py
@@ -29,7 +29,6 @@ pytestmark = marks
 def test_settings_include_in_total_balance(main_screen: MainWindow, name, watched_address):
     with (step('Open wallet on main screen and check the total balance for new account is 0')):
         wallet_main_screen = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         total_balance_before = float(wallet_main_screen.left_panel.get_total_balance_value().replace("\xa0", ""
                                                                                                      ).replace(",",
                                                                                                                ""))

--- a/test/e2e/tests/wallet_main_screen/test_wallet_share_address_popup.py
+++ b/test/e2e/tests/wallet_main_screen/test_wallet_share_address_popup.py
@@ -18,7 +18,6 @@ def test_share_wallet_address(main_screen: MainWindow):
     with step('Open wallet and choose default account'):
         default_name = WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         wallet_account = wallet.left_panel.select_account(default_name)
         wallet.left_panel.copy_account_address_in_context_menu(default_name)
         wallet_address = pyperclip.paste()

--- a/test/e2e/tests/wallet_main_screen/wallet - assets tab/test_wallet_assets_sorting.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - assets tab/test_wallet_assets_sorting.py
@@ -40,7 +40,6 @@ def test_wallet_sort_assets(main_screen: MainWindow, address, name, dai, wrapped
 
     with step('Add watched address with plus action button'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_origin_watched_address(address).save_changes()
         account_popup.wait_until_hidden()
@@ -159,7 +158,6 @@ def test_custom_ordering(main_screen: MainWindow, address, name, dai, wrappedeth
 
     with step('Add watched address with plus action button'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_origin_watched_address(address).save_changes()
         account_popup.wait_until_hidden()

--- a/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_default_account_values.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - footer actions/test_footer_actions_default_account_values.py
@@ -16,7 +16,6 @@ from gui.components.signing_phrase_popup import SigningPhrasePopup
 def test_wallet_modals_default_account_values(main_screen, default_name, address, name, color, emoji):
     with step('Add watched address with plus action button'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_watched_address(address).save_changes()
         account_popup.wait_until_hidden()

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_add_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_add_watched_address.py
@@ -25,7 +25,6 @@ def test_plus_button_add_watched_address(
         name: str):
     with step('Add watched address with plus action button'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_watched_address(address).save_changes()
         account_popup.wait_until_hidden()

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
@@ -24,7 +24,6 @@ def test_plus_button_manage_account_added_for_new_seed(main_screen: MainWindow, 
 
     with step('Create generated seed phrase wallet account'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_origin_new_seed_phrase(
             keypair_name).save_changes()

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
@@ -26,7 +26,6 @@ def test_plus_button_manage_account_from_private_key(main_screen: MainWindow, us
 
     with step('Import an account within private key'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_origin_private_key(
             address_pair.private_key, address_pair.private_key[:5]).save_changes()

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
@@ -27,7 +27,6 @@ def test_plus_button_manage_account_from_seed_phrase(main_screen: MainWindow, us
     with step('Create imported seed phrase wallet account'):
         mnemonic_data = random_mnemonic()
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).open_add_new_account_popup().import_new_seed_phrase(mnemonic_data.split())
         account_popup.save_changes()

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
@@ -22,7 +22,6 @@ def test_plus_button_manage_generated_account_custom_derivation_path(main_screen
     with step('Create generated wallet account'):
         name = random_wallet_acc_keypair_name()
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name).set_derivation_path(
             DerivationPathName.select_random_path_name().value,

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_use_keycard.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_use_keycard.py
@@ -16,7 +16,6 @@ pytestmark = marks
 def test_use_keycard_when_adding_account(main_screen: MainWindow):
     with step('Choose continue in keycard settings'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.continue_in_keycard_settings()
 

--- a/test/e2e/tests/wallet_main_screen/wallet - right click on account/test_context_menu_edit_default_account.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click on account/test_context_menu_edit_default_account.py
@@ -22,7 +22,6 @@ def test_context_menu_edit_default_account(main_screen: MainWindow, user_account
 
     with step('Select wallet account'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
         wallet.left_panel.select_account(name)
 
     with step("Verify default status account can't be deleted"):

--- a/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
@@ -28,9 +28,8 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
                                                             emoji_unicode: str,
                                                             name: str, new_name: str, new_color: str, new_emoji: str,
                                                             new_emoji_unicode: str):
-    with step('Open wallet main screen and close signing phrase dialog'):
+    with step('Open wallet main screen'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().wait_until_appears().confirm_phrase()
 
     with step('Create watched address from context menu'):
         account_popup = wallet.left_panel.add_watched_address_from_context.click()

--- a/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
@@ -29,7 +29,6 @@ pytestmark = marks
 def test_manage_saved_address(main_screen: MainWindow, name: str, address: str, new_name: str):
     with step('Add new saved address'):
         wallet = main_screen.left_panel.open_wallet()
-        SigningPhrasePopup().confirm_phrase()
         wallet.left_panel.open_saved_addresses().open_add_saved_address_popup().add_saved_address(name, address)
 
     with step('Verify that saved address is in the list of saved addresses'):

--- a/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -11,8 +11,8 @@ Rectangle {
     id: root
     objectName: "statusAppNavBar"
 
-    property alias chatItemsModel: chatItemsListView.model
-    property alias chatItemDelegate: chatItemsListView.delegate
+    property alias topSectionModel: topSectionListview.model
+    property alias topSectionDelegate: topSectionListview.delegate
 
     property alias communityItemsModel: communityItemsListView.model
     property alias communityItemDelegate: communityItemsListView.delegate
@@ -51,7 +51,7 @@ Rectangle {
         spacing: d.spacing
 
         ListView {
-            id: chatItemsListView
+            id: topSectionListview
 
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -75,7 +75,7 @@ Rectangle {
             Layout.alignment: Qt.AlignHCenter
             color: Theme.palette.directColor7
 
-            visible: chatItemsListView.count && communityItemsListView.contentHeight > communityItemsListView.height
+            visible: topSectionListview.count && communityItemsListView.contentHeight > communityItemsListView.height
         }
 
         ListView {
@@ -101,7 +101,7 @@ Rectangle {
             Layout.preferredWidth: d.separatorWidth
             Layout.alignment: Qt.AlignHCenter
             color: Theme.palette.directColor7
-            visible: chatItemsListView.count || communityItemsListView.count
+            visible: topSectionListview.count || communityItemsListView.count
         }
 
         ListView {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -87,10 +87,6 @@ Item {
         d.displayAllAddresses()
 
         d.resetRightPanelStackView()
-
-        if(!hideSignPhraseModal && !RootStore.hideSignPhraseModal){
-            signPhrasePopup.open();
-        }
     }
 
     function openDesiredView(leftPanelSelection, rightPanelSelection, data) {
@@ -189,6 +185,7 @@ Item {
         id: signPhrasePopup
         onRemindLaterClicked: hideSignPhraseModal = true
         onAcceptClicked: { RootStore.setHideSignPhraseModal(true); }
+        visible: !root.hideSignPhraseModal && !RootStore.hideSignPhraseModal
     }
 
     SeedPhraseBackupWarning {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -669,12 +669,18 @@ Item {
         anchors.fill: parent
 
         leftPanel: StatusAppNavBar {
-            chatItemsModel: SortFilterProxyModel {
+            topSectionModel: SortFilterProxyModel {
                 sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
                 filters: [
-                    ValueFilter {
-                        roleName: "sectionType"
-                        value: Constants.appSection.chat
+                    AnyOf {
+                        ValueFilter {
+                            roleName: "sectionType"
+                            value: Constants.appSection.wallet
+                        }
+                        ValueFilter {
+                            roleName: "sectionType"
+                            value: Constants.appSection.chat
+                        }
                     },
                     ValueFilter {
                         roleName: "enabled"
@@ -682,7 +688,7 @@ Item {
                     }
                 ]
             }
-            chatItemDelegate: navbarButton
+            topSectionDelegate: navbarButton
 
             communityItemsModel: SortFilterProxyModel {
                 sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
@@ -814,7 +820,7 @@ Item {
                 filters: [
                     RangeFilter {
                         roleName: "sectionType"
-                        minimumValue: Constants.appSection.wallet
+                        minimumValue: Constants.appSection.profile
                         maximumValue: Constants.appSection.loadingSection
                     },
                     ValueFilter {
@@ -1435,6 +1441,7 @@ Item {
                             networkConnectionStore: appMain.networkConnectionStore
                             appMainVisible: appMain.visible
                             swapEnabled: featureFlagsStore.swapEnabled
+                            hideSignPhraseModal: userAgreementLoader.active
                         }
                         onLoaded: {
                             item.resetView()

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -320,9 +320,9 @@ QtObject {
     readonly property int chatSectionLeftColumnWidth: 304
 
     readonly property QtObject appSection: QtObject {
-        readonly property int chat: 0
-        readonly property int community: 1
-        readonly property int wallet: 2
+        readonly property int chat: 1
+        readonly property int community: 2
+        readonly property int wallet: 0
         readonly property int profile: 3
         readonly property int node: 4
         readonly property int communitiesPortal: 5


### PR DESCRIPTION
### What does the PR do

Closes #16778

1. Wallet section is the default section
2. Wallet section is the first section in the left nav bar

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Acceptance criteria:

Wallet is loaded after onboarding
Wallet is the first item in the left side bar
The active session is persisted after restart

### Affected areas

Left nav bar
The default active section
Active section persistency
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/2cd66578-1124-4b00-aa09-46277e7ca446


### User stories:
```
Given the user has logged in
When the app starts
Then the wallet button is the first one in the left navigation bar
```
```
Given the user has signed up for a new account
When the onboarding process ends
Then the wallet section is displayed
```
```
Given the user has selected [chat,wallet,community,communityPortal] section
And quits the app
When the user logs in again
Then the last selected section is displayed
```
```
Given the user has selected settings section
And quits the app
When the user logs in again
The the wallet section is displayed
```
