### PR TITLE
fix(Onboarding): Seed Phrase Entry UX Issues

### DIFF
--- a/storybook/pages/EnterSeedPhrasePage.qml
+++ b/storybook/pages/EnterSeedPhrasePage.qml
@@ -1,14 +1,53 @@
 import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import shared.panels 1.0
 
 import Storybook 1.0
 
-
 Item {
+    QtObject {
+        id: mockDriver
+
+        readonly property var seedWords: ["apple", "banana", "cat", "cow", "catalog", "catch", "category", "cattle", "dog", "elephant", "fish", "grape"]
+
+        function isSeedPhraseValid(mnemonic: string) {
+            return mnemonic === seedWords.join(" ")
+        }
+    }
+
     EnterSeedPhrase {
+        id: panel
         anchors.centerIn: parent
+        isSeedPhraseValid: mockDriver.isSeedPhraseValid
+    }
+
+    Row {
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.margins: 10
+        spacing: 8
+
+        Label {
+            anchors.verticalCenter: parent.verticalCenter
+            text: "Valid: %1".arg(panel.seedPhraseIsValid ? "yes" : "no")
+        }
+        Button {
+            text: "Paste seed phrase"
+            focusPolicy: Qt.NoFocus
+            onClicked: {
+                for (let i = 1;; i++) {
+                    const input = StorybookUtils.findChild(panel, `enterSeedPhraseInputField${i}`)
+
+                    if (input === null)
+                        break
+
+                    input.text = mockDriver.seedWords[i-1]
+                }
+            }
+        }
     }
 }
 
 // category: Panels
+// status: good

--- a/storybook/qmlTests/tests/tst_EnterSeedPhrase.qml
+++ b/storybook/qmlTests/tests/tst_EnterSeedPhrase.qml
@@ -183,7 +183,12 @@ Item {
             ClipboardUtils.setText(expectedSeedPhrase.join(" "))
 
             // Trigger the paste action
-            keyClick("v", Qt.ControlModifier)
+            keySequence(StandardKey.Paste)
+
+            // verify the last field has focus (https://github.com/status-im/status-desktop/issues/17105; issue 18)
+            const lastInputField = findChild(itemUnderTest, "enterSeedPhraseInputField12")
+            verify(!!lastInputField)
+            tryCompare(lastInputField, "activeFocus", true)
 
             verify(isSeedPhraseValidCalled, "isSeedPhraseValid was not called")
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -374,7 +374,7 @@ Item {
                         selectionColor: Theme.palette.primaryColor2
                         selectedTextColor: color
                         focus: true
-                        font.pixelSize: 15
+                        font.pixelSize: Theme.primaryTextFontSize
                         font.family: Theme.baseFont.name
                         color: root.enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
                         wrapMode: root.multiline ? Text.WrapAtWordBoundaryOrAnywhere : TextEdit.NoWrap
@@ -442,7 +442,6 @@ Item {
                             visible: (edit.length === 0)
                             anchors.fill: parent
                             verticalAlignment: parent.verticalAlignment
-                            font.pixelSize: 15
                             wrapMode: root.multiline ? Text.WrapAnywhere : Text.NoWrap
                             elide: root.multiline? Text.ElideNone : Text.ElideRight
                             color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor6

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -155,7 +155,7 @@ Item {
             for (var i = 0; i < inputList.count; i++) {
                 const word = inputList.get(i).seedWord
                 if (word.startsWith(textToCheck)) {
-                    filteredList.insert(filteredList.count, {"seedWord": word})
+                    filteredList.append({"seedWord": word})
                 }
             }
 

--- a/ui/app/AppLayouts/Onboarding2/components/SeedphraseVerifyInput.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/SeedphraseVerifyInput.qml
@@ -18,25 +18,34 @@ StatusTextField {
     placeholderText: qsTr("Enter word")
 
     leftPadding: Theme.padding
-    rightPadding: Theme.padding + rightIcon.width + spacing
+    rightPadding: Theme.padding + rightIcon.width + d.contentSpacing
     topPadding: Theme.smallPadding
     bottomPadding: Theme.smallPadding
 
     background: Rectangle {
         radius: Theme.radius
-        color: d.isEmpty ? Theme.palette.baseColor2 : root.valid ? Theme.palette.successColor2 : Theme.palette.dangerColor3
-        border.width: 1
+
+        color: {
+            if (root.activeFocus || d.isEmpty)
+                return Theme.palette.baseColor2
+            if (root.valid)
+                return Theme.palette.successColor2
+            return Theme.palette.dangerColor3
+        }
+
+        border.width: root.activeFocus ? 1 : 0
         border.color: {
-            if (d.isEmpty)
+            if (root.activeFocus || d.isEmpty)
                 return Theme.palette.primaryColor1
             if (root.valid)
-                return Theme.palette.successColor3
-            return Theme.palette.dangerColor2
+                return Theme.palette.successColor1
+            return Theme.palette.dangerColor1
         }
     }
 
     QtObject {
         id: d
+        readonly property int contentSpacing: 4
         readonly property int delegateHeight: 33
         readonly property bool isEmpty: root.text === ""
     }
@@ -68,7 +77,7 @@ StatusTextField {
 
     StatusDropdown {
         x: 0
-        y: parent.height + 4
+        y: parent.height + d.contentSpacing
         width: parent.width
         contentHeight: ((suggestionsList.count <= 5) ? suggestionsList.count : 5) * d.delegateHeight // max 5 delegates
         visible: filteredModel.count > 0 && root.cursorVisible && !d.isEmpty && !root.valid
@@ -105,28 +114,26 @@ StatusTextField {
     }
 
     StatusIcon {
-        id: rightIcon
+        id: clearIcon
         width: 20
         height: 20
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
         anchors.rightMargin: Theme.padding
-        visible: !d.isEmpty
-        icon: root.valid ? "checkmark-circle" : root.activeFocus ? "clear" : "warning"
-        color: root.valid ? Theme.palette.successColor1 :
-                            root.activeFocus ? Theme.palette.directColor9 : Theme.palette.dangerColor1
+        visible: !d.isEmpty && root.activeFocus
+        icon: "clear"
+        color: Theme.palette.directColor9
 
         HoverHandler {
             id: hhandler
             cursorShape: hovered ? Qt.PointingHandCursor : undefined
         }
         TapHandler {
-            enabled: rightIcon.icon === "clear"
             onSingleTapped: root.clear()
         }
         StatusToolTip {
-            text: root.valid ? qsTr("Correct word") : root.activeFocus ? qsTr("Clear") : qsTr("Wrong word")
-            visible: hhandler.hovered && rightIcon.visible
+            text: qsTr("Clear")
+            visible: hhandler.hovered && clearIcon.visible
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseVerify.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseVerify.qml
@@ -64,8 +64,6 @@ OnboardingPage {
                     id: seedRepeater
                     model: root.seedWordsToVerify
                     delegate: RowLayout {
-                        id: seedWordDelegate
-
                         required property var modelData
                         required property int index
 
@@ -79,6 +77,7 @@ OnboardingPage {
                         StatusBaseText {
                             Layout.preferredWidth: 20
                             text: modelData.seedWordNumber
+                            horizontalAlignment: Text.AlignHCenter
                         }
                         SeedphraseVerifyInput {
                             readonly property int seedWordIndex: modelData.seedWordNumber - 1 // 0 based idx into the seedWords
@@ -97,6 +96,26 @@ OnboardingPage {
                                         nextItem.input.forceActiveFocus()
                                     }
                                 }
+                            }
+                        }
+                        StatusIcon {
+                            id: statusIcon
+                            width: 20
+                            height: 20
+                            icon: seedInput.text === "" ? "help" : seedInput.valid ? "checkmark-circle" : "warning"
+                            color: seedInput.text === "" ? Theme.palette.baseColor1 : seedInput.valid ? Theme.palette.successColor1
+                                                                                                      : Theme.palette.dangerColor1
+
+                            HoverHandler {
+                                id: hhandler
+                                cursorShape: hovered ? Qt.PointingHandCursor : undefined
+                            }
+                            TapHandler {
+                                onSingleTapped: seedInput.forceActiveFocus()
+                            }
+                            StatusToolTip {
+                                text: seedInput.text === "" ? qsTr("Empty") : seedInput.valid ? qsTr("Correct word") : qsTr("Wrong word")
+                                visible: hhandler.hovered && statusIcon.visible
                             }
                         }
                     }

--- a/ui/app/AppLayouts/Onboarding2/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/qmldir
@@ -2,7 +2,7 @@ CreateNewProfileFlow 1.0 CreateNewProfileFlow.qml
 KeycardCreateProfileFlow 1.0 KeycardCreateProfileFlow.qml
 KeycardCreateReplacementFlow 1.0 KeycardCreateReplacementFlow.qml
 KeycardFactoryResetFlow 1.0 KeycardFactoryResetFlow.qml
-LoginByKeycardFlow 1.0 LoginByKeycardFlow.qml
+LoginWithKeycardFlow 1.0 LoginWithKeycardFlow.qml
 LoginBySyncingFlow 1.0 LoginBySyncingFlow.qml
 OnboardingFlow 1.0 OnboardingFlow.qml
 OnboardingLayout 1.0 OnboardingLayout.qml

--- a/ui/imports/shared/controls/Timer.qml
+++ b/ui/imports/shared/controls/Timer.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.15
 
 Timer {
     id: timer

--- a/ui/imports/shared/panels/EnterSeedPhrase.qml
+++ b/ui/imports/shared/panels/EnterSeedPhrase.qml
@@ -280,8 +280,6 @@ ColumnLayout {
                 grid.currentIndex = index
             }
             onKeyPressed: {
-                grid.currentIndex = index
-
                 if (event.key === Qt.Key_Backtab) {
                     for (let i = 0; i < grid.count; i++) {
                         if (grid.itemAtIndex(i).mnemonicIndex === ((mnemonicIndex - 1) >= 0 ? (mnemonicIndex - 1) : 0)) {

--- a/ui/imports/shared/panels/EnterSeedPhrase.qml
+++ b/ui/imports/shared/panels/EnterSeedPhrase.qml
@@ -131,6 +131,12 @@ ColumnLayout {
                                      const pos = item.mnemonicIndex
                                      item.setWord(words[pos - 1])
                                  }
+
+                                 // position on the last field
+                                 const lastItem = grid.itemAtIndex(grid.count - 1)
+                                 if (!!lastItem)
+                                     lastItem.textEdit.input.edit.forceActiveFocus()
+
                                  d.checkMnemonicLength()
                              }, timeout)
             return true


### PR DESCRIPTION
### What does the PR do

Fixes a couple of UX issues in the `EnterSeedPhrase` component (cf respective commits):
- focus last input field after paste
- fix backspace, delete or overwrite with selected text
- add regression QML tests
- improve the corresponding SB page

Separate commit to fix the Seed verification UX issue

Fixes #17105
Fixes #17219

### Affected areas

Onboarding/Seedphrase

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/a01b1cfb-5e20-4c7c-af76-d8fe2f1f3c42
