### PR TITLE
fix(admin): fix nicknames not showing in the admin tab immediately

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -521,6 +521,10 @@ proc init*(self: Controller) =
     let args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
 
+  self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
+    var args = ContactArgs(e)
+    self.delegate.contactUpdated(args.contactId)
+
   self.events.on(SIGNAL_LOGGEDIN_USER_NAME_CHANGED) do(e: Args):
     self.delegate.contactUpdated(singletonInstance.userProfile.getPubKey())
 


### PR DESCRIPTION
Fixes #16957

We didn't listen to the event in the main module.

[nickname-update.webm](https://github.com/user-attachments/assets/7665d609-e790-48b4-8e89-9bd3cbd75f27)
