### PR TITLE
feat(community): add option to see community rules

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/CommunityRulesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityRulesPopup.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    id: root
+
+    required property string name
+    required property string introMessage
+    required property string image
+    required property string color
+    
+
+    implicitWidth: 640 // design
+    title: qsTr("%1 community rules").arg(root.name)
+
+    onClosed: destroy()
+
+    contentItem: StatusScrollView {
+        id: scrollView
+        contentWidth: availableWidth
+        padding: 0
+
+        ColumnLayout {
+            width: scrollView.availableWidth
+            spacing: 24
+
+            StatusSmartIdenticon {
+                Layout.alignment: Qt.AlignHCenter
+                name: asset.isImage ? "" : root.name
+                asset.isImage: root.image !== ""
+                asset.name: root.image
+                asset.isLetterIdenticon: !asset.isImage
+                asset.color: root.color
+                asset.charactersLen: 1
+                asset.useAcronymForLetterIdenticon: false
+                asset.width: 64
+                asset.height: 64
+            }
+
+            StatusBaseText {
+                text: root.introMessage
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusButton {
+                text: qsTr("Done")
+                onClicked: root.close()
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -1,6 +1,7 @@
 AlertPopup 1.0 AlertPopup.qml
 BurnTokensPopup 1.0 BurnTokensPopup.qml
 CommunityProfilePopup 1.0 CommunityProfilePopup.qml
+CommunityRulesPopup 1.0 CommunityRulesPopup.qml
 CreateCategoryPopup 1.0 CreateCategoryPopup.qml
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CreateCommunityPopup 1.0 CreateCommunityPopup.qml

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1009,9 +1009,15 @@ Item {
                         }
 
                         StatusAction {
-                            text: qsTr("View Community")
-                            icon.name: "group-chat"
+                            text: qsTr("Community Info")
+                            icon.name: "info"
                             onTriggered: popups.openCommunityProfilePopup(appMain.rootStore, model, communityContextMenu.chatCommunitySectionModule)
+                        }
+
+                        StatusAction {
+                            text: qsTr("Community Rules")
+                            icon.name: "text"
+                            onTriggered: popups.openCommunityRulesPopup(model.name, model.introMessage, model.image, model.color)
                         }
 
                         StatusMenuSeparator {}

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -206,6 +206,10 @@ QtObject {
         openPopup(communityProfilePopup, { store: store, community: community, communitySectionModule: communitySectionModule})
     }
 
+    function openCommunityRulesPopup(name, introMessage, image, color) {
+        openPopup(communityRulesPopup, { name, introMessage, image, color })
+    }
+
     function openMarkAsIDVerifiedPopup(publicKey, cb) {
         const contactDetails = Utils.getContactDetailsAsJson(
                                  publicKey, true, true, true)
@@ -627,6 +631,14 @@ QtObject {
             id: communityProfilePopup
 
             CommunityProfilePopup {
+                onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: communityRulesPopup
+
+            CommunityRulesPopup {
                 onClosed: destroy()
             }
         },


### PR DESCRIPTION
### What does the PR do

Fixes #16826

Adds the option to see the community rules in the community context menu on the left.

Also adapts a few things according to designs.

### Affected areas

Community context menu

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Design: 
![image](https://github.com/user-attachments/assets/4b1c8301-a487-4f05-91f9-6f8b9d92fb22)


App:
![image](https://github.com/user-attachments/assets/f7b5afe8-40c1-4660-94de-d8b9b65dde96)

### Impact on end user

It's now possible to see the community rules after joining

### How to test

- Right click a community a click "View community rules"

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case: :shrug: 
