### PR TITLE
feat(metrics)_: update initializeapplication params with metrics flag and port

### DIFF
--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -268,6 +268,8 @@ proc openedAccounts*(path: string): RpcResponse[JsonNode] =
       "logDir": "", # Empty value defaults to `dataDir`
       "logLevel": status_const.getStatusGoLogLevel(),
       "apiLoggingEnabled": status_const.API_LOGGING,
+      "metricsEnabled": status_const.METRICS_ENABLED,
+      "metricsAddress": status_const.METRICS_ADDRESS
     }
     # Do not remove the sleep 700
     # This sleep prevents a crash on intel MacOS

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -76,6 +76,8 @@ let
   SENTRY_DSN_STATUS_GO_DESKTOP* = BUILD_SENTRY_DSN_STATUS_DESKTOP
   API_LOGGING* = desktopConfig.apiLogging
   KEYCARD_LOGS_ENABLED* = if defined(production): false else: true
+  METRICS_ENABLED* = desktopConfig.metricsEnabled
+  METRICS_ADDRESS* = desktopConfig.metricsAddress
 
 proc hasLogLevelOption*(): bool =
   for p in cliParams:

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -290,6 +290,16 @@ type StatusDesktopConfig = object
     desc: "Enables status-go API logging"
     name: $BASE_NAME_API_LOGGING
     abbr: "api-logging" .}: bool
+  metricsEnabled* {.
+    defaultValue: false
+    desc: "Enables metrics and starts prometheus"
+    name: "METRICS"
+    abbr: "metrics" .}: bool
+  metricsAddress* {.
+    defaultValue: "0.0.0.0:9305"
+    desc: "Sets address for prometheus metrics"
+    name: "METRICS_ADDRESS"
+    abbr: "metrics-address" .}: string
 
 # On macOS the first time when a user gets the "App downloaded from the
 # internet" warning, and clicks the Open button, the OS passes a unique process


### PR DESCRIPTION
### What does the PR do

Add parameters to `InitializeApplication` request for enabling prometheus and specifying port.
Corresponding status-go PR: https://github.com/status-im/status-go/pull/6256

This change is necessary to enable viewing metrics locally by running Prometheus/Grafana as specified here: https://github.com/waku-org/status-metrics

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

Application startup. Default behavior introduced by this change does not change anything.

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

(I glanced at the document but this is a relatively minor change that doesn't involve complex logic and only touches a small part of the application)
