### PR TITLE
Added the legal docs as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -114,3 +114,6 @@
 [submodule "vendor/qzxing"]
 	path = vendor/qzxing
 	url = https://github.com/status-im/qzxing.git
+[submodule "ui/imports/assets/legal-docs"]
+	path = ui/imports/assets/legal-docs
+	url = https://github.com/status-im/status-software-legal-documents.git


### PR DESCRIPTION
Resolves https://github.com/status-im/status-desktop/issues/16787
See https://github.com/status-im/status-software-legal-documents/issues/5
Also see: https://github.com/status-im/status-mobile/pull/21654

Adding the status-software-legal-documents repo as a submodule makes life easier by keeping all legal documents consistent across platforms. Instead of copying files around and hoping they stay in sync, we can just point to the same source. This way, any updates to the main legal docs automatically flow to all the repos, reducing the chances of mistakes or outdated files. It’s a simple, reliable way to stay organised and keep everything aligned.