### PR TITLE
fix(Onboarding): fixup and extract info button to `OnboardingInfoButton`

### DIFF
--- a/ui/app/AppLayouts/Onboarding2/controls/OnboardingInfoButton.qml
+++ b/ui/app/AppLayouts/Onboarding2/controls/OnboardingInfoButton.qml
@@ -1,0 +1,14 @@
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
+StatusFlatButton {
+    width: 32
+    height: 32
+    icon.width: 24
+    icon.height: 24
+    horizontalPadding: 0
+    verticalPadding: 0
+    icon.color: Theme.palette.directColor1
+    hoverColor: Theme.palette.baseColor2
+    icon.name: "info"
+}

--- a/ui/app/AppLayouts/Onboarding2/controls/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/controls/qmldir
@@ -1,6 +1,7 @@
 BulletPoint 1.0 BulletPoint.qml
 OnboardingButtonFrame 1.0 OnboardingButtonFrame.qml
 OnboardingFrame 1.0 OnboardingFrame.qml
+OnboardingInfoButton 1.0 OnboardingInfoButton.qml
 ListItemButton 1.0 ListItemButton.qml
 MaybeOutlineButton 1.0 MaybeOutlineButton.qml
 LoginUserSelector 1.0 LoginUserSelector.qml

--- a/ui/app/AppLayouts/Onboarding2/pages/CreatePasswordPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/CreatePasswordPage.qml
@@ -10,6 +10,8 @@ import StatusQ.Popups 0.1
 import utils 1.0
 import shared.views 1.0
 
+import AppLayouts.Onboarding2.controls 1.0
+
 OnboardingPage {
     id: root
 
@@ -58,18 +60,10 @@ OnboardingPage {
         }
     }
 
-    StatusButton {
-        objectName: "infoButton"
-        width: 32
-        height: 32
-        icon.width: 20
-        icon.height: 20
-        icon.color: Theme.palette.directColor1
-        normalColor: Theme.palette.baseColor2
-        padding: 0
+    OnboardingInfoButton {
         anchors.right: parent.right
         anchors.top: parent.top
-        icon.name: "info"
+        objectName: "infoButton"
         onClicked: passwordDetailsPopup.createObject(root).open()
     }
 
@@ -78,6 +72,7 @@ OnboardingPage {
         StatusSimpleTextPopup {
             objectName: "passwordDetailsPopup"
             title: qsTr("Create profile password")
+            okButtonText: qsTr("Got it")
             width: 480
             destroyOnClose: true
             content.text: qsTr("Your Status keys are the foundation of your self-sovereign identity in Web3. You have complete control over these keys, which you can use to sign transactions, access your data, and interact with Web3 services.

--- a/ui/app/AppLayouts/Onboarding2/pages/HelpUsImproveStatusPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/HelpUsImproveStatusPage.qml
@@ -70,18 +70,10 @@ OnboardingPage {
         }
     }
 
-    StatusButton {
-        objectName: "infoButton"
-        width: 32
-        height: 32
-        icon.width: 20
-        icon.height: 20
-        icon.color: Theme.palette.directColor1
-        normalColor: Theme.palette.baseColor2
-        padding: 0
+    OnboardingInfoButton {
         anchors.right: parent.right
         anchors.top: parent.top
-        icon.name: "info"
+        objectName: "infoButton"
         onClicked: helpUsImproveDetails.createObject(root).open()
     }
 
@@ -105,6 +97,8 @@ OnboardingPage {
                 OnboardingFrame {
                     Layout.fillWidth: true
                     dropShadow: false
+                    padding: Theme.padding
+                    cornerRadius: Theme.radius
                     contentItem: ColumnLayout {
                         spacing: 12
                         BulletPoint {


### PR DESCRIPTION
### What does the PR do

- create a reusable component
- fix the bg and hover colors as specified in Figma

Fixes #17102

### Affected areas

Onboarding/Info button(s)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Normal:
![image](https://github.com/user-attachments/assets/9bb58d6f-ada8-4524-9ef9-74665dfe57b6)

Hover:
![image](https://github.com/user-attachments/assets/d432d0c4-5421-4335-8743-269d50195c01)

