### PR TITLE
[CHERRY-PICK] fix(admin): fix nicknames not showing in the admin tab immediately

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -521,6 +521,10 @@ proc init*(self: Controller) =
     let args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
 
+  self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
+    var args = ContactArgs(e)
+    self.delegate.contactUpdated(args.contactId)
+
   self.events.on(SIGNAL_LOGGEDIN_USER_NAME_CHANGED) do(e: Args):
     self.delegate.contactUpdated(singletonInstance.userProfile.getPubKey())
 


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/16959

Fixes #16957

We didn't listen to the event in the main module.
