### PR TITLE
feat:  post-onboarding keycard replacement task

### DIFF
--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -5,6 +5,7 @@ from app_service/service/settings/dto/settings import SettingsDto
 from app_service/service/accounts/dto/accounts import AccountDto
 from app_service/service/keycardV2/dto import KeycardEventDto, KeycardExportedKeysDto
 from app_service/service/devices/dto/local_pairing_status import LocalPairingStatus
+import app/modules/onboarding/post_onboarding/task
 
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
@@ -82,6 +83,9 @@ method onAccountLoginError*(self: AccessInterface, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method exportRecoverKeys*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getPostOnboardingTasks*(self: AccessInterface): seq[PostOnboardingTask] {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/onboarding/post_onboarding/keycard_replacement_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/keycard_replacement_task.nim
@@ -1,0 +1,57 @@
+import sequtils, chronicles, sugar
+import task
+
+import app_service/service/wallet_account/service as wallet_account_service
+import app_service/service/keycardV2/service as keycard_serviceV2
+
+export task
+
+type KeycardReplacementTask* = ref object of PostOnboardingTask
+  keyUid: string
+  keycardInstanceUID: string
+
+proc newKeycardReplacementTask*(keyUid: string,
+                                keycardInstanceUID: string): KeycardReplacementTask =
+  result = KeycardReplacementTask(
+    kind: kPostOnboardingTaskKeycardReplacement,
+    keyUid: keyUid,
+    keycardInstanceUID: keycardInstanceUID,
+  )
+
+proc run*(self: KeycardReplacementTask,
+            walletAccountService: wallet_account_service.Service,
+            keycardServiceV2: keycard_serviceV2.Service) =
+
+  # NOTE: This implementation was taken from `doKeycardReplacement` in `app_controller.nim`
+
+  debug "running post-onbaording KeycardReplacementTask"
+
+  let keypair = walletAccountService.getKeypairByKeyUid(self.keyUid)
+  if keypair.isNil:
+    error "cannot resolve appropriate keypair for logged in user"
+    return
+
+  if self.keycardInstanceUID.len == 0 or self.keyUid != self.keyUid:
+      warn "keycard replacement process is not fully completed, try the same again"
+      return
+
+  # we have to delete all keycards with the same key uid to cover the case if user had more then a single keycard for the same keypair
+  discard walletAccountService.deleteAllKeycardsWithKeyUid(self.keyUid)
+
+  # store new keycard with accounts, in this context no need to check if accounts match the default Status derivation path,
+  # cause otherwise we wouldn't be here (cannot have keycard profile with any such path)
+  let accountsAddresses = keypair.accounts.filter(acc => not acc.isChat).map(acc => acc.address)
+  let keycard = KeycardDto(
+    keycardUid: self.keycardInstanceUID,
+    keycardName: keypair.name,
+    keyUid: self.keyUid,
+    accountsAddresses: accountsAddresses
+  )
+  discard walletAccountService.addKeycardOrAccounts(keycard, accountsComingFromKeycard = true)
+
+  # FIXME: store metadata to a Keycard - https://github.com/status-im/status-desktop/issues/17128
+  # let accountsPathsToStore = keypair.accounts.filter(acc => not acc.isChat).map(acc => acc.path)
+  # keycardServiceV2.asyncStoreMetadata(keypair.name, self.startupModule.getPin(), accountsPathsToStore)
+
+  info "keycard replacement fully done"
+

--- a/src/app/modules/onboarding/post_onboarding/task.nim
+++ b/src/app/modules/onboarding/post_onboarding/task.nim
@@ -1,0 +1,21 @@
+type PostOnboardingTaskKind* = enum
+  # NOTE: Call from Login apge when the keycard was lost and is being replaced.
+  kPostOnboardingTaskKeycardReplacement = 0
+
+  # NOTE: This syncs the list of wallets between the app and the keycard.
+  kPostOnboardingSyncKeycardWallets = 1 # Onboarding V1 name: syncKeycardBasedOnAppWalletState
+
+  # NOTE: Do when restoring same keycard from recovery phrase.
+  #       In theory this means that the old UID will never be used again, as it is being destroyed on the same physical keycard. # TODO: But do we really need to bother?
+  #       Comparing to the `KeycardReplacementTask` which is used when the keycard is lost and a new one is being used. Theoretically the old keycard can still be found and used. # WARNING: But is this secure?
+  kPostOnboardingUpdateKeycardUid = 2 # Onboarding V1 name: changedKeycardUids
+
+type PostOnboardingTask* = ref object of RootObj
+  kind*: PostOnboardingTaskKind
+
+# NOTE: In theory we could define a `run` {.base.} method here.
+# But for now there are not many task kinds, and they require different arguments.
+# proc run*(self: KeycardReplacementTask)
+
+proc kind*(self: PostOnboardingTask): PostOnboardingTaskKind =
+  return self.kind

--- a/src/app/modules/onboarding/post_onboarding/task.nim
+++ b/src/app/modules/onboarding/post_onboarding/task.nim
@@ -1,5 +1,5 @@
 type PostOnboardingTaskKind* = enum
-  # NOTE: Call from Login apge when the keycard was lost and is being replaced.
+  # NOTE: Call from Login page when the keycard was lost and is being replaced.
   kPostOnboardingTaskKeycardReplacement = 0
 
   # NOTE: This syncs the list of wallets between the app and the keycard.


### PR DESCRIPTION
Iterates:
-  https://github.com/status-im/status-desktop/issues/17238

# Description

1. Added a concept of post-onboarding task. These can be added during `onboarding` and will be executed after login.
    For now it's only 1 task, but I have defined 2 more that we will need to migrate from old `startup` as well.
2. Added `doKeycardReplacement` to the new onboarding