### PR TITLE
fix(WC): Fixing the namespace negotiation for non eip155 chains in pairing process

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/plugins/DAppConnectionsPlugin.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/plugins/DAppConnectionsPlugin.qml
@@ -195,9 +195,8 @@ SQUtils.QObject {
             const proposal = d.activeProposals.get(key.toString()).context
             const dAppUrl = proposal.params.proposer.metadata.url
 
-            if(error || !approvedNamespaces) {
-                // Check that it contains Non conforming namespaces"
-                if (error.includes("Non conforming namespaces")) {
+            if(error || !approvedNamespaces || !approvedNamespaces.eip155) {
+                if (!approvedNamespaces.eip155 || error.includes("Non conforming namespaces")) {
                     root.newConnectionFailed(proposal.id, dAppUrl, Pairing.errors.unsupportedNetwork)
                 } else {
                     root.newConnectionFailed(proposal.id, dAppUrl, Pairing.errors.unknownError)


### PR DESCRIPTION
### What does the PR do


Closes #16756 

Check if the approved namespaces contains `eip155` property. Show an unsupported chain error if it doesn't.

We should display the unsupported network error when the required namespaces is empty or meets the app supported namespace, but the optional namespace contains only non eip155 chains.

This kind of session proposal will generate an empty approvedNamespaces object. We'll check if the `approvedNamespaces` contains `eip155` property and dismiss the proposal if it doesn't.

```
    "optionalNamespaces": {
      "near": {
        "chains": [
          "near:testnet"
        ],
        "events": [],
        "methods": [
          "near_signIn",
          "near_signOut",
          "near_getAccounts",
          "near_signAndSendTransaction",
          "near_signAndSendTransactions"
        ]
      }
    },
    "requiredNamespaces": {}
```

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Impact on end user

https://github.com/user-attachments/assets/3b166929-1915-4f5d-b110-4cdfd5c0e956


What is the impact of these changes on the end user (before/after behaviour)

### How to test

Try to connect to `BTC Mainnet` or `NEAR Testnet` using https://react-app.walletconnect.com. This will produce an empty approvedNamespaces object.

Try to connect to https://polygonscan.com/tokenapprovalchecker. This will produce an unsupported chain error from the WC sdk in the approvedNamespaces negotiation.

In both flows we should display the `unsupported chains error`

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
