### PR TITLE
feat(@desktop/wallet): Filter out community owner and master tokens rom single network send modal

### DIFF
--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -203,6 +203,8 @@ SplitView {
 
         networksModel: d.filteredNetworksModel
         collectiblesModel: collectiblesBySymbolModel
+
+        filterCommunityOwnerAndMasterTokens: true
     }
 
     ListModel {

--- a/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
@@ -78,6 +78,9 @@ QObject {
     // In case collectibles are to be shown only on specific networks
     property var enabledChainIds: []
 
+    // in case the community ownership and master tokens are to be filtered out
+    property bool filterCommunityOwnerAndMasterTokens: false
+
     LeftJoinModel {
         id: jointCollectiblesByNwChainId
         leftModel: collectiblesModel ?? null
@@ -140,6 +143,18 @@ QObject {
                 expression: root.enabledChainIds.includes(model.chainId)
                 expectedRoles: ["chainId"]
                 enabled: root.enabledChainIds.length
+            },
+            ValueFilter {
+                roleName: "communityPrivilegesLevel"
+                value: Constants.TokenPrivilegesLevel.Owner
+                enabled: root.filterCommunityOwnerAndMasterTokens
+                inverted: true
+            },
+            ValueFilter {
+                roleName: "communityPrivilegesLevel"
+                value: Constants.TokenPrivilegesLevel.TMaster
+                enabled: root.filterCommunityOwnerAndMasterTokens
+                inverted: true
             }
         ]
 

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -369,6 +369,7 @@ QtObject {
                             value: false
                         }
                     }
+                    filterCommunityOwnerAndMasterTokens: true
                 }
 
                 readonly property var totalFeesAggregator: FunctionAggregator {


### PR DESCRIPTION
### What does the PR do

Filters out community owner and master tokens from the tokens list in the new single network send modal

### Affected areas

SimpleSendModal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
