### PR TITLE
Fix some search issues

### DIFF
--- a/src/app/modules/main/app_search/location_menu_sub_item.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_item.nim
@@ -7,15 +7,28 @@ export base_item
 type
   SubItem* = ref object of BaseItem
     isUserIcon: bool
+    isImage: bool
     colorId: int
     colorHash: color_hash_model.Model
     position: int
 
-proc initSubItem*(value, text, image, icon, iconColor: string,
-  isUserIcon: bool = false, position: int, colorId: int = 0, colorHash: seq[ColorHashSegment] = @[]): SubItem =
+proc initSubItem*(
+    value,
+    text,
+    image,
+    icon,
+    iconColor: string,
+    isUserIcon: bool,
+    isImage: bool,
+    position: int,
+    lastMessageTimestamp: int,
+    colorId: int = 0,
+    colorHash: seq[ColorHashSegment] = @[]
+  ): SubItem =
   result = SubItem()
   result.setup(value, text, image, icon, iconColor)
   result.isUserIcon = isUserIcon
+  result.isImage = isImage
   result.position = position
   result.colorId = colorId
   result.colorHash = color_hash_model.newModel()
@@ -29,6 +42,9 @@ proc `$`*(self: SubItem): string =
     value: {self.value},
     text: {self.text},
     position: {self.position},
+    lastMessageTimestamp: {self.lastMessageTimestamp},
+    isUserIcon: {self.isUserIcon},
+    isImage: {self.isImage},
     imageSource: {self.image},
     iconName: {self.icon},
     iconColor: {self.iconColor},
@@ -43,6 +59,7 @@ proc toJsonNode*(self: SubItem): JsonNode =
     "iconName": self.icon,
     "iconColor": self.iconColor,
     "isUserIcon": self.isUserIcon,
+    "isImage": self.isImage,
     "colorId": self.colorId,
     "colorHash": self.colorHash.toJson()
   }
@@ -52,6 +69,9 @@ proc position*(self: SubItem): int =
 
 proc isUserIcon*(self: SubItem): bool =
   return self.isUserIcon
+
+proc isImage*(self: SubItem): bool =
+  return self.isImage
 
 proc colorId*(self: SubItem): int =
   return self.colorId

--- a/src/app/modules/main/app_search/location_menu_sub_item.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_item.nim
@@ -11,6 +11,7 @@ type
     colorId: int
     colorHash: color_hash_model.Model
     position: int
+    lastMessageTimestamp: int
 
 proc initSubItem*(
     value,
@@ -30,6 +31,7 @@ proc initSubItem*(
   result.isUserIcon = isUserIcon
   result.isImage = isImage
   result.position = position
+  result.lastMessageTimestamp = lastMessageTimestamp
   result.colorId = colorId
   result.colorHash = color_hash_model.newModel()
   result.colorHash.setItems(map(colorHash, x => color_hash_item.initItem(x.len, x.colorIdx)))
@@ -55,6 +57,7 @@ proc toJsonNode*(self: SubItem): JsonNode =
     "value": self.value,
     "text": self.text,
     "position": self.position,
+    "lastMessageTimestamp": self.lastMessageTimestamp,
     "imageSource": self.image,
     "iconName": self.icon,
     "iconColor": self.iconColor,
@@ -66,6 +69,9 @@ proc toJsonNode*(self: SubItem): JsonNode =
 
 proc position*(self: SubItem): int =
   return self.position
+
+proc lastMessageTimestamp*(self: SubItem): int =
+  return self.lastMessageTimestamp
 
 proc isUserIcon*(self: SubItem): bool =
   return self.isUserIcon

--- a/src/app/modules/main/app_search/location_menu_sub_item.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_item.nim
@@ -9,12 +9,14 @@ type
     isUserIcon: bool
     colorId: int
     colorHash: color_hash_model.Model
+    position: int
 
 proc initSubItem*(value, text, image, icon, iconColor: string,
-  isUserIcon: bool = false, colorId: int = 0, colorHash: seq[ColorHashSegment] = @[]): SubItem =
+  isUserIcon: bool = false, position: int, colorId: int = 0, colorHash: seq[ColorHashSegment] = @[]): SubItem =
   result = SubItem()
   result.setup(value, text, image, icon, iconColor)
   result.isUserIcon = isUserIcon
+  result.position = position
   result.colorId = colorId
   result.colorHash = color_hash_model.newModel()
   result.colorHash.setItems(map(colorHash, x => color_hash_item.initItem(x.len, x.colorIdx)))
@@ -26,6 +28,7 @@ proc `$`*(self: SubItem): string =
   result = fmt"""SearchMenuSubItem(
     value: {self.value},
     text: {self.text},
+    position: {self.position},
     imageSource: {self.image},
     iconName: {self.icon},
     iconColor: {self.iconColor},
@@ -35,6 +38,7 @@ proc toJsonNode*(self: SubItem): JsonNode =
   result = %* {
     "value": self.value,
     "text": self.text,
+    "position": self.position,
     "imageSource": self.image,
     "iconName": self.icon,
     "iconColor": self.iconColor,
@@ -42,6 +46,9 @@ proc toJsonNode*(self: SubItem): JsonNode =
     "colorId": self.colorId,
     "colorHash": self.colorHash.toJson()
   }
+
+proc position*(self: SubItem): int =
+  return self.position
 
 proc isUserIcon*(self: SubItem): bool =
   return self.isUserIcon

--- a/src/app/modules/main/app_search/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_model.nim
@@ -10,6 +10,7 @@ type
     Icon
     IconColor
     IsUserIcon
+    Position
     ColorId
     ColorHash
 
@@ -57,6 +58,7 @@ QtObject:
       SubModelRole.Icon.int:"iconName",
       SubModelRole.IconColor.int:"iconColor",
       SubModelRole.IsUserIcon.int:"isUserIcon",
+      SubModelRole.Position.int:"position",
       SubModelRole.ColorId.int:"colorId",
       SubModelRole.ColorHash.int:"colorHash"
     }.toTable
@@ -84,6 +86,8 @@ QtObject:
       result = newQVariant(item.iconColor)
     of SubModelRole.IsUserIcon:
       result = newQVariant(item.isUserIcon)
+    of SubModelRole.Position:
+      result = newQVariant(item.position)
     of SubModelRole.ColorId:
       result = newQVariant(item.colorId)
     of SubModelRole.ColorHash:

--- a/src/app/modules/main/app_search/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_model.nim
@@ -12,6 +12,7 @@ type
     IsUserIcon
     IsImage
     Position
+    LastMessageTimestamp
     ColorId
     ColorHash
 
@@ -61,6 +62,7 @@ QtObject:
       SubModelRole.IsUserIcon.int:"isUserIcon",
       SubModelRole.IsImage.int:"isImage",
       SubModelRole.Position.int:"position",
+      SubModelRole.LastMessageTimestamp.int:"lastMessageTimestamp",
       SubModelRole.ColorId.int:"colorId",
       SubModelRole.ColorHash.int:"colorHash"
     }.toTable
@@ -92,6 +94,8 @@ QtObject:
       result = newQVariant(item.isImage)
     of SubModelRole.Position:
       result = newQVariant(item.position)
+    of SubModelRole.LastMessageTimestamp:
+      result = newQVariant(item.lastMessageTimestamp)
     of SubModelRole.ColorId:
       result = newQVariant(item.colorId)
     of SubModelRole.ColorHash:

--- a/src/app/modules/main/app_search/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_model.nim
@@ -10,6 +10,7 @@ type
     Icon
     IconColor
     IsUserIcon
+    IsImage
     Position
     ColorId
     ColorHash
@@ -58,6 +59,7 @@ QtObject:
       SubModelRole.Icon.int:"iconName",
       SubModelRole.IconColor.int:"iconColor",
       SubModelRole.IsUserIcon.int:"isUserIcon",
+      SubModelRole.IsImage.int:"isImage",
       SubModelRole.Position.int:"position",
       SubModelRole.ColorId.int:"colorId",
       SubModelRole.ColorHash.int:"colorHash"
@@ -86,6 +88,8 @@ QtObject:
       result = newQVariant(item.iconColor)
     of SubModelRole.IsUserIcon:
       result = newQVariant(item.isUserIcon)
+    of SubModelRole.IsImage:
+      result = newQVariant(item.isImage)
     of SubModelRole.Position:
       result = newQVariant(item.position)
     of SubModelRole.ColorId:

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -103,6 +103,7 @@ proc getChatSubItems(self: Module, chats: seq[ChatDto], categories: seq[Category
       "",
       chatDto.color,
       isOneToOneChat,
+      isImage = chatImage != "",
       chatDto.position,
       colorId,
       colorHash,
@@ -122,6 +123,7 @@ proc getChatSubItems(self: Module, chats: seq[ChatDto], categories: seq[Category
         "",
         chat.color,
         isUserIcon = false,
+        isImage = false,
         chatPosition,
       ))
     highestPosition += categoryChats[categoryPosition].len

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -99,12 +99,13 @@ proc getChatSubItems(self: Module, chats: seq[ChatDto], categories: seq[Category
     let subItem = location_menu_sub_item.initSubItem(
       chatDto.id,
       chatName,
-      if (chatImage != ""): chatImage else: chatDto.emoji,
-      "",
+      image = if (chatImage != ""): chatImage else: chatDto.emoji,
+      icon = "",
       chatDto.color,
       isOneToOneChat,
       isImage = chatImage != "",
       chatDto.position,
+      chatDto.timestamp.int,
       colorId,
       colorHash,
     )
@@ -120,11 +121,12 @@ proc getChatSubItems(self: Module, chats: seq[ChatDto], categories: seq[Category
         chat.id,
         chat.name,
         chat.emoji,
-        "",
+        icon = "",
         chat.color,
         isUserIcon = false,
         isImage = false,
         chatPosition,
+        chat.timestamp.int,
       ))
     highestPosition += categoryChats[categoryPosition].len
 

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -71,7 +71,7 @@ proc getChatSubItems(self: Module, chats: seq[ChatDto], categories: seq[Category
   var categoryChats: OrderedTable[int, seq[ChatDto]] = initOrderedTable[int, seq[ChatDto]]()
 
   for chatDto in chats:
-    if chatDto.isHiddenChat:
+    if not chatDto.canView and not chatDto.missingEncryptionKey:
       continue
     
     var chatName = chatDto.name

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -163,7 +163,8 @@ method prepareLocationMenuModel*(self: Module) =
   # Community sections
   let communities = self.controller.getJoinedAndSpectatedCommunities()
   for c in communities:
-    items.add(self.buildLocationMenuForCommunity(c))
+    if c.joined:
+      items.add(self.buildLocationMenuForCommunity(c))
 
   self.view.locationMenuModel().setItems(items)
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -316,8 +316,6 @@ proc buildChatSectionUI(
     items.add(self.addCategoryItem(categoryDto, community.memberRole, community.id))
 
   for chatDto in chats:
-    var categoryPosition = -1
-
     # Add an empty chat item that has the category info
     var isActive = false
     # restore on a startup last open channel for the section or
@@ -325,12 +323,6 @@ proc buildChatSectionUI(
     if (selectedItemId.len == 0 and sectionLastOpenChat.len == 0) or chatDto.id == sectionLastOpenChat:
       selectedItemId = chatDto.id
       isActive = true
-
-    if chatDto.categoryId != "":
-      for category in community.categories:
-        if category.id == chatDto.categoryId:
-          categoryPosition = category.position
-          break
 
     items.add(self.addOrUpdateChat(
       chatDto,

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -254,10 +254,6 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
   discard jsonObj.getProp("readMessagesAtClockValue", result.readMessagesAtClockValue)
   discard jsonObj.getProp("unviewedMessagesCount", result.unviewedMessagesCount)
   discard jsonObj.getProp("unviewedMentionsCount", result.unviewedMentionsCount)
-  discard jsonObj.getProp("canPostReactions", result.canPostReactions)
-  discard jsonObj.getProp("canPost", result.canPost)
-  discard jsonObj.getProp("canView", result.canView)
-  discard jsonObj.getProp("viewersCanPostReactions", result.viewersCanPostReactions)
   discard jsonObj.getProp("alias", result.alias)
   discard jsonObj.getProp("muted", result.muted)
   discard jsonObj.getProp("categoryId", result.categoryId)
@@ -285,6 +281,17 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
   if (jsonObj.getProp("chatType", chatTypeInt) and
     (chatTypeInt >= ord(low(ChatType)) or chatTypeInt <= ord(high(ChatType)))):
       result.chatType = ChatType(chatTypeInt)
+
+  # Default those properties to true as they are only provided for community chats
+  # To be refactored with https://github.com/status-im/status-desktop/issues/11694
+  result.canPostReactions = true
+  result.canPost = true
+  result.canView = true
+  result.viewersCanPostReactions = true
+  discard jsonObj.getProp("canPostReactions", result.canPostReactions)
+  discard jsonObj.getProp("canPost", result.canPost)
+  discard jsonObj.getProp("canView", result.canView)
+  discard jsonObj.getProp("viewersCanPostReactions", result.viewersCanPostReactions)
 
   var chatImage: string
   discard jsonObj.getProp("image", chatImage)

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQml 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQml 2.15
+import QtQuick.Controls 2.15
 
 import Qt.labs.qmlmodels 1.0
 
@@ -24,10 +24,10 @@ StatusMenu {
     signal setSearchSelection(string text,
                               string secondaryText,
                               string imageSource,
-                              string isIdenticon,
+                              bool isIdenticon,
                               string iconName,
                               string iconColor,
-                              var isUserIcon,
+                              bool isUserIcon,
                               int colorId,
                               string colorHash)
 
@@ -80,9 +80,12 @@ StatusMenu {
                         root.setSearchSelection(text,
                                                 "",
                                                 "",
-                                                assetSettings.isIdenticon,
+                                                assetSettings.imgIsIdenticon,
                                                 assetSettings.name,
-                                                assetSettings.color)
+                                                assetSettings.color,
+                                                model.isUserIcon,
+                                                model.colorId,
+                                                JSON.stringify(model.colorHash))
                         root.itemClicked(model.value, "")
                     }
                 }
@@ -115,7 +118,7 @@ StatusMenu {
                         readonly property string parentIconName: subMenuDelegate.parentIconName
                         readonly property string parentImageSource: subMenuDelegate.parentImageSource
                         readonly property string parentIdenticonColor: subMenuDelegate.parentIdenticonColor
-                        readonly property string parentIsIdenticon: subMenuDelegate.parentIsIdenticon
+                        readonly property bool parentIsIdenticon: subMenuDelegate.parentIsIdenticon
 
                         menu: subMenuDelegate
                         model: SortFilterProxyModel {
@@ -129,13 +132,14 @@ StatusMenu {
                         delegate: StatusSearchPopupMenuItem {
                             value: model.value
                             text: model.text
-                            assetSettings.isImage: !!model.imageSource
-                            assetSettings.name: !!StatusQUtils.Emoji.iconSource(model.imageSource) ?
-                                                  StatusQUtils.Emoji.iconSource(model.imageSource) : model.imageSource
+
+                            assetSettings.name: model.isImage ? model.imageSource : ""
+                            assetSettings.emoji: !model.isUserIcon ? model.imageSource : ""
                             assetSettings.color: model.isUserIcon ? Theme.palette.userCustomizationColors[model.colorId] : model.iconColor
                             assetSettings.bgColor: model.iconColor
                             assetSettings.charactersLen: model.isUserIcon ? 2 : 1
                             ringSettings.ringSpecModel: model.colorHash
+
                             onTriggered: {
                                 root.resetSearchSelection()
                                 if (menuLoader.parentTitleText === "Chat") {
@@ -147,7 +151,7 @@ StatusMenu {
                                                             model.iconColor,
                                                             model.isUserIcon,
                                                             model.colorId,
-                                                            model.colorHash.toJson())
+                                                            JSON.stringify(model.colorHash))
                                 } else {
                                     root.setSearchSelection(menuLoader.parentTitleText,
                                                             model.text,
@@ -168,5 +172,4 @@ StatusMenu {
             }
         }
     }
-
 }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
@@ -123,10 +123,16 @@ StatusMenu {
                         menu: subMenuDelegate
                         model: SortFilterProxyModel {
                             sourceModel: subMenuDelegate.subItemsModel
-                            sorters: RoleSorter {
-                                roleName: "position"
-                                sortOrder: Qt.AscendingOrder
-                            }
+                            sorters: [
+                                RoleSorter {
+                                    roleName: "position"
+                                    sortOrder: Qt.AscendingOrder
+                                },
+                                RoleSorter {
+                                    roleName: "lastMessageTimestamp"
+                                    sortOrder: Qt.DescendingOrder
+                                }
+                            ]
                         }
 
                         delegate: StatusSearchPopupMenuItem {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
@@ -9,6 +9,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
+import SortFilterProxyModel 0.2
+
 StatusMenu {
     id: root
 
@@ -116,7 +118,13 @@ StatusMenu {
                         readonly property string parentIsIdenticon: subMenuDelegate.parentIsIdenticon
 
                         menu: subMenuDelegate
-                        model: subMenuDelegate.subItemsModel
+                        model: SortFilterProxyModel {
+                            sourceModel: subMenuDelegate.subItemsModel
+                            sorters: RoleSorter {
+                                roleName: "position"
+                                sortOrder: Qt.AscendingOrder
+                            }
+                        }
 
                         delegate: StatusSearchPopupMenuItem {
                             value: model.value


### PR DESCRIPTION
### What does the PR do

Fixes #10184

- Fixes the order of channels in the location menu
- Makes sure that only channels that can be read are shown in the location menu

Missing part: the emoji size wasn't fixed as I need help

### Affected areas

Location menu in the search popup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

Fixed order: 
![image](https://github.com/user-attachments/assets/1d6be51d-cda1-4fb3-82de-110a8cf84bb6)

Spectated community not appearing:
![image](https://github.com/user-attachments/assets/2592ae73-324f-4b66-a787-a9aeead569f7)

Encrypted channels don't show:
![image](https://github.com/user-attachments/assets/00979634-2ef2-431a-afe5-32c1088b6104)

### Impact on end user

Fixes the location menu

### How to test

1. Be part of a community with lots of channels with categories
2. Press CTRL+F
3. Check the location menu for the channels of that community
4. Have an encrypted channel (a channel the user can't view)
5. As a member of the channel (not owner), check the menu again
6. The encrypted channel doesn't show

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the order of channel could still be messed up
