### PR TITLE
fix(ci): add missing deps for building Python deps

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,8 @@ FROM ubuntu:20.04 AS qt-install
 
 ARG QT_VERSION
 
-RUN apt update && apt full-upgrade -y && apt install -y --no-install-recommends sudo python3 python3-pip \
+RUN apt update && apt full-upgrade -y \
+ && apt install -y --no-install-recommends sudo python3 python3-pip python3-dev build-essential \
  && apt-get -qq clean
 
 RUN chmod -R 777 /opt

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Necessary image with Ubuntu 20.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.5.0-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.5.1-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -8,7 +8,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.5.0-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.5.1-qt5.15.2'
     }
   }
 


### PR DESCRIPTION
Without `python3-dev` and `build-essential` build of `pyzstd` fails with:
```
error: command 'x86_64-linux-gnu-gcc' failed: No such file or directory
```