### PR TITLE
feat(OnboardingLayout): Decompose into smaller, pure ui sub-flows

### DIFF
--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -42,9 +42,12 @@ SplitView {
 
     OnboardingLayout {
         id: onboarding
+
         SplitView.fillWidth: true
         SplitView.fillHeight: true
+
         networkChecksEnabled: true
+
         onboardingStore: OnboardingStore {
             readonly property int keycardState: ctrlKeycardState.currentValue // enum Onboarding.KeycardState
             property int keycardRemainingPinAttempts: 5
@@ -118,9 +121,9 @@ SplitView {
             property bool metricsPopupSeen
         }
 
-        onFinished: (primaryFlow, secondaryFlow, data) => {
-            console.warn("!!! ONBOARDING FINISHED; primary flow:", primaryFlow, "; secondary:", secondaryFlow, "; data:", JSON.stringify(data))
-            logs.logEvent("onFinished", ["primaryFlow", "secondaryFlow", "data"], arguments)
+        onFinished: (flow, data) => {
+            console.warn("!!! ONBOARDING FINISHED; flow:", flow, "; data:", JSON.stringify(data))
+            logs.logEvent("onFinished", ["flow", "data"], arguments)
 
             console.warn("!!! SIMULATION: SHOWING SPLASH")
             stack.clear()
@@ -185,9 +188,6 @@ SplitView {
                 Layout.fillWidth: true
                 Label {
                     text: "Current page: %1".arg(onboarding.stack.currentItem ? onboarding.stack.currentItem.pageClassName : "")
-                }
-                Label {
-                    text: `Current flow: ${onboarding.primaryFlow} -> ${onboarding.secondaryFlow}`
                 }
                 Label {
                     text: "Stack depth: %1".arg(onboarding.stack.depth)

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -213,6 +213,24 @@ SplitView {
                         onClicked: ClipboardUtils.setText(mockDriver.mnemonic)
                     }
                     Button {
+                        text: "Paste seed phrase verification"
+                        focusPolicy: Qt.NoFocus
+                        onClicked: {
+                            for (let i = 0;; i++) {
+                                const input = StorybookUtils.findChild(
+                                                onboarding.stack.currentItem,
+                                                `seedInput_${i}`)
+
+                                if (input === null)
+                                    break
+
+                                const index = input.seedWordIndex
+                                input.text = mockDriver.seedWords[index]
+                            }
+                        }
+                    }
+
+                    Button {
                         text: "Copy PIN (\"%1\")".arg(ctrlPin.text)
                         focusPolicy: Qt.NoFocus
                         enabled: ctrlPin.acceptableInput

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -280,8 +280,7 @@ Item {
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.CreateProfile)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.CreateProfileWithPassword)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.CreateProfileWithPassword)
         }
 
         // FLOW: Create Profile -> Use a recovery phrase (create profile with seedphrase)
@@ -372,8 +371,7 @@ Item {
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.CreateProfile)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.CreateProfileWithSeedphrase)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.CreateProfileWithSeedphrase)
         }
 
         function test_flow_createProfile_withKeycardAndNewSeedphrase_data() {
@@ -536,8 +534,7 @@ Item {
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.CreateProfile)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.CreateProfileWithKeycardNewSeedphrase)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.CreateProfileWithKeycardNewSeedphrase)
         }
 
         function test_flow_createProfile_withKeycardAndExistingSeedphrase_data() {
@@ -642,8 +639,7 @@ Item {
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.CreateProfile)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase)
         }
 
         // FLOW: Log in -> Log in with recovery phrase
@@ -729,10 +725,8 @@ Item {
                 compare(dynamicSpy.signalArguments[0][0], data.bioEnabled)
             }
 
-            // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.Login)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.LoginWithSeedphrase)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.LoginWithSeedphrase)
         }
 
         // FLOW: Log in -> Log in by syncing
@@ -818,8 +812,7 @@ Item {
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.Login)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.LoginWithSyncing)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.LoginWithSyncing)
         }
 
         // FLOW: Log in -> Log in with Keycard
@@ -878,8 +871,7 @@ Item {
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)
-            compare(finishedSpy.signalArguments[0][0], Onboarding.PrimaryFlow.Login)
-            compare(finishedSpy.signalArguments[0][1], Onboarding.SecondaryFlow.LoginWithKeycard)
+            compare(finishedSpy.signalArguments[0][0], Onboarding.SecondaryFlow.LoginWithKeycard)
         }
     }
 }

--- a/storybook/src/Storybook/StorybookUtils.qml
+++ b/storybook/src/Storybook/StorybookUtils.qml
@@ -28,7 +28,13 @@ QtObject {
         for (let i = 0; i < parent.children.length; i++) {
             if (parent.children[i].objectName === name)
                 return parent.children[i]
+
+            const inner = findChild(parent.children[i], name)
+
+            if (inner !== null)
+                return inner
         }
+
         return null
     }
 }

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -66,6 +66,7 @@
         <file>StatusQ/Components/StatusVideo.qml</file>
         <file>StatusQ/Components/StatusWizardStepper.qml</file>
         <file>StatusQ/Components/WebEngineLoader.qml</file>
+        <file>StatusQ/Components/private/LoadingDotItem.qml</file>
         <file>StatusQ/Components/private/StatusComboboxBackground.qml</file>
         <file>StatusQ/Components/private/StatusComboboxIndicator.qml</file>
         <file>StatusQ/Components/private/chart/ChartCanvas.qml</file>

--- a/ui/app/AppLayouts/Onboarding2/CreateNewProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/CreateNewProfileFlow.qml
@@ -1,0 +1,30 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+    required property var passwordStrengthScoreFunction
+
+    signal finished(string password)
+
+    function init() {
+        root.stackView.push(createPasswordPage)
+    }
+
+    Component {
+        id: createPasswordPage
+
+        CreatePasswordPage {
+            passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
+
+            onSetPasswordRequested: root.finished(password)
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -1,0 +1,201 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+
+    required property int keycardState
+    required property int addKeyPairState
+
+    required property var seedWords
+    required property var isSeedPhraseValid
+    required property int splashScreenDurationMs
+
+    property bool displayKeycardPromoBanner
+
+    signal loginWithKeycardRequested
+    signal keycardFactoryResetRequested
+    signal keycardPinCreated(string pin)
+
+    signal keypairAddTryAgainRequested
+    signal reloadKeycardRequested
+    signal createProfileWithoutKeycardRequested
+
+    signal finished(bool fromBackupSeedphrase)
+
+    function init() {
+        root.stackView.push(d.initialComponent())
+    }
+
+    QtObject {
+        id: d
+
+        property bool fromBackupSeedphrase
+
+        function initialComponent() {
+            if (root.keycardState === Onboarding.KeycardState.Empty)
+                return createKeycardProfilePage
+
+            if (root.keycardState === Onboarding.KeycardState.NotEmpty)
+                return keycardNotEmptyPage
+
+            return keycardIntroPage
+        }
+    }
+
+    Component {
+        id: keycardIntroPage
+
+        KeycardIntroPage {
+            keycardState: root.keycardState
+            displayPromoBanner: root.displayKeycardPromoBanner
+
+            onReloadKeycardRequested: {
+                root.reloadKeycardRequested()
+                root.stackView.replace(d.initialComponent(),
+                                       StackView.PopTransition)
+            }
+
+            onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
+            onEmptyKeycardDetected: root.stackView.replace(createKeycardProfilePage)
+            onNotEmptyKeycardDetected: root.stackView.replace(keycardNotEmptyPage)
+        }
+    }
+
+    Component {
+        id: createKeycardProfilePage
+
+        CreateKeycardProfilePage {
+            onCreateKeycardProfileWithNewSeedphrase:
+                root.stackView.push(backupSeedIntroPage)
+            onCreateKeycardProfileWithExistingSeedphrase:
+                root.stackView.push(seedphrasePage)
+        }
+    }
+
+    Component {
+        id: keycardNotEmptyPage
+
+        KeycardNotEmptyPage {
+            onReloadKeycardRequested: {
+                root.reloadKeycardRequested()
+                root.stackView.replace(d.initialComponent(),
+                                       StackView.PopTransition)
+            }
+
+            onLoginWithThisKeycardRequested: root.loginWithKeycardRequested()
+            onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
+        }
+    }
+
+    Component {
+        id: backupSeedIntroPage
+
+        BackupSeedphraseIntro {
+            onBackupSeedphraseRequested: root.stackView.push(backupSeedAcksPage)
+        }
+    }
+
+    Component {
+        id: backupSeedAcksPage
+
+        BackupSeedphraseAcks {
+            onBackupSeedphraseContinue: root.stackView.push(backupSeedRevealPage)
+        }
+    }
+
+    Component {
+        id: backupSeedRevealPage
+        BackupSeedphraseReveal {
+            seedWords: root.seedWords
+
+            onBackupSeedphraseConfirmed:
+                root.stackView.push(backupSeedVerifyPage)
+        }
+    }
+
+    Component {
+        id: backupSeedVerifyPage
+        BackupSeedphraseVerify {
+            seedWordsToVerify: {
+                const randomIndexes = SQUtils.Utils.nSamples(4, root.seedWords.length)
+                return randomIndexes.map(i => ({ seedWordNumber: i+1,
+                                                 seedWord: root.seedWords[i]
+                                               }))
+            }
+
+            onBackupSeedphraseVerified: root.stackView.push(backupSeedOutroPage)
+        }
+    }
+
+    Component {
+        id: backupSeedOutroPage
+
+        BackupSeedphraseOutro {
+            onBackupSeedphraseRemovalConfirmed:
+                root.stackView.push(keycardCreatePinPage)
+        }
+    }
+
+    Component {
+        id: seedphrasePage
+
+        SeedphrasePage {
+            title: qsTr("Create profile on empty Keycard using a recovery phrase")
+
+            isSeedPhraseValid: root.isSeedPhraseValid
+            onSeedphraseSubmitted: root.stackView.push(keycardCreatePinPage)
+
+            StackView.onActivated: d.fromBackupSeedphrase = true
+        }
+    }
+
+    Component {
+        id: keycardCreatePinPage
+
+        KeycardCreatePinPage {
+            onKeycardPinCreated: {
+                root.keycardPinCreated(pin)
+                root.stackView.push(addKeypairPage)
+            }
+        }
+    }
+
+    Component {
+        id: addKeypairPage
+
+        KeycardAddKeyPairPage {
+            readonly property bool backAvailableHint: false
+
+            addKeyPairState: root.addKeyPairState
+            timeoutInterval: root.splashScreenDurationMs
+
+            onKeypairAddContinueRequested: root.finished(d.fromBackupSeedphrase)
+
+            onKeypairAddTryAgainRequested: {
+                root.stackView.replace(addKeypairPage)
+                root.keypairAddTryAgainRequested()
+            }
+
+            onReloadKeycardRequested: {
+                root.reloadKeycardRequested()
+
+                const page = root.stackView.find(
+                               item => item instanceof CreateKeycardProfilePage)
+
+                root.stackView.replace(page, d.initialComponent(),
+                                       StackView.PopTransition)
+            }
+
+            onCreateProfilePageRequested: root.createProfileWithoutKeycardRequested()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+    required property var validateConnectionString
+    required property int syncState
+
+    required property int splashScreenDurationMs
+
+    signal syncProceedWithConnectionString(string connectionString)
+    signal loginWithSeedphraseRequested
+    signal finished
+
+    function init() {
+        root.stackView.push(loginBySyncPage)
+    }
+
+    Component {
+        id: loginBySyncPage
+
+        LoginBySyncingPage {
+            validateConnectionString: root.validateConnectionString
+
+            onSyncProceedWithConnectionString: {
+                root.syncProceedWithConnectionString(connectionString)
+                root.stackView.push(syncProgressPage, { connectionString })
+            }
+        }
+    }
+
+    Component {
+        id: syncProgressPage
+
+        SyncProgressPage {
+            property string connectionString
+            readonly property bool backAvailableHint:
+                root.syncState !== Onboarding.SyncState.InProgress
+
+            syncState: root.syncState
+            timeoutInterval: root.splashScreenDurationMs
+
+            onLoginToAppRequested: root.finished()
+            onRestartSyncRequested: {
+                root.syncProceedWithConnectionString(connectionString)
+                root.stackView.replace(syncProgressPage)
+            }
+
+            onLoginWithSeedphraseRequested: root.loginWithSeedphraseRequested()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -1,0 +1,91 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+
+    required property int keycardState
+    required property var tryToSetPinFunction
+    required property int remainingAttempts
+
+    property bool displayKeycardPromoBanner
+
+    signal keycardPinEntered(string pin)
+    signal reloadKeycardRequested
+    signal keycardFactoryResetRequested
+    signal createProfileWithEmptyKeycardRequested
+    signal finished
+
+    function init() {
+        root.stackView.push(d.initialComponent())
+    }
+
+    QtObject {
+        id: d
+
+        function initialComponent() {
+            if (root.keycardState === Onboarding.KeycardState.Empty)
+                return keycardEmptyPage
+
+            if (root.keycardState === Onboarding.KeycardState.NotEmpty)
+                return keycardEnterPinPage
+
+            return keycardIntroPage
+        }
+
+        function reload() {
+            root.reloadKeycardRequested()
+            root.stackView.replace(d.initialComponent(),
+                                   StackView.PopTransition)
+        }
+    }
+
+    Component {
+        id: keycardIntroPage
+
+        KeycardIntroPage {
+            keycardState: root.keycardState
+            displayPromoBanner: root.displayKeycardPromoBanner
+
+            onReloadKeycardRequested: d.reload()
+            onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
+            onEmptyKeycardDetected: root.stackView.replace(keycardEmptyPage)
+            onNotEmptyKeycardDetected: root.stackView.replace(keycardEnterPinPage)
+        }
+    }
+
+    Component {
+        id: keycardEmptyPage
+
+        KeycardEmptyPage {
+            onCreateProfileWithEmptyKeycardRequested:
+                root.createProfileWithEmptyKeycardRequested()
+
+            onReloadKeycardRequested: d.reload()
+        }
+    }
+
+    Component {
+        id: keycardEnterPinPage
+
+        KeycardEnterPinPage {
+            tryToSetPinFunction: root.tryToSetPinFunction
+            remainingAttempts: root.remainingAttempts
+
+            onKeycardPinEntered: {
+                root.keycardPinEntered(pin)
+                root.finished()
+            }
+
+            onReloadKeycardRequested: d.reload()
+            onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -1,0 +1,263 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Popups 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+
+    required property int keycardState
+    required property int addKeyPairState
+    required property int syncState
+    required property var seedWords
+    required property int remainingAttempts
+    required property int splashScreenDurationMs
+
+    property bool biometricsAvailable
+    property bool displayKeycardPromoBanner
+    property bool networkChecksEnabled
+
+    // functions
+    required property var passwordStrengthScoreFunction
+    required property var isSeedPhraseValid
+    required property var validateConnectionString
+    required property var tryToSetPinFunction
+
+    signal keycardPinCreated(string pin)
+    signal keycardPinEntered(string pin)
+    signal enableBiometricsRequested(bool enable)
+    signal shareUsageDataRequested(bool enabled)
+    signal syncProceedWithConnectionString(string connectionString)
+    signal seedphraseSubmitted(string seedphrase)
+    signal setPasswordRequested(string password)
+    signal reloadKeycardRequested
+
+    signal finished(int flow)
+
+    function init() {
+        root.stackView.push(welcomePage)
+    }
+
+    QtObject {
+        id: d
+
+        property int flow
+
+        function pushOrSkipBiometricsPage() {
+            if (root.biometricsAvailable) {
+                root.stackView.replace(null, enableBiometricsPage)
+            } else {
+                root.finished(d.flow)
+            }
+        }
+
+        function openPrivacyPolicyPopup() {
+            privacyPolicyPopup.createObject(root.stackView).open()
+        }
+
+        function openTermsOfUsePopup() {
+            termsOfUsePopup.createObject(root.stackView).open()
+        }
+    }
+
+    Component {
+        id: welcomePage
+
+        WelcomePage {
+            function pushWithProxy(component) {
+                const page = root.stackView.push(helpUsImproveStatusPage)
+
+                page.shareUsageDataRequested.connect(enabled => {
+                    root.shareUsageDataRequested(enabled)
+                    root.stackView.push(component)
+                })
+            }
+
+            onCreateProfileRequested: pushWithProxy(createProfilePage)
+            onLoginRequested: pushWithProxy(loginPage)
+
+            onPrivacyPolicyRequested: d.openPrivacyPolicyPopup()
+            onTermsOfUseRequested: d.openTermsOfUsePopup()
+        }
+    }
+
+
+    Component {
+        id: helpUsImproveStatusPage
+
+        HelpUsImproveStatusPage {
+            onPrivacyPolicyRequested: d.openPrivacyPolicyPopup()
+        }
+    }
+
+    Component {
+        id: createProfilePage
+
+        CreateProfilePage {
+            onCreateProfileWithPasswordRequested: createNewProfileFlow.init()
+            onCreateProfileWithSeedphraseRequested: {
+                d.flow = Onboarding.SecondaryFlow.CreateProfileWithSeedphrase
+                useRecoveryPhraseFlow.init()
+            }
+            onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
+        }
+    }
+
+    Component {
+        id: loginPage
+
+        LoginPage {
+            networkChecksEnabled: root.networkChecksEnabled
+
+            onLoginWithSyncingRequested: logInBySyncingFlow.init()
+            onLoginWithKeycardRequested: loginWithKeycardFlow.init()
+
+            onLoginWithSeedphraseRequested: {
+                d.flow = Onboarding.SecondaryFlow.LoginWithSeedphrase
+                useRecoveryPhraseFlow.init()
+            }
+        }
+    }
+
+    CreateNewProfileFlow {
+        id: createNewProfileFlow
+
+        stackView: root.stackView
+        passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
+
+        onFinished: (password) => {
+            root.setPasswordRequested(password)
+            d.flow = Onboarding.SecondaryFlow.CreateProfileWithPassword
+            d.pushOrSkipBiometricsPage()
+        }
+    }
+
+    UseRecoveryPhraseFlow {
+        id: useRecoveryPhraseFlow
+
+        stackView: root.stackView
+        isSeedPhraseValid: root.isSeedPhraseValid
+        passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
+
+        onSeedphraseSubmitted: root.seedphraseSubmitted(seedphrase)
+        onSetPasswordRequested: root.setPasswordRequested(password)
+        onFinished: d.pushOrSkipBiometricsPage()
+    }
+
+    KeycardCreateProfileFlow {
+        id: keycardCreateProfileFlow
+
+        stackView: root.stackView
+        keycardState: root.keycardState
+        addKeyPairState: root.addKeyPairState
+        seedWords: root.seedWords
+        displayKeycardPromoBanner: root.displayKeycardPromoBanner
+        isSeedPhraseValid: root.isSeedPhraseValid
+        splashScreenDurationMs: root.splashScreenDurationMs
+
+        onReloadKeycardRequested: root.reloadKeycardRequested()
+        onKeycardPinCreated: root.keycardPinCreated(pin)
+        onLoginWithKeycardRequested: loginWithKeycardFlow.init()
+
+        onCreateProfileWithoutKeycardRequested: {
+            const page = stackView.find(
+                           item => item instanceof HelpUsImproveStatusPage)
+
+            stackView.replace(page, createProfilePage, StackView.PopTransition)
+        }
+
+        onFinished: (fromBackupSeedphrase) => {
+            d.flow = fromBackupSeedphrase
+                        ? Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase
+                        : Onboarding.SecondaryFlow.CreateProfileWithKeycardNewSeedphrase
+
+            d.pushOrSkipBiometricsPage()
+        }
+    }
+
+    LoginBySyncingFlow {
+        id: logInBySyncingFlow
+
+        stackView: root.stackView
+        validateConnectionString: root.validateConnectionString
+        syncState: root.syncState
+
+        splashScreenDurationMs: root.splashScreenDurationMs
+
+        onSyncProceedWithConnectionString:
+            root.syncProceedWithConnectionString(connectionString)
+
+        onLoginWithSeedphraseRequested: {
+            d.flow = Onboarding.SecondaryFlow.LoginWithSeedphrase
+            useRecoveryPhraseFlow.init()
+        }
+
+        onFinished: {
+            d.flow = Onboarding.SecondaryFlow.LoginWithSyncing
+            d.pushOrSkipBiometricsPage()
+        }
+    }
+
+    LoginWithKeycardFlow {
+        id: loginWithKeycardFlow
+
+        stackView: root.stackView
+        keycardState: root.keycardState
+        remainingAttempts: root.remainingAttempts
+        displayKeycardPromoBanner: root.displayKeycardPromoBanner
+        tryToSetPinFunction: root.tryToSetPinFunction
+
+        onKeycardPinEntered: root.keycardPinEntered(pin)
+        onReloadKeycardRequested: root.reloadKeycardRequested()
+        onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
+
+        onFinished: {
+            d.flow = Onboarding.SecondaryFlow.LoginWithKeycard
+            d.pushOrSkipBiometricsPage()
+        }
+    }
+
+    Component {
+        id: enableBiometricsPage
+
+        EnableBiometricsPage {
+            onEnableBiometricsRequested: {
+                root.enableBiometricsRequested(enable)
+                root.finished(d.flow)
+            }
+        }
+    }
+
+    // popups
+    Component {
+        id: privacyPolicyPopup
+
+        StatusSimpleTextPopup {
+            title: qsTr("Status Software Privacy Policy")
+            content {
+                textFormat: Text.MarkdownText
+                text: SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/privacy.mdwn"))
+            }
+            destroyOnClose: true
+        }
+    }
+
+    Component {
+        id: termsOfUsePopup
+
+        StatusSimpleTextPopup {
+            title: qsTr("Status Software Terms of Use")
+            content {
+                textFormat: Text.MarkdownText
+                text: SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/terms-of-use.mdwn"))
+            }
+            destroyOnClose: true
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -4,9 +4,6 @@ import Qt.labs.settings 1.1
 
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Core.Utils 0.1 as SQUtils
-import StatusQ.Core.Backpressure 0.1
-import StatusQ.Popups 0.1
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding2.stores 1.0
@@ -26,35 +23,28 @@ Page {
 
     property int splashScreenDurationMs: 30000
     property bool biometricsAvailable: Qt.platform.os === Constants.mac
-    required property bool networkChecksEnabled
+    property bool networkChecksEnabled
 
     readonly property alias stack: stack
-    readonly property alias primaryFlow: d.primaryFlow // Onboarding.PrimaryFlow enum
-    readonly property alias secondaryFlow: d.secondaryFlow // Onboarding.SecondaryFlow enum
 
-    signal finished(int primaryFlow, int secondaryFlow, var data)
+    // flow: Onboarding.SecondaryFlow
+    signal finished(int flow, var data)
+
     signal keycardFactoryResetRequested() // TODO integrate/switch to an external flow, needed?
     signal keycardReloaded()
 
     function restartFlow() {
         stack.clear()
-        stack.push(welcomePage)
         d.resetState()
         d.settings.reset()
+        onboardingFlow.init()
     }
 
     QtObject {
         id: d
-        // logic
-        property int primaryFlow: Onboarding.PrimaryFlow.Unknown
-        property int secondaryFlow: Onboarding.SecondaryFlow.Unknown
-        readonly property int currentKeycardState: root.onboardingStore.keycardState
-        readonly property var seedWords: root.onboardingStore.getMnemonic().split(" ")
-        readonly property int numWordsToVerify: 4
 
-        // UI
-        readonly property int opacityDuration: 50
-        readonly property int swipeDuration: 400
+        // constants
+        readonly property int numWordsToVerify: 4
 
         // state collected
         property string password
@@ -63,8 +53,6 @@ Page {
         property string seedphrase
 
         function resetState() {
-            d.primaryFlow = Onboarding.PrimaryFlow.Unknown
-            d.secondaryFlow = Onboarding.SecondaryFlow.Unknown
             d.password = ""
             d.keycardPin = ""
             d.enableBiometrics = false
@@ -79,66 +67,34 @@ Page {
             }
         }
 
-        function pushOrSkipBiometricsPage() {
-            if (root.biometricsAvailable) {
-                dbg.debugFlow("ENTERING BIOMETRICS PAGE")
-                stack.replace(null, enableBiometricsPage)
-            } else {
-                dbg.debugFlow("SKIPPING BIOMETRICS PAGE")
-                d.finishFlow()
+        function finishFlow(flow) {
+            const data = {
+                password: d.password,
+                keycardPin: d.keycardPin,
+                seedphrase: d.seedphrase,
+                enableBiometrics: d.enableBiometrics
             }
-        }
 
-        function finishFlow() {
-            dbg.debugFlow(`ONBOARDING FINISHED; ${d.primaryFlow} -> ${d.secondaryFlow}`)
-            root.finished(d.primaryFlow, d.secondaryFlow,
-                          {"password": d.password, "keycardPin": d.keycardPin,
-                              "seedphrase": d.seedphrase, "enableBiometrics": d.enableBiometrics})
-        }
-    }
-
-    LoggingCategory {
-        id: dbg
-        name: "app.status.onboarding"
-
-        function debugFlow(message) {
-            const currentPageName = stack.currentItem ? stack.currentItem.pageClassName : "<empty stack>"
-            console.info(dbg, "!!!", currentPageName, "->", message)
+            root.finished(flow, data)
         }
     }
 
     // page stack
-    StackView {
+    OnboardingStackView {
         id: stack
+
         objectName: "stack"
         anchors.fill: parent
-        initialItem: welcomePage
 
-        pushEnter: Transition {
-            ParallelAnimation {
-                NumberAnimation { property: "opacity"; from: 0; to: 1; duration: d.opacityDuration; easing.type: Easing.InQuint }
-                NumberAnimation { property: "x"; from: (stack.mirrored ? -0.3 : 0.3) * stack.width; to: 0; duration: d.swipeDuration; easing.type: Easing.OutCubic }
-            }
-        }
-        pushExit: Transition {
-            NumberAnimation { property: "opacity"; from: 1; to: 0; duration: d.opacityDuration; easing.type: Easing.OutQuint }
-        }
-        popEnter: Transition {
-            ParallelAnimation {
-                NumberAnimation { property: "opacity"; from: 0; to: 1; duration: d.opacityDuration; easing.type: Easing.InQuint }
-                NumberAnimation { property: "x"; from: (stack.mirrored ? -0.3 : 0.3) * -stack.width; to: 0; duration: d.swipeDuration; easing.type: Easing.OutCubic }
-            }
-        }
-        popExit: pushExit
-        replaceEnter: pushEnter
-        replaceExit: pushExit
+        property bool backAvailable:
+            stack.currentItem ? (stack.currentItem.backAvailableHint ?? true)
+                              : false
     }
 
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.BackButton
         enabled: stack.depth > 1 && !stack.busy
-        cursorShape: undefined // fall thru
         onClicked: stack.pop()
     }
 
@@ -146,446 +102,80 @@ Page {
         width: 44
         height: 44
         anchors.left: parent.left
-        anchors.leftMargin: Theme.padding
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Theme.padding
-        opacity: stack.depth > 1 && !stack.busy ? 1 : 0
+        anchors.margins: Theme.padding
+
+        opacity: stack.depth > 1 && !stack.busy && stack.backAvailable ? 1 : 0
         visible: opacity > 0
-        Behavior on opacity { NumberAnimation { duration: 100 } }
+
+        Behavior on opacity {
+            NumberAnimation { duration: 100 }
+        }
+
         onClicked: stack.pop()
     }
 
-    // main signal handler
+    OnboardingFlow {
+        id: onboardingFlow
+
+        stackView: stack
+
+        keycardState: root.onboardingStore.keycardState
+        syncState: root.onboardingStore.syncState
+        addKeyPairState: root.onboardingStore.addKeyPairState
+
+        seedWords: root.onboardingStore.getMnemonic().split(" ")
+
+        displayKeycardPromoBanner: !d.settings.keycardPromoShown
+        biometricsAvailable: root.biometricsAvailable
+        splashScreenDurationMs: root.splashScreenDurationMs
+        networkChecksEnabled: root.networkChecksEnabled
+
+        passwordStrengthScoreFunction: root.onboardingStore.getPasswordStrengthScore
+        isSeedPhraseValid: root.onboardingStore.validMnemonic
+        validateConnectionString: root.onboardingStore.validateLocalPairingConnectionString
+        tryToSetPinFunction: root.onboardingStore.setPin
+        remainingAttempts: root.onboardingStore.keycardRemainingPinAttempts
+
+        onKeycardPinCreated: {
+            d.keycardPin = pin
+            root.onboardingStore.setPin(pin)
+        }
+
+        onKeycardPinEntered: {
+            d.keycardPin = pin
+            root.onboardingStore.setPin(pin)
+        }
+
+        onShareUsageDataRequested: {
+            root.metricsStore.toggleCentralizedMetrics(enabled)
+            Global.addCentralizedMetricIfEnabled(
+                        "usage_data_shared",
+                        { placement: Constants.metricsEnablePlacement.onboarding })
+            localAppSettings.metricsPopupSeen = true
+        }
+
+        onSyncProceedWithConnectionString:
+            root.onboardingStore.inputConnectionStringForBootstrapping(
+                connectionString)
+
+        onSeedphraseSubmitted: d.seedphrase = seedphrase
+        onSetPasswordRequested: d.password = password
+
+        onFinished: d.finishFlow(flow)
+    }
+
     Connections {
-        id: mainHandler
         target: stack.currentItem
         ignoreUnknownSignals: true
 
-        // common popups
-        function onPrivacyPolicyRequested() {
-            dbg.debugFlow("AUX: PRIVACY POLICY")
-            privacyPolicyPopup.createObject(root).open()
-        }
-        function onTermsOfUseRequested() {
-            dbg.debugFlow("AUX: TERMS OF USE")
-            termsOfUsePopup.createObject(root).open()
-        }
         function onOpenLink(link: string) {
-            dbg.debugFlow(`OPEN LINK: ${link}`)
             Global.openLink(link)
         }
         function onOpenLinkWithConfirmation(link: string, domain: string) {
-            dbg.debugFlow(`OPEN LINK WITH CONFIRM: ${link}`)
             Global.openLinkWithConfirmation(link, domain)
         }
-
-        // welcome page
-        function onCreateProfileRequested() {
-            dbg.debugFlow("PRIMARY: CREATE PROFILE")
-            d.primaryFlow = Onboarding.PrimaryFlow.CreateProfile
-            stack.push(helpUsImproveStatusPage)
-        }
-        function onLoginRequested() {
-            dbg.debugFlow("PRIMARY: LOG IN")
-            d.primaryFlow = Onboarding.PrimaryFlow.Login
-            stack.push(helpUsImproveStatusPage)
-        }
-
-        // help us improve page
-        function onShareUsageDataRequested(enabled: bool) {
-            dbg.debugFlow(`SHARE USAGE DATA: ${enabled}`)
-            metricsStore.toggleCentralizedMetrics(enabled)
-            Global.addCentralizedMetricIfEnabled("usage_data_shared", {placement: Constants.metricsEnablePlacement.onboarding})
-            localAppSettings.metricsPopupSeen = true
-
-            if (d.primaryFlow === Onboarding.PrimaryFlow.CreateProfile)
-                stack.push(createProfilePage)
-            else if (d.primaryFlow === Onboarding.PrimaryFlow.Login)
-                stack.push(loginPage)
-        }
-
-        // create profile page
-        function onCreateProfileWithPasswordRequested() {
-            dbg.debugFlow("SECONDARY: CREATE PROFILE WITH PASSWORD")
-            d.secondaryFlow = Onboarding.SecondaryFlow.CreateProfileWithPassword
-            stack.push(createPasswordPage)
-        }
-        function onCreateProfileWithSeedphraseRequested() {
-            dbg.debugFlow("SECONDARY: CREATE PROFILE WITH SEEDPHRASE")
-            d.secondaryFlow = Onboarding.SecondaryFlow.CreateProfileWithSeedphrase
-            stack.push(seedphrasePage, { title: qsTr("Create profile using a recovery phrase")})
-        }
-        function onCreateProfileWithEmptyKeycardRequested() {
-            dbg.debugFlow("SECONDARY: CREATE PROFILE WITH KEYCARD")
-            d.secondaryFlow = Onboarding.SecondaryFlow.CreateProfileWithKeycard
-            stack.push(keycardIntroPage)
-        }
-
-        // login page
-        function onLoginWithSeedphraseRequested() {
-            dbg.debugFlow("SECONDARY: LOGIN WITH SEEDPHRASE")
-            d.secondaryFlow = Onboarding.SecondaryFlow.LoginWithSeedphrase
-            stack.push(seedphrasePage, { title: qsTr("Log in with your Status recovery phrase")})
-        }
-        function onLoginWithSyncingRequested() {
-            dbg.debugFlow("SECONDARY: LOGIN WITH SYNCING")
-            d.secondaryFlow = Onboarding.SecondaryFlow.LoginWithSyncing
-            stack.push(loginBySyncPage)
-        }
-        function onLoginWithKeycardRequested() {
-            dbg.debugFlow("SECONDARY: LOGIN WITH KEYCARD")
-            d.secondaryFlow = Onboarding.SecondaryFlow.LoginWithKeycard
-            stack.push(keycardIntroPage)
-        }
-
-        // create password page
-        function onSetPasswordRequested(password: string) {
-            dbg.debugFlow("SET PASSWORD REQUESTED")
-            d.password = password
-            d.pushOrSkipBiometricsPage()
-        }
-
-        // seedphrase page
-        function onSeedphraseSubmitted(seedphrase: string) {
-            dbg.debugFlow(`SEEDPHRASE SUBMITTED: ${seedphrase}`)
-            d.seedphrase = seedphrase
-            if (d.secondaryFlow === Onboarding.SecondaryFlow.CreateProfileWithSeedphrase || d.secondaryFlow === Onboarding.SecondaryFlow.LoginWithSeedphrase) {
-                dbg.debugFlow("AFTER SEEDPHRASE -> PASSWORD PAGE")
-                stack.push(createPasswordPage)
-            } else if (d.secondaryFlow === Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase) {
-                dbg.debugFlow("AFTER SEEDPHRASE -> KEYCARD PIN PAGE")
-                stack.push(keycardCreatePinPage)
-            }
-        }
-
-        // keycard pages
-        function onReloadKeycardRequested() {
-            dbg.debugFlow("RELOAD KEYCARD REQUESTED")
-            root.keycardReloaded()
-            stack.replace(keycardIntroPage)
-        }
-        function onKeycardFactoryResetRequested() {
-            dbg.debugFlow("KEYCARD FACTORY RESET REQUESTED")
-            // TODO start keycard factory reset in a popup here
-            // cf. KeycardStore.runFactoryResetPopup()
-            root.keycardFactoryResetRequested()
-        }
-        function onLoginWithThisKeycardRequested() {
-            dbg.debugFlow("LOGIN WITH THIS KEYCARD REQUESTED")
-            d.primaryFlow = Onboarding.PrimaryFlow.Login
-            d.secondaryFlow = Onboarding.SecondaryFlow.LoginWithKeycard
-            stack.push(keycardEnterPinPage)
-        }
-        function onEmptyKeycardDetected() {
-            dbg.debugFlow("EMPTY KEYCARD DETECTED")
-            if (d.secondaryFlow === Onboarding.SecondaryFlow.LoginWithKeycard)
-                stack.replace(keycardEmptyPage) // NB: replacing the loginPage
-            else
-                stack.replace(createKeycardProfilePage) // NB: replacing the keycardIntroPage
-        }
-        function onNotEmptyKeycardDetected() {
-            dbg.debugFlow("NOT EMPTY KEYCARD DETECTED")
-            if (d.secondaryFlow === Onboarding.SecondaryFlow.LoginWithKeycard)
-                stack.replace(keycardEnterPinPage)
-            else
-                stack.replace(keycardNotEmptyPage)
-        }
-
-        function onCreateKeycardProfileWithNewSeedphrase() {
-            dbg.debugFlow("CREATE KEYCARD PROFILE WITH NEW SEEDPHRASE")
-            d.secondaryFlow = Onboarding.SecondaryFlow.CreateProfileWithKeycardNewSeedphrase
-            stack.push(backupSeedIntroPage)
-        }
-        function onCreateKeycardProfileWithExistingSeedphrase() {
-            dbg.debugFlow("CREATE KEYCARD PROFILE WITH EXISTING SEEDPHRASE")
-            d.secondaryFlow = Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase
-            stack.push(seedphrasePage, { title: qsTr("Create profile on empty Keycard using a recovery phrase")})
-        }
-
-        function onKeycardPinCreated(pin: string) {
-            dbg.debugFlow(`KEYCARD PIN CREATED: ${pin}`)
-            d.keycardPin = pin
-            root.onboardingStore.setPin(pin)
-
-            if (d.secondaryFlow === Onboarding.SecondaryFlow.CreateProfileWithKeycardNewSeedphrase ||
-                    d.secondaryFlow === Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase) {
-                dbg.debugFlow("ENTERING KEYPAIR TRANSFER PAGE")
-                stack.clear()
-                root.onboardingStore.startKeypairTransfer()
-                stack.push(addKeypairPage)
-            } else {
-                Backpressure.debounce(root, 2000, function() {
-                    d.pushOrSkipBiometricsPage()
-                })()
-            }
-        }
-
-        function onKeycardPinEntered(pin: string) {
-            dbg.debugFlow(`KEYCARD PIN ENTERED: ${pin}`)
-            d.keycardPin = pin
-            root.onboardingStore.setPin(pin)
-
-            if (d.secondaryFlow === Onboarding.SecondaryFlow.CreateProfileWithKeycardNewSeedphrase ||
-                    d.secondaryFlow === Onboarding.SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase) {
-                dbg.debugFlow("ENTERING KEYPAIR TRANSFER PAGE")
-                stack.clear()
-                root.onboardingStore.startKeypairTransfer()
-                stack.push(addKeypairPage)
-            } else {
-                d.pushOrSkipBiometricsPage()
-            }
-        }
-
-        // backup seedphrase pages
-        function onBackupSeedphraseRequested() {
-            dbg.debugFlow("BACKUP SEED REQUESTED")
-            stack.push(backupSeedAcksPage)
-        }
-
-        function onBackupSeedphraseContinue() {
-            dbg.debugFlow("BACKUP SEED CONTINUE")
-            stack.push(backupSeedRevealPage)
-        }
-
-        function onBackupSeedphraseConfirmed() {
-            dbg.debugFlow("BACKUP SEED CONFIRMED")
-            root.onboardingStore.mnemonicWasShown()
-            stack.push(backupSeedVerifyPage)
-        }
-
-        function onBackupSeedphraseVerified() {
-            dbg.debugFlow("BACKUP SEED VERIFIED")
-            stack.push(backupSeedOutroPage)
-        }
-
-        function onBackupSeedphraseRemovalConfirmed() {
-            dbg.debugFlow("BACKUP SEED REMOVAL CONFIRMED")
-            root.onboardingStore.removeMnemonic()
-            stack.replace(keycardCreatePinPage)
-        }
-
-        // login with sync pages
-        function onSyncProceedWithConnectionString(connectionString) {
-            dbg.debugFlow(`SYNC PROCEED WITH CONNECTION STRING: ${connectionString}`)
-            root.onboardingStore.inputConnectionStringForBootstrapping(connectionString)
-            stack.replace(syncProgressPage)
-        }
-
-        function onRestartSyncRequested() {
-            dbg.debugFlow("RESTART SYNC REQUESTED")
-            stack.replace(loginBySyncPage)
-        }
-
-        function onLoginToAppRequested() {
-            dbg.debugFlow("LOGIN TO APP REQUESTED")
-            d.pushOrSkipBiometricsPage()
-        }
-
-        // keypair transfer page
-        function onKeypairAddContinueRequested() {
-            dbg.debugFlow("KEYPAIR TRANSFER COMPLETED")
-            d.pushOrSkipBiometricsPage()
-        }
-        function onKeypairAddTryAgainRequested() {
-            dbg.debugFlow("RESTART KEYPAIR TRANSFER REQUESTED")
-            root.onboardingStore.startKeypairTransfer()
-            stack.clear()
-            stack.push(addKeypairPage)
-        }
-        function onCreateProfilePageRequested() {
-            dbg.debugFlow("KEYPAIR TRANSFER -> CREATE PROFILE")
-            stack.replace([welcomePage, createProfilePage])
-        }
-
-        // enable biometrics page
-        function onEnableBiometricsRequested(enabled: bool) {
-            dbg.debugFlow(`ENABLE BIOMETRICS: ${enabled}`)
-            d.enableBiometrics = enabled
-            d.finishFlow()
-        }
     }
 
-    // pages
-    Component {
-        id: welcomePage
-        WelcomePage {
-            StackView.onActivated: d.resetState()
-        }
-    }
-
-    Component {
-        id: helpUsImproveStatusPage
-        HelpUsImproveStatusPage {}
-    }
-
-    Component {
-        id: createProfilePage
-        CreateProfilePage {
-            StackView.onActivated: {
-                // reset when we get back here
-                d.primaryFlow = Onboarding.PrimaryFlow.CreateProfile
-                d.secondaryFlow = Onboarding.SecondaryFlow.Unknown
-            }
-        }
-    }
-
-    Component {
-        id: createPasswordPage
-        CreatePasswordPage {
-            passwordStrengthScoreFunction: root.onboardingStore.getPasswordStrengthScore
-        }
-    }
-
-    Component {
-        id: enableBiometricsPage
-        EnableBiometricsPage {}
-    }
-
-    Component {
-        id: seedphrasePage
-        SeedphrasePage {
-            isSeedPhraseValid: root.onboardingStore.validMnemonic
-        }
-    }
-
-    Component {
-        id: createKeycardProfilePage
-        CreateKeycardProfilePage {
-            StackView.onActivated: {
-                d.primaryFlow = Onboarding.PrimaryFlow.CreateProfile
-                d.secondaryFlow = Onboarding.SecondaryFlow.CreateProfileWithKeycard
-            }
-        }
-    }
-
-    Component {
-        id: keycardIntroPage
-        KeycardIntroPage {
-            keycardState: d.currentKeycardState
-            displayPromoBanner: !d.settings.keycardPromoShown
-            StackView.onActivated: {
-                // NB just to make sure we don't miss the signal when we (re)load the page in the final state already
-                if (keycardState === Onboarding.KeycardState.Empty)
-                    emptyKeycardDetected()
-                else if (keycardState === Onboarding.KeycardState.NotEmpty)
-                    notEmptyKeycardDetected()
-            }
-        }
-    }
-
-    Component {
-        id: keycardEmptyPage
-        KeycardEmptyPage {}
-    }
-
-    Component {
-        id: keycardNotEmptyPage
-        KeycardNotEmptyPage {}
-    }
-
-    Component {
-        id: keycardCreatePinPage
-        KeycardCreatePinPage {}
-    }
-
-    Component {
-        id: keycardEnterPinPage
-        KeycardEnterPinPage {
-            tryToSetPinFunction: root.onboardingStore.setPin
-            remainingAttempts: root.onboardingStore.keycardRemainingPinAttempts
-        }
-    }
-
-    Component {
-        id: backupSeedIntroPage
-        BackupSeedphraseIntro {}
-    }
-
-    Component {
-        id: backupSeedAcksPage
-        BackupSeedphraseAcks {}
-    }
-
-    Component {
-        id: backupSeedRevealPage
-        BackupSeedphraseReveal {
-            seedWords: d.seedWords
-        }
-    }
-
-    Component {
-        id: backupSeedVerifyPage
-        BackupSeedphraseVerify {
-            seedWordsToVerify: {
-                let result = []
-                const randomIndexes = SQUtils.Utils.nSamples(d.numWordsToVerify, d.seedWords.length)
-                return randomIndexes.map(i => ({ seedWordNumber: i+1, seedWord: d.seedWords[i] }))
-            }
-        }
-    }
-
-    Component {
-        id: backupSeedOutroPage
-        BackupSeedphraseOutro {}
-    }
-
-    Component {
-        id: loginPage
-        LoginPage {
-            networkChecksEnabled: root.networkChecksEnabled
-            StackView.onActivated: {
-                // reset when we get back here
-                d.primaryFlow = Onboarding.PrimaryFlow.Login
-                d.secondaryFlow = Onboarding.SecondaryFlow.Unknown
-            }
-        }
-    }
-
-    Component {
-        id: loginBySyncPage
-        LoginBySyncingPage {
-            validateConnectionString: root.onboardingStore.validateLocalPairingConnectionString
-        }
-    }
-
-    Component {
-        id: syncProgressPage
-        SyncProgressPage {
-            syncState: root.onboardingStore.syncState
-            timeoutInterval: root.splashScreenDurationMs
-        }
-    }
-
-    Component {
-        id: addKeypairPage
-        KeycardAddKeyPairPage {
-            addKeyPairState: root.onboardingStore.addKeyPairState
-            timeoutInterval: root.splashScreenDurationMs
-        }
-    }
-
-    // common popups
-    Component {
-        id: privacyPolicyPopup
-        StatusSimpleTextPopup {
-            title: qsTr("Status Software Privacy Policy")
-            content {
-                textFormat: Text.MarkdownText
-                text: SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/privacy.mdwn"))
-            }
-            destroyOnClose: true
-        }
-    }
-
-    Component {
-        id: termsOfUsePopup
-        StatusSimpleTextPopup {
-            title: qsTr("Status Software Terms of Use")
-            content {
-                textFormat: Text.MarkdownText
-                text: SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/terms-of-use.mdwn"))
-            }
-            destroyOnClose: true
-        }
-    }
+    Component.onCompleted: root.restartFlow()
 }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingStackView.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingStackView.qml
@@ -1,0 +1,56 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+
+StackView {
+    id: root
+
+    QtObject {
+        id: d
+
+        readonly property int opacityDuration: 50
+        readonly property int swipeDuration: 400
+    }
+
+    pushEnter: Transition {
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"
+                from: 0; to: 1
+                duration: d.opacityDuration
+                easing.type: Easing.InQuint
+            }
+            NumberAnimation {
+                property: "x"
+                from: (root.mirrored ? -0.3 : 0.3) * root.width; to: 0
+                duration: d.swipeDuration
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+    pushExit: Transition {
+        NumberAnimation {
+            property: "opacity"; from: 1; to: 0
+            duration: d.opacityDuration
+            easing.type: Easing.OutQuint
+        }
+    }
+    popEnter: Transition {
+        ParallelAnimation {
+            NumberAnimation {
+                property: "opacity"
+                from: 0; to: 1
+                duration: d.opacityDuration
+                easing.type: Easing.InQuint
+            }
+            NumberAnimation {
+                property: "x"
+                from: (root.mirrored ? -0.3 : 0.3) * -root.width; to: 0
+                duration: d.swipeDuration; easing.type: Easing.OutCubic
+            }
+        }
+    }
+    popExit: pushExit
+    replaceEnter: pushEnter
+    replaceExit: pushExit
+}

--- a/ui/app/AppLayouts/Onboarding2/RecoveryPhraseCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/RecoveryPhraseCreateProfileFlow.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+
+import utils 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+
+    function init() {
+
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -1,0 +1,50 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+
+    required property var passwordStrengthScoreFunction
+    required property var isSeedPhraseValid
+
+    signal seedphraseSubmitted(string seedphrase)
+    signal setPasswordRequested(string password)
+    signal finished
+
+    function init() {
+        root.stackView.push(seedphrasePage)
+    }
+
+    Component {
+        id: seedphrasePage
+
+        SeedphrasePage {
+            title: qsTr("Create profile using a recovery phrase")
+            isSeedPhraseValid: root.isSeedPhraseValid
+
+            onSeedphraseSubmitted: {
+                root.seedphraseSubmitted(seedphrase)
+                root.stackView.push(createPasswordPage)
+            }
+        }
+    }
+
+    Component {
+        id: createPasswordPage
+        CreatePasswordPage {
+            passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
+
+            onSetPasswordRequested: {
+                root.setPasswordRequested(password)
+                root.finished()
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -68,7 +68,7 @@ KeycardBasePage {
             width: 320
             anchors.horizontalCenter: parent.horizontalCenter
             visible: false
-            text: qsTr("I’ve inserted a Keycard")
+            text: qsTr("I’ve inserted a different Keycard")
             normalColor: "transparent"
             borderWidth: 1
             borderColor: Theme.palette.baseColor2

--- a/ui/app/AppLayouts/Onboarding2/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/qmldir
@@ -1,1 +1,9 @@
+CreateNewProfileFlow 1.0 CreateNewProfileFlow.qml
+KeycardCreateProfileFlow 1.0 KeycardCreateProfileFlow.qml
+LoginByKeycardFlow 1.0 LoginByKeycardFlow.qml
+LoginBySyncingFlow 1.0 LoginBySyncingFlow.qml
+OnboardingFlow 1.0 OnboardingFlow.qml
 OnboardingLayout 1.0 OnboardingLayout.qml
+OnboardingStackView 1.0 OnboardingStackView.qml
+RecoveryPhraseCreateProfileFlow 1.0 RecoveryPhraseCreateProfileFlow.qml
+UseRecoveryPhraseFlow 1.0 UseRecoveryPhraseFlow.qml


### PR DESCRIPTION
### What does the PR do

Decomposes `OnboardingLayout` into following elements:
- `OnboardingFlow` orchestrating all on-boarding flows on the stack
- `OnboardingStackView` which is specifically configured `StackView` for handling all on-boarding flows
- `OnboardingLayout` itself integrating `OboardingFlow` with stores and `OnboardingStackView`

Moreover `OnboardingFlow` consists of sub-flows:
- `CreateNewProfileFlow`
- `KeycardCreateProfileFlow`
- `RecoveryPhraseCreateProfileFlow`
- `LoginBySyncingFlow`
- `LoginWithKeycardFlow`
- `UseRecoveryPhraseFlow`

Flows don't operate on own `StackView`, which must be provided from outside. This allows to compose complex flows from smaller ones within one `StackView`.

Other:
- little change in syncing flow, retry causes instantaneous retry with the previously provided connection string, user can change the connection string by pressing back button
- changed approach regarding back button control. It's no longer needed to have single element on the stack to hide back button. Every page may define `backAvailableHint` to indicate if back button should be available or not. It brings two benefits:
  - back button can be easily hidden when some operation is in progress, like syncing (aligned to the design in this pr)
  - no need to artificially clear the whole stack and push multiple elements later to compensate clearing
  - works seamlessly with the sub-flows because sub-flows shouldn't clear the whole stack on their own, affecting parent flow
- minor wording fix in `KeycardEnterPinPage`
- fixes broken unitests (last commit to `onboarding-rework-1` broke them)

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

## Further work

- `primaryFlow`/`secondaryFlow` enums should be replaced by one enum, probably can be kept in the QML file
- the `flow` type exposed via `OnboardingFlow::finish` is not collected in an elegant way. Maybe there is better option for that.
- reconsider how jumping from one flow to another should be handled. In case of keycard flow it's possible to push pages on the stack infinitely.
- introducing minimal times for some "in progress" pages. E.g. `Sync in progress` should be notified for some time even if the underlying operation was very quick (no matter if error or success). This gives the user the opportunity to familiarize themselves with the message and prevents from "blinking" when things happen quickly.
- property `timeoutInterval` is probably not needed in `SyncProgressPage` and `KeycardAddKeyPairPage`. It should be decided on the backend level what's the actual timeout.
- add detailed tests for particular flows, maybe also for particular pages
- consider adding storybook pages for so far not covered pages and flows
- add some additional utilities for existing page for `OnboardingLayout`
  - automatic fill on seedphrase confirmation page
  - showing full content of the stack, not only the current page
  - expose states for syncing and adding key pair
- document `backAvailableHint` as it's implicit way of communication between flows and provided stack view
- `localAppSettings` id used from outer scope, ideally whole settings handling should be externalized
- would be nice to have text in popups selectable/copyable
- modals open with a freeze delay, ideally text should be read async from the file
 
Closes: #16947

### Affected areas
`OnboardingLayout` and related components

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
