### PR TITLE
fix(dapps): Detach the pair instructions popup from the pairing popup

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
@@ -173,6 +173,22 @@ SQUtils.QObject {
             onClosed: pairWCLoader.active = false
             onPair: (uri) => root.pairingRequested(uri)
             onPairUriChanged: (uri) => root.pairingValidationRequested(uri)
+            onPairInstructionsRequested: pairInstructionsLoader.active = true
+        }
+    }
+
+    Loader {
+        id: pairInstructionsLoader
+
+        active: false
+        parent: root.visualParent
+
+        sourceComponent: Component {
+            DAppsUriCopyInstructionsPopup{
+                visible: true
+                destroyOnClose: false
+                onClosed: pairInstructionsLoader.active = false
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
@@ -72,6 +72,7 @@ SQUtils.QObject {
 
     /// Validates the pairing URI
     function validatePairingUri(uri) {
+        timeoutTimer.start()
         d.validatePairingUri(uri)
     }
 
@@ -190,14 +191,17 @@ SQUtils.QObject {
             root.pairingValidated(state)
         }
 
-        function onPairingResponse(key, state) {
-            timeoutTimer.stop()
+        function onPairingResponse(state) {
             if (state != Pairing.errors.uriOk) {
                 d.reportPairErrorState(state)
+                return
             }
+
+            timeoutTimer.restart()
         }
 
         function onConnectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, key) {
+            timeoutTimer.stop()
             const connectorIcon = Constants.dappImageByType[connectorId]
             root.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorIcon, key)
         }

--- a/ui/imports/shared/popups/walletconnect/PairWCModal.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal.qml
@@ -36,6 +36,7 @@ StatusDialog {
 
     signal pair(string uri)
     signal pairUriChanged(string uri)
+    signal pairInstructionsRequested()
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
@@ -72,12 +73,7 @@ StatusDialog {
             normalColor: linkColor
 
             onClicked: {
-                Global.openPopup(uriCopyInstructionsPopup)
-            }
-
-            Component {
-                id: uriCopyInstructionsPopup
-                DAppsUriCopyInstructionsPopup{}
+                root.pairInstructionsRequested()
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

closes #16887

The pairing popup can be destroyed while the pair instructions popup is active. As a result the pair instructions popup will misbehave. To fix this, the pair instructions component is moved outside of the pair popup scope

### Affected areas

dapps
<!-- List the affected areas (e.g wallet, browser, etc..) -->


https://github.com/user-attachments/assets/110ffc5f-fdaa-4ff3-aad2-b4f1f374b6b9

