### PR TITLE
feat(@desktop/wallet): Add option to not show Popular section in TokenSelectorViewAdaptor.qml

### DIFF
--- a/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/TokenSelectorViewAdaptor.qml
@@ -49,6 +49,8 @@ QObject {
     property var enabledChainIds: []
     property string accountAddress
     property bool showCommunityAssets
+    // Incase of SendModal we show SNT, ETH and DAI with 0 balance
+    property bool showZeroBalanceForDefaultTokens: false
 
     // output model
     readonly property SortFilterProxyModel outputAssetsModel: SortFilterProxyModel {
@@ -111,7 +113,7 @@ QObject {
         id: tokensWithBalance
         filters: [
             ValueFilter {
-                roleName: "currencyBalance"
+                roleName: "balancesModelCount"
                 value: 0
                 inverted: true
             }
@@ -154,6 +156,7 @@ QObject {
                                     : ""
 
                 readonly property var balances: this
+                readonly property int balancesModelCount: delegateRoot.ModelCount.count
 
                 sourceModel: joinModel
 
@@ -185,6 +188,7 @@ QObject {
                         roleName: "balance"
                         value: "0"
                         inverted: true
+                        enabled: !root.showZeroBalanceForDefaultTokens
                     },
                     RegExpFilter {
                         roleName: "account"
@@ -219,7 +223,7 @@ QObject {
                 }
             }
 
-            exposedRoles: ["tokensKey", "balances", "currentBalance", "currencyBalance", "currencyBalanceAsString", "balanceAsString"]
+            exposedRoles: ["tokensKey", "balances", "currentBalance", "currencyBalance", "currencyBalanceAsString", "balanceAsString", "balancesModelCount"]
             expectedRoles: [ "tokensKey", "communityId", "balances", "decimals", "marketDetails"]
         }
     }

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -23,6 +23,8 @@ Control {
 
     readonly property bool isTokenSelected: tokenSelectorButton.selected
 
+    property bool showSectionName: true
+
     signal assetSelected(string key)
     signal collectionSelected(string key)
     signal collectibleSelected(string key)
@@ -50,7 +52,7 @@ Control {
     QObject {
         id: d
 
-        readonly property int maxPopupHeight: 330
+        readonly property int maxPopupHeight: 455
     }
 
     contentItem: TokenSelectorButton {
@@ -100,6 +102,8 @@ Control {
                     tokenSelectorButton.selected = true
                     dropdown.close()
                 }
+
+                showSectionName: root.showSectionName
 
                 onAssetSelected: {
                     const entry = ModelUtils.getByKey(assetsModel, "tokensKey", key)

--- a/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.15
 import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Wallet.views 1.0
@@ -33,6 +34,7 @@ Control {
     property alias model: sfpm.sourceModel
     property string highlightedKey
     property string nonInteractiveKey
+    property bool showSectionName: true
 
     signal selected(string key)
 
@@ -63,13 +65,23 @@ Control {
     contentItem: ColumnLayout {
         spacing: 0
 
+        StatusBaseText {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.bottomMargin: 4
+            text: qsTr("Your assets will appear here")
+            color: Theme.palette.baseColor1
+            visible: !listView.count && !searchBox.text
+        }
+
         TokenSearchBox {
             id: searchBox
 
             objectName: "searchBox"
 
             Layout.fillWidth: true
-            placeholderText: qsTr("Search assets")
+            placeholderText: qsTr("Search for token or enter token address")
+
+            visible: listView.count || !!searchBox.text
 
             Keys.forwardTo: [listView]
         }
@@ -100,6 +112,7 @@ Control {
             section.delegate: TokenSelectorSectionDelegate {
                 width: ListView.view.width
                 text: section
+                height: root.showSectionName ? implicitHeight : 0
             }
 
             delegate: TokenSelectorAssetDelegate {

--- a/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
@@ -113,6 +113,7 @@ RowLayout {
                   TokenSelectorButton.Size.Normal
 
         enabled: root.interactive
+        showSectionName: false
 
         assetsModel: root.assetsModel
         collectiblesModel: root.displayOnlyAssets ? null: root.collectiblesModel

--- a/ui/app/AppLayouts/Wallet/panels/TokenSelectorPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/TokenSelectorPanel.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ.Popups.Dialog 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 
@@ -35,6 +36,8 @@ Control {
     // Index of the current tab, indexes ​​correspond to the Tabs enum values.
     property alias currentTab: tabBar.currentIndex
 
+    property bool showSectionName: true
+
     signal assetSelected(string key)
     signal collectionSelected(string key)
     signal collectibleSelected(string key)
@@ -47,6 +50,7 @@ Control {
     }
 
     contentItem: ColumnLayout {
+        spacing: 0
         StatusTabBar {
             id: tabBar
 
@@ -79,6 +83,11 @@ Control {
             }
         }
 
+        StatusDialogDivider {
+            Layout.topMargin: -9
+            Layout.fillWidth: true
+        }
+
         SearchableAssetsPanel {
             id: searchableAssetsPanel
 
@@ -88,6 +97,7 @@ Control {
             Layout.fillHeight: true
 
             highlightedKey: root.highlightedKey
+            showSectionName: root.showSectionName
 
             onSelected: root.assetSelected(key)
         }

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -629,6 +629,7 @@ QtObject {
 
                     currentCurrency: root.currentCurrency
                     showCommunityAssets: root.showCommunityAssetsInSend
+                    showZeroBalanceForDefaultTokens: true
 
                     accountAddress: simpleSendModal.selectedAccountAddress
                     enabledChainIds: [simpleSendModal.selectedChainId]


### PR DESCRIPTION
fixes #17148

### What does the PR do

Implements the logic to show default token (ETH, DAI and SNT) with 0 balance in SendModal

### Affected areas

SimpleSend

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/7cd5b357-5887-4028-98ff-e2bed4c4f31a

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
