### PR TITLE
chore(@e2e): don't rely on build number env var when generating port number

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -63,7 +63,7 @@ pipeline {
         }
         stage('Linux/x86_64/Nix') { steps { script {
           linux_x86_64_nix = getArtifacts(
-            'Linux', jenkins.Build('status-desktop/systems/linux/x86_64/package-nix')
+            'Linux-Nix', jenkins.Build('status-desktop/systems/linux/x86_64/package-nix')
           )
         } } }
         stage('Windows/x86_64') { steps { script {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -7,7 +7,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.21"
+    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.21 && xcode-15.1"
   }
 
   parameters {

--- a/test/e2e/configs/squish.py
+++ b/test/e2e/configs/squish.py
@@ -1,5 +1,5 @@
 import os
 
-AUT_PORT = 61500 + int(os.getenv('BUILD_NUMBER', 0))
-SERVER_PORT = 4322 + int(os.getenv('BUILD_NUMBER', 0))
+AUT_PORT = 61500 + int(os.getenv('EXECUTOR_NUMBER', 0))
+SERVER_PORT = 4322 + int(os.getenv('EXECUTOR_NUMBER', 0))
 CURSOR_ANIMATION = False


### PR DESCRIPTION
### What does the PR do

- fixes https://github.com/status-im/status-desktop/issues/17077. The issue was that we were relying on BUILD_NUMBER env var, which was wrong (we started exceeding the max port range)
- rename linux nix stage in order to avoid confusion



