### PR TITLE
Fixes to pinned messages

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -184,6 +184,12 @@ proc init*(self: Controller) =
       return
     self.delegate.onGroupChatDetailsUpdated(args.newName, args.newColor, args.newImage)
 
+  self.events.on(SIGNAL_MESSAGE_EDITED) do(e: Args):
+    let args = MessageEditedArgs(e)
+    if(self.chatId != args.chatId):
+      return
+    self.delegate.onMessageEdited(args.message)
+
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -1,9 +1,9 @@
 import NimQml
 
 import ../item as chat_item
-import ../../../../../app_service/service/message/dto/pinned_message
-import ../../../../../app_service/service/chat/dto/chat
-
+import app_service/service/message/dto/pinned_message
+import app_service/service/chat/dto/chat
+import app_service/service/message/dto/message
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
 
@@ -31,7 +31,10 @@ method newPinnedMessagesLoaded*(self: AccessInterface, pinnedMessages: seq[Pinne
 method onUnpinMessage*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onPinMessage*(self: AccessInterface, mmessageId: string, actionInitiatedBy: string) {.base.} =
+method onPinMessage*(self: AccessInterface, messageId: string, actionInitiatedBy: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onMessageEdited*(self: AccessInterface, message: MessageDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onChatMuted*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -271,6 +271,27 @@ method onPinMessage*(self: Module, messageId: string, actionInitiatedBy: string)
 
   self.view.pinnedModel().insertItemBasedOnClock(item)
 
+method onMessageEdited*(self: Module, message: MessageDto) =
+  let index = self.view.pinnedModel().findIndexForMessageId(message.id)
+  if index == -1:
+    return
+
+  let itemBeforeChange = self.view.pinnedModel().getItemWithMessageId(message.id)
+  let mentionedUsersPks = itemBeforeChange.mentionedUsersPks
+  let communityChats = self.controller.getCommunityDetails().chats
+
+  self.view.pinnedModel().updateEditedMsg(
+    message.id,
+    self.controller.getRenderedText(message.parsedText, communityChats),
+    message.text,
+    message.parsedText,
+    message.contentType,
+    message.mentioned,
+    message.containsContactMentions(),
+    message.links,
+    message.mentionedUsersPks
+  )
+
 method getMyChatId*(self: Module): string =
   self.controller.getMyChatId()
 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -519,7 +519,7 @@ QtObject:
 
       self.events.emit(SIGNAL_PINNED_MESSAGES_LOADED, data)
     except Exception as e:
-      error "Erorr load pinned messages for chat async", msg = e.msg
+      error "Error load pinned messages for chat async", msg = e.msg
       # notify view, this is important
       self.events.emit(SIGNAL_PINNED_MESSAGES_LOADED, PinnedMessagesLoadedArgs())
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/16639

- Fixes edits not showing up in pins until a restart
- Fixes deleted messages reappearing in the pinned messages after a restart (status-go PR: https://github.com/status-im/status-go/pull/6173)

### Affected areas

Pins

### Screenshot of functionality (including design for comparison)

[pin-fixes.webm](https://github.com/user-attachments/assets/e3a46b46-ca7a-4366-b534-2f870c787f94)

### Impact on end user

Fixes some scenarios of using pinned messages

### How to test

- Follow the repro steps in the og issue
- Delete the message that is pinned and restart

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case is issue still happens
