### PR TITLE
chore(@e2e): update mark for keycard tests

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -172,7 +172,7 @@ pipeline {
           ]) {
             /* Keep the --reruns flag first, or it won't work */
             sh """
-              python3 -m pytest -v --reruns=1 --timeout=240 ${flags.join(" ")} \
+              python3 -m pytest -m "not keycard" -v --reruns=1 --timeout=240 ${flags.join(" ")} \
                 --disable-warnings \
                 --alluredir=./allure-results \
                 -o timeout_func_only=true

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -44,7 +44,7 @@ def setup_function_scope(
         generate_test_data,
         check_result,
         application_logs,
-        keycard_controller
+        launch_keycard_controller
 ):
     # FIXME: broken due to KeyError: <_pytest.stash.StashKey object at 0x7fd1ba6d78c0>
     # caplog.set_level(configs.LOG_LEVEL)

--- a/test/e2e/fixtures/aut.py
+++ b/test/e2e/fixtures/aut.py
@@ -23,8 +23,9 @@ def options(request):
 
 
 @pytest.fixture
-def keycard_controller(request):
-    if 'settings_keycard' in str(getattr(request, 'fspath')):
+def launch_keycard_controller(request):
+    marker = request.node.get_closest_marker("keycard")
+    if marker:
         os.environ['STATUS_RUNTIME_USE_MOCKED_KEYCARD'] = 'True'
 
 

--- a/test/e2e/gui/screens/settings.py
+++ b/test/e2e/gui/screens/settings.py
@@ -43,13 +43,13 @@ class LeftPanel(QObject):
     @allure.step('Choose back up seed phrase in settings')
     @handle_settings_opening(BackUpYourSeedPhrasePopUp, '18-MenuItem')
     def open_back_up_seed_phrase(self, click_attempts: int = 2) -> 'BackUpYourSeedPhrasePopUp':
-        assert BackUpYourSeedPhrasePopUp().exists, 'Back up your seed phrase modal was not opened'
+        assert BackUpYourSeedPhrasePopUp().wait_until_appears(), 'Back up your seed phrase modal was not opened'
         return BackUpYourSeedPhrasePopUp()
 
     @allure.step('Open wallet settings')
     @handle_settings_opening(WalletSettingsView, '5-MenuItem')
     def open_wallet_settings(self, click_attempts: int = 2) -> 'WalletSettingsView':
-        assert WalletSettingsView().exists, 'Wallet view was not opened'
+        assert WalletSettingsView().wait_until_appears(), 'Wallet view was not opened'
         return WalletSettingsView()
 
     @allure.step('Open messaging settings')
@@ -61,25 +61,25 @@ class LeftPanel(QObject):
     @allure.step('Open communities settings')
     @handle_settings_opening(CommunitiesSettingsView, '12-MenuItem')
     def open_communities_settings(self, attempts: int = 2) -> 'CommunitiesSettingsView':
-        assert CommunitiesSettingsView().exists, 'Community settings view was not opened'
+        assert CommunitiesSettingsView().wait_until_appears(), 'Community settings view was not opened'
         return CommunitiesSettingsView()
 
     @allure.step('Open profile settings')
     @handle_settings_opening(ProfileSettingsView, '0-MenuItem')
     def open_profile_settings(self, click_attempts: int = 2) -> 'ProfileSettingsView':
-        assert ProfileSettingsView().exists, 'Profile settings view was not opened'
+        assert ProfileSettingsView().wait_until_appears(), 'Profile settings view was not opened'
         return ProfileSettingsView()
 
     @allure.step('Open password settings')
     @handle_settings_opening(ChangePasswordView, '1-MenuItem')
     def open_password_settings(self, click_attempts: int = 2) -> 'ChangePasswordView':
-        assert ChangePasswordView().exists, 'Password settings view was not opened'
+        assert ChangePasswordView().wait_until_appears(), 'Password settings view was not opened'
         return ChangePasswordView()
 
     @allure.step('Open syncing settings')
     @handle_settings_opening(SyncingSettingsView, '9-MenuItem')
     def open_syncing_settings(self, click_attempts: int = 2) -> 'SyncingSettingsView':
-        assert SyncingSettingsView().exists, 'Syncing settings view was not opened'
+        assert SyncingSettingsView().wait_until_appears(), 'Syncing settings view was not opened'
         return SyncingSettingsView()
 
     @allure.step('Choose sign out and quit in settings')

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -11,7 +11,7 @@ markers =
     critical: Critical checks for every PR
     smoke: Tests that we use for release smoke checks
     settings_all: All tests related to the settings
-    settings_keycard: Tests related to Keycard settings
+    keycard: Tests related to Keycard
     settings_messaging: Tests related to messaging settings
     settings_profile: Tests related to profile settings
     settings_password: Tests related to password settings

--- a/test/e2e/tests/settings/settings_keycard/__init__.py
+++ b/test/e2e/tests/settings/settings_keycard/__init__.py
@@ -1,4 +1,1 @@
-import pytest
-from .. import marks
 
-marks = [pytest.mark.settings_keycard, marks]

--- a/test/e2e/tests/settings/settings_keycard/test_check_whats_on_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_check_whats_on_keycard.py
@@ -16,7 +16,6 @@ from gui.mocked_keycard_controller import MockedKeycardController
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703627', 'Check whats on a Keycard')
 @pytest.mark.case(703627)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_check_whats_on_keycard(main_screen: MainWindow, user_account):
     main_screen.prepare()
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC

--- a/test/e2e/tests/settings/settings_keycard/test_check_whats_on_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_check_whats_on_keycard.py
@@ -4,11 +4,7 @@ import allure
 import pytest
 from allure import step
 
-from constants import RandomUser
-from . import marks
-
 import configs
-import constants
 import driver
 from constants.images_paths import PLUG_IN_KEYCARD_IMAGE_PATH, INSERT_KEYCARD_IMAGE_PATH, EMPTY_KEYCARD_IMAGE_PATH, \
     KEYCARD_SUCCESS_IMAGE_PATH, KEYCARD_INSERTED_IMAGE_PATH
@@ -16,11 +12,10 @@ from constants.keycard import Keycard
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController
 
-pytestmark = marks
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703627', 'Check whats on a Keycard')
 @pytest.mark.case(703627)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_check_whats_on_keycard(main_screen: MainWindow, user_account):
     main_screen.prepare()

--- a/test/e2e/tests/settings/settings_keycard/test_create_keycard_account_with_new_seed_phrase.py
+++ b/test/e2e/tests/settings/settings_keycard/test_create_keycard_account_with_new_seed_phrase.py
@@ -3,7 +3,6 @@ import time
 import allure
 import pytest
 from allure import step
-from . import marks
 
 import configs
 import driver
@@ -12,12 +11,11 @@ from constants.keycard import Keycard
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController
 
-pytestmark = marks
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703624',
                  'Create a new keycard account with a new seed phrase')
 @pytest.mark.case(703624)
+@pytest.mark.keycard
 @pytest.mark.parametrize(
     'name, color, emoji_name, emoji, name1, color1, emoji1_name, emoji1, name2, color2, emoji2_name, emoji2',
     [pytest.param('Test Account', '#216266', 'sunglasses', '😎 ', 'Test Account2', '#2a4af5',

--- a/test/e2e/tests/settings/settings_keycard/test_create_keycard_account_with_new_seed_phrase.py
+++ b/test/e2e/tests/settings/settings_keycard/test_create_keycard_account_with_new_seed_phrase.py
@@ -21,7 +21,6 @@ from gui.mocked_keycard_controller import MockedKeycardController
     [pytest.param('Test Account', '#216266', 'sunglasses', '😎 ', 'Test Account2', '#2a4af5',
                   'thumbsup', '👍 ', 'Test Account3', '#ff7d46', 'cool', '🆒 ')
      ])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_create_keycard_account_with_new_seed_phrase(main_screen: MainWindow, name, color, emoji_name, emoji, name1,
                                                      color1, emoji1_name, emoji1, name2, color2, emoji2_name, emoji2):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC

--- a/test/e2e/tests/settings/settings_keycard/test_factory_reset_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_factory_reset_keycard.py
@@ -2,22 +2,18 @@ import allure
 import pytest
 from allure_commons._allure import step
 
-from constants import RandomUser
-from . import marks
 
 import configs
-import constants
 import driver
 from constants.images_paths import KEYCARD_ERROR_IMAGE_PATH
 from constants.keycard import Keycard
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController
 
-pytestmark = marks
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703628', 'Factory reset a Keycard')
 @pytest.mark.case(703628)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_factory_reset_keycard(main_screen: MainWindow, user_account):
     main_screen.prepare()
@@ -71,6 +67,7 @@ def test_factory_reset_keycard(main_screen: MainWindow, user_account):
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704606',
                  'Factory reset a Keycard: incorrect PIN')
 @pytest.mark.case(704606)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_factory_reset_keycard_incorrect_pin(main_screen: MainWindow, user_account):
     main_screen.prepare()

--- a/test/e2e/tests/settings/settings_keycard/test_factory_reset_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_factory_reset_keycard.py
@@ -14,7 +14,6 @@ from gui.mocked_keycard_controller import MockedKeycardController
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703628', 'Factory reset a Keycard')
 @pytest.mark.case(703628)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_factory_reset_keycard(main_screen: MainWindow, user_account):
     main_screen.prepare()
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
@@ -68,7 +67,6 @@ def test_factory_reset_keycard(main_screen: MainWindow, user_account):
                  'Factory reset a Keycard: incorrect PIN')
 @pytest.mark.case(704606)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_factory_reset_keycard_incorrect_pin(main_screen: MainWindow, user_account):
     main_screen.prepare()
     incorrect_pin = Keycard.KEYCARD_INCORRECT_PIN.value

--- a/test/e2e/tests/settings/settings_keycard/test_import_restore_keycard_via_seed_phrase.py
+++ b/test/e2e/tests/settings/settings_keycard/test_import_restore_keycard_via_seed_phrase.py
@@ -3,25 +3,24 @@ import time
 import allure
 import pytest
 from allure import step
-from . import marks
 
 import configs
-import constants
 import driver
-from constants import ColorCodes, RandomUser
+from constants import ColorCodes
 from constants.images_paths import PLUG_IN_KEYCARD_IMAGE_PATH, INSERT_KEYCARD_IMAGE_PATH, KEYCARD_SUCCESS_IMAGE_PATH
 from constants.keycard import Keycard
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController
-
-pytestmark = marks
+from scripts.utils.generators import random_mnemonic
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703625',
                  'Import or restore a Keycard via a seed phrase')
 @pytest.mark.case(703625)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
-def test_import_restore_keycard_via_seed_phrase(main_screen: MainWindow, user_account):
+@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/17012')
+def test_import_restore_keycard_via_seed_phrase(main_screen: MainWindow):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     pin = Keycard.KEYCARD_PIN.value
     keycard_name = Keycard.KEYCARD_NAME.value
@@ -63,7 +62,7 @@ def test_import_restore_keycard_via_seed_phrase(main_screen: MainWindow, user_ac
                               timeout), f"There is no correct keycard instruction in {keycard_popup.keycard_instructions}"
 
     with step('Import keycard via seed phrase'):
-        keycard_popup.import_keycard_via_seed_phrase(user_account.seed_phrase, pin, keycard_name, account_name)
+        keycard_popup.import_keycard_via_seed_phrase(random_mnemonic().split(), pin, keycard_name, account_name)
 
     with step('Verify that preview shows correct keycard and account name and color and instructions are correct'):
         assert driver.waitFor(lambda: Keycard.KEYCARD_READY.value in keycard_popup.keycard_instructions), \

--- a/test/e2e/tests/settings/settings_keycard/test_import_restore_keycard_via_seed_phrase.py
+++ b/test/e2e/tests/settings/settings_keycard/test_import_restore_keycard_via_seed_phrase.py
@@ -18,8 +18,7 @@ from scripts.utils.generators import random_mnemonic
                  'Import or restore a Keycard via a seed phrase')
 @pytest.mark.case(703625)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/17012')
+@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/17012')
 def test_import_restore_keycard_via_seed_phrase(main_screen: MainWindow):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     pin = Keycard.KEYCARD_PIN.value

--- a/test/e2e/tests/settings/settings_keycard/test_setup_existing_account.py
+++ b/test/e2e/tests/settings/settings_keycard/test_setup_existing_account.py
@@ -22,7 +22,6 @@ from gui.mocked_keycard_controller import MockedKeycardController
 @pytest.mark.parametrize('account_name', [pytest.param('Account 1')])
 @pytest.mark.timeout(timeout=210)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_setup_keycard_with_existing_account(main_screen: MainWindow, user_account, account_name):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     first_details = '{}'

--- a/test/e2e/tests/settings/settings_keycard/test_setup_existing_account.py
+++ b/test/e2e/tests/settings/settings_keycard/test_setup_existing_account.py
@@ -4,12 +4,10 @@ from pathlib import Path
 import allure
 import pytest
 from allure import step
-from . import marks
 
 import configs
-import constants
 import driver
-from constants import ColorCodes, RandomUser
+from constants import ColorCodes
 from constants.images_paths import PLUG_IN_KEYCARD_IMAGE_PATH, CHOOSE_KEYCARD_PIN_IMAGE_PATH, \
     KEYCARD_SUCCESS_IMAGE_PATH
 from constants.keycard import Keycard
@@ -17,14 +15,13 @@ from gui.components.authenticate_popup import AuthenticatePopup
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController
 
-pytestmark = marks
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703623',
                  'Setup a keycard with an existing account')
 @pytest.mark.case(703623)
 @pytest.mark.parametrize('account_name', [pytest.param('Account 1')])
 @pytest.mark.timeout(timeout=210)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_setup_keycard_with_existing_account(main_screen: MainWindow, user_account, account_name):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
@@ -86,7 +83,8 @@ def test_setup_keycard_with_existing_account(main_screen: MainWindow, user_accou
     with step('Register and insert custom emtpy keycard with custom details'):
         main_screen.hide()
         keycard_controller.choose_custom_keycard()
-        keycard_controller.input_custom_keycard_details(first_details, 0).input_custom_keycard_details(second_details, 1)
+        keycard_controller.input_custom_keycard_details(first_details, 0)
+        keycard_controller.input_custom_keycard_details(second_details, 1)
         keycard_controller.register_keycard().insert_keycard_1()
         main_screen.show()
 

--- a/test/e2e/tests/settings/settings_keycard/test_unlock_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_unlock_keycard.py
@@ -4,22 +4,16 @@ import allure
 import pytest
 from allure import step
 
-from constants import UserAccount, RandomUser
-from scripts.utils.generators import random_name_string, random_password_string
-from . import marks
-
 import configs
-import constants
 import driver
 from constants.keycard import Keycard
 from gui.main_window import MainWindow
 from gui.mocked_keycard_controller import MockedKeycardController
 
-pytestmark = marks
-
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704607', 'Unlock Keycard')
 @pytest.mark.case(704607)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_unlock_keycard_using_correct_puk(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
@@ -84,6 +78,7 @@ def test_unlock_keycard_using_correct_puk(main_screen: MainWindow, user_account)
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704608', 'Unlock Keycard: incorrect PUK')
 @pytest.mark.case(704608)
+@pytest.mark.keycard
 @pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_unlock_keycard_using_incorrect_puk(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC

--- a/test/e2e/tests/settings/settings_keycard/test_unlock_keycard.py
+++ b/test/e2e/tests/settings/settings_keycard/test_unlock_keycard.py
@@ -14,7 +14,6 @@ from gui.mocked_keycard_controller import MockedKeycardController
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704607', 'Unlock Keycard')
 @pytest.mark.case(704607)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_unlock_keycard_using_correct_puk(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     pin = Keycard.KEYCARD_PIN.value
@@ -79,7 +78,6 @@ def test_unlock_keycard_using_correct_puk(main_screen: MainWindow, user_account)
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704608', 'Unlock Keycard: incorrect PUK')
 @pytest.mark.case(704608)
 @pytest.mark.keycard
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15741')
 def test_unlock_keycard_using_incorrect_puk(main_screen: MainWindow, user_account):
     timeout = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
     pin = Keycard.KEYCARD_PIN.value

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_use_keycard.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_use_keycard.py
@@ -1,13 +1,9 @@
 import allure
 import pytest
 from allure_commons._allure import step
-from tests.settings.settings_keycard import marks
 
-from gui.components.signing_phrase_popup import SigningPhrasePopup
 from gui.main_window import MainWindow
 from gui.screens.settings_keycard import KeycardSettingsView
-
-pytestmark = marks
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703514',


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/15741

- rename mark to `keycard`
- change fixture to rely on mark instead of tests path
- uncomment and fix all the keycard tests
- change the selection of tests for nightly run to exclude keycard tests instead of skipping them. These tests can't be run in nightly because we require a special build (with mocked keycard lib). However, there will be then a possibility to run these tests on Jenkins via manual launch

<img width="1552" alt="Screenshot 2024-12-25 at 14 12 07" src="https://github.com/user-attachments/assets/fd359faf-34d9-4856-b067-2a42856b8ad4" />

