### PR TITLE
fix(PasswordView): unbreak strength score and padding/margins

### DIFF
--- a/ui/imports/shared/popups/keycard/states/CreatePassword.qml
+++ b/ui/imports/shared/popups/keycard/states/CreatePassword.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ.Core.Theme 0.1
+
 import shared.stores 1.0
 import shared.views 1.0
 

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -23,6 +23,6 @@ QtObject {
     }
 
     function getPasswordStrengthScore(password) {
-        return root.privacyModule.getPasswordStrengthScore(password);
+        return root.privacyModule.getPasswordStrengthScore(password, "");
     }
 }


### PR DESCRIPTION
### What does the PR do

- the view was missing the import for `Theme`
- the `getPasswordStrengthScore` was not being called with the correct signature (like in every other store)

Fixes #17050

### Affected areas

Settings/Keycard

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/29c067af-fa41-4b63-836b-b631ee9f4955)
