### PR TITLE
feat(onboarding): hook metrics to the new onboarding

### DIFF
--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -22,7 +22,7 @@ Page {
     required property var loginAccountsModel
 
     property bool biometricsAvailable: Qt.platform.os === Constants.mac
-    required property bool isBiometricsLogin // FIXME should come from the loginAccountsModel for each profile separately?
+    property bool isBiometricsLogin // FIXME should come from the loginAccountsModel for each profile separately?
     signal biometricsRequested() // emitted when the user wants to try the biometrics prompt again
 
     property bool networkChecksEnabled: true
@@ -44,7 +44,7 @@ Page {
     function restartFlow() {
         unload()
 
-        if (loginAccountsModel.ModelCount.empty)
+        if (!loginAccountsModel || loginAccountsModel.ModelCount.empty)
             onboardingFlow.init()
         else
             stack.push(loginScreenComponent)

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -29,6 +29,7 @@ Page {
     property alias keycardPinInfoPageDelay: onboardingFlow.keycardPinInfoPageDelay
 
     readonly property alias stack: stack
+    readonly property string currentPageName: stack.currentItem ? Utils.objectTypeName(stack.currentItem) : ""
 
     signal shareUsageDataRequested(bool enabled)
 

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -13,15 +13,11 @@ QtObject {
         id: d
         readonly property var onboardingModuleInst: onboardingModule
 
-        readonly property var conn: Connections {
-            target: d.onboardingModuleInst
-
-            Component.onCompleted: {
-                onboardingModuleInst.appLoaded.connect(root.appLoaded)
-                onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
-                onboardingModuleInst.obtainingPasswordSuccess.connect(root.obtainingPasswordSuccess)
-                onboardingModuleInst.obtainingPasswordError.connect(root.obtainingPasswordError)
-            }
+        Component.onCompleted: {
+            onboardingModuleInst.appLoaded.connect(root.appLoaded)
+            onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
+            onboardingModuleInst.obtainingPasswordSuccess.connect(root.obtainingPasswordSuccess)
+            onboardingModuleInst.obtainingPasswordError.connect(root.obtainingPasswordError)
         }
     }
 

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -967,4 +967,23 @@ QtObject {
 
         return ""
     }
+
+    function objectTypeName(item) {
+        let typeName = item.toString()
+
+        if (typeName.startsWith("QQuick"))
+            typeName = name.substring(6)
+
+        const underscoreIndex = typeName.indexOf("_")
+
+        if (underscoreIndex !== -1)
+            return typeName.substring(0, underscoreIndex)
+
+        const bracketIndex = typeName.indexOf("(")
+
+        if (bracketIndex !== -1)
+            return typeName.substring(0, bracketIndex)
+
+        return typeName
+    }
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -468,6 +468,14 @@ StatusWindow {
                 stack.clear()
                 stack.push(splashScreenV2, { runningProgressAnimation: true })
             }
+
+            onShareUsageDataRequested: {
+                applicationWindow.metricsStore.toggleCentralizedMetrics(enabled)
+                if (enabled) {
+                    Global.addCentralizedMetricIfEnabled("usage_data_shared", {placement: Constants.metricsEnablePlacement.onboarding})
+                }
+            }
+            onCurrentPageNameChanged: Global.addCentralizedMetricIfEnabled("navigation", {viewId: currentPageName})
         }
     }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -446,6 +446,9 @@ StatusWindow {
             objectName: "startupOnboardingLayout"
             anchors.fill: parent
 
+            // TODO implement those two
+            loginAccountsModel: ListModel {}
+            isBiometricsLogin: false
             networkChecksEnabled: true
             biometricsAvailable: Qt.platform.os === Constants.mac
 


### PR DESCRIPTION
### What does the PR do

Fixes #17047

Hooks the same old metrics we had previously to the new onboarding.

The only difference is we cannot easily track the flow during page navigation because the flow is often jsut sent at the end. Anyway, I think mobile also doesn't give it and it's easy to infer the flow from the page name.

I added a required property to the OnboardinPages so that we cna get the page name and send it. If it's not set on some page, we just don't send a metric.

### Affected areas

Onboarding metrics

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

None, it works as before

### How to test

- Either enable the metrics in the onbaording and then check the metrics on mixpanel or just check the logs. You'll see `messageType=AsyncAddCentralizedMetricIfEnabledTaskArg`.

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

The only difference is the pages are not named the same as before, but that's expected since we changed the whole design.