### PR TITLE
fix(wallet): properly process ens transaction signals

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -443,8 +443,8 @@ proc sendNotification[T](self: Module[T], status: string, sendDetails: SendDetai
       addressFrom = sendDetails.fromAddress
       addressTo = sendDetails.toAddress
       txTo = "" # txFrom is always the same as addressFrom, but txTo is different from addressTo when the app performs any sending flow via certain contract
-      fromChain = sendDetails.fromChain
-      toChain = sendDetails.toChain
+      fromChain = sentTransaction.fromChain
+      toChain = sentTransaction.toChain
       fromAmount = sendDetails.fromAmount.toString(10)
       toAmount = sendDetails.toAmount.toString(10)
       fromAsset = sendDetails.fromToken

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -153,7 +153,7 @@ method ensTransactionConfirmed*(self: Module, trxType: string, ensUsername: stri
   let finalEnsUsername = ens_utils.addDomain(ensUsername)
   if(self.view.model().containsEnsUsername(chainId, finalEnsUsername)):
     self.view.model().updatePendingStatus(chainId, finalEnsUsername, false)
-  else:
+  elif trxType != $ReleaseENS:
     self.view.model().addItem(Item(chainId: chainId, ensUsername: finalEnsUsername, isPending: false))
   self.view.emitTransactionCompletedSignal(true, transactionHash, finalEnsUsername, trxType)
 

--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -63,7 +63,7 @@ proc init*(self: Controller) =
       isApprovalTx = args.sentTransaction.approvalTx
     self.delegate.transactionWasSent(
       args.sendDetails.uuid,
-      args.sendDetails.fromChain,
+      args.sentTransaction.fromChain,
       isApprovalTx,
       txHash,
       if not args.sendDetails.errorResponse.isNil: args.sendDetails.errorResponse.details else: ""

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -160,7 +160,7 @@ QtObject:
       self.marketStickerPacks[$args.sendDetails.packId].status = StickerPackStatus.Pending
       self.marketStickerPacks[$args.sendDetails.packId].txHash = args.sentTransaction.hash
       let data = StickerBuyResultArgs(
-        chainId: args.sendDetails.fromChain,
+        chainId: args.sentTransaction.fromChain,
         packId: args.sendDetails.packId,
         txHash: args.sentTransaction.hash,
         error: if not args.sendDetails.errorResponse.isNil: args.sendDetails.errorResponse.details else: ""

--- a/src/app_service/service/transaction/router_transactions_dto.nim
+++ b/src/app_service/service/transaction/router_transactions_dto.nim
@@ -16,8 +16,6 @@ type
   SendDetailsDto* = ref object
     uuid*: string
     sendType*: int
-    fromChain*: int
-    toChain*: int
     fromAddress*: string
     toAddress*: string
     fromToken*: string
@@ -81,8 +79,6 @@ proc toSendDetailsDto*(jsonObj: JsonNode): SendDetailsDto =
   result = SendDetailsDto()
   discard jsonObj.getProp("uuid", result.uuid)
   discard jsonObj.getProp("sendType", result.sendType)
-  discard jsonObj.getProp("fromChain", result.fromChain)
-  discard jsonObj.getProp("toChain", result.toChain)
   discard jsonObj.getProp("fromAddress", result.fromAddress)
   discard jsonObj.getProp("toAddress", result.toAddress)
   discard jsonObj.getProp("fromToken", result.fromToken)


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/16921 and https://github.com/status-im/status-desktop/issues/16922

`SendDetails` doesn't have chain information, that comes with each `RouterSentTransaction`
<img width="606" alt="image" src="https://github.com/user-attachments/assets/6472c470-608f-4636-8238-c48e2fcbd55b">
![image](https://github.com/user-attachments/assets/18f3b1b8-627d-4cca-b110-72822cb20e04)

This PR takes the chainID info from the proper field, indirectly fixing ENS name events and potentially other bugs.

This fix uncovered a new bug that re-added an ENS name to the list after a removal due to triggering a release. This is fixed in the second commit.