### PR TITLE
fix(wallet): cannot sing tx sent from imported key pair if the profile is migrated to keycard

### DIFF
--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -269,7 +269,9 @@ method prepareSignaturesForTransactions*(self:Module, txForSigning: RouterTransa
         self.tmpSendTransactionDetails.resolvedSignatures[h] = ("", "", "")
       self.signOnKeycard()
     else:
-      let finalPassword = hashPassword(self.tmpSendTransactionDetails.password)
+      var finalPassword = self.tmpSendTransactionDetails.password
+      if not singletonInstance.userProfile.getIsKeycardUser():
+        finalPassword = hashPassword(self.tmpSendTransactionDetails.password)
       for h in txForSigning.signingDetails.hashes:
         self.tmpSendTransactionDetails.resolvedSignatures[h] = ("", "", "")
         var


### PR DESCRIPTION
The code followed the `signOnKeycard` param, but the key pair itself should not be signed on the keycard, which is true. However, for the local signing, in case when the profile is migrated to a keycard we should not hash the password, just use the enc pub key as the password and that check was missed. It has been added now.

fixes: #16901