### PR TITLE
feat(@desktop/wallet): Adding features of Account, Network and Token Selection to the popup

### DIFF
--- a/storybook/pages/CollectiblesSelectionAdaptorPage.qml
+++ b/storybook/pages/CollectiblesSelectionAdaptorPage.qml
@@ -10,6 +10,7 @@ import AppLayouts.Wallet.controls 1.0
 import AppLayouts.Wallet.adaptors 1.0
 import utils 1.0
 
+import Models 1.0
 import Storybook 1.0
 
 import SortFilterProxyModel 0.2
@@ -24,6 +25,8 @@ Pane {
             // collection 2
             {
                 tokenId: "id_3",
+                symbol: "abc",
+                chainId: NetworksModel.mainnetChainId,
                 name: "Multi-sequencer Test NFT 1",
                 contractAddress: "contract_2",
                 collectionName: "Multi-sequencer Test NFT",
@@ -43,6 +46,8 @@ Pane {
             },
             {
                 tokenId: "id_4",
+                symbol: "def",
+                chainId: NetworksModel.mainnetChainId,
                 name: "Multi-sequencer Test NFT 2",
                 contractAddress: "contract_2",
                 collectionName: "Multi-sequencer Test NFT",
@@ -62,6 +67,8 @@ Pane {
             },
             {
                 tokenId: "id_5",
+                symbol: "ghi",
+                chainId: NetworksModel.mainnetChainId,
                 name: "Multi-sequencer Test NFT 3",
                 contractAddress: "contract_2",
                 collectionName: "Multi-sequencer Test NFT",
@@ -82,6 +89,8 @@ Pane {
             // collection 1
             {
                 tokenId: "id_1",
+                symbol: "jkl",
+                chainId: NetworksModel.mainnetChainId,
                 name: "Genesis",
                 contractAddress: "contract_1",
                 collectionName: "ERC-1155 Faucet",
@@ -106,6 +115,8 @@ Pane {
             },
             {
                 tokenId: "id_2",
+                symbol: "mno",
+                chainId: NetworksModel.mainnetChainId,
                 name: "QAERC1155",
                 contractAddress: "contract_1",
                 collectionName: "ERC-1155 Faucet",
@@ -126,6 +137,8 @@ Pane {
             // collection 3, community token
             {
                 tokenId: "id_6",
+                symbol: "pqr",
+                chainId: NetworksModel.optChainId,
                 name: "My Token",
                 contractAddress: "contract_3",
                 collectionName: "My Token",
@@ -145,6 +158,8 @@ Pane {
             },
             {
                 tokenId: "id_7",
+                symbol: "stu",
+                chainId: NetworksModel.optChainId,
                 name: "My Token",
                 contractAddress: "contract_3",
                 collectionName: "My Token",
@@ -164,6 +179,8 @@ Pane {
             },
             {
                 tokenId: "id_8",
+                symbol: "vwx",
+                chainId: NetworksModel.optChainId,
                 name: "My Token",
                 contractAddress: "contract_3",
                 collectionName: "My Token",
@@ -183,6 +200,8 @@ Pane {
             },
             {
                 tokenId: "id_9",
+                symbol: "yz1",
+                chainId: NetworksModel.optChainId,
                 name: "My Other Token",
                 contractAddress: "contract_4",
                 collectionName: "My Other Token",
@@ -202,6 +221,8 @@ Pane {
             },
             {
                 tokenId: "id_10",
+                symbol: "234",
+                chainId: NetworksModel.arbChainId,
                 name: "My Community 2 Token",
                 contractAddress: "contract_5",
                 collectionName: "My Community 2 Token",
@@ -221,6 +242,8 @@ Pane {
             },
             {
                 tokenId: "id_11",
+                symbol: "567",
+                chainId: NetworksModel.arbChainId,
                 name: "My Community 2 Token",
                 contractAddress: "contract_5",
                 collectionName: "My Community 2 Token",
@@ -240,6 +263,8 @@ Pane {
             },
             {
                 tokenId: "id_11",
+                symbol: "8910",
+                chainId: NetworksModel.arbChainId,
                 name: "My Community 2 Token",
                 contractAddress: "contract_5",
                 collectionName: "My Community 2 Token",
@@ -259,6 +284,8 @@ Pane {
             },
             {
                 tokenId: "id_12",
+                symbol: "111213",
+                chainId: NetworksModel.arbChainId,
                 name: "My Community 2 Token",
                 contractAddress: "contract_5",
                 collectionName: "My Community 2 Token",
@@ -278,6 +305,8 @@ Pane {
             },
             {
                 tokenId: "id_13",
+                symbol: "141516",
+                chainId: NetworksModel.arbChainId,
                 name: "My Community 2 Token",
                 contractAddress: "contract_5",
                 collectionName: "My Community 2 Token",
@@ -312,6 +341,8 @@ Pane {
     CollectiblesSelectionAdaptor {
         id: adaptor
 
+        networksModel: NetworksModel.flatNetworks
+        enabledChainIds: [networksCombobox.currentValue]
         collectiblesModel: listModel
         accountKey: accountsSelector.selection
     }
@@ -330,6 +361,18 @@ Pane {
                 id: accountsSelector
 
                 Layout.fillWidth: true
+            }
+        }
+
+        RowLayout {
+            Label { text: "Enabled Networks:" }
+
+            ComboBox {
+                id: networksCombobox
+                model: NetworksModel.flatNetworks
+                textRole: "chainName"
+                valueRole: "chainId"
+                currentIndex: 0
             }
         }
 

--- a/storybook/pages/SendModalFooterPage.qml
+++ b/storybook/pages/SendModalFooterPage.qml
@@ -1,0 +1,56 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import StatusQ.Core.Theme 0.1
+
+import Storybook 1.0
+
+import AppLayouts.Wallet.views 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+    Logs { id: logs }
+
+    Rectangle {
+        SplitView.fillHeight: true
+        SplitView.fillWidth: true
+        color: Theme.palette.indirectColor1
+
+        SendModalFooter {
+            id: footer
+            anchors.centerIn: parent
+            width: 595
+
+            loading: loadingCheckbox.checked
+
+            onReviewSendClicked: console.log("review send clicked")
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        Column {
+            CheckBox {
+                id: loadingCheckbox
+                text: "loading"
+            }
+
+            Button {
+                text: "set fees values"
+                onClicked: {
+                    loadingCheckbox.checked = false
+                    footer.estimateTime = "~60s"
+                    footer.estimatedFees = "1.45 EUR"
+                }
+            }
+        }
+    }
+}
+
+// category: Views

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls 2.15
 import SortFilterProxyModel 0.2
 
 import StatusQ 0.1
+import StatusQ.Core 0.1
 
 import Models 1.0
 import Storybook 1.0
@@ -33,6 +34,15 @@ SplitView {
         }
 
         readonly property var walletAccountsModel: WalletAccountsModel{}
+
+        function getCurrencyAmount(amount, symbol) {
+            return ({
+                        amount: amount,
+                        symbol: symbol ? symbol.toUpperCase() : root.currentCurrency,
+                        displayDecimals: 2,
+                        stripTrailingZeroes: false
+                    })
+        }
     }
 
     PopupBackground {
@@ -60,10 +70,21 @@ SplitView {
         modal: false
         closePolicy: Popup.CloseOnEscape
 
+        interactive: interactiveCheckbox.checked
+
         accountsModel: d.walletAccountsModel
         assetsModel: assetsSelectorViewAdaptor.outputAssetsModel
         collectiblesModel: collectiblesSelectionAdaptor.model
         networksModel: d.filteredNetworksModel
+
+        currentCurrency: "USD"
+        fnFormatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
+            if (isNaN(amount)) {
+                return "N/A"
+            }
+            var currencyAmount = d.getCurrencyAmount(amount, symbol)
+            return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options, locale)
+        }
 
         Binding on selectedAccountAddress {
             value: accountsCombobox.currentValue ?? ""
@@ -123,7 +144,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "",
                 communityName: "",
-                communityImage: Qt.resolvedUrl("")
+                communityImage: Qt.resolvedUrl(""),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_4",
@@ -144,7 +166,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "",
                 communityName: "",
-                communityImage: Qt.resolvedUrl("")
+                communityImage: Qt.resolvedUrl(""),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_5",
@@ -165,7 +188,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "",
                 communityName: "",
-                communityImage: Qt.resolvedUrl("")
+                communityImage: Qt.resolvedUrl(""),
+                tokenType: Constants.TokenType.ERC721
             },
             // collection 1
             {
@@ -192,7 +216,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "",
                 communityName: "",
-                communityImage: Qt.resolvedUrl("")
+                communityImage: Qt.resolvedUrl(""),
+                tokenType: Constants.TokenType.ERC1155
             },
             {
                 tokenId: "id_2",
@@ -213,7 +238,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "",
                 communityName: "",
-                communityImage: Qt.resolvedUrl("")
+                communityImage: Qt.resolvedUrl(""),
+                tokenType: Constants.TokenType.ERC1155
             },
             // collection 3, community token
             {
@@ -235,7 +261,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_1",
                 communityName: "My community",
-                communityImage: Constants.tokenIcon("KIN", false)
+                communityImage: Constants.tokenIcon("KIN", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_7",
@@ -256,7 +283,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_1",
                 communityName: "My community",
-                communityImage: Constants.tokenIcon("KIN", false)
+                communityImage: Constants.tokenIcon("KIN", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_8",
@@ -277,7 +305,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_1",
                 communityName: "My community",
-                communityImage: Constants.tokenIcon("KIN", false)
+                communityImage: Constants.tokenIcon("KIN", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_9",
@@ -298,7 +327,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_1",
                 communityName: "My community",
-                communityImage: Constants.tokenIcon("KIN", false)
+                communityImage: Constants.tokenIcon("KIN", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_10",
@@ -319,7 +349,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_2",
                 communityName: "My community 2",
-                communityImage: Constants.tokenIcon("ICOS", false)
+                communityImage: Constants.tokenIcon("ICOS", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_11",
@@ -340,7 +371,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_2",
                 communityName: "My community 2",
-                communityImage: Constants.tokenIcon("ICOS", false)
+                communityImage: Constants.tokenIcon("ICOS", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_11",
@@ -361,7 +393,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_2",
                 communityName: "My community 2",
-                communityImage: Constants.tokenIcon("ICOS", false)
+                communityImage: Constants.tokenIcon("ICOS", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_12",
@@ -382,7 +415,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_2",
                 communityName: "My community 2",
-                communityImage: Constants.tokenIcon("ICOS", false)
+                communityImage: Constants.tokenIcon("ICOS", false),
+                tokenType: Constants.TokenType.ERC721
             },
             {
                 tokenId: "id_13",
@@ -403,7 +437,8 @@ SplitView {
                 mediaUrl: Qt.resolvedUrl(""),
                 communityId: "community_2",
                 communityName: "My community 2",
-                communityImage: Constants.tokenIcon("ICOS", false)
+                communityImage: Constants.tokenIcon("ICOS", false),
+                tokenType: Constants.TokenType.ERC721
             }
         ]
 
@@ -420,8 +455,10 @@ SplitView {
         ColumnLayout {
             spacing: 20
 
-            Text {
-                text: "Values to set before popup is launched"
+            CheckBox {
+                id: interactiveCheckbox
+                text: "Is interactive"
+                checked: true
             }
 
             Text {
@@ -489,6 +526,28 @@ SplitView {
             }
             Text {
                 text: "token selected is: " + simpleSend.selectedTokenKey
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                TextField {
+                    id: amountInput
+                    Layout.preferredWidth: 200
+                    Layout.preferredHeight: 50
+                    validator: RegularExpressionValidator {
+                        regularExpression: /^\d*\.?\d*$/
+                    }
+                }
+                Button {
+                    text: "update in modal"
+                    onClicked: simpleSend.selectedAmount = amountInput.text
+                }
+            }
+            Text {
+                text: "amount selected in base unit: " + simpleSend.selectedAmountInBaseUnit
+            }
+            Text {
+                text: "amount entered is: " + simpleSend.selectedAmount
             }
 
             RolesRenamingModel {

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -87,6 +87,7 @@ SplitView {
         modal: false
         closePolicy: Popup.CloseOnEscape
 
+        feesLoading: feesLoadingCheckbox.checked
         interactive: interactiveCheckbox.checked
 
         accountsModel: d.walletAccountsModel
@@ -488,6 +489,11 @@ SplitView {
                 id: interactiveCheckbox
                 text: "Is interactive"
                 checked: true
+            }
+
+            CheckBox {
+                id: feesLoadingCheckbox
+                text: "Fees loading"
             }
 
             Text {

--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -60,6 +60,12 @@ SplitView {
                        })
             }
         }
+
+        property var setFees: Backpressure.debounce(root, 1500, function () {
+            simpleSend.estimatedTime = "~60s"
+            simpleSend.estimatedFiatFees = "1.45 EUR"
+            simpleSend.estimatedCryptoFees = "0.0007 ETH"
+        })
     }
 
     PopupBackground {
@@ -87,7 +93,6 @@ SplitView {
         modal: false
         closePolicy: Popup.CloseOnEscape
 
-        feesLoading: feesLoadingCheckbox.checked
         interactive: interactiveCheckbox.checked
 
         accountsModel: d.walletAccountsModel
@@ -115,6 +120,12 @@ SplitView {
                 simpleSend.ensNameResolved(ensName, "", uuid) // invalid
             }
         })
+
+        onFetchFees: {
+            console.log("Fetch fees...")
+            d.setFees()
+        }
+        onReviewSendClicked: console.log("Review send clicked")
 
         Binding on selectedAccountAddress {
             value: accountsCombobox.currentValue ?? ""
@@ -489,11 +500,6 @@ SplitView {
                 id: interactiveCheckbox
                 text: "Is interactive"
                 checked: true
-            }
-
-            CheckBox {
-                id: feesLoadingCheckbox
-                text: "Fees loading"
             }
 
             Text {

--- a/storybook/pages/SimpleTransactionsFeesPage.qml
+++ b/storybook/pages/SimpleTransactionsFeesPage.qml
@@ -20,6 +20,8 @@ SplitView {
             anchors.centerIn: parent
             width: 400
 
+            cryptoFees: qsTr("0.0007 ETH")
+            fiatFees: qsTr("1.45 EUR")
             loading: loadingCheckbox.checked
         }
     }

--- a/storybook/pages/SimpleTransactionsFeesPage.qml
+++ b/storybook/pages/SimpleTransactionsFeesPage.qml
@@ -1,0 +1,42 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import StatusQ.Core.Theme 0.1
+
+import Storybook 1.0
+
+import AppLayouts.Wallet.panels 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+    Logs { id: logs }
+
+    Rectangle {
+        SplitView.fillHeight: true
+        SplitView.fillWidth: true
+        color: Theme.palette.baseColor3
+
+        SimpleTransactionsFees {
+            anchors.centerIn: parent
+            width: 400
+
+            loading: loadingCheckbox.checked
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        CheckBox {
+            id: loadingCheckbox
+            text: "loading"
+        }
+    }
+}
+
+// category: Views

--- a/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
@@ -46,6 +46,7 @@ QObject {
       Expected model structure:
 
         symbol              [string] - unique identifier of a collectible
+        chainId             [int] - unique identifier of a network
         collectionUid       [string] - unique identifier of a collection
         contractAddress     [string] - collectible's contract address
         name                [string] - collectible's name e.g. "Magicat"
@@ -73,6 +74,9 @@ QObject {
             icon            [url]    - icon of the subitem
     **/
     readonly property alias model: communityGroupsGrouppedByCollection
+
+    // In case collectibles are to be shown only on specific networks
+    property var enabledChainIds: []
 
     LeftJoinModel {
         id: jointCollectiblesByNwChainId
@@ -126,10 +130,18 @@ QObject {
             exposedRoles: ["balance", "groupingValue", "icon", "key"]
         }
 
-        filters: RangeFilter { /* 5 */
-            roleName: "balance"
-            minimumValue: 1
-        }
+        filters: [
+            RangeFilter { /* 5 */
+                roleName: "balance"
+                minimumValue: 1
+            },
+            // remove tokens not available on selected network(s)
+            FastExpressionFilter {
+                expression: root.enabledChainIds.includes(model.chainId)
+                expectedRoles: ["chainId"]
+                enabled: root.enabledChainIds.length
+            }
+        ]
 
         sorters: [ /* 6 */
             RoleSorter {

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -34,10 +34,15 @@ Control {
     property alias currentTab: tokenSelectorPanel.currentTab
 
     function setSelection(name: string, icon: url, key: string) {
-        tokenSelectorButton.selected = true
-        tokenSelectorButton.name = name
-        tokenSelectorButton.icon = icon
-        tokenSelectorPanel.highlightedKey = key ?? ""
+        // reset token selector in case of empty call
+        if (!key && !name && !icon) {
+            tokenSelectorButton.selected = false
+        } else {
+            tokenSelectorButton.selected = true
+            tokenSelectorButton.name = name
+            tokenSelectorButton.icon = icon
+            tokenSelectorPanel.highlightedKey = key ?? ""
+        }
     }
 
     QObject {

--- a/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
@@ -9,7 +9,7 @@ import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
 import shared.controls 1.0 as SharedControls
-// TODO: remove all files and dependecies with this location once old send modal is removed
+// TODO: remove all files and dependencies with this location once old send modal is removed
 import shared.popups.send.controls 1.0
 import shared.popups.send 1.0
 

--- a/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
@@ -130,8 +130,6 @@ Rectangle {
                     rotation: 45
                 },
                 StatusTextWithLoadingState {
-                    font.pixelSize: 15
-                    customColor: Theme.palette.directColor1
                     text: LocaleUtils.currencyAmountToLocaleString(entry.amountCurrency)
                 }
             ]

--- a/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
@@ -1,0 +1,187 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.1
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+
+import shared.controls 1.0 as SharedControls
+// TODO: remove all files and dependecies with this location once old send modal is removed
+import shared.popups.send.controls 1.0
+import shared.popups.send 1.0
+
+import utils 1.0
+
+import AppLayouts.Wallet.views 1.0
+
+Rectangle {
+    id: root
+
+    required property var savedAddressesModel
+    required property var myAccountsModel
+    required property var recentRecipientsModel
+
+    property alias selectedRecipientAddress: recipientInputLoader.selectedRecipientAddress
+    property alias selectedRecipientType: recipientInputLoader.selectedRecipientType
+
+    signal resolveENS(string ensName, string uuid)
+
+    function ensNameResolved(resolvedPubKey, resolvedAddress, uuid) {
+        recipientInputLoader.ensNameResolved(resolvedPubKey, resolvedAddress, uuid)
+    }
+
+    implicitHeight: childrenRect.height
+    color: Theme.palette.indirectColor1
+    radius: 8
+
+    ColumnLayout {
+        id: layout
+
+        width: parent.width
+        spacing: 0
+
+        RecipientView {
+            id: recipientInputLoader
+
+            Layout.fillWidth: true
+
+            savedAddressesModel: root.savedAddressesModel
+            myAccountsModel: root.myAccountsModel
+
+            onResolveENS: root.resolveENS(ensName, uuid)
+        }
+
+        StatusTabBar {
+            id: recipientTypeTabBar
+
+            objectName: "recipientTypeTabBar"
+
+            Layout.alignment: Qt.AlignTop
+            Layout.fillWidth: true
+            Layout.preferredHeight: implicitHeight
+            Layout.topMargin: 12
+
+            StatusTabButton {
+                width: implicitWidth
+                objectName: "recentAddressesTab"
+                text: qsTr("Recent")
+            }
+            StatusTabButton {
+                width: implicitWidth
+                objectName: "savedAddressesTab"
+                text: qsTr("Saved")
+            }
+            StatusTabButton {
+                width: implicitWidth
+                objectName: "myAccountsTab"
+                text: qsTr("My Accounts")
+            }
+
+            visible: !root.selectedRecipientAddress
+        }
+
+        Repeater {
+            id: repeater
+
+            Layout.alignment: Qt.AlignTop
+            Layout.fillWidth: true
+
+            model:  {
+                switch(recipientTypeTabBar.currentIndex) {
+                case 0:
+                    return recentsObjModel
+                case 1:
+                    return savedObjModel
+                case 2:
+                    return myAccountsObjModel
+                }
+            }
+        }
+    }
+
+    DelegateModel {
+        id: recentsObjModel
+
+        model: root.recentRecipientsModel
+        delegate: StatusListItem {
+            id: listItem
+
+            property var entry: model.activityEntry
+            property bool isIncoming: entry.txType === Constants.TransactionType.Receive
+
+            Layout.fillWidth: true
+            title: isIncoming ? StatusQUtils.Utils.elideText(entry.sender,6,4) : StatusQUtils.Utils.elideText(entry.recipient,6,4)
+            subTitle: LocaleUtils.getTimeDifference(new Date(parseInt(entry.timestamp) * 1000), new Date())
+            statusListItemTitle.elide: Text.ElideMiddle
+            statusListItemTitle.wrapMode: Text.NoWrap
+            radius: 0
+            color: sensor.containsMouse || highlighted ? Theme.palette.baseColor2 : "transparent"
+            statusListItemComponentsSlot.spacing: 5
+            components: [
+                StatusIcon {
+                    id: transferIcon
+                    height: 15
+                    width: 15
+                    color: listItem.isIncoming ? Theme.palette.successColor1 : Theme.palette.dangerColor1
+                    icon: listItem.isIncoming ? "arrow-down" : "arrow-up"
+                    rotation: 45
+                },
+                StatusTextWithLoadingState {
+                    font.pixelSize: 15
+                    customColor: Theme.palette.directColor1
+                    text: LocaleUtils.currencyAmountToLocaleString(entry.amountCurrency)
+                }
+            ]
+            onClicked: {
+                root.selectedRecipientType = Helpers.RecipientAddressObjectType.RecentsAddress
+                let isIncoming = entry.txType === Constants.TransactionType.Receive
+                let selectedAddress =  isIncoming ? entry.sender : entry.recipient
+                root.selectedRecipientAddress = selectedAddress
+            }
+            visible: !root.selectedRecipientAddress
+        }
+    }
+
+    DelegateModel {
+        id: savedObjModel
+
+        model: root.savedAddressesModel
+        delegate: SavedAddressListItem {
+            Layout.fillWidth: true
+            modelData: model
+            onClicked: {
+                root.selectedRecipientType = Helpers.RecipientAddressObjectType.SavedAddress
+                root.selectedRecipientAddress = modelData.address
+            }
+            visible: !root.selectedRecipientAddress
+        }
+    }
+
+    DelegateModel {
+        id: myAccountsObjModel
+
+        model: root.myAccountsModel
+        delegate: SharedControls.WalletAccountListItem {
+            required property var model
+
+            Layout.fillWidth: true
+
+            name: model.name
+            address: model.address
+            emoji: model.emoji
+            walletColor: Utils.getColorForId(model.colorId)
+            currencyBalance: model.currencyBalance
+            walletType: model.walletType
+            migratedToKeycard: model.migratedToKeycard ?? false
+            accountBalance: model.accountBalance ?? null
+            onClicked: {
+                root.selectedRecipientType = Helpers.RecipientAddressObjectType.Account
+                root.selectedRecipientAddress = model.address
+            }
+            visible: !root.selectedRecipientAddress
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
@@ -58,10 +58,6 @@ RowLayout {
     /** input property for programatic selection of network **/
     property int selectedChainId
 
-    /** input property for programatic selection of token
-    (asset/collectible/collection) **/
-    property string selectedTokenKey
-
     /** signal to propagate that an asset was selected **/
     signal assetSelected(string key)
     /** signal to propagate that a collection was selected **/
@@ -71,32 +67,10 @@ RowLayout {
     /** signal to propagate that a network was selected **/
     signal networkSelected(string chainId)
 
-    QtObject {
-        id: d
-        readonly property bool selectedTokenNotAvailableOnAssetsOrCollectiblesList: !selectedAssetEntry.available && !selectedCollectibleEntry.available
-        onSelectedTokenNotAvailableOnAssetsOrCollectiblesListChanged: {
-            if(selectedTokenNotAvailableOnAssetsOrCollectiblesList) {
-                // reset token selector in case selected tokens doesnt exist in either models
-                tokenSelector.setSelection("", "", "")
-            }
-        }
-
-        function updateAssetInTokenSelector(available, item) {
-            if(available) {
-                tokenSelector.setSelection(item.symbol,
-                                           Constants.tokenIcon(item.symbol),
-                                           item.tokensKey)
-            }
-        }
-
-        function updateCollectibleInTokenSelector(available, item) {
-            if(available) {
-                const id = item.communityId ? item.collectionUid : item.uid
-                tokenSelector.setSelection(item.name,
-                                           item.imageUrl || item.mediaUrl,
-                                           id)
-            }
-        }
+    /** input function for programatic selection of token
+    (asset/collectible/collection) **/
+    function setToken(name, icon, key) {
+        tokenSelector.setSelection(name, icon, key)
     }
 
     implicitHeight: sendModalTitleText.height
@@ -180,23 +154,5 @@ RowLayout {
         }
 
         onToggleNetwork: root.networkSelected(chainId)
-    }
-
-    ModelEntry {
-        id: selectedAssetEntry
-        sourceModel: root.assetsModel
-        key: "tokensKey"
-        value: root.selectedTokenKey
-        onAvailableChanged: d.updateAssetInTokenSelector(available, item)
-        onItemChanged: d.updateAssetInTokenSelector(available, item)
-    }
-
-    ModelEntry {
-        id: selectedCollectibleEntry
-        sourceModel: root.collectiblesModel
-        key: "symbol"
-        value: root.selectedTokenKey
-        onAvailableChanged: d.updateCollectibleInTokenSelector(available, item)
-        onItemChanged: d.updateCollectibleInTokenSelector(available, item)
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/SimpleTransactionsFees.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SimpleTransactionsFees.qml
@@ -1,0 +1,82 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+
+Control {
+    id: root
+
+    /** property to set fees in fiat along with fiat symbol **/
+    property alias cryptoFees: cryptoFeesText.text
+    /** property to set fees in crypto along with crypto symbol **/
+    property alias fiatFees: fiatFeesText.text
+
+    /** property to set loading state in the fees component **/
+    property bool loading
+
+    implicitHeight: 64
+
+    padding: Theme.padding
+    topPadding: 12
+    bottomPadding: 12
+
+    background: Rectangle {
+        color: Theme.palette.indirectColor1
+        radius: 8
+    }
+
+    contentItem: RowLayout {
+        width: parent.width
+        spacing: 12
+
+        StatusRoundIcon {
+            Layout.alignment: Qt.AlignTop
+
+            radius: 8
+            asset.name: "gas"
+            asset.color: Theme.palette.directColor1
+        }
+        ColumnLayout {
+            Layout.fillWidth: true
+
+            spacing: 0
+
+            StatusBaseText {
+                Layout.fillWidth: true
+
+                lineHeightMode: Text.FixedHeight
+                lineHeight: 22
+
+                text: qsTr("Est Mainnet transaction fee")
+            }
+            StatusTextWithLoadingState {
+                id: cryptoFeesText
+
+                Layout.fillWidth: true
+
+                loading: root.loading
+                customColor: Theme.palette.baseColor1
+                lineHeightMode: Text.FixedHeight
+                lineHeight: 22
+
+                text: qsTr("0.0007 ETH")
+            }
+        }
+        StatusTextWithLoadingState {
+            id: fiatFeesText
+
+            Layout.alignment: Qt.AlignRight
+
+            loading: root.loading
+            customColor: Theme.palette.baseColor1
+            lineHeightMode: Text.FixedHeight
+            lineHeight: 22
+
+            text: qsTr("1.45 EUR")
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/panels/SimpleTransactionsFees.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SimpleTransactionsFees.qml
@@ -11,12 +11,17 @@ Control {
     id: root
 
     /** property to set fees in fiat along with fiat symbol **/
-    property alias cryptoFees: cryptoFeesText.text
+    property string cryptoFees
     /** property to set fees in crypto along with crypto symbol **/
-    property alias fiatFees: fiatFeesText.text
-
+    property string fiatFees
     /** property to set loading state in the fees component **/
     property bool loading
+
+    QtObject {
+        id: d
+
+        readonly property string loadingText: "----------"
+    }
 
     implicitHeight: 64
 
@@ -63,7 +68,8 @@ Control {
                 lineHeightMode: Text.FixedHeight
                 lineHeight: 22
 
-                text: qsTr("0.0007 ETH")
+                text: !!root.cryptoFees ? root.cryptoFees:
+                                          d.loadingText
             }
         }
         StatusTextWithLoadingState {
@@ -76,7 +82,8 @@ Control {
             lineHeightMode: Text.FixedHeight
             lineHeight: 22
 
-            text: qsTr("1.45 EUR")
+            text: !!root.fiatFees ? root.fiatFees:
+                                   d.loadingText
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
@@ -53,10 +53,6 @@ Rectangle {
     /** input property for programatic selection of network **/
     property int selectedChainId: -1
 
-    /** input property for programatic selection of token
-    (asset/collectible/collection) **/
-    property string selectedTokenKey
-
     /** signal to propagate that an asset was selected **/
     signal assetSelected(string key)
     /** signal to propagate that a collection was selected **/
@@ -65,6 +61,12 @@ Rectangle {
     signal collectibleSelected(string key)
     /** signal to propagate that a network was selected **/
     signal networkSelected(string chainId)
+
+    /** input function for programatic selection of token
+    (asset/collectible/collection) **/
+    function setToken(name, icon, key) {
+        sendModalHeader.setToken(name, icon, key)
+    }
 
     enabled: root.isScrolling
     color: Theme.palette.baseColor3
@@ -114,7 +116,6 @@ Rectangle {
         collectiblesModel: root.collectiblesModel
 
         selectedChainId: root.selectedChainId
-        selectedTokenKey: root.selectedTokenKey
 
         onCollectibleSelected: root.collectibleSelected(key)
         onCollectionSelected: root.collectionSelected(key)

--- a/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
@@ -50,8 +50,12 @@ Rectangle {
     **/
     property bool isScrolling
 
-    /** property that exposes the selected network **/
-    readonly property int selectedNetworkChainId: sendModalHeader.selectedNetworkChainId
+    /** input property for programatic selection of network **/
+    property int selectedChainId: -1
+
+    /** input property for programatic selection of token
+    (asset/collectible/collection) **/
+    property string selectedTokenKey
 
     /** signal to propagate that an asset was selected **/
     signal assetSelected(string key)
@@ -59,6 +63,8 @@ Rectangle {
     signal collectionSelected(string key)
     /** signal to propagate that a collectible was selected **/
     signal collectibleSelected(string key)
+    /** signal to propagate that a network was selected **/
+    signal networkSelected(string chainId)
 
     enabled: root.isScrolling
     color: Theme.palette.baseColor3
@@ -107,9 +113,13 @@ Rectangle {
         assetsModel: root.assetsModel
         collectiblesModel: root.collectiblesModel
 
+        selectedChainId: root.selectedChainId
+        selectedTokenKey: root.selectedTokenKey
+
         onCollectibleSelected: root.collectibleSelected(key)
         onCollectionSelected: root.collectionSelected(key)
         onAssetSelected: root.assetSelected(key)
+        onNetworkSelected: root.networkSelected(chainId)
     }
 
     StatusDialogDivider {

--- a/ui/app/AppLayouts/Wallet/panels/qmldir
+++ b/ui/app/AppLayouts/Wallet/panels/qmldir
@@ -15,3 +15,4 @@ WalletHeader 1.0 WalletHeader.qml
 SendModalHeader 1.0 SendModalHeader.qml
 StickySendModalHeader 1.0 StickySendModalHeader.qml
 RecipientSelectorPanel 1.0 RecipientSelectorPanel.qml
+SimpleTransactionsFees 1.0 SimpleTransactionsFees.qml

--- a/ui/app/AppLayouts/Wallet/panels/qmldir
+++ b/ui/app/AppLayouts/Wallet/panels/qmldir
@@ -14,3 +14,4 @@ TokenSelectorPanel 1.0 TokenSelectorPanel.qml
 WalletHeader 1.0 WalletHeader.qml
 SendModalHeader 1.0 SendModalHeader.qml
 StickySendModalHeader 1.0 StickySendModalHeader.qml
+RecipientSelectorPanel 1.0 RecipientSelectorPanel.qml

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -71,6 +71,8 @@ StatusDialog {
     Only networks valid as per mainnet/testnet selection
     **/
     required property var networksModel
+    required property var savedAddressesModel
+    required property var recentRecipientsModel
     /** Input property holds currently selected Fiat currency **/
     required property string currentCurrency
     /** Input function to format currency amount to locale string **/
@@ -91,6 +93,14 @@ StatusDialog {
     Crypto value in a base unit as a string integer,
     e.g. 1000000000000000000 for 1 ETH **/
     readonly property string selectedAmountInBaseUnit: amountToSend.amount
+
+    /** TODO: replace with new and improved recipient selector StatusDateRangePicker
+    TBD under https://github.com/status-im/status-desktop/issues/16916 **/
+    property alias selectedRecipientAddress: recipientsPanel.selectedRecipientAddress
+    required property var fnResolveENS
+    function ensNameResolved(resolvedPubKey, resolvedAddress, uuid) {
+        recipientsPanel.ensNameResolved(resolvedPubKey, resolvedAddress, uuid)
+    }
 
     QtObject {
         id: d
@@ -172,7 +182,6 @@ StatusDialog {
     padding: 0
     leftPadding: Theme.xlPadding
     rightPadding: Theme.xlPadding
-    bottomPadding: Theme.xlPadding
     topMargin: margins + accountSelector.height + Theme.padding
 
     background: StatusDialogBackground {
@@ -343,6 +352,32 @@ StatusDialog {
                             color:  type === StatusBaseButton.Type.Danger ? Theme.palette.dangerColor3 : Theme.palette.primaryColor3
                         }
                         disabledTextColor: type === StatusBaseButton.Type.Danger ? Theme.palette.dangerColor1 : Theme.palette.primaryColor1
+                    }
+                }
+
+                /** TODO: replace with new and improved recipient selector TBD under
+                https://github.com/status-im/status-desktop/issues/16916 **/
+                ColumnLayout {
+                    spacing: Theme.halfPadding
+                    Layout.fillWidth: true
+                    StatusBaseText {
+                        elide: Text.ElideRight
+                        text: qsTr("To")
+                        font.pixelSize: 15
+                        color: Theme.palette.directColor1
+                    }
+                    RecipientSelectorPanel {
+                        id: recipientsPanel
+
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.bottomMargin: Theme.xlPadding
+
+                        savedAddressesModel: root.savedAddressesModel
+                        myAccountsModel: root.accountsModel
+                        recentRecipientsModel: root.recentRecipientsModel
+
+                        onResolveENS: root.fnResolveENS(ensName, uuid)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -65,10 +65,14 @@ StatusDialog {
     **/
     required property var networksModel
 
-    /** TODO: rethink property definitions needed to pre set values +
-    expose values to outside world **/
-    property int selectedChainId: sendModalHeader.selectedNetworkChainId
-    property string selectedAccountAddress: accountSelector.currentAccountAddress
+    /** property to set and expose currently selected account **/
+    property string selectedAccountAddress
+
+    /** property to set and expose currently selected network **/
+    property int selectedChainId
+
+    /** property to set and expose currently selected token key **/
+    property string selectedTokenKey
 
     QtObject {
         id: d
@@ -106,6 +110,13 @@ StatusDialog {
             anchors.leftMargin: -Theme.xlPadding
 
             model: root.accountsModel
+
+            selectedAddress: root.selectedAccountAddress
+            onCurrentAccountAddressChanged: {
+                if(currentAccountAddress !== root.selectedAccountAddress) {
+                    root.selectedAccountAddress = currentAccountAddress
+                }
+            }
         }
 
         // Sticky header only visible when scrolling
@@ -117,14 +128,19 @@ StatusDialog {
             anchors.leftMargin: -Theme.xlPadding
             z: 1
 
+            isScrolling: d.isScrolling
+
             networksModel: root.networksModel
             assetsModel: root.assetsModel
             collectiblesModel: root.collectiblesModel
-            isScrolling: d.isScrolling
 
-            onCollectibleSelected: console.log("collectible selected:", key)
-            onCollectionSelected: console.log("collection selected:", key)
-            onAssetSelected: console.log("asset selected:", key)
+            selectedChainId: root.selectedChainId
+            selectedTokenKey: root.selectedTokenKey
+
+            onCollectibleSelected: root.selectedTokenKey = key
+            onCollectionSelected: root.selectedTokenKey = key
+            onAssetSelected: root.selectedTokenKey = key
+            onNetworkSelected: root.selectedChainId = chainId
         }
 
         // Main scrollable Layout
@@ -162,9 +178,13 @@ StatusDialog {
                     assetsModel: root.assetsModel
                     collectiblesModel: root.collectiblesModel
 
-                    onCollectibleSelected: console.log("collectible selected:", key)
-                    onCollectionSelected: console.log("collection selected:", key)
-                    onAssetSelected: console.log("asset selected:", key)
+                    selectedChainId: root.selectedChainId
+                    selectedTokenKey: root.selectedTokenKey
+
+                    onCollectibleSelected: root.selectedTokenKey = key
+                    onCollectionSelected: root.selectedTokenKey = key
+                    onAssetSelected: root.selectedTokenKey = key
+                    onNetworkSelected: root.selectedChainId = chainId
                 }
 
                 // TODO: Remove these Dummy items added only to test dialog resizing

--- a/ui/app/AppLayouts/Wallet/views/RecipientView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RecipientView.qml
@@ -1,0 +1,193 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Backpressure 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
+import AppLayouts.Wallet 1.0
+
+import shared.controls 1.0 as SharedControls
+import shared.stores.send 1.0
+import shared.popups.send.panels 1.0
+import shared.popups.send 1.0
+import shared.popups.send.controls 1.0
+
+import utils 1.0
+
+Loader {
+    id: root
+
+    required property var savedAddressesModel
+    required property var myAccountsModel
+
+    property string selectedRecipientAddress
+    property int selectedRecipientType: Helpers.RecipientAddressObjectType.Address
+    property bool interactive: true
+
+    signal resolveENS(string ensName, string uuid)
+
+    function ensNameResolved(resolvedPubKey, resolvedAddress, uuid) {
+        if(uuid !== d.uuid) {
+            return
+        }
+        root.selectedRecipientAddress = resolvedAddress
+    }
+
+    QtObject {
+        id: d
+
+        property bool isValidAddress: true
+        property bool isBeingEvaluated: false
+
+        property string uuid
+
+        readonly property var validateInput: Backpressure.debounce(root, 500, function (address) {
+            d.isValidAddress = Utils.isValidAddress(address)
+            const isENSName = Utils.isValidEns(address)
+
+            if(d.isValidAddress) {
+                root.selectedRecipientAddress = address
+                d.isBeingEvaluated = false
+            }
+            else if(isENSName) {
+                d.uuid = Utils.uuid()
+                return root.resolveENS(address, uuid)
+            } else {
+                root.selectedRecipientAddress = ""
+                d.isBeingEvaluated = false
+            }
+        })
+
+        readonly property var accountsSelectedEntry: ModelEntry {
+            sourceModel: root.myAccountsModel
+            key: "address"
+            value: root.selectedRecipientAddress
+        }
+
+        readonly property var savedAddrSelectedEntry: ModelEntry {
+            sourceModel: root.savedAddressesModel
+            key: "address"
+            value: root.selectedRecipientAddress
+
+        }
+
+        function clearValues() {
+            root.selectedRecipientAddress = ""
+            root.selectedRecipientType = Helpers.RecipientAddressObjectType.Address
+        }
+    }
+
+    sourceComponent: root.selectedRecipientType === Helpers.RecipientAddressObjectType.SavedAddress ?
+                         savedAddressRecipient:
+                         root.selectedRecipientType === Helpers.RecipientAddressObjectType.Account ?
+                             myAccountRecipient:
+                             root.selectedRecipientType === Helpers.RecipientAddressObjectType.RecentsAddress ?
+                                 recentsRecipient : addressRecipient
+
+    Component {
+        id: savedAddressRecipient
+        SavedAddressListItem {
+            implicitWidth: parent.width
+            modelData: d.savedAddrSelectedEntry.item
+            radius: 8
+            clearVisible: true
+            color: Theme.palette.indirectColor1
+            sensor.enabled: false
+            subTitle:  {
+                if(!!modelData) {
+                    if (!!modelData && !!modelData.ens && modelData.ens.length > 0)
+                        return Utils.richColorText(modelData.ens, Theme.palette.directColor1)
+                    else
+                        return StatusQUtils.Utils.elideText(modelData.address,6,4)
+                }
+                return ""
+            }
+            onCleared: d.clearValues()
+        }
+    }
+
+    Component {
+        id: myAccountRecipient
+        SharedControls.WalletAccountListItem {
+            id: accountItem
+            readonly property var modelData: d.accountsSelectedEntry.item
+
+            name: !!modelData ? modelData.name : ""
+            address: !!modelData ? modelData.address : ""
+            emoji: !!modelData ? modelData.emoji : ""
+            walletColor: !!modelData ? Utils.getColorForId(modelData.colorId): ""
+            currencyBalance: !!modelData ? modelData.currencyBalance : ""
+            walletType: !!modelData ? modelData.walletType : ""
+            migratedToKeycard: !!modelData ? modelData.migratedToKeycard ?? false : false
+            accountBalance: !!modelData ? modelData.accountBalance : null
+
+            width: parent.width
+            radius: 8
+            clearVisible: true
+            color: Theme.palette.indirectColor1
+            sensor.enabled: false
+            subTitle: {
+                if(!!modelData) {
+                    return StatusQUtils.Utils.elideAndFormatWalletAddress(modelData.address)
+                }
+                return ""
+            }
+            onCleared: d.clearValues()
+        }
+    }
+
+    Component {
+        id: recentsRecipient
+
+        SendRecipientInput {
+            width: parent.width
+            height: visible ? implicitHeight: 0
+
+            interactive: root.interactive
+            input.edit.enabled: false
+            input.edit.textFormat: Text.AutoText
+            text: root.selectedRecipientAddress
+
+            onClearClicked: d.clearValues()
+        }
+    }
+
+    Component {
+        id: addressRecipient
+
+        SendRecipientInput {
+            function validateInput() {
+                const plainText = StatusQUtils.StringUtils.plainText(text)
+                d.isBeingEvaluated = true
+                d.validateInput(plainText)
+            }
+
+            width: parent.width
+            height: visible ? implicitHeight: 0
+
+            interactive: root.interactive
+            checkMarkVisible: !d.isBeingEvaluated && d.isValidAddress
+            loading: d.isBeingEvaluated
+            input.edit.textFormat: Text.AutoText
+
+            text: {
+                if(!!root.selectedRecipientAddress ) {
+                    return root.selectedRecipientAddress
+                }
+                return text
+            }
+
+            onTextChanged: Qt.callLater(() => validateInput())
+            onClearClicked: {
+                text = ""
+                d.clearValues()
+            }
+            onValidateInputRequested: Qt.callLater(() => validateInput())
+        }
+    }
+}
+

--- a/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
+++ b/ui/app/AppLayouts/Wallet/views/SendModalFooter.qml
@@ -1,0 +1,95 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialogFooter {
+    id: root
+
+    /** property to set loading state **/
+    property bool loading
+    /** property to set estimated time **/
+    property string estimateTime
+    /** property to set estimates fees in fiat **/
+    property string estimatedFees
+
+    // Signal to propogate Send clicked
+    signal reviewSendClicked()
+
+    implicitHeight: 82
+    spacing: Theme.bigPadding
+    color: Theme.palette.baseColor3
+    dropShadowEnabled: true
+
+    QtObject {
+        id: d
+
+        readonly property string emptyText: "--"
+        readonly property string loadingText: "----------"
+    }
+
+    leftButtons: ObjectModel {
+        ColumnLayout {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.leftMargin: Theme.padding
+
+            spacing: 0
+
+            StatusBaseText {
+                color: Theme.palette.directColor5
+                text: qsTr("Est time")
+            }
+            StatusTextWithLoadingState {
+                id: estimatedTime
+
+                customColor: !!root.estimateTime ? Theme.palette.directColor1:
+                                                   Theme.palette.directColor5
+                loading: root.loading
+
+                text: !!root.estimateTime ? root.estimateTime:
+                      root.loading ? d.loadingText : d.emptyText
+            }
+        }
+        ColumnLayout {
+            Layout.alignment: Qt.AlignVCenter
+
+            spacing: 0
+
+            StatusBaseText {
+                color: Theme.palette.directColor5
+                text: qsTr("Est fees")
+            }
+            StatusTextWithLoadingState {
+                id: estimatedFees
+
+                customColor: !!root.estimatedFees ? Theme.palette.directColor1:
+                                                   Theme.palette.directColor5
+                loading: root.loading
+
+                text: !!root.estimatedFees ? root.estimatedFees:
+                      loading ? d.loadingText : d.emptyText
+            }
+        }
+    }
+
+    rightButtons: ObjectModel {
+        StatusButton {
+            objectName: "transactionModalFooterButton"
+
+            Layout.rightMargin: Theme.padding
+
+            disabledColor: Theme.palette.directColor8
+            enabled: !!root.estimateTime &&
+                     !!root.estimatedFees &&
+                     !root.loading
+
+            text: qsTr("Review Send")
+
+            onClicked: root.reviewSendClicked()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/views/qmldir
+++ b/ui/app/AppLayouts/Wallet/views/qmldir
@@ -6,3 +6,4 @@ TokenSelectorAssetDelegate 1.0 TokenSelectorAssetDelegate.qml
 TokenSelectorCollectibleDelegate 1.0 TokenSelectorCollectibleDelegate.qml
 TokenSelectorSectionDelegate 1.0 TokenSelectorSectionDelegate.qml
 AccountContextMenu 1.0 AccountContextMenu.qml
+RecipientView 1.0 RecipientView.qml

--- a/ui/app/AppLayouts/Wallet/views/qmldir
+++ b/ui/app/AppLayouts/Wallet/views/qmldir
@@ -7,3 +7,4 @@ TokenSelectorCollectibleDelegate 1.0 TokenSelectorCollectibleDelegate.qml
 TokenSelectorSectionDelegate 1.0 TokenSelectorSectionDelegate.qml
 AccountContextMenu 1.0 AccountContextMenu.qml
 RecipientView 1.0 RecipientView.qml
+SendModalFooter 1.0 SendModalFooter.qml

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -671,6 +671,8 @@ Item {
         fnFormatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
             return appMain.currencyStore.formatCurrencyAmount(amount, symbol)
         }
+        savedAddressesModel: WalletStores.RootStore.savedAddresses
+        recentRecipientsModel: appMain.transactionStore.tempActivityController1Model
 
         Component.onCompleted: {
             // It's requested from many nested places, so as a workaround we use

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -660,6 +660,7 @@ Item {
 
         simpleSendEnabled: appMain.featureFlagsStore.simpleSendEnabled
 
+        // for simple send
         walletAccountsModel: WalletStores.RootStore.accounts
         flatNetworksModel: WalletStores.RootStore.flatNetworks
         areTestNetworksEnabled: WalletStores.RootStore.areTestNetworksEnabled
@@ -667,6 +668,9 @@ Item {
         currentCurrency: appMain.currencyStore.currentCurrency
         showCommunityAssetsInSend: appMain.tokensStore.showCommunityAssetsInSend
         collectiblesBySymbolModel: WalletStores.RootStore.collectiblesStore.jointCollectiblesBySymbolModel
+        fnFormatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
+            return appMain.currencyStore.formatCurrencyAmount(amount, symbol)
+        }
 
         Component.onCompleted: {
             // It's requested from many nested places, so as a workaround we use

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -671,6 +671,11 @@ Item {
         fnFormatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
             return appMain.currencyStore.formatCurrencyAmount(amount, symbol)
         }
+        // TODO remove this call to mainModule under #16919
+        fnResolveENS: function(ensName, uuid) {
+            mainModule.resolveENS(name, uuid)
+        }
+
         savedAddressesModel: WalletStores.RootStore.savedAddresses
         recentRecipientsModel: appMain.transactionStore.tempActivityController1Model
 
@@ -678,6 +683,8 @@ Item {
             // It's requested from many nested places, so as a workaround we use
             // Global to shorten the path via global signal.
             Global.sendToRecipientRequested.connect(sendToRecipient)
+            // TODO remove this call to mainModule under #16919
+            mainModule.resolvedENS.connect(ensNameResolved)
         }
     }
 

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -88,8 +88,14 @@ QtObject {
     required property var showCommunityAssetsInSend
     /** required function to format currency amount to locale string **/
     required property var fnFormatCurrencyAmount
+
     required property var savedAddressesModel
     required property var recentRecipientsModel
+
+    /** required function to resolve an ens name **/
+    required property var fnResolveENS
+    /** required signal to receive resolved ens name address **/
+    signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
 
     function openSend(params = {}) {
         // TODO remove once simple send is feature complete
@@ -228,6 +234,7 @@ QtObject {
 
             currentCurrency: root.currentCurrency
             fnFormatCurrencyAmount: root.fnFormatCurrencyAmount
+            fnResolveENS: root.fnResolveENS
 
             onClosed: destroy()
 
@@ -258,6 +265,10 @@ QtObject {
                         value: false
                     }
                 }
+            }
+
+            Component.onCompleted: {
+                root.ensNameResolved.connect(ensNameResolved)
             }
         }
     }

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -88,6 +88,8 @@ QtObject {
     required property var showCommunityAssetsInSend
     /** required function to format currency amount to locale string **/
     required property var fnFormatCurrencyAmount
+    required property var savedAddressesModel
+    required property var recentRecipientsModel
 
     function openSend(params = {}) {
         // TODO remove once simple send is feature complete
@@ -220,6 +222,9 @@ QtObject {
             assetsModel: assetsSelectorViewAdaptor.outputAssetsModel
             collectiblesModel: collectiblesSelectionAdaptor.model
             networksModel: root.filteredFlatNetworksModel
+
+            savedAddressesModel: root.savedAddressesModel
+            recentRecipientsModel: root.recentRecipientsModel
 
             currentCurrency: root.currentCurrency
             fnFormatCurrencyAmount: root.fnFormatCurrencyAmount

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -86,6 +86,8 @@ QtObject {
     /** whether community tokens are shown in send modal
     based on a global setting **/
     required property var showCommunityAssetsInSend
+    /** required function to format currency amount to locale string **/
+    required property var fnFormatCurrencyAmount
 
     function openSend(params = {}) {
         // TODO remove once simple send is feature complete
@@ -219,6 +221,9 @@ QtObject {
             collectiblesModel: collectiblesSelectionAdaptor.model
             networksModel: root.filteredFlatNetworksModel
 
+            currentCurrency: root.currentCurrency
+            fnFormatCurrencyAmount: root.fnFormatCurrencyAmount
+
             onClosed: destroy()
 
             TokenSelectorViewAdaptor {
@@ -241,7 +246,13 @@ QtObject {
                 enabledChainIds: [simpleSendModal.selectedChainId]
 
                 networksModel: root.filteredFlatNetworksModel
-                collectiblesModel: root.collectiblesBySymbolModel
+                collectiblesModel: SortFilterProxyModel {
+                    sourceModel: root.collectiblesBySymbolModel
+                    filters: ValueFilter {
+                        roleName: "soulbound"
+                        value: false
+                    }
+                }
             }
         }
     }

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -211,6 +211,7 @@ QtObject {
     readonly property Component simpleSendModalComponent: Component {
         SimpleSendModal {
             id: simpleSendModal
+
             /** TODO: use the newly defined WalletAccountsSelectorAdaptor
             in https://github.com/status-im/status-desktop/pull/16834 **/
             accountsModel: root.walletAccountsModel
@@ -237,6 +238,7 @@ QtObject {
                 id: collectiblesSelectionAdaptor
 
                 accountKey: simpleSendModal.selectedAccountAddress
+                enabledChainIds: [simpleSendModal.selectedChainId]
 
                 networksModel: root.filteredFlatNetworksModel
                 collectiblesModel: root.collectiblesBySymbolModel

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -197,8 +197,9 @@ Control {
                 return validator.maxDecimalDigits + validator.maxIntegralDigits
             } else {
                 let availableSpaceForAmount = root.availableWidth - currencyField.contentWidth - layout.spacing
-                // k is a coefficient based on the font style (typically 𝑘 ≈ 0.6)
-                let digitWidth = textField.font.pixelSize * 0.6
+                // k is a coefficient based on the font style (typically 𝑘 ≈ 0.65)
+                let digitWidth = textField.font.pixelSize * 0.65
+                // remove one for decimal separator
                 return Math.floor(availableSpaceForAmount/digitWidth)
             }
         }
@@ -297,7 +298,7 @@ Control {
 
                 objectName: "bottomItemText"
 
-                Layout.fillWidth: true
+                Layout.preferredWidth: contentWidth
 
                 text: {
                     const divisor = SQUtils.AmountsArithmetic.fromExponent(
@@ -347,8 +348,22 @@ Control {
                         textField.text = d.localize(trimmed)
                     }
                 }
+
+                HoverHandler { id: hoverHandler }
+
                 visible: !root.bottomTextLoading
             }
+            StatusIcon {
+                Layout.preferredWidth: 16
+                Layout.preferredHeight: 16
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+
+                icon: "swap"
+                rotation: 90
+                color: Theme.palette.directColor5
+                visible: hoverHandler.hovered
+            }
+            RowLayout {}
             Loader {
                 id: bottomRightComponent
                 Layout.alignment: Qt.AlignVCenter

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -229,7 +229,7 @@ Control {
 
                 objectName: "amountToSend_textField"
 
-                implicitHeight: 44
+                Layout.preferredHeight: 44
                 padding: 0
                 background: null
 
@@ -240,7 +240,7 @@ Control {
                        : Theme.palette.dangerColor1
 
                 placeholderText: {
-                    if (!d.fiatMode || root.fiatDecimalPlaces === 0)
+                    if (!d.fiatMode || root.fiatDecimalPlaces === 0 || !!text)
                         return "0"
 
                     return "0" + root.decimalPoint


### PR DESCRIPTION
fixes #16820, #16835, #16878

### What does the PR do

Adds logic to set and expose selected network, token and account. 

Also add synchronisation for the 2 header instances (sticky + scrollable)

### Affected areas

SimpleSend.qml

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/f36124a9-3836-4c4f-afbe-c4c4103b9498


https://github.com/user-attachments/assets/8b6fe65e-f569-4ceb-9224-9c61bae7af16



<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
