### PR TITLE
[CHERRY-PICK] fix(chat): fix blocked contact being able to be sent a CR (#16954)

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -104,6 +104,7 @@ ColumnLayout {
             chatId: root.chatId
             isOneToOne: root.chatType === Constants.chatType.oneToOne
             isChatBlocked: root.isBlocked || !root.isUserAllowedToSendMessage
+            isContactBlocked: root.isBlocked
             channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             areTestNetworksEnabled: root.areTestNetworksEnabled


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/16954

Fixes #16951

The property `isContactBlocked` was not passed to the component.