### PR TITLE
fix(chat): Fix disappearing payment request after message edit

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1

--- a/ui/app/AppLayouts/Chat/popups/PaymentRequestModal.qml
+++ b/ui/app/AppLayouts/Chat/popups/PaymentRequestModal.qml
@@ -55,7 +55,7 @@ StatusDialog {
     objectName: "paymentRequestModal"
 
     implicitWidth: 480
-    implicitHeight: 470
+    implicitHeight: 480
 
     modal: true
     padding: 0


### PR DESCRIPTION
Fixes #16870
Fixes #16869

### What does the PR do

* Fixed popup height, so that network selector isn't clipped
* Fixed import. That caused the payment request list to disappear. This also affected gifs and link previews.

### Affected areas

Chat view

### Architecture compliance

- [X] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/15607a1f-8f58-4289-8d0b-bd3bec4211f1

### Impact on end user

See decription at beginning

### How to test

- How should one proceed with testing this PR.
Height: Open payment request
Edit: Edit message with payment request in it.
- What kind of user flows should be checked?
Payment Request

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [X] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

