### PR TITLE
feat(@desktop/wallet): Adapt invocations to New Simple Send Modal

### DIFF
--- a/storybook/qmlTests/tests/tst_SwapInputPanel.qml
+++ b/storybook/qmlTests/tests/tst_SwapInputPanel.qml
@@ -329,11 +329,8 @@ Item {
 
             const bottomItemText = findChild(amountToSendInput, "bottomItemText")
             verify(!!bottomItemText)
-            verify(!bottomItemText.visible)
-
-            const bottomItemTextLoadingComponent = findChild(amountToSendInput, "bottomItemTextLoadingComponent")
-            verify(!!bottomItemTextLoadingComponent)
-            verify(bottomItemTextLoadingComponent.visible)
+            verify(bottomItemText.visible)
+            verify(bottomItemText.loading)
         }
 
         function test_max_button_when_different_tokens_clicked() {

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -46,7 +46,11 @@ QtObject {
             return value
         }
 
-        return value - Math.max(0.0001, Math.min(0.01, value * 0.1))
+        const estFee = Math.max(0.0001, Math.min(0.01, value * 0.1))
+        const result = value - estFee
+
+        // Ensure the result is not negative
+        return Math.max(result, 0)
     }
 
     function getLabelForEstimatedTxTime(estimatedFlag) {

--- a/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
@@ -75,6 +75,12 @@ QObject {
     **/
     readonly property alias model: communityGroupsGrouppedByCollection
 
+    /** output model which follows same structure as the input collectiblesModel
+      The only add on here is that this model is not grouped and is filtered
+      based on account and chainId
+    **/
+    readonly property alias filteredFlatModel: initiallyFilteredAndSorted
+
     // In case collectibles are to be shown only on specific networks
     property var enabledChainIds: []
 

--- a/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/RecipientSelectorPanel.qml
@@ -27,6 +27,8 @@ Rectangle {
     property alias selectedRecipientAddress: recipientInputLoader.selectedRecipientAddress
     property alias selectedRecipientType: recipientInputLoader.selectedRecipientType
 
+    property bool interactive: true
+
     signal resolveENS(string ensName, string uuid)
 
     function ensNameResolved(resolvedPubKey, resolvedAddress, uuid) {
@@ -47,6 +49,8 @@ Rectangle {
             id: recipientInputLoader
 
             Layout.fillWidth: true
+
+            interactive: root.interactive
 
             savedAddressesModel: root.savedAddressesModel
             myAccountsModel: root.myAccountsModel

--- a/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
@@ -55,6 +55,12 @@ RowLayout {
     /** input property holds if the header is the sticky header **/
     property bool isStickyHeader
 
+    /** input property to show only ERC20 assets and no collectibles **/
+    property bool displayOnlyAssets
+
+    /** input property to decide if the header can be interacted with **/
+    property bool interactive: true
+
     /** input property for programatic selection of network **/
     property int selectedChainId
 
@@ -106,8 +112,10 @@ RowLayout {
                   TokenSelectorButton.Size.Small:
                   TokenSelectorButton.Size.Normal
 
+        enabled: root.interactive
+
         assetsModel: root.assetsModel
-        collectiblesModel: root.collectiblesModel
+        collectiblesModel: root.displayOnlyAssets ? null: root.collectiblesModel
 
         onCollectibleSelected: root.collectibleSelected(key)
         onCollectionSelected: root.collectionSelected(key)
@@ -142,6 +150,7 @@ RowLayout {
         multiSelection: false
         showSelectionIndicator: false
         showTitle: false
+        selectionAllowed: root.interactive
 
         Binding on selection {
             value: [root.selectedChainId]

--- a/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/StickySendModalHeader.qml
@@ -54,6 +54,12 @@ Control {
     /** input property for programatic selection of network **/
     property int selectedChainId
 
+    /** input property to decide if the header can be interacted with **/
+    property bool interactive: true
+
+    /** input property to show only ERC20 assets and no collectibles **/
+    property bool displayOnlyAssets
+
     /** signal to propagate that an asset was selected **/
     signal assetSelected(string key)
     /** signal to propagate that a collection was selected **/
@@ -119,6 +125,8 @@ Control {
 
         isStickyHeader: true
         isScrolling: root.stickyHeaderVisible
+        interactive: root.interactive
+        displayOnlyAssets: root.displayOnlyAssets
 
         networksModel: root.networksModel
         assetsModel: root.assetsModel

--- a/ui/app/AppLayouts/Wallet/views/RecipientView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RecipientView.qml
@@ -94,7 +94,7 @@ Loader {
             implicitWidth: parent.width
             modelData: d.savedAddrSelectedEntry.item
             radius: 8
-            clearVisible: true
+            clearVisible: root.interactive
             color: Theme.palette.indirectColor1
             sensor.enabled: false
             subTitle:  {
@@ -127,7 +127,7 @@ Loader {
 
             width: parent.width
             radius: 8
-            clearVisible: true
+            clearVisible: root.interactive
             color: Theme.palette.indirectColor1
             sensor.enabled: false
             subTitle: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -660,13 +660,13 @@ Item {
 
         // for simple send
         walletAccountsModel: WalletStores.RootStore.accounts
+        filteredFlatNetworksModel: WalletStores.RootStore.filteredFlatModel
         flatNetworksModel: WalletStores.RootStore.flatNetworks
         areTestNetworksEnabled: WalletStores.RootStore.areTestNetworksEnabled
         groupedAccountAssetsModel: appMain.walletAssetsStore.groupedAccountAssetsModel
         plainTokensBySymbolModel: appMain.tokensStore.plainTokensBySymbolModel
         showCommunityAssetsInSend: appMain.tokensStore.showCommunityAssetsInSend
         collectiblesBySymbolModel: WalletStores.RootStore.collectiblesStore.jointCollectiblesBySymbolModel
-        tokenBySymbolModel: appMain.tokensStore.plainTokensBySymbolModel
         savedAddressesModel: WalletStores.RootStore.savedAddresses
         recentRecipientsModel: appMain.transactionStore.tempActivityController1Model
 

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -295,7 +295,7 @@ Control {
 
         RowLayout {
             Layout.fillWidth: true
-            StatusBaseText {
+            StatusTextWithLoadingState {
                 id: bottomItem
 
                 objectName: "bottomItemText"
@@ -317,7 +317,8 @@ Control {
 
                 elide: Text.ElideMiddle
                 font.pixelSize: 13
-                color: Theme.palette.directColor5
+                customColor: Theme.palette.directColor5
+                loading: root.bottomTextLoading
 
                 MouseArea {
                     objectName: "amountToSend_mouseArea"
@@ -352,8 +353,6 @@ Control {
                 }
 
                 HoverHandler { id: hoverHandler }
-
-                visible: !root.bottomTextLoading
             }
             StatusIcon {
                 Layout.preferredWidth: 16
@@ -370,13 +369,6 @@ Control {
                 id: bottomRightComponent
                 Layout.alignment: Qt.AlignVCenter
             }
-        }
-
-        LoadingComponent {
-            objectName: "bottomItemTextLoadingComponent"
-            Layout.preferredWidth: bottomItem.width
-            Layout.preferredHeight: bottomItem.height
-            visible: root.bottomTextLoading
         }
     }
 }


### PR DESCRIPTION
fixes #17023

### What does the PR do

Implements the different invocations for Single network send and the logic needed to handle it effectively
This also brings in the feature to send a collectible and owner token which would have no worked thus far

### Affected areas

SimpleSendModal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
