### PR TITLE
fix(contact): fix fetching contact info when sending a CR

### DIFF
--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -6,15 +6,32 @@ import utils 1.0
 QtObject {
     id: root
 
+    signal requestedContactResolved(string publicKey, bool ok)
+
     readonly property QtObject _d: QtObject {
         id: d
 
         readonly property var contactsModuleInst: profileSectionModule.contactsModule
         readonly property var mainModuleInst: mainModule
         readonly property var globalUtilsInst: globalUtils
+        property string requestedContactPubKey: ""
 
         Component.onCompleted: {
             mainModuleInst.resolvedENS.connect(root.resolvedENS)
+        }
+
+        readonly property var _conn: Connections {
+            enabled: d.requestedContactPubKey !== ""
+            target: d.contactsModuleInst
+
+            function onContactInfoRequestFinished(publicKey, ok) {
+                if (publicKey !== d.requestedContactPubKey) {
+                    return
+                }
+
+                root.requestedContactResolved(publicKey, ok)
+                d.requestedContactPubKey = ""
+            }
         }
     }
 
@@ -121,6 +138,7 @@ QtObject {
     }
 
     function requestContactInfo(publicKey) {
+        d.requestedContactPubKey = publicKey
         d.contactsModuleInst.requestContactInfo(publicKey)
     }
 

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -44,13 +44,16 @@ CommonContactDialog {
     }
 
     readonly property var _conn: Connections {
-        target: root.rootStore.contactStore.contactsModule
+        enabled: root.loadingContactDetails
+        target: root.rootStore.contactStore
 
-        function onContactInfoRequestFinished(publicKey, ok) {
-            if (publicKey !== root.publicKey)
+        function onRequestedContactResolved(publicKey, ok) {
+            if (publicKey !== root.publicKey) {
                 return
-            if (ok)
+            }
+            if (ok) {
                 root.contactDetails = Utils.getContactDetailsAsJson(root.publicKey, false)
+            }
             root.loadingContactDetails = false
         }
     }


### PR DESCRIPTION
### What does the PR do

Fixes #15205

The problem was that we were using the module directly in the Connections, but the store didn't expose it anymore, because it's against the guidelines.

Instead, I moved the Connections to the module to the store itself and the store sends a signal when we have the info.

### Affected areas

SendContactRequestModal and ContactsStore (for sending contact requests)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[fetch-info.webm](https://github.com/user-attachments/assets/09d87e99-fbf9-4c87-88a2-11dc53d4e595)

### Impact on end user

Fixes the issue

### How to test

0. Have an old user (backup its data for fun, though I'm pretty sure it doesn't do anything)
1. Create a new user
2. Paste the old user's link in the Start chat input
3. Profit

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the bug still happens
