### PR TITLE
ci: use sc5cmd for uploads

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -119,7 +119,9 @@ ENV HOME="/home/jenkins"
 ENV PATH="${HOME}/go/bin:${PATH}"
 
 # Nix for jenkins user to build status-go.
-RUN curl -s https://nixos.org/releases/nix/nix-2.19.3/install | sh -s -- --no-daemon
+RUN curl -s https://nixos.org/releases/nix/nix-2.24.11/install | sh -s -- --no-daemon
+# for nix-shell to work
+ENV PATH="/home/jenkins/.nix-profile/bin:${PATH}"
 
 LABEL maintainer="jakub@status.im"
 LABEL source="https://github.com/status-im/status-desktop"

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -96,7 +96,7 @@ pipeline {
         /* Generate sha256 checksums for all artifacts. */
         sha = "./${utils.pkgFilename(ext: 'sha256')}"
         sh "sha256sum * | tee ./${sha}"
-        urls['SHA'] = s3.uploadArtifact(sha)
+        urls['SHA'] = s5cmd.upload(sha)
         jenkins.setBuildDesc(urls)
       }
       archiveArtifacts('pkg/*')

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Necessary image with Ubuntu 20.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.5.1-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.5.3-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }
@@ -101,7 +101,7 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
-            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_TARBALL)
+            env.PKG_URL = s5cmd.upload(env.STATUS_CLIENT_TARBALL)
             jenkins.setBuildDesc(AppImage: env.PKG_URL)
           } }
         }

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -93,7 +93,7 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
-            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_TARBALL)
+            env.PKG_URL = s5cmd.upload(env.STATUS_CLIENT_TARBALL)
             jenkins.setBuildDesc(AppImage: env.PKG_URL)
           } }
         }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -120,7 +120,7 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
-            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_DMG)
+            env.PKG_URL = s5cmd.upload(env.STATUS_CLIENT_DMG)
             jenkins.setBuildDesc(Dmg: env.PKG_URL)
           } }
         }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -110,12 +110,12 @@ pipeline {
       parallel {
         stage('Upload 7Z') {
           steps { script {
-            zip_url = s3.uploadArtifact(env.STATUS_CLIENT_7Z)
+            zip_url = s5cmd.upload(env.STATUS_CLIENT_7Z)
           } }
         }
         stage('Upload EXE') {
           steps { script {
-            exe_url = s3.uploadArtifact(env.STATUS_CLIENT_EXE)
+            exe_url = s5cmd.upload(env.STATUS_CLIENT_EXE)
           } }
         }
       }

--- a/ci/cpp/Jenkinsfile.macos
+++ b/ci/cpp/Jenkinsfile.macos
@@ -67,7 +67,7 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
-            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_DMG)
+            env.PKG_URL = s5cmd.upload(env.STATUS_CLIENT_DMG)
             jenkins.setBuildDesc(Dmg: env.PKG_URL)
           } }
         }

--- a/ci/cpp/Jenkinsfile.windows
+++ b/ci/cpp/Jenkinsfile.windows
@@ -67,7 +67,7 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
-            exe_url = s3.uploadArtifact(env.STATUS_CLIENT_ZIP)
+            exe_url = s5cmd.upload(env.STATUS_CLIENT_ZIP)
             env.PKG_URL = exe_url
             jenkins.setBuildDesc(Zip: zip_url, Exe: exe_url)
           } }


### PR DESCRIPTION
## Summary

This PR fixes issues like :

```
11:16:59  + s3cmd --stats --acl-public --no-preserve --host=ams3.digitaloceanspaces.com 
'--host-bucket=%(bucket)s.ams3.digitaloceanspaces.com' put 
pkg/StatusIm-Desktop-250205-101034-e6dfac-pr17210-aarch64.dmg 
s3://status-im-desktop-prs/ 11:16:59  
/opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/S3Uri.py:122: 
SyntaxWarning: invalid escape sequence '\.'
11:16:59    m = re.match("(.*\.)?s3(?:\-[^\.]*)?(?:\.dualstack)?(?:\.[^\.]*)?\.amazonaws\.com(?:\.cn)?$",
11:16:59  /opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/S3Uri.py:170: 
SyntaxWarning: invalid escape sequence '\w'
11:16:59    _re = re.compile("^(\w+://)?(.*)", re.UNICODE)
11:16:59  /opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/FileLists.py:525: 
SyntaxWarning: invalid escape sequence '\*'
11:16:59    wildcard_split_result = re.split("\*|\?", uri_str, maxsplit=1)
11:17:00  ERROR: SSL certificate verification failure: [SSL: CERTIFICATE_VERIFY_FAILED] 
certificate verify failed: unable to get local issuer certificate (_ssl.c:1018)
```