### PR TITLE
[CHERRY-PICK] fix(StatusMessageHeader): unbreak context menu

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -78,7 +78,7 @@ Item {
             }
             TapHandler {
                 enabled: root.displayNameClickable
-                onSingleTapped: root.clicked(this)
+                onSingleTapped: root.clicked(primaryDisplayName)
             }
         }
 

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -91,7 +91,7 @@ Flow {
 
     Repeater {
         id: tempRepeater
-        visible: root.cankToUnfurlGifs
+        visible: root.canAskToUnfurlGifs
         model: root.gifUnfurlingEnabled ? gifLinks : []
 
         delegate: LinkPreviewGifDelegate {


### PR DESCRIPTION
### What does the PR do

- when clicking the underlined profile name; the prob was that `TapHandler` (unlike a `MouseArea`) is not a visual `Item` and hence can't be a parent for the context menu
- small (unrelated) typo fix to unbreak GIF link previews...

Fixes #16950

### Affected areas

StatusMessageHeader

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/96f36186-0033-4acd-bcf0-4da32e5e121e)
