### PR TITLE
fix(PasswordView): UI fixes and alignments with latest Figma

### DIFF
--- a/storybook/pages/ChangePasswordViewPage.qml
+++ b/storybook/pages/ChangePasswordViewPage.qml
@@ -30,7 +30,7 @@ SplitView {
             contentWidth: 560
             sectionTitle: "Password"
 
-            passwordStrengthScoreFunction: (newPass) => Math.min(newPass.length, 4)
+            passwordStrengthScoreFunction: (newPass) => Math.min(newPass.length-1, 4)
 
             privacyStore: PrivacyStore {
                  property QtObject privacyModule: QtObject {
@@ -57,6 +57,10 @@ SplitView {
                         privacyModule.storeToKeychainSuccess()
                     }
                  }
+
+                 function changePassword(from, to) {
+                     privacyModule.passwordChanged(ctrlChangePassSuccess.checked, ctrlChangePassSuccess.checked ? "" : "Err changing password")
+                 }
             }
 
             property QtObject localAccountSettings: QtObject {
@@ -79,10 +83,15 @@ SplitView {
                 text: "Generate key chain error"
                 checked: false
             }
+            Switch {
+                id: ctrlChangePassSuccess
+                text: "Password change will succeed"
+                checked: true
+            }
         }
     }
 }
 
 // category: Views
-
+// status: good
 // https://www.figma.com/file/d0G7m8X6ELjQlFOEKQpn1g/Profile-WIP?type=design&node-id=11-115317&mode=design&t=mBpxe2bJKzpseHGN-0

--- a/storybook/pages/PasswordViewPage.qml
+++ b/storybook/pages/PasswordViewPage.qml
@@ -19,15 +19,16 @@ SplitView {
 
         PasswordView {
             id: passwordView
-            width: 460
-            height: 416
+
+            readonly property string existingPassword: "Somepassword1."
+
             anchors.centerIn: parent
             onReturnPressed: logs.logEvent("Return pressed", ["Current Password", "New Password", "Confirmation Password"], [passwordView.currentPswText, passwordView.newPswText, passwordView.confirmationPswText])
 
             createNewPsw: createNewPassword.checked
             titleVisible: titleVisibleSwitch.checked
             highSizeIntro: highSizeIntroSwitch.checked
-            passwordStrengthScoreFunction: (newPass) => Math.min(newPass.length, 4)
+            passwordStrengthScoreFunction: (newPass) => Math.min(newPass.length-1, 4)
         }
     }
 
@@ -45,31 +46,56 @@ SplitView {
                 active: passwordView.ready
             }
 
-            Text {
-                leftPadding: 10
+            Label {
                 text: "Ready"
             }
 
             Switch {
                 id: createNewPassword
+                focusPolicy: Qt.NoFocus
                 text: "Create new password"
                 checked: true
             }
 
             Switch {
                 id: highSizeIntroSwitch
+                focusPolicy: Qt.NoFocus
                 text: "High size Intro"
             }
 
             Switch {
                 id: titleVisibleSwitch
+                focusPolicy: Qt.NoFocus
                 text: "Title visible"
                 checked: true
+            }
+
+            Button {
+                text: "Paste password"
+                focusPolicy: Qt.NoFocus
+
+                onClicked: {
+                    const input1 = StorybookUtils.findChild(
+                                     passwordView,
+                                     "passwordViewNewPassword")
+                    const input2 = StorybookUtils.findChild(
+                                     passwordView,
+                                     "passwordViewNewPasswordConfirm")
+
+                    if (!input1 || !input2)
+                        return
+
+                    input1.text = input2.text = passwordView.existingPassword
+                }
             }
         }
     }
 }
 
 // category: Views
-
-// https://www.figma.com/design/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=41014-22302&node-type=frame&t=0JUvGJPEhU9e9QB9-0
+// status: good
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=236-23883&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=884-44477&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=62-8230&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=62-10411&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=62-8752&m=dev

--- a/ui/StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml
@@ -53,7 +53,7 @@ StatusProgressBar {
        \li StatusPasswordStrengthIndicator.Strength.Great
        \endlist
     */
-    property int strength
+    required property int strength
     /*!
        \qmlproperty string StatusPasswordStrengthIndicator::labelVeryWeak
        This property holds the text shown when the strength is StatusPasswordStrengthIndicator.Strength.VeryWeak.
@@ -89,39 +89,32 @@ StatusProgressBar {
         Great // 5
     }
 
-    onValueChanged: if(value === 0) control.strength = StatusPasswordStrengthIndicator.Strength.None
-
     // Behavior:
     states: [
         // Strength states definition:
         State {
             when: control.strength === StatusPasswordStrengthIndicator.Strength.None
-            PropertyChanges { target: control; text: ""}
+            PropertyChanges { target: control; text: "" }
         },
         State {
             when: control.strength === StatusPasswordStrengthIndicator.Strength.VeryWeak
-            PropertyChanges { target: control; fillColor : Theme.palette.dangerColor1}
-            PropertyChanges { target: control; text: labelVeryWeak}
+            PropertyChanges { target: control; fillColor: Theme.palette.dangerColor1; text: labelVeryWeak }
         },
         State {
             when: control.strength === StatusPasswordStrengthIndicator.Strength.Weak
-            PropertyChanges { target: control; fillColor : Theme.palette.pinColor1}
-            PropertyChanges { target: control; text: labelWeak}
+            PropertyChanges { target: control; fillColor: Theme.palette.pinColor1; text: labelWeak }
         },
         State {
             when: control.strength === StatusPasswordStrengthIndicator.Strength.SoSo
-            PropertyChanges { target: control; fillColor : Theme.palette.miscColor7}
-            PropertyChanges { target: control; text: labelSoso}
+            PropertyChanges { target: control; fillColor: Theme.palette.miscColor7; text: labelSoso }
         },
         State {
             when: control.strength === StatusPasswordStrengthIndicator.Strength.Good
-            PropertyChanges { target: control; fillColor : Theme.palette.miscColor12}
-            PropertyChanges { target: control; text: labelGood}
+            PropertyChanges { target: control; fillColor: Theme.palette.miscColor12; text: labelGood }
         },
         State {
             when: control.strength === StatusPasswordStrengthIndicator.Strength.Great
-            PropertyChanges { target: control; fillColor : Theme.palette.successColor1}
-            PropertyChanges { target: control; text: labelGreat}
+            PropertyChanges { target: control; fillColor: Theme.palette.successColor1; text: labelGreat}
         }
     ]
 }

--- a/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ConfirmChangePasswordModal.qml
@@ -48,7 +48,6 @@ StatusDialog {
     }
 
     width: 480
-    height: 546
     closePolicy: d.passwordChanged || d.dbEncryptionInProgress
                      ? Popup.NoAutoClose
                      : Popup.CloseOnEscape | Popup.CloseOnPressOutside
@@ -161,12 +160,11 @@ StatusDialog {
     }
 
     footer: StatusDialogFooter {
-        id: footer
         leftButtons: ObjectModel {
             StatusFlatButton {
                 text: qsTr("Cancel")
                 visible: !d.dbEncryptionInProgress && !d.passwordChanged
-                onClicked: { root.close(); }
+                onClicked: root.close()
             }
         }
         rightButtons: ObjectModel {

--- a/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
+++ b/ui/app/AppLayouts/Profile/views/ChangePasswordView.qml
@@ -138,13 +138,8 @@ SettingsContentBase {
             title: qsTr("Change your password")
             titleSize: 17
             contentAlignment: Qt.AlignLeft
-
             highSizeIntro: true
-
             passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
-            onReadyChanged: {
-                submitBtn.enabled = ready
-            }
 
             onReturnPressed: {
                 if (ready) {
@@ -167,7 +162,6 @@ SettingsContentBase {
             }
             Item { Layout.fillWidth: true }
             StatusButton {
-                id: submitBtn
                 Layout.alignment: Qt.AlignRight
                 objectName: "changePasswordModalSubmitButton"
                 text: qsTr("Change password")


### PR DESCRIPTION
### What does the PR do

- display validation messages closer to the input fields
- warn about pass too long, info for "passwords match"
- fix an actual bug when two too long passwords would be considered as "valid" by the UI
- various fixes and UX improvements for the respective SB pages

Iterates: #17101

To fully fix the above issue, we need a more complete Figma design, depicting the various error scenarios

### Affected areas

Password input component(s) and panels

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Matching correct passwords:
![image](https://github.com/user-attachments/assets/95e9128e-153c-4327-92d1-0434c57379be)

Min. length not met:
![image](https://github.com/user-attachments/assets/a2d3a2d0-801a-4ac8-a06d-04f0d27cbdea)

Max length exceeded:
![image](https://github.com/user-attachments/assets/9985d150-a508-4074-845c-7a1b7ea8c4c9)

