### PR TITLE
Onboarding: LoginScreen location adjusted

### DIFF
--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -3,11 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
 
-import StatusQ 0.1
-import StatusQ.Core.Theme 0.1
-import StatusQ.Core 0.1
-import StatusQ.Controls 0.1
-import StatusQ.Components 0.1
+import Qt.labs.settings 1.0
 
 import AppLayouts.Onboarding.enums 1.0
 import AppLayouts.Onboarding2 1.0
@@ -379,9 +375,11 @@ SplitView {
                     const stack = onboarding.stack
                     let content = `Stack (${stack.depth}):`
 
-                    for (let i = 0; i < stack.depth; i++)
-                        content += " " + InspectionUtils.baseName(
-                                    stack.get(i, StackView.ForceLoad))
+                    for (let i = 0; i < stack.depth; i++) {
+                        const stackEntry = stack.get(i, StackView.ForceLoad)
+                        content += " " + InspectionUtils.baseName(stackEntry instanceof Loader
+                                                                  ? stackEntry.item : stackEntry)
+                    }
 
                     return content
                 }
@@ -525,6 +523,12 @@ SplitView {
                 Layout.fillHeight: true
             }
         }
+    }
+
+    Settings {
+        property alias useBiometrics: ctrlBiometrics.checked
+        property alias showLoginScreen: ctrlLoginScreen.checked
+        property alias useTouchId: ctrlTouchIdUser.checked
     }
 }
 

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -172,6 +172,11 @@ Item {
             verify(!!stack)
             tryCompare(stack, "busy", false) // wait for page transitions to stop
 
+            if (stack.currentItem instanceof Loader) {
+                verify(stack.currentItem.item instanceof pageClass)
+                return stack.currentItem.item
+            }
+
             verify(stack.currentItem instanceof pageClass)
             return stack.currentItem
         }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -972,7 +972,7 @@ QtObject {
         let typeName = item.toString()
 
         if (typeName.startsWith("QQuick"))
-            typeName = name.substring(6)
+            typeName = typeName.substring(6)
 
         const underscoreIndex = typeName.indexOf("_")
 


### PR DESCRIPTION
### What does the PR do

- `LoginScreen` and related SB page simplified
- OnboardingLayoutPage - settings introduced for handier testing
- LoginScreen moved from OnboardingLayout to OnboardingFlow, making first flow's page bound to model content (instead of relying on check during initialization)
- UnblockWithPukFlow removed from OnboardingLayout (now it's used only in OnboardingFlow)
- Login error/success processing extracted from LoginScreen to OnboardingLayout
- small bug fixed in Utils::objectTypeName

Closes: #17160

### Affected areas
`OnboardingLayout` and related components

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

