### PR TITLE
feat(@desktop/wallet): Adapt AmountToSend for Simple Send

### DIFF
--- a/storybook/pages/AmountToSendPage.qml
+++ b/storybook/pages/AmountToSendPage.qml
@@ -19,6 +19,8 @@ SplitView {
 
             anchors.centerIn: parent
 
+            width: 400
+
             interactive: interactiveCheckBox.checked
             fiatInputInteractive: fiatInteractiveCheckBox.checked
             markAsInvalid: markAsInvalidCheckBox.checked
@@ -26,7 +28,7 @@ SplitView {
             mainInputLoading: ctrlMainInputLoading.checked
             bottomTextLoading: ctrlBottomTextLoading.checked
 
-            caption: "Amount to send"
+            caption: captionField.text
 
             decimalPoint: decimalPointRadioButton.checked ? "." : ","
             price: parseFloat(priceTextField.text)
@@ -35,6 +37,10 @@ SplitView {
 
             formatFiat: balance => `${balance.toLocaleString(Qt.locale())} USD`
             formatBalance: balance => `${balance.toLocaleString(Qt.locale())} ETH`
+
+            dividerVisible: ctrlDividerVisible.checked
+            selectedSymbol: ctrlShowMainInputSymbol.checked ? amountToSend.fiatMode ? "USD": "ETH": ""
+            progressivePixelReduction: ctrlProgressivePixelReduction.checked
         }
     }
 
@@ -45,6 +51,19 @@ SplitView {
 
         ColumnLayout {
             spacing: 15
+
+
+            RowLayout {
+                Label {
+                    text: "Caption"
+                }
+
+                TextField {
+                    id: captionField
+
+                    text: "Amount to send"
+                }
+            }
 
             RowLayout {
                 Label {
@@ -118,6 +137,22 @@ SplitView {
                 CheckBox {
                     id: ctrlBottomTextLoading
                     text: "Bottom text loading"
+                }
+
+                CheckBox {
+                    id: ctrlDividerVisible
+                    text: "Divider"
+                }
+
+                CheckBox {
+                    id: ctrlProgressivePixelReduction
+                    text: "Progressive Pixel Reduction"
+                    checked: true
+                }
+
+                CheckBox {
+                    id: ctrlShowMainInputSymbol
+                    text: "Show Main Input Symbol"
                 }
             }
 

--- a/storybook/pages/AmountValidatorPage.qml
+++ b/storybook/pages/AmountValidatorPage.qml
@@ -20,6 +20,7 @@ Item {
 
                 maxIntegralDigits: maxIntegralDigitsSpinBox.value
                 maxDecimalDigits: maxDecimalDigitsSpinBox.value
+                maxDigits: maxTotalDigitsSpinBox.value
             }
         }
 
@@ -78,6 +79,20 @@ Item {
                 id: maxDecimalDigitsSpinBox
 
                 value: 5
+            }
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+
+            Label {
+                text: "Max total digits:"
+            }
+
+            SpinBox {
+                id: maxTotalDigitsSpinBox
+
+                value: maxIntegralDigitsSpinBox.value + maxDecimalDigitsSpinBox.value
             }
         }
     }

--- a/storybook/qmlTests/tests/tst_AmountValidator.qml
+++ b/storybook/qmlTests/tests/tst_AmountValidator.qml
@@ -171,5 +171,27 @@ Item {
             compare(textField.acceptableInput, true)
             compare(textField.text, ".22")
         }
+
+        function test_maxTotalDigits() {
+            textField.text = "1234567891."
+            textField.forceActiveFocus()
+            textField.validator.maxDecimalDigits = 18
+            textField.validator.maxDigits = 15
+            textField.cursorPosition = 11
+
+            type(Qt.Key_1)
+            type(Qt.Key_2)
+            type(Qt.Key_3)
+            type(Qt.Key_4)
+            type(Qt.Key_5)
+
+            compare(textField.acceptableInput, true)
+            compare(textField.text, "1234567891.12345")
+
+            type(Qt.Key_6)
+
+            compare(textField.acceptableInput, true)
+            compare(textField.text, "1234567891.12345")
+        }
     }
 }

--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -176,7 +176,11 @@ Item {
 
             const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
             verify(!!amountToSendInput)
-            mouseClick(amountToSendInput)
+
+            const amountToSend_textField = findChild(controlUnderTest, "amountToSend_textField")
+            verify(!!amountToSend_textField)
+
+            mouseClick(amountToSend_textField)
             waitForRendering(amountToSendInput)
             verify(amountToSendInput.cursorVisible)
 
@@ -221,7 +225,11 @@ Item {
 
             const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
             verify(!!amountToSendInput)
-            mouseClick(amountToSendInput)
+
+            const amountToSend_textField = findChild(controlUnderTest, "amountToSend_textField")
+            verify(!!amountToSend_textField)
+
+            mouseClick(amountToSend_textField)
             waitForRendering(amountToSendInput)
             verify(amountToSendInput.cursorVisible)
 
@@ -398,10 +406,13 @@ Item {
             const amountToSendInput = findChild(controlUnderTest, "amountToSendInput")
             verify(!!amountToSendInput)
 
+            const amountToSend_textField = findChild(controlUnderTest, "amountToSend_textField")
+            verify(!!amountToSend_textField)
+
             const bottomItemText = findChild(amountToSendInput, "bottomItemText")
             verify(!!bottomItemText)
 
-            mouseClick(amountToSendInput)
+            mouseClick(amountToSend_textField)
             // enter 5.42 as entered amount
             keyClick(Qt.Key_5)
             keyClick(Qt.Key_Period)

--- a/ui/StatusQ/src/StatusQ/Validators/AmountValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Validators/AmountValidator.qml
@@ -24,6 +24,7 @@ GenericValidator {
     property string decimalPoint: Qt.locale(locale).decimalPoint
     property int maxIntegralDigits: 10
     property int maxDecimalDigits: 10
+    property int maxDigits: maxIntegralDigits + maxDecimalDigits
 
     validate: {
         if (input.length === 0)
@@ -51,6 +52,9 @@ GenericValidator {
 
         const [integral, decimal] = pointsCount ? delocalized.split(".")
                                                 : [delocalized, ""]
+
+        if ((integral.length + decimal.length) > root.maxDigits)
+            return GenericValidator.Invalid
 
         if (integral.length > root.maxIntegralDigits)
             return GenericValidator.Invalid


### PR DESCRIPTION
fixes #16703

### What does the PR do

Adapts the send Amount to send as per new simple send modal design https://www.figma.com/design/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=25233-292013&t=lyrihnGzlWTKcnI8-4

### Affected areas

AmountToSend.qml
SendModal.qml
SwapModal.qml

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://github.com/user-attachments/assets/1d23dffd-65f2-4b7f-bb9e-36e35569ac4b

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
