### PR TITLE
fix(block): remove chat and messages when blocking a contact

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -882,7 +882,7 @@ method onCategoryNameChanged*(self: Module, category: Category) =
   self.view.chatsModel().renameCategory(category.id, category.name)
 
 method onCommunityChannelDeletedOrChatLeft*(self: Module, chatId: string) =
-  if(not self.chatContentModules.contains(chatId)):
+  if not self.chatContentModules.contains(chatId):
     return
   self.view.chatsModel().removeItemById(chatId)
   self.removeSubmodule(chatId)
@@ -1197,6 +1197,7 @@ method blockContact*(self: Module, publicKey: string) =
 method onContactBlocked*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemById(publicKey)
   self.view.chatsModel().changeBlockedOnItemById(publicKey, blocked=true)
+  self.onCommunityChannelDeletedOrChatLeft(publicKey)
 
 method onContactUnblocked*(self: Module, publicKey: string) =
   self.view.chatsModel().changeBlockedOnItemById(publicKey, blocked=false)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -84,9 +84,6 @@ type
     role*: MemberRole
     joined*: bool
 
-  RpcResponseArgs* = ref object of Args
-    response*: RpcResponse[JsonNode]
-
   CheckChannelPermissionsResponseArgs* = ref object of Args
     communityId*: string
     chatId*: string
@@ -120,7 +117,6 @@ const SIGNAL_CHAT_MEMBER_UPDATED* = "chatMemberUpdated"
 const SIGNAL_CHAT_SWITCH_TO_OR_CREATE_1_1_CHAT* = "switchToOrCreateOneToOneChat"
 const SIGNAL_CHAT_ADDED_OR_UPDATED* = "chatAddedOrUpdated"
 const SIGNAL_CHAT_CREATED* = "chatCreated"
-const SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND* = "chatRequestUpdateAfterSend"
 const SIGNAL_CHECK_CHANNEL_PERMISSIONS_RESPONSE* = "checkChannelPermissionsResponse"
 const SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_RESPONSE* = "checkAllChannelsPermissionsResponse"
 const SIGNAL_CHECK_ALL_CHANNELS_PERMISSIONS_FAILED* = "checkAllChannelsPermissionsFailed"
@@ -182,10 +178,6 @@ QtObject:
       if (receivedData.clearedHistories.len > 0):
         for clearedHistoryDto in receivedData.clearedHistories:
           self.events.emit(SIGNAL_CHAT_HISTORY_CLEARED, ChatArgs(chatId: clearedHistoryDto.chatId))
-
-    self.events.on(SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND) do(e: Args):
-      var args = RpcResponseArgs(e)
-      discard self.processMessengerResponse(args.response)
 
   proc asyncGetActiveChats*(self: Service) =
     let arg = AsyncGetActiveChatsTaskArg(

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -52,9 +52,6 @@ type
     publicKey*: string
     ok*: bool
 
-  RpcResponseArgs* = ref object of Args
-    response*: RpcResponse[JsonNode]
-
   AppendChatMessagesArgs* = ref object of Args
     chatId*: string
     messages*: JsonNode
@@ -395,9 +392,9 @@ QtObject:
     if self.contacts.hasKey(publicKey):
       if self.contacts[publicKey].dto.added and not self.contacts[publicKey].dto.removed and contact.added and not contact.removed:
         signal = SIGNAL_CONTACT_UPDATED
-    if contact.removed:
-      singletonInstance.globalEvents.showContactRemoved("Contact removed", fmt "You removed {contact.displayName} as a contact", contact.id)
-      signal = SIGNAL_CONTACT_REMOVED
+      if contact.removed and not self.contacts[publicKey].dto.removed:
+        singletonInstance.globalEvents.showContactRemoved("Contact removed", fmt "You removed {contact.displayName} as a contact", contact.id)
+        signal = SIGNAL_CONTACT_REMOVED
 
     self.contacts[publicKey] = self.constructContactDetails(contact)
     self.events.emit(signal, ContactArgs(contactId: publicKey))

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -9,7 +9,7 @@ proc getContacts*(): RpcResponse[JsonNode] =
   result = callPrivateRPC("contacts".prefix, payload)
 
 proc blockContact*(id: string): RpcResponse[JsonNode] =
-  result = callPrivateRPC("blockContactDesktop".prefix, %* [id])
+  result = callPrivateRPC("blockContact".prefix, %* [id])
 
 proc unblockContact*(id: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("unblockContact".prefix, %* [id])


### PR DESCRIPTION
### What does the PR do

Fixes #16640

This makes it so that when you block a contact, it now also removes the chat and the messages as expected by the requirements and as Mobile does.

To do so, I use the same API as mobile instead of the forked desktop one. I removed the desktop one as it is no longer needed [(see status-go PR)](https://github.com/status-im/status-go/pull/6172)

I also fixed an issue when unblocking where it would send a double toast messages with one saying you "removed the contact", but it was already removed.

### Affected areas

Chat and contacts

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[block-user.webm](https://github.com/user-attachments/assets/15eceac5-819f-4f1c-960f-65ec5f25003c)

### Impact on end user

Removes the chat and message when blocking

### How to test

- Block a contact that had sent messages
- Unblock them
- Add them again to see the 1-1 (no more messages from them [except the new CR])

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Not much. Worst case some parts of the blocked user still appear until a restart.
