### PR TITLE
Add a "Dismissed contact requests" tab in the Contacts panel

### DIFF
--- a/storybook/pages/ContactsViewPage.qml
+++ b/storybook/pages/ContactsViewPage.qml
@@ -42,6 +42,7 @@ Item {
         mutualContactsModel: adaptor.mutualContacts
         blockedContactsModel: adaptor.blockedContacts
         pendingContactsModel: adaptor.pendingContacts
+        dismissedReceivedRequestContactsModel: adaptor.dismissedReceivedRequestContactsModel
         pendingReceivedContactsCount: adaptor.pendingReceivedRequestContacts.count
     }
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -57,6 +57,7 @@ StatusSectionLayout {
     property var blockedContactsModel
     property var pendingContactsModel
     property int pendingReceivedContactsCount
+    property var dismissedReceivedRequestContactsModel
 
     required property bool isCentralizedMetricsEnabled
 
@@ -246,6 +247,7 @@ StatusSectionLayout {
                 blockedContactsModel: root.blockedContactsModel
                 pendingContactsModel: root.pendingContactsModel
                 pendingReceivedContactsCount: root.pendingReceivedContactsCount
+                dismissedReceivedRequestContactsModel: root.dismissedReceivedRequestContactsModel
             }
         }
 

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -12,12 +12,14 @@ ContactListItemDelegate {
     property bool showSendMessageButton: false
     property bool showRejectContactRequestButton: false
     property bool showAcceptContactRequestButton: false
+    property bool showRemoveRejectionButton: false
     property string contactText: ""
 
     signal contextMenuRequested
     signal sendMessageRequested
     signal acceptContactRequested
     signal rejectRequestRequested
+    signal removeRejectionRequested
 
     icon.width: 40
     icon.height: 40

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -32,6 +32,11 @@ ContactListItemDelegate {
             icon.color: Theme.palette.directColor1
             tooltip.text: qsTr("Send message")
             onClicked: root.sendMessageRequested()
+
+            StatusToolTip {
+                text: qsTr('Send message')
+                visible: parent.hovered
+            }
         },
         StatusFlatRoundButton {
             objectName: "declineBtn"
@@ -42,6 +47,11 @@ ContactListItemDelegate {
             icon.color: Theme.palette.dangerColor1
             tooltip.text: qsTr("Reject")
             onClicked: root.rejectRequestRequested()
+
+            StatusToolTip {
+                text: qsTr('Decline Request')
+                visible: parent.hovered
+            }
         },
         StatusFlatRoundButton {
             objectName: "acceptBtn"
@@ -52,6 +62,25 @@ ContactListItemDelegate {
             icon.color: Theme.palette.successColor1
             tooltip.text: qsTr("Accept")
             onClicked: root.acceptContactRequested()
+
+            StatusToolTip {
+                text: qsTr('Accept Request')
+                visible: parent.hovered
+            }
+        },
+        StatusFlatRoundButton {
+            objectName: "removeRejectBtn"
+            visible: showRemoveRejectionButton
+            width: visible ? 32 : 0
+            height: visible ? 32 : 0
+            icon.name: "cancel"
+            icon.color: Theme.palette.dangerColor1
+            onClicked: root.removeRejectionRequested()
+
+            StatusToolTip {
+                text: qsTr('Remove Rejection')
+                visible: parent.hovered
+            }
         },
         StatusBaseText {
             text: root.contactText

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -16,6 +16,7 @@ StatusListView {
     signal sendMessageRequested(string publicKey)
     signal acceptContactRequested(string publicKey)
     signal rejectContactRequested(string publicKey)
+    signal rejectionRemoved(string publicKey)
 
     objectName: "ContactListPanel_ListView"
 
@@ -32,6 +33,7 @@ StatusListView {
         showRejectContactRequestButton:
             model.contactRequest === Constants.ContactRequestState.Received
         showAcceptContactRequestButton: showRejectContactRequestButton
+        showRemoveRejectionButton: model.contactRequest === Constants.ContactRequestState.Dismissed
 
         contactText: model.contactRequest === Constants.ContactRequestState.Sent
                      ? qsTr("Contact Request Sent") : ""
@@ -41,5 +43,6 @@ StatusListView {
         onSendMessageRequested: root.sendMessageRequested(model.pubKey)
         onAcceptContactRequested: root.acceptContactRequested(model.pubKey)
         onRejectRequestRequested: root.rejectContactRequested(model.pubKey)
+        onRemoveRejectionRequested: root.rejectionRemoved(model.pubKey)
     }
 }

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -31,6 +31,7 @@ SettingsContentBase {
     required property var blockedContactsModel
     required property var pendingContactsModel
     required property int pendingReceivedContactsCount
+    required property var dismissedReceivedRequestContactsModel
 
     property alias searchStr: searchBox.text
 
@@ -86,6 +87,13 @@ SettingsContentBase {
                 enabled: !root.pendingContactsModel.ModelCount.empty
                 text: qsTr("Pending Requests")
                 badge.value: root.pendingReceivedContactsCount
+            }
+            StatusTabButton {
+                objectName: "ContactsView_DismissedRequest_Button"
+
+                width: implicitWidth
+                enabled: !root.dismissedReceivedRequestContactsModel.ModelCount.empty
+                text: qsTr("Dismissed Requests")
             }
             StatusTabButton {
                 objectName: "ContactsView_Blocked_Button"
@@ -177,6 +185,21 @@ SettingsContentBase {
 
         ContactsList {
             model: SortFilterProxyModel {
+                sourceModel: root.dismissedReceivedRequestContactsModel
+
+                filters: UserSearchFilter {
+                    searchString: searchBox.text
+                }
+
+                sorters: StringSorter {
+                    roleName: "preferredDisplayName"
+                    caseSensitivity: Qt.CaseInsensitive
+                }
+            }
+        }
+
+        ContactsList {
+            model: SortFilterProxyModel {
                 sourceModel: root.blockedContactsModel
 
                 filters: UserSearchFilter {
@@ -198,6 +221,7 @@ SettingsContentBase {
         onSendMessageRequested: root.contactsStore.joinPrivateChat(publicKey)
         onAcceptContactRequested: root.contactsStore.acceptContactRequest(publicKey, "")
         onRejectContactRequested: root.contactsStore.dismissContactRequest(publicKey, "")
+        onRejectionRemoved: root.contactsStore.acceptContactRequest(publicKey, "")
     }
 
     component SectionComponent: Rectangle {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1752,6 +1752,7 @@ Item {
                             blockedContactsModel: contactsModelAdaptor.blockedContacts
                             pendingContactsModel: contactsModelAdaptor.pendingContacts
                             pendingReceivedContactsCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
+                            dismissedReceivedRequestContactsModel: contactsModelAdaptor.dimissedReceivedRequestContacts
 
                             Binding on settingsSubsection {
                                 value: profileLoader.settingsSubsection

--- a/ui/app/mainui/adaptors/ContactsModelAdaptor.qml
+++ b/ui/app/mainui/adaptors/ContactsModelAdaptor.qml
@@ -92,4 +92,19 @@ QObject {
             }
         ]
     }
+
+    readonly property var dimissedReceivedRequestContacts: SortFilterProxyModel {
+        sourceModel: root.allContacts ?? null
+
+        filters: [
+            ValueFilter {
+                roleName: "contactRequest"
+                value: Constants.ContactRequestState.Dismissed
+            },
+            ValueFilter {
+                roleName: "isBlocked"
+                value: false
+            }
+        ]
+    }
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -500,6 +500,7 @@ QtObject {
         readonly property int mutualContacts: 0
         readonly property int pendingContacts: 1
         readonly property int blockedContacts: 2
+        readonly property int rejectedReceivedContactRequest: 3
     }
 
     readonly property QtObject keypair: QtObject {


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/16844

Adds a tab in the Messaging>Contacts page that shows the dismissed contact requests.
it has a button to undo the rejection. That is simply a call to accept the old contact request, which then makes the two users mutual contacts

The first commit just adds tooltips to the buttons for the panel as the button without tooltip was very confusing.

### Affected areas

Contacts settings in Messaging

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

[dismissed-tab.webm](https://github.com/user-attachments/assets/118b597b-26e8-4ec7-b482-508f5b251346)

### Impact on end user

Makes it clearer that you can undo a dismissed contact request.

### How to test

0. Receive a contact request
1. Dismiss it
2. Check the new tab
3. Click the Remove Rejection button

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case something doesn't update until a restart
