### PR TITLE
New onboarding integration (happy paths)

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -405,8 +405,7 @@ proc checkForStoringPasswordToKeychain(self: AppController) =
   else:
     self.keychainService.storeData(account.keyUid, self.startupModule.getPin())
 
-proc startupDidLoad*(self: AppController) =
-  # TODO move these functions to onboardingDidLoad
+proc initializeQmlContext(self: AppController) =
   singletonInstance.engine.setRootContextProperty("localAppSettings", self.localAppSettingsVariant)
   singletonInstance.engine.setRootContextProperty("localAccountSettings", self.localAccountSettingsVariant)
   singletonInstance.engine.setRootContextProperty("globalUtils", self.globalUtilsVariant)
@@ -415,11 +414,18 @@ proc startupDidLoad*(self: AppController) =
 
   # We need to init a language service once qml is loaded
   self.languageService.init()
-  # We need this to set app width/height appropriatelly on the app start.
+  # We need this to set app width/height appropriately on the app start.
   self.startupModule.startUpUIRaised()
+
+proc startupDidLoad*(self: AppController) =
+  if singletonInstance.featureFlags().getOnboardingV2Enabled():
+    # We will inialize in onboardingDidLoad
+    return
+  self.initializeQmlContext()
 
 proc onboardingDidLoad*(self: AppController) =
   debug "NEW ONBOARDING LOADED"
+  self.initializeQmlContext()
   # TODO when removing the old startup module, we should move the functions above here
 
 proc mainDidLoad*(self: AppController) =

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -53,6 +53,13 @@ proc init*(self: Controller) =
     self.delegate.onNodeLogin(signal.error, signal.account, signal.settings)
   self.connectionIds.add(handlerId)
 
+  handlerId = self.events.onWithUUID(SIGNAL_LOCAL_PAIRING_STATUS_UPDATE) do(e: Args):
+    let args = LocalPairingStatus(e)
+    if args.pairingType != PairingType.AppSync:
+      return
+    self.delegate.onLocalPairingStatusUpdate(args)
+  self.connectionIds.add(handlerId)
+
 proc setPin*(self: Controller, pin: string): bool =
   self.keycardServiceV2.setPin(pin)
   discard
@@ -106,3 +113,10 @@ proc restoreAccountAndLogin*(self: Controller, password, mnemonic: string, recov
 proc setLoggedInAccount*(self: Controller, account: AccountDto) =
   self.accountsService.setLoggedInAccount(account)
   self.accountsService.updateLoggedInAccount(account.name, account.images)
+
+proc loginLocalPairingAccount*(self: Controller, account: AccountDto, password, chatkey: string) =
+  self.accountsService.login(
+    account,
+    password,
+    chatPrivateKey = chatKey
+  )

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -43,6 +43,9 @@ proc delete*(self: Controller) =
 proc init*(self: Controller) =
   discard
 
+proc shouldStartWithOnboardingScreen*(self: Controller): bool =
+  return self.accountsService.openedAccounts().len == 0
+
 proc setPin*(self: Controller, pin: string): bool =
   self.keycardServiceV2.setPin(pin)
   discard

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -53,9 +53,6 @@ proc init*(self: Controller) =
     self.delegate.onNodeLogin(signal.error, signal.account, signal.settings)
   self.connectionIds.add(handlerId)
 
-proc shouldStartWithOnboardingScreen*(self: Controller): bool =
-  return self.accountsService.openedAccounts().len == 0
-
 proc setPin*(self: Controller, pin: string): bool =
   self.keycardServiceV2.setPin(pin)
   discard

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -120,3 +120,6 @@ proc loginLocalPairingAccount*(self: Controller, account: AccountDto, password, 
     password,
     chatPrivateKey = chatKey
   )
+
+proc finishPairingThroughSeedPhraseProcess*(self: Controller, installationId: string) =
+  self.devicesService.finishPairingThroughSeedPhraseProcess(installationId)

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -1,7 +1,9 @@
 import chronicles, strutils
 import io_interface
+import uuids
 
 import app/core/eventemitter
+import app/core/signals/types
 import app_service/service/general/service as general_service
 import app_service/service/accounts/service as accounts_service
 import app_service/service/accounts/dto/image_crop_rectangle
@@ -15,6 +17,7 @@ type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     events: EventEmitter
+    connectionIds: seq[UUID]
     generalService: general_service.Service
     accountsService: accounts_service.Service
     devicesService: devices_service.Service
@@ -37,11 +40,18 @@ proc newController*(
   result.devicesService = devicesService
   result.keycardServiceV2 = keycardServiceV2
 
+proc disconnect*(self: Controller) =
+  for id in self.connectionIds:
+    self.events.disconnect(id)
+
 proc delete*(self: Controller) =
-  discard
+  self.disconnect()
 
 proc init*(self: Controller) =
-  discard
+  var handlerId = self.events.onWithUUID(SignalType.NodeLogin.event) do(e:Args):
+    let signal = NodeSignal(e)
+    self.delegate.onNodeLogin(signal.error, signal.account, signal.settings)
+  self.connectionIds.add(handlerId)
 
 proc shouldStartWithOnboardingScreen*(self: Controller): bool =
   return self.accountsService.openedAccounts().len == 0
@@ -95,3 +105,7 @@ proc restoreAccountAndLogin*(self: Controller, password, mnemonic: string, recov
     ImageCropRectangle(),
     keycardInstanceUID,
   )
+
+proc setLoggedInAccount*(self: Controller, account: AccountDto) =
+  self.accountsService.setLoggedInAccount(account)
+  self.accountsService.updateLoggedInAccount(account.name, account.images)

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -16,9 +16,6 @@ method onNodeLogin*(self: AccessInterface, error: string, account: AccountDto, s
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method shouldStartWithOnboardingScreen*(self: AccessInterface): bool {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method setPin*(self: AccessInterface, pin: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -1,10 +1,16 @@
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
 
+from app_service/service/settings/dto/settings import SettingsDto
+from app_service/service/accounts/dto/accounts import AccountDto
+
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onAppLoaded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onNodeLogin*(self: AccessInterface, error: string, account: AccountDto, settings: SettingsDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method load*(self: AccessInterface) {.base.} =
@@ -38,3 +44,6 @@ method finishOnboardingFlow*(self: AccessInterface, flowInt: int, dataJson: stri
 type
   DelegateInterface* = concept c
     c.onboardingDidLoad()
+    c.appReady()
+    c.finishAppLoading()
+    c.userLoggedIn()

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -3,6 +3,7 @@ type
 
 from app_service/service/settings/dto/settings import SettingsDto
 from app_service/service/accounts/dto/accounts import AccountDto
+from app_service/service/devices/dto/local_pairing_status import LocalPairingStatus
 
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
@@ -35,6 +36,9 @@ method inputConnectionStringForBootstrapping*(self: AccessInterface, connectionS
   raise newException(ValueError, "No implementation available")
 
 method finishOnboardingFlow*(self: AccessInterface, flowInt: int, dataJson: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onLocalPairingStatusUpdate*(self: AccessInterface, status: LocalPairingStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -10,6 +10,9 @@ method onAppLoaded*(self: AccessInterface) {.base.} =
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method shouldStartWithOnboardingScreen*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setPin*(self: AccessInterface, pin: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -28,7 +28,7 @@ method validateLocalPairingConnectionString*(self: AccessInterface, connectionSt
 method inputConnectionStringForBootstrapping*(self: AccessInterface, connectionString: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method finishOnboardingFlow*(self: AccessInterface, primaryFlowInt, secondaryFlowInt: int, dataJson: string): string {.base.} =
+method finishOnboardingFlow*(self: AccessInterface, flowInt: int, dataJson: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -75,6 +75,9 @@ method load*[T](self: Module[T]) =
   self.controller.init()
   self.delegate.onboardingDidLoad()
 
+method shouldStartWithOnboardingScreen*[T](self: Module[T]): bool =
+  self.controller.shouldStartWithOnboardingScreen()
+
 method setPin*[T](self: Module[T], pin: string): bool =
   self.controller.setPin(pin)
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -135,7 +135,7 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
           seedPhrase,
           recoverAccount = true,
           keycardInstanceUID = "",
-        )
+        )        
       of SecondaryFlow.LoginWithSyncing:
         # The pairing was already done directly through inputConnectionStringForBootstrapping, we can login
         self.controller.loginLocalPairingAccount(
@@ -183,6 +183,10 @@ method onNodeLogin*[T](self: Module[T], error: string, account: AccountDto, sett
   #   # TODO: Handle error
   #   return
 
+  if self.localPairingStatus.installation.id != "":
+    # We tried to login by pairing, so finilize the process
+    self.controller.finishPairingThroughSeedPhraseProcess(self.localPairingStatus.installation.id)
+  
   self.finishAppLoading2()
 
 method onLocalPairingStatusUpdate*[T](self: Module[T], status: LocalPairingStatus) =

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -176,7 +176,7 @@ method onNodeLogin*[T](self: Module[T], error: string, account: AccountDto, sett
 
   self.controller.setLoggedInAccount(account)
 
-  if self.localPairingStatus.installation.id != "":
+  if self.localPairingStatus != nil and self.localPairingStatus.installation != nil and self.localPairingStatus.installation.id != "":
     # We tried to login by pairing, so finilize the process
     self.controller.finishPairingThroughSeedPhraseProcess(self.localPairingStatus.installation.id)
   

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -78,9 +78,6 @@ method load*[T](self: Module[T]) =
   self.controller.init()
   self.delegate.onboardingDidLoad()
 
-method shouldStartWithOnboardingScreen*[T](self: Module[T]): bool =
-  self.controller.shouldStartWithOnboardingScreen()
-
 method setPin*[T](self: Module[T], pin: string): bool =
   self.controller.setPin(pin)
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -34,6 +34,7 @@ type
     view: View
     viewVariant: QVariant
     controller: Controller
+    localPairingStatus: LocalPairingStatus
 
 proc newModule*[T](
     delegate: T,
@@ -136,7 +137,12 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
           keycardInstanceUID = "",
         )
       of SecondaryFlow.LoginWithSyncing:
-        self.controller.inputConnectionStringForBootstrapping(data["connectionString"].str)
+        # The pairing was already done directly through inputConnectionStringForBootstrapping, we can login
+        self.controller.loginLocalPairingAccount(
+          self.localPairingStatus.account,
+          self.localPairingStatus.password,
+          self.localPairingStatus.chatKey,
+        )
       of SecondaryFlow.LoginWithKeycard:
         # TODO implement keycard function
         discard
@@ -178,5 +184,9 @@ method onNodeLogin*[T](self: Module[T], error: string, account: AccountDto, sett
   #   return
 
   self.finishAppLoading2()
+
+method onLocalPairingStatusUpdate*[T](self: Module[T], status: LocalPairingStatus) =
+  self.localPairingStatus = status
+  self.view.setSyncState(status.state.int)
 
 {.pop.}

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -176,13 +176,6 @@ method onNodeLogin*[T](self: Module[T], error: string, account: AccountDto, sett
 
   self.controller.setLoggedInAccount(account)
 
-  # TODO this might be only needed on other calls?
-  # let err = self.delegate.userLoggedIn()
-  # if err.len > 0:
-  #   echo "ERROR from userLoggedIn: ", error
-  #   # TODO: Handle error
-  #   return
-
   if self.localPairingStatus.installation.id != "":
     # We tried to login by pairing, so finilize the process
     self.controller.finishPairingThroughSeedPhraseProcess(self.localPairingStatus.installation.id)

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -18,6 +18,9 @@ QtObject:
     result.QObject.setup
     result.delegate = delegate
 
+
+  ### QtProperties ###
+
   proc syncStateChanged*(self: View) {.signal.}
   proc getSyncState(self: View): int {.slot.} =
     return self.syncState
@@ -57,6 +60,12 @@ QtObject:
   proc setAddKeyPairState*(self: View, addKeyPairState: int) =
     self.addKeyPairState = addKeyPairState
     self.addKeyPairStateChanged()
+
+
+  ### slots ###
+
+  proc shouldStartWithOnboardingScreen(self: View): bool {.slot.} =
+    return self.delegate.shouldStartWithOnboardingScreen()
 
   proc setPin(self: View, pin: string): bool {.slot.} =
     return self.delegate.setPin(pin)

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -84,5 +84,5 @@ QtObject:
   # proc mnemonicWasShown(self: View): string {.slot.} =
   #   return self.delegate.getMnemonic()
 
-  proc finishOnboardingFlow(self: View, primaryFlowInt: int, secondaryFlowInt: int, dataJson: string): string {.slot.} =
-    self.delegate.finishOnboardingFlow(primaryFlowInt, secondaryFlowInt, dataJson)
+  proc finishOnboardingFlow(self: View, flowInt: int, dataJson: string): string {.slot.} =
+    self.delegate.finishOnboardingFlow(flowInt, dataJson)

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -19,6 +19,10 @@ QtObject:
     result.delegate = delegate
 
 
+  ### QtSignals ###
+
+  proc appLoaded*(self: View) {.signal.}
+
   ### QtProperties ###
 
   proc syncStateChanged*(self: View) {.signal.}

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -68,9 +68,6 @@ QtObject:
 
   ### slots ###
 
-  proc shouldStartWithOnboardingScreen(self: View): bool {.slot.} =
-    return self.delegate.shouldStartWithOnboardingScreen()
-
   proc setPin(self: View, pin: string): bool {.slot.} =
     return self.delegate.setPin(pin)
 

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -47,9 +47,10 @@ public:
     };
 
     enum class SyncState {
+        Idle,
         InProgress,
-        Success,
-        Failed
+        Failed,
+        Success
     };
 
 private:

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -34,6 +34,12 @@ Page {
         onboardingFlow.init()
     }
 
+    function unload() {
+        stack.clear()
+        d.resetState()
+        d.settings.reset()
+    }
+
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -5,9 +5,17 @@ import StatusQ.Core.Utils 0.1 as StatusQUtils
 import AppLayouts.Onboarding.enums 1.0
 
 QtObject {
+    id: root
+    signal appLoaded()
+
     readonly property QtObject d: StatusQUtils.QObject {
         id: d
         readonly property var onboardingModuleInst: onboardingModule
+    }
+
+    readonly property var _conn: Connections {
+        target: d.onboardingModuleInst
+        onAppLoaded: root.appLoaded()
     }
 
     // keycard

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -14,6 +14,10 @@ QtObject {
     readonly property int keycardState: d.onboardingModuleInst.keycardState // cf. enum Onboarding.KeycardState
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
 
+    function finishOnboardingFlow(flow: int, data: Object) { // -> bool
+        return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
+    }
+
     function setPin(pin: string) { // -> bool
         return d.onboardingModuleInst.setPin(pin)
     }

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -14,6 +14,10 @@ QtObject {
     readonly property int keycardState: d.onboardingModuleInst.keycardState // cf. enum Onboarding.KeycardState
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
 
+    function shouldStartWithOnboardingScreen() { // -> bool
+        return d.onboardingModuleInst.shouldStartWithOnboardingScreen()
+    }
+
     function finishOnboardingFlow(flow: int, data: Object) { // -> bool
         return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
     }

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -11,11 +11,10 @@ QtObject {
     readonly property QtObject d: StatusQUtils.QObject {
         id: d
         readonly property var onboardingModuleInst: onboardingModule
-    }
-
-    readonly property var _conn: Connections {
-        target: d.onboardingModuleInst
-        onAppLoaded: root.appLoaded()
+        readonly property var conn: Connections {
+            target: d.onboardingModuleInst
+            onAppLoaded: root.appLoaded()
+        }
     }
 
     // keycard

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -22,10 +22,6 @@ QtObject {
     readonly property int keycardState: d.onboardingModuleInst.keycardState // cf. enum Onboarding.KeycardState
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
 
-    function shouldStartWithOnboardingScreen() { // -> bool
-        return d.onboardingModuleInst.shouldStartWithOnboardingScreen()
-    }
-
     function finishOnboardingFlow(flow: int, data: Object) { // -> bool
         return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
     }

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -33,7 +33,7 @@ QtObject {
 
     // password
     function getPasswordStrengthScore(password: string) { // -> int
-        return d.onboardingModuleInst.getPasswordStrengthScore(password)
+        return d.onboardingModuleInst.getPasswordStrengthScore(password, "") // The second argument is username
     }
 
     // seedphrase/mnemonic

--- a/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
@@ -7,4 +7,5 @@ QtObject {
     property bool sendViaPersonalChatEnabled
     property bool paymentRequestEnabled
     property bool simpleSendEnabled
+    property bool onboardingV2Enabled
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -93,16 +93,7 @@ Item {
     }
     readonly property WalletStores.BuyCryptoStore buyCryptoStore: WalletStores.BuyCryptoStore {}
 
-    readonly property AppStores.FeatureFlagsStore featureFlagsStore: AppStores.FeatureFlagsStore {
-        readonly property var featureFlags: typeof featureFlagsRootContextProperty !== undefined ? featureFlagsRootContextProperty : null
-
-        connectorEnabled: featureFlags ? featureFlags.connectorEnabled : false
-        dappsEnabled: featureFlags ? featureFlags.dappsEnabled : false
-        swapEnabled: featureFlags ? featureFlags.swapEnabled : false
-        sendViaPersonalChatEnabled: featureFlags ? featureFlags.sendViaPersonalChatEnabled : false
-        paymentRequestEnabled: featureFlags ? featureFlags.paymentRequestEnabled : false
-        simpleSendEnabled: featureFlags ? featureFlags.simpleSendEnabled : false
-    }
+    required property AppStores.FeatureFlagsStore featureFlagsStore
     // TODO: Only until the  old send modal transaction store can be replaced with this one
     readonly property WalletStores.TransactionStoreNew transactionStoreNew: WalletStores.TransactionStoreNew {}
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -178,12 +178,6 @@ StatusWindow {
     }
 
     function moveToAppMain() {
-        // We set main module to the Global singleton once user is logged in and we move to the main app.
-        appLoadingAnimation.active = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
-        appLoadingAnimation.runningProgressAnimation = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
-        if (!appLoadingAnimation.runningProgressAnimation) {
-            mainModule.fakeLoadingScreenFinished()
-        }
         Global.appIsReady = true
 
         loader.sourceComponent = app
@@ -233,6 +227,12 @@ StatusWindow {
                 startupOnboardingLoader.item.visible = false
             }
             else if(state === Constants.appState.main) {
+                // We set main module to the Global singleton once user is logged in and we move to the main app.
+                appLoadingAnimation.active = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
+                appLoadingAnimation.runningProgressAnimation = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
+                if (!appLoadingAnimation.runningProgressAnimation) {
+                    mainModule.fakeLoadingScreenFinished()
+                }
                 moveToAppMain()
             } else if(state === Constants.appState.appEncryptionProcess) {
                 loader.sourceComponent = undefined

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -388,12 +388,10 @@ StatusWindow {
             NumberAnimation on progress {
                 from: 0.0
                 to: 1
-                duration: startupOnboardingLoader.item.splashScreenDurationMs
+                // TODO find a way to unhardcode this
+                // Though there is no easy way to do it, because we do not get progress signals
+                duration: 3000
                 running: runningProgressAnimation
-                onStopped: {
-                    console.warn("!!! SPLASH SCREEN DONE")
-                    // TODO move to main screen
-                }
             }
         }
     }
@@ -438,7 +436,6 @@ StatusWindow {
             anchors.fill: parent
 
             networkChecksEnabled: true
-            splashScreenDurationMs: 3000
             biometricsAvailable: Qt.platform.os === Constants.mac
 
             onboardingStore: onboardingStoreLoader.item

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -29,7 +29,7 @@ StatusWindow {
     readonly property var featureFlags: typeof featureFlagsRootContextProperty !== undefined ? featureFlagsRootContextProperty : null
     // TODO get rid of direct access when the new login is available
     // We need this to make sure the module is loaded before we can use it
-    readonly property bool onboardingV2Enabled: featureFlags && featureFlags.onboardingV2Enabled && !!onboardingModule
+    readonly property bool onboardingV2Enabled: featureFlags && featureFlags.onboardingV2Enabled && typeof onboardingModule !== "undefined"
     property MetricsStore metricsStore: MetricsStore {}
     property UtilsStore utilsStore: UtilsStore {}
 
@@ -404,39 +404,6 @@ StatusWindow {
 
         sourceComponent: OnboardingStore {
             onAppLoaded: moveToAppMain()
-
-            function setPin(pin: string) { // -> bool
-                console.log("OnboardingStore.setPin", ["pin"])
-                return true
-            }
-
-            function startKeypairTransfer() { // -> void
-                console.log("OnboardingStore.startKeypairTransfer")
-            }
-
-            // seedphrase/mnemonic
-            function validMnemonic(mnemonic: string) { // -> bool
-                console.log("OnboardingStore.validMnemonic", ["mnemonic"])
-                return true
-            }
-            function getMnemonic() { // -> string
-                console.log("OnboardingStore.getMnemonic()")
-                return ["apple", "banana", "cat", "cow", "catalog", "catch", "category", "cattle", "dog", "elephant", "fish", "grape"].join(" ")
-            }
-            function mnemonicWasShown() { // -> void
-                console.log("OnboardingStore.mnemonicWasShown()")
-            }
-            function removeMnemonic() { // -> void
-                console.log("OnboardingStore.removeMnemonic()")
-            }
-
-            function validateLocalPairingConnectionString(connectionString: string) { // -> bool
-                console.log("OnboardingStore.validateLocalPairingConnectionString", ["connectionString"])
-                return !Number.isNaN(parseInt(connectionString))
-            }
-            function inputConnectionStringForBootstrapping(connectionString: string) { // -> void
-                console.log("OnboardingStore.inputConnectionStringForBootstrapping", ["connectionString"])
-            }
         }
     }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -378,12 +378,11 @@ StatusWindow {
             NumberAnimation on progress {
                 from: 0.0
                 to: 1
-                duration: onboarding.splashScreenDurationMs
+                duration: startupOnbaordingLoader.item.splashScreenDurationMs
                 running: runningProgressAnimation
                 onStopped: {
                     console.warn("!!! SPLASH SCREEN DONE")
-                    console.warn("!!! RESTARTING FLOW")
-                    onboarding.restartFlow()
+                    // TODO move to main screen
                 }
             }
         }
@@ -478,7 +477,14 @@ StatusWindow {
             onFinished: (flow, data) => {
                 console.warn("!!! ONBOARDING FINISHED; flow:", flow, "; data:", JSON.stringify(data))
 
-                console.warn("!!! SIMULATION: SHOWING SPLASH")
+                let error = onboardingStore.finishOnboardingFlow(flow, data)
+
+                if (error != "") {
+                    console.error("!!! ONBOARDING FINISHED WITH ERROR:", error)
+                    // TODO show error
+                    return
+                }
+                console.warn("!!! Onboarding completed!")
                 stack.clear()
                 stack.push(splashScreenV2, { runningProgressAnimation: true })
             }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -403,12 +403,6 @@ StatusWindow {
                 console.log("OnboardingStore.startKeypairTransfer")
             }
 
-            // password
-            function getPasswordStrengthScore(password: string) { // -> int
-                console.log("OnboardingStore.getPasswordStrengthScore", ["password"])
-                return Math.min(password.length-1, 4)
-            }
-
             // seedphrase/mnemonic
             function validMnemonic(mnemonic: string) { // -> bool
                 console.log("OnboardingStore.validMnemonic", ["mnemonic"])

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -193,8 +193,7 @@ StatusWindow {
         Theme.changeTheme(localAppSettings.theme, systemPalette.isCurrentSystemThemeDark())
         Theme.changeFontSize(localAccountSensitiveSettings.fontSize)
 
-        // TODO is this still needed
-        // d.runMockedKeycardControllerWindow()
+        d.runMockedKeycardControllerWindow()
     }
 
     //TODO remove direct backend access

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -27,7 +27,9 @@ StatusWindow {
     property bool appIsReady: false
 
     readonly property var featureFlags: typeof featureFlagsRootContextProperty !== undefined ? featureFlagsRootContextProperty : null
-    readonly property bool onboardingV2Enabled: featureFlags && featureFlags.onboardingV2Enabled
+    // TODO get rid of direct access when the new login is available
+    // We need this to make sure the module is loaded before we can use it
+    readonly property bool onboardingV2Enabled: featureFlags && featureFlags.onboardingV2Enabled && !!onboardingModule
     property MetricsStore metricsStore: MetricsStore {}
     property UtilsStore utilsStore: UtilsStore {}
 
@@ -443,10 +445,8 @@ StatusWindow {
         anchors.fill: parent
         sourceComponent: {
             if (applicationWindow.onboardingV2Enabled) {
-                if (onboardingStoreLoader.item.shouldStartWithOnboardingScreen()) {
-                    // TODO select a new component when we have the new login screens (for old users)
-                    return onboardingV2
-                }
+                // TODO select a new component when we have the new login screens (for old users)
+                return onboardingV2
             }
             return onboardingV1
         }


### PR DESCRIPTION
### What does the PR do

Fixes [#17044 ](https://github.com/status-im/status-desktop/issues/17004)
(I'll create a new issue for unhappy paths)

Branched on top of https://github.com/status-im/status-desktop/pull/16722

Integrates all the non-keycard flows for the new onboarding. All happy paths for those should work, including the pairing fallback.

Do note that the new onboarding only applies for **new** users. If you have a profile already, it will show the old startup/login/onboarding.
This is because the new screens for the Login are not implemented yet and the LoginView is super tied with the old startup module, so it's not worth it to extract it.

To use the new onboarding, you need to delete or rename your data folder.
Then, run the app with `export FLAG_ONBOARDING_V2_ENABLED=1`.

### Affected areas

None by default, because all of the new stuff is behind a feature flag.

The only thing that goes outside the scope of the feature flag is a small change on the status-go side to enable creating accounts without a displayName. (status-go PR: https://github.com/status-im/status-go/pull/6242)

Otherwise, if the feature flag is activated, the new onboarding module will be initiated **instead** of the old one and the new onboarding screens will show, but only for new users.

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

All flows except pairing (ignore the last part, I forgot to remove the forced error on pairing):
[new-onboarding.webm](https://github.com/user-attachments/assets/d6346875-03e5-424f-bc83-24f445427d0b)

Pairing:
[new-onboarding-pairing.webm](https://github.com/user-attachments/assets/cf7466c0-7ae0-4f2e-a74b-3700f7def7a8)

### Impact on end user

Nothing for now as it's hidden behind the feature flag

### How to test

- Clear or rename your data folder
- Launch with `export FLAG_ONBOARDING_V2_ENABLED=1`

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Low risk because it is behind a feature flag, but it would be better to have it tested by a QA still to catch bugs as early as possible
