### PR TITLE
fix(BC): Fixing the testnet dApp connection

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -334,7 +334,7 @@ WalletConnectSDKBase {
                             url
                         }
                     },
-                    requiredNamespaces: supportedNamespaces
+                    requiredNamespaces: JSON.parse(supportedNamespaces)
                 }
             }
             return proposal

--- a/ui/app/AppLayouts/Wallet/services/dapps/plugins/DAppConnectionsPlugin.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/plugins/DAppConnectionsPlugin.qml
@@ -139,8 +139,17 @@ SQUtils.QObject {
 
         function onSessionProposal(sessionProposal) {
             const key = sessionProposal.id
+            const namespaces = sessionProposal.params.requiredNamespaces
+            const { chains, _ } = DAppsHelpers.extractChainsAndAccountsFromApprovedNamespaces(namespaces)
             d.activeProposals.set(key.toString(), { context: sessionProposal, promise: bcConnectionPromise })
-            root.newConnectionProposed(key, [1], sessionProposal.params.proposer.metadata.url, sessionProposal.params.proposer.metadata.name, sessionProposal.params.proposer.metadata.icons[0], Constants.DAppConnectors.StatusConnect)
+            root.newConnectionProposed(
+                key,
+                chains,
+                sessionProposal.params.proposer.metadata.url,
+                sessionProposal.params.proposer.metadata.name,
+                sessionProposal.params.proposer.metadata.icons[0],
+                Constants.DAppConnectors.StatusConnect
+            )
         }
 
         function onApproveSessionResult(proposalId, session, err) {


### PR DESCRIPTION
### What does the PR do

closes #16830 

The plugin connection was hardcoded on chainId 1. As a result it was impossible to establish a connection on testnet.
Fixing connection flows to include all supported chains.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Browser connect
<!-- List the affected areas (e.g wallet, browser, etc..) -->

https://github.com/user-attachments/assets/f4143439-2bc9-4068-8382-e99ca37cda04


@virginiabalducci @benjthayer This PR proposes an update to the chains selection proposed to the user. In the [BC designs](https://www.figma.com/design/1OYKMzU6KTQHQAqDhojk0r/Status-connector?node-id=2009-321&node-type=frame&m=dev) we're asking the user to approve the dApp session on Mainnet. But this is not accurate (at least until we implement the chains management views). We don't know in advance on what chain the dApp wants to operate on. As a result, the best way forward I see for now is to propose to the user a session on all supported chains. The dApp will be initially connected on Eth, but this can change at any time if the dApp requests a chain switch as long as we support the requested chain.


