### PR TITLE
Wallet: add missing notification on keypairImportModule change

### DIFF
--- a/src/app/modules/main/profile_section/wallet/module.nim
+++ b/src/app/modules/main/profile_section/wallet/module.nim
@@ -102,10 +102,12 @@ method destroyKeypairImportPopup*(self: Module) =
   self.view.emitDestroyKeypairImportPopup()
   self.keypairImportModule.delete
   self.keypairImportModule = nil
+  self.view.emitKeypairImportModuleChangedSignal()
 
 method runKeypairImportPopup*(self: Module, keyUid: string, mode: ImportKeypairModuleMode) =
   self.keypairImportModule = keypair_import_module.newModule(self, self.events, self.accountsService,
     self.walletAccountService, self.devicesService)
+  self.view.emitKeypairImportModuleChangedSignal()
   self.keypairImportModule.load(keyUid, mode)
 
 method getKeypairImportModule*(self: Module): QVariant =

--- a/src/app/modules/main/profile_section/wallet/view.nim
+++ b/src/app/modules/main/profile_section/wallet/view.nim
@@ -29,10 +29,14 @@ QtObject:
   proc runKeypairImportPopup*(self: View, keyUid: string, mode: int) {.slot.} =
     self.delegate.runKeypairImportPopup(keyUid, ImportKeypairModuleMode(mode))
 
+  proc keypairImportModuleChanged*(self: View) {.signal.}
+  proc emitKeypairImportModuleChangedSignal*(self: View) =
+    self.keypairImportModuleChanged()
   proc getKeypairImportModule(self: View): QVariant {.slot.} =
     return self.delegate.getKeypairImportModule()
   QtProperty[QVariant] keypairImportModule:
     read = getKeypairImportModule
+    notify = keypairImportModuleChanged
 
   proc displayKeypairImportPopup*(self: View) {.signal.}
   proc emitDisplayKeypairImportPopup*(self: View) =

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -487,6 +487,7 @@ method destroyKeypairImportPopup*(self: Module) =
   self.view.emitDestroyKeypairImportPopup()
   self.keypairImportModule.delete
   self.keypairImportModule = nil
+  self.view.emitKeypairImportModuleChangedSignal()
 
 method runKeypairImportPopup*(self: Module) =
   if self.filter.addresses.len != 1:
@@ -497,6 +498,7 @@ method runKeypairImportPopup*(self: Module) =
   self.keypairImportModule = keypair_import_module.newModule(self, self.events, self.accountsService,
     self.walletAccountService, self.devicesService)
   self.keypairImportModule.load(keypair.keyUid, ImportKeypairModuleMode.SelectImportMethod)
+  self.view.emitKeypairImportModuleChangedSignal()
 
 method getKeypairImportModule*(self: Module): QVariant =
   if self.keypairImportModule.isNil:

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -223,10 +223,14 @@ QtObject:
   proc runKeypairImportPopup*(self: View) {.slot.} =
     self.delegate.runKeypairImportPopup()
 
+  proc keypairImportModuleChanged*(self: View) {.signal.}
+  proc emitKeypairImportModuleChangedSignal*(self: View) =
+    self.keypairImportModuleChanged()
   proc getKeypairImportModule(self: View): QVariant {.slot.} =
     return self.delegate.getKeypairImportModule()
   QtProperty[QVariant] keypairImportModule:
     read = getKeypairImportModule
+    notify = keypairImportModuleChanged
 
   proc displayKeypairImportPopup*(self: View) {.signal.}
   proc emitDisplayKeypairImportPopup*(self: View) =


### PR DESCRIPTION
### What does the PR do

Adds missing notification on `keypairImportModule` change.

Without the notification it was possible to use `keypairImportModule` only directly, e.g.:

```qml
 sourceComponent: KeypairImportPopup {
    store.keypairImportModule: walletSection.keypairImportModule
 }
```
Assigning the module to some property and using it via that property wasn't working because the lack of change propagation.

With the change introduced, changes are notified and `keypairImportModule` can be used indirectly as any other object.

Closes: #16773

### Affected areas

`profile_section/wallet/module.nim`
`profile_section/wallet/view.nim`
`wallet_section/module.nim`
`wallet_section/view.nim`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[Screencast from 11.12.2024 14:24:43.webm](https://github.com/user-attachments/assets/cc335089-9f61-420a-aac5-dc84ceb30e22)

