### PR TITLE
fix: No toast on removal of untrusted mark

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -64,6 +64,7 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_REMOVED_TRUST_STATUS) do(e: Args):
     var args = TrustArgs(e)
     self.delegate.contactTrustStatusChanged(args.publicKey, args.trustStatus)
+    self.delegate.onTrustStatusRemoved(args.publicKey)
     
   self.events.on(SIGNAL_CONTACT_UPDATED) do(e: Args):
     var args = ContactArgs(e)

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -71,6 +71,9 @@ method contactNicknameChanged*(self: AccessInterface, publicKey: string) {.base.
 method contactTrustStatusChanged*(self: AccessInterface, publicKey: string, trustStatus: TrustStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onTrustStatusRemoved*(self: AccessInterface, publicKey: string): void {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method contactsStatusUpdated*(self: AccessInterface, statusUpdates: seq[StatusUpdateDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -203,6 +203,9 @@ method contactNicknameChanged*(self: Module, publicKey: string) =
 method contactTrustStatusChanged*(self: Module, publicKey: string, trustStatus: TrustStatus) =
   self.view.contactsModel().updateTrustStatus(publicKey, trustStatus)
 
+method onTrustStatusRemoved(self: Module, publicKey: string) =
+  self.view.trustStatusRemoved(publicKey)
+
 method markAsTrusted*(self: Module, publicKey: string): void =
   self.controller.markAsTrusted(publicKey)
 

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -108,6 +108,8 @@ QtObject:
   proc removeTrustStatus*(self: View, publicKey: string) {.slot.} =
     self.delegate.removeTrustStatus(publicKey)
 
+  proc trustStatusRemoved*(self: View, publicKey: string) {.signal.}
+
   proc shareUserUrlWithData*(self: View, pubkey: string): string {.slot.} =
     return self.delegate.shareUserUrlWithData(pubkey)
 

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -148,7 +148,7 @@ Item {
                             emojiHash: model.emojiHash,
                             colorHash: model.colorHash,
                             colorId: model.colorId,
-                            displayName: nickName || userName,
+                            displayName: model.preferredDisplayName,
                             userIcon: model.icon,
                             trustStatus: model.trustStatus,
                             onlineStatus: model.onlineStatus,

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.15
 
 import StatusQ 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
+
 import utils 1.0
 
 QtObject {
@@ -15,6 +17,7 @@ QtObject {
 
         Component.onCompleted: {
             mainModuleInst.resolvedENS.connect(root.resolvedENS)
+            contactsModuleInst.trustStatusRemoved.connect(root.trustStatusRemoved)
         }
     }
 
@@ -38,6 +41,7 @@ QtObject {
     readonly property var showcaseCollectiblesModel: d.contactsModuleInst.showcaseCollectiblesModel
 
     signal resolvedENS(string resolvedPubKey, string resolvedAddress, string uuid)
+    signal trustStatusRemoved(string pubKey)
 
     // Sets showcasePublicKey and updates showcase models with corresponding data
     function requestProfileShowcase(publicKey) {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -458,8 +458,6 @@ QtObject {
                 utilsStore: root.utilsStore
 
                 onAccepted: {
-                    rootStore.contactStore.removeTrustStatus(publicKey)
-
                     if (markAsUntrusted && removeContact) {
                         rootStore.contactStore.markUntrustworthy(publicKey)
                         rootStore.contactStore.removeContact(publicKey)
@@ -471,7 +469,7 @@ QtObject {
                         rootStore.contactStore.removeContact(publicKey)
                         Global.displaySuccessToastMessage(qsTr("%1 trust mark removed and removed from contacts").arg(mainDisplayName))
                     } else {
-                        Global.displaySuccessToastMessage(qsTr("%1 trust mark removed").arg(mainDisplayName))
+                        rootStore.contactStore.removeTrustStatus(publicKey)
                     }
                     close()
                 }

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.15
 
+import StatusQ.Core.Utils 0.1 as SQUtils
+
 import utils 1.0
 
 import AppLayouts.Wallet 1.0
@@ -227,6 +229,15 @@ QtObject {
                                        false,
                                         Constants.ephemeralNotificationType.danger,
                                        "")
+        }
+    }
+
+    readonly property Connections _contactStoreConnections: Connections {
+        target: root.rootStore.contactStore
+
+        function onTrustStatusRemoved(pubKey: string) {
+            const displayName = SQUtils.ModelUtils.getByKey(root.rootStore.contactStore.contactsModel, "pubKey", pubKey, "preferredDisplayName")
+            Global.displaySuccessToastMessage(qsTr("Trust mark removed for %1").arg(displayName))
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- listen to the NIM's signal `SIGNAL_REMOVED_TRUST_STATUS`
- emit a signal for QML signal accordingly
- emit a toast/notification as a result

Fixes #16949

### Affected areas

Profile

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Marked as untrusted:
![Snímek obrazovky z 2024-12-16 11-40-18](https://github.com/user-attachments/assets/f50add0c-5c00-4eeb-a0b1-0d7a790bd82c)

Removed the untrusted mark:
![image](https://github.com/user-attachments/assets/1241936e-4948-4c25-9d31-a11d3a5dfe8e)


