### PR TITLE
feat(onboarding): add AC notif for importing old accounts

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -2,12 +2,13 @@ import ./io_interface
 
 import ../../../global/app_signals
 import ../../../core/eventemitter
-import ../../../../app_service/service/activity_center/service as activity_center_service
-import ../../../../app_service/service/contacts/service as contacts_service
-import ../../../../app_service/service/message/service as message_service
-import ../../../../app_service/service/community/service as community_service
-import ../../../../app_service/service/chat/service as chat_service
-import ../../../../app_service/service/devices/service as devices_service
+import app_service/service/activity_center/service as activity_center_service
+import app_service/service/contacts/service as contacts_service
+import app_service/service/message/service as message_service
+import app_service/service/community/service as community_service
+import app_service/service/chat/service as chat_service
+import app_service/service/devices/service as devices_service
+import app_service/service/general/service as general_service
 
 type
   Controller* = ref object of RootObj
@@ -19,6 +20,7 @@ type
     chatService: chat_service.Service
     communityService: community_service.Service
     devicesService: devices_service.Service
+    generalService: general_service.Service
 
 proc newController*(
     delegate: io_interface.AccessInterface,
@@ -29,6 +31,7 @@ proc newController*(
     chatService: chat_service.Service,
     communityService: community_service.Service,
     devicesService: devices_service.Service,
+    generalService: general_service.Service,
     ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -39,6 +42,7 @@ proc newController*(
   result.chatService = chatService
   result.communityService = communityService
   result.devicesService = devicesService
+  result.generalService = generalService
 
 proc delete*(self: Controller) =
   discard
@@ -169,3 +173,6 @@ proc getActivityCenterReadType*(self: Controller): ActivityCenterReadType =
 
 proc enableInstallationAndSync*(self: Controller, installationId: string) =
   self.devicesService.enableInstallationAndSync(installationId)
+
+proc tryFetchingAgain*(self: Controller) =
+  self.generalService.asyncFetchWakuBackupMessages()

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -113,3 +113,6 @@ method setActivityGroupCounters*(self: AccessInterface, counters: Table[Activity
 
 method enableInstallationAndSync*(self: AccessInterface, installationId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method tryFetchingAgain*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -8,12 +8,13 @@ import ../../shared_models/message_item_qobject as msg_item_qobj
 import ../../../global/global_singleton
 import ../../../global/app_sections_config as conf
 import ../../../core/eventemitter
-import ../../../../app_service/service/activity_center/service as activity_center_service
-import ../../../../app_service/service/contacts/service as contacts_service
-import ../../../../app_service/service/message/service as message_service
-import ../../../../app_service/service/chat/service as chat_service
-import ../../../../app_service/service/community/service as community_service
-import ../../../../app_service/service/devices/service as devices_service
+import app_service/service/activity_center/service as activity_center_service
+import app_service/service/contacts/service as contacts_service
+import app_service/service/message/service as message_service
+import app_service/service/chat/service as chat_service
+import app_service/service/community/service as community_service
+import app_service/service/devices/service as devices_service
+import app_service/service/general/service as general_service
 
 export io_interface
 
@@ -35,6 +36,7 @@ proc newModule*(
     chatService: chat_service.Service,
     communityService: community_service.Service,
     devicesService: devices_service.Service,
+    generalService: general_service.Service,
     ): Module =
   result = Module()
   result.delegate = delegate
@@ -49,6 +51,7 @@ proc newModule*(
     chatService,
     communityService,
     devicesService,
+    generalService,
   )
   result.moduleLoaded = false
 
@@ -288,3 +291,6 @@ method setActivityGroupCounters*(self: Module, counters: Table[ActivityCenterGro
 
 method enableInstallationAndSync*(self: Module, installationId: string) =
   self.controller.enableInstallationAndSync(installationId)
+
+method tryFetchingAgain*(self: Module) =
+  self.controller.tryFetchingAgain()

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -207,3 +207,6 @@ QtObject:
 
   proc enableInstallationAndSync*(self: View, installationId: string) {.slot.} =
     self.delegate.enableInstallationAndSync(installationId)
+
+  proc tryFetchingAgain*(self: View) {.slot.} =
+    self.delegate.tryFetchingAgain()

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -233,7 +233,7 @@ proc newModule*[T](
     networkService, tokenService)
   result.gifsModule = gifs_module.newModule(result, events, gifService)
   result.activityCenterModule = activity_center_module.newModule(result, events, activityCenterService, contactsService,
-  messageService, chatService, communityService, devicesService)
+  messageService, chatService, communityService, devicesService, generalService)
   result.communitiesModule = communities_module.newModule(result, events, communityService, contactsService, communityTokensService,
     networkService, transactionService, tokenService, chatService, walletAccountService, keycardService)
   result.appSearchModule = app_search_module.newModule(result, events, contactsService, chatService, communityService,

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -89,5 +89,6 @@ type
   DelegateInterface* = concept c
     c.onboardingDidLoad()
     c.appReady()
+    c.userLoggedIn()
     c.finishAppLoading()
     c.userLoggedIn()

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -248,13 +248,18 @@ method onAccountLoginError*[T](self: Module[T], error: string) =
   if error.contains("file is not a database"):
     wrongPassword = true
   self.view.accountLoginError(error, wrongPassword)
-
-method onNodeLogin*[T](self: Module[T], error: string, account: AccountDto, settings: SettingsDto) =
-  if error.len != 0:
+  
+method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settings: SettingsDto) =
+  if err.len != 0:
     self.onAccountLoginError(error)
     return
 
   self.controller.setLoggedInAccount(account)
+
+  let err2 = self.delegate.userLoggedIn()
+  if err2.len != 0:
+    error "error from userLoggedIn", err2
+    return
 
   if self.localPairingStatus != nil and self.localPairingStatus.installation != nil and self.localPairingStatus.installation.id != "":
     # We tried to login by pairing, so finilize the process

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -251,7 +251,7 @@ method onAccountLoginError*[T](self: Module[T], error: string) =
   
 method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settings: SettingsDto) =
   if err.len != 0:
-    self.onAccountLoginError(error)
+    self.onAccountLoginError(err)
     return
 
   self.controller.setLoggedInAccount(account)

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -219,8 +219,8 @@ proc generateImage*(self: Controller, imageUrl: string, aX: int, aY: int, bX: in
       )
       return img.uri
 
-proc fetchWakuMessages*(self: Controller) =
-  self.generalService.fetchWakuMessages()
+proc asyncFetchWakuBackupMessages*(self: Controller) =
+  self.generalService.asyncFetchWakuBackupMessages()
 
 proc getCroppedProfileImage*(self: Controller): string =
   return self.tmpProfileImageDetails.croppedImage

--- a/src/app/modules/startup/internal/profile_fetching_announcement_state.nim
+++ b/src/app/modules/startup/internal/profile_fetching_announcement_state.nim
@@ -11,7 +11,7 @@ proc delete*(self: ProfileFetchingAnnouncementState) =
 method executePrimaryCommand*(self: ProfileFetchingAnnouncementState, controller: Controller) =
   if self.flowType == FlowType.FirstRunOldUserImportSeedPhrase or
     self.flowType == FlowType.FirstRunOldUserKeycardImport:
-      controller.fetchWakuMessages()
+      controller.asyncFetchWakuBackupMessages()
 
 method getNextPrimaryState*(self: ProfileFetchingAnnouncementState, controller: Controller): State =
   if self.flowType == FlowType.FirstRunOldUserImportSeedPhrase or

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -34,6 +34,10 @@ type ActivityCenterNotificationType* {.pure.}= enum
   CommunityUnbanned = 22
   NewInstallationReceived = 23
   NewInstallationCreated = 24
+  BackupSyncingFetching = 25
+  BackupSyncingSuccess = 26
+  BackupSyncingPartialFailure = 27
+  BackupSyncingFailure = 28
 
 type ActivityCenterGroup* {.pure.}= enum
   All = 0,
@@ -178,6 +182,10 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
         ActivityCenterNotificationType.CommunityUnbanned.int,
         ActivityCenterNotificationType.NewInstallationReceived.int,
         ActivityCenterNotificationType.NewInstallationCreated.int,
+        ActivityCenterNotificationType.BackupSyncingFetching.int,
+        ActivityCenterNotificationType.BackupSyncingSuccess.int,
+        ActivityCenterNotificationType.BackupSyncingPartialFailure.int,
+        ActivityCenterNotificationType.BackupSyncingFailure.int,
       ]
     of ActivityCenterGroup.Mentions:
       return @[ActivityCenterNotificationType.Mention.int]

--- a/src/app_service/service/general/async_tasks.nim
+++ b/src/app_service/service/general/async_tasks.nim
@@ -1,0 +1,16 @@
+
+type
+  AsyncFetchBackupWakuMessagesTaskArg = ref object of QObjectTaskArg
+
+proc asyncFetchWakuBackupMessagesTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncFetchBackupWakuMessagesTaskArg](argEncoded)
+  try:
+    let response = status_mailservers.requestAllHistoricMessagesWithRetries(forceFetchingBackup = true)
+    arg.finish(%* {
+      "response": response,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -152,6 +152,11 @@ Popup {
                 case ActivityCenterStore.ActivityCenterNotificationType.NewInstallationReceived:
                 case ActivityCenterStore.ActivityCenterNotificationType.NewInstallationCreated:
                     return newDeviceDetectedComponent
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingFetching:
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingSuccess:
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingPartialFailure:
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingFailure:
+                    return backupSyncingComponent
                 default:
                     return null
                 }
@@ -334,6 +339,23 @@ Popup {
                         });
                         break;
                 }
+            }
+        }
+    }
+
+    Component {
+        id: backupSyncingComponent
+
+        ActivityNotificationProfileFetching {
+            id: activityNotificationProfileFetching
+            type: setType(notification)
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            onTryAgainClicked: {
+                // Force the type back to in progress since the fetching is async and the state will not update imediately
+                activityNotificationProfileFetching.type = ActivityNotificationProfileFetching.FetchingState.Fetching
+
+                root.activityCenterStore.tryFetchingAgain()
             }
         }
     }

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -42,7 +42,11 @@ QtObject {
         CommunityBanned = 21,
         CommunityUnbanned = 22,
         NewInstallationReceived = 23,
-        NewInstallationCreated = 24
+        NewInstallationCreated = 24,
+        BackupSyncingFetching = 25,
+        BackupSyncingSuccess = 26,
+        BackupSyncingPartialFailure = 27,
+        BackupSyncingFailure = 28
     }
 
     enum ActivityCenterReadType {
@@ -122,5 +126,9 @@ QtObject {
 
     function enableInstallationAndSync(installationId) {
         root.activityCenterModuleInst.enableInstallationAndSync(installationId)
+    }
+
+    function tryFetchingAgain() {
+        root.activityCenterModuleInst.tryFetchingAgain()
     }
 }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationProfileFetching.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationProfileFetching.qml
@@ -1,0 +1,157 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+
+import shared 1.0
+import shared.panels 1.0
+import utils 1.0
+import mainui.activitycenter.stores 1.0
+
+
+ActivityNotificationBase {
+    id: root
+
+    required property int type // Possible values [FetchingState]
+
+    signal tryAgainClicked
+
+    function setType(notification) {
+        if (notification) {
+            switch (notification.notificationType) {
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingFetching:
+                    return ActivityNotificationProfileFetching.FetchingState.Fetching
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingSuccess:
+                    return ActivityNotificationProfileFetching.FetchingState.Success
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingPartialFailure:
+                    return ActivityNotificationProfileFetching.FetchingState.PartialFailure
+                case ActivityCenterStore.ActivityCenterNotificationType.BackupSyncingFailure:
+                    return ActivityNotificationProfileFetching.FetchingState.Failure
+            }
+        }
+        return ActivityNotificationProfileFetching.FetchingState.Unknown
+    }
+
+    enum FetchingState {
+        Unknown,
+        Fetching,
+        Success,
+        PartialFailure,
+        Failure
+    }
+
+    QtObject {
+        id: d
+
+        property string title: qsTr("Fetching profile details")
+        property string info: ""
+        property string badgeName: ""
+        property string ctaText: ""
+        property string badgeColor: ""
+    }
+
+    bodyComponent: RowLayout {
+        spacing: 8
+
+        StatusSmartIdenticon {
+            Layout.preferredWidth: 40
+            Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignTop
+            Layout.leftMargin: Theme.padding
+            Layout.topMargin: 2
+
+            asset {
+                width: 24
+                height: width
+                name: "download"
+                color: Theme.palette.primaryColor1
+                bgWidth: 40
+                bgHeight: 40
+                bgColor: Theme.palette.primaryColor3
+            }
+
+            bridgeBadge.visible: true
+            bridgeBadge.border.width: 2
+            bridgeBadge.color: d.badgeColor
+            bridgeBadge.image.source: Theme.svg(d.badgeName)
+        }
+
+        ColumnLayout {
+            spacing: 2
+            Layout.alignment: Qt.AlignTop
+            Layout.fillWidth: true
+
+            StatusMessageHeader {
+                Layout.fillWidth: true
+                displayNameLabel.text: d.title
+                timestamp: root.notification.timestamp
+            }
+
+            RowLayout {
+                spacing: Theme.padding
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    text: d.info
+                    font.italic: true
+                    wrapMode: Text.WordWrap
+                    color: Theme.palette.baseColor1
+                }
+            }
+        }
+    }
+
+    ctaComponent: StatusFlatButton {
+        size: StatusBaseButton.Size.Small
+        text: d.ctaText
+        onClicked: {
+            root.tryAgainClicked()
+        }
+    }
+
+    states: [
+        State {
+            when: root.type === ActivityNotificationProfileFetching.FetchingState.Fetching
+            PropertyChanges {
+                target: d
+                info: qsTr("Fetching all data may take some time")
+                badgeName: "dotsLoadings"
+                ctaText: ""
+                badgeColor: Theme.palette.baseColor3
+            }
+        },
+        State {
+            when: root.type === ActivityNotificationProfileFetching.FetchingState.Success
+            PropertyChanges {
+                target: d
+                info: qsTr("Profile details fetched successfully")
+                badgeName: "check"// TODO fix icon it looks bad
+                ctaText: ""
+                badgeColor: Theme.palette.successColor1
+            }
+        },
+        State {
+            when: root.type === ActivityNotificationProfileFetching.FetchingState.PartialFailure
+            PropertyChanges {
+                target: d
+                info: qsTr("Some profile details could not be fetched")
+                badgeName: "exclamation_outline" // TODO fix icon it looks bad
+                ctaText: qsTr("Try again")
+                badgeColor: Theme.palette.dangerColor1
+            }
+        },
+        State {
+            when: root.type === ActivityNotificationProfileFetching.FetchingState.Failure
+            PropertyChanges {
+                target: d
+                info: qsTr("Profile details could not be fetched")
+                badgeName: "exclamation_outline" // TODO fix icon it looks bad
+                ctaText: qsTr("Try again")
+                badgeColor: Theme.palette.dangerColor1
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### What does the PR do

Fixes #17028

When an old user imports an account, we now fetch the backups in the background and show an AC notification.

When the fetch is successful, the AC notif switches to a success message.

If after a timeout we detect that we didn't fetch anything or just part, we show an error and the possibility to try again.

Based on top of https://github.com/status-im/status-desktop/pull/17058

Status-go PR: https://github.com/status-im/status-go/pull/6255

### Affected areas

Onboarding and AC. In the status-go side, backup handling

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it (kindof lol)

[backup-fetching.webm](https://github.com/user-attachments/assets/e8efc850-9c44-4455-b4e0-6fe1c2a3ce0b)

@micieslak @caybro if I could request your help please. I managed to make all the states (pending, failure, success), but the badge looks ugly in all but the pending state.
If you could give me a hand in making sure the badge icon looks ok, I'd appreciate. See in the video how the checkmark is way to big for no reason.

### Impact on end user

Instead of waiting on a screen for the fetching to work only at the end they could move to the main screen, now they can see the app straight away and data is fetched in the background and shows up when it's ready.

### How to test

- Have an account that is backed up and import it using the new onboading with the recovery phrase
- To test the failure state, either let me know and I can tell you how to hack the code to simulate a failure or use the recovery phrase for an account that hasn't been used in 30 days. Or just use a random mnemonic

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case, the bakcup fetching doesn't work
