### PR TITLE
fix(dapps): Fixing the dApps disabled state if the dapps service is not online

### DIFF
--- a/storybook/pages/DappsComboBoxPage.qml
+++ b/storybook/pages/DappsComboBoxPage.qml
@@ -19,6 +19,7 @@ SplitView {
             anchors.horizontalCenter: parent.horizontalCenter
             model: emptyModelCheckbox.checked ? emptyModel : smallModelCheckbox.checked ? smallModel: dappsModel
             popup.visible: true
+            enabled: enabledCheckbox.checked
 
             onPairDapp: console.log("onPairDapp")
         }
@@ -127,6 +128,12 @@ SplitView {
             RadioButton {
                 id: smallModelCheckbox
                 text: "Small model"
+            }
+
+            CheckBox {
+                id: enabledCheckbox
+                text: "Enabled"
+                checked: true
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -43,6 +43,7 @@ Item {
 
     property bool swapEnabled
     property bool dAppsEnabled
+    property bool dAppsVisible
     property bool walletConnectEnabled: true
     property bool browserConnectEnabled: true
 
@@ -241,6 +242,7 @@ Item {
 
             swapEnabled: root.swapEnabled
             dAppsEnabled: root.dAppsEnabled
+            dAppsVisible: root.dAppsVisible
             walletConnectEnabled: root.walletConnectEnabled
             browserConnectEnabled: root.browserConnectEnabled
 

--- a/ui/app/AppLayouts/Wallet/controls/DappsComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/DappsComboBox.qml
@@ -31,6 +31,10 @@ ComboBox {
     background: SQP.StatusComboboxBackground {
         objectName: "dappsBackground"
         active: root.down || root.hovered
+        Binding on color {
+            when: !root.enabled
+            value: Theme.palette.baseColor2
+        }
     }
 
     indicator: null

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -35,6 +35,7 @@ Item {
     property alias networkFilter: networkFilter
 
     property bool dAppsEnabled: true
+    property bool dAppsVisible: true
     property bool walletConnectEnabled: true
     property bool browserConnectEnabled: true
     property var dAppsModel
@@ -145,7 +146,8 @@ Item {
                 Layout.alignment: Qt.AlignTop
                 spacing: 8
 
-                visible: !root.walletStore.showSavedAddresses && root.dAppsEnabled
+                visible: !root.walletStore.showSavedAddresses && root.dAppsVisible
+                enabled: root.dAppsEnabled
                 walletConnectEnabled: root.walletConnectEnabled
                 connectorEnabled: root.browserConnectEnabled
                 model: root.dAppsModel

--- a/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
@@ -21,6 +21,7 @@ FocusScope {
 
     property bool swapEnabled
     property bool dAppsEnabled
+    property bool dAppsVisible
     property bool walletConnectEnabled
     property bool browserConnectEnabled
 
@@ -49,6 +50,7 @@ FocusScope {
             networkConnectionStore: root.networkConnectionStore
             loginType: root.store.loginType
             dAppsEnabled: root.dAppsEnabled
+            dAppsVisible: root.dAppsVisible
             dAppsModel: root.dAppsModel
             walletConnectEnabled: root.walletConnectEnabled
             browserConnectEnabled: root.browserConnectEnabled

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1656,7 +1656,8 @@ Item {
                             appMainVisible: appMain.visible
                             swapEnabled: featureFlagsStore.swapEnabled
                             hideSignPhraseModal: userAgreementLoader.active
-                            dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
+                            dAppsVisible: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
+                            dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.isServiceOnline : false
                             walletConnectEnabled: featureFlagsStore.dappsEnabled
                             browserConnectEnabled: featureFlagsStore.connectorEnabled
                             dAppsModel: dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null

--- a/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
+++ b/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
@@ -196,8 +196,8 @@ StatusDialog {
                     if (d.connectionInProgress)
                         return false
                     if (!d.connectionAttempted)
-                        return root.selectedChains.length > 0
-                    return root.connectButtonEnabled
+                        return root.selectedChains.length > 0 && root.connectButtonEnabled
+                    return true
                 }
 
                 onClicked: {


### PR DESCRIPTION
### What does the PR do

closes #16883 #16882

1. connect the dapps service online state to the enabled state for the dapps button
2. Fix the connect modal primary action button
3. Align DappsComboBox disabled color with the refresh button disabled color

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

dapps
<!-- List the affected areas (e.g wallet, browser, etc..) -->

https://github.com/user-attachments/assets/c62f4787-0ca8-452b-a3b6-a621fc253217