### PR TITLE
chore: add a reminder in feature template to cover metrics

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue.md
@@ -14,6 +14,10 @@ labels: feature
 [comment]: # (Describe the use cases the implementation should cover. E.g. New users, existing users, public chat, group chat, etc)
 *Summary*: ...
 
+### Metrics
+
+Does that feature need metrics to be added? If yes, describe which events should be tracked and add them to Mixpanel
+
 ### Acceptance Criteria
 
 [comment]: # (Rules for the future PR to be accepted.)


### PR DESCRIPTION
### What does the PR do

Update the feature template to remind about metrics

We might need something similar to https://www.notion.so/Event-Tracking-Specification-Mobile-11a8f96fb65c8032a05efcebea3a1ce6

We started tracking it on our side in https://www.notion.so/Metrics-to-be-collected-7d8139a5a048476b8e6cc9ea51773f0c , i will discuss what is the best place to keep the metrics from now on and then i we will need to place the link in the template of the PR as well

### Affected areas

GH PR template
