### PR TITLE
fix(chat): fix blocked contact being able to be sent a CR

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -104,6 +104,7 @@ ColumnLayout {
             chatId: root.chatId
             isOneToOne: root.chatType === Constants.chatType.oneToOne
             isChatBlocked: root.isBlocked || !root.isUserAllowedToSendMessage
+            isContactBlocked: root.isBlocked
             channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             areTestNetworksEnabled: root.areTestNetworksEnabled


### PR DESCRIPTION
Fixes #16951

The property `isContactBlocked` was not passed to the component.

![image](https://github.com/user-attachments/assets/a1796daf-39a4-41cf-af6f-5227280cd7d3)
