### PR TITLE
Re-enable watch only accounts on release

### DIFF
--- a/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
@@ -23,7 +23,6 @@ pytestmark = marks
                              pytest.param('0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A', 'AccWatch1', '#2a4af5',
                                           'sunglasses', '1f60e', 'AccWatch1edited', '#216266', 'thumbsup', '1f44d')
                          ])
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15995')
 def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWindow, address: str, color: str, emoji: str,
                                                             emoji_unicode: str,
                                                             name: str, new_name: str, new_color: str, new_emoji: str,
@@ -32,8 +31,8 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
         wallet = main_screen.left_panel.open_wallet()
 
     with step('Create watched address from context menu'):
-        account_popup = wallet.left_panel.add_watched_address_from_context.click()
-        account_popup.set_name(name).set_emoji(emoji).set_color(color).set_eth_address(address).save_changes()
+        account_popup = wallet.left_panel.select_add_watched_address_from_context_menu()
+        account_popup.set_name(name).set_eth_address(address).save_changes()
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
@@ -46,10 +45,10 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
         account_popup = wallet.left_panel.open_edit_account_popup_from_context_menu(name)
 
     with step('Set new name, emoji and color for account and save'):
-        account_popup.set_name(new_name).set_emoji(new_emoji).set_color(new_color).save_changes()
+        account_popup.set_name(new_name).save_changes()
 
     with step('Verify that the account is correctly displayed in accounts list'):
-        expected_account = constants.user.account_list_item(new_name, new_color.lower(), new_emoji_unicode)
+        expected_account = constants.user.account_list_item(new_name, None, None)
         started_at = time.monotonic()
         while expected_account not in wallet.left_panel.accounts:
             time.sleep(1)

--- a/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
+++ b/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
@@ -14,7 +14,7 @@ StatusMenu {
     property string walletType
     property bool canDelete
     property bool hideFromTotalBalance
-    property bool canAddWatchOnlyAccount: false
+    property bool canAddWatchOnlyAccount: true
 
     signal editAccountClicked()
     signal deleteAccountClicked()

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -75,7 +75,6 @@ Rectangle {
             walletType: account ? account.walletType : ""
             canDelete: account && !account.isWallet
             hideFromTotalBalance: account && account.hideFromTotalBalance
-            canAddWatchOnlyAccount: !production
 
             onClosed: {
                 walletAccountContextMenu.active = false

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -20,12 +20,6 @@ StatusModal {
 
     property AddAccountStore store: AddAccountStore { }
 
-    enum LimitWarning {
-        Accounts,
-        Keypairs,
-        WatchOnlyAccounts
-    }
-
     width: Constants.addAccountPopup.popupWidth
 
     closePolicy: root.store.disablePopup? Popup.NoAutoClose : Popup.CloseOnEscape | Popup.CloseOnPressOutside
@@ -74,13 +68,13 @@ StatusModal {
                 property string content
 
                 function showPopup(warningType) {
-                    if (warningType === AddAccountPopup.LimitWarning.Accounts) {
+                    if (warningType === Constants.LimitWarning.Accounts) {
                         limitPopup.title = Constants.walletConstants.maxNumberOfAccountsTitle
                         limitPopup.content = Constants.walletConstants.maxNumberOfAccountsContent
-                    } else if (warningType === AddAccountPopup.LimitWarning.Keypairs) {
+                    } else if (warningType === Constants.LimitWarning.Keypairs) {
                         limitPopup.title = Constants.walletConstants.maxNumberOfKeypairsTitle
                         limitPopup.content = Constants.walletConstants.maxNumberOfKeypairsContent
-                    } else if (warningType === AddAccountPopup.LimitWarning.WatchOnlyAccounts) {
+                    } else if (warningType === Constants.LimitWarning.WatchOnlyAccounts) {
                         limitPopup.title = Constants.walletConstants.maxNumberOfWatchOnlyAccountsTitle
                         limitPopup.content = Constants.walletConstants.maxNumberOfSavedAddressesContent
                     } else {
@@ -158,10 +152,10 @@ StatusModal {
                     store: root.store
 
                     onWatchOnlyAccountsLimitReached: {
-                        limitPopup.showPopup(AddAccountPopup.LimitWarning.WatchOnlyAccounts)
+                        limitPopup.showPopup(Constants.LimitWarning.WatchOnlyAccounts)
                     }
                     onKeypairLimitReached: {
-                        limitPopup.showPopup(AddAccountPopup.LimitWarning.Keypairs)
+                        limitPopup.showPopup(Constants.LimitWarning.Keypairs)
                     }
                 }
             }

--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -9,8 +9,6 @@ import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
 import utils 1.0
-import StatusQ 0.1
-import SortFilterProxyModel 0.2
 
 import "../stores"
 import "../panels"
@@ -54,20 +52,6 @@ Item {
     QtObject {
         id: d
         readonly property bool isEdit: root.store.editMode
-
-        readonly property SortFilterProxyModel originModelWithoutWatchOnlyAcc: SortFilterProxyModel {
-            id: originModelWithoutWatchOnlyAcc
-            objectName: "originModelWithoutWatchOnlyAcc"
-            sourceModel: root.store.originModel
-
-            readonly property string addWatchOnlyAccKeyUid: Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
-            filters: [
-                FastExpressionFilter {
-                    expression: model.keyPair.keyUid !== originModelWithoutWatchOnlyAcc.addWatchOnlyAccKeyUid
-                    expectedRoles: ["keyPair"]
-                }
-            ]
-        }
 
         function openEmojiPopup(showLeft) {
             if (!root.store.emojiPopup) {
@@ -191,7 +175,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 userProfilePublicKey: root.store.userProfilePublicKey
-                originModel: root.store.editMode? [] : d.originModelWithoutWatchOnlyAcc
+                originModel: root.store.editMode? [] : root.store.originModel
                 selectedOrigin: root.store.selectedOrigin
                 caretVisible: !root.store.editMode
                 enabled: !root.store.editMode

--- a/ui/imports/shared/popups/addaccount/states/Main.qml
+++ b/ui/imports/shared/popups/addaccount/states/Main.qml
@@ -63,7 +63,6 @@ Item {
             readonly property string addWatchOnlyAccKeyUid: Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
             filters: [
                 FastExpressionFilter {
-                    enabled: production
                     expression: model.keyPair.keyUid !== originModelWithoutWatchOnlyAcc.addWatchOnlyAccKeyUid
                     expectedRoles: ["keyPair"]
                 }

--- a/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
+++ b/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
@@ -54,6 +54,9 @@ BasePopupStore {
         Constants.addAccountPopup.predefinedPaths.ethereumLedgerLive
     ]
 
+    readonly property bool isWatchOnlyImport: root.selectedOrigin.pairType === Constants.addAccountPopup.keyPairType.unknown &&
+                                            root.selectedOrigin.keyUid === Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc
+
     signal showLimitPopup(int warningType)
     signal resolvedENS(string resolvedPubKey, string resolvedAddress, string uuid)
 
@@ -97,23 +100,31 @@ BasePopupStore {
             return
         }
 
-        if(!event) {
-            if (!root.editMode && root.remainingAccountCapacity() === 0) {
-                root.showLimitPopup(0)
-                return
-            }
-
-            root.currentState.doPrimaryAction()
+        const handleEvent = !event || event.key === Qt.Key_Return || event.key === Qt.Key_Enter
+        if (!handleEvent) {
+            return
         }
-        else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+
+        if (handleEvent && !!event) {
             event.accepted = true
-            if (!root.editMode && root.remainingAccountCapacity() === 0) {
-                root.showLimitPopup(0)
-                return
-            }
-
-            root.currentState.doPrimaryAction()
         }
+
+        if (root.editMode) {
+            root.currentState.doPrimaryAction()
+            return
+        }
+
+        if (root.isWatchOnlyImport && root.remainingWatchOnlyAccountCapacity() === 0) {
+            root.showLimitPopup(Constants.LimitWarning.WatchOnlyAccounts)
+            return
+        }
+
+        if (root.remainingAccountCapacity() === 0) {
+            root.showLimitPopup(Constants.LimitWarning.Accounts)
+            return
+        }
+
+        root.currentState.doPrimaryAction()
     }
 
     function getSeedPhrase() {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1433,4 +1433,10 @@ QtObject {
         Theme.svg("walletconnect"),
         Theme.png("status-logo")
     ]
+
+    enum LimitWarning {
+        Accounts,
+        Keypairs,
+        WatchOnlyAccounts
+    }
 }


### PR DESCRIPTION
### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->
closes #15995

Revert the changes done by https://github.com/status-im/status-desktop/issues/15979 to enable the watch accounts on release.

