### PR TITLE
chore(wallet): new send modal improvements

### DIFF
--- a/src/app/modules/main/wallet_section/send_new/module.nim
+++ b/src/app/modules/main/wallet_section/send_new/module.nim
@@ -1,6 +1,6 @@
 import tables, NimQml, sequtils, sugar, strutils, chronicles, stint
 
-import ./io_interface, ./view, ./controller, ./path_item
+import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
 
 import app/global/global_singleton
@@ -274,7 +274,8 @@ method transactionWasSent*(self: Module, uuid: string, chainId: int = 0, approva
 
 method suggestedRoutesReady*(self: Module, uuid: string, routes: seq[TransactionPathDtoV2], errCode: string, errDescription: string) =
   let paths = routes.map(x => self.convertTransactionPathDtoV2ToPathItem(x))
-  self.view.setTransactionRoute(uuid, paths, errCode, errDescription)
+  self.view.getPathModel().setItems(paths)
+  self.view.sendSuggestedRoutesReadySignal(uuid, errCode, errDescription)
 
 method suggestedRoutes*(self: Module,
   uuid: string,

--- a/src/app/modules/main/wallet_section/send_new/path_model.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_model.nim
@@ -2,9 +2,12 @@ import NimQml, Tables, strutils, stew/shims/strformat
 
 import ./path_item
 
+export path_item
+
 type
   ModelRole {.pure.} = enum
-    ProcessorName = UserRole + 1,
+    Index = UserRole + 1,
+    ProcessorName,
     FromChain,
     ToChain,
     FromToken,
@@ -67,6 +70,7 @@ QtObject:
 
   method roleNames(self: PathModel): Table[int, string] =
     {
+      ModelRole.Index.int: "index",
       ModelRole.ProcessorName.int: "processorName",
       ModelRole.FromChain.int: "fromChain",
       ModelRole.ToChain.int: "toChain",
@@ -122,6 +126,8 @@ QtObject:
     let enumRole = role.ModelRole
 
     case enumRole:
+    of ModelRole.Index:
+      result = newQVariant(index.row)
     of ModelRole.ProcessorName:
       result = newQVariant(item.processorName)
     of ModelRole.FromChain:

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -6,6 +6,8 @@ import app_service/service/eth/utils as eth_utils
 import app_service/service/transaction/dto as transaction_dto
 from backend/eth import ExtraKeyPackId
 
+export path_model
+
 QtObject:
   type
     View* = ref object of QObject
@@ -24,6 +26,9 @@ QtObject:
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
+
+  proc getPathModel*(self: View): PathModel {.inline.} =
+    return self.pathModel
 
   proc fetchSuggestedRoutes*(self: View,
     uuid: string,
@@ -75,8 +80,7 @@ QtObject:
     self.delegate.authenticateAndTransfer(uuid, fromAddr, slippagePercentage)
 
   proc suggestedRoutesReady*(self: View, uuid: string, pathModel: QVariant, errCode: string, errDescription: string) {.signal.}
-  proc setTransactionRoute*(self: View, uuid: string, paths: seq[PathItem], errCode: string, errDescription: string) =
-    self.pathModel.setItems(paths)
+  proc sendSuggestedRoutesReadySignal*(self: View, uuid: string, errCode: string, errDescription: string) =
     self.suggestedRoutesReady(uuid, newQVariant(self.pathModel), errCode, errDescription)
 
   proc transactionSendingComplete*(self: View, txHash: string, status: string) {.signal.}

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -885,6 +885,7 @@ QtObject {
     readonly property string networkRopsten: "Ropsten"
 
     readonly property string ethToken: "ETH"
+    readonly property int ethTokenDecimals: 18
 
     readonly property QtObject networkShortChainNames: QtObject {
         readonly property string mainnet: "eth"


### PR DESCRIPTION
Updated Sign Send popup (that is going to be a review popup soon) to operate over a single tx path instead like it's now. It needs to display a path-specific time, fees, later priority fees ranges, nonce and so.

These changes are necessary to ensure the correctness of the displayed data, align with step-by-step tx review while sending/bridging and prepare the code for introducing custom tx settings.