### PR TITLE
Cherrypick/dapps connect

### DIFF
--- a/storybook/pages/DappsComboBoxPage.qml
+++ b/storybook/pages/DappsComboBoxPage.qml
@@ -19,6 +19,7 @@ SplitView {
             anchors.horizontalCenter: parent.horizontalCenter
             model: emptyModelCheckbox.checked ? emptyModel : smallModelCheckbox.checked ? smallModel: dappsModel
             popup.visible: true
+            enabled: enabledCheckbox.checked
 
             onPairDapp: console.log("onPairDapp")
         }
@@ -127,6 +128,12 @@ SplitView {
             RadioButton {
                 id: smallModelCheckbox
                 text: "Small model"
+            }
+
+            CheckBox {
+                id: enabledCheckbox
+                text: "Enabled"
+                checked: true
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -42,6 +42,7 @@ Item {
 
     property bool swapEnabled
     property bool dAppsEnabled
+    property bool dAppsVisible
     property bool walletConnectEnabled: true
     property bool browserConnectEnabled: true
 
@@ -246,6 +247,7 @@ Item {
 
             swapEnabled: root.swapEnabled
             dAppsEnabled: root.dAppsEnabled
+            dAppsVisible: root.dAppsVisible
             walletConnectEnabled: root.walletConnectEnabled
             browserConnectEnabled: root.browserConnectEnabled
 

--- a/ui/app/AppLayouts/Wallet/controls/DappsComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/DappsComboBox.qml
@@ -31,6 +31,10 @@ ComboBox {
     background: SQP.StatusComboboxBackground {
         objectName: "dappsBackground"
         active: root.down || root.hovered
+        Binding on color {
+            when: !root.enabled
+            value: Theme.palette.baseColor2
+        }
     }
 
     indicator: null

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -35,6 +35,7 @@ Item {
     property alias networkFilter: networkFilter
 
     property bool dAppsEnabled: true
+    property bool dAppsVisible: true
     property bool walletConnectEnabled: true
     property bool browserConnectEnabled: true
     property var dAppsModel
@@ -145,7 +146,8 @@ Item {
                 Layout.alignment: Qt.AlignTop
                 spacing: 8
 
-                visible: !root.walletStore.showSavedAddresses && root.dAppsEnabled
+                visible: !root.walletStore.showSavedAddresses && root.dAppsVisible
+                enabled: root.dAppsEnabled
                 walletConnectEnabled: root.walletConnectEnabled
                 connectorEnabled: root.browserConnectEnabled
                 model: root.dAppsModel

--- a/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
+++ b/ui/app/AppLayouts/Wallet/popups/dapps/DAppsWorkflow.qml
@@ -173,6 +173,22 @@ SQUtils.QObject {
             onClosed: pairWCLoader.active = false
             onPair: (uri) => root.pairingRequested(uri)
             onPairUriChanged: (uri) => root.pairingValidationRequested(uri)
+            onPairInstructionsRequested: pairInstructionsLoader.active = true
+        }
+    }
+
+    Loader {
+        id: pairInstructionsLoader
+
+        active: false
+        parent: root.visualParent
+
+        sourceComponent: Component {
+            DAppsUriCopyInstructionsPopup{
+                visible: true
+                destroyOnClose: false
+                onClosed: pairInstructionsLoader.active = false
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsService.qml
@@ -72,6 +72,7 @@ SQUtils.QObject {
 
     /// Validates the pairing URI
     function validatePairingUri(uri) {
+        timeoutTimer.start()
         d.validatePairingUri(uri)
     }
 
@@ -190,14 +191,17 @@ SQUtils.QObject {
             root.pairingValidated(state)
         }
 
-        function onPairingResponse(key, state) {
-            timeoutTimer.stop()
+        function onPairingResponse(state) {
             if (state != Pairing.errors.uriOk) {
                 d.reportPairErrorState(state)
+                return
             }
+
+            timeoutTimer.restart()
         }
 
         function onConnectDApp(dappChains, dappUrl, dappName, dappIcon, connectorId, key) {
+            timeoutTimer.stop()
             const connectorIcon = Constants.dappImageByType[connectorId]
             root.connectDApp(dappChains, dappUrl, dappName, dappIcon, connectorIcon, key)
         }

--- a/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
@@ -21,6 +21,7 @@ FocusScope {
 
     property bool swapEnabled
     property bool dAppsEnabled
+    property bool dAppsVisible
     property bool walletConnectEnabled
     property bool browserConnectEnabled
 
@@ -47,6 +48,7 @@ FocusScope {
             networkConnectionStore: root.networkConnectionStore
             loginType: root.store.loginType
             dAppsEnabled: root.dAppsEnabled
+            dAppsVisible: root.dAppsVisible
             dAppsModel: root.dAppsModel
             walletConnectEnabled: root.walletConnectEnabled
             browserConnectEnabled: root.browserConnectEnabled

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1681,7 +1681,8 @@ Item {
                             appMainVisible: appMain.visible
                             swapEnabled: featureFlagsStore.swapEnabled
                             hideSignPhraseModal: userAgreementLoader.active
-                            dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
+                            dAppsVisible: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
+                            dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.isServiceOnline : false
                             walletConnectEnabled: featureFlagsStore.dappsEnabled
                             browserConnectEnabled: featureFlagsStore.connectorEnabled
                             dAppsModel: dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null

--- a/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
+++ b/ui/imports/shared/popups/walletconnect/ConnectDAppModal.qml
@@ -196,8 +196,8 @@ StatusDialog {
                     if (d.connectionInProgress)
                         return false
                     if (!d.connectionAttempted)
-                        return root.selectedChains.length > 0
-                    return root.connectButtonEnabled
+                        return root.selectedChains.length > 0 && root.connectButtonEnabled
+                    return true
                 }
 
                 onClicked: {

--- a/ui/imports/shared/popups/walletconnect/PairWCModal.qml
+++ b/ui/imports/shared/popups/walletconnect/PairWCModal.qml
@@ -36,6 +36,7 @@ StatusDialog {
 
     signal pair(string uri)
     signal pairUriChanged(string uri)
+    signal pairInstructionsRequested()
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
@@ -72,12 +73,7 @@ StatusDialog {
             normalColor: linkColor
 
             onClicked: {
-                Global.openPopup(uriCopyInstructionsPopup)
-            }
-
-            Component {
-                id: uriCopyInstructionsPopup
-                DAppsUriCopyInstructionsPopup{}
+                root.pairInstructionsRequested()
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

fix(dapps): Fixing the dApps disabled state if the dapps service is not online
closes https://github.com/status-im/status-desktop/issues/16883 https://github.com/status-im/status-desktop/issues/16882

1. connect the dapps service online state to the enabled state for the dapps button
2. Fix the connect modal primary action button
3. Align DappsComboBox disabled color with the refresh button disabled color

(cherry picked from commit https://github.com/status-im/status-desktop/commit/2c4f6b5da3d484b8e36f2ec572ba738e490cda40)

fix(dapps): Detach the pairInstructions popup from the pairing popup
closes https://github.com/status-im/status-desktop/issues/16887

The pairing popup can be destroyed while the pairInstructions popup is active. As a result the pair instructions popup will misbehave.
To fix this, the pair instructions component is moved outside of the pair popup scope

(cherry picked from commit https://github.com/status-im/status-desktop/commit/007f75ad4c4823692abf9c12ee7c1a0806a87659)

