### PR TITLE
fix: Remove threadpool data from logs on production builds

### DIFF
--- a/src/app/core/tasks/threadpool.nim
+++ b/src/app/core/tasks/threadpool.nim
@@ -53,8 +53,12 @@ proc runTask(safeTaskArg: ThreadSafeTaskArg) {.gcsafe, nimcall, raises: [].} =
 
   let messageType = parsed{"$type"}.getStr
 
-  debug "[threadpool task thread] initiating task", messageType=messageType,
-    threadid=getThreadId(), task=taskArg
+  if defined(production):
+    debug "[threadpool task thread] initiating task", messageType=messageType,
+      threadid=getThreadId()
+  else:
+    debug "[threadpool task thread] initiating task", messageType=messageType,
+      threadid=getThreadId(), task=taskArg
 
   try:
     safeTaskArg.tptr(taskArg)


### PR DESCRIPTION
### What does the PR do

Don't log the data shared between threads to reduce the risk of sensitive data leaks.