### PR TITLE
[Oboarding]: Biometrics integration for login screen

### DIFF
--- a/storybook/pages/KeychainMock.qml
+++ b/storybook/pages/KeychainMock.qml
@@ -29,10 +29,6 @@ Keychain {
 
             parent: root.parent
             x: parent.width - width
-
-            password: ""
-            pin: ""
-            selectedProfileIsKeycard: false
         }
     }
 

--- a/storybook/pages/KeychainMock.qml
+++ b/storybook/pages/KeychainMock.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import Storybook 1.0
+
+Keychain {
+    id: root
+
+    required property Item parent
+
+    service: "StatusStorybookMocked"
+
+    // shadowing Keychain's "loading" property
+    readonly property alias loading: d.loading
+
+    readonly property QObject _d: QObject {
+        id: d
+
+        property bool loading: false
+        property string key
+        property string value
+        property string operation // save, delete, get
+        property var store: ({})
+
+        BiometricsPopup {
+            id: biometricsPopup
+
+            parent: root.parent
+            x: parent.width - width
+
+            password: ""
+            pin: ""
+            selectedProfileIsKeycard: false
+        }
+    }
+
+    // shadowing Keychain's functions
+    function requestSaveCredential(reason, account, password) {
+        d.loading = true
+        d.key = account
+        d.value = password
+        d.operation = "save"
+        biometricsPopup.open()
+    }
+
+    function requestDeleteCredential(reason, account) {
+        d.loading = true
+        d.key = account
+        d.operation = "delete"
+        biometricsPopup.open()
+    }
+
+    function requestGetCredential(reason, account) {
+        d.loading = true
+        d.key = account
+        d.operation = "get"
+        biometricsPopup.open()
+    }
+
+    function cancelActiveRequest() {
+        if (!d.loading)
+            return
+
+        d.loading = false
+        biometricsPopup.cancel()
+    }
+
+    readonly property Connections connections: Connections {
+        target: biometricsPopup
+
+        function onObtainingPasswordSuccess(password) {
+            d.loading = false
+
+            switch (d.operation) {
+            case "get":
+                const value = d.store[d.key]
+                let rc = Keychain.StatusSuccess
+                if (value === undefined)
+                    rc = Keychain.StatusNotFound
+                root.getCredentialRequestCompleted(rc, value)
+                break
+            case "save":
+                d.store[d.key] = d.value
+                root.saveCredentialRequestCompleted(Keychain.StatusSuccess)
+                break;
+            case "delete":
+                delete d.store[d.key]
+                root.deleteCredentialRequestCompleted(Keychain.StatusSuccess)
+                break;
+            }
+        }
+
+        function onCancelled() {
+            d.loading = false
+
+            switch (d.operation) {
+            case "get":
+                root.getCredentialRequestCompleted(Keychain.StatusCancelled, "")
+                break;
+            case "save":
+                root.saveCredentialRequestCompleted(Keychain.StatusCancelled)
+                break;
+            case "delete":
+                root.deleteCredentialRequestCompleted(Keychain.StatusCancelled)
+                break;
+            }
+        }
+    }
+}

--- a/storybook/pages/KeychainPage.qml
+++ b/storybook/pages/KeychainPage.qml
@@ -22,16 +22,6 @@ Page {
                          ? nativeKeychainComponent : mockedKeychainComponent
     }
 
-    BiometricsPopup {
-        id: biometricsPopup
-
-        x: root.Window.width - width
-
-        password: ""
-        pin: ""
-        selectedProfileIsKeycard: false
-    }
-
     Component {
         id: nativeKeychainComponent
 

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -51,10 +51,6 @@ SplitView {
 
         // password signals
         signal accountLoginError(string error, bool wrongPassword)
-
-        // biometrics signals
-        signal obtainingPasswordSuccess(string password)
-        signal obtainingPasswordError(string errorDescription, string errorType /* Constants.keychain.errorType.* */, bool wrongFingerprint)
     }
 
     LoginScreen {
@@ -72,7 +68,9 @@ SplitView {
 
         biometricsAvailable: ctrlBiometrics.checked
         isBiometricsLogin: localAccountSettings.storeToKeychainValue === Constants.keychain.storedValue.store
+
         onBiometricsRequested: biometricsPopup.open()
+
         onLoginRequested: (keyUid, method, data) => {
                               logs.logEvent("onLoginRequested", ["keyUid", "method", "data"], arguments)
 
@@ -92,19 +90,17 @@ SplitView {
             id: localAccountSettings
             readonly property string storeToKeychainValue: ctrlTouchIdUser.checked ? Constants.keychain.storedValue.store : ""
         }
-        onSelectedProfileKeyIdChanged: biometricsPopup.visible = Qt.binding(() => ctrlBiometrics.checked && ctrlTouchIdUser.checked)
     }
 
     BiometricsPopup {
         id: biometricsPopup
-        visible: ctrlBiometrics.checked && ctrlTouchIdUser.checked
+
         x: root.Window.width - width
-        password: ctrlPassword.text
-        pin: ctrlPin.text
-        selectedProfileIsKeycard: loginScreen.selectedProfileIsKeycard
-        onAccountLoginError: (error, wrongPassword) => driver.accountLoginError(error, wrongPassword)
-        onObtainingPasswordSuccess: (password) => driver.obtainingPasswordSuccess(password)
-        onObtainingPasswordError: (errorDescription, errorType, wrongFingerprint) => driver.obtainingPasswordError(errorDescription, errorType, wrongFingerprint)
+
+        onObtainingPasswordSuccess: {
+            loginScreen.setBiometricResponse(loginScreen.selectedProfileIsKeycard
+                                             ? ctrlPin.text : ctrlPassword.text)
+        }
     }
 
     LogsAndControlsPanel {

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -158,6 +158,7 @@ SplitView {
         isBiometricsLogin: localAccountSettings.storeToKeychainValue === Constants.keychain.storedValue.store
 
         onBiometricsRequested: (profileId) => biometricsPopup.open()
+        onDismissBiometricsRequested: biometricsPopup.close()
 
         onFinished: (flow, data) => {
             console.warn("!!! ONBOARDING FINISHED; flow:", flow, "; data:", JSON.stringify(data))

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -102,11 +102,8 @@ Item {
 
                 // password signals
                 signal accountLoginError(string error, bool wrongPassword)
-
-                // biometrics signals
-                signal obtainingPasswordSuccess(string password)
-                signal obtainingPasswordError(string errorDescription, string errorType /* Constants.keychain.errorType.* */, bool wrongFingerprint)
             }
+
             onLoginRequested: (keyUid, method, data) => {
                 // SIMULATION: emit an error in case of wrong password
                 if (method === Onboarding.LoginMethod.Password && data.password !== mockDriver.dummyNewPassword) {
@@ -979,8 +976,8 @@ Item {
                 tryCompare(passwordInput, "activeFocus", true)
                 if (data.biometrics) { // biometrics + password
                     if (data.password === mockDriver.dummyNewPassword) { // expecting correct fingerprint
-                        // simulate the external biometrics signal
-                        controlUnderTest.onboardingStore.obtainingPasswordSuccess(data.password)
+                        // simulate the external biometrics response
+                        controlUnderTest.setBiometricResponse(data.password)
 
                         tryCompare(passwordBox, "biometricsSuccessful", true)
                         tryCompare(passwordBox, "biometricsFailed", false)
@@ -988,19 +985,19 @@ Item {
 
                         // this fills the password and submits it, emits the loginRequested() signal below
                         tryCompare(passwordInput, "text", data.password)
-                    } else { // expecting wrong fingerprint
-                        // simulate the external biometrics signal
-                        controlUnderTest.onboardingStore.obtainingPasswordError("ERROR", Constants.keychain.errorType.keychain, true)
+                    } else { // expecting failed fetching credentials via biometrics
+                        // simulate the external biometrics response
+                        controlUnderTest.setBiometricResponse("", "ERROR", "", true)
 
                         tryCompare(passwordBox, "biometricsSuccessful", false)
                         tryCompare(passwordBox, "biometricsFailed", true)
-                        tryCompare(passwordBox, "validationError", "Fingerprint not recognised. Try entering password instead.")
+                        tryCompare(passwordBox, "validationError", "ERROR")
 
                         // this fails and switches to the password method; so just verify we have an error and can enter the pass manually
                         tryCompare(passwordInput, "hasError", true)
                         tryCompare(passwordInput, "activeFocus", true)
                         tryCompare(passwordInput, "text", "")
-                        expectFail(data.tag, "Wrong fingerprint, expected to fail to login")
+                        expectFail(data.tag, "Biometrics failed, expected to fail to login")
                     }
                 } else { // manual password
                     keyClickSequence(data.password)
@@ -1032,25 +1029,24 @@ Item {
 
                 if (data.biometrics) { // biometrics + PIN
                     if (data.pin === mockDriver.existingPin) { // expecting correct fingerprint
-                        // simulate the external biometrics signal
-                        controlUnderTest.onboardingStore.obtainingPasswordSuccess(data.pin)
+                        // simulate the external biometrics response
+                        controlUnderTest.setBiometricResponse(data.pin)
 
                         tryCompare(keycardBox, "biometricsSuccessful", true)
                         tryCompare(keycardBox, "biometricsFailed", false)
 
                         // this fills the password and submits it, emits the loginRequested() signal below
                         tryCompare(pinInput, "pinInput", data.pin)
-                    } else { // expecting wrong fingerprint
-                        // simulate the external biometrics signal
-                        controlUnderTest.onboardingStore.obtainingPasswordError("Fingerprint not recognized",
-                                                                                Constants.keychain.errorType.keychain, true)
+                    } else { // expecting failed fetching credentials via biometrics
+                        // simulate the external biometrics response
+                        controlUnderTest.setBiometricResponse("", "ERROR", "", true)
 
                         tryCompare(keycardBox, "biometricsSuccessful", false)
                         tryCompare(keycardBox, "biometricsFailed", true)
 
                         // this fails and lets the user enter the PIN manually; so just verify we have an error and empty PIN
                         tryCompare(pinInput, "pinInput", "")
-                        expectFail(data.tag, "Wrong fingerprint, expected to fail to login")
+                        expectFail(data.tag, "Biometrics failed, expected to fail to login")
                     }
                 } else { // manual PIN
                     keyClickSequence(data.pin)

--- a/storybook/src/Storybook/BiometricsPopup.qml
+++ b/storybook/src/Storybook/BiometricsPopup.qml
@@ -13,17 +13,9 @@ import utils 1.0
 Dialog {
     id: root
 
-    required property string password
-    required property string pin
-    required property string selectedProfileIsKeycard
-
-    // password signals
-    signal accountLoginError(string error, bool wrongPassword)
-
     // biometrics signals
-    signal obtainingPasswordSuccess(string password)
-    signal obtainingPasswordError(string errorDescription, string errorType /* Constants.keychain.errorType.* */, bool wrongFingerprint)
-    signal cancelled()
+    signal obtainingPasswordSuccess
+    signal cancelled
 
     function cancel() {
         close()
@@ -72,7 +64,7 @@ Dialog {
             text: "Simulate correct fingerprint"
             onClicked: {
                 root.close()
-                root.obtainingPasswordSuccess(root.selectedProfileIsKeycard ? root.pin : root.password)
+                root.obtainingPasswordSuccess()
             }
         }
     }

--- a/ui/StatusQ/include/StatusQ/keychain.h
+++ b/ui/StatusQ/include/StatusQ/keychain.h
@@ -13,7 +13,6 @@ class Keychain : public QObject {
     Q_OBJECT
 
     Q_PROPERTY(QString service READ service WRITE setService NOTIFY serviceChanged)
-    Q_PROPERTY(QString reason READ reason WRITE setReason NOTIFY reasonChanged)
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
 public:
@@ -34,14 +33,11 @@ public:
     QString service() const;
     void setService(const QString &service);
 
-    QString reason() const;
-    void setReason(const QString& reason);
-
     bool loading() const;
 
-    Q_INVOKABLE void requestSaveCredential(const QString &account, const QString &password);
-    Q_INVOKABLE void requestDeleteCredential(const QString &account);
-    Q_INVOKABLE void requestGetCredential(const QString &account);
+    Q_INVOKABLE void requestSaveCredential(const QString &reason, const QString &account, const QString &password);
+    Q_INVOKABLE void requestDeleteCredential(const QString &reason, const QString &account);
+    Q_INVOKABLE void requestGetCredential(const QString &reason, const QString &account);
     Q_INVOKABLE void cancelActiveRequest();
 
 signals:

--- a/ui/StatusQ/src/keychain.cpp
+++ b/ui/StatusQ/src/keychain.cpp
@@ -19,20 +19,6 @@ void Keychain::setService(const QString &service)
     emit serviceChanged();
 }
 
-QString Keychain::reason() const
-{
-    return m_reason;
-}
-
-void Keychain::setReason(const QString &reason)
-{
-    if (m_reason == reason)
-        return;
-
-    m_reason = reason;
-    emit reasonChanged();
-}
-
 bool Keychain::loading() const
 {
     return m_loading;

--- a/ui/StatusQ/src/keychain_osx.mm
+++ b/ui/StatusQ/src/keychain_osx.mm
@@ -91,11 +91,13 @@ Keychain::Status authenticate(QString &reason, LAContext **context)
     return Keychain::StatusSuccess;
 }
 
-void Keychain::requestSaveCredential(const QString &account, const QString &password)
+void Keychain::requestSaveCredential(const QString &reason, const QString &account, const QString &password)
 {
     if (m_future.isRunning()) {
         return;
     }
+
+    m_reason = reason;
 
     m_future = QtConcurrent::run([this, account, password]() {
         setLoading(true);
@@ -105,11 +107,13 @@ void Keychain::requestSaveCredential(const QString &account, const QString &pass
     });
 }
 
-void Keychain::requestDeleteCredential(const QString &account)
+void Keychain::requestDeleteCredential(const QString &reason, const QString &account)
 {
     if (m_future.isRunning()) {
         return;
     }
+
+    m_reason = reason;
 
     m_future = QtConcurrent::run([this, account]() {
         setLoading(true);
@@ -119,11 +123,13 @@ void Keychain::requestDeleteCredential(const QString &account)
     });
 }
 
-void Keychain::requestGetCredential(const QString &account)
+void Keychain::requestGetCredential(const QString &reason, const QString &account)
 {
     if (m_future.isRunning()) {
         return;
     }
+
+    m_reason = reason;
 
     m_future = QtConcurrent::run([this, account]() {
         setLoading(true);

--- a/ui/StatusQ/src/keychain_other.cpp
+++ b/ui/StatusQ/src/keychain_other.cpp
@@ -2,25 +2,31 @@
 
 Keychain::~Keychain() = default;
 
-void Keychain::requestSaveCredential(const QString &account, const QString &password)
+void Keychain::requestSaveCredential(const QString &reason, const QString &account, const QString &password)
 {
     Q_UNUSED(account);
     Q_UNUSED(password);
+
     qWarning() << "Keychain::requestSaveCredential is intended to be called only on MacOS.";
-    emit saveCredentialRequestCompleted(Keychain::StatusNotSupported);
+
+    emit this->saveCredentialRequestCompleted(Keychain::StatusNotSupported);
 }
 
-void Keychain::requestDeleteCredential(const QString &account)
+void Keychain::requestDeleteCredential(const QString &reason, const QString &account)
 {
     Q_UNUSED(account);
+
     qWarning() << "Keychain::requestDeleteCredential is intended to be called only on MacOS.";
+
     emit deleteCredentialRequestCompleted(Keychain::StatusNotSupported);
 }
 
-void Keychain::requestGetCredential(const QString &account)
+void Keychain::requestGetCredential(const QString &reason, const QString &account)
 {
     Q_UNUSED(account);
+
     qWarning() << "Keychain::requestGetCredential is intended to be called only on MacOS.";
+
     emit getCredentialRequestCompleted(Keychain::StatusNotSupported, "");
 }
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -42,6 +42,7 @@ SQUtils.QObject {
     required property var tryToSetPukFunction
 
     signal biometricsRequested(string profileId)
+    signal dismissBiometricsRequested
     signal loginRequested(string keyUid, int method, var data)
     signal keycardPinCreated(string pin)
     signal enableBiometricsRequested(bool enable)
@@ -153,12 +154,20 @@ SQUtils.QObject {
             isBiometricsLogin: root.isBiometricsLogin
 
             onBiometricsRequested: (profileId) => root.biometricsRequested(profileId)
+            onDismissBiometricsRequested: root.dismissBiometricsRequested()
             onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
             onOnboardingCreateProfileFlowRequested: root.stackView.push(createProfilePage)
             onOnboardingLoginFlowRequested: root.stackView.push(loginPage)
             onLostKeycard: root.stackView.push(keycardLostPage)
             onUnblockWithSeedphraseRequested: unblockWithSeedphraseFlow.init()
             onUnblockWithPukRequested: unblockWithPukFlow.init()
+
+            onVisibleChanged: {
+                if (!visible)
+                    root.dismissBiometricsRequested()
+            }
+
+            Component.onDestruction: root.dismissBiometricsRequested()
 
             Binding {
                 target: d

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -41,7 +41,7 @@ SQUtils.QObject {
     required property var tryToSetPinFunction
     required property var tryToSetPukFunction
 
-    signal biometricsRequested
+    signal biometricsRequested(string profileId)
     signal loginRequested(string keyUid, int method, var data)
     signal keycardPinCreated(string pin)
     signal enableBiometricsRequested(bool enable)
@@ -62,6 +62,16 @@ SQUtils.QObject {
 
     function init() {
         root.stackView.push(entryPage)
+    }
+
+    function setBiometricResponse(secret: string, error = "",
+                                  detailedError = "",
+                                  wrongFingerprint = false) {
+        if (!loginScreen)
+            return
+
+        loginScreen.setBiometricResponse(secret, error, detailedError,
+                                         wrongFingerprint)
     }
 
     readonly property LoginScreen loginScreen: d.loginScreen
@@ -141,9 +151,9 @@ SQUtils.QObject {
             loginAccountsModel: root.loginAccountsModel
             biometricsAvailable: root.biometricsAvailable
             isBiometricsLogin: root.isBiometricsLogin
-            onBiometricsRequested: root.biometricsRequested()
-            onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
 
+            onBiometricsRequested: (profileId) => root.biometricsRequested(profileId)
+            onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
             onOnboardingCreateProfileFlowRequested: root.stackView.push(createProfilePage)
             onOnboardingLoginFlowRequested: root.stackView.push(loginPage)
             onLostKeycard: root.stackView.push(keycardLostPage)

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -33,6 +33,7 @@ Page {
     signal finished(int flow, var data)
 
     signal biometricsRequested(string profileId)
+    signal dismissBiometricsRequested
 
     // -> "keyUid:string": User ID to login; "method:int": password or keycard (cf Onboarding.LoginMethod.*) enum;
     //    "data:var": contains "password" or "pin"
@@ -183,6 +184,7 @@ Page {
         remainingPukAttempts: root.onboardingStore.keycardRemainingPukAttempts
 
         onBiometricsRequested: (profileId) => root.biometricsRequested(profileId)
+        onDismissBiometricsRequested: root.dismissBiometricsRequested()
         onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
 
         onKeycardPinCreated: (pin) => {

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -34,6 +34,7 @@ OnboardingPage {
     readonly property bool selectedProfileIsKeycard: d.currentProfileIsKeycard
 
     signal biometricsRequested(string profileId)
+    signal dismissBiometricsRequested
 
     function setBiometricResponse(secret: string, error = "",
                                   detailedError = "",
@@ -198,6 +199,8 @@ OnboardingPage {
                                       root.keycardState === Onboarding.KeycardState.BlockedPUK
 
                 onSelectedProfileKeyIdChanged: {
+                    root.dismissBiometricsRequested()
+
                     d.resetBiometricsResult()
                     d.settings.lastKeyUid = selectedProfileKeyId
 

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -68,10 +68,6 @@ QtObject {
         return d.onboardingModuleInst.getPasswordStrengthScore(password, "") // The second argument is username
     }
 
-    // biometrics
-    signal obtainingPasswordSuccess(string password)
-    signal obtainingPasswordError(string errorDescription, string errorType /* Constants.keychain.errorType.* */, bool wrongFingerprint)
-
     // seedphrase/mnemonic
     function validMnemonic(mnemonic: string) { // -> bool
         return d.onboardingModuleInst.validMnemonic(mnemonic)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -420,7 +420,7 @@ StatusWindow {
     }
 
     Keychain {
-        service: Qt.application.name
+        service: "StatusDesktop"
 
         id: keychain
     }
@@ -445,7 +445,9 @@ StatusWindow {
 
             anchors.fill: parent
 
-            isBiometricsLogin: false
+            // FIXME, https://github.com/status-im/status-desktop/issues/17240
+            isBiometricsLogin: Qt.platform.os === Constants.mac
+
             networkChecksEnabled: true
             biometricsAvailable: Qt.platform.os === Constants.mac
 
@@ -459,6 +461,11 @@ StatusWindow {
                 const reason = isKeycardProfile ? qsTr("fetch pin") : qsTr("fetch password")
 
                 keychain.requestGetCredential(reason, profileId)
+            }
+
+            onDismissBiometricsRequested: {
+                if (keychain.loading)
+                    keychain.cancelActiveRequest()
             }
 
             onFinished: (flow, data) => {


### PR DESCRIPTION
### What does the PR do

- changes the `Keychain` to take `reason` as a function argument
- removes biometrics-related signals from `OnboardingStore`
- slightly simplifies SB's mock popup for biometrics (`BiometricsPopup`)
- introduces ability to dismiss biometrics request from the flows
- allows `LoginScreen` to call for credentials in generic way (can be used with `Keychain`, mock or any other potential implementation)
- changes behavior of `LoginScreen`:
  -  pin is requested via biometrics only if keycard is in a proper state
- adds `Keychain` to `main.qml` and combines with `OnboardingLayout`

### Affected areas
`LoginScreen`, `OnboardingFlow`, `OnboardingLayout`, `Keychain` and others

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
