### PR TITLE
fix(community): fix community image not updating

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -269,7 +269,7 @@ Item {
 
         StatusChatInfoButton {
             readonly property string emojiIcon: chatContentModule? chatContentModule.chatDetails.emoji : "" // Needed for test
-            readonly property string assetName: chatContentModule && Utils.addTimestampToURL(chatContentModule.chatDetails.icon)
+            readonly property string assetName: chatContentModule && chatContentModule.chatDetails.icon
 
             objectName: "chatInfoBtnInHeader"
             title: chatContentModule? chatContentModule.chatDetails.name : ""


### PR DESCRIPTION
### What does the PR do

Fixes #16688

Fixes the issue by adding a version to the URL on the status-go side. No extra code needed on our side. The only change is that we no longer need the `addTimestampToURL` hack for the community now.

Status-go PR: https://github.com/status-im/status-go/pull/6118

### Affected areas

Community image url

### Screenshot of functionality (including design for comparison)

[edit-img.webm](https://github.com/user-attachments/assets/391934b7-6757-4118-96e7-96d6e67a263f)

Note that the app on the right is on master, hence why it still has the issue

### Impact on end user

Updated image will show straight away

### How to test

- Update the image of your community
- Update the image of a community you joined or spectated

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case: the bug still happens
