### PR TITLE
fix(wallet): cannot recover Status profile if there is no metadata on a keycard

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -269,7 +269,7 @@ proc handleKeycardSyncing[T](self: Module[T]) =
     if flowEvent.keyUid != self.controller.getKeyUidWhichIsBeingSyncing():
       self.controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
       return
-    if eventType == ResponseTypeValueKeycardFlowResult and flowEvent.error.len == 0:
+    if eventType == ResponseTypeValueKeycardFlowResult and (flowEvent.error.len == 0 or flowEvent.error == ErrorNoData):
       var kpDto = KeycardDto(keycardUid: flowEvent.instanceUID,
         keycardName: flowEvent.cardMetadata.name,
         keycardLocked: false,


### PR DESCRIPTION
fixes: #16907

<img width="1363" alt="_a1" src="https://github.com/user-attachments/assets/e12ab7a0-a61d-4fb1-8503-1db746d4932b">

<img width="1247" alt="_a2" src="https://github.com/user-attachments/assets/7f0e973c-9c5d-40e9-83e2-a2de01cbdd20">
