### PR TITLE
feat: status-go API logging option

### DIFF
--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -135,11 +135,6 @@ QtObject:
   proc openedAccountsContainsKeyUid*(self: Service, keyUid: string): bool =
     return (keyUID in self.openedAccounts().mapIt(it.keyUid))
 
-  proc toStatusGoSupportedLogLevel*(logLevel: string): string =
-    if logLevel == "TRACE":
-      return "DEBUG"
-    return logLevel
-
   # FIXME: remove this method, settings should be processed in status-go
   # https://github.com/status-im/status-go/issues/5359
   proc addKeycardDetails(self: Service, kcInstance: string, settingsJson: var JsonNode, accountData: var JsonNode) =
@@ -182,7 +177,7 @@ QtObject:
         rootDataDir: main_constants.STATUSGODIR,
         kdfIterations: KDF_ITERATIONS,
         customizationColor: DEFAULT_CUSTOMIZATION_COLOR,
-        logLevel: some(toStatusGoSupportedLogLevel(main_constants.LOG_LEVEL)),
+        logLevel: some(main_constants.getStatusGoLogLevel()),
         wakuV2LightClient: false,
         wakuV2EnableMissingMessageVerification: true,
         wakuV2EnableStoreConfirmationForMessagesSent: true,
@@ -389,7 +384,7 @@ QtObject:
     )
 
     if main_constants.runtimeLogLevelSet():
-      request.runtimeLogLevel = toStatusGoSupportedLogLevel(main_constants.LOG_LEVEL)
+      request.runtimeLogLevel = main_constants.getStatusGoLogLevel()
 
     let response = status_account.loginAccount(request)
 

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -276,7 +276,7 @@ proc openedAccounts*(path: string): RpcResponse[JsonNode] =
       sleep 700
     let response = status_go.initializeApplication($payload)
     let jsonResponse = parseJson(response)
-    let error = jsonResponse["error"].getStr()
+    let error = jsonResponse{"error"}.getStr()
     if error.len > 0:
       raise newException(RpcException, error)
     result.result = jsonResponse

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -264,6 +264,10 @@ proc openedAccounts*(path: string): RpcResponse[JsonNode] =
       "mixpanelAppId": MIXPANEL_APP_ID, 
       "mixpanelToken": MIXPANEL_TOKEN,
       "sentryDSN": SENTRY_DSN_STATUS_GO,
+      "logEnabled": true,
+      "logDir": "", # Empty value defaults to `dataDir`
+      "logLevel": status_const.getStatusGoLogLevel(),
+      "apiLoggingEnabled": status_const.API_LOGGING,
     }
     # Do not remove the sleep 700
     # This sleep prevents a crash on intel MacOS
@@ -271,7 +275,11 @@ proc openedAccounts*(path: string): RpcResponse[JsonNode] =
     if status_const.IS_MACOS and status_const.IS_INTEL:
       sleep 700
     let response = status_go.initializeApplication($payload)
-    result.result = Json.decode(response, JsonNode)
+    let jsonResponse = parseJson(response)
+    let error = jsonResponse["error"].getStr()
+    if error.len > 0:
+      raise newException(RpcException, error)
+    result.result = jsonResponse
   except RpcException as e:
     error "error doing rpc request", methodName = "openedAccounts", exception=e.msg
     raise newException(RpcException, e.msg)

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -66,6 +66,7 @@ let
   WS_API_ENABLED* = desktopConfig.wsApiEnabled
   SENTRY_DSN_STATUS_GO* = BUILD_SENTRY_DSN_STATUS_GO
   SENTRY_DSN_STATUS_GO_DESKTOP* = BUILD_SENTRY_DSN_STATUS_DESKTOP
+  API_LOGGING* = desktopConfig.apiLogging
 
 proc hasLogLevelOption*(): bool =
   for p in cliParams:

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -76,4 +76,9 @@ proc hasLogLevelOption*(): bool =
 proc runtimeLogLevelSet*(): bool =
   return existsEnv(RUN_TIME_PREFIX & "_LOG_LEVEL") or hasLogLevelOption()
 
+proc getStatusGoLogLevel*(): string =
+  if LOG_LEVEL == "TRACE":
+    return "DEBUG"
+  return LOG_LEVEL
+
 const MAIN_STATUS_SHARD_CLUSTER_ID* = 16

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -33,6 +33,7 @@ const BASE_NAME_MIXPANEL_APP_ID = "MIXPANEL_APP_ID"
 const BASE_NAME_MIXPANEL_TOKEN = "MIXPANEL_TOKEN"
 const BASE_NAME_SENTRY_DSN_STATUS_GO = "SENTRY_DSN_STATUS_GO"
 const BASE_NAME_SENTRY_DSN_STATUS_DESKTOP = "SENTRY_DSN_STATUS_DESKTOP"
+const BASE_NAME_API_LOGGING = "API_LOGGING"
 
 
 ################################################################################
@@ -249,6 +250,11 @@ type StatusDesktopConfig = object
     desc: "Enable WebSocket RPC API"
     name: "WS_API"
     abbr: "ws-api" .}: bool
+  apiLogging* {.
+    defaultValue: false
+    desc: "Enables status-go API logging"
+    name: $BASE_NAME_API_LOGGING
+    abbr: "api-logging" .}: bool
 
 # On macOS the first time when a user gets the "App downloaded from the
 # internet" warning, and clicks the Open button, the OS passes a unique process


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/16414

Requires:
- https://github.com/status-im/status-go/pull/6117

### What does the PR do

1. Added ability to enable `status-go` API logging. Run with `--api-logging` or env var `STATUS_RUNTIME_API_LOGGING=1`.
The log will appear in `<account>/data/api.log` file.

2. Also added proper initialization of logging in status-go. 
Before this PR logs would appear in `geth.log` file only after logging into account, and before logging it it was in in console.
Now all logs go into the file right from the start.

### Affected areas

Logging, initialize application

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.