### PR TITLE
chore(onboarding): add scaffolding for the new onboarding

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -7,6 +7,7 @@ const DEFAULT_FLAG_CONNECTOR_ENABLED* = true
 const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED = true
 const DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED = true
 const DEFAULT_FLAG_SIMPLE_SEND_ENABLED = false
+const DEFAULT_FLAG_ONBOARDING_V2_ENABLED = false
 
 proc boolToEnv*(defaultValue: bool): string =
   return if defaultValue: "1" else: "0"
@@ -19,6 +20,7 @@ QtObject:
     sendViaPersonalChatEnabled: bool
     paymentRequestEnabled: bool
     simpleSendEnabled: bool
+    onboardingV2Enabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
@@ -28,6 +30,7 @@ QtObject:
     self.sendViaPersonalChatEnabled = getEnv("FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED", boolToEnv(DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED)) != "0"
     self.paymentRequestEnabled = getEnv("FLAG_PAYMENT_REQUEST_ENABLED", boolToEnv(DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED)) != "0"
     self.simpleSendEnabled = getEnv("FLAG_SIMPLE_SEND_ENABLED", boolToEnv(DEFAULT_FLAG_SIMPLE_SEND_ENABLED)) != "0"
+    self.onboardingV2Enabled = getEnv("FLAG_ONBOARDING_V2_ENABLED", boolToEnv(DEFAULT_FLAG_ONBOARDING_V2_ENABLED)) != "0"
 
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
@@ -71,3 +74,9 @@ QtObject:
 
   QtProperty[bool] simpleSendEnabled:
     read = getSimpleSendEnabled
+
+  proc getOnboardingV2Enabled*(self: FeatureFlags): bool {.slot.} =
+    return self.onboardingV2Enabled
+
+  QtProperty[bool] onboardingV2Enabled:
+    read = getOnboardingV2Enabled

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -1,0 +1,24 @@
+import chronicles
+import io_interface
+
+import app/core/eventemitter
+
+logScope:
+  topics = "onboarding-controller"
+
+type
+  Controller* = ref object of RootObj
+    delegate: io_interface.AccessInterface
+    events: EventEmitter
+
+proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter):
+  Controller =
+  result = Controller()
+  result.delegate = delegate
+  result.events = events
+
+proc delete*(self: Controller) =
+  discard
+
+proc init*(self: Controller) =
+  discard

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -1,0 +1,16 @@
+type
+  AccessInterface* {.pure inheritable.} = ref object of RootObj
+
+method delete*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onAppLoaded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method load*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+# This way (using concepts) is used only for the modules managed by AppController
+type
+  DelegateInterface* = concept c
+    c.onboardingDidLoad()

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -1,0 +1,49 @@
+import NimQml, chronicles, json
+
+import io_interface
+import view, controller
+
+import app/global/global_singleton
+import app/core/eventemitter
+
+export io_interface
+
+logScope:
+  topics = "onboarding-module"
+
+type
+  Module*[T: io_interface.DelegateInterface] = ref object of io_interface.AccessInterface
+    delegate: T
+    view: View
+    viewVariant: QVariant
+    controller: Controller
+
+proc newModule*[T](delegate: T, events: EventEmitter): Module[T] =
+  result = Module[T]()
+  result.delegate = delegate
+  result.view = view.newView(result)
+  result.viewVariant = newQVariant(result.view)
+  result.controller = controller.newController(result, events)
+
+{.push warning[Deprecated]: off.}
+
+method delete*[T](self: Module[T]) =
+  self.view.delete
+  self.viewVariant.delete
+  self.controller.delete
+
+method onAppLoaded*[T](self: Module[T]) =
+  singletonInstance.engine.setRootContextProperty("onboardingModule", newQVariant())
+  self.view.delete
+  self.view = nil
+  self.viewVariant.delete
+  self.viewVariant = nil
+  self.controller.delete
+  self.controller = nil
+
+method load*[T](self: Module[T]) =
+  singletonInstance.engine.setRootContextProperty("onboardingModule", self.viewVariant)
+  self.controller.init()
+  self.delegate.onboardingDidLoad()
+
+{.pop.}

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -1,0 +1,15 @@
+import NimQml, json
+import io_interface
+
+QtObject:
+  type
+    View* = ref object of QObject
+      delegate: io_interface.AccessInterface
+
+  proc delete*(self: View) =
+    self.QObject.delete
+
+  proc newView*(delegate: io_interface.AccessInterface): View =
+    new(result, delete)
+    result.QObject.setup
+    result.delegate = delegate


### PR DESCRIPTION
Part of #16832

Adds the basic files needed for the new onboarding, aka onboarding V2. It does not do anything yet, but it's ready to be implemented.

It is locked behind a feature flag.
To enable it,  run the app with `export FLAG_ONBOARDING_V2_ENABLED=1`

Creating a small PR straightaway, that way subsequent PRs will be easier to review, since it won't contain all the file creation.