### PR TITLE
fix(wallet): set up an new keycard with an existing account screen does not show key pairs

### DIFF
--- a/ui/imports/shared/popups/keycard/states/SelectKeyPair.qml
+++ b/ui/imports/shared/popups/keycard/states/SelectKeyPair.qml
@@ -24,7 +24,7 @@ Item {
 
     QtObject {
         id: d
-        readonly property string profilePairTypeValue: Constants.keycard.keyPairType.profile
+        readonly property int profilePairTypeValue: Constants.keycard.keyPairType.profile
     }
 
     ColumnLayout {


### PR DESCRIPTION
Fixes: #16785