### PR TITLE
Properly handle tx send errors

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -450,11 +450,13 @@ proc sendNotification[T](self: Module[T], status: string, sendDetails: SendDetai
       fromAsset = sendDetails.fromToken
       toAsset = sendDetails.toToken
       error = ""
+      txHash = ""
+      isApprovalTx = false
 
     if not sendDetails.errorResponse.isNil:
       error = sendDetails.errorResponse.details
 
-    if sentTransaction.hash.len > 0:
+    if not sentTransaction.isNil and sentTransaction.hash.len > 0:
       txTo = sentTransaction.toAddress
       if sentTransaction.fromChain > 0:
         fromChain = sentTransaction.fromChain
@@ -471,6 +473,8 @@ proc sendNotification[T](self: Module[T], status: string, sendDetails: SendDetai
         fromAsset = sentTransaction.fromToken
       if sentTransaction.toToken.len > 0:
         toAsset = sentTransaction.toToken
+      txHash = sentTransaction.hash
+      isApprovalTx = sentTransaction.approvalTx
 
 
     var accFromName = ""
@@ -505,8 +509,8 @@ proc sendNotification[T](self: Module[T], status: string, sendDetails: SendDetai
       accToName,
       txTo,
       txToName,
-      sentTransaction.hash,
-      sentTransaction.approvalTx,
+      txHash,
+      isApprovalTx,
       fromAmount,
       toAmount,
       fromAsset,

--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -55,11 +55,17 @@ proc delete*(self: Controller) =
 proc init*(self: Controller) =
   self.events.on(SIGNAL_TRANSACTION_SENT) do(e:Args):
     let args = TransactionArgs(e)
+    var 
+      txHash = ""
+      isApprovalTx = false
+    if not args.sentTransaction.isNil:
+      txHash = args.sentTransaction.hash
+      isApprovalTx = args.sentTransaction.approvalTx
     self.delegate.transactionWasSent(
       args.sendDetails.uuid,
       args.sendDetails.fromChain,
-      args.sentTransaction.approvalTx,
-      args.sentTransaction.hash,
+      isApprovalTx,
+      txHash,
       if not args.sendDetails.errorResponse.isNil: args.sendDetails.errorResponse.details else: ""
     )
 


### PR DESCRIPTION
### What does the PR do

When some tx send error occurred, no `sentTransaction` field is sent with the event. Some parts of the code reacting to that event were not performing the necessary nil checks, causing a crash. This PR fixes that.

We also bump status-go to bring https://github.com/status-im/status-go/pull/6132/files
