### PR TITLE
fix: use mnemonic as BIP-39 string

### DIFF
--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -30,7 +30,7 @@ method getPasswordStrengthScore*(self: AccessInterface, password, userName: stri
 method validMnemonic*(self: AccessInterface, mnemonic: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getMnemonic*(self: AccessInterface): string {.base.} =
+method generateMnemonic*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method validateLocalPairingConnectionString*(self: AccessInterface, connectionString: string): bool {.base.} =

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -132,7 +132,7 @@ method getPasswordStrengthScore*[T](self: Module[T], password, userName: string)
 method validMnemonic*[T](self: Module[T], mnemonic: string): bool =
   self.controller.validMnemonic(mnemonic)
 
-method getMnemonic*[T](self: Module[T]): string =
+method generateMnemonic*[T](self: Module[T]): string =
   return self.controller.generateMnemonic(SupportedMnemonicLength12)
 
 method validateLocalPairingConnectionString*[T](self: Module[T], connectionString: string): bool =

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -145,8 +145,8 @@ QtObject:
   proc validMnemonic(self: View, mnemonic: string): bool {.slot.} =
     return self.delegate.validMnemonic(mnemonic)
 
-  proc getMnemonic(self: View): string {.slot.} =
-    return self.delegate.getMnemonic()
+  proc generateMnemonic(self: View): string {.slot.} =
+    return self.delegate.generateMnemonic()
 
   proc validateLocalPairingConnectionString(self: View, connectionString: string): bool {.slot.} =
     return self.delegate.validateLocalPairingConnectionString(connectionString)

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -103,11 +103,10 @@ QtObject:
           let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
           raise newException(RpcException, "Error loading mnemonic: " & error.message)
 
-      let words = buildSeedPhrasesFromIndexes(rpcResponseObj["result"]["indexes"])
-      var jArray = newJArray()
-      for item in words:
-        jArray.add(%item)
-      return $jArray
+      let indexes = rpcResponseObj["result"]["indexes"]
+      let words = buildSeedPhrasesFromIndexes(indexes)
+      let mnemonic = words.join(" ")
+      return mnemonic
     except Exception as e:
       error "error generating mnemonic", err=e.msg
 

--- a/storybook/pages/BackupSeedphraseFlowPage.qml
+++ b/storybook/pages/BackupSeedphraseFlowPage.qml
@@ -18,7 +18,7 @@ Item {
 
     QtObject {
         id: d
-        readonly property var seedWords: ["apple", "banana", "cat", "cow", "catalog", "catch", "category", "cattle", "dog", "elephant", "fish", "grape"]
+        readonly property string mnemonic: "apple banana cat cow catalog catch category cattle dog elephant fish grape"
         readonly property int numWordsToVerify: 4
     }
 
@@ -53,7 +53,7 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         text: !!stack.currentItem && stack.currentItem instanceof BackupSeedphraseVerify ?
-                  "Hint: %1".arg(stack.currentItem.seedWordsToVerify.map((entry) => entry.seedWord))
+                  "Hint: %1".arg(stack.currentItem.verificationWordsMap.map((entry) => entry.seedWord))
                 : ""
     }
 
@@ -101,7 +101,7 @@ Item {
     Component {
         id: backupSeedRevealPage
         BackupSeedphraseReveal {
-            seedWords: d.seedWords
+            mnemonic: d.mnemonic
             onBackupSeedphraseConfirmed: console.warn("!!! SEED CONFIRMED")
         }
     }
@@ -109,14 +109,8 @@ Item {
     Component {
         id: backupSeedVerifyPage
         BackupSeedphraseVerify {
-            seedWordsToVerify: {
-                let result = []
-                const randomIndexes = SQUtils.Utils.nSamples(d.numWordsToVerify, d.seedWords.length)
-                for (const i of randomIndexes) {
-                    result.push({seedWordNumber: i+1, seedWord: d.seedWords[i]})
-                }
-                return result
-            }
+            mnemonic: d.mnemonic
+            countToVerify: d.numWordsToVerify
             onBackupSeedphraseVerified: console.warn("!!! ALL VERIFIED")
         }
     }

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -30,8 +30,7 @@ SplitView {
     QtObject {
         id: mockDriver
 
-        readonly property string mnemonic: "dog dog dog dog dog dog dog dog dog dog dog dog"
-        readonly property var seedWords: ["apple", "banana", "cat", "cow", "catalog", "catch", "category", "cattle", "dog", "elephant", "fish", "grape"]
+        readonly property string mnemonic: "apple banana cat cow catalog catch category cattle dog elephant fish grape"
         readonly property string pin: "111111"
         readonly property string puk: "111111111111"
         readonly property string password: "somepassword"
@@ -136,9 +135,9 @@ SplitView {
                 return mnemonic === mockDriver.mnemonic
             }
 
-            function getMnemonic() { // -> string
-                logs.logEvent("OnboardingStore.getMnemonic()")
-                return JSON.stringify(mockDriver.seedWords)
+            function generateMnemonic() { // -> string
+                logs.logEvent("OnboardingStore.generateMnemonic()")
+                return mockDriver.mnemonic
             }
 
             function validateLocalPairingConnectionString(connectionString: string) { // -> bool
@@ -292,6 +291,8 @@ SplitView {
             text: "Paste seed phrase verification"
             focusPolicy: Qt.NoFocus
             onClicked: {
+                const words = Utils.parseMnemonicWords(mockDriver.mnemonic)
+
                 for (let i = 0;; i++) {
                     const input = StorybookUtils.findChild(
                                     onboarding.currentPage,
@@ -301,7 +302,7 @@ SplitView {
                         break
 
                     const index = input.seedWordIndex
-                    input.text = mockDriver.seedWords[index]
+                    input.text = words[index]
                 }
             }
         }

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -30,8 +30,7 @@ Item {
         property bool biometricsAvailable
         property string existingPin
 
-        readonly property string mnemonic: "dog dog dog dog dog dog dog dog dog dog dog dog"
-        readonly property var seedWords: ["apple", "banana", "cat", "cow", "catalog", "catch", "category", "cattle", "dog", "elephant", "fish", "grape"]
+        readonly property string mnemonic: "apple banana cat cow catalog catch category cattle dog elephant fish grape"
         readonly property string dummyNewPassword: "0123456789"
     }
 
@@ -88,8 +87,8 @@ Item {
                 function validMnemonic(mnemonic: string) {
                     return mnemonic === mockDriver.mnemonic
                 }
-                function getMnemonic() {
-                    return JSON.stringify(mockDriver.seedWords)
+                function generateMnemonic() {
+                    return mockDriver.mnemonic
                 }
                 function loadMnemonic(mnemonic) {}
                 function exportRecoverKeys() {}
@@ -515,12 +514,12 @@ Item {
             btnContinue = findChild(page, "btnContinue")
             verify(!!btnContinue)
             compare(btnContinue.enabled, false)
-            const seedWords = page.seedWordsToVerify.map((entry) => entry.seedWord)
-            for (let i = 0; i < 4; i++) {
+            const mnemonicWords = page.verificationWordsMap.map((entry) => entry.seedWord)
+            for (let i = 0; i < page.countToVerify; i++) {
                 const seedInput = findChild(page, "seedInput_%1".arg(i))
                 verify(!!seedInput)
                 mouseClick(seedInput)
-                keyClickSequence(seedWords[i])
+                keyClickSequence(mnemonicWords[i])
                 keyClick(Qt.Key_Tab)
             }
             compare(btnContinue.enabled, true)
@@ -567,7 +566,7 @@ Item {
             compare(resultData.password, "")
             compare(resultData.enableBiometrics, data.biometrics && data.bioEnabled)
             compare(resultData.keycardPin, newPin)
-            compare(resultData.seedphrase, mockDriver.seedWords.join(","))
+            compare(resultData.seedphrase, mockDriver.mnemonic)
         }
 
         // FLOW: Create Profile -> Use an empty Keycard -> Use an existing recovery phrase (create profile with keycard + existing seedphrase)

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -7,6 +7,8 @@ import StatusQ.Core.Backpressure 0.1
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
+import utils 1.0
+
 SQUtils.QObject {
     id: root
 
@@ -18,7 +20,7 @@ SQUtils.QObject {
     required property int addKeyPairState
     required property int keycardPinInfoPageDelay
 
-    required property var getSeedWords
+    required property var generateMnemonic
     required property var isSeedPhraseValid
 
     property bool displayKeycardPromoBanner
@@ -44,7 +46,7 @@ SQUtils.QObject {
         id: d
 
         property bool withNewSeedphrase
-        property var seedWords
+        property var mnemonic
 
         function initialComponent() {
             if (root.keycardState === Onboarding.KeycardState.Empty)
@@ -128,14 +130,13 @@ SQUtils.QObject {
         BackupSeedphraseReveal {
             Component.onCompleted: {
                 try {
-                    const seedwords = root.getSeedWords()
-                    d.seedWords = JSON.parse(seedwords)
-                    root.seedphraseSubmitted(d.seedWords)
+                    d.mnemonic = root.generateMnemonic()
+                    root.seedphraseSubmitted(d.mnemonic)
                 } catch (e) {
-                    console.error('Failed to get seedwords', e)
+                    console.error('failed to generate mnemonic', e)
                 }
             }
-            seedWords: d.seedWords
+            mnemonic: d.mnemonic
 
             onBackupSeedphraseConfirmed: root.stackView.push(backupSeedVerifyPage)
         }
@@ -144,13 +145,8 @@ SQUtils.QObject {
     Component {
         id: backupSeedVerifyPage
         BackupSeedphraseVerify {
-            seedWordsToVerify: {
-                const randomIndexes = SQUtils.Utils.nSamples(4, d.seedWords.length)
-                return randomIndexes.map(i => ({ seedWordNumber: i+1,
-                                                 seedWord: d.seedWords[i]
-                                               }))
-            }
-
+            mnemonic: d.mnemonic
+            countToVerify: 4
             onBackupSeedphraseVerified: root.stackView.push(backupSeedOutroPage)
         }
     }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -22,7 +22,7 @@ SQUtils.QObject {
     required property int restoreKeysExportState
     required property int addKeyPairState
     required property int syncState
-    required property var getSeedWords
+    required property var generateMnemonic
     required property int remainingPinAttempts
     required property int remainingPukAttempts
 
@@ -264,7 +264,7 @@ SQUtils.QObject {
         pinSettingState: root.pinSettingState
         authorizationState: root.authorizationState
         addKeyPairState: root.addKeyPairState
-        getSeedWords: root.getSeedWords
+        generateMnemonic: root.generateMnemonic
         displayKeycardPromoBanner: root.displayKeycardPromoBanner
         isSeedPhraseValid: root.isSeedPhraseValid
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -169,7 +169,7 @@ Page {
         syncState: root.onboardingStore.syncState
         addKeyPairState: root.onboardingStore.addKeyPairState
 
-        getSeedWords: root.onboardingStore.getMnemonic
+        generateMnemonic: root.onboardingStore.generateMnemonic
 
         displayKeycardPromoBanner: !d.settings.keycardPromoShown
         isBiometricsLogin: root.isBiometricsLogin

--- a/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseReveal.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseReveal.qml
@@ -10,16 +10,19 @@ import StatusQ.Core.Theme 0.1
 
 import AppLayouts.Onboarding2.components 1.0
 
+import utils 1.0
+
 OnboardingPage {
     id: root
 
-    required property var seedWords
+    required property string mnemonic
 
     signal backupSeedphraseConfirmed()
 
     QtObject {
         id: d
         property bool seedphraseRevealed
+        property var mnemonicWords: Utils.parseMnemonicWords(root.mnemonic)
     }
 
     contentItem: Item {
@@ -58,7 +61,7 @@ OnboardingPage {
                     rowSpacing: columnSpacing
 
                     Repeater {
-                        model: root.seedWords
+                        model: d.mnemonicWords
                         delegate: Frame {
                             Layout.fillWidth: true
                             Layout.fillHeight: true

--- a/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseVerify.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/BackupSeedphraseVerify.qml
@@ -11,19 +11,31 @@ import StatusQ.Core.Theme 0.1
 import AppLayouts.Onboarding2.components 1.0
 
 import shared.stores 1.0
+import utils 1.0
 
 import SortFilterProxyModel 0.2
 
 OnboardingPage {
     id: root
 
-    required property var seedWordsToVerify // [{seedWordNumber:int, seedWord:string}, ...]
+    required property string mnemonic
+    required property int countToVerify
+    readonly property var verificationWordsMap: d.verificationWordsMap
 
     signal backupSeedphraseVerified()
 
     QtObject {
         id: d
         readonly property var seedSuggestions: BIP39_en {} // [{seedWord:string}, ...]
+        readonly property var allWords: Utils.parseMnemonicWords(root.mnemonic)
+        readonly property var verificationWordsMap: { // [{wordNumber:int, word:string}, ...]
+            const words = d.allWords
+            const randomIndexes = SQUtils.Utils.nSamples(root.countToVerify, words.length)
+            return randomIndexes.map(i => ({
+                                               seedWordNumber: i+1,
+                                               seedWord: words[i]
+                                           }))
+        }
     }
 
     contentItem: Item {
@@ -62,7 +74,7 @@ OnboardingPage {
                     }
 
                     id: seedRepeater
-                    model: root.seedWordsToVerify
+                    model: d.verificationWordsMap
                     delegate: RowLayout {
                         required property var modelData
                         required property int index
@@ -80,7 +92,7 @@ OnboardingPage {
                             horizontalAlignment: Text.AlignHCenter
                         }
                         SeedphraseVerifyInput {
-                            readonly property int seedWordIndex: modelData.seedWordNumber - 1 // 0 based idx into the seedWords
+                            readonly property int seedWordIndex: modelData.seedWordNumber - 1 // 0 based idx in the mnemonic
                             objectName: "seedInput_%1".arg(index)
                             Layout.fillWidth: true
                             id: seedInput

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -72,8 +72,8 @@ QtObject {
     function validMnemonic(mnemonic: string) { // -> bool
         return d.onboardingModuleInst.validMnemonic(mnemonic)
     }
-    function getMnemonic() { // -> string
-        return d.onboardingModuleInst.getMnemonic()
+    function generateMnemonic() { // -> string as per BIP-39 (space-separated list of words)
+        return d.onboardingModuleInst.generateMnemonic()
     }
 
     // sync

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -96,6 +96,13 @@ QtObject {
         return seedPhraseValidWordCount(value);
     }
 
+    function parseMnemonicWords(mnemonic) {
+        const trimmed = mnemonic.trim()
+        if (trimmed === "")
+            return []
+        return trimmed.replace(/  +/g, " ").split(" ")
+    }
+
     function compactAddress(addr, numberOfChars) {
         if(addr.length <= 5 + (numberOfChars * 2)){  //   5 represents these chars 0x...
             return addr;
@@ -186,9 +193,7 @@ QtObject {
     }
 
     function countWords(text) {
-        if (text.trim() === "")
-            return 0;
-        return text.trim().replace(/  +/g, " ").split(" ").length;
+        return parseMnemonicWords(text).length
     }
 
     function seedPhraseValidWordCount(text) {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17241

Iterates:
-  https://github.com/status-im/status-desktop/issues/17207

### What does the PR do

1. Use _mnemonic_ format (as per BIP-39) in QML, instead of a JSON array of words
2. Moved random words selection for verification to `BackupSeedphraseVerify.qml`
3. Replace `getMnemonic` with `generateMnemonic` everywhere, according to Keycard API
4. A few minor improvements on the way