### PR TITLE
fix(MyProfileView): unbreak showing the "Preview as..." combo

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -34,7 +34,7 @@ Dialog {
 
     padding: 16
     // by design
-    margins: root.contentItem.Window.window.height <= 780 ? 28: 64
+    margins: root.contentItem.Window.height <= 780 ? 28 : 64
     modal: true
 
     // workaround for https://bugreports.qt.io/browse/QTBUG-87804

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -132,7 +132,7 @@ SettingsContentBase {
             colorId: root.profileStore.colorId
             colorHash: root.profileStore.colorHash
             onlineStatus: root.profileStore.currentUserStatus
-
+            isCurrentUser: true
             displayName: descriptionPanel.displayName.text
             bio: descriptionPanel.bio.text
             largeImage: profileHeader.previewIcon


### PR DESCRIPTION
### What does the PR do

- we are inside Settings, and `isCurrentUser` needs to be true for the profile perspective selector (aka the "Preview as..." combo) to be shown
- also fix the (unrelated) warning about `Window` being null

Fixes #17041

### Affected areas

Settings/Profile

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2025-01-09 14-31-25](https://github.com/user-attachments/assets/7fbb2af1-d4e8-458e-a046-d3d8cfd54d22)

