### PR TITLE
feat(community): add mark as read to community button

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -781,3 +781,6 @@ proc deleteCommunityMemberMessages*(self: Controller, memberPubKey: string, mess
 
 proc isMyCommunityRequestPending*(self: Controller): bool =
   return self.communityService.isMyCommunityRequestPending(self.sectionId)
+
+proc markAllReadInCommunity*(self: Controller) =
+  self.communityService.markAllReadInCommunity(self.sectionId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -434,3 +434,6 @@ method updateRequestToJoinState*(self: AccessInterface, state: RequestToJoinStat
 
 method communityMemberReevaluationStatusUpdated*(self: AccessInterface, status: CommunityMemberReevaluationStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method markAllReadInCommunity*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1632,3 +1632,6 @@ method updateRequestToJoinState*(self: Module, state: RequestToJoinState) =
 
 method communityMemberReevaluationStatusUpdated*(self: Module, status: CommunityMemberReevaluationStatus) =
   self.view.setCommunityMemberReevaluationStatus(status.int)
+
+method markAllReadInCommunity*(self: Module) =
+  self.controller.markAllReadInCommunity()

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -556,3 +556,6 @@ QtObject:
   QtProperty[QVariant] membersModel:
     read = getMembersModel
     notify = membersModelChanged
+
+  proc markAllReadInCommunity*(self: View) {.slot.} =
+    self.delegate.markAllReadInCommunity()

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -328,7 +328,7 @@ QtObject:
     # TODO: Signal is not handled anywhere
     self.events.emit(SIGNAL_MESSAGE_REMOVE, MessageArgs(id: messageId, channel: chats[0].id))
 
-  proc emitUpdate(self: Service, response: RpcResponse[JsonNode]) =
+  proc parseChatResponseAndEmit*(self: Service, response: RpcResponse[JsonNode]) =
     var (chats, _) = self.parseChatResponse(response)
     self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgs(chats: chats))
 
@@ -407,7 +407,7 @@ QtObject:
       let chat = self.chats[chatId]
       if chat.chatType == chat_dto.ChatType.PrivateGroupChat:
         let leaveGroupResponse = status_chat.leaveGroupChat(chatId)
-        self.emitUpdate(leaveGroupResponse)
+        self.parseChatResponseAndEmit(leaveGroupResponse)
 
       discard status_chat.deactivateChat(chatId, preserveHistory = chat.chatType == chat_dto.ChatType.OneToOne)
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2441,3 +2441,14 @@ QtObject:
       if (not chatDto.muted and chatDto.unviewedMessagesCount > 0) or chatDto.unviewedMentionsCount > 0:
         return true
     return false
+
+  proc markAllReadInCommunity*(self: Service, communityId: string) =
+    try:
+      let response = status_go.markAllReadInCommunity(communityId)
+      if response.error != nil:
+        let error = Json.decode($response.error, RpcError)
+        raise newException(RpcException, error.message)
+
+      self.chatService.parseChatResponseAndEmit(response)
+    except Exception as e:
+      error "error marking all read in community", msg = e.msg

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -558,3 +558,5 @@ proc setCommunityShard*(communityId: string, index: int): RpcResponse[JsonNode] 
         "communityId": communityId,
       }])
 
+proc markAllReadInCommunity*(communityId: string,): RpcResponse[JsonNode] =
+  return callPrivateRPC("markAllReadInCommunity".prefix, %*[communityId])

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -993,9 +993,13 @@ Item {
                             enabled: model.muted
                             text: qsTr("Unmute Community")
                             icon.name: "notification"
-                            onTriggered: {
-                                communityContextMenu.chatCommunitySectionModule.setCommunityMuted(Constants.MutingVariations.Unmuted)
-                            }
+                            onTriggered: communityContextMenu.chatCommunitySectionModule.setCommunityMuted(Constants.MutingVariations.Unmuted)
+                        }
+
+                        StatusAction {
+                            text: qsTr("Mark as read")
+                            icon.name: "check-circle"
+                            onTriggered: communityContextMenu.chatCommunitySectionModule.markAllReadInCommunity()
                         }
 
                         StatusAction {


### PR DESCRIPTION
### What does the PR do

Fixes #16573

Adds the "Mark as read" to the community context menu that marks all channels in the community as read

### Affected areas

Community context menu

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[mark-as-read.webm](https://github.com/user-attachments/assets/f476c4ed-7256-40ec-bf8f-c52dff349c5a)

### Impact on end user

New feature

### How to test

- Mark some messages as unread or receive new messages
- Click the new option in the context menu

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case, the feature doesn't work lol