### PR TITLE
Fix unread badge on the chat section button + fix unread count not being counted when the  chat is active and the app is not in focus

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -75,7 +75,7 @@ Item {
         }
 
         function markAllMessagesReadIfMostRecentMessageIsInViewport() {
-            if (!isMostRecentMessageInViewport || !chatLogView.visible || keepUnread) {
+            if (Qt.application.state != Qt.ApplicationActive || !isMostRecentMessageInViewport || !chatLogView.visible || keepUnread) {
                 return
             }
 
@@ -90,6 +90,15 @@ Item {
         }
 
         onIsMostRecentMessageInViewportChanged: markAllMessagesReadIfMostRecentMessageIsInViewport()
+    }
+
+    Connections {
+        target: Qt.application
+        onStateChanged: {
+            if (Qt.application.state == Qt.ApplicationActive) {
+                d.markAllMessagesReadIfMostRecentMessageIsInViewport()
+            }
+        }
     }
 
     Connections {
@@ -137,7 +146,7 @@ Item {
 
             // HACK: we call `addNewMessagesMarker` later because messages model
             // may not be yet propagated with unread messages when this signal is emitted
-            if (chatLogView.visible && !d.isMostRecentMessageInViewport) {
+            if (chatLogView.visible && (Qt.application.state != Qt.ApplicationActive || !d.isMostRecentMessageInViewport)) {
                 Qt.callLater(() => messageStore.addNewMessagesMarker())
             }
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1119,9 +1119,10 @@ Item {
                     tooltip.text: Utils.translatedSectionName(model.sectionType, model.name)
                     checked: model.active
                     badge.value: model.notificationsCount
-                    badge.visible: model.sectionType === Constants.appSection.profile &&
-                                   (contactsModelAdaptor.pendingReceivedRequestContacts.ModelCount.empty ? // pending contact request
-                                        model.hasNotification : true)
+                    badge.visible: (model.sectionType === Constants.appSection.profile &&
+                                   contactsModelAdaptor.pendingReceivedRequestContacts.ModelCount.count > 0) ? // pending contact request
+                                        true :
+                                        model.hasNotification // Otherwise, use the value coming from the model
                     badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusBadge.borderColor
                     badge.border.width: 2
                     onClicked: {


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/16098

The first problem was just a misplaces parenthesis. It prevented the Chat section badge to appear.

The second problem was that we were marking messages as read even if the app is in the background,  because the chat kept scrolling, even if the app was not active.
I fixed that by only marking as read if the app is active. I added a Connections to the active property of the Applicaiton too to mark as read when the app comes back active.
I also removed a condition that prevented the Unread messages line appearing in that condition.

Now, when a message is sent to the active chat, but the app is not in focus, the red dot appears, as well as the badges. Then when the app comes active, it is marked as read, but the unread messages line is shown to show when is the last time the user saw messages. This is similar to what Discord has.

### Affected areas

All chats, especially 1-1 since the first issue didn't affect communities

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[unread-badge.webm](https://github.com/user-attachments/assets/6af1e5eb-a03f-4002-9747-6f35933f2a68)

### Impact on end user

Fixes the issue and makes the UX of getting new messages way better, as you can now know exactly where you left off

### How to test

#### Issue 1 with the main badge

1. Have two apps that are in the same chats (1-1 or community)
2. Switch chat or section on one of them
3. send a message to the chat with the other
4. see that the chat section has a badge

#### Issue 2 with the active chat in background

1. Have two apps that are in the same chats
5. make the chat active on both
6. move one app to the background
7. send messages to the chat
8. see that the red dot shows in the task bar
9. When you make it active, the chat is marked as read (if it's scrolled at the bottom) and you have the unread messages line

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the issue still appears or the unread messages line behaves weird (as I have changed the condition on it)