### PR TITLE
fix(edit): fix message edits loses the album of images

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -292,8 +292,8 @@ proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], commun
 proc deleteMessage*(self: Controller, messageId: string) =
   self.messageService.deleteMessage(messageId)
 
-proc editMessage*(self: Controller, messageId: string, contentType: int, updatedMsg: string) =
-  self.messageService.editMessage(messageId, contentType, updatedMsg)
+proc editMessage*(self: Controller, messageId: string, updatedMsg: string) =
+  self.messageService.editMessage(messageId, updatedMsg)
 
 proc getSearchedMessageId*(self: Controller): string =
   return self.searchedMessageId

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -129,7 +129,7 @@ method onMessageRemoved*(self: AccessInterface, messageId, removedBy: string) {.
 method onMessagesDeleted*(self: AccessInterface, messageIds: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method editMessage*(self: AccessInterface, messageId: string, contentType: int, updatedMsg: string) {.base.} =
+method editMessage*(self: AccessInterface, messageId: string, updatedMsg: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onHistoryCleared*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -601,8 +601,8 @@ method onMessagesDeleted*(self: Module, messageIds: seq[string]) =
   for messageId in messageIds:
     self.view.model().removeItem(messageId)
 
-method editMessage*(self: Module, messageId: string, contentType: int, updatedMsg: string) =
-  self.controller.editMessage(messageId, contentType, updatedMsg)
+method editMessage*(self: Module, messageId: string, updatedMsg: string) =
+  self.controller.editMessage(messageId, updatedMsg)
 
 method onMessageEdited*(self: Module, message: MessageDto) =
   let itemBeforeChange = self.view.model().getItemWithMessageId(message.id)

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -120,8 +120,8 @@ QtObject:
   proc setEditModeOff*(self: View, messageId: string) {.slot.} =
    self.model.setEditModeOff(messageId)
 
-  proc editMessage*(self: View, messageId: string, contentType: int, updatedMsg: string) {.slot.} =
-    self.delegate.editMessage(messageId, contentType, updatedMsg)
+  proc editMessage*(self: View, messageId: string, updatedMsg: string) {.slot.} =
+    self.delegate.editMessage(messageId, updatedMsg)
 
   proc switchToMessage(self: View, messageIndex: int) {.signal.}
   proc emitSwitchToMessageSignal*(self: View, messageIndex: int) =

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1157,12 +1157,12 @@ proc bulkReplacePubKeysWithDisplayNames(self: Service, messages: var seq[Message
   for i in 0..<messages.len:
     messages[i].text = message_common.replacePubKeysWithDisplayNames(allKnownContacts, messages[i].text)
 
-proc editMessage*(self: Service, messageId: string, contentType: int, msg: string) =
+proc editMessage*(self: Service, messageId: string, msg: string) =
   try:
     let allKnownContacts = self.contactService.getContactsByGroup(ContactsGroup.AllKnownContacts)
     let processedMsg = message_common.replaceMentionsWithPubKeys(allKnownContacts, msg)
 
-    let response = status_go.editMessage(messageId, contentType, processedMsg)
+    let response = status_go.editMessage(messageId, processedMsg)
 
     var messagesArr: JsonNode
     var messages: seq[MessageDto]

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -66,8 +66,8 @@ proc markCertainMessagesFromChatWithIdAsRead*(chatId: string, messageIds: seq[st
 proc deleteMessageAndSend*(messageID: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("deleteMessageAndSend".prefix, %* [messageID])
 
-proc editMessage*(messageId: string, contentType: int, msg: string): RpcResponse[JsonNode] =
-  result = callPrivateRPC("editMessage".prefix, %* [{"id": messageId, "text": msg, "content-type": contentType}])
+proc editMessage*(messageId: string, msg: string): RpcResponse[JsonNode] =
+  result = callPrivateRPC("editMessage".prefix, %* [{"id": messageId, "text": msg}])
 
 proc resendChatMessage*(messageId: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("reSendChatMessage".prefix, %* [messageId])

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -168,10 +168,10 @@ QtObject {
         messageModule.setEditModeOff(messageId)
     }
 
-    function editMessage(messageId, contentType, updatedMsg) {
+    function editMessage(messageId, updatedMsg) {
         if(!messageModule)
             return
-        messageModule.editMessage(messageId, contentType, updatedMsg)
+        messageModule.editMessage(messageId, updatedMsg)
     }
 
     function interpretMessage(msg) {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -690,7 +690,6 @@ Loader {
                     root.messageStore.setEditModeOff(root.messageId)
                     root.messageStore.editMessage(
                         root.messageId,
-                        Utils.isOnlyEmoji(message) ? Constants.messageContentType.emojiType : Constants.messageContentType.messageType,
                         interpretedMessage
                     )
                 }


### PR DESCRIPTION
### What does the PR do

Fixes #16741

status-go PR: https://github.com/status-im/status-go/pull/6133

The problem was that we replaced the ContentType from Image to Text, so on restart, it doesn't understand it had images anymore.

Fixed in status-go by reusing the ContentType of the original message.

This makes it so that we don't need to pass the ContentType from Nim anymore, so I removed that param from the code.

### Affected areas

Message edits

### Screenshot of functionality (including design for comparison)

[edit-images.webm](https://github.com/user-attachments/assets/53ce366b-91d3-4a21-87e9-ab60c6dc76e0)

### Impact on end user

Fixes editing messages with Images

### How to test

1. Send an image or images
2. Edit the message on it
3. restart the app

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case: the issue still happens
