### PR TITLE
fix: Remove threadpool data from logs on production builds

### DIFF
--- a/src/app/core/tasks/threadpool.nim
+++ b/src/app/core/tasks/threadpool.nim
@@ -53,8 +53,12 @@ proc runTask(safeTaskArg: ThreadSafeTaskArg) {.gcsafe, nimcall, raises: [].} =
 
   let messageType = parsed{"$type"}.getStr
 
-  debug "[threadpool task thread] initiating task", messageType=messageType,
-    threadid=getThreadId(), task=taskArg
+  if defined(production):
+    debug "[threadpool task thread] initiating task", messageType=messageType,
+      threadid=getThreadId()
+  else:
+    debug "[threadpool task thread] initiating task", messageType=messageType,
+      threadid=getThreadId(), task=taskArg
 
   try:
     safeTaskArg.tptr(taskArg)


### PR DESCRIPTION
(cherry picked from commit cd33dfb23d404654922f21554d26a4bbefb3460d)

### What does the PR do

Disable logging thread-pool shared data on production builds to avoid leaking user secrets.
