### PR TITLE
tests: reimplement test for banning and kicking community member

### DIFF
--- a/test/e2e/constants/community.py
+++ b/test/e2e/constants/community.py
@@ -60,6 +60,7 @@ class ToastMessages(Enum):
     REMOVED_CONTACT_TOAST = 'Contact removed'
     BANNED_USER_TOAST = ' was banned from '
     UNBANNED_USER_TOAST = ' unbanned from '
+    UNBANNED_USER_CONFIRM = 'You were unbanned from '
 
 
 class LimitWarnings(Enum):

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -27,7 +27,6 @@ class QObject:
             raise LookupError(f"Object {self.real_name} was not found within {configs.timeouts.UI_LOAD_TIMEOUT_MSEC}")
         return obj
 
-
     def set_text_property(self, text):
         self.object.forceActiveFocus()
         self.object.clear()

--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -32,6 +32,11 @@ channel_name_StatusBaseText = {"container": None, "type": "StatusBaseText", "unn
 mainWindow_createChannelOrCategoryBtn_StatusBaseText = {"container": mainWindow_communityColumnView_CommunityColumnView, "objectName": "createChannelOrCategoryBtn", "type": "StatusBaseText", "visible": True}
 create_channel_StatusMenuItem = {"container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": "createCommunityChannelBtn", "type": "StatusMenuItem", "visible": True}
 mainWindow_Join_Community_StatusButton = {"checkable": False, "container": mainWindow_StatusWindow, "type": "StatusButton", "unnamed": 1, "visible": True}
+
+# Banned Panel
+mainWindow_CommunityBannedMemberPanel = {"container": statusDesktop_mainWindow, "objectName": "communityBannedMemberPanel", "type": "CommunityBannedMemberCenterPanel", "visible": True}
+mainWindow_CommunityBannedMemberPanel_UserInfo = {"container": statusDesktop_mainWindow, "objectName": "userInfoPanelBase", "type": "Rectangle", "visible": True}
+
 add_categories_StatusFlatButton = {"checkable": False, "container": mainWindow_scrollView_StatusScrollView, "id": "manageBtn", "type": "StatusFlatButton", "visible": True}
 categoryItem_StatusChatListCategoryItem = {"container": mainWindow_scrollView_StatusScrollView, "objectName": "categoryItem", "type": "StatusChatListCategoryItem", "visible": True}
 delete_Category_StatusMenuItem = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "enabled": True, "objectName": "deleteCategoryMenuItem", "type": "StatusMenuItem", "visible": True}
@@ -83,10 +88,10 @@ mainWindow_Edit_Community_StatusButton = {"container": statusDesktop_mainWindow,
 
 # Members Settings View
 mainWindow_MembersSettingsPanel = {"container": mainWindow_communityLoader_Loader, "type": "MembersSettingsPanel", "unnamed": 1, "visible": True}
-membersListViews_ListView = {"container": mainWindow_MembersSettingsPanel, "objectName": "CommunityMembersTabPanel_MembersListViews", "type": "ListView", "visible": True}
+membersListViews_ListView = {"container": statusDesktop_mainWindow, "objectName": "CommunityMembersTabPanel_MembersListViews", "type": "StatusListView", "visible": True}
 memberItem_StatusMemberListItem = {"container": membersListViews_ListView, "id": "memberItem", "type": "StatusMemberListItem", "unnamed": 1, "visible": True}
 communitySettings_MembersTab_Member_Kick_Button = {"container": membersListViews_ListView, "objectName": "MemberListItem_KickButton", "type": "StatusButton", "visible": True}
-memberItem_Ban_StatusButton = {"checkable": False, "container": membersListViews_ListView, "objectName": "MemberListItem_BanButton", "type": "StatusButton", "visible": True}
+memberItem_Ban_StatusButton = {"container": membersListViews_ListView, "objectName": "MemberListItem_BanButton", "type": "StatusButton", "visible": True}
 memberItem_Unban_StatusButton = {"checkable": False, "container": membersListViews_ListView, "objectName": "MemberListItem_UnbanButton", "type": "StatusButton", "visible": True}
 
 # Tokens View

--- a/test/e2e/gui/screens/community.py
+++ b/test/e2e/gui/screens/community.py
@@ -22,6 +22,7 @@ from gui.elements.text_label import TextLabel
 from gui.objects_map import names, communities_names, messaging_names
 from gui.screens.community_settings import CommunitySettingsScreen
 from scripts.tools.image import Image
+from scripts.utils.parsers import remove_tags
 
 
 class CommunityScreen(QObject):
@@ -91,6 +92,21 @@ class CommunityScreen(QObject):
     def verify_category(self, category_name: str):
         category = self.left_panel.find_category_in_list(category_name)
         assert category.category_name == category_name
+
+
+class BannedCommunityScreen(QObject):
+    def __init__(self):
+        super().__init__(communities_names.mainWindow_communityLoader_Loader)
+        self.community_header_button = Button(communities_names.mainWindow_communityHeaderButton_StatusChatInfoButton)
+        self.community_start_chat_button = Button(messaging_names.mainWindow_startChatButton_StatusIconTabButton)
+        self.community_banned_member_panel = QObject(communities_names.mainWindow_CommunityBannedMemberPanel)
+        self.community_banned_member_panel_user_info = QObject(
+            communities_names.mainWindow_CommunityBannedMemberPanel_UserInfo)
+
+    def banned_title(self):
+        for child in walk_children(self.community_banned_member_panel_user_info.object):
+            if str(getattr(child, 'objectName', '')) == 'userInfoPanelBaseText':
+                return remove_tags(str(child.text))
 
 
 class ToolBar(QObject):

--- a/test/e2e/gui/screens/community_settings.py
+++ b/test/e2e/gui/screens/community_settings.py
@@ -272,8 +272,8 @@ class MembersView(QObject):
         self._unban_member_button = Button(communities_names.memberItem_Unban_StatusButton)
 
     @property
-    @allure.step('Get community members')
-    def members(self) -> typing.List[str]:
+    @allure.step('Get community members names')
+    def members_names(self) -> typing.List[str]:
         return [str(member.userName) for member in driver.findAllObjects(self._member_list_item.real_name)]
 
     @allure.step('Get community member objects')
@@ -300,29 +300,29 @@ class MembersView(QObject):
     def kick_member(self, member_name: str):
         member = self.get_member_object(member_name)
         QObject(real_name=driver.objectMap.realName(member)).hover()
-        self._kick_member_button.click()
+        self._kick_member_button.hover()
+        time.sleep(1)
+        self._kick_member_button.native_mouse_click()
         kick_member_popup = KickMemberPopup()
-        assert kick_member_popup.exists
         kick_member_popup.confirm_kicking()
 
     @allure.step('Ban community member')
     def ban_member(self, member_name: str):
         member = self.get_member_object(member_name)
         QObject(real_name=driver.objectMap.realName(member)).hover()
-        self._ban_member_button.click()
+        self._ban_member_button.hover()
+        time.sleep(1)
+        self._ban_member_button.native_mouse_click()
         return BanMemberPopup().wait_until_appears()
 
     @allure.step('Unban community member')
-    def unban_member(self, member_name: str, attempt: int = 2):
+    def unban_member(self, member_name: str):
         member = self.get_member_object(member_name)
         QObject(real_name=driver.objectMap.realName(member)).hover()
-        try:
-            self._unban_member_button.wait_until_appears().click()
-        except AssertionError as er:
-            if attempt:
-                self.unban_member(member_name, attempt-1)
-            else:
-                raise er
+        self._unban_member_button.hover()
+        time.sleep(1)
+        self._unban_member_button.native_mouse_click()
+        return self
 
 
 class AirdropsView(QObject):

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -27,7 +27,7 @@ from gui.elements.scroll import Scroll
 from gui.elements.text_edit import TextEdit
 from gui.elements.text_label import TextLabel
 from gui.objects_map import messaging_names, communities_names
-from gui.screens.community import CommunityScreen
+from gui.screens.community import CommunityScreen, BannedCommunityScreen
 from scripts.tools.image import Image
 from scripts.utils.parsers import remove_tags
 
@@ -175,6 +175,11 @@ class Message:
         self.delegate_button.click()
         return CommunityScreen().wait_until_appears()
 
+    def open_banned_community_invitation(self):
+        driver.waitFor(lambda: self.delegate_button.is_visible, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+        self.delegate_button.click()
+        return BannedCommunityScreen().wait_until_appears()
+
     @allure.step('Hover message')
     def hover_message(self):
         self.delegate_button.hover()
@@ -275,8 +280,17 @@ class ChatView(QObject):
                 raise LookupError(f'Message not found')
         return message
 
-    @allure.step('Accept community invitation')
-    def accept_community_invite(self, community: str, index: int) -> 'CommunityScreen':
+    @allure.step('Open community invitation')
+    def click_community_invite(self, community: str, index: int) -> 'CommunityScreen':
+        message = self.search_for_invitation(community, index)
+        return message.open_community_invitation()
+
+    @allure.step('Open banned community invitation')
+    def open_banned_community(self, community, index) -> 'BannedCommunityScreen':
+        message = self.search_for_invitation(community, index)
+        return message.open_banned_community_invitation()
+
+    def search_for_invitation(self, community, index):
         message = None
         started_at = time.monotonic()
         while message is None:
@@ -286,8 +300,9 @@ class ChatView(QObject):
                     break
             if time.monotonic() - started_at > 80:
                 raise LookupError(f'Community invitation was not found')
+        return message
 
-        return message.open_community_invitation()
+
 
 
 class CreateChatView(QObject):

--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -78,7 +78,7 @@ def test_join_community_and_pin_unpin_message(multiple_instances):
             main_screen.prepare()
             messages_view = main_screen.left_panel.open_messages_screen()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            chat.accept_community_invite(community.name, 0)
+            chat.click_community_invite(community.name, 0)
 
         with step(f'User {user_one.name}, verify welcome community popup'):
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()

--- a/test/e2e/tests/communities/test_communities_send_accept_decline_request_from_profile.py
+++ b/test/e2e/tests/communities/test_communities_send_accept_decline_request_from_profile.py
@@ -107,7 +107,7 @@ def test_communities_send_accept_decline_request_remove_contact_from_profile(mul
             main_screen.prepare()
             messages_view = main_screen.left_panel.open_messages_screen()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            community_screen = chat.accept_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite(community.name, 0)
 
         with step(f'User {user_three.name}, verify welcome community popup'):
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
@@ -123,7 +123,7 @@ def test_communities_send_accept_decline_request_remove_contact_from_profile(mul
             main_screen.prepare()
             messages_view = main_screen.left_panel.open_messages_screen()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
-            community_screen = chat.accept_community_invite(community.name, 0)
+            community_screen = chat.click_community_invite(community.name, 0)
 
         with step(f'User {user_one.name}, verify welcome community popup'):
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()

--- a/ui/app/AppLayouts/Communities/panels/CommunityBannedMemberCenterPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/CommunityBannedMemberCenterPanel.qml
@@ -11,6 +11,8 @@ import StatusQ.Layout 0.1
 ColumnLayout {
     id: root
 
+    objectName: "communityBannedMemberPanel"
+
     property string name
     property string chatDateTimeText
     property string listUsersText
@@ -81,6 +83,8 @@ ColumnLayout {
     Rectangle {
         id: panelBase
 
+        objectName: "userInfoPanelBase"
+
         Layout.fillWidth: true
         Layout.fillHeight: true
         color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
@@ -121,6 +125,7 @@ ColumnLayout {
                 }
 
                 StatusBaseText {
+                    objectName: "userInfoPanelBaseText"
                     text: qsTr("You've been banned from <b>%1<b>").arg(root.name)
                     color: Theme.palette.dangerColor1
                     font.pixelSize: Theme.secondaryAdditionalTextSize


### PR DESCRIPTION
### What does the PR do

reimplement test for banning and kicking community member. What the test does now:
- creates 2 separate users, adds them to mutual contacts
- creates community, invites a user to community
- as community owner (control node) - ban community member -> check notification about this action + check that user is listed on the Banned members tab
- as banned member, check that community disappeared from the left pane. open the community by clicking direct link from chat and verify that messages about being banned appears
- as community owner, unban user, check notification about this action
- as banned member -> open community by direct link and wait for a notification that you are unbanned. Note: the notification is not coming when you are not opening the community link it seems, i have to investigate later why it is that. Then, close community. Open the community again and see that Join community button appears. NOTE: the screen is not changing from **Banned** to **Join community** if i dont reopen the link. This has to be investigated later. Then, join the community again and share your addresses
- as community owner, kick the member and check notification. Also, check that this member is not present in community members list
- as kicked member, reopen community by clicking direct link and join it again (with sharing addresses)

CI run https://ci.status.im/job/status-desktop/job/e2e/job/manual/2606/allure/#suites/fb5aaa3e880cddbdd49c36e78b1d872a/d50402754bf122e6/

<img width="1552" alt="Screenshot 2024-12-27 at 16 39 30" src="https://github.com/user-attachments/assets/d7a5995d-982c-4d97-a0d5-65ba4bbfb5c1" />


