### PR TITLE
feat(dapps): Adding dapp metrics

### DIFF
--- a/storybook/pages/DAppsMetricsPage.qml
+++ b/storybook/pages/DAppsMetricsPage.qml
@@ -1,0 +1,354 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Components 0.1
+
+import Models 1.0
+import Storybook 1.0
+
+import utils 1.0
+
+import shared.stores 1.0
+import AppLayouts.Wallet.services.dapps 1.0
+import AppLayouts.Wallet.controls 1.0
+
+Item {
+    id: root
+
+    property string mixpanelToken: ""
+
+    component MethodsPicker: StatusListPicker {
+        id: methodsPicker
+        multiSelection: true
+        inputList: ListModel {
+            ListElement {
+                key: 0
+                name: "personal_sign"
+                shortName: "personal_sign"
+                category: ""
+                selected: true
+            }
+            ListElement {
+                key: 1
+                name: "eth_signTypedData"
+                shortName: "eth_signTypedData"
+                category: ""
+                selected: false
+            }
+            ListElement {
+                key: 2
+                name: "eth_sign"
+                shortName: "eth_sign"
+                category: ""
+                selected: false
+            }
+            ListElement {
+                key: 3
+                name: "eth_sendTransaction"
+                shortName: "eth_sendTransaction"
+                category: ""
+                selected: false
+            }
+        }
+
+        function getSelection() {
+            var selection = []
+            for (var i = 0; i < inputList.count; i++) {
+                if (inputList.get(i).selected) {
+                    selection.push(inputList.get(i).name)
+                }
+            }
+            return selection
+        }
+    }
+
+    DAppsMetrics {
+        id: metrics
+
+        metricsStore: MetricsStore {
+            id: metricsStore
+            function addCentralizedMetricIfEnabled(eventName, eventValue = null) {
+                if (root.mixpanelToken !== "") {
+                    var http = new XMLHttpRequest()
+                    var url = "https://api.mixpanel.com/track";
+                    eventValue.token = root.mixpanelToken
+                    const strEvent = JSON.stringify(eventValue)
+                    var event = `[{"properties":${strEvent},"event":"${eventName}"}]`
+                    http.open("POST", url, true);
+
+                    // Send the proper header information along with the request
+                    http.setRequestHeader("Content-type", "application/json");
+                    http.setRequestHeader("accept", "text/plain");
+
+                    http.onreadystatechange = function() { // Call a function when the state changes.
+                                if (http.readyState == 4) {
+                                    if (http.status == 200) {
+                                        console.log("ok")
+                                    } else {
+                                        console.log("error: " + http.status)
+                                    }
+                                }
+                            }
+                    logs.logEvent("Sending Mixpanel event", ["eventName", "eventValue"], arguments)
+                    http.send(event);
+                    return
+                }
+                logs.logEvent("Mixpanel simulated event", ["eventName", "eventValue"], arguments)
+            }
+        }
+    }
+
+    Logs { id: logs }
+
+    ColumnLayout {
+        anchors.fill: parent
+        ColumnLayout {
+            z: 10
+            spacing: 10
+
+            Pane {
+                Layout.fillWidth: true
+                background: Rectangle {
+                    border.width: 2
+                    border.color: "black"
+                }
+                ColumnLayout {
+                    Label {
+                        text: "Warning! Configuring the mixpanel token will send the events to Mixpanel"
+                        font.bold: true
+                    }
+                    RowLayout {
+                        Label {
+                            text: "Mixpanel Config"
+                        }
+                        TextField {
+                            id: mixpanelToken
+                            placeholderText: "Mixpanel Token"
+                        }
+                        Button {
+                            text: "Set Mixpanel Token"
+                            onClicked: root.mixpanelToken = mixpanelToken.text
+                        }
+                        Button {
+                            text: "Remove Mixpanel Token"
+                            onClicked: root.mixpanelToken = ""
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+                background: Rectangle {
+                    border.width: 2
+                    border.color: "black"
+                }
+                ColumnLayout {
+                    Label {
+                        text: "DApps Health Events"
+                    }
+
+                    RowLayout {
+                        spacing: 10
+
+                        Button {
+                            id: logHealthEvent
+                            text: "Log Health Event"
+                            onClicked: metrics.logHealthEvent(healthState.currentIndex, error.text)
+                        }
+
+                        ComboBox {
+                            id: healthState
+                            model: ["WC Available", "WC Unavailable", "Chains Down", "Network Down", "Pair Error", "Connect Error", "Sign Error", "undefined"]
+                        }
+
+                        TextField {
+                            id: error
+                            placeholderText: "Error"
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+                background: Rectangle {
+                    border.width: 2
+                    border.color: "black"
+                }
+                ColumnLayout {
+                    Label {
+                        text: "DApps Navigation Events"
+                    }
+
+                    RowLayout {
+                        spacing: 10
+
+                        Button {
+                            id: logNavigation
+                            text: "Log Navigation Event"
+                            onClicked: metrics.logNavigationEvent(navigationAction.currentIndex, connector.currentIndex)
+                        }
+
+                        ComboBox {
+                            id: navigationAction
+                            Layout.fillWidth: true
+                            model: ["DApp List Opened", "DApp Connect Initiated", "DApp Disconnect Initiated", "DApp Pair Initiated", "undefined"]
+                        }
+
+                        ComboBox {
+                            id: connector
+                            currentIndex: 1
+                            model: ["undefined", "WalletConnect", "BrowserConnect"]
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                id: connectionProposal
+                z: 10
+                Layout.fillWidth: true
+                background: Rectangle {
+                    border.width: 2
+                    border.color: "black"
+                }
+                ColumnLayout {
+                    Label {
+                        text: "Connection Proposal"
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        z: 10
+
+                        TextField {
+                            id: dappProposal
+                            text: "https://dapp.com"
+                        }
+
+                        ComboBox {
+                            id: proposalConnector
+                            currentIndex: 1
+                            model: ["undefined", "WalletConnect", "BrowserConnect"]
+                        }
+                        NetworkFilter {
+                            id: networkFilter
+                            flatNetworks: NetworksModel.flatNetworks
+                        }
+                        MethodsPicker {
+                            id: methodsPicker
+                        }
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Button {
+                            id: logConnectionProposal
+                            text: "Log Connection Proposal"
+                            onClicked: metrics.logConnectionProposal(networkFilter.selection.map(String), methodsPicker.getSelection(), dappProposal.text, proposalConnector.currentIndex)
+                        }
+                        Button {
+                            text: "Log SIWE Connection rejected"
+                            onClicked: metrics.logSiweConnectionProposal(networkFilter.selection.map(String), dappProposal.text, proposalConnector.currentIndex)
+                        }
+                        Button {
+                            text: "Log Connection accepted"
+                            onClicked: metrics.logConnectionProposalAccepted(dappProposal.text, networkFilter.selection.map(String), proposalConnector.currentIndex)
+                        }
+
+                        Button {
+                            text: "Log Connection rejected"
+                            onClicked: metrics.logConnectionProposalRejected(dappProposal.text, proposalConnector.currentIndex)
+                        }
+
+                        Button {
+                            text: "Log dapp connected"
+                            onClicked: metrics.logDAppConnected(dappProposal.text, proposalConnector.currentIndex)
+                        }
+
+                        Button {
+                            text: "Log dapp disconnected"
+                            onClicked: metrics.logDAppDisconnected(dappProposal.text, proposalConnector.currentIndex)
+                        }
+                    }
+                }
+            }
+
+            Pane {
+                Layout.fillWidth: true
+                background: Rectangle {
+                    border.width: 2
+                    border.color: "black"
+                }
+
+                ColumnLayout {
+                    Label {
+                        text: "DApps Sign Events"
+                    }
+
+                    RowLayout {
+                        spacing: 10
+
+                        TextField {
+                            id: dappSign
+                            text: "https://dapp.com"
+                        }
+
+                        ComboBox {
+                            id: connectorSign
+                            currentIndex: 1
+                            model: ["undefined", "WalletConnect", "BrowserConnect"]
+                        }
+                        NetworkFilter {
+                            id: networkFilterSign
+                            flatNetworks: NetworksModel.flatNetworks
+                            multiSelection: false
+                        }
+                        MethodsPicker {
+                            id: methodsPickerSign
+                            multiSelection: false
+                        }
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Button {
+                            id: logSignEvent
+                            text: "Log Sign Event"
+                            onClicked: metrics.logSignRequestReceived(connectorSign.currentIndex, methodsPickerSign.getSelection()[0], networkFilterSign.singleSelectionItemData.chainId, dappSign.text)
+                        }
+
+                        Button {
+                            text: "Log Sign Request Accepted"
+                            onClicked: metrics.logSignRequestAccepted(connectorSign.currentIndex, methodsPickerSign.getSelection()[0], networkFilterSign.singleSelectionItemData.chainId, dappSign.text)
+                        }
+
+                        Button {
+                            text: "Log Sign Request Rejected"
+                            onClicked: metrics.logSignRequestRejected(connectorSign.currentIndex, methodsPickerSign.getSelection()[0], networkFilterSign.singleSelectionItemData.chainId, dappSign.text)
+                        }
+                    }
+                }
+            }
+        }
+        
+        Pane {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            background: Rectangle {
+                border.width: 2
+                border.color: "black"
+            }
+            LogsView {
+                id: logsAndControlsPanel
+                anchors.fill: parent
+                logText: logs.logText
+            }
+        }
+    }
+}
+
+// category: Wallet

--- a/storybook/pages/DappsComboBoxPage.qml
+++ b/storybook/pages/DappsComboBoxPage.qml
@@ -21,7 +21,15 @@ SplitView {
             popup.visible: true
             enabled: enabledCheckbox.checked
 
-            onPairDapp: console.log("onPairDapp")
+            onDappListRequested: {
+                console.log("Dapps list requested")
+            }
+            onConnectDapp: {
+                console.log("Connect dapp")
+            }
+            onDisconnectDapp: {
+                console.log("Disconnect dapp")
+            }
         }
 
         ListModel {

--- a/storybook/qmlTests/tests/tst_ChainsSupervisorPlugin.qml
+++ b/storybook/qmlTests/tests/tst_ChainsSupervisorPlugin.qml
@@ -99,7 +99,9 @@ Item {
 
         function init() {
             componentUnderTest = chainsSupervisorPluginComponent.createObject(root)
-            tryVerify(() => componentUnderTest.anyChainAvailable)
+            tryVerify(() => componentUnderTest.isOnline)
+            tryVerify(() => !componentUnderTest.allChainsOffline)
+            tryVerify(() => !componentUnderTest.networkOffline)
             componentUnderTest.sdk.getActiveSessionsCallbacks = []
             componentUnderTest.sdk.emitSessionEventCalls = []
         }
@@ -108,7 +110,7 @@ Item {
             componentUnderTest.networksModel.setProperty(0, "isOnline", false)
             componentUnderTest.networksModel.setProperty(1, "isOnline", false)
 
-            tryVerify(() => !componentUnderTest.anyChainAvailable)
+            tryVerify(() => componentUnderTest.allChainsOffline)
         }
 
         function test_disconnectEventAllValid() {

--- a/storybook/qmlTests/tests/tst_DappsComboBox.qml
+++ b/storybook/qmlTests/tests/tst_DappsComboBox.qml
@@ -13,8 +13,10 @@ Item {
     Component {
         id: componentUnderTest
         DappsComboBox {
-            property SignalSpy dappsListReadySpy: SignalSpy { target: controlUnderTest; signalName: "dappsListReady" }
-            property SignalSpy pairDappSpy: SignalSpy { target: controlUnderTest; signalName: "pairDapp" }
+            id: controlUnderTest
+            property SignalSpy dappListRequestedSpy: SignalSpy { target: controlUnderTest; signalName: "dappListRequested" }
+            property SignalSpy connectDappSpy: SignalSpy { target: controlUnderTest; signalName: "connectDapp" }
+            property SignalSpy disconnectDappSpy: SignalSpy { target: controlUnderTest; signalName: "disconnectDapp" }
 
             anchors.centerIn: parent
             model: ListModel {}
@@ -40,7 +42,7 @@ Item {
             const indicator = findChild(controlUnderTest, "dappBadge")
             compare(indicator.visible, false)
 
-            controlUnderTest.model.append({name: "Test dApp 1", url: "https://dapp.test/1", iconUrl: "https://se-sdk-dapp.vercel.app/assets/eip155:1.png"})
+            controlUnderTest.model.append({name: "Test dApp 1", url: "https://dapp.test/1", iconUrl: "https://se-sdk-dapp.vercel.app/assets/eip155:1.png", connectorBadge: "status"})
             compare(indicator.visible, true)
 
             controlUnderTest.model.clear()
@@ -63,7 +65,7 @@ Item {
             compare(popup.y, controlUnderTest.height + 4)
             compare(popup.width, 312)
             verify(popup.height > 0)
-            compare(controlUnderTest.dappsListReadySpy.count, 1)
+            compare(controlUnderTest.dappListRequestedSpy.count, 1)
 
             const background = findChild(controlUnderTest, "dappsBackground")
             compare(background.active, true)
@@ -93,48 +95,29 @@ Item {
             compare(dappTooltip.visible, false)
         }
 
-        function test_connectorsEnabledOrDisabled() {
+        function test_clickConnect() {
             mouseClick(controlUnderTest)
-            const dappListPopup = findChild(controlUnderTest, "dappsListPopup")
-            verify(!!dappListPopup)
+            waitForRendering(controlUnderTest, 200)
 
-            dappListPopup.connectDapp()
-            waitForRendering(controlUnderTest)
-            waitForItemPolished(controlUnderTest)
 
-            const connectorButton = findChild(controlUnderTest, "btnStatusConnector")
-            const wcButton = findChild(controlUnderTest, "btnWalletConnect")
-            verify(!!connectorButton)
-            verify(!!wcButton)
+            const connectButton = findChild(controlUnderTest, "connectDappButton")
+            verify(!!connectButton)
 
-            compare(controlUnderTest.walletConnectEnabled, true)
-            compare(controlUnderTest.connectorEnabled, true)
-
-            controlUnderTest.walletConnectEnabled = false
-            compare(wcButton.enabled, false)
-
-            controlUnderTest.walletConnectEnabled = true
-            compare(wcButton.enabled, true)
-
-            controlUnderTest.connectorEnabled = false
-            compare(connectorButton.enabled, false)
-
-            controlUnderTest.connectorEnabled = true
-            compare(connectorButton.enabled, true)
+            mouseClick(connectButton)
+            compare(controlUnderTest.connectDappSpy.count, 1)
         }
 
-        function test_openPairModal() {
+        function test_disconnect() {
+            controlUnderTest.model.append({name: "Test dApp 1", url: "https://dapp.test/1", iconUrl: "https://se-sdk-dapp.vercel.app/assets/eip155:1.png", connectorBadge: "status"})
             mouseClick(controlUnderTest)
-            const dappListPopup = findChild(controlUnderTest, "dappsListPopup")
-            verify(!!dappListPopup)
+            waitForRendering(controlUnderTest, 200)
 
-            dappListPopup.connectDapp()
-            const wcButton = findChild(controlUnderTest, "btnWalletConnect")
-            verify(!!wcButton)
+            const dapplist = findChild(controlUnderTest, "dappsListPopup")
+            const disconnectButton = findChild(dapplist.contentItem, "disconnectDappButton")
+            verify(!!disconnectButton)
 
-            mouseClick(wcButton)
-            compare(dappListPopup.visible, false)
-            compare(controlUnderTest.pairDappSpy.count, 1)
+            mouseClick(disconnectButton)
+            compare(controlUnderTest.disconnectDappSpy.count, 1)
         }
     }
 }

--- a/storybook/stubs/shared/stores/qmldir
+++ b/storybook/stubs/shared/stores/qmldir
@@ -3,10 +3,10 @@ CommunityTokensStore 1.0 CommunityTokensStore.qml
 CurrenciesStore 1.0 CurrenciesStore.qml
 DAppsStore 1.0 DAppsStore.qml
 GifStore 1.0 GifStore.qml
+MetricsStore 1.0 MetricsStore.qml
 NetworkConnectionStore 1.0 NetworkConnectionStore.qml
 PermissionsStore 1.0 PermissionsStore.qml
 ProfileStore 1.0 ProfileStore.qml
 RootStore 1.0 RootStore.qml
 UtilsStore 1.0 UtilsStore.qml
 BrowserConnectStore 1.0 BrowserConnectStore.qml
-MetricsStore 1.0 MetricsStore.qml

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -43,12 +43,11 @@ Item {
     property bool swapEnabled
     property bool dAppsEnabled
     property bool dAppsVisible
-    property bool walletConnectEnabled: true
-    property bool browserConnectEnabled: true
 
     property var dAppsModel
 
-    signal dappPairRequested()
+    signal dappListRequested()
+    signal dappConnectRequested()
     signal dappDisconnectRequested(string dappUrl)
 
     // TODO: remove tokenType parameter from signals below
@@ -248,8 +247,6 @@ Item {
             swapEnabled: root.swapEnabled
             dAppsEnabled: root.dAppsEnabled
             dAppsVisible: root.dAppsVisible
-            walletConnectEnabled: root.walletConnectEnabled
-            browserConnectEnabled: root.browserConnectEnabled
 
             dAppsModel: root.dAppsModel
 
@@ -266,8 +263,9 @@ Item {
                 d.swapFormData.defaultToTokenKey = RootStore.areTestNetworksEnabled ? Constants.swap.testStatusTokenKey : Constants.swap.mainnetStatusTokenKey
                 Global.openSwapModalRequested(d.swapFormData)
             }
-            onDappPairRequested: root.dappPairRequested()
-            onDappDisconnectRequested: (dappUrl) => root.dappDisconnectRequested(dappUrl)
+            onDappListRequested: root.dappListRequested()
+            onDappConnectRequested: root.dappConnectRequested()
+            onDappDisconnectRequested: (dappUrl) =>root.dappDisconnectRequested(dappUrl)
             onLaunchBuyCryptoModal: d.launchBuyCryptoModal()
 
             onSendTokenRequested: root.sendTokenRequested(senderAddress, tokenId, tokenType)

--- a/ui/app/AppLayouts/Wallet/controls/DappsComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/DappsComboBox.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQml.Models 2.15
 
 import utils 1.0
 import shared.controls 1.0
@@ -12,17 +11,13 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
-import StatusQ.Popups.Dialog 0.1
 import StatusQ.Components.private 0.1 as SQP
 
 ComboBox {
     id: root
-    
-    property bool walletConnectEnabled: true
-    property bool connectorEnabled: true
 
-    signal dappsListReady
-    signal pairDapp
+    signal dappListRequested()
+    signal connectDapp()
     signal disconnectDapp(string dappUrl)
 
     implicitHeight: 38
@@ -80,79 +75,12 @@ ComboBox {
         delegateModel: root.delegateModel
 
         onConnectDapp: {
-            dappConnectSelectComponent.createObject(root).open()
+            root.connectDapp()
             this.close()
         }
 
         onOpened: {
-            root.dappsListReady()
-        }
-    }
-
-    Component {
-        id: dappConnectSelectComponent
-        StatusDialog {
-            id: dappConnectSelect
-            objectName: "dappConnectSelect"
-            width: 480
-            topPadding: Theme.bigPadding
-            leftPadding: Theme.padding
-            rightPadding: Theme.padding
-            bottomPadding: 4
-            destroyOnClose: true
-
-            title: qsTr("Connect a dApp")
-            footer: StatusDialogFooter {
-                rightButtons: ObjectModel {
-                    StatusButton {
-                        text: qsTr("Cancel")
-                        onClicked: dappConnectSelect.close()
-                    }
-                }
-            }
-
-            contentItem: ColumnLayout {
-                StatusBaseText {
-                    Layout.fillWidth: true
-                    Layout.leftMargin: Theme.padding
-                    color: Theme.palette.baseColor1
-                    text: qsTr("How would you like to connect?")
-                }
-                StatusListItem {
-                    objectName: "btnStatusConnector"
-                    title: "Status Connector"
-                    asset.name: Theme.png("status-logo")
-                    asset.isImage: true
-                    enabled: root.connectorEnabled
-                    components: [
-                        StatusIcon {
-                            icon: "external-link"
-                            color: Theme.palette.baseColor1
-                        }
-                    ]
-                    onClicked: {
-                        dappConnectSelect.close()
-                        Global.openLink("https://chromewebstore.google.com/detail/a-wallet-connector-by-sta/kahehnbpamjplefhpkhafinaodkkenpg")
-                    }
-                }
-                StatusListItem {
-                    objectName: "btnWalletConnect"
-                    title: "Wallet Connect"
-                    asset.name: Theme.svg("walletconnect")
-                    asset.isImage: true
-                    enabled: root.walletConnectEnabled
-                    components: [
-                        StatusIcon {
-                            icon: "next"
-                            color: Theme.palette.baseColor1
-                        }
-                    ]
-                    onClicked: {
-                        dappConnectSelect.close()
-                        root.pairDapp()
-                    }
-                }
-            }
+            root.dappListRequested()
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/helpers/ChainsAvailabilityWatchdog.qml
+++ b/ui/app/AppLayouts/Wallet/helpers/ChainsAvailabilityWatchdog.qml
@@ -12,6 +12,7 @@ QObject {
 
     readonly property bool allOffline: d.allOffline
     readonly property bool allOnline: d.allOnline
+    readonly property bool networkOnline: networkChecker.isOnline
 
     property bool active: true
 
@@ -48,9 +49,8 @@ QObject {
 
     QtObject {
         id: d
-        readonly property bool allOffline: !networkChecker.isOnline || aggregator.value === 0
-        readonly property bool allOnline: networkChecker.isOnline &&
-                                        aggregator.value > 0 &&
+        readonly property bool allOffline: aggregator.value === 0
+        readonly property bool allOnline: aggregator.value > 0 &&
                                         aggregator.value === networksModel.ModelCount.count
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -36,12 +36,10 @@ Item {
 
     property bool dAppsEnabled: true
     property bool dAppsVisible: true
-    property bool walletConnectEnabled: true
-    property bool browserConnectEnabled: true
     property var dAppsModel
 
-    signal buttonClicked()
-    signal dappPairRequested()
+    signal dappListRequested()
+    signal dappConnectRequested()
     signal dappDisconnectRequested(string dappUrl)
 
     implicitHeight: 88
@@ -148,11 +146,10 @@ Item {
 
                 visible: !root.walletStore.showSavedAddresses && root.dAppsVisible
                 enabled: root.dAppsEnabled
-                walletConnectEnabled: root.walletConnectEnabled
-                connectorEnabled: root.browserConnectEnabled
                 model: root.dAppsModel
-                onPairDapp: root.dappPairRequested()
+                onDappListRequested: () => root.dappListRequested()
                 onDisconnectDapp: (dappUrl) => root.dappDisconnectRequested(dappUrl)
+                onConnectDapp: () => root.dappConnectRequested()
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsMetrics.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsMetrics.qml
@@ -1,0 +1,253 @@
+import QtQml 2.15
+
+import shared.stores 1.0
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import utils 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property MetricsStore metricsStore
+
+    enum DAppsHealthState {
+        WcAvailable,
+        WcUnavailable,
+        ChainsDown,
+        NetworkDown,
+        PairError,
+        ConnectError,
+        SignError
+    }
+
+    enum DAppsNavigationAction {
+        DAppListOpened,
+        DAppConnectInitiated,
+        DAppDisconnectInitiated,
+        DAppPairInitiated
+    }
+
+    enum DAppsConnectFlows {
+        ProposalReceived,
+        ProposalAccepted,
+        ProposalRejected,
+        Connected,
+        Disconnected
+    }
+
+    enum DAppsSignFlows {
+        SignRequestReceived,
+        SignRequestAccepted,
+        SignRequestRejected
+    }
+    //checked
+    function logHealthEvent(healthState /*DAppsHealthState*/, error = "") {
+        try {
+            const { eventName, eventValue } = d.buildDappsHealthEvent(healthState, error)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps health check", e)
+        }
+    }
+
+    function logNavigationEvent(navigationAction /*DAppsNavigationAction*/, connector /*Constants.DAppConnectors*/) {
+        try {
+            const { eventName, eventValue } = d.buildDappsNavigationEvent(navigationAction, connector)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps navigation", e)
+        }
+    }
+
+    function logConnectionProposal(networks, methods, dapp, connector) {
+        try {
+            const { eventName, eventValue } = d.buildDAppConnectionEvent(DAppsMetrics.DAppsConnectFlows.ProposalReceived, networks, methods, dapp, connector, false)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps session proposal", e)
+        }
+    }
+
+    function logSiweConnectionProposal(networks, dapp, connector) {
+        try {
+            const { eventName, eventValue } = d.buildDAppConnectionEvent(DAppsMetrics.DAppsConnectFlows.ProposalReceived, networks, [], dapp, connector, true)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps session proposal", e)
+        }
+    }
+
+    function logConnectionProposalAccepted(dapp, networks, connector) {
+        try {
+            const { eventName, eventValue } = d.buildDAppConnectionEvent(DAppsMetrics.DAppsConnectFlows.ProposalAccepted, networks, [], dapp, connector, null)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps session proposal accepted", e)
+        }
+    }
+
+    function logConnectionProposalRejected(dapp, connector) {
+        try {
+            const { eventName, eventValue } = d.buildDAppConnectionEvent(DAppsMetrics.DAppsConnectFlows.ProposalRejected, [], [], dapp, connector, null)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps session proposal rejected", e)
+        }
+    }
+
+    function logDAppConnected(dapp, connector) {
+        try {
+            const { eventName, eventValue } = d.buildDAppConnectionEvent(DAppsMetrics.DAppsConnectFlows.Connected, [], [], dapp, connector, null)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps session connected", e)
+        }
+    }
+
+    function logDAppDisconnected(dapp, connector) {
+        try {
+            const { eventName, eventValue } = d.buildDAppConnectionEvent(DAppsMetrics.DAppsConnectFlows.Disconnected, [], [], dapp, connector, null)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps session disconnected", e)
+        }
+    }
+
+    function logSignRequestReceived(connector, method, chainId, dapp) {
+        try {
+            const { eventName, eventValue } = d.buildDAppSignEvent(DAppsMetrics.DAppsSignFlows.SignRequestReceived, connector, method, chainId, dapp)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps sign request received", e)
+        }
+    }
+
+    function logSignRequestAccepted(connector, method, chainId, dapp) {
+        try {
+            const { eventName, eventValue } = d.buildDAppSignEvent(DAppsMetrics.DAppsSignFlows.SignRequestAccepted, connector, method, chainId, dapp)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps sign request accepted", e)
+        }
+    }
+
+    function logSignRequestRejected(connector, method, chainId, dapp) {
+        try {
+            const { eventName, eventValue } = d.buildDAppSignEvent(DAppsMetrics.DAppsSignFlows.SignRequestRejected, connector, method, chainId, dapp)
+            metricsStore.addCentralizedMetricIfEnabled(eventName, eventValue)
+        } catch (e) {
+            console.error("Failed to log dapps sign request rejected", e)
+        }
+    }
+
+    SQUtils.QObject {
+        id: d
+
+        readonly property var healthStateMap: new Map([
+            [DAppsMetrics.DAppsHealthState.WcAvailable, "wc-available"],
+            [DAppsMetrics.DAppsHealthState.WcUnavailable, "wc-unavailable"],
+            [DAppsMetrics.DAppsHealthState.ChainsDown, "chains-down"],
+            [DAppsMetrics.DAppsHealthState.NetworkDown, "network-down"],
+            [DAppsMetrics.DAppsHealthState.PairError, "pair-error"],
+            [DAppsMetrics.DAppsHealthState.ConnectError, "connect-error"],
+            [DAppsMetrics.DAppsHealthState.SignError, "sign-error"]
+        ])
+
+        readonly property var navigationActionMap: new Map([
+            [DAppsMetrics.DAppsNavigationAction.DAppListOpened, "dapp-list-opened"],
+            [DAppsMetrics.DAppsNavigationAction.DAppConnectInitiated, "dapp-connect-initiated"],
+            [DAppsMetrics.DAppsNavigationAction.DAppDisconnectInitiated, "dapp-disconnect-initiated"],
+            [DAppsMetrics.DAppsNavigationAction.DAppPairInitiated, "dapp-pair-initiated"]
+        ])
+
+        readonly property var connectorMap: new Map([
+            [Constants.DAppConnectors.WalletConnect, "wallet-connect"],
+            [Constants.DAppConnectors.StatusConnect, "browser-connect"]
+        ])
+
+        readonly property var dappConnectFlowMap: new Map([
+            [DAppsMetrics.DAppsConnectFlows.ProposalReceived, "proposal-received"],
+            [DAppsMetrics.DAppsConnectFlows.ProposalAccepted, "proposal-accepted"],
+            [DAppsMetrics.DAppsConnectFlows.ProposalRejected, "proposal-rejected"],
+            [DAppsMetrics.DAppsConnectFlows.Connected, "connected"],
+            [DAppsMetrics.DAppsConnectFlows.Disconnected, "disconnected"]
+        ])
+
+        readonly property var dappSignFlowMap: new Map([
+            [DAppsMetrics.DAppsSignFlows.SignRequestReceived, "sign-received"],
+            [DAppsMetrics.DAppsSignFlows.SignRequestAccepted, "sign-accepted"],
+            [DAppsMetrics.DAppsSignFlows.SignRequestRejected, "sign-rejected"]
+        ])
+
+        function buildDappsHealthEvent(healthState, error) {
+            if (!d.healthStateMap.has(healthState)) {
+                throw new Error("Invalid health state")
+            }
+            let state = d.healthStateMap.get(healthState)
+
+            return {
+                eventName: "dapps-health",
+                eventValue: {
+                    state,
+                    error
+                }
+            }
+        }
+
+        function buildDappsNavigationEvent(navigationAction, connector) {
+            if (!d.navigationActionMap.has(navigationAction)) {
+                throw new Error("Invalid navigation action")
+            }
+
+            const action = d.navigationActionMap.get(navigationAction)
+            const connectorStr = d.connectorMap.has(connector) ? d.connectorMap.get(connector) : ""
+
+            return {
+                eventName: "dapps-navigation",
+                eventValue: {
+                    action,
+                    connector: connectorStr
+                }
+            }
+        }
+
+        function buildDAppConnectionEvent(flow, networks, methods, dapp, connector, isSiwe) {
+            if (!d.dappConnectFlowMap.has(flow)) {
+                throw new Error("Invalid dapp connect flow")
+            }
+
+            const connectorStr = d.connectorMap.has(connector) ? d.connectorMap.get(connector) : ""
+
+            return {
+                eventName: "dapps-connection",
+                eventValue: {
+                    flow: d.dappConnectFlowMap.get(flow),
+                    networks,
+                    methods,
+                    dapp,
+                    connector: connectorStr,
+                    isSiwe
+                }
+            }
+        }
+
+        function buildDAppSignEvent(flow, connector, method, chain, dapp) {
+            if (!d.dappSignFlowMap.has(flow)) {
+                throw new Error("Invalid dapp sign flow")
+            }
+
+            const connectorStr = d.connectorMap.has(connector) ? d.connectorMap.get(connector) : ""
+
+            return {
+                eventName: "dapps-sign",
+                eventValue: {
+                    flow: d.dappSignFlowMap.get(flow),
+                    connector: connectorStr,
+                    method,
+                    chain,
+                    dapp
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDK.qml
@@ -389,7 +389,7 @@ WalletConnectSDKBase {
 
         function onPairResponse(error) {
             console.debug(`WC WalletConnectSDK.onPairResponse; error: ${error}`)
-            root.pairResponse(error == "")
+            root.pairResponse(error == "", error)
         }
 
         function onPingResponse(error) {

--- a/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/WalletConnectSDKBase.qml
@@ -7,7 +7,7 @@ Item {
 
     signal statusChanged(string message)
     signal sdkInit(bool success, var result)
-    signal pairResponse(bool success)
+    signal pairResponse(bool success, string error)
     signal sessionProposal(var sessionProposal)
     signal sessionProposalExpired()
     signal buildApprovedNamespacesResult(string id, var session, string error)

--- a/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
+++ b/ui/app/AppLayouts/Wallet/services/dapps/helpers.js
@@ -39,6 +39,24 @@ function extractChainsAndAccountsFromApprovedNamespaces(approvedNamespaces) {
     return { chains, accounts: uniqueAccounts };
 }
 
+function extractMethodsFromProposal(proposal) {
+    const optionalMethods = (((((proposal || {}).params) || {}).optionalNamespaces || {}).eip155 || {}).methods || []
+    const requiredMethods = (((((proposal || {}).params) || {}).requiredNamespaces || {}).eip155 || {}).methods || []
+    let methods = [...optionalMethods, ...requiredMethods]
+    return methods
+}
+
+function extractChainsFromProposal(proposal) {
+    const optionalChains = (((((proposal || {}).params) || {}).optionalNamespaces || {}).eip155 || {}).chains || []
+    const requiredChains = (((((proposal || {}).params) || {}).requiredNamespaces || {}).eip155 || {}).chains || []
+    let chains = [...optionalChains, ...requiredChains].map(chainIdFromEip155)
+    return chains
+}
+
+function extractChainsFromAuthenticationProposal(proposal) {
+    return ((((proposal || {}).params || {}).authPayload || {}).chains || []).map(chainIdFromEip155)
+}
+
 function buildSupportedNamespacesFromModels(chainsModel, accountsModel, methods) {
     var chainIds = []
     var addresses = []

--- a/ui/app/AppLayouts/Wallet/services/dapps/plugins/ChainsSupervisorPlugin.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/plugins/ChainsSupervisorPlugin.qml
@@ -19,7 +19,9 @@ QObject {
     // Required roles: chainId, isOnline
     required property var networksModel
     // Happens when any chain is available
-    readonly property bool anyChainAvailable: !chainsAvailabilityWatchdog.allOffline
+    readonly property bool isOnline: !chainsAvailabilityWatchdog.allOffline && chainsAvailabilityWatchdog.networkOnline
+    readonly property bool allChainsOffline: chainsAvailabilityWatchdog.allOffline
+    readonly property bool networkOffline: !chainsAvailabilityWatchdog.networkOnline
 
     ChainsAvailabilityWatchdog {
         id: chainsAvailabilityWatchdog

--- a/ui/app/AppLayouts/Wallet/services/dapps/plugins/SiweRequestPlugin.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/plugins/SiweRequestPlugin.qml
@@ -58,6 +58,24 @@ SQUtils.QObject {
         return true
     }
 
+    function getProposalChains(key) {
+        const siweLifeCycle = d.getSiweLifeCycle(key)
+        if (!siweLifeCycle) {
+            return []
+        }
+
+        return DAppsHelpers.extractChainsFromAuthenticationProposal(siweLifeCycle.request)
+    }
+
+    function getDAppUrl(key) {
+        const siweLifeCycle = d.getSiweLifeCycle(key)
+        if (!siweLifeCycle) {
+            return ""
+        }
+
+        return ((((siweLifeCycle.request || {}).params || {}).requester || {}).metadata || {}).url || ""
+    }
+
     Instantiator {
         id: requestLifecycle
         model: d.requests

--- a/ui/app/AppLayouts/Wallet/services/dapps/qmldir
+++ b/ui/app/AppLayouts/Wallet/services/dapps/qmldir
@@ -1,6 +1,7 @@
 BCDappsProvider 1.0 BCDappsProvider.qml
 DappsConnectorSDK 1.0 DappsConnectorSDK.qml
 DAppsHelpers 1.0 helpers.js
+DAppsMetrics 1.0 DAppsMetrics.qml
 DAppsModel 1.0 DAppsModel.qml
 DAppsModule 1.0 DAppsModule.qml
 DAppsService 1.0 DAppsService.qml

--- a/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestsModel.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/types/SessionRequestsModel.qml
@@ -4,8 +4,11 @@ import QtQuick 2.15
 ListModel {
     id: root
 
+    signal requestAdded(var request)
+
     function enqueue(request) {
         root.append({requestId: request.requestId, requestItem: request});
+        requestAdded(request);
     }
 
     function dequeue() {

--- a/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabBaseView.qml
@@ -22,8 +22,6 @@ FocusScope {
     property bool swapEnabled
     property bool dAppsEnabled
     property bool dAppsVisible
-    property bool walletConnectEnabled
-    property bool browserConnectEnabled
 
     property var dAppsModel
 
@@ -33,7 +31,8 @@ FocusScope {
 
     default property alias content: contentWrapper.children
 
-    signal dappPairRequested()
+    signal dappListRequested()
+    signal dappConnectRequested()
     signal dappDisconnectRequested(string dappUrl)
 
     ColumnLayout {
@@ -50,10 +49,9 @@ FocusScope {
             dAppsEnabled: root.dAppsEnabled
             dAppsVisible: root.dAppsVisible
             dAppsModel: root.dAppsModel
-            walletConnectEnabled: root.walletConnectEnabled
-            browserConnectEnabled: root.browserConnectEnabled
 
-            onDappPairRequested: root.dappPairRequested()
+            onDappListRequested: root.dappListRequested()
+            onDappConnectRequested: root.dappConnectRequested()
             onDappDisconnectRequested: (dappUrl) =>root.dappDisconnectRequested(dappUrl)
         }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1715,13 +1715,18 @@ Item {
                             hideSignPhraseModal: userAgreementLoader.active
                             dAppsVisible: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
                             dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.isServiceOnline : false
-                            walletConnectEnabled: featureFlagsStore.dappsEnabled
-                            browserConnectEnabled: featureFlagsStore.connectorEnabled
                             dAppsModel: dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
 
-                            onDappPairRequested: dAppsServiceLoader.dappPairRequested()
-                            onDappDisconnectRequested: (dappUrl) => dAppsServiceLoader.dappDisconnectRequested(dappUrl)
-			     onSendTokenRequested: sendModalHandler.sendToken(
+                            onDappListRequested: () => dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppListOpened)
+                            onDappConnectRequested: () => {
+                                dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppConnectInitiated)
+                                dAppsServiceLoader.dappConnectRequested()
+                            }
+                            onDappDisconnectRequested: (dappUrl) => {
+                                dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppDisconnectInitiated)
+                                dAppsServiceLoader.dappDisconnectRequested(dappUrl)
+                            }
+			                onSendTokenRequested: sendModalHandler.sendToken(
                                                       senderAddress, tokenId, tokenType)
                             onBridgeTokenRequested: sendModalHandler.bridgeToken(tokenId, tokenType)
                         }
@@ -2383,11 +2388,16 @@ Item {
         }
     }
 
+    DAppsMetrics {
+        id: dappMetrics
+        metricsStore: SharedStores.MetricsStore {}
+    }
+
     Loader {
         id: dAppsServiceLoader
 
-        signal dappPairRequested()
         signal dappDisconnectRequested(string dappUrl)
+        signal dappConnectRequested()
 
         // It seems some of the functionality of the dapp connector depends on the DAppsService
         active: {
@@ -2408,6 +2418,8 @@ Item {
                 accountsModel: WalletStores.RootStore.nonWatchAccounts
                 networksModel: WalletStores.RootStore.filteredFlatModel
                 sessionRequestsModel: dAppsService.sessionRequestsModel
+                walletConnectEnabled: featureFlagsStore.dappsEnabled
+                connectorEnabled: featureFlagsStore.connectorEnabled
 
                 formatBigNumber: (number, symbol, noSymbolOption) => WalletStores.RootStore.currencyStore.formatBigNumber(number, symbol, noSymbolOption)
 
@@ -2419,12 +2431,20 @@ Item {
                 onSignRequestAccepted: (connectionId, requestId) => dAppsService.sign(connectionId, requestId)
                 onSignRequestRejected: (connectionId, requestId) => dAppsService.rejectSign(connectionId, requestId, false /*hasError*/)
                 onSignRequestIsLive: (connectionId, requestId) => dAppsService.signRequestIsLive(connectionId, requestId)
+                onPairWithConnectorRequested: (connectorId) => {
+                    dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppPairInitiated, connectorId)
+                    if (connectorId == Constants.DAppConnectors.WalletConnect) {
+                        dappsWorkflow.openPairing()
+                    } else if (connectorId == Constants.DAppConnectors.StatusConnect) {
+                        Global.openLink("https://chromewebstore.google.com/detail/a-wallet-connector-by-sta/kahehnbpamjplefhpkhafinaodkkenpg")
+                    }
+                }
 
                 Connections {
                     target: dAppsServiceLoader
 
-                    function onDappPairRequested() {
-                        dappsWorkflow.openPairing()
+                    function onDappConnectRequested() {
+                        dappsWorkflow.chooseConnector()
                     }
 
                     function onDappDisconnectRequested(dappUrl) {
@@ -2438,6 +2458,7 @@ Item {
                 currenciesStore: WalletStores.RootStore.currencyStore
                 groupedAccountAssetsModel: WalletStores.RootStore.walletAssetsStore.groupedAccountAssetsModel
                 accountsModel: WalletStores.RootStore.nonWatchAccounts
+                dappsMetrics: dappMetrics
                 networksModel: SortFilterProxyModel {
                     sourceModel: WalletStores.RootStore.filteredFlatModel
                     proxyRoles: [

--- a/ui/imports/shared/popups/walletconnect/controls/DAppDelegate.qml
+++ b/ui/imports/shared/popups/walletconnect/controls/DAppDelegate.qml
@@ -76,6 +76,7 @@ MouseArea {
         }
 
         StatusFlatButton {
+            objectName: "disconnectDappButton"
             size: StatusBaseButton.Size.Large
 
             asset.color: root.containsMouse ? Theme.palette.directColor1


### PR DESCRIPTION
### What does the PR do

closes #16912

Sending the dapps events to mixpanel

Events structure: https://www.notion.so/Event-Tracking-Specification-Desktop-1518f96fb65c8026a3a5c8a0459f7f21?pvs=4#63de5b7c3b6c4a7cab492cff6aa95957

Events description: https://www.notion.so/Metrics-for-Wallet-Connect-d3d1e60e7ea24479bd35cbb11219540c?pvs=4#375a52965a98458eb45b2e2eea6a4bd5

New board created here: https://eu.mixpanel.com/s/3kYRpk

+ Moved the `Connect dialog` from dapps comboBox to the dappsWorkflow where the other modals are placed
+ Extend component with necessary signals/functions of collect metrics data
+ Update tests and storybook
+ Implement fully functional storybook metrics page to test the events with Mixpanel

### Affected areas

dapps
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

