### PR TITLE
feat(Onboarding): implement the new `UnblockWithPukFlow` 

### DIFF
--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import AppLayouts.Onboarding2.pages 1.0
 
@@ -18,6 +19,7 @@ Item {
                                  return valid
                              }
         remainingAttempts: 3
+        unblockWithPukAvailable: ctrlUnblockWithPUK.checked
         onKeycardPinEntered: (pin) => {
                                  console.warn("!!! PIN:", pin)
                                  console.warn("!!! RESETTING FLOW")
@@ -35,10 +37,21 @@ Item {
         }
     }
 
-    Label {
-        anchors.bottom: parent.bottom
+    RowLayout {
         anchors.right: parent.right
-        text: "Hint: %1".arg(root.existingPin)
+        anchors.bottom: parent.bottom
+
+        CheckBox {
+            id: ctrlUnblockWithPUK
+            text: "Unblock with PUK available"
+            checked: true
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Label {
+            text: "Hint: %1".arg(root.existingPin)
+        }
     }
 }
 

--- a/storybook/pages/KeycardEnterPukPagePage.qml
+++ b/storybook/pages/KeycardEnterPukPagePage.qml
@@ -11,15 +11,25 @@ Item {
     KeycardEnterPukPage {
         id: page
         anchors.fill: parent
+        remainingAttempts: 3
         tryToSetPukFunction: (puk) => {
                                  console.warn("!!! ATTEMPTED PUK:", puk)
-                                 return puk === root.existingPuk
+                                 const valid = puk === root.existingPuk
+                                 if (!valid)
+                                     remainingAttempts--
+                                 return valid
                              }
         onKeycardPukEntered: (puk) => {
                                  console.warn("!!! CORRECT PUK:", puk)
                                  console.warn("!!! RESETTING FLOW")
                                  state = "entering"
                              }
+        onKeycardFactoryResetRequested: {
+            console.warn("onKeycardFactoryResetRequested")
+            console.warn("!!! RESETTING FLOW")
+            state = "entering"
+            remainingAttempts = 3
+        }
     }
 
     Label {
@@ -31,8 +41,3 @@ Item {
 
 // category: Onboarding
 // status: good
-// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45942&node-type=frame&m=dev
-// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45950&node-type=frame&m=dev
-// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45959&node-type=frame&m=dev
-// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45966&node-type=frame&m=dev
-// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45996&node-type=frame&m=dev

--- a/storybook/pages/KeycardEnterPukPagePage.qml
+++ b/storybook/pages/KeycardEnterPukPagePage.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import AppLayouts.Onboarding2.pages 1.0
+
+Item {
+    id: root
+
+    readonly property string existingPuk: "111111111111"
+
+    KeycardEnterPukPage {
+        id: page
+        anchors.fill: parent
+        tryToSetPukFunction: (puk) => {
+                                 console.warn("!!! ATTEMPTED PUK:", puk)
+                                 return puk === root.existingPuk
+                             }
+        onKeycardPukEntered: (puk) => {
+                                 console.warn("!!! CORRECT PUK:", puk)
+                                 console.warn("!!! RESETTING FLOW")
+                                 state = "entering"
+                             }
+    }
+
+    Label {
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        text: "Hint: %1".arg(root.existingPuk)
+    }
+}
+
+// category: Onboarding
+// status: good
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45942&node-type=frame&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45950&node-type=frame&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45959&node-type=frame&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45966&node-type=frame&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=1281-45996&node-type=frame&m=dev

--- a/storybook/pages/KeycardIntroPagePage.qml
+++ b/storybook/pages/KeycardIntroPagePage.qml
@@ -24,6 +24,9 @@ Item {
         id: introPage
         KeycardIntroPage {
             keycardState: ctrlKeycardState.currentValue
+            unblockWithPukAvailable: ctrlUnblockWithPUK.checked
+            unblockUsingSeedphraseAvailable: ctrlUnblockWithSeedphrase.checked
+            factoryResetAvailable: ctrlFactoryReset.checked
             displayPromoBanner: ctrlDisplayPromo.checked
             onEmptyKeycardDetected: console.warn("!!! EMPTY DETECTED")
             onNotEmptyKeycardDetected: console.warn("!!! NOT EMPTY DETECTED")
@@ -31,6 +34,8 @@ Item {
             onOpenLink: Qt.openUrlExternally(link)
             onOpenLinkWithConfirmation: Qt.openUrlExternally(link)
             onKeycardFactoryResetRequested: console.warn("!!! FACTORY RESET")
+            onUnblockWithSeedphraseRequested: console.warn("!!! UNBLOCK WITH SEEDPHRASE")
+            onUnblockWithPukRequested: console.warn("!!! UNBLOCK WITH PUK")
         }
     }
 
@@ -54,6 +59,26 @@ Item {
     RowLayout {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
+
+        CheckBox {
+            id: ctrlUnblockWithPUK
+            text: "Unblock with PUK available"
+            checked: true
+        }
+
+        CheckBox {
+            id: ctrlUnblockWithSeedphrase
+            text: "Unblock with seedphrase available"
+            checked: true
+        }
+
+        CheckBox {
+            id: ctrlFactoryReset
+            text: "Factory reset available"
+            checked: true
+        }
+
+        Item { Layout.fillWidth: true }
 
         CheckBox {
             id: ctrlDisplayPromo

--- a/storybook/pages/UnblockWithPukFlowPage.qml
+++ b/storybook/pages/UnblockWithPukFlowPage.qml
@@ -1,0 +1,210 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+import Models 1.0
+import Storybook 1.0
+
+import utils 1.0
+
+import AppLayouts.Onboarding2 1.0
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+SplitView {
+    id: root
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        OnboardingStackView {
+            id: stackView
+            anchors.fill: parent
+            Component.onCompleted: flow.init()
+        }
+
+        // needs to be on top of the stack
+        // we're here only to provide the Back button feature
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.BackButton
+            cursorShape: undefined // don't override the cursor coming from the stack
+            enabled: stackView.depth > 1 && !stackView.busy
+            onClicked: stackView.pop()
+        }
+
+        StatusBackButton {
+            width: 44
+            height: 44
+            anchors.left: parent.left
+            anchors.bottom: parent.bottom
+            anchors.margins: Theme.padding
+
+            opacity: stackView.depth > 1 && !stackView.busy && stackView.backAvailable ? 1 : 0
+            visible: opacity > 0
+
+            Behavior on opacity {
+                NumberAnimation { duration: 100 }
+            }
+
+            onClicked: stackView.pop()
+        }
+
+        Button {
+            anchors.bottom: parent.bottom
+            anchors.right: parent.right
+            anchors.margins: 10
+
+            visible: stackView.currentItem instanceof KeycardEnterPukPage
+
+            text: "Copy valid PUK (\"%1\")".arg(mockDriver.puk)
+            focusPolicy: Qt.NoFocus
+            onClicked: {
+                ClipboardUtils.setText(mockDriver.puk)
+            }
+        }
+    }
+
+    UnblockWithPukFlow {
+        id: flow
+        stackView: stackView
+        keycardState: mockDriver.keycardState
+        tryToSetPukFunction: mockDriver.setPuk
+        remainingAttempts: mockDriver.keycardRemainingPukAttempts
+        keycardPinInfoPageDelay: 1000
+        onKeycardPinCreated: (pin) => {
+                                 logs.logEvent("keycardPinCreated", ["pin"], arguments)
+                                 console.warn("!!! PIN CREATED:", pin)
+                             }
+        onReloadKeycardRequested: mockDriver.keycardState = Onboarding.KeycardState.NoPCSCService
+        onKeycardFactoryResetRequested: {
+            logs.logEvent("keycardFactoryResetRequested", ["pin"], arguments)
+            console.warn("!!! FACTORY RESET REQUESTED")
+        }
+        onFinished: {
+            console.warn("!!! UNLOCK WITH PUK FINISHED")
+            logs.logEvent("finished")
+            console.warn("!!! RESTARTING FLOW")
+
+            stackView.clear()
+            mockDriver.reset()
+            flow.init()
+        }
+    }
+
+    QtObject {
+        id: mockDriver
+
+        function reset() {
+            keycardState = Onboarding.KeycardState.NoPCSCService
+            keycardRemainingPukAttempts = 3
+        }
+
+        property int keycardState: Onboarding.KeycardState.NoPCSCService
+        property int keycardRemainingPukAttempts: 3
+
+        function setPuk(puk) { // -> bool
+            logs.logEvent("setPuk", ["puk"], arguments)
+            console.warn("!!! SET PUK:", puk)
+            const valid = puk === mockDriver.puk
+            if (!valid)
+                keycardRemainingPukAttempts--
+            if (keycardRemainingPukAttempts <= 0) { // SIMULATION: "block" the keycard
+                keycardState = Onboarding.KeycardState.BlockedPUK
+                keycardRemainingPukAttempts = 0
+            }
+            return valid
+        }
+
+        readonly property string puk: "111111111111"
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 200
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            spacing: 10
+
+            TextField {
+                Layout.fillWidth: true
+
+                text: {
+                    const stack = stackView
+                    let content = `Stack (${stack.depth}):`
+
+                    for (let i = 0; i < stack.depth; i++)
+                        content += " -> " + InspectionUtils.baseName(
+                                    stack.get(i, StackView.ForceLoad))
+
+                    return content
+                }
+
+                background: null
+                readOnly: true
+                selectByMouse: true
+                wrapMode: Text.Wrap
+            }
+
+            RowLayout {
+                Label {
+                    text: "Keycard state:"
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 2
+
+                    ButtonGroup {
+                        id: keycardStateButtonGroup
+                    }
+
+                    Repeater {
+                        model: [
+                            { value: Onboarding.KeycardState.NoPCSCService, text: "NoPCSCService" },
+                            { value: Onboarding.KeycardState.PluginReader, text: "PluginReader" },
+                            { value: Onboarding.KeycardState.InsertKeycard, text: "InsertKeycard" },
+                            { value: Onboarding.KeycardState.ReadingKeycard, text: "ReadingKeycard" },
+                            { value: Onboarding.KeycardState.WrongKeycard, text: "WrongKeycard" },
+                            { value: Onboarding.KeycardState.NotKeycard, text: "NotKeycard" },
+                            { value: Onboarding.KeycardState.MaxPairingSlotsReached, text: "MaxPairingSlotsReached" },
+                            { value: Onboarding.KeycardState.BlockedPIN, text: "BlockedPIN" },
+                            { value: Onboarding.KeycardState.BlockedPUK, text: "BlockedPUK" },
+                            { value: Onboarding.KeycardState.NotEmpty, text: "NotEmpty" },
+                            { value: Onboarding.KeycardState.Empty, text: "Empty" }
+                        ]
+
+                        RoundButton {
+                            text: modelData.text
+                            checkable: true
+                            checked: flow.keycardState === modelData.value
+
+                            ButtonGroup.group: keycardStateButtonGroup
+
+                            onClicked: mockDriver.keycardState = modelData.value
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// category: Onboarding
+// status: good

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -1032,8 +1032,8 @@ Item {
         function test_loginScreen_launchesExternalFlow_data() {
             return [
               { tag: "onboarding: create profile", delegateName: "createProfileDelegate", signalName: "onboardingCreateProfileFlowRequested", landingPageTitle: "Create profile" },
-              { tag: "onboarding: log in", delegateName: "logInDelegate", signalName: "onboardingLoginFlowRequested",  landingPageTitle: "Log in"},
-              // TODO cover also `signal unlockWithSeedphraseRequested()` and `signal lostKeycard()`
+              { tag: "onboarding: log in", delegateName: "logInDelegate", signalName: "onboardingLoginFlowRequested", landingPageTitle: "Log in" },
+              // TODO cover also `signal unblockWithSeedphraseRequested()` and `signal lostKeycard()`
             ]
         }
         function test_loginScreen_launchesExternalFlow(data) {

--- a/storybook/src/Storybook/BiometricsPopup.qml
+++ b/storybook/src/Storybook/BiometricsPopup.qml
@@ -15,6 +15,7 @@ Dialog {
 
     required property string password
     required property string pin
+    required property string selectedProfileIsKeycard
 
     // password signals
     signal accountLoginError(string error, bool wrongPassword)
@@ -76,7 +77,7 @@ Dialog {
             text: "Simulate correct fingerprint"
             onClicked: {
                 root.close()
-                root.obtainingPasswordSuccess(loginScreen.selectedProfileIsKeycard ? root.pin : root.password)
+                root.obtainingPasswordSuccess(root.selectedProfileIsKeycard ? root.pin : root.password)
             }
         }
         StatusButton {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSimpleTextPopup.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSimpleTextPopup.qml
@@ -5,11 +5,15 @@ import StatusQ.Core 0.1
 import StatusQ.Popups.Dialog 0.1
 
 StatusDialog {
+    id: root
+
     width: 600
     padding: 0
     standardButtons: Dialog.Ok
 
     property alias content: contentText
+
+    signal linkActivated(string link)
 
     StatusScrollView {
         id: scrollView
@@ -19,6 +23,7 @@ StatusDialog {
             id: contentText
             width: scrollView.availableWidth
             wrapMode: Text.Wrap
+            onLinkActivated: (link) => root.linkActivated(link)
         }
     }
 }

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -64,7 +64,8 @@ public:
         WrongKeycard,
         NotKeycard,
         MaxPairingSlotsReached,
-        Locked,
+        BlockedPIN, // PIN remaining attempts == 0
+        BlockedPUK, // PUK remaining attempts == 0
         // exit states
         NotEmpty,
         Empty

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -61,6 +61,7 @@ SQUtils.QObject {
         KeycardIntroPage {
             keycardState: root.keycardState
             displayPromoBanner: root.displayKeycardPromoBanner
+            factoryResetAvailable: true
 
             onReloadKeycardRequested: {
                 root.reloadKeycardRequested()

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -14,7 +14,8 @@ SQUtils.QObject {
 
     required property int keycardState
     required property var tryToSetPinFunction
-    required property int remainingAttempts
+    required property int remainingPinAttempts
+    required property int remainingPukAttempts
     required property var isSeedPhraseValid
 
     required property int keycardPinInfoPageDelay
@@ -26,6 +27,7 @@ SQUtils.QObject {
     signal seedphraseSubmitted(string seedphrase)
     signal reloadKeycardRequested
     signal keycardFactoryResetRequested
+    signal unblockWithPukRequested
     signal createProfileWithEmptyKeycardRequested
     signal finished
 
@@ -59,11 +61,13 @@ SQUtils.QObject {
         KeycardIntroPage {
             keycardState: root.keycardState
             displayPromoBanner: root.displayKeycardPromoBanner
-            unlockUsingSeedphrase: true
+            unblockUsingSeedphraseAvailable: true
+            unblockWithPukAvailable: root.remainingPukAttempts > 0 && (root.remainingPinAttempts === 1 || root.remainingPinAttempts === 2)
 
             onReloadKeycardRequested: d.reload()
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-            onUnlockWithSeedphraseRequested: root.stackView.push(seedphrasePage)
+            onUnblockWithSeedphraseRequested: root.stackView.push(seedphrasePage)
+            onUnblockWithPukRequested: root.unblockWithPukRequested()
             onEmptyKeycardDetected: root.stackView.replace(keycardEmptyPage)
             onNotEmptyKeycardDetected: root.stackView.replace(keycardEnterPinPage)
         }
@@ -85,8 +89,8 @@ SQUtils.QObject {
 
         KeycardEnterPinPage {
             tryToSetPinFunction: root.tryToSetPinFunction
-            remainingAttempts: root.remainingAttempts
-            unlockUsingSeedphrase: true
+            remainingAttempts: root.remainingPinAttempts
+            unblockWithPukAvailable: root.remainingPukAttempts > 0
 
             onKeycardPinEntered: (pin) => {
                 Backpressure.debounce(root, root.keycardPinInfoPageDelay, () => {
@@ -97,7 +101,7 @@ SQUtils.QObject {
 
             onReloadKeycardRequested: d.reload()
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-            onUnlockWithSeedphraseRequested: root.stackView.push(seedphrasePage)
+            onUnblockWithSeedphraseRequested: root.stackView.push(seedphrasePage)
         }
     }
 
@@ -105,8 +109,8 @@ SQUtils.QObject {
         id: seedphrasePage
 
         SeedphrasePage {
-            title: qsTr("Unlock Keycard using the recovery phrase")
-            btnContinueText: qsTr("Unlock")
+            title: qsTr("Unblock Keycard using the recovery phrase")
+            btnContinueText: qsTr("Unblock Keycard")
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -16,7 +16,8 @@ SQUtils.QObject {
     required property int addKeyPairState
     required property int syncState
     required property var seedWords
-    required property int remainingAttempts
+    required property int remainingPinAttempts
+    required property int remainingPukAttempts
 
     required property bool biometricsAvailable
     required property bool displayKeycardPromoBanner
@@ -29,6 +30,7 @@ SQUtils.QObject {
     required property var isSeedPhraseValid
     required property var validateConnectionString
     required property var tryToSetPinFunction
+    required property var tryToSetPukFunction
 
     signal keycardPinCreated(string pin)
     signal keycardPinEntered(string pin)
@@ -43,6 +45,8 @@ SQUtils.QObject {
 
     signal mnemonicWasShown()
     signal mnemonicRemovalRequested()
+
+    signal linkActivated(string link)
 
     signal finished(int flow)
 
@@ -250,7 +254,8 @@ SQUtils.QObject {
 
         stackView: root.stackView
         keycardState: root.keycardState
-        remainingAttempts: root.remainingAttempts
+        remainingPinAttempts: root.remainingPinAttempts
+        remainingPukAttempts: root.remainingPukAttempts
         displayKeycardPromoBanner: root.displayKeycardPromoBanner
         tryToSetPinFunction: root.tryToSetPinFunction
         isSeedPhraseValid: root.isSeedPhraseValid
@@ -262,6 +267,27 @@ SQUtils.QObject {
         onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
         onReloadKeycardRequested: root.reloadKeycardRequested()
         onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
+        onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
+        onUnblockWithPukRequested: unblockWithPukFlow.init()
+
+        onFinished: {
+            d.flow = Onboarding.SecondaryFlow.LoginWithKeycard
+            d.pushOrSkipBiometricsPage()
+        }
+    }
+
+    UnblockWithPukFlow {
+        id: unblockWithPukFlow
+
+        stackView: root.stackView
+        keycardState: root.keycardState
+        tryToSetPukFunction: root.tryToSetPukFunction
+        remainingAttempts: root.remainingPukAttempts
+
+        keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+
+        onReloadKeycardRequested: root.reloadKeycardRequested()
+        onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
 
         onFinished: {
@@ -321,10 +347,11 @@ SQUtils.QObject {
             title: qsTr("Status Software Privacy Policy")
             content {
                 textFormat: Text.MarkdownText
-                text: SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/privacy.mdwn"))
             }
             okButtonText: qsTr("Done")
             destroyOnClose: true
+            onOpened: content.text = SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/privacy.mdwn"))
+            onLinkActivated: (link) => root.linkActivated(link)
         }
     }
 
@@ -335,10 +362,11 @@ SQUtils.QObject {
             title: qsTr("Status Software Terms of Use")
             content {
                 textFormat: Text.MarkdownText
-                text: SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/terms-of-use.mdwn"))
             }
             okButtonText: qsTr("Done")
             destroyOnClose: true
+            onOpened: content.text = SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/terms-of-use.mdwn"))
+            onLinkActivated: (link) => root.linkActivated(link)
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -121,7 +121,7 @@ SQUtils.QObject {
             onCreateProfileWithPasswordRequested: createNewProfileFlow.init()
             onCreateProfileWithSeedphraseRequested: {
                 d.flow = Onboarding.SecondaryFlow.CreateProfileWithSeedphrase
-                useRecoveryPhraseFlow.init()
+                useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.NewProfile)
             }
             onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
         }
@@ -138,7 +138,7 @@ SQUtils.QObject {
 
             onLoginWithSeedphraseRequested: {
                 d.flow = Onboarding.SecondaryFlow.LoginWithSeedphrase
-                useRecoveryPhraseFlow.init()
+                useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.Login)
             }
         }
     }
@@ -236,7 +236,7 @@ SQUtils.QObject {
 
         onLoginWithSeedphraseRequested: {
             d.flow = Onboarding.SecondaryFlow.LoginWithSeedphrase
-            useRecoveryPhraseFlow.init()
+            useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.Login)
         }
 
         onFinished: {

--- a/ui/app/AppLayouts/Onboarding2/OnboardingStackView.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingStackView.qml
@@ -6,6 +6,9 @@ import StatusQ.Core.Theme 0.1
 StackView {
     id: root
 
+    readonly property bool backAvailable: currentItem ? (currentItem.backAvailableHint ?? true)
+                                                      : false
+
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
@@ -1,0 +1,109 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
+import StatusQ.Core.Backpressure 0.1
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+
+    required property int keycardState
+    required property var tryToSetPukFunction
+    required property int remainingAttempts
+
+    required property int keycardPinInfoPageDelay
+
+    signal keycardPinCreated(string pin)
+    signal reloadKeycardRequested
+    signal keycardFactoryResetRequested
+    signal finished
+
+    function init() {
+        root.stackView.push(d.initialComponent())
+    }
+
+    QtObject {
+        id: d
+
+        function initialComponent() {
+            if (root.keycardState === Onboarding.KeycardState.BlockedPIN)
+                return keycardEnterPukPage
+            if (root.keycardState === Onboarding.KeycardState.Empty || root.keycardState === Onboarding.KeycardState.NotEmpty)
+                return keycardUnblockedPage
+            return keycardIntroPage
+        }
+
+        function reload() {
+            root.reloadKeycardRequested()
+            root.stackView.replace(d.initialComponent(), StackView.PopTransition)
+        }
+
+        function finishWithFactoryReset() {
+            root.keycardFactoryResetRequested()
+            root.finished()
+        }
+    }
+
+    Component {
+        id: keycardIntroPage
+
+        KeycardIntroPage {
+            keycardState: root.keycardState
+            unblockWithPukAvailable: root.remainingAttempts > 0
+            unblockUsingSeedphraseAvailable: true
+            factoryResetAvailable: !unblockWithPukAvailable
+            onReloadKeycardRequested: d.reload()
+            onKeycardFactoryResetRequested: d.finishWithFactoryReset()
+            onEmptyKeycardDetected: root.stackView.replace(keycardUnblockedPage)
+            onNotEmptyKeycardDetected: root.stackView.replace(keycardUnblockedPage)
+            onUnblockWithPukRequested: root.stackView.push(keycardEnterPukPage)
+        }
+    }
+
+    Component {
+        id: keycardEnterPukPage
+
+        KeycardEnterPukPage {
+            tryToSetPukFunction: root.tryToSetPukFunction
+            remainingAttempts: root.remainingAttempts
+            onKeycardPukEntered: (puk) => root.stackView.replace(keycardCreatePinPage)
+            onKeycardFactoryResetRequested: d.finishWithFactoryReset()
+        }
+    }
+
+    Component {
+        id: keycardCreatePinPage
+
+        KeycardCreatePinPage {
+            onKeycardPinCreated: (pin) => {
+                Backpressure.debounce(root, root.keycardPinInfoPageDelay, () => {
+                    root.keycardPinCreated(pin)
+                    root.stackView.replace(keycardUnblockedPage, {title: qsTr("Unblock successful")})
+                })()
+            }
+        }
+    }
+
+    Component {
+        id: keycardUnblockedPage
+
+        KeycardBasePage {
+            image.source: Theme.png("onboarding/keycard/success")
+            title: qsTr("Your Keycard is already unblocked!")
+            buttons: [
+                StatusButton {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: qsTr("Continue")
+                    onClicked: root.finished()
+                }
+            ]
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -5,13 +5,13 @@ import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Onboarding2.pages 1.0
 
-
 SQUtils.QObject {
     id: root
 
     enum Type {
         NewProfile,
-        KeycardRecovery
+        KeycardRecovery,
+        Login
     }
 
     required property StackView stackView
@@ -30,6 +30,8 @@ SQUtils.QObject {
             title = qsTr("Create profile using a recovery phrase")
         else if (type === UseRecoveryPhraseFlow.Type.KeycardRecovery)
             title = qsTr("Enter recovery phrase of lost Keycard")
+        else if (type === UseRecoveryPhraseFlow.Type.Login)
+            title = qsTr("Log in with your Status recovery phrase")
 
         root.stackView.push(seedphrasePage, { title })
     }

--- a/ui/app/AppLayouts/Onboarding2/controls/MaybeOutlineButton.qml
+++ b/ui/app/AppLayouts/Onboarding2/controls/MaybeOutlineButton.qml
@@ -1,29 +1,11 @@
 import QtQuick 2.15
-import QtQml 2.15
 
-import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
-import StatusQ.Core.Theme 0.1
 
 StatusButton {
     id: root
 
     implicitWidth: 320
-
     // inside a Column (or another Positioner), make all but the first button outline
-    Binding on normalColor {
-        value: "transparent"
-        when: !root.Positioner.isFirstItem
-        restoreMode: Binding.RestoreBindingOrValue
-    }
-    Binding on borderWidth {
-        value: 1
-        when: !root.Positioner.isFirstItem
-        restoreMode: Binding.RestoreBindingOrValue
-    }
-    Binding on borderColor {
-        value: Theme.palette.baseColor2
-        when: !root.Positioner.isFirstItem
-        restoreMode: Binding.RestoreBindingOrValue
-    }
+    isOutline: !root.Positioner.isFirstItem
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -36,6 +36,7 @@ KeycardBasePage {
         StatusPinInput {
             id: pinInput
             anchors.horizontalCenter: parent.horizontalCenter
+            pinLen: Constants.keycard.general.keycardPinLength
             validator: StatusIntValidator { bottom: 0; top: 999999 }
             onPinInputChanged: {
                 if (pinInput.pinInput.length === pinInput.pinLen) { // we have the full length PIN now

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -17,12 +17,13 @@ KeycardBasePage {
 
     property var tryToSetPinFunction: (pin) => { console.error("tryToSetPinFunction: IMPLEMENT ME"); return false }
     required property int remainingAttempts
-    property bool unlockUsingSeedphrase
+    property bool unblockWithPukAvailable
 
     signal keycardPinEntered(string pin)
-    signal reloadKeycardRequested()
-    signal unlockWithSeedphraseRequested()
-    signal keycardFactoryResetRequested()
+    signal reloadKeycardRequested
+    signal unblockWithSeedphraseRequested
+    signal unblockWithPukRequested
+    signal keycardFactoryResetRequested
 
     image.source: Theme.png("onboarding/keycard/reading")
 
@@ -56,28 +57,27 @@ KeycardBasePage {
             color: Theme.palette.dangerColor1
             visible: false
         },
-        StatusButton {
-            id: btnFactoryReset
-            width: 320
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.topMargin: Theme.halfPadding
+        MaybeOutlineButton {
+            id: btnUnblockWithPuk
             visible: false
-            text: qsTr("Factory reset Keycard")
-            onClicked: root.keycardFactoryResetRequested()
-        },
-        StatusButton {
-            id: btnUnlockWithSeedphrase
-            visible: false
-            text: qsTr("Unlock with recovery phrase")
+            isOutline: false
+            text: qsTr("Unblock using PUK")
             anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: root.unlockWithSeedphraseRequested()
+            onClicked: root.unblockWithPukRequested()
         },
-        StatusButton {
+        MaybeOutlineButton {
+            id: btnUnblockWithSeedphrase
+            visible: false
+            isOutline: btnUnblockWithPuk.visible
+            text: qsTr("Unblock with recovery phrase")
+            anchors.horizontalCenter: parent.horizontalCenter
+            onClicked: root.unblockWithSeedphraseRequested()
+        },
+        MaybeOutlineButton {
             id: btnReload
-            width: 320
             anchors.horizontalCenter: parent.horizontalCenter
             visible: false
-            text: qsTr("I’ve inserted a different Keycard")
+            text: qsTr("I've inserted a different Keycard")
             normalColor: "transparent"
             borderWidth: 1
             borderColor: Theme.palette.baseColor2
@@ -89,11 +89,11 @@ KeycardBasePage {
 
     states: [
         State {
-            name: "locked"
+            name: "blocked"
             when: root.remainingAttempts <= 0
             PropertyChanges {
                 target: root
-                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Keycard locked") + "</font>"
+                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Keycard blocked") + "</font>"
             }
             PropertyChanges {
                 target: pinInput
@@ -104,12 +104,12 @@ KeycardBasePage {
                 source: Theme.png("onboarding/keycard/error")
             }
             PropertyChanges {
-                target: btnFactoryReset
-                visible: !root.unlockUsingSeedphrase
+                target: btnUnblockWithSeedphrase
+                visible: true
             }
             PropertyChanges {
-                target: btnUnlockWithSeedphrase
-                visible: root.unlockUsingSeedphrase
+                target: btnUnblockWithPuk
+                visible: root.unblockWithPukAvailable
             }
             PropertyChanges {
                 target: btnReload

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPukPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPukPage.qml
@@ -1,0 +1,103 @@
+import QtQuick 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
+import StatusQ.Core.Theme 0.1
+
+import AppLayouts.Onboarding2.controls 1.0
+
+import utils 1.0
+
+KeycardBasePage {
+    id: root
+
+    property var tryToSetPukFunction: (puk) => { console.error("tryToSetPukFunction: IMPLEMENT ME"); return false }
+
+    signal keycardPukEntered(string puk)
+
+    image.source: Theme.png("onboarding/keycard/reading")
+
+    QtObject {
+        id: d
+        readonly property int pukLen: Constants.keycard.general.keycardPukLength
+        property string tempPuk
+        property bool pukValid
+    }
+
+    buttons: [
+        StatusPinInput {
+            id: pukInput
+            anchors.horizontalCenter: parent.horizontalCenter
+            validator: StatusRegularExpressionValidator { regularExpression: new RegExp(`\\d{${d.pukLen}}`) }
+            pinLen: d.pukLen
+            additionalSpacingOnEveryNItems: 4
+            additionalSpacing: Theme.xlPadding
+            onPinInputChanged: {
+                if (pinInput.length === pinLen) { // we have the full length PUK now
+                    d.tempPuk = pinInput
+                    d.pukValid = root.tryToSetPukFunction(d.tempPuk)
+                    if (!d.pukValid) {
+                        pukInput.statesInitialization()
+                    }
+                }
+            }
+        },
+        StatusBaseText {
+            id: errorText
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: qsTr("The PUK is incorrect, try entering it again")
+            font.pixelSize: Theme.tertiaryTextFontSize
+            color: Theme.palette.dangerColor1
+            visible: false
+        }
+    ]
+
+    state: "entering"
+
+    states: [
+        State {
+            name: "incorrect"
+            when: !!d.tempPuk && !d.pukValid
+            PropertyChanges {
+                target: root
+                title: qsTr("PUK incorrect")
+            }
+            PropertyChanges {
+                target: errorText
+                visible: true
+            }
+        },
+        State {
+            name: "success"
+            when: d.pukValid
+            PropertyChanges {
+                target: root
+                title: qsTr("PUK correct")
+            }
+            PropertyChanges {
+                target: pukInput
+                enabled: false
+            }
+            StateChangeScript {
+                script: root.keycardPukEntered(pukInput.pinInput)
+            }
+        },
+        State {
+            name: "entering"
+            PropertyChanges {
+                target: root
+                title: qsTr("Enter Keycard PUK")
+            }
+            StateChangeScript {
+                script: {
+                    pukInput.statesInitialization()
+                    pukInput.forceFocus()
+                    d.tempPuk = ""
+                    d.pukValid = false
+                }
+            }
+        }
+    ]
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
@@ -17,10 +17,14 @@ KeycardBasePage {
 
     required property int keycardState // cf Onboarding.KeycardState
     property bool displayPromoBanner
-    property bool unlockUsingSeedphrase
+
+    property bool unblockWithPukAvailable
+    property bool unblockUsingSeedphraseAvailable
+    property bool factoryResetAvailable
 
     signal keycardFactoryResetRequested()
-    signal unlockWithSeedphraseRequested()
+    signal unblockWithSeedphraseRequested()
+    signal unblockWithPukRequested()
     signal reloadKeycardRequested()
     signal emptyKeycardDetected()
     signal notEmptyKeycardDetected()
@@ -81,18 +85,25 @@ KeycardBasePage {
 
     buttons: [
         MaybeOutlineButton {
+            id: btnUnblockWithPuk
+            visible: false
+            text: qsTr("Unblock using PUK")
+            anchors.horizontalCenter: parent.horizontalCenter
+            onClicked: root.unblockWithPukRequested()
+        },
+        MaybeOutlineButton {
+            id: btnUnblockWithSeedphrase
+            visible: false
+            text: qsTr("Unblock with recovery phrase")
+            anchors.horizontalCenter: parent.horizontalCenter
+            onClicked: root.unblockWithSeedphraseRequested()
+        },
+        MaybeOutlineButton {
             id: btnFactoryReset
             visible: false
             text: qsTr("Factory reset Keycard")
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: root.keycardFactoryResetRequested()
-        },
-        MaybeOutlineButton {
-            id: btnUnlockWithSeedphrase
-            visible: false
-            text: qsTr("Unlock with recovery phrase")
-            anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: root.unlockWithSeedphraseRequested()
         },
         MaybeOutlineButton {
             id: btnReload
@@ -192,22 +203,47 @@ KeycardBasePage {
             }
         },
         State {
-            name: "locked"
-            when: root.keycardState === Onboarding.KeycardState.Locked
+            name: "blockedPin"
+            when: root.keycardState === Onboarding.KeycardState.BlockedPIN
             PropertyChanges {
                 target: root
-                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Keycard locked") + "</font>"
-                subtitle: root.unlockUsingSeedphrase ? qsTr("The Keycard you have inserted is locked, you will need to unlock it using the recovery phrase or insert a different one")
-                                                     : qsTr("The Keycard you have inserted is locked, you will need to factory reset it or insert a different one")
+                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Keycard blocked") + "</font>"
+                subtitle: qsTr("The Keycard you have inserted is blocked, you will need to unblock it or insert a different one")
                 image.source: Theme.png("onboarding/keycard/error")
             }
             PropertyChanges {
-                target: btnFactoryReset
-                visible: !root.unlockUsingSeedphrase
+                target: btnUnblockWithPuk
+                visible: root.unblockWithPukAvailable
             }
             PropertyChanges {
-                target: btnUnlockWithSeedphrase
-                visible: root.unlockUsingSeedphrase
+                target: btnUnblockWithSeedphrase
+                visible: root.unblockUsingSeedphraseAvailable
+            }
+            PropertyChanges {
+                target: btnFactoryReset
+                visible: root.factoryResetAvailable
+            }
+            PropertyChanges {
+                target: btnReload
+                visible: true
+            }
+        },
+        State {
+            name: "blockedPuk"
+            when: root.keycardState === Onboarding.KeycardState.BlockedPUK
+            PropertyChanges {
+                target: root
+                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Keycard blocked") + "</font>"
+                subtitle: qsTr("The Keycard you have inserted is blocked, you will need to unblock it, factory reset or insert a different one")
+                image.source: Theme.png("onboarding/keycard/error")
+            }
+            PropertyChanges {
+                target: btnUnblockWithSeedphrase
+                visible: root.unblockUsingSeedphraseAvailable
+            }
+            PropertyChanges {
+                target: btnFactoryReset
+                visible: true
             }
             PropertyChanges {
                 target: btnReload

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -39,8 +39,9 @@ OnboardingPage {
     // "internal" onboarding signals, starting other flows
     signal onboardingCreateProfileFlowRequested()
     signal onboardingLoginFlowRequested()
-    signal unlockWithSeedphraseRequested()
-    signal unlockWithPukRequested()
+    signal unblockWithSeedphraseRequested()
+    signal unblockWithPukRequested()
+    signal keycardFactoryResetRequested()
     signal lostKeycard()
 
     QtObject {
@@ -176,7 +177,8 @@ OnboardingPage {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 64
                 model: root.loginAccountsModel
-                currentKeycardLocked: root.onboardingStore.keycardState === Onboarding.KeycardState.Locked
+                currentKeycardLocked: root.onboardingStore.keycardState === Onboarding.KeycardState.BlockedPIN ||
+                                      root.onboardingStore.keycardState === Onboarding.KeycardState.BlockedPUK
                 onSelectedProfileKeyIdChanged: {
                     d.resetBiometricsResult()
                     d.settings.lastKeyUid = selectedProfileKeyId
@@ -222,8 +224,10 @@ OnboardingPage {
                 keycardState: root.onboardingStore.keycardState
                 tryToSetPinFunction: root.onboardingStore.setPin
                 keycardRemainingPinAttempts: root.onboardingStore.keycardRemainingPinAttempts
-                onUnlockWithSeedphraseRequested: root.unlockWithSeedphraseRequested()
-                onUnlockWithPukRequested: root.unlockWithPukRequested()
+                keycardRemainingPukAttempts: root.onboardingStore.keycardRemainingPukAttempts
+                onUnblockWithSeedphraseRequested: root.unblockWithSeedphraseRequested()
+                onUnblockWithPukRequested: root.unblockWithPukRequested()
+                onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
                 onPinEditedManually: {
                     // reset state when typing the PIN manually; not to break the bindings inside the component
                     d.resetBiometricsResult()

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -12,6 +12,7 @@ KeycardAddKeyPairPage 1.0 KeycardAddKeyPairPage.qml
 KeycardCreatePinPage 1.0 KeycardCreatePinPage.qml
 KeycardEmptyPage 1.0 KeycardEmptyPage.qml
 KeycardEnterPinPage 1.0 KeycardEnterPinPage.qml
+KeycardEnterPukPage 1.0 KeycardEnterPukPage.qml
 KeycardIntroPage 1.0 KeycardIntroPage.qml
 KeycardLostPage 1.0 KeycardLostPage.qml
 KeycardNotEmptyPage 1.0 KeycardNotEmptyPage.qml

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -9,6 +9,7 @@ CreateProfilePage 1.0 CreateProfilePage.qml
 EnableBiometricsPage 1.0 EnableBiometricsPage.qml
 HelpUsImproveStatusPage 1.0 HelpUsImproveStatusPage.qml
 KeycardAddKeyPairPage 1.0 KeycardAddKeyPairPage.qml
+KeycardBasePage 1.0 KeycardBasePage.qml
 KeycardCreatePinPage 1.0 KeycardCreatePinPage.qml
 KeycardEmptyPage 1.0 KeycardEmptyPage.qml
 KeycardEnterPinPage 1.0 KeycardEnterPinPage.qml

--- a/ui/app/AppLayouts/Onboarding2/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/qmldir
@@ -7,4 +7,5 @@ OnboardingFlow 1.0 OnboardingFlow.qml
 OnboardingLayout 1.0 OnboardingLayout.qml
 OnboardingStackView 1.0 OnboardingStackView.qml
 RecoveryPhraseCreateProfileFlow 1.0 RecoveryPhraseCreateProfileFlow.qml
+UnblockWithPukFlow 1.0 UnblockWithPukFlow.qml
 UseRecoveryPhraseFlow 1.0 UseRecoveryPhraseFlow.qml

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -24,6 +24,7 @@ QtObject {
     // keycard
     readonly property int keycardState: d.onboardingModuleInst.keycardState // cf. enum Onboarding.KeycardState
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
+    readonly property int keycardRemainingPukAttempts: d.onboardingModuleInst.keycardRemainingPukAttempts
 
     function finishOnboardingFlow(flow: int, data: Object) { // -> bool
         return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
@@ -31,6 +32,10 @@ QtObject {
 
     function setPin(pin: string) { // -> bool
         return d.onboardingModuleInst.setPin(pin)
+    }
+
+    function setPuk(puk: string) { // -> bool
+        return d.onboardingModuleInst.setPuk(puk)
     }
 
     readonly property int addKeyPairState: d.onboardingModuleInst.addKeyPairState // cf. enum Onboarding.AddKeyPairState


### PR DESCRIPTION
### What does the PR do

- integrate the PUK unblock flow into the Onboarding and Login screen
- added a dedicated SB page for it
- remove the `Locked` keycard state everywhere in favor of `BlockedPIN` and `BlockedPUK`
- fix the various "(B)locked" buttons, based on the context and the state of the keycard

Fixes: https://github.com/status-im/status-desktop/issues/17092
Fixes: #17109
Iterates: #17098

### Affected areas

Onboarding

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Unblocking with PUK from both Onboarding and Login screens:

https://github.com/user-attachments/assets/0cfb1aaf-ee79-4abc-81f6-266b0862f6c3

