### PR TITLE
chore(Onboarding): Remove all "Reload keycard state" buttons

### DIFF
--- a/storybook/pages/KeycardAddKeyPairPagePage.qml
+++ b/storybook/pages/KeycardAddKeyPairPagePage.qml
@@ -24,7 +24,6 @@ Item {
             })()
         }
         onKeypairAddContinueRequested: console.warn("!!! onKeypairAddContinueRequested")
-        onReloadKeycardRequested: console.warn("!!! onReloadKeycardRequested")
         onCreateProfilePageRequested: console.warn("!!! onCreateProfilePageRequested")
     }
 

--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -24,11 +24,6 @@ Item {
                                  console.warn("!!! RESETTING FLOW")
                                  state = "entering"
                              }
-        onReloadKeycardRequested: {
-            console.warn("!!! RELOAD KEYCARD")
-            remainingAttempts--
-            state = "entering"
-        }
         onKeycardFactoryResetRequested: {
             console.warn("!!! FACTORY RESET KEYCARD")
             remainingAttempts = 3

--- a/storybook/pages/KeycardIntroPagePage.qml
+++ b/storybook/pages/KeycardIntroPagePage.qml
@@ -30,7 +30,6 @@ Item {
             displayPromoBanner: ctrlDisplayPromo.checked
             onEmptyKeycardDetected: console.warn("!!! EMPTY DETECTED")
             onNotEmptyKeycardDetected: console.warn("!!! NOT EMPTY DETECTED")
-            onReloadKeycardRequested: console.warn("!!! RELOAD REQUESTED")
             onOpenLink: Qt.openUrlExternally(link)
             onOpenLinkWithConfirmation: Qt.openUrlExternally(link)
             onKeycardFactoryResetRequested: console.warn("!!! FACTORY RESET")
@@ -43,14 +42,12 @@ Item {
         id: emptyPage
         KeycardEmptyPage {
             onCreateProfileWithEmptyKeycardRequested: console.warn("!!! CREATE NEW PROFILE")
-            onReloadKeycardRequested: console.warn("!!! RELOAD REQUESTED")
         }
     }
 
     Component {
         id: notEmptyPage
         KeycardNotEmptyPage {
-            onReloadKeycardRequested: console.warn("!!! RELOAD REQUESTED")
             onLoginWithThisKeycardRequested: console.warn("!!! LOGIN REQUESTED")
             onKeycardFactoryResetRequested: console.warn("!!! FACTORY RESET")
         }

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -35,12 +35,19 @@ SplitView {
         readonly property string pin: "111111"
         readonly property string puk: "111111111111"
         readonly property string password: "somepassword"
+    }
 
-        // TODO simulation
-        function restart() {
-            // add keypair state
-            // sync state
-        }
+    function restart() {
+        store.keycardState = Onboarding.KeycardState.NoPCSCService
+        store.addKeyPairState = Onboarding.ProgressState.Idle
+        store.pinSettingState = Onboarding.ProgressState.Idle
+        store.authorizationState = Onboarding.ProgressState.Idle
+        store.restoreKeysExportState = Onboarding.ProgressState.Idle
+        store.syncState = Onboarding.ProgressState.Idle
+        store.keycardRemainingPinAttempts = 3
+        store.keycardRemainingPukAttempts = 5
+
+        onboarding.restartFlow()
     }
 
     LoginAccountsModel {
@@ -76,7 +83,7 @@ SplitView {
             property var loginAccountsModel: ctrlLoginScreen.checked ? loginAccountsModel : emptyModel
 
             property int keycardRemainingPinAttempts: 3
-            property int keycardRemainingPukAttempts: 3
+            property int keycardRemainingPukAttempts: 5
 
             function setPin(pin: string) { // -> bool
                 logs.logEvent("OnboardingStore.setPin", ["pin"], arguments)
@@ -181,12 +188,6 @@ SplitView {
             } else {
                 ctrlLoginResult.result = "<font color='green'>✔</font>"
             }
-        }
-
-        onReloadKeycardRequested: {
-            store.keycardState = Onboarding.KeycardState.NoPCSCService
-            store.keycardRemainingPinAttempts = 2
-            store.keycardRemainingPukAttempts = 3
         }
 
         // mocks
@@ -357,7 +358,7 @@ SplitView {
                 onStopped: {
                     console.warn("!!! SPLASH SCREEN DONE")
                     console.warn("!!! RESTARTING FLOW")
-                    onboarding.restartFlow()
+                    root.restart()
                 }
             }
         }
@@ -404,7 +405,7 @@ SplitView {
                 Button {
                     text: "Restart"
                     focusPolicy: Qt.NoFocus
-                    onClicked: onboarding.restartFlow()
+                    onClicked: root.restart()
                 }
 
                 Switch {
@@ -419,7 +420,7 @@ SplitView {
                     id: ctrlLoginScreen
                     text: "Show login screen"
                     checkable: true
-                    onToggled: onboarding.restartFlow()
+                    onToggled: root.restart()
                 }
 
                 Switch {

--- a/storybook/pages/UnblockWithPukFlowPage.qml
+++ b/storybook/pages/UnblockWithPukFlowPage.qml
@@ -86,7 +86,6 @@ SplitView {
                                  logs.logEvent("keycardPinCreated", ["pin"], arguments)
                                  console.warn("!!! PIN CREATED:", pin)
                              }
-        onReloadKeycardRequested: mockDriver.keycardState = Onboarding.KeycardState.NoPCSCService
         onKeycardFactoryResetRequested: {
             logs.logEvent("keycardFactoryResetRequested", ["pin"], arguments)
             console.warn("!!! FACTORY RESET REQUESTED")

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -30,7 +30,6 @@ SQUtils.QObject {
     signal seedphraseSubmitted(string seedphrase)
 
     signal keypairAddTryAgainRequested
-    signal reloadKeycardRequested
     signal createProfileWithoutKeycardRequested
     signal authorizationRequested
 
@@ -65,12 +64,6 @@ SQUtils.QObject {
             displayPromoBanner: root.displayKeycardPromoBanner
             factoryResetAvailable: true
 
-            onReloadKeycardRequested: {
-                root.reloadKeycardRequested()
-                root.stackView.replace(d.initialComponent(),
-                                       StackView.PopTransition)
-            }
-
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
             onEmptyKeycardDetected: root.stackView.replace(createKeycardProfilePage)
             onNotEmptyKeycardDetected: root.stackView.replace(keycardNotEmptyPage)
@@ -96,12 +89,6 @@ SQUtils.QObject {
         id: keycardNotEmptyPage
 
         KeycardNotEmptyPage {
-            onReloadKeycardRequested: {
-                root.reloadKeycardRequested()
-                root.stackView.replace(d.initialComponent(),
-                                       StackView.PopTransition)
-            }
-
             onLoginWithThisKeycardRequested: root.loginWithKeycardRequested()
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
         }
@@ -229,16 +216,6 @@ SQUtils.QObject {
             onKeypairAddTryAgainRequested: {
                 root.stackView.replace(addKeypairPage)
                 root.keypairAddTryAgainRequested()
-            }
-
-            onReloadKeycardRequested: {
-                root.reloadKeycardRequested()
-
-                const page = root.stackView.find(
-                               item => item instanceof CreateKeycardProfilePage)
-
-                root.stackView.replace(page, d.initialComponent(),
-                                       StackView.PopTransition)
             }
 
             onCreateProfilePageRequested: root.createProfileWithoutKeycardRequested()

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -29,7 +29,6 @@ SQUtils.QObject {
     signal seedphraseSubmitted(string seedphrase)
 
     signal loadMnemonicRequested
-    signal reloadKeycardRequested
     signal createProfileWithoutKeycardRequested
 
     signal finished
@@ -59,12 +58,6 @@ SQUtils.QObject {
             keycardState: root.keycardState
             displayPromoBanner: root.displayKeycardPromoBanner
 
-            onReloadKeycardRequested: {
-                root.reloadKeycardRequested()
-                root.stackView.replace(d.initialComponent(),
-                                       StackView.PopTransition)
-            }
-
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
             onEmptyKeycardDetected: root.stackView.replace(seedphrasePage)
             onNotEmptyKeycardDetected: root.stackView.replace(keycardNotEmptyPage)
@@ -75,12 +68,6 @@ SQUtils.QObject {
         id: keycardNotEmptyPage
 
         KeycardNotEmptyPage {
-            onReloadKeycardRequested: {
-                root.reloadKeycardRequested()
-                root.stackView.replace(d.initialComponent(),
-                                       StackView.PopTransition)
-            }
-
             onLoginWithThisKeycardRequested: root.loginWithKeycardRequested()
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
         }
@@ -133,16 +120,6 @@ SQUtils.QObject {
             onKeypairAddTryAgainRequested: {
                 root.stackView.replace(addKeypairPage)
                 root.loadMnemonicRequested()
-            }
-
-            onReloadKeycardRequested: {
-                root.reloadKeycardRequested()
-
-                const page = root.stackView.find(
-                               item => item instanceof CreateKeycardProfilePage)
-
-                root.stackView.replace(page, d.initialComponent(),
-                                       StackView.PopTransition)
             }
 
             onCreateProfilePageRequested: root.createProfileWithoutKeycardRequested()

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -25,7 +25,6 @@ SQUtils.QObject {
     signal keycardPinCreated(string pin)
     signal seedphraseSubmitted(string seedphrase)
     signal authorizationRequested(string pin)
-    signal reloadKeycardRequested
     signal keycardFactoryResetRequested
     signal unblockWithSeedphraseRequested
     signal unblockWithPukRequested
@@ -49,12 +48,6 @@ SQUtils.QObject {
 
             return keycardIntroPage
         }
-
-        function reload() {
-            root.reloadKeycardRequested()
-            root.stackView.replace(d.initialComponent(),
-                                   StackView.PopTransition)
-        }
     }
 
     Component {
@@ -66,7 +59,6 @@ SQUtils.QObject {
             unblockUsingSeedphraseAvailable: true
             unblockWithPukAvailable: root.remainingPukAttempts > 0 && (root.remainingPinAttempts === 1 || root.remainingPinAttempts === 2)
 
-            onReloadKeycardRequested: d.reload()
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
             onUnblockWithSeedphraseRequested: root.unblockWithSeedphraseRequested()
             onUnblockWithPukRequested: root.unblockWithPukRequested()
@@ -79,10 +71,7 @@ SQUtils.QObject {
         id: keycardEmptyPage
 
         KeycardEmptyPage {
-            onCreateProfileWithEmptyKeycardRequested:
-                root.createProfileWithEmptyKeycardRequested()
-
-            onReloadKeycardRequested: d.reload()
+            onCreateProfileWithEmptyKeycardRequested: root.createProfileWithEmptyKeycardRequested()
         }
     }
 
@@ -101,7 +90,6 @@ SQUtils.QObject {
             onExportKeysRequested: root.exportKeysRequested()
             onExportKeysDone: root.finished()
 
-            onReloadKeycardRequested: d.reload()
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
             onUnblockWithSeedphraseRequested: root.unblockWithSeedphraseRequested()
         }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -50,7 +50,6 @@ SQUtils.QObject {
     signal syncProceedWithConnectionString(string connectionString)
     signal seedphraseSubmitted(string seedphrase)
     signal setPasswordRequested(string password)
-    signal reloadKeycardRequested
     signal exportKeysRequested
     signal loadMnemonicRequested
     signal authorizationRequested(string pin)
@@ -270,7 +269,6 @@ SQUtils.QObject {
 
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
-        onReloadKeycardRequested: root.reloadKeycardRequested()
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
         onLoadMnemonicRequested: root.loadMnemonicRequested()
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
@@ -333,7 +331,6 @@ SQUtils.QObject {
 
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
-        onReloadKeycardRequested: root.reloadKeycardRequested()
         onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
         onExportKeysRequested: root.exportKeysRequested()
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
@@ -380,7 +377,6 @@ SQUtils.QObject {
 
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
-        onReloadKeycardRequested: root.reloadKeycardRequested()
         onKeycardPinCreated: (pin) => {
             unblockWithPukFlow.pin = pin
             root.keycardPinCreated(pin)
@@ -415,7 +411,6 @@ SQUtils.QObject {
 
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
-        onReloadKeycardRequested: root.reloadKeycardRequested()
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init(true)
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -39,8 +39,6 @@ Page {
     //    "data:var": contains "password" or "pin"
     signal loginRequested(string keyUid, int method, var data)
 
-    signal reloadKeycardRequested()
-
     function restartFlow() {
         unload()
         onboardingFlow.init()
@@ -196,7 +194,6 @@ Page {
         onLoadMnemonicRequested: d.loadMnemonic()
         onAuthorizationRequested: d.authorize(pin)
         onShareUsageDataRequested: (enabled) => root.shareUsageDataRequested(enabled)
-        onReloadKeycardRequested: root.reloadKeycardRequested()
         onPerformKeycardFactoryResetRequested: root.onboardingStore.startKeycardFactoryReset()
         onSyncProceedWithConnectionString: (connectionString) =>
             root.onboardingStore.inputConnectionStringForBootstrapping(connectionString)

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
@@ -21,7 +21,6 @@ SQUtils.QObject {
     required property int keycardPinInfoPageDelay
 
     signal keycardPinCreated(string pin)
-    signal reloadKeycardRequested
     signal keycardFactoryResetRequested
     signal finished(bool success)
 
@@ -40,11 +39,6 @@ SQUtils.QObject {
             return keycardIntroPage
         }
 
-        function reload() {
-            root.reloadKeycardRequested()
-            root.stackView.replace(d.initialComponent(), StackView.PopTransition)
-        }
-
         function finishWithFactoryReset() {
             root.keycardFactoryResetRequested()
             root.finished(false)
@@ -59,7 +53,6 @@ SQUtils.QObject {
             unblockWithPukAvailable: root.remainingAttempts > 0
             unblockUsingSeedphraseAvailable: true
             factoryResetAvailable: !unblockWithPukAvailable
-            onReloadKeycardRequested: d.reload()
             onKeycardFactoryResetRequested: d.finishWithFactoryReset()
             onEmptyKeycardDetected: root.stackView.replace(keycardUnblockedPage)
             onNotEmptyKeycardDetected: root.stackView.replace(keycardUnblockedPage)

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
@@ -17,7 +17,6 @@ OnboardingPage {
 
     signal keypairAddContinueRequested()
     signal keypairAddTryAgainRequested()
-    signal reloadKeycardRequested()
     signal createProfilePageRequested()
 
     states: [
@@ -163,12 +162,6 @@ OnboardingPage {
                     width: parent.width
                     text: qsTr("Try again")
                     onClicked: root.keypairAddTryAgainRequested()
-                }
-                StatusButton {
-                    text: qsTr("I've inserted a different Keycard")
-                    width: parent.width
-                    isOutline: true
-                    onClicked: root.reloadKeycardRequested()
                 }
                 StatusButton {
                     text: qsTr("Create profile without Keycard")

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEmptyPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEmptyPage.qml
@@ -8,7 +8,6 @@ KeycardBasePage {
     id: root
 
     signal createProfileWithEmptyKeycardRequested()
-    signal reloadKeycardRequested()
 
     title: qsTr("Keycard is empty")
     subtitle: qsTr("There is no profile key pair on this Keycard")
@@ -19,11 +18,6 @@ KeycardBasePage {
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Create new profile on this Keycard")
             onClicked: root.createProfileWithEmptyKeycardRequested()
-        },
-        MaybeOutlineButton {
-            text: qsTr("I’ve inserted a different Keycard")
-            anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: root.reloadKeycardRequested()
         }
     ]
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -24,7 +24,6 @@ KeycardBasePage {
     property string pinCorrectText: qsTr("PIN correct")
 
     signal keycardPinEntered(string pin)
-    signal reloadKeycardRequested
     signal unblockWithSeedphraseRequested
     signal unblockWithPukRequested
     signal keycardFactoryResetRequested
@@ -89,16 +88,6 @@ KeycardBasePage {
             text: qsTr("Unblock with recovery phrase")
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: root.unblockWithSeedphraseRequested()
-        },
-        MaybeOutlineButton {
-            id: btnReload
-            anchors.horizontalCenter: parent.horizontalCenter
-            visible: false
-            text: qsTr("I've inserted a different Keycard")
-            normalColor: "transparent"
-            borderWidth: 1
-            borderColor: Theme.palette.baseColor2
-            onClicked: root.reloadKeycardRequested()
         }
     ]
 
@@ -127,10 +116,6 @@ KeycardBasePage {
             PropertyChanges {
                 target: btnUnblockWithPuk
                 visible: root.unblockWithPukAvailable
-            }
-            PropertyChanges {
-                target: btnReload
-                visible: true
             }
             StateChangeScript {
                 script: {
@@ -172,10 +157,6 @@ KeycardBasePage {
             }
             PropertyChanges {
                 target: errorExportingText
-                visible: true
-            }
-            PropertyChanges {
-                target: btnReload
                 visible: true
             }
         },

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
@@ -25,7 +25,6 @@ KeycardBasePage {
     signal keycardFactoryResetRequested()
     signal unblockWithSeedphraseRequested()
     signal unblockWithPukRequested()
-    signal reloadKeycardRequested()
     signal emptyKeycardDetected()
     signal notEmptyKeycardDetected()
 
@@ -104,13 +103,6 @@ KeycardBasePage {
             text: qsTr("Factory reset Keycard")
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: root.keycardFactoryResetRequested()
-        },
-        MaybeOutlineButton {
-            id: btnReload
-            visible: false
-            text: qsTr("I've inserted a different Keycard")
-            anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: root.reloadKeycardRequested()
         }
     ]
 
@@ -163,11 +155,6 @@ KeycardBasePage {
                 subtitle: qsTr("Remove card and insert a Keycard")
                 image.source: Theme.png("onboarding/keycard/invalid")
             }
-            PropertyChanges {
-                target: btnReload
-                visible: true
-                text: qsTr("I’ve inserted a Keycard")
-            }
         },
         State {
             name: "noService"
@@ -177,11 +164,6 @@ KeycardBasePage {
                 title: qsTr("Smartcard reader service unavailable")
                 subtitle: qsTr("The Smartcard reader service (PCSC service), required for using Keycard, is not currently working. Ensure PCSC is installed and running and try again.")
                 image.source: Theme.png("onboarding/keycard/error")
-            }
-            PropertyChanges {
-                target: btnReload
-                visible: true
-                text: qsTr("Retry")
             }
         },
         State {
@@ -195,10 +177,6 @@ KeycardBasePage {
             }
             PropertyChanges {
                 target: btnFactoryReset
-                visible: true
-            }
-            PropertyChanges {
-                target: btnReload
                 visible: true
             }
         },
@@ -223,10 +201,6 @@ KeycardBasePage {
                 target: btnFactoryReset
                 visible: root.factoryResetAvailable
             }
-            PropertyChanges {
-                target: btnReload
-                visible: true
-            }
         },
         State {
             name: "blockedPuk"
@@ -243,10 +217,6 @@ KeycardBasePage {
             }
             PropertyChanges {
                 target: btnFactoryReset
-                visible: true
-            }
-            PropertyChanges {
-                target: btnReload
                 visible: true
             }
         },

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardNotEmptyPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardNotEmptyPage.qml
@@ -7,7 +7,6 @@ import AppLayouts.Onboarding2.controls 1.0
 KeycardBasePage {
     id: root
 
-    signal reloadKeycardRequested()
     signal loginWithThisKeycardRequested()
     signal keycardFactoryResetRequested()
 
@@ -16,11 +15,6 @@ KeycardBasePage {
     image.source: Theme.png("onboarding/keycard/error")
 
     buttons: [
-        MaybeOutlineButton {
-            text: qsTr("I’ve inserted a different Keycard")
-            anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: root.reloadKeycardRequested()
-        },
         MaybeOutlineButton {
             text: qsTr("Log in with this Keycard")
             anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
### What does the PR do

- the manual "I've inserted a keycard" reload buttons are no longer needed; we can rely solely on the HW keycard state
- when doing a "Restart", also reset the internal mock/store states

Fixes #17234

### Affected areas

Onboarding

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Onboarding flow with no Reload button:
![image](https://github.com/user-attachments/assets/7416833c-58e1-4bcb-839b-930912c6ddd9)

Login screen with no Reload button:
![image](https://github.com/user-attachments/assets/45783ca5-36f3-4a7f-abe8-230f5f01321d)
