### PR TITLE
fix(ac): fix review CR popup not showing correct data from the AC

### DIFF
--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -49,25 +49,11 @@ ActivityNotificationMessage {
             root.store.contactsStore.blockContact(root.contactId)
         }
         onDetailsClicked: {
-            Global.openPopup(reviewContactRequestPopupComponent, {
-                messageDetails: root.messageDetails,
-                compressedPubKey: contactDetails ? contactDetails.compressedPublicKey : "",
-                timestamp: notification ? notification.timestamp : 0
-            })
+            Global.openReviewContactRequestPopup(root.contactId, null)
         }
     }
 
     onMessageClicked: {
         root.openProfilePopup()
-    }
-
-    Component {
-        id: reviewContactRequestPopupComponent
-
-        ReviewContactRequestPopup {
-            id: reviewRequestPopup
-            onAccepted: root.store.contactsStore.acceptContactRequest(root.contactId, root.contactRequestId)
-            onDeclined: root.store.contactsStore.dismissContactRequest(root.contactId, root.contactRequestId)
-        }
     }
 }


### PR DESCRIPTION
### What does the PR do

Fixes #16601

The original issue of seeing `&nbsp;`  was already fixed, but the popup, when opening from the activity center didn't have any spaces. However, when displayed from the profile, everything showed fine. So the fix was simply to remove the old way of opening from the AC and use the same call that is used in the profile popup.

### Affected areas

Review contact request popup (when opened from the AC)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

![image](https://github.com/user-attachments/assets/14604ef4-522b-4f5d-bd0b-d4b66099c6c3)

![image](https://github.com/user-attachments/assets/f41ff9c0-3839-4f9d-8615-bac631dab893)

### Impact on end user

Fixes the issue with spaces not working in the popup

### How to test

0. Receive a CR that contains spaces
1. Go in the AC and click the three dots on the right
2. Click "Details"
Everything should look ok

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the spaces look weird still