### PR TITLE
Implement the keycard flows for the new onboarding

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -178,7 +178,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   # Services
   result.generalService = general_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.keycardService = keycard_service.newService(statusFoundation.events, statusFoundation.threadpool)
-  result.keycardServiceV2 = keycard_serviceV2.newService(statusFoundation.events, statusFoundation.threadpool)
+  result.keycardServiceV2 = keycard_serviceV2.newService(statusFoundation.events, statusFoundation.threadpool, result.keycardService)
   result.nodeConfigurationService = node_configuration_service.newService(statusFoundation.fleetConfiguration,
   result.settingsService, statusFoundation.events)
   result.keychainService = keychain_service.newService(statusFoundation.events)
@@ -441,8 +441,10 @@ proc mainDidLoad*(self: AppController) =
     self.checkForStoringPasswordToKeychain()
 
 proc start*(self: AppController) =
+  if self.shouldUseTheNewOnboardingModule():
+    self.keycardServiceV2.init()
+
   self.keycardService.init()
-  self.keycardServiceV2.init()
   self.keychainService.init()
   self.generalService.init()
   self.accountsService.init()

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -3,6 +3,7 @@ type
 
 from app_service/service/settings/dto/settings import SettingsDto
 from app_service/service/accounts/dto/accounts import AccountDto
+from app_service/service/keycardV2/dto import KeycardEventDto, KeycardExportedKeysDto
 from app_service/service/devices/dto/local_pairing_status import LocalPairingStatus
 
 method delete*(self: AccessInterface) {.base.} =
@@ -17,7 +18,10 @@ method onNodeLogin*(self: AccessInterface, error: string, account: AccountDto, s
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setPin*(self: AccessInterface, pin: string): bool {.base.} =
+method initialize*(self: AccessInterface, pin: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method authorize*(self: AccessInterface, pin: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getPasswordStrengthScore*(self: AccessInterface, password, userName: string): int {.base.} =
@@ -35,10 +39,37 @@ method validateLocalPairingConnectionString*(self: AccessInterface, connectionSt
 method inputConnectionStringForBootstrapping*(self: AccessInterface, connectionString: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method loadMnemonic*(self: AccessInterface, dataJson: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method finishOnboardingFlow*(self: AccessInterface, flowInt: int, dataJson: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onLocalPairingStatusUpdate*(self: AccessInterface, status: LocalPairingStatus) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardStateUpdated*(self: AccessInterface, keycardEvent: KeycardEventDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardSetPinFailure*(self: AccessInterface, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardAuthorizeFailure*(self: AccessInterface, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardLoadMnemonicFailure*(self: AccessInterface, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardLoadMnemonicSuccess*(self: AccessInterface, keyUID: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardExportKeysFailure*(self: AccessInterface, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardExportKeysSuccess*(self: AccessInterface, exportedKeys: KeycardExportedKeysDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method exportRecoverKeys*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -12,6 +12,7 @@ import app_service/service/devices/service as devices_service
 import app_service/service/keycardV2/service as keycard_serviceV2
 from app_service/service/settings/dto/settings import SettingsDto
 from app_service/service/accounts/dto/accounts import AccountDto
+from app_service/service/keycardV2/dto import KeycardEventDto, KeycardExportedKeysDto, KeycardState
 
 export io_interface
 
@@ -22,13 +23,18 @@ type SecondaryFlow* {.pure} = enum
   Unknown = 0,
   CreateProfileWithPassword,
   CreateProfileWithSeedphrase,
-  CreateProfileWithKeycard,
   CreateProfileWithKeycardNewSeedphrase,
   CreateProfileWithKeycardExistingSeedphrase,
   LoginWithSeedphrase,
   LoginWithSyncing,
   LoginWithKeycard,
   ActualLogin, # TODO get the real name and value for this when it's implemented on the front-end
+
+type ProgressState* {.pure.} = enum
+  Idle,
+  InProgress,
+  Success,
+  Failed
 
 type
   Module*[T: io_interface.DelegateInterface] = ref object of io_interface.AccessInterface
@@ -38,6 +44,7 @@ type
     controller: Controller
     localPairingStatus: LocalPairingStatus
     currentFlow: SecondaryFlow
+    exportedKeys: KeycardExportedKeysDto
 
 proc newModule*[T](
     delegate: T,
@@ -82,8 +89,13 @@ method load*[T](self: Module[T]) =
   self.controller.init()
   self.delegate.onboardingDidLoad()
 
-method setPin*[T](self: Module[T], pin: string): bool =
-  self.controller.setPin(pin)
+method initialize*[T](self: Module[T], pin: string) =
+  self.view.setPinSettingState(ProgressState.InProgress.int)
+  self.controller.initialize(pin)
+
+method authorize*[T](self: Module[T], pin: string) =
+  self.view.setAuthorizationState(ProgressState.InProgress.int)
+  self.controller.authorize(pin)
 
 method getPasswordStrengthScore*[T](self: Module[T], password, userName: string): int =
   self.controller.getPasswordStrengthScore(password, userName)
@@ -92,13 +104,17 @@ method validMnemonic*[T](self: Module[T], mnemonic: string): bool =
   self.controller.validMnemonic(mnemonic)
 
 method getMnemonic*[T](self: Module[T]): string =
-  self.controller.getMnemonic()
+  return self.controller.generateMnemonic(SupportedMnemonicLength12)
 
 method validateLocalPairingConnectionString*[T](self: Module[T], connectionString: string): bool =
   self.controller.validateLocalPairingConnectionString(connectionString)
 
 method inputConnectionStringForBootstrapping*[T](self: Module[T], connectionString: string) =
   self.controller.inputConnectionStringForBootstrapping(connectionString)
+
+method loadMnemonic*[T](self: Module[T], mnemonic: string) =
+  self.view.setAddKeyPairState(ProgressState.InProgress.int)
+  self.controller.loadMnemonic(mnemonic)
 
 method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string): string =
   try:
@@ -121,15 +137,24 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
           recoverAccount = false,
           keycardInstanceUID = "",
         )
-      of SecondaryFlow.CreateProfileWithKeycard:
-        # TODO implement keycard function
-        discard
       of SecondaryFlow.CreateProfileWithKeycardNewSeedphrase:
-        # TODO implement keycard function
-        discard
+        # New user with a seedphrase we showed them
+        let keycardEvent = self.view.getKeycardEvent()
+        err = self.controller.restoreAccountAndLogin(
+          password = "", # For keycard it will be substituted with`encryption.publicKey` in status-go
+          seedPhrase,
+          recoverAccount = false,
+          keycardInstanceUID = keycardEvent.keycardInfo.instanceUID,
+        )
       of SecondaryFlow.CreateProfileWithKeycardExistingSeedphrase:
-        # TODO implement keycard function
-        discard
+        # New user who entered their own seed phrase
+        let keycardEvent = self.view.getKeycardEvent()
+        err = self.controller.restoreAccountAndLogin(
+          password = "", # For keycard it will be substituted with`encryption.publicKey` in status-go
+          seedPhrase,
+          recoverAccount = false,
+          keycardInstanceUID = keycardEvent.keycardInfo.instanceUID,
+        )
       
       # LOGIN FLOWS
       of SecondaryFlow.LoginWithSeedphrase:
@@ -147,8 +172,12 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
           self.localPairingStatus.chatKey,
         )
       of SecondaryFlow.LoginWithKeycard:
-        # TODO implement keycard function
-        discard
+        err = self.controller.restoreKeycardAccountAndLogin(
+          self.view.getKeycardEvent().keycardInfo.keyUID,
+          self.view.getKeycardEvent().keycardInfo.instanceUID,
+          self.exportedKeys,
+          recoverAccount = true
+          )
       else:
         raise newException(ValueError, "Unknown flow: " & $self.currentFlow)
 
@@ -166,6 +195,8 @@ proc finishAppLoading2[T](self: Module[T]) =
     eventType = "onboarding-completed"
   singletonInstance.globalEvents.addCentralizedMetricIfEnabled(eventType,
     $(%*{"flowType": repr(self.currentFlow)}))
+
+  self.controller.stopKeycardService()
 
   self.delegate.finishAppLoading()
   
@@ -186,5 +217,39 @@ method onNodeLogin*[T](self: Module[T], error: string, account: AccountDto, sett
 method onLocalPairingStatusUpdate*[T](self: Module[T], status: LocalPairingStatus) =
   self.localPairingStatus = status
   self.view.setSyncState(status.state.int)
+
+method onKeycardStateUpdated*[T](self: Module[T], keycardEvent: KeycardEventDto) =
+  self.view.setKeycardEvent(keycardEvent)
+
+  if keycardEvent.state == KeycardState.NotEmpty and self.view.getPinSettingState() == ProgressState.InProgress.int:
+    # We just finished setting the pin
+    self.view.setPinSettingState(ProgressState.Success.int)
+
+  if keycardEvent.state == KeycardState.Authorized and self.view.getAuthorizationState() == ProgressState.InProgress.int:
+    # We just finished authorizing
+    self.view.setAuthorizationState(ProgressState.Success.int)
+
+method onKeycardSetPinFailure*[T](self: Module[T], error: string) =
+  self.view.setPinSettingState(ProgressState.Failed.int)
+
+method onKeycardAuthorizeFailure*[T](self: Module[T], error: string) =
+  self.view.setAuthorizationState(ProgressState.Failed.int)
+
+method onKeycardLoadMnemonicFailure*[T](self: Module[T], error: string) =
+  self.view.setAddKeyPairState(ProgressState.Failed.int)
+
+method onKeycardLoadMnemonicSuccess*[T](self: Module[T], keyUID: string) =
+  self.view.setAddKeyPairState(ProgressState.Success.int)
+
+method onKeycardExportKeysFailure*[T](self: Module[T], error: string) =
+  self.view.setRestoreKeysExportState(ProgressState.Failed.int)
+
+method onKeycardExportKeysSuccess*[T](self: Module[T], exportedKeys: KeycardExportedKeysDto) =
+  self.exportedKeys = exportedKeys
+  self.view.setRestoreKeysExportState(ProgressState.Success.int)
+
+method exportRecoverKeys*[T](self: Module[T]) =
+  self.view.setRestoreKeysExportState(ProgressState.InProgress.int)
+  self.controller.exportRecoverKeysFromKeycard()
 
 {.pop.}

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -83,6 +83,13 @@ QtObject:
     read = getKeycardRemainingPinAttempts
     notify = keycardRemainingPinAttemptsChanged
 
+  proc keycardRemainingPukAttemptsChanged*(self: View) {.signal.}
+  proc getKeycardRemainingPukAttempts(self: View): int {.slot.} =
+    return self.keycardEvent.keycardStatus.remainingAttemptsPUK
+  QtProperty[int] keycardRemainingPukAttempts:
+    read = getKeycardRemainingPukAttempts
+    notify = keycardRemainingPukAttemptsChanged
+
   proc addKeyPairStateChanged*(self: View) {.signal.}
   proc getAddKeyPairState(self: View): int {.slot.} =
     return self.addKeyPairState
@@ -97,6 +104,7 @@ QtObject:
     self.keycardEvent = keycardEvent
     self.keycardStateChanged()
     self.keycardRemainingPinAttemptsChanged()
+    self.keycardRemainingPukAttemptsChanged()
 
   proc getKeycardEvent*(self: View): KeycardEventDto =
     return self.keycardEvent

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -25,7 +25,7 @@ QtObject:
   ### QtSignals ###
 
   proc appLoaded*(self: View) {.signal.}
-  proc accountLoginError*(self: View) {.signal.}
+  proc accountLoginError*(self: View, error: string, wrongPassword: bool) {.signal.}
 
   ### QtProperties ###
 

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -25,6 +25,7 @@ QtObject:
   ### QtSignals ###
 
   proc appLoaded*(self: View) {.signal.}
+  proc accountLoginError*(self: View) {.signal.}
 
   ### QtProperties ###
 

--- a/src/app_service/service/keycard/internal.nim
+++ b/src/app_service/service/keycard/internal.nim
@@ -95,7 +95,7 @@ proc toTransactionSignature(jsonObj: JsonNode): TransactionSignature =
   if v == 1:
     result.v = "01"
 
-proc toKeycardEvent(jsonObj: JsonNode): KeycardEvent =
+proc toKeycardEvent*(jsonObj: JsonNode): KeycardEvent =
   discard jsonObj.getProp(ResponseParamErrorKey, result.error)
   discard jsonObj.getProp(ResponseParamInstanceUID, result.instanceUID)
   discard jsonObj.getProp(ResponseParamFreeSlots, result.freePairingSlots)

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -127,7 +127,7 @@ QtObject:
     self.lastReceivedKeycardData = (flowType: flowType, flowEvent: flowEvent)
     self.events.emit(SIGNAL_KEYCARD_RESPONSE, KeycardLibArgs(flowType: flowType, flowEvent: flowEvent))
 
-  proc receiveKeycardSignal(self: Service, signal: string) {.slot.} =
+  proc receiveKeycardSignal*(self: Service, signal: string) {.slot.} =
     self.busy = false
     self.processSignal(signal)
     if self.waitingFlows.len > 0:

--- a/src/app_service/service/keycardV2/async_tasks.nim
+++ b/src/app_service/service/keycardV2/async_tasks.nim
@@ -1,13 +1,68 @@
 type
-  AsyncSetPinTaskArg = ref object of QObjectTaskArg
+  AsyncInitializeTaskArg = ref object of QObjectTaskArg
     pin: string
+    puk: string
+    rpcCounter: int
 
-proc asyncSetPinTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncSetPinTaskArg](argEncoded)
+proc asyncInitializeTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncInitializeTaskArg](argEncoded)
   try:
-    # TODO Call function from keycard_go
-    echo "Set pin ", arg.pin
+    let response = callRPC(arg.rpcCounter, "Initialize", %*{"pin": arg.pin, "puk": arg.puk})
     arg.finish(%*{
+      "response": response,
+      "error": ""
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })
+
+type
+  AsyncAuthorizeArg = ref object of QObjectTaskArg
+    pin: string
+    rpcCounter: int
+
+proc asyncAuthorizeTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncInitializeTaskArg](argEncoded)
+  try:
+    let response = callRPC(arg.rpcCounter, "Authorize", %*{"pin": arg.pin})
+    arg.finish(%*{
+      "response": response,
+      "error": ""
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })
+
+type
+  AsyncLoadMnemonicArg = ref object of QObjectTaskArg
+    mnemonic: string
+    rpcCounter: int
+
+proc asyncLoadMnemonicTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncLoadMnemonicArg](argEncoded)
+  try:
+    let response = callRPC(arg.rpcCounter, "LoadMnemonic", %*{"mnemonic": arg.mnemonic})
+    arg.finish(%*{
+      "response": response,
+      "error": ""
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })
+
+type
+  AsyncExportRecoverKeysArg = ref object of QObjectTaskArg
+    rpcCounter: int
+
+proc asyncExportRecoverKeysTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncExportRecoverKeysArg](argEncoded)
+  try:
+    let response = callRPC(arg.rpcCounter, "ExportRecoverKeys")
+    arg.finish(%*{
+      "response": response,
       "error": ""
     })
   except Exception as e:

--- a/src/app_service/service/keycardV2/dto.nim
+++ b/src/app_service/service/keycardV2/dto.nim
@@ -1,0 +1,170 @@
+import json, strutils
+include ../../common/json_utils
+
+
+
+type StateString* = enum
+  UnknownReaderState = "unknown"
+  NoPCSC = "no-pcsc"
+  InternalError = "internal-error"
+  WaitingForReader = "waiting-for-reader"
+  WaitingForCard = "waiting-for-card"
+  ConnectingCard = "connecting-card"
+  ConnectionError = "connection-error"
+  NotKeycard = "not-keycard"
+  PairingError = "pairing-error"
+  EmptyKeycard = "empty-keycard"
+  NoAvailablePairingSlots = "no-available-pairing-slots"
+  BlockedPIN = "blocked-pin" # PIN remaining attempts == 0
+  BlockedPUK = "blocked-puk" # PUK remaining attempts == 0
+  FactoryResetting = "factory-resetting"
+  Ready = "ready"
+  Authorized = "authorized"
+
+type KeycardState* = enum
+  UnknownReaderState = -1,
+  NoPCSCService,
+  PluginReader,
+  InsertKeycard,
+  ReadingKeycard,
+  WrongKeycard,
+  NotKeycard,
+  MaxPairingSlotsReached,
+  BlockedPIN,
+  BlockedPUK,
+  NotEmpty,
+  Empty,
+  Authorized
+
+type KeycardInfoDto* = object
+  initialized*: bool
+  instanceUID*: string
+  version*: string
+  availableSlots*: int
+  keyUID*: string
+
+type KeycardStatusDto* = object
+  remainingAttemptsPIN*: int
+  remainingAttemptsPUK*: int
+  keyInitialized*: bool
+  path*: string
+
+type KeycardEventDto* = object
+  state*: KeycardState
+  keycardInfo*: KeycardInfoDto
+  keycardStatus*: KeycardStatusDto
+
+type
+  KeyDetailsV2* = object
+    address*: string
+    publicKey*: string
+    privateKey*: string
+
+type KeycardExportedKeysDto* = object
+  eip1581Key*: KeyDetailsV2
+  encryptionKey*: KeyDetailsV2
+  masterKey*: KeyDetailsV2
+  walletKey*: KeyDetailsV2
+  walletRootKey*: KeyDetailsV2
+  whisperKey*: KeyDetailsV2
+  masterKeyAddress*: string
+
+proc fromStringStateToInt*(state: StateString): KeycardState =
+  case state
+  of StateString.UnknownReaderState:
+    result = KeycardState.UnknownReaderState
+  of StateString.NoPCSC:
+    result = KeycardState.NoPCSCService
+  of StateString.InternalError:
+    result = KeycardState.UnknownReaderState
+  of StateString.WaitingForReader:
+    result = KeycardState.PluginReader
+  of StateString.WaitingForCard:
+    result = KeycardState.InsertKeycard
+  of StateString.ConnectingCard:
+    result = KeycardState.ReadingKeycard
+  of StateString.ConnectionError:
+    result = KeycardState.NoPCSCService # TODO Change the UI states to have a connection error state
+  of StateString.NotKeycard:
+    result = KeycardState.NotKeycard
+  of StateString.PairingError:
+    result = KeycardState.NoPCSCService # TODO Change the UI states to have a pairing error state
+  of StateString.EmptyKeycard:
+    result = KeycardState.Empty
+  of StateString.NoAvailablePairingSlots:
+    result = KeycardState.MaxPairingSlotsReached
+  of StateString.BlockedPIN:
+    result = KeycardState.BlockedPIN
+  of StateString.BlockedPUK:
+    result = KeycardState.BlockedPUK # TODO do we need a new state for the PUK lock or we don't use PUK anymore?
+  of StateString.FactoryResetting:
+    result = KeycardState.NotEmpty # TODO create a new UI state
+  of StateString.Ready:
+    result = KeycardState.NotEmpty
+  of StateString.Authorized:
+    result = KeycardState.Authorized
+  else:
+    result = KeycardState.UnknownReaderState
+
+proc toKeycardInfoDto*(jsonObj: JsonNode): KeycardInfoDto =
+  result = KeycardInfoDto()
+  discard jsonObj.getProp("initialized", result.initialized)
+  discard jsonObj.getProp("instanceUID", result.instanceUID)
+  discard jsonObj.getProp("version", result.version)
+  discard jsonObj.getProp("availableSlots", result.availableSlots)
+  if jsonObj.getProp("keyUID", result.keyUID) and
+    result.keyUID.len > 0 and
+    not result.keyUID.startsWith("0x"):
+      result.keyUID = "0x" & result.keyUID
+
+proc toKeycardStatusDto*(jsonObj: JsonNode): KeycardStatusDto =
+  result = KeycardStatusDto()
+  discard jsonObj.getProp("remainingAttemptsPIN", result.remainingAttemptsPIN)
+  discard jsonObj.getProp("remainingAttemptsPUK", result.remainingAttemptsPUK)
+  discard jsonObj.getProp("keyInitialized", result.keyInitialized)
+  discard jsonObj.getProp("path", result.path)
+
+proc toKeycardEventDto*(jsonObj: JsonNode): KeycardEventDto =
+  result = KeycardEventDto()
+
+  try:
+    result.state = parseEnum[StateString](jsonObj["state"].getStr).fromStringStateToInt
+  except:
+    result.state = KeycardState.UnknownReaderState
+
+  var keycardInfoObj: JsonNode
+  if jsonObj.getProp("keycardInfo", keycardInfoObj):
+    result.keycardInfo = keycardInfoObj.toKeycardInfoDto
+
+  var keycardStatusObj: JsonNode
+  if jsonObj.getProp("keycardStatus", keycardStatusObj):
+    result.keycardStatus = keycardStatusObj.toKeycardStatusDto
+
+proc toKeyDetails(jsonObj: JsonNode): KeyDetailsV2 =
+  discard jsonObj.getProp("address", result.address)
+  discard jsonObj.getProp("privateKey", result.privateKey)
+  if jsonObj.getProp("publicKey", result.publicKey):
+    result.publicKey = "0x" & result.publicKey
+
+proc toKeycardExportedKeysDto*(jsonObj: JsonNode): KeycardExportedKeysDto =
+  result = KeycardExportedKeysDto()
+
+  var obj: JsonNode
+
+  if jsonObj.getProp("eip1581", obj):
+    result.eip1581Key = toKeyDetails(obj)
+
+  if jsonObj.getProp("encryptionPrivateKey", obj):
+    result.encryptionKey = toKeyDetails(obj)
+
+  if jsonObj.getProp("masterKey", obj):
+    result.masterKey = toKeyDetails(obj)
+
+  if jsonObj.getProp("walletKey", obj):
+    result.walletKey = toKeyDetails(obj)
+
+  if jsonObj.getProp("walletRootKey", obj):
+    result.walletRootKey = toKeyDetails(obj)
+
+  if jsonObj.getProp("whisperPrivateKey", obj):
+    result.whisperKey = toKeyDetails(obj)

--- a/src/app_service/service/keycardV2/dto.nim
+++ b/src/app_service/service/keycardV2/dto.nim
@@ -21,6 +21,7 @@ type StateString* = enum
   Ready = "ready"
   Authorized = "authorized"
 
+# NOTE: Keep in sync with KeycardState in ui/StatusQ/src/onboarding/enums.h
 type KeycardState* = enum
   UnknownReaderState = -1,
   NoPCSCService,
@@ -32,6 +33,7 @@ type KeycardState* = enum
   MaxPairingSlotsReached,
   BlockedPIN,
   BlockedPUK,
+  FactoryResetting,
   NotEmpty,
   Empty,
   Authorized
@@ -98,7 +100,7 @@ proc fromStringStateToInt*(state: StateString): KeycardState =
   of StateString.BlockedPUK:
     result = KeycardState.BlockedPUK # TODO do we need a new state for the PUK lock or we don't use PUK anymore?
   of StateString.FactoryResetting:
-    result = KeycardState.NotEmpty # TODO create a new UI state
+    result = KeycardState.FactoryResetting
   of StateString.Ready:
     result = KeycardState.NotEmpty
   of StateString.Authorized:

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -1,67 +1,239 @@
-import NimQml, json, chronicles, strutils
-# import keycard_go
+import NimQml, json, chronicles, strutils, random, json_serialization
+import keycard_go
 import app/global/global_singleton
 import app/core/eventemitter
 import app/core/tasks/[qt, threadpool]
+import app_service/service/keycard/service as old_keycard_service
+import ../../../backend/response_type
+import ../../../constants as status_const
+import ./dto
+
+proc callRPC*(rpcCounter: int, methodName: string, params: JsonNode = %*{}): string  =
+    var request = %*{
+      "id": rpcCounter,
+      "method": "keycard." & methodName,
+      "params": %*[ params ],
+    }
+    var response = keycard_go.keycardCallRPC($request)
+    return response
+
 include ../../common/mnemonics
 include async_tasks
 
 logScope:
   topics = "keycardV2-service"
 
+const SupportedMnemonicLength12* = 12
+const PUKLengthForStatusApp* = 12
+
+const SIGNAL_KEYCARD_STATE_UPDATED* = "keycardStateUpdated"
+const SIGNAL_KEYCARD_SET_PIN_FAILURE* = "keycardSetPinFailure"
+const SIGNAL_KEYCARD_AUTHORIZE_FAILURE* = "keycardAuthorizeFailure"
+const SIGNAL_KEYCARD_LOAD_MNEMONIC_FAILURE* = "keycardLoadMnemonicFailure"
+const SIGNAL_KEYCARD_LOAD_MNEMONIC_SUCCESS* = "keycardLoadMnemonicSuccess"
+const SIGNAL_KEYCARD_EXPORT_KEYS_FAILURE* = "keycardExportKeysFailure"
+const SIGNAL_KEYCARD_EXPORT_KEYS_SUCCESS* = "keycardExportKeysSuccess"
+
+type
+  KeycardEventArg* = ref object of Args
+    keycardEvent*: KeycardEventDto
+
+  KeycardErrorArg* = ref object of Args
+    error*: string
+
+  KeycardKeyUIDArg* = ref object of Args
+    keyUID*: string
+
+  KeycardExportedKeysArg* = ref object of Args
+    exportedKeys*: KeycardExportedKeysDto
+
 QtObject:
   type Service* = ref object of QObject
     events: EventEmitter
     threadpool: ThreadPool
+    rpcCounter: int
+    oldKeyCardService: old_keycard_service.Service
 
   proc delete*(self: Service) =
     self.QObject.delete
 
-  proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
+  proc newService*(events: EventEmitter, threadpool: ThreadPool, oldKeyCardService: old_keycard_service.Service): Service =
     new(result, delete)
     result.QObject.setup
     result.events = events
     result.threadpool = threadpool
+    result.rpcCounter = 0
+    result.oldKeyCardService = oldKeyCardService
+
+  proc initializeRPC(self: Service)
+  proc start*(self: Service, storageDir: string)
 
   proc init*(self: Service) =
+    debug "KeycardServiceV2 init"
+    self.initializeRPC()
+    self.start(status_const.KEYCARDPAIRINGDATAFILE)
     discard
 
-  proc receiveKeycardSignal(self: Service, signal: string) {.slot.} =
-    var jsonSignal: JsonNode
-    try:
-      jsonSignal = signal.parseJson
-    except:
-      error "Invalid signal received", data = signal
-      return
+  proc initializeRPC(self: Service) {.slot.} =
+    var response = keycard_go.keycardInitializeRPC()
 
-    debug "keycard_signal", response=signal
+  proc callRPC(self: Service, methodName: string, params: JsonNode = %*{}): string  =
+    self.rpcCounter += 1
+    return callRPC(self.rpcCounter, methodName, params)
 
-  proc buildSeedPhrasesFromIndexes*(self: Service, seedPhraseIndexes: seq[int]): seq[string] =
+  proc start*(self: Service, storageDir: string) =
+    discard self.callRPC("Start", %*{"storageFilePath": storageDir})
+
+  proc stop*(self: Service) =
+    discard self.callRPC("Stop")
+  
+  proc buildSeedPhrasesFromIndexes*(seedPhraseIndexes: JsonNode): seq[string] =
     var seedPhrase: seq[string]
-    for ind in seedPhraseIndexes:
-      seedPhrase.add(englishWords[ind])
+    for ind in seedPhraseIndexes.items:
+      seedPhrase.add(englishWords[ind.getInt])
     return seedPhrase
 
-  proc getMnemonicIndexes*(self: Service): seq[int] =
-    # TODO call lib to get mnemonic indexes
-    echo "Get mnemonic indexes"
-    return @[]
+  proc generateMnemonic*(self: Service, length: int): string =
+    try:
+      let response = self.callRPC("GenerateMnemonic", %*{"length": length})
+      let rpcResponseObj = response.parseJson
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+          let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+          raise newException(RpcException, "Error loading mnemonic: " & error.message)
 
-  proc setPin*(self: Service, pin: string) =
-    let arg = AsyncSetPinTaskArg(
-      tptr: asyncSetPinTask,
+      let words = buildSeedPhrasesFromIndexes(rpcResponseObj["result"]["indexes"])
+      var jArray = newJArray()
+      for item in words:
+        jArray.add(%item)
+      return $jArray
+    except Exception as e:
+      error "error generating mnemonic", err=e.msg
+
+  proc loadMnemonic*(self: Service, mnemonic: string) =
+    self.rpcCounter += 1
+    let arg = AsyncLoadMnemonicArg(
+      tptr: asyncLoadMnemonicTask,
       vptr: cast[uint](self.vptr),
-      slot: "onAsyncSetPinResponse",
+      slot: "onAsyncLoadMnemonicResponse",
+      mnemonic: mnemonic,
+      rpcCounter: self.rpcCounter,
+    )
+    self.threadpool.start(arg)
+    
+  proc onAsyncLoadMnemonicResponse(self: Service, response: string) {.slot.} =
+    try:
+      let responseObj = response.parseJson
+      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
+        raise newException(CatchableError, responseObj{"error"}.getStr)
+
+      let rpcResponseObj = responseObj["response"].getStr().parseJson()
+
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+        raise newException(RpcException, "Error loading mnemonic: " & error.message)
+
+      self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_SUCCESS, KeycardKeyUIDArg(keyUID: rpcResponseObj["result"]["keyUID"].getStr))
+    except Exception as e:
+      error "error loading mnemonic", err=e.msg
+      self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_FAILURE, KeycardErrorArg(error: e.msg))
+
+  proc asyncAuthorize*(self: Service, pin: string) =
+    self.rpcCounter += 1
+    let arg = AsyncAuthorizeArg(
+      tptr: asyncAuthorizeTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncAuthorizeResponse",
       pin: pin,
+      rpcCounter: self.rpcCounter,
     )
     self.threadpool.start(arg)
 
-  proc onAsyncSetPinResponse*(self: Service, response: string) {.slot.} =
+  proc onAsyncAuthorizeResponse*(self: Service, response: string) {.slot.} =
     try:
-      let rpcResponseObj = response.parseJson
-      echo "Set the pin ", response
+      let responseObj = response.parseJson
 
-      if (rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != ""):
-        raise newException(CatchableError, rpcResponseObj{"error"}.getStr)
+      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
+        raise newException(CatchableError, responseObj{"error"}.getStr)
+
+      let rpcResponseObj = responseObj["response"].getStr().parseJson()
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+        raise newException(RpcException, "Error authorizing: " & error.message)
     except Exception as e:
       error "error set pin: ", msg = e.msg
+      self.events.emit(SIGNAL_KEYCARD_AUTHORIZE_FAILURE, KeycardErrorArg(error: e.msg))
+
+  proc receiveKeycardSignalV2(self: Service, signal: string) {.slot.} =
+    try:
+      # Since only one service can register to signals, we pass the signal to the old service too
+      self.oldKeyCardService.receiveKeycardSignal(signal)
+      var jsonSignal = signal.parseJson
+
+      if jsonSignal["type"].getStr == "status-changed":
+        let keycardEvent = jsonSignal["event"].toKeycardEventDto()
+        
+        self.events.emit(SIGNAL_KEYCARD_STATE_UPDATED, KeycardEventArg(keycardEvent: keycardEvent))
+    except Exception as e:
+      error "error receiving a keycard signal", err=e.msg, data = signal
+
+  proc initialize*(self: Service, pin: string, puk: string) =
+    self.rpcCounter += 1
+    let arg = AsyncInitializeTaskArg(
+      tptr: asyncInitializeTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncInitializeResponse",
+      pin: pin,
+      puk: puk,
+      rpcCounter: self.rpcCounter,
+    )
+    self.threadpool.start(arg)
+
+  proc onAsyncInitializeResponse*(self: Service, response: string) {.slot.} =
+    try:
+      let responseObj = response.parseJson
+
+      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
+        raise newException(CatchableError, responseObj{"error"}.getStr)
+
+      let rpcResponseObj = responseObj["response"].getStr().parseJson()
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+        raise newException(RpcException, "Error authorizing: " & error.message)
+    except Exception as e:
+      error "error set pin: ", msg = e.msg
+      self.events.emit(SIGNAL_KEYCARD_SET_PIN_FAILURE, KeycardErrorArg(error: e.msg))
+
+  proc generateRandomPUK*(self: Service): string =
+    randomize()
+    for i in 0 ..< PUKLengthForStatusApp:
+      result = result & $rand(0 .. 9)
+
+  proc asyncExportRecoverKeys*(self: Service) =
+    self.rpcCounter += 1
+    let arg = AsyncExportRecoverKeysArg(
+      tptr: asyncExportRecoverKeysTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncExportRecoverKeys",
+      rpcCounter: self.rpcCounter,
+    )
+    self.threadpool.start(arg)
+
+  proc onAsyncExportRecoverKeys*(self: Service, response: string) {.slot.} =
+    try:
+      let responseObj = response.parseJson
+
+      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
+        raise newException(CatchableError, responseObj{"error"}.getStr)
+
+      let rpcResponseObj = responseObj["response"].getStr().parseJson()
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+        raise newException(RpcException, "Error authorizing: " & error.message)
+
+      let keys = rpcResponseObj["result"]["keys"].toKeycardExportedKeysDto()
+      self.events.emit(SIGNAL_KEYCARD_EXPORT_KEYS_SUCCESS, KeycardExportedKeysArg(exportedKeys: keys))
+    except Exception as e:
+      error "error exporting recover keys", msg = e.msg
+      self.events.emit(SIGNAL_KEYCARD_EXPORT_KEYS_FAILURE, KeycardErrorArg(error: e.msg))
+
+    

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -9,12 +9,12 @@ import ../../../constants as status_const
 import ./dto
 
 proc callRPC*(rpcCounter: int, methodName: string, params: JsonNode = %*{}): string  =
-    var request = %*{
+    let request = %*{
       "id": rpcCounter,
       "method": "keycard." & methodName,
       "params": %*[ params ],
     }
-    var response = keycard_go.keycardCallRPC($request)
+    let response = keycard_go.keycardCallRPC($request)
     return response
 
 include ../../common/mnemonics

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -34,6 +34,7 @@ type
 
 type
   PendingTransactionTypeDto* {.pure.} = enum
+    Unknown = "Unknown"
     RegisterENS = "RegisterENS",
     SetPubKey = "SetPubKey",
     ReleaseENS = "ReleaseENS",
@@ -81,15 +82,15 @@ type
     symbol*: string
 
 proc getTotalFees(tip: string, baseFee: string, gasUsed: string, maxFee: string): string =
-    var maxFees = stint.fromHex(Uint256, maxFee)
-    var totalGasUsed = stint.fromHex(Uint256, tip) + stint.fromHex(Uint256, baseFee)
-    if totalGasUsed >  maxFees:
-      totalGasUsed = maxFees
-    var totalGasUsedInHex = (totalGasUsed * stint.fromHex(Uint256, gasUsed)).toHex
-    return totalGasUsedInHex
+  var maxFees = stint.fromHex(Uint256, maxFee)
+  var totalGasUsed = stint.fromHex(Uint256, tip) + stint.fromHex(Uint256, baseFee)
+  if totalGasUsed >  maxFees:
+    totalGasUsed = maxFees
+  var totalGasUsedInHex = (totalGasUsed * stint.fromHex(Uint256, gasUsed)).toHex
+  return totalGasUsedInHex
 
 proc getMaxTotalFees(maxFee: string, gasLimit: string): string =
-    return (stint.fromHex(Uint256, maxFee) * stint.fromHex(Uint256, gasLimit)).toHex
+  return (stint.fromHex(Uint256, maxFee) * stint.fromHex(Uint256, gasLimit)).toHex
 
 proc toTransactionDto*(jsonObj: JsonNode): TransactionDto =
   result = TransactionDto()

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -277,7 +277,13 @@ QtObject:
           toTokenKey: watchTxResult["toTokenKey"].getStr,
           toAmount: watchTxResult["toAmount"].getStr,
         )
-        self.events.emit(parseEnum[PendingTransactionTypeDto](watchTxResult["trxType"].getStr).event, ev)
+        var transactionType = PendingTransactionTypeDto.Unknown
+        try:
+          transactionType = parseEnum[PendingTransactionTypeDto](watchTxResult["trxType"].getStr)
+        except:
+          discard
+        
+        self.events.emit(transactionType.event, ev)
         transactions.checkRecentHistory(@[chainId], @[address])
 
   proc watchTransaction*(

--- a/storybook/pages/KeycardAddKeyPairPagePage.qml
+++ b/storybook/pages/KeycardAddKeyPairPagePage.qml
@@ -17,10 +17,10 @@ Item {
 
         onKeypairAddTryAgainRequested: {
             console.warn("!!! onKeypairAddTryAgainRequested")
-            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.AddKeyPairState.InProgress)
+            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.ProgressState.InProgress)
             Backpressure.debounce(root, 2000, function() {
                 console.warn("!!! SIMULATION: SUCCESS")
-                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.AddKeyPairState.Success)
+                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.ProgressState.Success)
             })()
         }
         onKeypairAddContinueRequested: console.warn("!!! onKeypairAddContinueRequested")
@@ -35,7 +35,7 @@ Item {
         width: 350
         textRole: "name"
         valueRole: "value"
-        model: Onboarding.getModelFromEnum("AddKeyPairState")
+        model: Onboarding.getModelFromEnum("ProgressState")
     }
 }
 

--- a/storybook/pages/KeycardCreatePinPagePage.qml
+++ b/storybook/pages/KeycardCreatePinPagePage.qml
@@ -7,6 +7,8 @@ Item {
 
     KeycardCreatePinPage {
         anchors.fill: parent
+        pinSettingState: 0
+        authorizationState: 0
         onKeycardPinCreated: (pin) => console.warn("!!! PIN CREATED:", pin)
     }
 }

--- a/storybook/pages/KeycardCreatePinPagePage.qml
+++ b/storybook/pages/KeycardCreatePinPagePage.qml
@@ -1,14 +1,15 @@
 import QtQuick 2.15
 
 import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
 
 Item {
     id: root
 
     KeycardCreatePinPage {
         anchors.fill: parent
-        pinSettingState: 0
-        authorizationState: 0
+        pinSettingState: Onboarding.ProgressState.Idle
+        authorizationState: Onboarding.ProgressState.Idle
         onKeycardPinCreated: (pin) => console.warn("!!! PIN CREATED:", pin)
     }
 }

--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -16,6 +16,7 @@ Item {
 
         remainingAttempts: 3
         unblockWithPukAvailable: ctrlUnblockWithPUK.checked
+        keycardPinInfoPageDelay: 1000
         authorizationState: Onboarding.ProgressState.Idle
         restoreKeysExportState: Onboarding.ProgressState.Idle
         onAuthorizationRequested: (pin) => {

--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
 
 Item {
     id: root
@@ -12,15 +13,12 @@ Item {
     KeycardEnterPinPage {
         id: page
         anchors.fill: parent
-        tryToSetPinFunction: (pin) => {
-                                 const valid = pin === root.existingPin
-                                 if (!valid)
-                                     remainingAttempts--
-                                 return valid
-                             }
+
         remainingAttempts: 3
         unblockWithPukAvailable: ctrlUnblockWithPUK.checked
-        onKeycardPinEntered: (pin) => {
+        authorizationState: Onboarding.ProgressState.Idle
+        restoreKeysExportState: Onboarding.ProgressState.Idle
+        onAuthorizationRequested: (pin) => {
                                  console.warn("!!! PIN:", pin)
                                  console.warn("!!! RESETTING FLOW")
                                  state = "entering"

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -58,8 +58,11 @@ SplitView {
             id: store
 
             property int keycardState: Onboarding.KeycardState.NoPCSCService
-            property int addKeyPairState: Onboarding.AddKeyPairState.InProgress
-            property int syncState: Onboarding.SyncState.InProgress
+            property int addKeyPairState: Onboarding.ProgressState.Idle
+            property int pinSettingState: Onboarding.ProgressState.Idle
+            property int authorizationState: Onboarding.ProgressState.Idle
+            property int restoreKeysExportState: Onboarding.ProgressState.Idle
+            property int syncState: Onboarding.ProgressState.Idle
 
             property int keycardRemainingPinAttempts: 2
             property int keycardRemainingPukAttempts: 3
@@ -89,9 +92,16 @@ SplitView {
                 return valid
             }
 
-            function startKeypairTransfer() { // -> void
-                logs.logEvent("OnboardingStore.startKeypairTransfer")
-                addKeyPairState = Onboarding.AddKeyPairState.InProgress
+            function authorize(pin: string) {
+                logs.logEvent("OnboardingStore.authorize", ["pin"], arguments)
+            }
+
+            function loadMnemonic(mnemonic) { // -> void
+                logs.logEvent("OnboardingStore.loadMnemonic", ["mnemonic"], arguments)
+            }
+
+            function exportRecoverKeys() { // -> void
+                logs.logEvent("OnboardingStore.exportRecoverKeys")
             }
 
             // password
@@ -108,15 +118,11 @@ SplitView {
 
             function getMnemonic() { // -> string
                 logs.logEvent("OnboardingStore.getMnemonic()")
-                return mockDriver.seedWords.join(" ")
+                return JSON.stringify(mockDriver.seedWords)
             }
 
             function mnemonicWasShown() { // -> void
                 logs.logEvent("OnboardingStore.mnemonicWasShown()")
-            }
-
-            function removeMnemonic() { // -> void
-                logs.logEvent("OnboardingStore.removeMnemonic()")
             }
 
             function validateLocalPairingConnectionString(connectionString: string) { // -> bool
@@ -477,7 +483,7 @@ SplitView {
                     }
 
                     Repeater {
-                        model: Onboarding.getModelFromEnum("AddKeyPairState")
+                        model: Onboarding.getModelFromEnum("ProgressState")
 
                         RoundButton {
                             text: modelData.name
@@ -498,7 +504,6 @@ SplitView {
                 }
 
                 Flow {
-                    Layout.fillWidth: true
                     spacing: 2
 
                     ButtonGroup {
@@ -506,7 +511,7 @@ SplitView {
                     }
 
                     Repeater {
-                        model: Onboarding.getModelFromEnum("SyncState")
+                        model: Onboarding.getModelFromEnum("ProgressState")
 
                         RoundButton {
                             text: modelData.name
@@ -516,6 +521,90 @@ SplitView {
                             ButtonGroup.group: syncStateButtonGroup
 
                             onClicked: store.syncState = modelData.value
+                        }
+                    }
+                }
+
+                ToolSeparator {}
+
+                Label {
+                    text: "Pin Setting state:"
+                }
+
+                Flow {
+                    spacing: 2
+
+                    ButtonGroup {
+                        id: pinSettingStateButtonGroup
+                    }
+
+                    Repeater {
+                        model: Onboarding.getModelFromEnum("ProgressState")
+
+                        RoundButton {
+                            text: modelData.name
+                            checkable: true
+                            checked: store.pinSettingState === modelData.value
+
+                            ButtonGroup.group: pinSettingStateButtonGroup
+
+                            onClicked: store.pinSettingState = modelData.value
+                        }
+                    }
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "Authorization state:"
+                }
+
+                Flow {
+                    spacing: 2
+
+                    ButtonGroup {
+                        id: authorizationStateButtonGroup
+                    }
+
+                    Repeater {
+                        model: Onboarding.getModelFromEnum("ProgressState")
+
+                        RoundButton {
+                            text: modelData.name
+                            checkable: true
+                            checked: store.authorizationState === modelData.value
+
+                            ButtonGroup.group: authorizationStateButtonGroup
+
+                            onClicked: store.authorizationState = modelData.value
+                        }
+                    }
+                }
+
+                ToolSeparator {}
+
+                Label {
+                    text: "Restore Keys Export state:"
+                }
+
+                Flow {
+                    spacing: 2
+
+                    ButtonGroup {
+                        id: restoreKeysExportStateButtonGroup
+                    }
+
+                    Repeater {
+                        model: Onboarding.getModelFromEnum("ProgressState")
+
+                        RoundButton {
+                            text: modelData.name
+                            checkable: true
+                            checked: store.restoreKeysExportState === modelData.value
+
+                            ButtonGroup.group: restoreKeysExportStateButtonGroup
+
+                            onClicked: store.restoreKeysExportState = modelData.value
                         }
                     }
                 }

--- a/storybook/pages/SyncProgressPagePage.qml
+++ b/storybook/pages/SyncProgressPagePage.qml
@@ -15,10 +15,10 @@ Item {
         syncState: ctrlState.currentValue
         onRestartSyncRequested: {
             console.warn("!!! RESTART SYNC REQUESTED")
-            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.SyncState.InProgress)
+            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.ProgressState.InProgress)
             Backpressure.debounce(root, 2000, function() {
                 console.warn("!!! SIMULATION: SUCCESS")
-                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.SyncState.Success)
+                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.ProgressState.Success)
             })()
         }
         onLoginToAppRequested: console.warn("!!! LOGIN TO APP REQUESTED")
@@ -32,7 +32,7 @@ Item {
         width: 300
         textRole: "name"
         valueRole: "value"
-        model: Onboarding.getModelFromEnum("SyncState")
+        model: Onboarding.getModelFromEnum("ProgressState")
     }
 }
 

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -1209,9 +1209,9 @@ Item {
             // PAGE 2: Keycard lost page
             page = getCurrentPage(stack, KeycardLostPage)
 
-            const startUsingWithoutKeycardButton = findChild(page, "createReplacementButton")
-            verify(!!startUsingWithoutKeycardButton)
-            mouseClick(startUsingWithoutKeycardButton)
+            const createReplacementButton = findChild(page, "createReplacementButton")
+            verify(!!createReplacementButton)
+            mouseClick(createReplacementButton)
 
             // PAGE 3: Keycard intro
             page = getCurrentPage(stack, KeycardIntroPage)

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -24,6 +24,9 @@ Item {
     QtObject {
         id: mockDriver
         property int keycardState // enum Onboarding.KeycardState
+        property int pinSettingState // enum Onboarding.ProgressState
+        property int authorizationState // enum Onboarding.ProgressState
+        property int restoreKeysExportState // enum Onboarding.ProgressState
         property bool biometricsAvailable
         property string existingPin
 
@@ -55,6 +58,9 @@ Item {
 
             onboardingStore: OnboardingStore {
                 readonly property int keycardState: mockDriver.keycardState // enum Onboarding.KeycardState
+                readonly property int pinSettingState: mockDriver.pinSettingState // enum Onboarding.ProgressState
+                readonly property int authorizationState: mockDriver.authorizationState // enum Onboarding.ProgressState
+                readonly property int restoreKeysExportState: mockDriver.restoreKeysExportState // enum Onboarding.ProgressState
                 property int keycardRemainingPinAttempts: 5
 
                 function setPin(pin: string) {
@@ -64,12 +70,17 @@ Item {
                     return valid
                 }
 
-                readonly property int addKeyPairState: Onboarding.AddKeyPairState.InProgress // enum Onboarding.AddKeyPairState
-                function startKeypairTransfer() {}
+                function authorize(pin: string) {}
+
+                readonly property int addKeyPairState: Onboarding.ProgressState.InProgress // enum Onboarding.ProgressState
 
                 // password
                 function getPasswordStrengthScore(password: string) {
                     return Math.min(password.length-1, 4)
+                }
+
+                function finishOnboardingFlow(flow: int, data: Object) { // -> bool
+                    return true
                 }
 
                 // seedphrase/mnemonic
@@ -77,12 +88,12 @@ Item {
                     return mnemonic === mockDriver.mnemonic
                 }
                 function getMnemonic() {
-                    return mockDriver.seedWords.join(" ")
+                    return JSON.stringify(mockDriver.seedWords)
                 }
-                function mnemonicWasShown() {}
-                function removeMnemonic() {}
+                function loadMnemonic(mnemonic) {}
+                function exportRecoverKeys() {}
 
-                readonly property int syncState: Onboarding.SyncState.InProgress // enum Onboarding.SyncState
+                readonly property int syncState: Onboarding.ProgressState.InProgress // enum Onboarding.ProgressState
                 function validateLocalPairingConnectionString(connectionString: string) {
                     return !Number.isNaN(parseInt(connectionString))
                 }
@@ -153,6 +164,9 @@ Item {
 
         function cleanup() {
             mockDriver.keycardState = -1
+            mockDriver.pinSettingState = 0
+            mockDriver.authorizationState = 0
+            mockDriver.restoreKeysExportState = 0
             mockDriver.biometricsAvailable = false
             mockDriver.existingPin = ""
             dynamicSpy.cleanup()
@@ -184,13 +198,13 @@ Item {
         // common variant data for all flow related TDD tests
         function init_data() {
             return [ { tag: "shareUsageData+bioEnabled", shareBtnName: "btnShare", shareResult: true, biometrics: true, bioEnabled: true },
-                    { tag: "dontShareUsageData+bioEnabled", shareBtnName: "btnDontShare", shareResult: false, biometrics: true, bioEnabled: true },
+                   { tag: "dontShareUsageData+bioEnabled", shareBtnName: "btnDontShare", shareResult: false, biometrics: true, bioEnabled: true },
 
-                    { tag: "shareUsageData+bioDisabled", shareBtnName: "btnShare", shareResult: true, biometrics: true, bioEnabled: false },
-                    { tag: "dontShareUsageData+bioDisabled", shareBtnName: "btnDontShare", shareResult: false, biometrics: true, bioEnabled: false },
+                   { tag: "shareUsageData+bioDisabled", shareBtnName: "btnShare", shareResult: true, biometrics: true, bioEnabled: false },
+                   { tag: "dontShareUsageData+bioDisabled", shareBtnName: "btnDontShare", shareResult: false, biometrics: true, bioEnabled: false },
 
-                    { tag: "shareUsageData-bio", shareBtnName: "btnShare", shareResult: true, biometrics: false },
-                    { tag: "dontShareUsageData-bio", shareBtnName: "btnDontShare", shareResult: false, biometrics: false },
+                   { tag: "shareUsageData-bio", shareBtnName: "btnShare", shareResult: true, biometrics: false },
+                   { tag: "dontShareUsageData-bio", shareBtnName: "btnDontShare", shareResult: false, biometrics: false },
                     ]
         }
 
@@ -310,6 +324,7 @@ Item {
             compare(resultData.keycardPin, "")
             compare(resultData.seedphrase, "")
         }
+
 
         // FLOW: Create Profile -> Use a recovery phrase (create profile with seedphrase)
         function test_flow_createProfile_withSeedphrase(data) {
@@ -459,6 +474,9 @@ Item {
             keyClickSequence(newPin)
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], newPin)
+            dynamicSpy.setup(page, "keycardAuthorized")
+            mockDriver.authorizationState = Onboarding.ProgressState.Success
+            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 7: Backup your recovery phrase (intro)
             page = getCurrentPage(stack, BackupSeedphraseIntro)
@@ -525,8 +543,8 @@ Item {
 
             // PAGE 12: Adding key pair to Keycard
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
-            tryCompare(page, "addKeyPairState", Onboarding.AddKeyPairState.InProgress)
-            page.addKeyPairState = Onboarding.AddKeyPairState.Success // SIMULATION
+            tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
+            page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
             btnContinue = findChild(page, "btnContinue")
             verify(!!btnContinue)
             compare(btnContinue.enabled, true)
@@ -551,7 +569,7 @@ Item {
             compare(resultData.password, "")
             compare(resultData.enableBiometrics, data.biometrics && data.bioEnabled)
             compare(resultData.keycardPin, newPin)
-            compare(resultData.seedphrase, "")
+            compare(resultData.seedphrase, mockDriver.seedWords.join(","))
         }
 
         // FLOW: Create Profile -> Use an empty Keycard -> Use an existing recovery phrase (create profile with keycard + existing seedphrase)
@@ -605,6 +623,10 @@ Item {
             keyClickSequence(newPin)
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], newPin)
+            dynamicSpy.setup(page, "keycardPinSuccessfullySet")
+            mockDriver.pinSettingState = Onboarding.ProgressState.Success
+            tryCompare(dynamicSpy, "count", 1)
+
 
             // PAGE 7: Create profile on empty Keycard using a recovery phrase
             page = getCurrentPage(stack, SeedphrasePage)
@@ -618,11 +640,14 @@ Item {
             keySequence(StandardKey.Paste)
             compare(btnContinue.enabled, true)
             mouseClick(btnContinue)
+            dynamicSpy.setup(page, "keycardAuthorized")
+            mockDriver.authorizationState = Onboarding.ProgressState.Success
+            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 8: Adding key pair to Keycard
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
-            tryCompare(page, "addKeyPairState", Onboarding.AddKeyPairState.InProgress)
-            page.addKeyPairState = Onboarding.AddKeyPairState.Success // SIMULATION
+            tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
+            page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
             const btnContinue2 = findChild(page, "btnContinue")
             verify(!!btnContinue2)
             compare(btnContinue2.enabled, true)
@@ -806,8 +831,8 @@ Item {
 
             // PAGE 5: Profile sync in progress
             page = getCurrentPage(stack, SyncProgressPage)
-            tryCompare(page, "syncState", Onboarding.SyncState.InProgress)
-            page.syncState = Onboarding.SyncState.Success // SIMULATION
+            tryCompare(page, "syncState", Onboarding.ProgressState.InProgress)
+            page.syncState = Onboarding.ProgressState.Success // SIMULATION
             const btnLogin2 = findChild(page, "btnLogin") // TODO test other flows/buttons here as well
             verify(!!btnLogin2)
             compare(btnLogin2.enabled, true)
@@ -873,10 +898,18 @@ Item {
 
             // PAGE 5: Enter Keycard PIN
             page = getCurrentPage(stack, KeycardEnterPinPage)
-            dynamicSpy.setup(page, "keycardPinEntered")
+            dynamicSpy.setup(page, "authorizationRequested")
             keyClickSequence(mockDriver.existingPin)
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], mockDriver.existingPin)
+
+            dynamicSpy.setup(page, "exportKeysRequested")
+            mockDriver.authorizationState = Onboarding.ProgressState.Success
+            tryCompare(dynamicSpy, "count", 1)
+
+            dynamicSpy.setup(page, "exportKeysDone")
+            mockDriver.restoreKeysExportState = Onboarding.ProgressState.Success
+            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 6: Enable Biometrics
             if (data.biometrics) {
@@ -896,7 +929,7 @@ Item {
             verify(!!resultData)
             compare(resultData.password, "")
             compare(resultData.enableBiometrics, data.biometrics && data.bioEnabled)
-            compare(resultData.keycardPin, mockDriver.existingPin)
+            compare(resultData.keycardPin, "")
             compare(resultData.seedphrase, "")
         }
 
@@ -1211,11 +1244,14 @@ Item {
             keyClickSequence(newPin)
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], newPin)
+            dynamicSpy.setup(page, "keycardAuthorized")
+            mockDriver.authorizationState = Onboarding.ProgressState.Success
+            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 6: Adding key pair to Keycard
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
-            tryCompare(page, "addKeyPairState", Onboarding.AddKeyPairState.InProgress)
-            page.addKeyPairState = Onboarding.AddKeyPairState.Success // SIMULATION
+            tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
+            page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
 
             btnContinue = findChild(page, "btnContinue")
             verify(!!btnContinue)

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -164,9 +164,9 @@ Item {
 
         function cleanup() {
             mockDriver.keycardState = -1
-            mockDriver.pinSettingState = 0
-            mockDriver.authorizationState = 0
-            mockDriver.restoreKeysExportState = 0
+            mockDriver.pinSettingState = Onboarding.ProgressState.Idle
+            mockDriver.authorizationState = Onboarding.ProgressState.Idle
+            mockDriver.restoreKeysExportState = Onboarding.ProgressState.Idle
             mockDriver.biometricsAvailable = false
             mockDriver.existingPin = ""
             dynamicSpy.cleanup()

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -54,6 +54,7 @@ public:
         Keycard,
     };
 
+    // NOTE: Keep in sync with KeycardState in src/app_service/service/keycardV2/dto.nim
     enum class KeycardState {
         NoPCSCService,
         PluginReader,
@@ -65,6 +66,7 @@ public:
         MaxPairingSlotsReached,
         BlockedPIN, // PIN remaining attempts == 0
         BlockedPUK, // PUK remaining attempts == 0
+        FactoryResetting,
         // exit states
         NotEmpty,
         Empty,

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -38,7 +38,6 @@ public:
 
         CreateProfileWithPassword,
         CreateProfileWithSeedphrase,
-        CreateProfileWithKeycard,
         CreateProfileWithKeycardNewSeedphrase,
         CreateProfileWithKeycardExistingSeedphrase,
 
@@ -68,20 +67,15 @@ public:
         BlockedPUK, // PUK remaining attempts == 0
         // exit states
         NotEmpty,
-        Empty
+        Empty,
+        Authorized
     };
 
-    enum class AddKeyPairState {
+    enum class ProgressState {
+        Idle,
         InProgress,
         Success,
         Failed
-    };
-
-    enum class SyncState {
-        Idle,
-        InProgress,
-        Failed,
-        Success
     };
 
 private:
@@ -89,6 +83,5 @@ private:
     Q_ENUM(SecondaryFlow)
     Q_ENUM(LoginMethod)
     Q_ENUM(KeycardState)
-    Q_ENUM(AddKeyPairState)
-    Q_ENUM(SyncState)
+    Q_ENUM(ProgressState)
 };

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -14,6 +14,8 @@ SQUtils.QObject {
 
     required property int keycardState
     required property int addKeyPairState
+    required property int authorizationState
+    required property int pinSettingState
     required property int keycardPinInfoPageDelay
 
     required property var isSeedPhraseValid
@@ -22,8 +24,8 @@ SQUtils.QObject {
 
     signal loginWithKeycardRequested
     signal keycardFactoryResetRequested
-    signal keyPairTransferRequested
     signal keycardPinCreated(string pin)
+    signal authorizationRequested
     signal seedphraseSubmitted(string seedphrase)
 
     signal keypairAddTryAgainRequested
@@ -90,6 +92,7 @@ SQUtils.QObject {
         SeedphrasePage {
             title: qsTr("Enter recovery phrase of lost Keycard")
 
+            authorizationState: root.authorizationState
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
@@ -102,12 +105,14 @@ SQUtils.QObject {
         id: keycardCreatePinPage
 
         KeycardCreatePinPage {
+            pinSettingState: root.pinSettingState
+            authorizationState: root.authorizationState
             onKeycardPinCreated: (pin) => {
-                Backpressure.debounce(root, root.keycardPinInfoPageDelay, () => {
                     root.keycardPinCreated(pin)
-                    root.keyPairTransferRequested()
-                    root.stackView.push(addKeypairPage)
-                })()
+                    root.authorizationRequested()
+            }
+            onKeycardAuthorized: {
+                root.stackView.push(addKeypairPage)
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
@@ -39,7 +39,7 @@ SQUtils.QObject {
 
         SyncProgressPage {
             readonly property bool backAvailableHint:
-                root.syncState === Onboarding.SyncState.Failed
+                root.syncState === Onboarding.ProgressState.Failed
 
             syncState: root.syncState
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -249,7 +249,7 @@ SQUtils.QObject {
         onLoadMnemonicRequested: root.loadMnemonicRequested()
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
-        // onKeypairAddTryAgainRequested: root.keyPairTransferRequested() // FIXME?
+        onKeypairAddTryAgainRequested: root.loadMnemonicRequested()
         onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
 
         onCreateProfileWithoutKeycardRequested: {
@@ -391,7 +391,7 @@ SQUtils.QObject {
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
         onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
-        // onKeypairAddTryAgainRequested: root.keyPairTransferRequested() // FIXME?
+        onKeypairAddTryAgainRequested: root.loadMnemonicRequested()
 
         onCreateProfileWithoutKeycardRequested: {
             const page = stackView.find(

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -302,7 +302,6 @@ SQUtils.QObject {
         remainingPukAttempts: root.remainingPukAttempts
         displayKeycardPromoBanner: root.displayKeycardPromoBanner
         onAuthorizationRequested: root.authorizationRequested(pin)
-        isSeedPhraseValid: root.isSeedPhraseValid
 
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -17,9 +17,12 @@ SQUtils.QObject {
     required property var loginAccountsModel
 
     required property int keycardState
+    required property int pinSettingState
+    required property int authorizationState
+    required property int restoreKeysExportState
     required property int addKeyPairState
     required property int syncState
-    required property var seedWords
+    required property var getSeedWords
     required property int remainingPinAttempts
     required property int remainingPukAttempts
 
@@ -41,7 +44,6 @@ SQUtils.QObject {
     signal biometricsRequested
     signal loginRequested(string keyUid, int method, var data)
     signal keycardPinCreated(string pin)
-    signal keycardPinEntered(string pin)
     signal enableBiometricsRequested(bool enable)
     signal shareUsageDataRequested(bool enabled)
     signal syncProceedWithConnectionString(string connectionString)
@@ -49,10 +51,9 @@ SQUtils.QObject {
     signal setPasswordRequested(string password)
     signal reloadKeycardRequested
     signal keycardFactoryResetRequested
-    signal keyPairTransferRequested
-
-    signal mnemonicWasShown()
-    signal mnemonicRemovalRequested()
+    signal exportKeysRequested
+    signal loadMnemonicRequested
+    signal authorizationRequested(string pin)
 
     signal linkActivated(string link)
 
@@ -234,8 +235,10 @@ SQUtils.QObject {
 
         stackView: root.stackView
         keycardState: root.keycardState
+        pinSettingState: root.pinSettingState
+        authorizationState: root.authorizationState
         addKeyPairState: root.addKeyPairState
-        seedWords: root.seedWords
+        getSeedWords: root.getSeedWords
         displayKeycardPromoBanner: root.displayKeycardPromoBanner
         isSeedPhraseValid: root.isSeedPhraseValid
 
@@ -243,10 +246,11 @@ SQUtils.QObject {
 
         onReloadKeycardRequested: root.reloadKeycardRequested()
         onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-        onKeyPairTransferRequested: root.keyPairTransferRequested()
+        onLoadMnemonicRequested: root.loadMnemonicRequested()
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
-        onKeypairAddTryAgainRequested: root.keyPairTransferRequested() // FIXME?
+        // onKeypairAddTryAgainRequested: root.keyPairTransferRequested() // FIXME?
+        onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
 
         onCreateProfileWithoutKeycardRequested: {
             const page = stackView.find(
@@ -254,9 +258,6 @@ SQUtils.QObject {
 
             stackView.replace(page, createProfilePage, StackView.PopTransition)
         }
-
-        onMnemonicWasShown: root.mnemonicWasShown()
-        onMnemonicRemovalRequested: root.mnemonicRemovalRequested()
 
         onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
 
@@ -295,17 +296,22 @@ SQUtils.QObject {
 
         stackView: root.stackView
         keycardState: root.keycardState
+        authorizationState: root.authorizationState
+        restoreKeysExportState: root.restoreKeysExportState
         remainingPinAttempts: root.remainingPinAttempts
         remainingPukAttempts: root.remainingPukAttempts
         displayKeycardPromoBanner: root.displayKeycardPromoBanner
-        tryToSetPinFunction: root.tryToSetPinFunction
+        onAuthorizationRequested: root.authorizationRequested(pin)
+        isSeedPhraseValid: root.isSeedPhraseValid
+
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
-        onKeycardPinEntered: (pin) => root.keycardPinEntered(pin)
+        onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
+        onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
         onReloadKeycardRequested: root.reloadKeycardRequested()
         onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
         onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-        onUnblockWithSeedphraseRequested: unblockWithSeedphraseFlow.init()
+        onExportKeysRequested: root.exportKeysRequested()
         onUnblockWithPukRequested: unblockWithPukFlow.init()
 
         onFinished: {
@@ -372,6 +378,8 @@ SQUtils.QObject {
         stackView: root.stackView
 
         keycardState: root.keycardState
+        pinSettingState: root.pinSettingState
+        authorizationState: root.authorizationState
         addKeyPairState: root.addKeyPairState
 
         displayKeycardPromoBanner: root.displayKeycardPromoBanner
@@ -381,10 +389,10 @@ SQUtils.QObject {
 
         onReloadKeycardRequested: root.reloadKeycardRequested()
         onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-        onKeyPairTransferRequested: root.keyPairTransferRequested()
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
-        onKeypairAddTryAgainRequested: root.keyPairTransferRequested() // FIXME?
+        onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
+        // onKeypairAddTryAgainRequested: root.keyPairTransferRequested() // FIXME?
 
         onCreateProfileWithoutKeycardRequested: {
             const page = stackView.find(

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -93,6 +93,20 @@ Page {
 
             root.finished(flow, data)
         }
+
+        function loadMnemonic() {
+            root.onboardingStore.loadMnemonic(d.seedphrase)
+        }
+
+        function authorize(pin) {
+            if (!pin && !d.keycardPin) {
+                return
+            }
+            if (!pin) {
+                pin = d.keycardPin
+            }
+            root.onboardingStore.authorize(pin)
+        }
     }
 
     background: Rectangle {
@@ -142,10 +156,15 @@ Page {
         loginAccountsModel: root.loginAccountsModel
 
         keycardState: root.onboardingStore.keycardState
+        pinSettingState: root.onboardingStore.pinSettingState
+        authorizationState: root.onboardingStore.authorizationState
+        restoreKeysExportState: root.onboardingStore.restoreKeysExportState
         syncState: root.onboardingStore.syncState
         addKeyPairState: root.onboardingStore.addKeyPairState
 
-        seedWords: root.onboardingStore.getMnemonic().split(" ")
+        getSeedWords: function () {
+            return root.onboardingStore.getMnemonic().split(" ")
+        }
 
         displayKeycardPromoBanner: !d.settings.keycardPromoShown
         isBiometricsLogin: root.isBiometricsLogin
@@ -168,16 +187,10 @@ Page {
             root.onboardingStore.setPin(pin)
         }
 
-        onKeycardPinEntered: (pin) => {
-            d.keycardPin = pin
-            root.onboardingStore.setPin(pin)
-        }
-
-        onKeyPairTransferRequested: root.onboardingStore.startKeypairTransfer()
+        onLoadMnemonicRequested: d.loadMnemonic()
+        onAuthorizationRequested: d.authorize(pin)
         onShareUsageDataRequested: (enabled) => root.shareUsageDataRequested(enabled)
         onReloadKeycardRequested: root.reloadKeycardRequested()
-        onMnemonicWasShown: root.onboardingStore.mnemonicWasShown()
-        onMnemonicRemovalRequested: root.onboardingStore.removeMnemonic()
 
         onSyncProceedWithConnectionString: (connectionString) =>
             root.onboardingStore.inputConnectionStringForBootstrapping(connectionString)
@@ -185,6 +198,7 @@ Page {
         onSetPasswordRequested: (password) => d.password = password
         onEnableBiometricsRequested: (enabled) => d.enableBiometrics = enabled
         onLinkActivated: (link) => Qt.openUrlExternally(link)
+        onExportKeysRequested: root.onboardingStore.exportRecoverKeys()
         onFinished: (flow) => d.finishFlow(flow)
         onKeycardFactoryResetRequested: console.warn("!!! FIXME OnboardingLayout::onKeycardFactoryResetRequested")
     }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -162,9 +162,7 @@ Page {
         syncState: root.onboardingStore.syncState
         addKeyPairState: root.onboardingStore.addKeyPairState
 
-        getSeedWords: function () {
-            return root.onboardingStore.getMnemonic().split(" ")
-        }
+        getSeedWords: root.onboardingStore.getMnemonic
 
         displayKeycardPromoBanner: !d.settings.keycardPromoShown
         isBiometricsLogin: root.isBiometricsLogin

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.15
 import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
 
 SQUtils.QObject {
     id: root
@@ -41,6 +42,7 @@ SQUtils.QObject {
 
         SeedphrasePage {
             isSeedPhraseValid: root.isSeedPhraseValid
+            authorizationState: Onboarding.ProgressState.Idle
 
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)

--- a/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseReveal.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseReveal.qml
@@ -15,7 +15,6 @@ OnboardingPage {
 
     required property var seedWords
 
-    signal mnemonicWasShown()
     signal backupSeedphraseConfirmed()
 
     QtObject {
@@ -103,7 +102,6 @@ OnboardingPage {
                     visible: !d.seedphraseRevealed
                     onClicked: {
                         d.seedphraseRevealed = true
-                        root.mnemonicWasShown()
                     }
                 }
             }

--- a/ui/app/AppLayouts/Onboarding2/pages/CreateKeycardProfilePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/CreateKeycardProfilePage.qml
@@ -77,7 +77,7 @@ OnboardingPage {
                         StatusButton {
                             objectName: "btnCreateWithEmptySeedphrase"
                             Layout.fillWidth: true
-                            text: qsTr("Let’s go!")
+                            text: qsTr("Let's go!")
                             font.pixelSize: Theme.additionalTextSize
                             onClicked: root.createKeycardProfileWithNewSeedphrase()
                         }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
@@ -13,7 +13,7 @@ import AppLayouts.Onboarding.enums 1.0
 OnboardingPage {
     id: root
 
-    required property int addKeyPairState // Onboarding.AddKeyPairState.xxx
+    required property int addKeyPairState // Onboarding.ProgressState.xxx
 
     signal keypairAddContinueRequested()
     signal keypairAddTryAgainRequested()
@@ -23,7 +23,7 @@ OnboardingPage {
     states: [
         State {
             name: "inprogress"
-            when: root.addKeyPairState === Onboarding.AddKeyPairState.InProgress
+            when: root.addKeyPairState === Onboarding.ProgressState.InProgress
             PropertyChanges {
                 target: root
                 title: qsTr("Adding key pair to Keycard")
@@ -44,7 +44,7 @@ OnboardingPage {
         },
         State {
             name: "success"
-            when: root.addKeyPairState === Onboarding.AddKeyPairState.Success
+            when: root.addKeyPairState === Onboarding.ProgressState.Success
             PropertyChanges {
                 target: root
                 title: qsTr("Key pair added to Keycard")
@@ -68,7 +68,7 @@ OnboardingPage {
         },
         State {
             name: "failed"
-            when: root.addKeyPairState === Onboarding.AddKeyPairState.Failed
+            when: root.addKeyPairState === Onboarding.ProgressState.Failed
             PropertyChanges {
                 target: root
                 title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Failed to add key pair to Keycard") + "</font>"

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
@@ -17,7 +17,7 @@ import utils 1.0
 KeycardBasePage {
     id: root
 
-    required property int keycardPinInfoPageDelay
+    property int keycardPinInfoPageDelay: 1000
     required property int pinSettingState
     required property int authorizationState
 

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
@@ -7,15 +7,23 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Onboarding2.controls 1.0
+import AppLayouts.Onboarding.enums 1.0
 
 import utils 1.0
 
 KeycardBasePage {
     id: root
 
+    property int keycardPinInfoPageDelay
+    required property int pinSettingState
+    required property int authorizationState
+
     signal keycardPinCreated(string pin)
+    signal keycardPinSuccessfullySet()
+    signal keycardAuthorized()
 
     image.source: Theme.png("onboarding/keycard/reading")
 
@@ -53,9 +61,15 @@ KeycardBasePage {
         StatusBaseText {
             id: errorText
             anchors.horizontalCenter: parent.horizontalCenter
-            text: qsTr("PINs don’t match")
+            text: qsTr("PINs don't match")
             font.pixelSize: Theme.tertiaryTextFontSize
             color: Theme.palette.dangerColor1
+            visible: false
+        },
+        StatusLoadingIndicator {
+            id: loadingIndicator
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.topMargin: Theme.halfPadding
             visible: false
         }
     ]
@@ -84,12 +98,24 @@ KeycardBasePage {
             }
         },
         State {
-            name: "success"
-            extend: "repeating"
-            when: !!d.pin && !!d.pin2 && d.pin === d.pin2
+            name: "error"
+            when: root.pinSettingState === Onboarding.ProgressState.Failed || root.authorizationState === Onboarding.ProgressState.Failed
+            PropertyChanges {
+                target: errorText
+                visible: true
+                text: qsTr("Error setting pin")
+            }
             PropertyChanges {
                 target: root
-                title: qsTr("Keycard PIN set")
+                image.source: Theme.png("onboarding/keycard/error")
+            }
+        },
+        State {
+            name: "authorized"
+            when: root.authorizationState === Onboarding.ProgressState.Success
+            PropertyChanges {
+                target: root
+                title: qsTr("PIN set")
             }
             PropertyChanges {
                 target: pinInput
@@ -101,8 +127,59 @@ KeycardBasePage {
             }
             StateChangeScript {
                 script: {
-                    pinInput.setPin(d.pin)
-                    root.keycardPinCreated(d.pin)
+                    Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
+                        root.keycardAuthorized()
+                    })()
+                }
+            }
+        },
+        State {
+            name: "success"
+            when: root.pinSettingState === Onboarding.ProgressState.Success
+            PropertyChanges {
+                target: root
+                title: qsTr("PIN set")
+            }
+            PropertyChanges {
+                target: pinInput
+                enabled: false
+            }
+            PropertyChanges {
+                target: root
+                image.source: Theme.png("onboarding/keycard/success")
+            }
+            StateChangeScript {
+                script: {
+                    root.keycardPinSuccessfullySet()
+                }
+            }
+        },
+        State {
+            name: "settingPin"
+            extend: "repeating"
+            when: !!d.pin && !!d.pin2 && d.pin === d.pin2 && (root.pinSettingState === Onboarding.ProgressState.Idle || root.pinSettingState === Onboarding.ProgressState.InProgress)
+            PropertyChanges {
+                target: root
+                title: qsTr("Setting Keycard PIN")
+            }
+            PropertyChanges {
+                target: pinInput
+                enabled: false
+            }
+            PropertyChanges {
+                target: loadingIndicator
+                visible: true
+            }
+            PropertyChanges {
+                target: root
+                image.source: Theme.png("onboarding/keycard/success")
+            }
+            StateChangeScript {
+                script: {
+                    Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
+                        pinInput.setPin(d.pin)
+                        root.keycardPinCreated(d.pin)
+                    })()
                 }
             }
         },

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
@@ -17,7 +17,7 @@ import utils 1.0
 KeycardBasePage {
     id: root
 
-    property int keycardPinInfoPageDelay
+    required property int keycardPinInfoPageDelay
     required property int pinSettingState
     required property int authorizationState
 

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -19,8 +19,8 @@ KeycardBasePage {
     required property int authorizationState
     required property int restoreKeysExportState
     required property int remainingAttempts
-    property bool unblockWithPukAvailable
-    property int keycardPinInfoPageDelay
+    required property bool unblockWithPukAvailable
+    required property int keycardPinInfoPageDelay
 
     signal keycardPinEntered(string pin)
     signal reloadKeycardRequested

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
@@ -108,7 +108,7 @@ KeycardBasePage {
         MaybeOutlineButton {
             id: btnReload
             visible: false
-            text: qsTr("I’ve inserted a different Keycard")
+            text: qsTr("I've inserted a different Keycard")
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: root.reloadKeycardRequested()
         }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardLostPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardLostPage.qml
@@ -12,7 +12,7 @@ KeycardBasePage {
     signal useProfileWithoutKeycardRequested()
 
     title: qsTr("Lost Keycard")
-    subtitle: qsTr("Sorry you’ve lost your Keycard")
+    subtitle: qsTr("Sorry you've lost your Keycard")
     image.source: Theme.png("onboarding/keycard/empty")
 
     buttons: [

--- a/ui/app/AppLayouts/Onboarding2/pages/SeedphrasePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SeedphrasePage.qml
@@ -7,6 +7,8 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 
+import AppLayouts.Onboarding.enums 1.0
+
 import shared.panels 1.0
 
 OnboardingPage {
@@ -16,9 +18,12 @@ OnboardingPage {
     property string subtitle: qsTr("Enter your 12, 18 or 24 word recovery phrase")
     property alias btnContinueText: btnContinue.text
 
+    required property int authorizationState
+
     property var isSeedPhraseValid: (mnemonic) => { console.error("isSeedPhraseValid IMPLEMENT ME"); return false }
 
     signal seedphraseSubmitted(string seedphrase)
+    signal keycardAuthorized()
 
     contentItem: Item {
         ColumnLayout {
@@ -62,4 +67,30 @@ OnboardingPage {
             }
         }
     }
+
+    state: "creating"
+
+    states: [
+        State {
+            name: "creating"
+        },
+        State {
+            name: "authorized"
+            when: root.authorizationState === Onboarding.ProgressState.Success
+            StateChangeScript {
+                script: {
+                    root.keycardAuthorized()
+                }
+            }
+        },
+        State {
+            name: "loadingMnemonic"
+            when: root.authorizationState === Onboarding.ProgressState.InProgress
+
+            PropertyChanges {
+                target: btnContinue
+                loading: true
+            }
+        }
+    ]
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
@@ -12,7 +12,7 @@ import AppLayouts.Onboarding.enums 1.0
 OnboardingPage {
     id: root
 
-    required property int syncState // Onboarding.SyncState.xxx
+    required property int syncState // Onboarding.ProgressState.xxx
 
     signal loginToAppRequested()
     signal restartSyncRequested()
@@ -21,7 +21,7 @@ OnboardingPage {
     states: [
         State {
             name: "inprogress"
-            when: root.syncState === Onboarding.SyncState.InProgress || root.syncState === Onboarding.SyncState.Idle
+            when: root.syncState === Onboarding.ProgressState.InProgress || root.syncState === Onboarding.ProgressState.Idle
             PropertyChanges {
                 target: root
                 title: qsTr("Profile sync in progress...")
@@ -46,7 +46,7 @@ OnboardingPage {
         },
         State {
             name: "success"
-            when: root.syncState === Onboarding.SyncState.Success
+            when: root.syncState === Onboarding.ProgressState.Success
             PropertyChanges {
                 target: root
                 title: qsTr("Profile synced")
@@ -70,7 +70,7 @@ OnboardingPage {
         },
         State {
             name: "failed"
-            when: root.syncState === Onboarding.SyncState.Failed
+            when: root.syncState === Onboarding.ProgressState.Failed
             PropertyChanges {
                 target: root
                 title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Profile syncing failed") + "</font>"

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -14,10 +14,7 @@ QtObject {
 
         Component.onCompleted: {
             d.onboardingModuleInst.appLoaded.connect(root.appLoaded)
-            // TODO implement the following signals
-            // d.onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
-            // d.onboardingModuleInst.obtainingPasswordSuccess.connect(root.obtainingPasswordSuccess)
-            // d.onboardingModuleInst.obtainingPasswordError.connect(root.obtainingPasswordError)
+            d.onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -7,22 +7,25 @@ import AppLayouts.Onboarding.enums 1.0
 QtObject {
     id: root
 
-    signal appLoaded()
-
+    signal appLoaded
     readonly property QtObject d: StatusQUtils.QObject {
         id: d
         readonly property var onboardingModuleInst: onboardingModule
 
         Component.onCompleted: {
-            onboardingModuleInst.appLoaded.connect(root.appLoaded)
-            onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
-            onboardingModuleInst.obtainingPasswordSuccess.connect(root.obtainingPasswordSuccess)
-            onboardingModuleInst.obtainingPasswordError.connect(root.obtainingPasswordError)
+            d.onboardingModuleInst.appLoaded.connect(root.appLoaded)
+            // TODO implement the following signals
+            // d.onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
+            // d.onboardingModuleInst.obtainingPasswordSuccess.connect(root.obtainingPasswordSuccess)
+            // d.onboardingModuleInst.obtainingPasswordError.connect(root.obtainingPasswordError)
         }
     }
 
     // keycard
     readonly property int keycardState: d.onboardingModuleInst.keycardState // cf. enum Onboarding.KeycardState
+    readonly property int pinSettingState: d.onboardingModuleInst.pinSettingState // cf. enum Onboarding.ProgressState
+    readonly property int authorizationState: d.onboardingModuleInst.authorizationState // cf. enum Onboarding.ProgressState
+    readonly property int restoreKeysExportState: d.onboardingModuleInst.restoreKeysExportState // cf. enum Onboarding.ProgressState
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
     readonly property int keycardRemainingPukAttempts: d.onboardingModuleInst.keycardRemainingPukAttempts
 
@@ -30,17 +33,24 @@ QtObject {
         return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
     }
 
-    function setPin(pin: string) { // -> bool
-        return d.onboardingModuleInst.setPin(pin)
+    function setPin(pin: string) {
+        d.onboardingModuleInst.setPin(pin)
     }
 
     function setPuk(puk: string) { // -> bool
         return d.onboardingModuleInst.setPuk(puk)
     }
 
-    readonly property int addKeyPairState: d.onboardingModuleInst.addKeyPairState // cf. enum Onboarding.AddKeyPairState
-    function startKeypairTransfer() { // -> void
-        d.onboardingModuleInst.startKeypairTransfer()
+    function authorize(pin: string) {
+        d.onboardingModuleInst.authorize(pin)
+    }
+
+    readonly property int addKeyPairState: d.onboardingModuleInst.addKeyPairState // cf. enum Onboarding.ProgressState
+    function loadMnemonic(mnemonic) { // -> void
+        d.onboardingModuleInst.loadMnemonic(mnemonic)
+    }
+    function exportRecoverKeys() { // -> void
+        d.onboardingModuleInst.exportRecoverKeys()
     }
 
     // password
@@ -59,17 +69,11 @@ QtObject {
         return d.onboardingModuleInst.validMnemonic(mnemonic)
     }
     function getMnemonic() { // -> string
-        return d.onboardingModuleInst.mnemonic()
-    }
-    function mnemonicWasShown() { // -> void
-        d.onboardingModuleInst.mnemonicWasShown()
-    }
-    function removeMnemonic() { // -> void
-        d.onboardingModuleInst.removeMnemonic()
+        return d.onboardingModuleInst.getMnemonic()
     }
 
     // sync
-    readonly property int syncState: d.onboardingModuleInst.syncState // cf. enum Onboarding.SyncState
+    readonly property int syncState: d.onboardingModuleInst.syncState // cf. enum Onboarding.ProgressState
     function validateLocalPairingConnectionString(connectionString: string) { // -> bool
         return d.onboardingModuleInst.validateLocalPairingConnectionString(connectionString)
     }


### PR DESCRIPTION
Fixes #17079

Requres:
- https://github.com/keycard-tech/status-keycard-go/pull/16

# What does the PR do

Hooks all the keycard flows for the new onboarding.

Based on top of https://github.com/status-im/status-desktop/pull/17058 to have the fix for required properties

status-keycard-go PR here done by @igor-sirotin : https://github.com/keycard-tech/status-keycard-go/pull/13

### Affected areas

The new onboarding (using the feature flag).

This is mostly Nim code, but I had to modify the QML a lot because I needed to make a lot of the keycard calls async, because they can be slow and would freeze the app (most notable case is the setPin).

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Create account from scratch:

[new-account-basic.webm](https://github.com/user-attachments/assets/f498ea18-b8ae-4ab2-a1b5-767ff223f694)

Create account with mnemonic:

[new-account-mnemonic.webm](https://github.com/user-attachments/assets/c9a4c246-2cb8-4811-b3ae-fec7b7e5c033)

"Login" with old keycard:

[old-account-keycard.webm](https://github.com/user-attachments/assets/437b8f53-56b7-4ed9-9763-491e15d2c085)


### Impact on end user

Nothing without the feature flag.

When it is active, the new onboarding shows and all the flows for the keycard should work when there is no previous account (you need to delete or rename the data dir).

### How to test

1. Enable the feature flag: `export FLAG_ONBOARDING_V2_ENABLED=1 && make run`
2. Make sure you have no previous account (delete the data dir)
3. Use the onboarding. All flows to create an account should work now

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Low because the feature flag needs to be enabled. 

When enabled, worst case is some flows don't work properly.
