### PR TITLE
ci: only use hosts with Xcode 15.x

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -7,7 +7,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.21"
+    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.21 && xcode-15.1"
   }
 
   parameters {


### PR DESCRIPTION
## Summary

Restricts CI jobs to pick hosts with Xcode 15.
To fix errors like: 

```

[2025-01-16T06:24:14.963Z] + make status-go
[2025-01-16T06:24:15.412Z] ln: /Users/jenkins/workspace/s_macos_aarch64_package_PR-17076/vendor/status-go/vendor/github.com/siphiuel/lc-proxy-wrapper//.git/hooks: No such file or directory
[2025-01-16T06:24:15.859Z] ln: /Users/jenkins/workspace/s_macos_aarch64_package_PR-17076/vendor/status-go/vendor/github.com/siphiuel/lc-proxy-wrapper//.git/hooks: No such file or directory
[2025-01-16T06:24:16.303Z] Building: status-go
[2025-01-16T06:24:16.303Z] ln: /Users/jenkins/workspace/s_macos_aarch64_package_PR-17076/vendor/status-go/vendor/github.com/siphiuel/lc-proxy-wrapper//.git/hooks: No such file or directory
[2025-01-16T06:24:19.165Z] contracts/contracts.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:19.165Z] multiaccounts/settings/database_settings_manager.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] rpc/client.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] rpc/chain/client.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] rpc/chain/ethclient/eth_client.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] rpc/network/network.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/peer/service.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/reader.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/collectibles/collectible_data_db.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/onramp/types.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/router/pathprocessor/processor.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/thirdparty/collectible_types.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/thirdparty/paraswap/types.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] services/wallet/token/balance_persistence.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] transactions/transactor.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] transactions/fake/txservice.go:3: running "mockgen": signal: killed
[2025-01-16T06:24:20.104Z] make[1]: *** [generate] Error 1
[2025-01-16T06:24:20.104Z] make: *** [vendor/status-go/build/bin/libstatus.dylib] Error 2
script returned exit code 2
```
