### PR TITLE
refactoring(dapps): Move WC and BC popups in the global scope

### DIFF
--- a/storybook/pages/DAppsWorkflowPage.qml
+++ b/storybook/pages/DAppsWorkflowPage.qml
@@ -24,7 +24,9 @@ import AppLayouts.Wallet.services.dapps.types 1.0
 
 import SortFilterProxyModel 0.2
 
+import AppLayouts.Wallet.controls 1.0
 import AppLayouts.Wallet.panels 1.0
+import AppLayouts.Wallet.popups.dapps 1.0
 import AppLayouts.Profile.stores 1.0
 import AppLayouts.Wallet.stores 1.0 as WalletStore
 import AppLayouts.stores 1.0 as AppLayoutStores
@@ -52,31 +54,39 @@ Item {
 
             Rectangle {
                 Layout.alignment: Qt.AlignCenter
-                Layout.preferredWidth: dappsWorkflow.implicitHeight + 20
-                Layout.preferredHeight: dappsWorkflow.implicitHeight + 20
+                Layout.preferredWidth: dappsComboBox.implicitHeight + 20
+                Layout.preferredHeight: dappsComboBox.implicitHeight + 20
 
                 border.color: "blue"
                 border.width: 1
 
+                DappsComboBox {
+                    id: dappsComboBox
+                    anchors.centerIn: parent
+                    spacing: 8
+                    enabled: dappsService.isServiceOnline
+
+                    onPairDapp: dappsWorkflow.openPairing()
+                    onDisconnectDapp: dappsWorkflow.disconnectDapp(dappUrl)
+                    model: dappsService.dappsModel
+                    walletConnectEnabled: dappsService.walletConnectFeatureEnabled
+                    connectorEnabled: dappsService.connectorFeatureEnabled
+                }
+
                 DAppsWorkflow {
                     id: dappsWorkflow
 
-                    anchors.centerIn: parent
-
-                    spacing: 8
+                    visualParent: root
+                    enabled: dappsService.isServiceOnline
 
                     readonly property var wcService: dappsService
                     loginType: Constants.LoginType.Biometrics
                     selectedAccountAddress: ""
 
-                    model: wcService.dappsModel
+                    dAppsModel: wcService.dappsModel
                     accountsModel: dappModule.accountsModel
                     networksModel: dappModule.networksModel
                     sessionRequestsModel: wcService.sessionRequestsModel
-                    enabled: wcService.isServiceOnline
-
-                    walletConnectEnabled: wcService.walletConnectFeatureEnabled
-                    connectorEnabled: wcService.connectorFeatureEnabled
 
                     formatBigNumber: (number, symbol, noSymbolOption) => {
                         print ("formatBigNumber", number, symbol, noSymbolOption)
@@ -565,7 +575,7 @@ Item {
         function startTestCase() {
             d.activeTestCase = settings.testCase
             if(root.visible) {
-                dappsWorkflow.popup.open()
+                dappsComboBox.popup.open()
             }
         }
 

--- a/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
+++ b/storybook/qmlTests/tests/tst_DAppsWorkflow.qml
@@ -14,6 +14,7 @@ import AppLayouts.Wallet.services.dapps.types 1.0
 import AppLayouts.Profile.stores 1.0
 import AppLayouts.Wallet.panels 1.0
 import AppLayouts.Wallet.stores 1.0 as WalletStore
+import AppLayouts.Wallet.popups.dapps 1.0
 
 import shared.stores 1.0
 
@@ -937,7 +938,9 @@ Item {
         id: componentUnderTest
         DAppsWorkflow {
             loginType: Constants.LoginType.Password
-            model: ListModel {}
+            visualParent: root
+            enabled: true
+            dAppsModel: ListModel {}
             accountsModel: ListModel {}
             networksModel: ListModel {}
             sessionRequestsModel: SessionRequestsModel {}
@@ -1019,41 +1022,10 @@ Item {
             signRequestRejectedSpy.clear()
         }
 
-        function test_OpenAndCloseDappList() {
-            waitForRendering(controlUnderTest)
-
-            mouseClick(controlUnderTest)
-            waitForRendering(controlUnderTest)
-            let popup = findChild(controlUnderTest, "dappsListPopup")
-            verify(!!popup)
-            verify(popup.opened)
-
-            popup.close()
-            waitForRendering(controlUnderTest)
-            verify(!popup.opened)
-        }
-
         function openPairModal() {
-            waitForRendering(controlUnderTest)
 
-            mouseClick(controlUnderTest)
-
-            let popup = findChild(controlUnderTest, "dappsListPopup")
-            verify(!!popup)
-            verify(popup.opened)
-
-            let connectButton = findChild(popup, "connectDappButton")
-            verify(!!connectButton)
-
-            mouseClick(connectButton)
-            const btnWalletConnect = findChild(controlUnderTest, "btnWalletConnect")
-            verify(!!btnWalletConnect)
-            mouseClick(btnWalletConnect)
-
-            verify(pairWCReadySpy.count === 1, "expected pairWCReady signal to be emitted")
-
+            controlUnderTest.openPairing()
             let pairWCModal = findChild(controlUnderTest, "pairWCModal")
-            verify(!!pairWCModal)
             return pairWCModal
         }
 
@@ -1087,7 +1059,6 @@ Item {
         }
 
         function test_OpenDappRequestModal() {
-            waitForRendering(controlUnderTest)
             const request = buildSessionRequestResolved(dappsWorkflowTest, "0x1", "1", "b536a")
             controlUnderTest.accountsModel.append({
                     address: request.accountAddress,
@@ -1103,7 +1074,7 @@ Item {
                     layer: 1
             })
             controlUnderTest.sessionRequestsModel.enqueue(request)
-            waitForRendering(controlUnderTest)
+            waitForRendering(controlUnderTest.visualParent, 200)
             let popup = findChild(controlUnderTest, "dappsRequestModal")
             verify(!!popup)
             verify(popup.opened)
@@ -1113,13 +1084,11 @@ Item {
             compare(popup.accountAddress, request.accountAddress)
 
             popup.close()
-            waitForRendering(controlUnderTest)
             verify(!popup.opened)
             verify(!popup.visible)
         }
 
         function showRequestModal(topic, requestId) {
-            waitForRendering(controlUnderTest)
             const request = buildSessionRequestResolved(dappsWorkflowTest, "0x1", "1", topic, requestId)
             controlUnderTest.accountsModel.append({
                     address: request.accountAddress,
@@ -1135,7 +1104,7 @@ Item {
                     layer: 1
             })
             controlUnderTest.sessionRequestsModel.enqueue(request)
-            waitForRendering(controlUnderTest)
+            waitForRendering(controlUnderTest.visualParent, 200)
             const popup = findChild(controlUnderTest, "dappsRequestModal")
             verify(popup.opened)
 
@@ -1177,7 +1146,6 @@ Item {
             compare(signRequestAcceptedSpy.signalArguments[0][0], topic, "expected id to be set")
             compare(signRequestAcceptedSpy.signalArguments[0][1], requestId, "expected requestId to be set")
 
-            waitForRendering(controlUnderTest)
             verify(!popup.opened)
             verify(!popup.visible)
         }
@@ -1248,8 +1216,8 @@ Item {
 
             controlUnderTest.sessionRequestsModel.removeRequest(topic, requestId)
             verify(!controlUnderTest.sessionRequestsModel.findRequest(topic, requestId))
+            waitForRendering(controlUnderTest.visualParent, 200)
 
-            waitForRendering(controlUnderTest)
             popup = findChild(controlUnderTest, "dappsRequestModal")
             verify(!popup)
         }

--- a/storybook/qmlTests/tests/tst_DappsComboBox.qml
+++ b/storybook/qmlTests/tests/tst_DappsComboBox.qml
@@ -13,15 +13,12 @@ Item {
     Component {
         id: componentUnderTest
         DappsComboBox {
+            property SignalSpy dappsListReadySpy: SignalSpy { target: controlUnderTest; signalName: "dappsListReady" }
+            property SignalSpy pairDappSpy: SignalSpy { target: controlUnderTest; signalName: "pairDapp" }
+
             anchors.centerIn: parent
             model: ListModel {}
         }
-    }
-
-    SignalSpy {
-        id: dappsListReadySpy
-        target: controlUnderTest
-        signalName: "dappsListReady"
     }
 
     property DappsComboBox controlUnderTest: null
@@ -32,7 +29,6 @@ Item {
 
         function init() {
             controlUnderTest = createTemporaryObject(componentUnderTest, root)
-            dappsListReadySpy.clear()
         }
 
         function test_basicGeometry() {
@@ -67,7 +63,7 @@ Item {
             compare(popup.y, controlUnderTest.height + 4)
             compare(popup.width, 312)
             verify(popup.height > 0)
-            compare(dappsListReadySpy.count, 1)
+            compare(controlUnderTest.dappsListReadySpy.count, 1)
 
             const background = findChild(controlUnderTest, "dappsBackground")
             compare(background.active, true)
@@ -125,6 +121,20 @@ Item {
 
             controlUnderTest.connectorEnabled = true
             compare(connectorButton.enabled, true)
+        }
+
+        function test_openPairModal() {
+            mouseClick(controlUnderTest)
+            const dappListPopup = findChild(controlUnderTest, "dappsListPopup")
+            verify(!!dappListPopup)
+
+            dappListPopup.connectDapp()
+            const wcButton = findChild(controlUnderTest, "btnWalletConnect")
+            verify(!!wcButton)
+
+            mouseClick(wcButton)
+            compare(dappListPopup.visible, false)
+            compare(controlUnderTest.pairDappSpy.count, 1)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -42,6 +42,14 @@ Item {
     property bool appMainVisible
 
     property bool swapEnabled
+    property bool dAppsEnabled
+    property bool walletConnectEnabled: true
+    property bool browserConnectEnabled: true
+
+    property var dAppsModel
+
+    signal dappPairRequested()
+    signal dappDisconnectRequested(string dappUrl)
 
     onAppMainVisibleChanged: {
         resetView()
@@ -232,6 +240,11 @@ Item {
             networkConnectionStore: root.networkConnectionStore
 
             swapEnabled: root.swapEnabled
+            dAppsEnabled: root.dAppsEnabled
+            walletConnectEnabled: root.walletConnectEnabled
+            browserConnectEnabled: root.browserConnectEnabled
+
+            dAppsModel: root.dAppsModel
 
             headerButton.text: RootStore.overview.ens || StatusQUtils.Utils.elideAndFormatWalletAddress(RootStore.overview.mixedcaseAddress)
             headerButton.visible: !RootStore.overview.isAllAccounts
@@ -246,6 +259,8 @@ Item {
                 d.swapFormData.defaultToTokenKey = RootStore.areTestNetworksEnabled ? Constants.swap.testStatusTokenKey : Constants.swap.mainnetStatusTokenKey
                 Global.openSwapModalRequested(d.swapFormData)
             }
+            onDappPairRequested: root.dappPairRequested()
+            onDappDisconnectRequested: (dappUrl) => root.dappDisconnectRequested(dappUrl)
             onLaunchBuyCryptoModal: d.launchBuyCryptoModal()
         }
     }

--- a/ui/app/AppLayouts/Wallet/panels/qmldir
+++ b/ui/app/AppLayouts/Wallet/panels/qmldir
@@ -2,7 +2,6 @@ ActivityFilterPanel 1.0 ActivityFilterPanel.qml
 BuyCryptoProvidersListPanel 1.0 BuyCryptoProvidersListPanel.qml
 BuyReceiveBanner 1.0 BuyReceiveBanner.qml
 ContractInfoButtonWithMenu 1.0 ContractInfoButtonWithMenu.qml
-DAppsWorkflow 1.0 DAppsWorkflow.qml
 ManageAssetsPanel 1.0 ManageAssetsPanel.qml
 ManageCollectiblesPanel 1.0 ManageCollectiblesPanel.qml
 ManageHiddenPanel 1.0 ManageHiddenPanel.qml

--- a/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
@@ -16,9 +16,13 @@ import shared.popups.walletconnect 1.0
 
 import utils 1.0
 
-DappsComboBox {
+SQUtils.QObject {
     id: root
 
+    // Parent item for the popups
+    required property Item visualParent
+    // Whether the dapps can interract with the wallet
+    required property bool enabled
     // Values mapped to Constants.LoginType
     required property int loginType
     /*
@@ -60,6 +64,15 @@ DappsComboBox {
         requestItem   [SessionRequestResolved]  - request object
     */ 
     property SessionRequestsModel sessionRequestsModel
+    /*
+      ObjectModel containing dApps
+        name          [string] - dApp name
+        iconUrl       [string] - dApp icon url
+        dAppUrl       [string] - dApp url
+        topic         [string] - dApp topic
+    */
+    property var dAppsModel
+
     property string selectedAccountAddress
 
     property var formatBigNumber: (number, symbol, noSymbolOption) => console.error("formatBigNumber not set")
@@ -97,11 +110,11 @@ DappsComboBox {
         connectDappLoader.connect(dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId)
     }
 
-    onPairDapp: {
+    function openPairing() {
         pairWCLoader.active = true
     }
 
-    onDisconnectDapp: (dappUrl) => {
+    function disconnectDapp(dappUrl) {
         disconnectdAppDialogLoader.dAppUrl = dappUrl
         disconnectdAppDialogLoader.active = true
     }
@@ -112,9 +125,10 @@ DappsComboBox {
         property string dAppUrl
 
         active: false
+        parent: root.visualParent
 
         onLoaded: {
-            const dApp = SQUtils.ModelUtils.getByKey(root.model, "url", dAppUrl);
+            const dApp = SQUtils.ModelUtils.getByKey(root.dAppsModel, "url", dAppUrl);
             if (dApp) {
                 item.dappName = dApp.name;
                 item.dappIcon = dApp.iconUrl;
@@ -133,7 +147,7 @@ DappsComboBox {
             }
 
             onAccepted: {
-                SQUtils.ModelUtils.forEach(model, (dApp) => {
+                SQUtils.ModelUtils.forEach(root.dAppsModel, (dApp) => {
                     if (dApp.url === dAppUrl) {
                         root.disconnectRequested(dApp.topic)
                     }
@@ -146,6 +160,7 @@ DappsComboBox {
         id: pairWCLoader
 
         active: false
+        parent: root.visualParent
 
         onLoaded: {
             item.open()
@@ -165,6 +180,7 @@ DappsComboBox {
         id: connectDappLoader
 
         active: false
+        parent: root.visualParent
 
         // Array of chaind ids
         property var dappChains
@@ -304,7 +320,7 @@ DappsComboBox {
                 root.signRequestRejected(request.topic, request.requestId)
             }
 
-            parent: root
+            parent: root.visualParent
 
             loginType: account.migratedToKeycard ? Constants.LoginType.Keycard : root.loginType
             formatBigNumber: root.formatBigNumber

--- a/ui/app/AppLayouts/Wallet/popups/dapps/qmldir
+++ b/ui/app/AppLayouts/Wallet/popups/dapps/qmldir
@@ -1,0 +1,1 @@
+DAppsWorkflow 1.0 DAppsWorkflow.qml

--- a/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
@@ -20,6 +20,11 @@ FocusScope {
     property NetworkConnectionStore networkConnectionStore
 
     property bool swapEnabled
+    property bool dAppsEnabled
+    property bool walletConnectEnabled
+    property bool browserConnectEnabled
+
+    property var dAppsModel
 
     property var sendModal
 
@@ -28,6 +33,9 @@ FocusScope {
     property alias networkFilter: header.networkFilter
 
     default property alias content: contentWrapper.children
+
+    signal dappPairRequested()
+    signal dappDisconnectRequested(string dappUrl)
 
     ColumnLayout {
         anchors.fill: parent
@@ -40,6 +48,13 @@ FocusScope {
             walletStore: WalletStores.RootStore
             networkConnectionStore: root.networkConnectionStore
             loginType: root.store.loginType
+            dAppsEnabled: root.dAppsEnabled
+            dAppsModel: root.dAppsModel
+            walletConnectEnabled: root.walletConnectEnabled
+            browserConnectEnabled: root.browserConnectEnabled
+
+            onDappPairRequested: root.dappPairRequested()
+            onDappDisconnectRequested: (dappUrl) =>root.dappDisconnectRequested(dappUrl)
         }
 
         Item {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -43,6 +43,7 @@ import AppLayouts.Chat.stores 1.0 as ChatStores
 import AppLayouts.Communities.stores 1.0
 import AppLayouts.Profile.stores 1.0 as ProfileStores
 import AppLayouts.Wallet.popups 1.0 as WalletPopups
+import AppLayouts.Wallet.popups.dapps 1.0 as DAppsPopups
 import AppLayouts.Wallet.stores 1.0 as WalletStores
 import AppLayouts.stores 1.0 as AppStores
 
@@ -1604,6 +1605,13 @@ Item {
                             appMainVisible: appMain.visible
                             swapEnabled: featureFlagsStore.swapEnabled
                             hideSignPhraseModal: userAgreementLoader.active
+                            dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
+                            walletConnectEnabled: featureFlagsStore.dappsEnabled
+                            browserConnectEnabled: featureFlagsStore.connectorEnabled
+                            dAppsModel: dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
+
+                            onDappPairRequested: dAppsServiceLoader.dappPairRequested()
+                            onDappDisconnectRequested: (dappUrl) => dAppsServiceLoader.dappDisconnectRequested(dappUrl)
                         }
                         onLoaded: {
                             item.resetView()
@@ -2344,6 +2352,9 @@ Item {
     Loader {
         id: dAppsServiceLoader
 
+        signal dappPairRequested()
+        signal dappDisconnectRequested(string dappUrl)
+
         // It seems some of the functionality of the dapp connector depends on the DAppsService
         active: {
             return (featureFlagsStore.dappsEnabled || featureFlagsStore.connectorEnabled) && appMain.visible
@@ -2351,8 +2362,41 @@ Item {
 
         sourceComponent: DAppsService {
             id: dAppsService
-            Component.onCompleted: {
-                Global.dAppsService = dAppsService
+
+            DAppsPopups.DAppsWorkflow {
+                id: dappsWorkflow
+
+                enabled: dAppsService.isServiceOnline
+                visualParent: appMain
+                loginType: appMain.rootStore.loginType
+                selectedAccountAddress: WalletStores.RootStore.selectedAddress
+                dAppsModel: dAppsService.dappsModel
+                accountsModel: WalletStores.RootStore.nonWatchAccounts
+                networksModel: WalletStores.RootStore.filteredFlatModel
+                sessionRequestsModel: dAppsService.sessionRequestsModel
+
+                formatBigNumber: (number, symbol, noSymbolOption) => WalletStores.RootStore.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
+
+                onDisconnectRequested: (connectionId) => dAppsService.disconnectDapp(connectionId)
+                onPairingRequested: (uri) => dAppsService.pair(uri)
+                onPairingValidationRequested: (uri) => dAppsService.validatePairingUri(uri)
+                onConnectionAccepted: (pairingId, chainIds, selectedAccount) => dAppsService.approvePairSession(pairingId, chainIds, selectedAccount)
+                onConnectionDeclined: (pairingId) => dAppsService.rejectPairSession(pairingId)
+                onSignRequestAccepted: (connectionId, requestId) => dAppsService.sign(connectionId, requestId)
+                onSignRequestRejected: (connectionId, requestId) => dAppsService.rejectSign(connectionId, requestId, false /*hasError*/)
+                onSignRequestIsLive: (connectionId, requestId) => dAppsService.signRequestIsLive(connectionId, requestId)
+
+                Connections {
+                    target: dAppsServiceLoader
+
+                    function onDappPairRequested() {
+                        dappsWorkflow.openPairing()
+                    }
+
+                    function onDappDisconnectRequested(dappUrl) {
+                        dappsWorkflow.disconnectDapp(dappUrl)
+                    }
+                }
             }
 
             // DAppsModule provides the middleware for the dapps
@@ -2396,6 +2440,20 @@ Item {
                 const icon = type === Constants.ephemeralNotificationType.danger ? "warning" : 
                             type === Constants.ephemeralNotificationType.success ? "checkmark-circle" : "info"
                 Global.displayToastMessage(message, "", icon, false, type, "")
+            }
+            onPairingValidated: (validationState) => {
+                dappsWorkflow.pairingValidated(validationState)
+            }
+            onApproveSessionResult: (pairingId, err, newConnectionId) => {
+                if (err) {
+                    dappsWorkflow.connectionFailed(pairingId)
+                    return
+                }
+
+                dappsWorkflow.connectionSuccessful(pairingId, newConnectionId)
+            }
+            onConnectDApp: (dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId) => {
+                dappsWorkflow.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorIcon, pairingId)
             }
         }
     }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -9,9 +9,6 @@ QtObject {
 
     property bool appIsReady: false
 
-    // use the generic var as type to break the cyclic dependency
-    property var dAppsService: null
-
     signal openPinnedMessagesPopupRequested(var store, var messageStore, var pinnedMessagesModel, string messageToPin, string chatId)
     signal openCommunityProfilePopupRequested(var store, var community, var chatCommunitySectionModule)
 


### PR DESCRIPTION
### What does the PR do

closes #16831

Moving the dapp popups to the global scope in order for them to be triggered on any view. There are a few changes required for this:
1. DAppsWorkflow has been split. Previously all popups were declared in the `DappsComboBox`. Now the DAppsWorkflow inherits the QObject instead and the `DappsComboBox` is used as is in the wallet header.
2. The DAppsWorkflow has been moved to AppMain. The DAppsWorkflow will be constructed in the scope of DAppsService and connected directly to the service signals
3. Updated tests and storybook with the new structure
4. Removed the `dAppsService` from `Global`. There's no reason to keep the `dAppsService` instance in the `Global` singleton.

Extra: Reduce the test execution time by configuring a 200ms timeout.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

WalletConnect
BrowserConnect

@virginiabalducci High regression risk on these two features.

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

#### WalletConnect

https://github.com/user-attachments/assets/068f3bfc-67b3-4f7f-898e-9eda37ac93e8

#### BrowserConnect

https://github.com/user-attachments/assets/23e201ac-7622-4882-b056-100a2d45c077

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->


### Impact on end user

The user will be able to interact with dApps from any Status view
### How to test

Trigger sign or connect events from dApps while the Wallet is not visible.

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [x] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
