### PR TITLE
[DO NOT MERGE] feat: trigger status-go panic button

### DIFF
--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -6,6 +6,7 @@ import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service as settings_service
 import ../../../../../app_service/service/stickers/service as stickers_service
 import ../../../../../app_service/service/node_configuration/service as node_configuration_service
+import ../../../../../backend/general as backend_general
 
 logScope:
   topics = "profile-section-advanced-module-controller"
@@ -148,3 +149,6 @@ proc enableCommunityHistoryArchiveSupport*(self: Controller): bool =
 
 proc disableCommunityHistoryArchiveSupport*(self: Controller): bool =
   self.nodeConfigurationService.disableCommunityHistoryArchiveSupport()
+
+proc statusgoIntendedPanic*(self: Controller, message: string) =
+  backend_general.intendedPanic(message)

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -110,3 +110,6 @@ method setMaxLogBackups*(self: AccessInterface, value: int) {.base.} =
 
 method onLogMaxBackupsChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method statusgoIntendedPanic*(self: AccessInterface, message: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -148,3 +148,6 @@ method setMaxLogBackups*(self: Module, value: int) =
 
 method onLogMaxBackupsChanged*(self: Module) =
   self.view.logMaxBackupsChanged()
+
+method statusgoIntendedPanic*(self: Module, message: string) =
+  self.controller.statusgoIntendedPanic(message)

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -140,3 +140,6 @@ QtObject:
 
   proc setMaxLogBackups*(self: View, value: int) {.slot.} =
     self.delegate.setMaxLogBackups(value)
+
+  proc statusgoIntendedPanic*(self: View, message: string) {.slot.} =
+    self.delegate.statusgoIntendedPanic(message)

--- a/src/backend/general.nim
+++ b/src/backend/general.nim
@@ -94,3 +94,6 @@ proc hashMessageForSigning*(message: string): string =
   except Exception as e:
     error "hashMessage: failed to parse json response", error = e.msg
     return ""
+
+proc intendedPanic*(message: string) =
+  discard status_go.intendedPanic(message)

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -200,4 +200,13 @@ QtObject {
 
         localAppSettings.scrollDeceleration = value
     }
+
+    function statusgoIntendedPanic() {
+        if (!advancedModule)
+            return
+
+        const message = Utils.uuid()
+        console.log("triggering status-go panic with message:", message)
+        advancedModule.statusgoIntendedPanic(message)
+    }
 }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -481,6 +481,20 @@ SettingsContentBase {
                 text: qsTr("RPC statistics")
                 onClicked: rpcStatsModal.open()
             }
+
+            Separator {
+                width: parent.width
+                height: Theme.padding
+            }
+
+            StatusButton {
+                Layout.leftMargin: Theme.padding
+                type: StatusBaseButton.Type.Danger
+                text: qsTr("Trigger status-go panic")
+                onClicked: {
+                    root.advancedStore.statusgoIntendedPanic()
+                }
+            }
         }
 
         FleetsModal {


### PR DESCRIPTION
> [!CAUTION]
> For testing purposes only. Do not merge.

# Description

This PR adds a button that calls the `IntendedPanic` status-go endpoint.

# How to test

1. Get a production build of this PR with https://ci.infra.status.im/
2. Have `Share usage data with Status` enabled
    <img width="1312" alt="Screenshot 2024-11-29 at 17 21 16" src="https://github.com/user-attachments/assets/55e09f35-ad9e-4352-a9a5-76d336d4a341">
3. Go to `Settings` -> `Advanced` and click `Trigger status-go panic`
    <img width="1312" alt="Screenshot 2024-11-29 at 17 21 22" src="https://github.com/user-attachments/assets/b0986f32-1ae6-4fe7-9762-1b04de8690e2">
4. Check the generated random panic message in logs:
    ```
    panic: m430g1g4gyh0z [recovered]
    ```
5. Find the panic with such code reported in [Sentry](https://sentry.infra.status.im/organizations/sentry/issues/?project=7&query=&statsPeriod=30d)
    <img width="642" alt="Screenshot 2024-11-29 at 17 25 18" src="https://github.com/user-attachments/assets/b951b6de-26ba-4467-ac61-40ef626ea18d">