### PR TITLE
Fix context menus not updating when blocking/unblocking or when getting a CR

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -98,6 +98,7 @@ method contactUpdated*(self: Module, publicKey: string) =
     icon = contactDetails.icon,
     isContact = contactDetails.dto.isContact,
     trustStatus = contactDetails.dto.trustStatus,
+    isBlocked = contactDetails.dto.isBlocked,
   )
 
 method userProfileUpdated*(self: Module) =
@@ -149,6 +150,7 @@ proc processChatMember(self: Module,  member: ChatMember, reset: bool = false): 
     colorHash = contactDetails.colorHash,
     onlineStatus = status,
     isContact = contactDetails.dto.isContact,
+    isBlocked = contactDetails.dto.isBlocked,
     isCurrentUser = isMe,
     memberRole = member.role,
     joined = member.joined,
@@ -202,6 +204,7 @@ method onChatMemberUpdated*(self: Module, publicKey: string, memberRole: MemberR
     alias = contactDetails.dto.alias,
     icon = contactDetails.icon,
     isContact = contactDetails.dto.isContact,
+    isBlocked = contactDetails.dto.isBlocked,
     memberRole,
     joined,
     trustStatus = contactDetails.dto.trustStatus,

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -97,8 +97,9 @@ method contactUpdated*(self: Module, publicKey: string) =
     alias = contactDetails.dto.alias,
     icon = contactDetails.icon,
     isContact = contactDetails.dto.isContact,
-    trustStatus = contactDetails.dto.trustStatus,
     isBlocked = contactDetails.dto.isBlocked,
+    trustStatus = contactDetails.dto.trustStatus,
+    contactRequest = toContactStatus(contactDetails.dto.contactRequestState),
   )
 
 method userProfileUpdated*(self: Module) =
@@ -152,6 +153,7 @@ proc processChatMember(self: Module,  member: ChatMember, reset: bool = false): 
     isContact = contactDetails.dto.isContact,
     isBlocked = contactDetails.dto.isBlocked,
     isCurrentUser = isMe,
+    contactRequest = toContactStatus(contactDetails.dto.contactRequestState),
     memberRole = member.role,
     joined = member.joined,
     trustStatus = contactDetails.dto.trustStatus,
@@ -208,6 +210,7 @@ method onChatMemberUpdated*(self: Module, publicKey: string, memberRole: MemberR
     memberRole,
     joined,
     trustStatus = contactDetails.dto.trustStatus,
+    contactRequest = toContactStatus(contactDetails.dto.contactRequestState),
   )
 
 method addGroupMembers*(self: Module, pubKeys: seq[string]) =

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -525,6 +525,14 @@ proc init*(self: Controller) =
     var args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
 
+  self.events.on(SIGNAL_CONTACT_BLOCKED) do(e: Args):
+    let args = ContactArgs(e)
+    self.delegate.contactUpdated(args.contactId)
+
+  self.events.on(SIGNAL_CONTACT_UNBLOCKED) do(e: Args):
+    let args = ContactArgs(e)
+    self.delegate.contactUpdated(args.contactId)
+
   self.events.on(SIGNAL_LOGGEDIN_USER_NAME_CHANGED) do(e: Args):
     self.delegate.contactUpdated(singletonInstance.userProfile.getPubKey())
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1894,6 +1894,7 @@ proc createMemberItem[T](
     colorHash = contactDetails.colorHash,
     onlineStatus = toOnlineStatus(status.statusType),
     isContact = contactDetails.dto.isContact,
+    isBlocked = contactDetails.dto.isBlocked,
     isCurrentUser = contactDetails.isCurrentUser,
     trustStatus = contactDetails.dto.trustStatus,
     memberRole = role,
@@ -1913,6 +1914,7 @@ method contactUpdated*[T](self: Module[T], contactId: string) =
     alias = contactDetails.dto.alias,
     icon = contactDetails.icon,
     isContact = contactDetails.dto.isContact,
+    isBlocked = contactDetails.dto.isBlocked,
     trustStatus = contactDetails.dto.trustStatus,
   )
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1897,6 +1897,7 @@ proc createMemberItem[T](
     isBlocked = contactDetails.dto.isBlocked,
     isCurrentUser = contactDetails.isCurrentUser,
     trustStatus = contactDetails.dto.trustStatus,
+    contactRequest = toContactStatus(contactDetails.dto.contactRequestState),
     memberRole = role,
     membershipRequestState = state,
     requestToJoinId = requestId,
@@ -1916,6 +1917,7 @@ method contactUpdated*[T](self: Module[T], contactId: string) =
     isContact = contactDetails.dto.isContact,
     isBlocked = contactDetails.dto.isBlocked,
     trustStatus = contactDetails.dto.trustStatus,
+    contactRequest = toContactStatus(contactDetails.dto.contactRequestState),
   )
 
 {.pop.}

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -288,6 +288,7 @@ QtObject:
       alias: string,
       icon: string,
       isContact: bool,
+      isBlocked: bool,
       memberRole: MemberRole,
       joined: bool,
       membershipRequestState: MembershipRequestState = MembershipRequestState.None,
@@ -316,6 +317,7 @@ QtObject:
     updateRole(memberRole, MemberRole)
     updateRole(joined, Joined)
     updateRole(trustStatus, TrustStatus)
+    updateRole(isBlocked, IsBlocked)
 
     var updatedMembershipRequestState = membershipRequestState
     if updatedMembershipRequestState == MembershipRequestState.None:
@@ -357,6 +359,7 @@ QtObject:
         item.alias,
         item.icon,
         item.isContact,
+        item.isBlocked,
         item.memberRole,
         item.joined,
         item.membershipRequestState,
@@ -427,6 +430,7 @@ QtObject:
       alias: string,
       icon: string,
       isContact: bool,
+      isBlocked: bool,
       trustStatus: TrustStatus,
     ) =
     let ind = self.findIndexForMember(pubKey)
@@ -442,6 +446,7 @@ QtObject:
       alias,
       icon,
       isContact,
+      isBlocked,
       memberRole = self.items[ind].memberRole,
       joined = self.items[ind].joined,
       self.items[ind].membershipRequestState,

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -293,6 +293,7 @@ QtObject:
       joined: bool,
       membershipRequestState: MembershipRequestState = MembershipRequestState.None,
       trustStatus: TrustStatus,
+      contactRequest: ContactRequest,
       callDataChanged: bool = true,
     ): seq[int] =
     let ind = self.findIndexForMember(pubKey)
@@ -318,6 +319,7 @@ QtObject:
     updateRole(joined, Joined)
     updateRole(trustStatus, TrustStatus)
     updateRole(isBlocked, IsBlocked)
+    updateRole(contactRequest, ContactRequest)
 
     var updatedMembershipRequestState = membershipRequestState
     if updatedMembershipRequestState == MembershipRequestState.None:
@@ -364,6 +366,7 @@ QtObject:
         item.joined,
         item.membershipRequestState,
         item.trustStatus,
+        item.contactRequest,
         callDataChanged = false,
       )
 
@@ -432,6 +435,7 @@ QtObject:
       isContact: bool,
       isBlocked: bool,
       trustStatus: TrustStatus,
+      contactRequest: ContactRequest
     ) =
     let ind = self.findIndexForMember(pubKey)
     if ind == -1:
@@ -451,6 +455,7 @@ QtObject:
       joined = self.items[ind].joined,
       self.items[ind].membershipRequestState,
       trustStatus,
+      contactRequest,
     )
 
   proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -338,30 +338,6 @@ proc hasMember*(self: SectionItem, pubkey: string): bool =
 proc setOnlineStatusForMember*(self: SectionItem, pubKey: string, onlineStatus: OnlineStatus) =
   self.membersModel.setOnlineStatus(pubkey, onlineStatus)
 
-proc updateMember*(
-    self: SectionItem,
-    pubkey: string,
-    name: string,
-    ensName: string,
-    isEnsVerified: bool,
-    nickname: string,
-    alias: string,
-    image: string,
-    isContact: bool,
-    trustStatus: TrustStatus,
-  ) =
-  self.membersModel.updateItem(
-    pubkey,
-    name,
-    ensName,
-    isEnsVerified,
-    nickname,
-    alias,
-    image,
-    isContact,
-    trustStatus,
-  )
-
 proc amIBanned*(self: SectionItem): bool {.inline.} =
   return self.membersModel.isUserBanned(singletonInstance.userProfile.getPubKey())
 

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -346,6 +346,7 @@ QtObject:
       isContact: bool,
       isBlocked: bool,
       trustStatus: TrustStatus,
+      contactRequest: ContactRequest,
     ) =
     for item in self.items:
       item.members.updateItem(
@@ -359,6 +360,7 @@ QtObject:
         isContact,
         isBlocked,
         trustStatus,
+        contactRequest,
       )
 
   proc getNthEnabledItem*(self: SectionModel, nth: int): SectionItem =

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -344,6 +344,7 @@ QtObject:
       alias: string,
       icon: string,
       isContact: bool,
+      isBlocked: bool,
       trustStatus: TrustStatus,
     ) =
     for item in self.items:
@@ -356,6 +357,7 @@ QtObject:
         alias,
         icon,
         isContact,
+        isBlocked,
         trustStatus,
       )
 

--- a/test/nim/member_model_test.nim
+++ b/test/nim/member_model_test.nim
@@ -44,9 +44,11 @@ suite "updating member items":
         alias = "",
         icon = "",
         isContact = false,
+        isBlocked = false,
         memberRole = MemberRole.None,
         joined = false,
         trustStatus = TrustStatus.Unknown,
+        contactRequest = ContactRequest.None,
         callDataChanged = false,
       )
     # Two updated roles, because preferredDisplayName gets updated too
@@ -64,9 +66,11 @@ suite "updating member items":
         alias = "",
         icon = "icon",
         isContact = true,
+        isBlocked = false,
         memberRole = MemberRole.None,
         joined = false,
         trustStatus = TrustStatus.Unknown,
+        contactRequest = ContactRequest.None,
         callDataChanged = false,
       )
     check(updatedRoles.len() == 2)

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -196,8 +196,6 @@ Item {
         id: profileContextMenuComponent
 
         ProfileContextMenu {
-            id: profileContextMenu
-
             property string pubKey
 
             margins: 8


### PR DESCRIPTION
### What does the PR do

Fixes #16948 and #16952

The problem was that we just didn't pass `isBlocked` to the `Item`. So either it never worked or we broke it during the refactors.

We also didn't have updates when the events were called in the main module.

Same thing for the `contactRequest`

### Affected areas

Member list in the admin panel and on the right bar of a community.

### Screenshot of functionality (including design for comparison)

Block/unblock:

[block-unblock.webm](https://github.com/user-attachments/assets/51aafa9f-d786-47a3-a937-de3eac29983d)

CR:

[contact-request-context-menu.webm](https://github.com/user-attachments/assets/77595a82-debf-4e28-be5e-0089148cf8b8)

### Impact on end user

Fixes the issue of missing updates

### How to test

- Block and unblock a user and check the different member lists
- Send a contact request to the user and check the member lists

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case, the issue still happens
