### PR TITLE
fix(perf): Optimize token prices propagation

### DIFF
--- a/src/app/modules/main/wallet_section/assets/view.nim
+++ b/src/app/modules/main/wallet_section/assets/view.nim
@@ -42,6 +42,8 @@ QtObject:
     notify = hasBalanceCacheChanged
 
   proc setHasBalanceCache*(self: View, hasBalanceCache: bool) =
+    if self.hasBalanceCache == hasBalanceCache:
+      return
     self.hasBalanceCache = hasBalanceCache
     self.hasBalanceCacheChanged()
 
@@ -53,6 +55,8 @@ QtObject:
     notify = hasMarketValuesCacheChanged
 
   proc setHasMarketValuesCache*(self: View, hasMarketValuesCache: bool) =
+    if self.hasMarketValuesCache == hasMarketValuesCache:
+      return
     self.hasMarketValuesCache = hasMarketValuesCache
     self.hasMarketValuesCacheChanged()
 

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -112,6 +112,8 @@ QtObject:
     self.delegate.setFilterAllAddresses()
 
   proc setTotalCurrencyBalance*(self: View, totalCurrencyBalance: CurrencyAmount) =
+    if totalCurrencyBalance == self.totalCurrencyBalance:
+      return
     self.totalCurrencyBalance = totalCurrencyBalance
     self.totalCurrencyBalanceChanged()
 

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -564,6 +564,10 @@ QtObject:
       error "error: ", procName="updateTokenPreferences", errName=e.name, errDesription=e.msg
 
   proc updateTokenPrices*(self: Service, updatedPrices: Table[string, float64]) =
-      for tokenSymbol, price in updatedPrices:
+    var anyUpdated = false
+    for tokenSymbol, price in updatedPrices:
+      if not self.tokenPriceTable.hasKey(tokenSymbol) or self.tokenPriceTable[tokenSymbol] != price:
+        anyUpdated = true
         self.tokenPriceTable[tokenSymbol] = price
+    if anyUpdated:
       self.events.emit(SIGNAL_TOKENS_PRICES_UPDATED, Args())


### PR DESCRIPTION
### What does the PR do

Closes #16994

Check if something has actually change in prices before reseting the wallet.

This would be the first line of defense for token prices updates. It seems to be enough for the send modal performance improvements.

The full solution to this issue (and maybe to a lot of wallet related UI perf issues) would be to send granular QML updates only for values that have actually changed. But this implies extensive nim+qml refactoring.

### Affected areas

SendModal
SwapModal
