### PR TITLE
feat(channel): show channels with unread messages  even if collapsed

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -170,7 +170,13 @@ Item {
                         objectName: model.name
                         Layout.fillWidth: true
                         height: visible ? (statusChatListItem.implicitHeight + 4) /*spacing between non-collapsed items*/ : 0
-                        visible: (!draggableItem.isCategory && model.categoryOpened)
+                        visible: !draggableItem.isCategory &&
+                            (
+                                model.active ||
+                                (!model.muted && model.hasUnreadMessages) || // Show channel if it has unread messages but not muted
+                                model.notificationsCount > 0 || // unless it's a notification (mentions, replies)
+                                model.categoryOpened
+                            )
                         originalOrder: model.position
                         chatId: model.itemId
                         categoryId: model.categoryId


### PR DESCRIPTION
### What does the PR do

Fixes #17016

Sets the channel as visible when it has unread messages, but not muted, or has a notification (reply or mention) or it's active, even when collapsed.

### Affected areas

Channel list (only for communities)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

Unread messages (shows even if it's collapsed):
![image](https://github.com/user-attachments/assets/4b12c180-30b2-4689-9827-30427369c80f)

Active channel (shows even if read and collapsed):
![image](https://github.com/user-attachments/assets/e5188965-2fe5-4986-804b-befe62cc89f3)

Muted channel (doesn't show):
![image](https://github.com/user-attachments/assets/c500b9a1-ceb9-46be-a551-cbeb73fd8d7a)

Muted but it's a notification (shows even if muted and collapsed):
![image](https://github.com/user-attachments/assets/769ebd78-de19-4c99-a302-9a2ed3974957)

### Impact on end user

Makes it easier to manage a community with a lot of channels. Currently, it's not useful to collapse unmuted categories, because then when you have messages in a collapsed channel, you have to manually open the category to see which channel it is.

With this small change, it's now easy to know which channel it is and only one click to see the unread messages.

### How to test

- Mark as unread some messages in a channel in a collapsed category.
- test muting the channel
- test mentions

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case, the feature doesn't work in some edge scenario