### PR TITLE
fix(dapps): Update the connect modal close policy

### DIFF
--- a/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
+++ b/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
@@ -99,6 +99,14 @@ StatusDialog {
                                     qsTr("Connection request")
 
     padding: 0
+    closePolicy: Popup.NoAutoClose
+
+    header: StatusDialogHeader {
+        visible: root.title || root.subtitle
+        headline.title: root.title
+        headline.subtitle: root.subtitle
+        actions.closeButton.visible: false
+    }
 
     StatusScrollView {
         id: scrollView


### PR DESCRIPTION
### What does the PR do

closes: #16829

Adding NoAutoClose option to the popup.
Removing the close button in the popup header.

This will align the connect modal to the sign modal close policy.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

WalletConnect
BrowserConnect


https://github.com/user-attachments/assets/4aa833cf-52d7-49b9-b5cb-d7840a976ce9


