### PR TITLE
Fix e2e version not found

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -86,8 +86,7 @@ pipeline {
     stage('Publish') {
       when { expression { params.PUBLISH } }
       steps { script {
-        def version = sh(script: './scripts/version.sh', returnStdout: true).trim()
-        github.publishReleaseFiles(repo: 'status-desktop', version: version);
+        github.publishReleaseFiles(repo: 'status-desktop');
       } }
     }
   }

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.14'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.14'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.14'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.14'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.7'
+library 'status-jenkins-lib@v1.9.16'
 
 pipeline {
 
@@ -69,7 +69,7 @@ pipeline {
     SQUISH_DIR = '/opt/squish-runner-7.2.1'
     PYTHONPATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/lib/python:${PYTHONPATH}"
     LD_LIBRARY_PATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/python3/lib:${LD_LIBRARY_PATH}"
-    
+
     /* To stop e2e tests using port 8545 */
     STATUS_RUNTIME_HTTP_API = 'False'
     STATUS_RUNTIME_WS_API = 'False'

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.7'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.7'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.14'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.linux
+++ b/ci/cpp/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.7'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.macos
+++ b/ci/cpp/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.7'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.windows
+++ b/ci/cpp/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.7'
+library 'status-jenkins-lib@v1.9.16'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
### What does the PR do
This PR updates `status-jenkins-lib` which contains the fixes for `getVersion` function throwing an exception when `VERSION` file was not found.
Also reverts @igor-sirotin 's recent change since thats not needed anymore.

relevant changes in `status-jenkins-lib`: https://github.com/status-im/status-jenkins-lib/pull/106

### Affected areas
none, this just fixes the build issues which happen in nightly

### How to test
- Run nightly job from this branch
