### PR TITLE
perf(SwapModal): improve the performance on tokenSelectorAdaptor

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -21,15 +21,8 @@ Item {
     width: 1200
     height: 800
 
-    ListModel {
+    TokensBySymbolModel {
         id: plainTokensModel
-        ListElement {
-            key: "aave"
-            name: "Aave"
-            symbol: "AAVE"
-            image: "https://cryptologos.cc/logos/aave-aave-logo.png"
-            communityId: ""
-        }
     }
 
     QtObject {

--- a/storybook/qmlTests/tests/tst_TokenSelectorViewAdaptor.qml
+++ b/storybook/qmlTests/tests/tst_TokenSelectorViewAdaptor.qml
@@ -3,6 +3,7 @@ import QtTest 1.15
 
 import Models 1.0
 
+import StatusQ 0.1
 import StatusQ.Core.Utils 0.1
 
 import AppLayouts.Wallet.stores 1.0
@@ -46,21 +47,6 @@ Item {
 
         function init() {
             controlUnderTest = createTemporaryObject(componentUnderTest, root)
-        }
-
-        function test_search() {
-            verify(!!controlUnderTest)
-
-            const searchText = "dAi"
-            const originalCount = controlUnderTest.outputAssetsModel.count
-            controlUnderTest.searchString = searchText
-
-            // search yields 1 result
-            tryCompare(controlUnderTest.outputAssetsModel, "count", 1)
-
-            // resetting search string resets the view back to original count
-            controlUnderTest.searchString = ""
-            tryCompare(controlUnderTest.outputAssetsModel, "count", originalCount)
         }
 
         function test_showCommunityAssets() {
@@ -128,11 +114,14 @@ Item {
             verify(!!controlUnderTest)
 
             controlUnderTest.showAllTokens = true
-            const searchText = "DAI"
-            controlUnderTest.searchString = searchText
+            let count = 0
+            ModelUtils.forEach(controlUnderTest.outputAssetsModel, (modelItem) => {
+                if (modelItem.tokensKey === "DAI")
+                    count++
+            })
 
-            // search yields 1 result
-            tryCompare(controlUnderTest.outputAssetsModel, "count", 1)
+            // only one DAI entry should be present
+            compare(count, 1)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -264,7 +264,11 @@ Item {
                 d.swapFormData.selectedNetworkChainId = StatusQUtils.ModelUtils.getByKey(RootStore.filteredFlatModel, "layer", 1, "chainId")
                 d.swapFormData.fromTokensKey = tokensKey
                 d.swapFormData.defaultToTokenKey = RootStore.areTestNetworksEnabled ? Constants.swap.testStatusTokenKey : Constants.swap.mainnetStatusTokenKey
-                Global.openSwapModalRequested(d.swapFormData)
+                Global.openSwapModalRequested(d.swapFormData, (popup) => {
+                    popup.Component.destruction.connect(() => {
+                        d.swapFormData.resetFormData()
+                    })
+                })
             }
             onDappPairRequested: root.dappPairRequested()
             onDappDisconnectRequested: (dappUrl) => root.dappDisconnectRequested(dappUrl)
@@ -391,7 +395,11 @@ Item {
                     d.swapFormData.fromTokensKey =  walletStore.currentViewedHoldingTokensKey
                 }
                 d.swapFormData.defaultToTokenKey = RootStore.areTestNetworksEnabled ? Constants.swap.testStatusTokenKey : Constants.swap.mainnetStatusTokenKey
-                Global.openSwapModalRequested(d.swapFormData)
+                Global.openSwapModalRequested(d.swapFormData, (popup) => {
+                    popup.Component.destruction.connect(() => {
+                        d.swapFormData.resetFormData()
+                    })
+                })
             }
             onLaunchBuyCryptoModal: d.launchBuyCryptoModal()
 

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -42,6 +42,9 @@ QtObject {
       rationale: https://github.com/status-im/status-desktop/pull/14959#discussion_r1627110880
       */
     function calculateMaxSafeSendAmount(value, symbol) {
+        if (!value) {
+            return 0
+        }
         if (symbol !== Constants.ethToken || value === 0) {
             return value
         }

--- a/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1
 import StatusQ.Popups.Dialog 0.1
@@ -93,7 +94,7 @@ Control {
 
             spacing: 4
 
-            model: sfpm
+            model: sfpm.ModelCount.count > 0 ? sfpm : null
             section.property: "sectionName"
 
             section.delegate: TokenSelectorSectionDelegate {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -126,7 +126,6 @@ StatusDialog {
     }
     onClosed: {
         root.swapAdaptor.stopUpdatesForSuggestedRoute()
-        root.swapAdaptor.reset()
         d.addMetricsEvent("popup closed")
     }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -401,8 +401,8 @@ QtObject {
         })
     }
 
-    function openSwapModal(parameters) {
-        openPopup(swapModal, {swapInputParamsForm: parameters})
+    function openSwapModal(parameters, callback) {
+        openPopup(swapModal, {swapInputParamsForm: parameters}, callback)
     }
 
     function openBuyCryptoModal(parameters) {
@@ -1254,7 +1254,10 @@ QtObject {
                     swapOutputData: SwapOutputData{}
                 }
                 loginType: root.rootStore.loginType
-                onClosed: destroy()
+                onClosed: {
+                    destroy()
+                    swapInputParamsForm.resetFormData()
+                }
             }
         },
         Component {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -90,7 +90,7 @@ QtObject {
     signal openPaymentRequestModalRequested(var callback)
 
     // Swap
-    signal openSwapModalRequested(var formDataParams)
+    signal openSwapModalRequested(var formDataParams, var callback)
 
     // BuyCrypto
     signal openBuyCryptoModalRequested(var formDataParams)


### PR DESCRIPTION
### What does the PR do

Closes #16981

Fixing the performance issues related to the data transformations done in `TokenSelectorViewAdaptor.qml` by reducing the complexity.

#### How was the data being processed

There are two inputs in the adaptor. The assets with balances submodels and a plain model of all tokens.
The output consists in a single model holding the assets with transformed balances as plain properties.

There are two options for the adaptor: To show all tokens,  or only the tokens with positive balance. When the output model provides all tokens, the ones with positive balance will be the first ones in the list, with a specific `sectionName` property.

The main culprit for the bad performance was that we've been transforming the two input models, concatenating the items in a single model and then process the model again to remove the duplicates and the other extra items based on network selection or unwanted items from the model with balances.

#### How it is processed now

The two input models are processed to provide lighter data as two different intermediate models. One holding only the items with positive balance and the other with all the assets, transformed to provide the data in the necessary format. These two models are joined using the left join proxy and filtered with lighter filters.

The proxies are structured in a more natural way processing only the necessary data, avoiding the access to synthetic roles as much as possible.

#### Improvements

Opening the modal:
before - 6sec
after - ~500ms

Closing the modal:
before - 4 sec
after - immediately

### Affected areas

SwapModal
SendModal
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### High regression risk

The regression risk is limited to the token list processing for the token selectors in Swap and Send modals.
Regressions to confirm:
- the tokens list provides the expected tokens, with the expected balances for the selected networks
- the tokens list can be searched
- the tokens list is updated once the balance is updated
- the tokens list works well with assets, collectibles and community tokens
- there is no performance regression

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

https://github.com/user-attachments/assets/767fef0e-0aa7-4a5a-bd91-a6c3fe9dfe60


