### PR TITLE
fix(Onboarding/SyncProgressPagePage): fixup back buttons 

### DIFF
--- a/storybook/pages/KeycardAddKeyPairPagePage.qml
+++ b/storybook/pages/KeycardAddKeyPairPagePage.qml
@@ -13,14 +13,14 @@ Item {
         id: progressPage
 
         anchors.fill: parent
-        addKeyPairState: Onboarding.AddKeyPairState.InProgress
+        addKeyPairState: ctrlState.currentValue
 
         onKeypairAddTryAgainRequested: {
             console.warn("!!! onKeypairAddTryAgainRequested")
-            addKeyPairState = Onboarding.AddKeyPairState.InProgress
+            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.AddKeyPairState.InProgress)
             Backpressure.debounce(root, 2000, function() {
                 console.warn("!!! SIMULATION: SUCCESS")
-                addKeyPairState = Onboarding.AddKeyPairState.Success
+                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.AddKeyPairState.Success)
             })()
         }
         onKeypairAddContinueRequested: console.warn("!!! onKeypairAddContinueRequested")
@@ -33,8 +33,13 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         width: 350
-        model: ["Onboarding.AddKeyPairState.InProgress", "Onboarding.AddKeyPairState.Success", "Onboarding.AddKeyPairState.Failed"]
-        onCurrentIndexChanged: progressPage.addKeyPairState = currentIndex
+        textRole: "name"
+        valueRole: "value"
+        model: [
+            {name: "InProgress", value: Onboarding.AddKeyPairState.InProgress},
+            {name: "Success", value: Onboarding.AddKeyPairState.Success},
+            {name: "Failed", value: Onboarding.AddKeyPairState.Failed}
+        ]
     }
 }
 

--- a/storybook/pages/KeycardAddKeyPairPagePage.qml
+++ b/storybook/pages/KeycardAddKeyPairPagePage.qml
@@ -35,11 +35,7 @@ Item {
         width: 350
         textRole: "name"
         valueRole: "value"
-        model: [
-            {name: "InProgress", value: Onboarding.AddKeyPairState.InProgress},
-            {name: "Success", value: Onboarding.AddKeyPairState.Success},
-            {name: "Failed", value: Onboarding.AddKeyPairState.Failed}
-        ]
+        model: Onboarding.getModelFromEnum("AddKeyPairState")
     }
 }
 

--- a/storybook/pages/KeycardIntroPagePage.qml
+++ b/storybook/pages/KeycardIntroPagePage.qml
@@ -70,20 +70,9 @@ Item {
 
             focusPolicy: Qt.NoFocus
             Layout.preferredWidth: 250
-            textRole: "text"
+            textRole: "name"
             valueRole: "value"
-            model: [
-                { value: Onboarding.KeycardState.NoPCSCService, text: "NoPCSCService" },
-                { value: Onboarding.KeycardState.PluginReader, text: "PluginReader" },
-                { value: Onboarding.KeycardState.InsertKeycard, text: "InsertKeycard" },
-                { value: Onboarding.KeycardState.ReadingKeycard, text: "ReadingKeycard" },
-                { value: Onboarding.KeycardState.WrongKeycard, text: "WrongKeycard" },
-                { value: Onboarding.KeycardState.NotKeycard, text: "NotKeycard" },
-                { value: Onboarding.KeycardState.MaxPairingSlotsReached, text: "MaxPairingSlotsReached" },
-                { value: Onboarding.KeycardState.Locked, text: "Locked" },
-                { value: Onboarding.KeycardState.NotEmpty, text: "NotEmpty" },
-                { value: Onboarding.KeycardState.Empty, text: "Empty" }
-            ]
+            model: Onboarding.getModelFromEnum("KeycardState")
         }
         ToolButton {
             text: ">"

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -157,20 +157,9 @@ SplitView {
                     Layout.preferredWidth: 300
                     id: ctrlKeycardState
                     focusPolicy: Qt.NoFocus
-                    textRole: "text"
+                    textRole: "name"
                     valueRole: "value"
-                    model: [
-                        { value: Onboarding.KeycardState.NoPCSCService, text: "NoPCSCService" },
-                        { value: Onboarding.KeycardState.PluginReader, text: "PluginReader" },
-                        { value: Onboarding.KeycardState.InsertKeycard, text: "InsertKeycard" },
-                        { value: Onboarding.KeycardState.ReadingKeycard, text: "ReadingKeycard" },
-                        { value: Onboarding.KeycardState.WrongKeycard, text: "WrongKeycard" },
-                        { value: Onboarding.KeycardState.NotKeycard, text: "NotKeycard" },
-                        { value: Onboarding.KeycardState.MaxPairingSlotsReached, text: "MaxPairingSlotsReached" },
-                        { value: Onboarding.KeycardState.Locked, text: "Locked" },
-                        { value: Onboarding.KeycardState.NotEmpty, text: "NotEmpty" },
-                        { value: Onboarding.KeycardState.Empty, text: "Empty" }
-                    ]
+                    model: Onboarding.getModelFromEnum("KeycardState")
                     onActivated: store.keycardState = currentValue
                     Component.onCompleted: currentIndex = Qt.binding(() => indexOfValue(store.keycardState))
                 }

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -419,21 +419,10 @@ SplitView {
                     }
 
                     Repeater {
-                        model: [
-                            { value: Onboarding.KeycardState.NoPCSCService, text: "NoPCSCService" },
-                            { value: Onboarding.KeycardState.PluginReader, text: "PluginReader" },
-                            { value: Onboarding.KeycardState.InsertKeycard, text: "InsertKeycard" },
-                            { value: Onboarding.KeycardState.ReadingKeycard, text: "ReadingKeycard" },
-                            { value: Onboarding.KeycardState.WrongKeycard, text: "WrongKeycard" },
-                            { value: Onboarding.KeycardState.NotKeycard, text: "NotKeycard" },
-                            { value: Onboarding.KeycardState.MaxPairingSlotsReached, text: "MaxPairingSlotsReached" },
-                            { value: Onboarding.KeycardState.Locked, text: "Locked" },
-                            { value: Onboarding.KeycardState.NotEmpty, text: "NotEmpty" },
-                            { value: Onboarding.KeycardState.Empty, text: "Empty" }
-                        ]
+                        model: Onboarding.getModelFromEnum("KeycardState")
 
                         RoundButton {
-                            text: modelData.text
+                            text: modelData.name
                             checkable: true
                             checked: store.keycardState === modelData.value
 
@@ -461,14 +450,10 @@ SplitView {
                     }
 
                     Repeater {
-                        model: [
-                            { value: Onboarding.AddKeyPairState.InProgress, text: "InProgress" },
-                            { value: Onboarding.AddKeyPairState.Success, text: "Success" },
-                            { value: Onboarding.AddKeyPairState.Failed, text: "Failed" }
-                        ]
+                        model: Onboarding.getModelFromEnum("AddKeyPairState")
 
                         RoundButton {
-                            text: modelData.text
+                            text: modelData.name
                             checkable: true
                             checked: store.addKeyPairState === modelData.value
 
@@ -494,14 +479,10 @@ SplitView {
                     }
 
                     Repeater {
-                        model: [
-                            { value: Onboarding.SyncState.InProgress, text: "InProgress" },
-                            { value: Onboarding.SyncState.Success, text: "Success" },
-                            { value: Onboarding.SyncState.Failed, text: "Failed" }
-                        ]
+                        model: Onboarding.getModelFromEnum("SyncState")
 
                         RoundButton {
-                            text: modelData.text
+                            text: modelData.name
                             checkable: true
                             checked: store.syncState === modelData.value
 

--- a/storybook/pages/SyncProgressPagePage.qml
+++ b/storybook/pages/SyncProgressPagePage.qml
@@ -12,13 +12,13 @@ Item {
     SyncProgressPage {
         id: progressPage
         anchors.fill: parent
-        syncState: Onboarding.SyncState.InProgress
+        syncState: ctrlState.currentValue
         onRestartSyncRequested: {
             console.warn("!!! RESTART SYNC REQUESTED")
-            syncState = Onboarding.SyncState.InProgress
+            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.SyncState.InProgress)
             Backpressure.debounce(root, 2000, function() {
                 console.warn("!!! SIMULATION: SUCCESS")
-                syncState = Onboarding.SyncState.Success
+                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.SyncState.Success)
             })()
         }
         onLoginToAppRequested: console.warn("!!! LOGIN TO APP REQUESTED")
@@ -30,8 +30,13 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         width: 300
-        model: ["Onboarding.SyncState.InProgress", "Onboarding.SyncState.Success", "Onboarding.SyncState.Failed"]
-        onCurrentIndexChanged: progressPage.syncState = currentIndex
+        textRole: "name"
+        valueRole: "value"
+        model: [
+            {name: "InProgress", value: Onboarding.SyncState.InProgress},
+            {name: "Success", value: Onboarding.SyncState.Success},
+            {name: "Failed", value: Onboarding.SyncState.Failed}
+        ]
     }
 }
 

--- a/storybook/pages/SyncProgressPagePage.qml
+++ b/storybook/pages/SyncProgressPagePage.qml
@@ -32,11 +32,7 @@ Item {
         width: 300
         textRole: "name"
         valueRole: "value"
-        model: [
-            {name: "InProgress", value: Onboarding.SyncState.InProgress},
-            {name: "Success", value: Onboarding.SyncState.Success},
-            {name: "Failed", value: Onboarding.SyncState.Failed}
-        ]
+        model: Onboarding.getModelFromEnum("SyncState")
     }
 }
 

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -1,10 +1,32 @@
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QMetaEnum>
 #include <QObject>
 
-class OnboardingEnums
+class OnboardingEnums: public QObject
 {
-    Q_GADGET
+    Q_OBJECT
     Q_CLASSINFO("RegisterEnumClassesUnscoped", "false")
+
 public:
+    Q_INVOKABLE QJsonArray getModelFromEnum(const QString &name) const {
+        if (name.isEmpty())
+            return {};
+
+        QMetaEnum e = staticMetaObject.enumerator(staticMetaObject.indexOfEnumerator(name.toLatin1().constData()));
+        if (!e.isValid())
+            return {};
+
+        QJsonArray result;
+        for (int i = 0; i < e.keyCount(); ++i) {
+            result.append(
+                {{{QStringLiteral("name"), e.key(i)}, {QStringLiteral("value"), e.value(i)}}});
+        }
+
+        return result;
+    }
+
     enum class PrimaryFlow {
         Unknown,
         CreateProfile,

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -105,8 +105,10 @@ void registerStatusQTypes() {
         });
 
     // onboarding
-    qmlRegisterUncreatableType<OnboardingEnums>("AppLayouts.Onboarding.enums", 1, 0,
-                                                "Onboarding", "This is an enum type, cannot be created directly.");
+    qmlRegisterSingletonType<OnboardingEnums>("AppLayouts.Onboarding.enums", 1, 0,
+                                              "Onboarding", [](QQmlEngine*, QJSEngine*) {
+                                                  return new OnboardingEnums;
+                                              });
 
     QZXing::registerQMLTypes();
     qqsfpm::registerTypes();

--- a/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
@@ -29,7 +29,7 @@ SQUtils.QObject {
 
             onSyncProceedWithConnectionString: {
                 root.syncProceedWithConnectionString(connectionString)
-                root.stackView.push(syncProgressPage, { connectionString })
+                root.stackView.push(syncProgressPage)
             }
         }
     }
@@ -38,17 +38,13 @@ SQUtils.QObject {
         id: syncProgressPage
 
         SyncProgressPage {
-            property string connectionString
             readonly property bool backAvailableHint:
-                root.syncState !== Onboarding.SyncState.InProgress
+                root.syncState === Onboarding.SyncState.Failed
 
             syncState: root.syncState
 
             onLoginToAppRequested: root.finished()
-            onRestartSyncRequested: {
-                root.syncProceedWithConnectionString(connectionString)
-                root.stackView.replace(syncProgressPage)
-            }
+            onRestartSyncRequested: root.stackView.pop()
 
             onLoginWithSeedphraseRequested: root.loginWithSeedphraseRequested()
         }

--- a/ui/app/AppLayouts/Onboarding2/pages/HelpUsImproveStatusPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/HelpUsImproveStatusPage.qml
@@ -62,9 +62,7 @@ OnboardingPage {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.preferredWidth: 320
                 text: qsTr("Not now")
-                normalColor: "transparent"
-                borderWidth: 1
-                borderColor: Theme.palette.baseColor2
+                isOutline: true
                 onClicked: root.shareUsageDataRequested(false)
             }
         }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
@@ -159,19 +159,21 @@ OnboardingPage {
                 spacing: 12
                 visible: false
 
-                MaybeOutlineButton {
+                StatusButton {
                     width: parent.width
                     text: qsTr("Try again")
                     onClicked: root.keypairAddTryAgainRequested()
                 }
-                MaybeOutlineButton {
-                    text: qsTr("I’ve inserted a different Keycard")
+                StatusButton {
+                    text: qsTr("I've inserted a different Keycard")
                     width: parent.width
+                    isOutline: true
                     onClicked: root.reloadKeycardRequested()
                 }
-                MaybeOutlineButton {
+                StatusButton {
                     text: qsTr("Create profile without Keycard")
                     width: parent.width
+                    isOutline: true
                     onClicked: root.createProfilePageRequested()
                 }
             }

--- a/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
@@ -21,7 +21,7 @@ OnboardingPage {
     states: [
         State {
             name: "inprogress"
-            when: root.syncState === Onboarding.SyncState.InProgress
+            when: root.syncState === Onboarding.SyncState.InProgress || root.syncState === Onboarding.SyncState.Idle
             PropertyChanges {
                 target: root
                 title: qsTr("Profile sync in progress...")

--- a/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
@@ -176,9 +176,7 @@ OnboardingPage {
                 id: loginWithSeedphraseButton
                 text: qsTr("Log in via recovery phrase")
                 visible: false
-                normalColor: "transparent"
-                borderWidth: 1
-                borderColor: Theme.palette.baseColor2
+                isOutline: true
                 onClicked: root.loginWithSeedphraseRequested()
             }
 
@@ -188,9 +186,7 @@ OnboardingPage {
                 id: loginAnywayButton
                 text: qsTr("Log in anyway")
                 visible: false
-                normalColor: "transparent"
-                borderWidth: 1
-                borderColor: Theme.palette.baseColor2
+                isOutline: true
                 onClicked: root.loginToAppRequested()
             }
         }

--- a/ui/app/AppLayouts/Onboarding2/pages/WelcomePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/WelcomePage.qml
@@ -110,10 +110,8 @@ OnboardingPage {
                     objectName: "btnLogin"
                     Layout.fillWidth: true
                     text: qsTr("Log in")
+                    isOutline: true
                     onClicked: root.loginRequested()
-                    normalColor: "transparent"
-                    borderWidth: 1
-                    borderColor: Theme.palette.baseColor2
                 }
                 StatusBaseText {
                     objectName: "approvalLinks"


### PR DESCRIPTION
### What does the PR do

- SyncProgressPagePage: enable the back button only in the failed state
- SyncProgressPagePage: fix the "Try again" and "Back" button to go to the Scan QR step; the connection code is disposable and can't be used again anyway
- adjust the respective SB pages to reflect the correct enum values
- seperate small commit to simplify the code and use the new `isOutline` variants of `StatusButton`

Fixes #17108

### Affected areas

Onboarding/progress pages

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/20e5424e-eb15-434a-a2f3-6c8efab96b4e
