### PR TITLE
[cherry-pick] fix(wallet): cannot recover Status profile if there is no metadata on a keycard

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -269,7 +269,7 @@ proc handleKeycardSyncing[T](self: Module[T]) =
     if flowEvent.keyUid != self.controller.getKeyUidWhichIsBeingSyncing():
       self.controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
       return
-    if eventType == ResponseTypeValueKeycardFlowResult and flowEvent.error.len == 0:
+    if eventType == ResponseTypeValueKeycardFlowResult and (flowEvent.error.len == 0 or flowEvent.error == ErrorNoData):
       var kpDto = KeycardDto(keycardUid: flowEvent.instanceUID,
         keycardName: flowEvent.cardMetadata.name,
         keycardLocked: false,


### PR DESCRIPTION
Cherry-picked:
- https://github.com/status-im/status-desktop/pull/16908