### PR TITLE
fix(SyncingDeviceView): fix user image misalignment

### DIFF
--- a/ui/imports/shared/views/SyncingDeviceView.qml
+++ b/ui/imports/shared/views/SyncingDeviceView.qml
@@ -47,6 +47,7 @@ Item {
         spacing: 0
 
         UserImage {
+            Layout.alignment: Qt.AlignHCenter
             name: root.userDisplayName
             colorId: root.userColorId
             colorHash: root.userColorHash


### PR DESCRIPTION
### What does the PR do

- re-add forgotten `Layout.alignment: Qt.AlignHCenter`

Fixes #16879

### Affected areas

Settings/Syncing

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/1bd8b343-00d1-478b-8551-30b512ad6ef3)

