### PR TITLE
chore(wallet): added param to fetchOrGetCachedWalletBalances call to align with statusgo change

### DIFF
--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -90,7 +90,7 @@ proc prepareTokensTask(argEncoded: string) {.gcsafe, nimcall.} =
     "storeResult": false
   }
   try:
-    let response = backend.fetchOrGetCachedWalletBalances(arg.accounts)
+    let response = backend.fetchOrGetCachedWalletBalances(arg.accounts, false) # TODO: think should we need to use arg.storeResult or not and if yes, is it everywhere set proprely
     output["result"] = response.result
     output["storeResult"] = %* arg.storeResult
   except Exception as e:

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -132,6 +132,7 @@ rpc(getWalletToken, "wallet"):
 
 rpc(fetchOrGetCachedWalletBalances, "wallet"):
   accounts: seq[string]
+  forceRefresh: bool
 
 rpc(fetchMarketValues, "wallet"):
   symbols: seq[string]


### PR DESCRIPTION
Corresponding `statusgo` PR: 
- https://github.com/status-im/status-go/pull/6160/files

This PR aligns with the updated `fetchOrGetCachedWalletBalances ` call. A new param was added to the call.