### PR TITLE
feat(StatusButton): add an "outline" variant

### DIFF
--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -59,6 +59,7 @@ SplitView {
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
+                        isOutline: ctrlIsOutline.checked
                     }
                 }
 
@@ -78,6 +79,7 @@ SplitView {
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
+                        isOutline: ctrlIsOutline.checked
                     }
                 }
 
@@ -98,6 +100,7 @@ SplitView {
                         enabled: ctrlEnabled.checked
                         interactive: ctrlInteractive.checked
                         textFillWidth: ctrlFillWidth.checked
+                        isOutline: ctrlIsOutline.checked
                     }
                 }
 
@@ -119,6 +122,7 @@ SplitView {
                         interactive: ctrlInteractive.checked
                         isRoundIcon: true
                         textFillWidth: ctrlFillWidth.checked
+                        isOutline: ctrlIsOutline.checked
                     }
                 }
 
@@ -270,6 +274,10 @@ SplitView {
                         id: ctrlType
                         model: ["Normal", "Danger", "Primary", "Warning", "Success"] // enum StatusBaseButton.Type.xxx
                     }
+                    CheckBox {
+                        id: ctrlIsOutline
+                        text: "isOutline"
+                    }
                 }
                 RowLayout {
                     Label { text: "Width:" }
@@ -310,5 +318,12 @@ SplitView {
 }
 
 // category: Controls
-
-// https://www.figma.com/file/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?type=design&node-id=1-12&t=UHegCbqAa5K7qUKd-0
+// status: good
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-5905&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-5906&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-5612&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-5613&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-4920&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-4921&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-5328&m=dev
+// https://www.figma.com/design/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?node-id=1029-5329&m=dev

--- a/storybook/qmlTests/tests/tst_StatusButton.qml
+++ b/storybook/qmlTests/tests/tst_StatusButton.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtTest 1.15
 
 import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
 
 import Models 1.0
 
@@ -254,6 +255,27 @@ Item {
             compare(buttonIcon.visible, false)
             compare(buttonText.visible, true)
             compare(buttonEmoji.visible, false)
+        }
+
+        function test_outlineButton_data() {
+            return [
+                { tag: "normal", type: StatusBaseButton.Type.Normal },
+                { tag: "danger", type: StatusBaseButton.Type.Danger },
+                { tag: "warning", type: StatusBaseButton.Type.Warning },
+                { tag: "success", type: StatusBaseButton.Type.Success },
+                { tag: "primary", type: StatusBaseButton.Type.Primary },
+            ]
+        }
+
+        function test_outlineButton(data) {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, { text: "Hello", "icon.name": "gif", isOutline: true, type: data.type })
+            verify(!!controlUnderTest)
+
+            expectFail("primary", "Primary button can not be outline")
+            verify(Qt.colorEqual(controlUnderTest.normalColor, "transparent"))
+            verify(Qt.colorEqual(controlUnderTest.disabledColor, "transparent"))
+            compare(controlUnderTest.borderWidth, 1)
+            verify(Qt.colorEqual(controlUnderTest.borderColor, Theme.palette.baseColor2))
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -85,24 +85,25 @@ Button {
 
     font.family: Theme.baseFont.name
     font.weight: Font.Medium
-    font.pixelSize: size === StatusBaseButton.Size.Large ? 15 : 13
+    font.pixelSize: size === StatusBaseButton.Size.Large ? Theme.primaryTextFontSize
+                                                         : Theme.additionalTextSize
 
     horizontalPadding: {
         if (d.iconOnly) {
-            return isRoundIcon ? 8 : spacing
+            return isRoundIcon ? Theme.halfPadding : spacing
         }
         if (root.icon.name) {
             switch (size) {
             case StatusBaseButton.Size.Tiny:
-                return 8
+                return Theme.halfPadding
             case StatusBaseButton.Size.Small:
-                return 16
+                return Theme.padding
             case StatusBaseButton.Size.Large:
             default:
                 return 18
             }
         }
-        return size === StatusBaseButton.Size.Large ? 24 : 12
+        return size === StatusBaseButton.Size.Large ? Theme.bigPadding : 12
     }
     verticalPadding: {
         if (d.iconOnly) {
@@ -112,7 +113,7 @@ Button {
         case StatusBaseButton.Size.Tiny:
             return 5
         case StatusBaseButton.Size.Small:
-            return 8
+            return Theme.halfPadding
         case StatusBaseButton.Size.Large:
         default:
             return 11

--- a/ui/StatusQ/src/StatusQ/Controls/StatusButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusButton.qml
@@ -4,6 +4,24 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 StatusBaseButton {
+    id: root
+
+    property bool isOutline
+
+    states: [
+        State {
+            name: "outline"
+            when: root.isOutline && root.type !== StatusBaseButton.Type.Primary
+            PropertyChanges {
+                target: root
+                normalColor: "transparent"
+                disabledColor: "transparent"
+                borderWidth: 1
+                borderColor: Theme.palette.baseColor2
+            }
+        }
+    ]
+
     normalColor: {
         switch(type) {
         case StatusBaseButton.Type.Primary:


### PR DESCRIPTION
### What does the PR do

- only for `StatusButton` as for the `StatusFlatButton` it's not desired
- add support for showing the new variant to SB
- also use defined metrics for padding/spacing
- add a QML test

Fixes #17124

### Affected areas

StatusButton

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Light:
![image](https://github.com/user-attachments/assets/2a9ac127-50cc-4acb-b253-345227e091d3)

Dark: 
![image](https://github.com/user-attachments/assets/615d4d4e-44b6-45df-9746-c9a3e3c67de8)

