### PR TITLE
feat(Onboarding): implement the KeycardFactoryReset flow

### DIFF
--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -41,7 +41,7 @@ SplitView {
             logs.logEvent("setPuk", ["puk"], arguments)
             const valid = puk === ctrlPuk.text
             if (!valid)
-                keycardRemainingPukAttempts--
+                keycardRemainingPukAttempts-- // SIMULATION: decrease the remaining PUK attempts
             if (keycardRemainingPukAttempts <= 0) { // SIMULATION: "block" the keycard
                 keycardState = Onboarding.KeycardState.BlockedPUK
                 keycardRemainingPukAttempts = 0
@@ -86,7 +86,6 @@ SplitView {
         onUnblockWithSeedphraseRequested: logs.logEvent("onUnblockWithSeedphraseRequested")
         onUnblockWithPukRequested: logs.logEvent("onUnblockWithPukRequested")
         onLostKeycard: logs.logEvent("onLostKeycard")
-        onKeycardFactoryResetRequested: logs.logEvent("onKeycardFactoryResetRequested")
 
         // mocks
         QtObject {

--- a/ui/app/AppLayouts/Onboarding2/KeycardFactoryResetFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardFactoryResetFlow.qml
@@ -1,0 +1,108 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+SQUtils.QObject {
+    id: root
+
+    required property StackView stackView
+    required property int keycardState
+
+    signal performKeycardFactoryResetRequested
+
+    signal finished
+
+    function init(fromLoginScreen = false) {
+        d.fromLoginScreen = fromLoginScreen
+        root.stackView.push(d.initialComponent())
+    }
+
+    QtObject {
+        id: d
+
+        property bool fromLoginScreen
+
+        function initialComponent() {
+            if (root.keycardState === Onboarding.KeycardState.FactoryResetting)
+                return keycardResetPageComponent
+            return keycardResetAcks
+        }
+    }
+
+    Component {
+        id: keycardResetAcks
+
+        KeycardBasePage {
+            image.source: Theme.png("onboarding/keycard/reading")
+            title: qsTr("Factory reset Keycard")
+            subtitle: "<font color='%1'>".arg(Theme.palette.dangerColor1) +
+                      qsTr("All data including the stored key pair and derived accounts will be removed from the Keycard") +
+                      "</font>"
+            buttons: [
+                StatusCheckBox {
+                    id: ack
+                    width: Math.min(implicitWidth, parent.width)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: qsTr("I understand the key pair will be deleted")
+                },
+                Item {
+                    width: parent.width
+                    height: parent.spacing
+                },
+                StatusButton {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    type: StatusBaseButton.Type.Danger
+                    text: qsTr("Factory reset this Keycard")
+                    enabled: ack.checked
+                    onClicked: {
+                        root.performKeycardFactoryResetRequested()
+                        root.stackView.replace(null, keycardResetPageComponent)
+                    }
+                }
+            ]
+        }
+    }
+
+    Component {
+        id: keycardResetPageComponent
+
+        KeycardBasePage {
+            id: keycardResetPage
+            readonly property bool resetting: root.keycardState === Onboarding.KeycardState.FactoryResetting
+
+            image.source: resetting ? Theme.png("onboarding/keycard/empty") // FIXME correct image
+                                    : Theme.png("onboarding/keycard/success")
+            title: resetting ? qsTr("Reseting Keycard") : qsTr("Keycard successfully factory reset")
+            subtitle: resetting ? "" : qsTr("You can now use this Keycard like it's a brand-new, empty Keycard")
+            infoText.text: resetting ? qsTr("Do not remove your Keycard or reader") : ""
+            buttons: [
+                Row {
+                    spacing: 4
+                    visible: keycardResetPage.resetting
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    StatusLoadingIndicator {
+                        color: Theme.palette.directColor1
+                    }
+                    StatusBaseText {
+                        text: qsTr("Please wait while the Keycard is being reset")
+                    }
+                },
+                StatusButton {
+                    visible: !keycardResetPage.resetting
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    width: 320
+                    text: d.fromLoginScreen ? qsTr("Back to Login screen") : qsTr("Log in or Create profile")
+                    onClicked: root.finished()
+                }
+            ]
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -96,6 +96,7 @@ SQUtils.QObject {
             remainingAttempts: root.remainingPinAttempts
             unblockWithPukAvailable: root.remainingPukAttempts > 0
             keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+            pinCorrectText: qsTr("PIN correct. Exporting keys.")
 
             onExportKeysRequested: root.exportKeysRequested()
             onExportKeysDone: root.finished()

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -360,7 +360,9 @@ SQUtils.QObject {
         }
         onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
 
-        onFinished: {
+        onFinished: (success) => {
+            if (!success)
+               return
             if (root.loginScreen) {
                 root.loginRequested(root.loginScreen.selectedProfileKeyId,
                                     Onboarding.LoginMethod.Keycard, { pin })

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -185,7 +185,7 @@ Page {
         onAuthorizationRequested: d.authorize(pin)
         onShareUsageDataRequested: (enabled) => root.shareUsageDataRequested(enabled)
         onReloadKeycardRequested: root.reloadKeycardRequested()
-
+        onPerformKeycardFactoryResetRequested: root.onboardingStore.startKeycardFactoryReset()
         onSyncProceedWithConnectionString: (connectionString) =>
             root.onboardingStore.inputConnectionStringForBootstrapping(connectionString)
         onSeedphraseSubmitted: (seedphrase) => d.seedphrase = seedphrase
@@ -194,7 +194,6 @@ Page {
         onLinkActivated: (link) => Qt.openUrlExternally(link)
         onExportKeysRequested: root.onboardingStore.exportRecoverKeys()
         onFinished: (flow) => d.finishFlow(flow)
-        onKeycardFactoryResetRequested: console.warn("!!! FIXME OnboardingLayout::onKeycardFactoryResetRequested")
     }
 
     Connections {

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
@@ -23,7 +23,7 @@ SQUtils.QObject {
     signal keycardPinCreated(string pin)
     signal reloadKeycardRequested
     signal keycardFactoryResetRequested
-    signal finished
+    signal finished(bool success)
 
     function init() {
         root.stackView.push(d.initialComponent())
@@ -47,7 +47,7 @@ SQUtils.QObject {
 
         function finishWithFactoryReset() {
             root.keycardFactoryResetRequested()
-            root.finished()
+            root.finished(false)
         }
     }
 
@@ -101,7 +101,7 @@ SQUtils.QObject {
                 StatusButton {
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: qsTr("Continue")
-                    onClicked: root.finished()
+                    onClicked: root.finished(true)
                 }
             ]
         }

--- a/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
@@ -27,7 +27,6 @@ Control {
 
     signal unblockWithSeedphraseRequested()
     signal unblockWithPukRequested()
-    signal keycardFactoryResetRequested()
 
     signal loginRequested(string pin)
 
@@ -92,15 +91,9 @@ Control {
             }
             MaybeOutlineButton {
                 width: parent.width
-                visible: root.keycardState === Onboarding.KeycardState.BlockedPIN
+                visible: root.keycardState === Onboarding.KeycardState.BlockedPIN || root.keycardState === Onboarding.KeycardState.BlockedPUK
                 text: qsTr("Unblock with recovery phrase")
                 onClicked: root.unblockWithSeedphraseRequested()
-            }
-            MaybeOutlineButton {
-                width: parent.width
-                visible: root.keycardState === Onboarding.KeycardState.BlockedPUK
-                text: qsTr("Factory reset Keycard")
-                onClicked: root.keycardFactoryResetRequested()
             }
         }
         StatusPinInput {

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -21,6 +21,7 @@ KeycardBasePage {
     required property int remainingAttempts
     required property bool unblockWithPukAvailable
     required property int keycardPinInfoPageDelay
+    property string pinCorrectText: qsTr("PIN correct")
 
     signal keycardPinEntered(string pin)
     signal reloadKeycardRequested
@@ -157,6 +158,10 @@ KeycardBasePage {
                     })()
                 }
             }
+            PropertyChanges {
+                target: image
+                source: Theme.png("onboarding/keycard/error")
+            }
         },
         State {
             name: "error"
@@ -167,6 +172,10 @@ KeycardBasePage {
             }
             PropertyChanges {
                 target: errorExportingText
+                visible: true
+            }
+            PropertyChanges {
+                target: btnReload
                 visible: true
             }
         },
@@ -197,6 +206,10 @@ KeycardBasePage {
                 target: pinInput
                 enabled: false
             }
+            PropertyChanges {
+                target: image
+                source: Theme.png("onboarding/keycard/success")
+            }
             StateChangeScript {
                 script: {
                     Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
@@ -210,7 +223,7 @@ KeycardBasePage {
             when: root.authorizationState === Onboarding.ProgressState.Success
             PropertyChanges {
                 target: root
-                title: qsTr("PIN correct. Exporting keys.")
+                title: root.pinCorrectText
             }
             PropertyChanges {
                 target: pinInput

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -45,7 +45,6 @@ OnboardingPage {
     signal onboardingLoginFlowRequested()
     signal unblockWithSeedphraseRequested()
     signal unblockWithPukRequested()
-    signal keycardFactoryResetRequested()
     signal lostKeycard()
 
     QtObject {
@@ -235,7 +234,6 @@ OnboardingPage {
                 keycardRemainingPukAttempts: root.keycardRemainingPukAttempts
                 onUnblockWithSeedphraseRequested: root.unblockWithSeedphraseRequested()
                 onUnblockWithPukRequested: root.unblockWithPukRequested()
-                onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
                 onPinEditedManually: {
                     // reset state when typing the PIN manually; not to break the bindings inside the component
                     d.resetBiometricsResult()

--- a/ui/app/AppLayouts/Onboarding2/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/qmldir
@@ -1,6 +1,7 @@
 CreateNewProfileFlow 1.0 CreateNewProfileFlow.qml
 KeycardCreateProfileFlow 1.0 KeycardCreateProfileFlow.qml
 KeycardCreateReplacementFlow 1.0 KeycardCreateReplacementFlow.qml
+KeycardFactoryResetFlow 1.0 KeycardFactoryResetFlow.qml
 LoginByKeycardFlow 1.0 LoginByKeycardFlow.qml
 LoginBySyncingFlow 1.0 LoginBySyncingFlow.qml
 OnboardingFlow 1.0 OnboardingFlow.qml

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -57,6 +57,10 @@ QtObject {
         d.onboardingModuleInst.exportRecoverKeys()
     }
 
+    function startKeycardFactoryReset() {
+        d.onboardingModuleInst.startKeycardFactoryReset()
+    }
+
     // password
     signal accountLoginError(string error, bool wrongPassword)
 


### PR DESCRIPTION
### What does the PR do

- integrate it into the UI and StoryBook
- a new keycardState is introduced: `FactoryResetting` (matching the backend)
- a new store method introduced: `startKeycardFactoryReset()`

Fixes: #17094

### Affected areas

Onboarding

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/19fa9a76-2913-4d67-ae0b-bee1f6e25c43
