### PR TITLE
fix(curated): fix crash when loading curated communities

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -226,9 +226,6 @@ proc isDisplayNameDupeOfCommunityMember*(self: Controller, displayName: string):
 proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
   result = self.communityService.getCommunityById(communityId)
 
-proc getCuratedCommunities*(self: Controller): seq[CommunityDto] =
-  result = self.communityService.getCuratedCommunities()
-
 proc spectateCommunity*(self: Controller, communityId: string): string =
   self.communityService.spectateCommunity(communityId)
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -873,9 +873,6 @@ QtObject:
   proc getAllCommunities*(self: Service): seq[CommunityDto] =
     return toSeq(self.communities.values)
 
-  proc getCuratedCommunities*(self: Service): seq[CommunityDto] =
-    return toSeq(self.getFilteredCuratedCommunities.values)
-
   proc getCommunityById*(self: Service, communityId: string): CommunityDto =
     if communityId == "":
       return
@@ -1855,7 +1852,7 @@ QtObject:
       let curatedCommunities = parseCuratedCommunities(rpcResponseObj["response"]["result"])
       for curatedCommunity in curatedCommunities:
         self.communities[curatedCommunity.id] = curatedCommunity
-      self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADED, CommunitiesArgs(communities: self.getCuratedCommunities()))
+      self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADED, CommunitiesArgs(communities: curatedCommunities))
     except Exception as e:
       let errMsg = e.msg
       error "error loading curated communities: ", errMsg


### PR DESCRIPTION
Fixes #16967

I cannot confirm for sure if the crash is fixed.
However, using the trace from the crash, I removed the function that caused the crash, since it's not useful, and since then, I couldn't reproduce the issue. The problem is that the issue was not that easily reproducible.

@anastasiyaig if you could give it a run and tell me if you can reproduce in the same conditions, it would be great. Thanks
