### PR TITLE
feat(Onboarding): KeycardExtractingKeysPage excluded from KeycardEnterPinPage

### DIFF
--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -14,26 +14,30 @@ Item {
         id: page
         anchors.fill: parent
 
-        remainingAttempts: 3
+        authorizationState: authorizationProgressSelector.value
+        remainingAttempts: remainingAttemptsSpinBox.value
+
         unblockWithPukAvailable: ctrlUnblockWithPUK.checked
-        keycardPinInfoPageDelay: 1000
-        authorizationState: Onboarding.ProgressState.Idle
-        restoreKeysExportState: Onboarding.ProgressState.Idle
+
         onAuthorizationRequested: (pin) => {
-                                 console.warn("!!! PIN:", pin)
-                                 console.warn("!!! RESETTING FLOW")
-                                 state = "entering"
-                             }
-        onKeycardFactoryResetRequested: {
-            console.warn("!!! FACTORY RESET KEYCARD")
-            remainingAttempts = 3
-            state = "entering"
+            console.log("authorization requested:", pin)
         }
+
+        onUnblockWithSeedphraseRequested: console.log("unblock with seed phrase requested")
+        onUnblockWithPukRequested: console.log("unblock with puk requested")
+        onKeycardFactoryResetRequested: console.log("factory reset requested")
     }
 
-    RowLayout {
-        anchors.right: parent.right
+    ColumnLayout {
+        anchors.left: parent.left
         anchors.bottom: parent.bottom
+        anchors.margins: 15
+
+        spacing: 15
+
+        Label {
+            text: "Hint: %1".arg(root.existingPin)
+        }
 
         CheckBox {
             id: ctrlUnblockWithPUK
@@ -41,10 +45,25 @@ Item {
             checked: true
         }
 
-        Item { Layout.fillWidth: true }
+        RowLayout {
+            Label {
+                text: "Remaining attempts: "
+            }
 
-        Label {
-            text: "Hint: %1".arg(root.existingPin)
+            SpinBox {
+                id: remainingAttemptsSpinBox
+
+                from: 0
+                to: 3
+                value: 3
+            }
+        }
+
+        ProgressSelector {
+            id: authorizationProgressSelector
+
+            label: "Authorization progress"
+
         }
     }
 }

--- a/storybook/pages/KeycardExtractingKeysPagePage.qml
+++ b/storybook/pages/KeycardExtractingKeysPagePage.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.15
+
+import AppLayouts.Onboarding2.pages 1.0
+
+Item {
+    id: root
+
+    KeycardExtractingKeysPage {
+        id: progressPage
+
+        anchors.fill: parent
+    }
+}
+
+// category: Onboarding
+// status: good

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -382,6 +382,10 @@ SplitView {
 
                 text: {
                     const stack = onboarding.stack
+
+                    // trigger change when only curret item changes on replace
+                    stack.currentItem
+
                     let content = `Stack (${stack.depth}):`
 
                     for (let i = 0; i < stack.depth; i++) {

--- a/storybook/pages/ProgressSelector.qml
+++ b/storybook/pages/ProgressSelector.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import Storybook 1.0
+
+import AppLayouts.Onboarding.enums 1.0
+
+Control {
+    id: root
+
+    readonly property alias value: d.value
+
+    property string label
+
+    QtObject {
+        id: d
+
+        property int value: Onboarding.ProgressState.Idle
+    }
+
+    contentItem: RowLayout {
+        Label {
+            id: label
+
+            text: root.label + ": "
+        }
+
+        Flow {
+            spacing: 2
+
+            ButtonGroup {
+                id: group
+            }
+
+            Repeater {
+                model: Onboarding.getModelFromEnum("ProgressState")
+
+                RoundButton {
+                    text: modelData.name
+                    checkable: true
+                    checked: root.value === modelData.value
+
+                    ButtonGroup.group: group
+
+                    onClicked: d.value = modelData.value
+                }
+            }
+        }
+    }
+}

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -71,7 +71,15 @@ Item {
                     return valid
                 }
 
-                function authorize(pin: string) {}
+                function authorize(pin: string) {
+                    authorizeCalled(pin)
+                }
+                function loadMnemonic(mnemonic) {
+                    loadMnemonicCalled()
+                }
+                function exportRecoverKeys() {
+                    exportRecoverKeysCalled()
+                }
 
                 readonly property int addKeyPairState: Onboarding.ProgressState.InProgress // enum Onboarding.ProgressState
 
@@ -91,8 +99,6 @@ Item {
                 function getMnemonic() {
                     return JSON.stringify(mockDriver.seedWords)
                 }
-                function loadMnemonic(mnemonic) {}
-                function exportRecoverKeys() {}
 
                 readonly property int syncState: Onboarding.ProgressState.InProgress // enum Onboarding.ProgressState
                 function validateLocalPairingConnectionString(connectionString: string) {
@@ -102,6 +108,10 @@ Item {
 
                 // password signals
                 signal accountLoginError(string error, bool wrongPassword)
+
+                signal authorizeCalled(string pin)
+                signal loadMnemonicCalled
+                signal exportRecoverKeysCalled
             }
 
             onLoginRequested: (keyUid, method, data) => {
@@ -896,21 +906,24 @@ Item {
 
             // PAGE 5: Enter Keycard PIN
             page = getCurrentPage(stack, KeycardEnterPinPage)
-            dynamicSpy.setup(page, "authorizationRequested")
+            dynamicSpy.setup(controlUnderTest.onboardingStore, "authorizeCalled")
             keyClickSequence(mockDriver.existingPin)
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], mockDriver.existingPin)
 
-            dynamicSpy.setup(page, "exportKeysRequested")
+            dynamicSpy.setup(controlUnderTest.onboardingStore, "exportRecoverKeysCalled")
             mockDriver.authorizationState = Onboarding.ProgressState.Success
             tryCompare(dynamicSpy, "count", 1)
 
-            dynamicSpy.setup(page, "exportKeysDone")
+            // PAGE 6: Extracting keys from Keycard
+            page = getCurrentPage(stack, KeycardExtractingKeysPage)
             mockDriver.restoreKeysExportState = Onboarding.ProgressState.Success
-            tryCompare(dynamicSpy, "count", 1)
 
-            // PAGE 6: Enable Biometrics
+            // PAGE 7: Enable Biometrics
             if (data.biometrics) {
+                dynamicSpy.setup(stack, "currentItemChanged")
+                tryCompare(dynamicSpy, "count", 1)
+
                 page = getCurrentPage(stack, EnableBiometricsPage)
 
                 const enableBioButton = findChild(controlUnderTest, data.bioEnabled ? "btnEnableBiometrics" : "btnDontEnableBiometrics")

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -22,8 +22,6 @@ SQUtils.QObject {
 
     property bool displayKeycardPromoBanner
 
-    signal keycardPinCreated(string pin)
-    signal seedphraseSubmitted(string seedphrase)
     signal authorizationRequested(string pin)
     signal keycardFactoryResetRequested
     signal unblockWithSeedphraseRequested
@@ -126,37 +124,6 @@ SQUtils.QObject {
                     Backpressure.debounce(page, root.keycardPinInfoPageDelay,
                                           root.finished)()
                 }
-            }
-        }
-    }
-
-    Component {
-        id: seedphrasePage
-
-        SeedphrasePage {
-            title: qsTr("Unblock Keycard using the recovery phrase")
-            btnContinueText: qsTr("Unblock Keycard")
-            authorizationState: root.authorizationState
-            isSeedPhraseValid: root.isSeedPhraseValid
-            onSeedphraseSubmitted: (seedphrase) => {
-                root.seedphraseSubmitted(seedphrase)
-                root.stackView.push(keycardCreatePinPage)
-            }
-        }
-    }
-
-    Component {
-        id: keycardCreatePinPage
-
-        KeycardCreatePinPage {
-            id: createPinPage
-
-            onKeycardPinCreated: (pin) => {
-                createPinPage.loading = true
-                Backpressure.debounce(root, root.keycardPinInfoPageDelay, () => {
-                    root.keycardPinCreated(pin)
-                    root.finished()
-                })()
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -329,8 +329,6 @@ SQUtils.QObject {
 
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
-        onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
-        onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
         onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
         onExportKeysRequested: root.exportKeysRequested()
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -1,12 +1,12 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 
-import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
-import StatusQ.Core.Theme 0.1
+import StatusQ.Core 0.1
 import StatusQ.Core.Backpressure 0.1
+import StatusQ.Core.Theme 0.1
 
 import AppLayouts.Onboarding2.controls 1.0
 import AppLayouts.Onboarding.enums 1.0
@@ -17,42 +17,163 @@ KeycardBasePage {
     id: root
 
     required property int authorizationState
-    required property int restoreKeysExportState
     required property int remainingAttempts
     required property bool unblockWithPukAvailable
-    required property int keycardPinInfoPageDelay
-    property string pinCorrectText: qsTr("PIN correct")
 
-    signal keycardPinEntered(string pin)
+    signal authorizationRequested(string pin)
     signal unblockWithSeedphraseRequested
     signal unblockWithPukRequested
     signal keycardFactoryResetRequested
-    signal authorizationRequested(string pin)
-    signal exportKeysRequested()
-    signal exportKeysDone()
-
-    image.source: Theme.png("onboarding/keycard/reading")
 
     QtObject {
         id: d
         property string tempPin
     }
 
+    StateGroup {
+        //state: "entering"
+
+        states: [
+            State {
+                name: "entering"
+                when: root.authorizationState === Onboarding.ProgressState.Idle
+                      && root.remainingAttempts > 0
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Enter Keycard PIN")
+                }
+                StateChangeScript {
+                    script: {
+                        pinInput.statesInitialization()
+                        pinInput.forceFocus()
+                    }
+                }
+
+                PropertyChanges {
+                    target: image
+                    source: Theme.png("onboarding/keycard/reading")
+                }
+            },
+            State {
+                name: "incorrect"
+                when: root.authorizationState === Onboarding.ProgressState.Failed
+                      && root.remainingAttempts > 0
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("PIN incorrect")
+                }
+                PropertyChanges {
+                    target: errorText
+                    visible: true
+                }
+                StateChangeScript {
+                    script: {
+                        Backpressure.debounce(root, 100, function() {
+                            pinInput.clearPin()
+                        })()
+                    }
+                }
+                PropertyChanges {
+                    target: image
+                    source: Theme.png("onboarding/keycard/error")
+                }
+            },
+            State {
+                name: "authorizing"
+                when: root.authorizationState === Onboarding.ProgressState.InProgress
+                      && root.remainingAttempts > 0
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Authorizing")
+                }
+                PropertyChanges {
+                    target: pinInput
+                    enabled: false
+                }
+                PropertyChanges {
+                    target: loadingIndicator
+                    visible: true
+                }
+
+                PropertyChanges {
+                    target: image
+                    source: Theme.png("onboarding/keycard/reading")
+                }
+            },
+            State {
+                name: "pinSuccess"
+                when: root.authorizationState === Onboarding.ProgressState.Success
+                      && root.remainingAttempts > 0
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("PIN correct")
+                }
+                PropertyChanges {
+                    target: pinInput
+                    enabled: false
+                }
+
+                PropertyChanges {
+                    target: image
+                    source: Theme.png("onboarding/keycard/success")
+                }
+            },
+            State {
+                name: "blocked"
+                when: root.remainingAttempts <= 0
+
+                PropertyChanges {
+                    target: root
+
+                    title: `<font color='${Theme.palette.dangerColor1}'>`
+                           + `${qsTr("Keycard blocked")}</font>`
+                }
+                PropertyChanges {
+                    target: pinInput
+                    enabled: false
+                }
+                PropertyChanges {
+                    target: image
+                    source: Theme.png("onboarding/keycard/error")
+                }
+                PropertyChanges {
+                    target: btnUnblockWithSeedphrase
+                    visible: true
+                }
+                PropertyChanges {
+                    target: btnUnblockWithPuk
+                    visible: root.unblockWithPukAvailable
+                }
+                StateChangeScript {
+                    script: {
+                        Backpressure.debounce(root, 100, function() {
+                            pinInput.clearPin()
+                        })()
+                    }
+                }
+            }
+        ]
+    }
+
     buttons: [
         StatusPinInput {
             id: pinInput
+
             anchors.horizontalCenter: parent.horizontalCenter
             pinLen: Constants.keycard.general.keycardPinLength
             validator: StatusIntValidator { bottom: 0; top: 999999 }
             onPinInputChanged: {
-                if (pinInput.pinInput.length === pinInput.pinLen) { // we have the full length PIN now
-                    d.tempPin = pinInput.pinInput
-                    root.authorizationRequested(d.tempPin)
-                }
+                if (pinInput.pinInput.length === pinInput.pinLen)
+                    root.authorizationRequested(pinInput.pinInput)
             }
         },
         StatusBaseText {
             id: errorText
+
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("%n attempt(s) remaining", "", root.remainingAttempts)
             font.pixelSize: Theme.tertiaryTextFontSize
@@ -61,6 +182,7 @@ KeycardBasePage {
         },
         StatusBaseText {
             id: errorExportingText
+
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Error exporting the keys, please try again")
             font.pixelSize: Theme.tertiaryTextFontSize
@@ -69,12 +191,14 @@ KeycardBasePage {
         },
         StatusLoadingIndicator {
             id: loadingIndicator
+
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.topMargin: Theme.halfPadding
             visible: false
         },
         MaybeOutlineButton {
             id: btnUnblockWithPuk
+
             visible: false
             isOutline: false
             text: qsTr("Unblock using PUK")
@@ -83,158 +207,12 @@ KeycardBasePage {
         },
         MaybeOutlineButton {
             id: btnUnblockWithSeedphrase
+
             visible: false
             isOutline: btnUnblockWithPuk.visible
             text: qsTr("Unblock with recovery phrase")
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: root.unblockWithSeedphraseRequested()
-        }
-    ]
-
-    state: "entering"
-
-    states: [
-        State {
-            name: "blocked"
-            when: root.remainingAttempts <= 0
-            PropertyChanges {
-                target: root
-                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Keycard blocked") + "</font>"
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: image
-                source: Theme.png("onboarding/keycard/error")
-            }
-            PropertyChanges {
-                target: btnUnblockWithSeedphrase
-                visible: true
-            }
-            PropertyChanges {
-                target: btnUnblockWithPuk
-                visible: root.unblockWithPukAvailable
-            }
-            StateChangeScript {
-                script: {
-                    Backpressure.debounce(root, 100, function() {
-                        pinInput.clearPin()
-                    })()
-                }
-            }
-        },
-        State {
-            name: "incorrect"
-            when: root.authorizationState === Onboarding.ProgressState.Failed
-            PropertyChanges {
-                target: root
-                title: qsTr("PIN incorrect")
-            }
-            PropertyChanges {
-                target: errorText
-                visible: true
-            }
-            StateChangeScript {
-                script: {
-                    Backpressure.debounce(root, 100, function() {
-                        pinInput.clearPin()
-                    })()
-                }
-            }
-            PropertyChanges {
-                target: image
-                source: Theme.png("onboarding/keycard/error")
-            }
-        },
-        State {
-            name: "error"
-            when: root.restoreKeysExportState === Onboarding.ProgressState.Failed
-            PropertyChanges {
-                target: root
-                title: qsTr("Keys export failed")
-            }
-            PropertyChanges {
-                target: errorExportingText
-                visible: true
-            }
-        },
-        State {
-            name: "authorizing"
-            when: root.authorizationState === Onboarding.ProgressState.InProgress
-            PropertyChanges {
-                target: root
-                title: qsTr("Authorizing")
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: loadingIndicator
-                visible: true
-            }
-        },
-        State {
-            name: "exportSuccess"
-            when: root.restoreKeysExportState === Onboarding.ProgressState.Success
-            PropertyChanges {
-                target: root
-                title: qsTr("Keys exported successfully")
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: image
-                source: Theme.png("onboarding/keycard/success")
-            }
-            StateChangeScript {
-                script: {
-                    Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
-                        root.exportKeysDone()
-                    })()
-                }
-            }
-        },
-        State {
-            name: "pinSuccess"
-            when: root.authorizationState === Onboarding.ProgressState.Success
-            PropertyChanges {
-                target: root
-                title: root.pinCorrectText
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: loadingIndicator
-                visible: true
-            }
-            StateChangeScript {
-                script: {
-                    Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
-                        root.exportKeysRequested()
-                    })()
-                }
-            }
-        },
-        State {
-            name: "entering"
-            PropertyChanges {
-                target: root
-                title: qsTr("Enter Keycard PIN")
-            }
-            StateChangeScript {
-                script: {
-                    pinInput.statesInitialization()
-                    pinInput.forceFocus()
-                    d.tempPin = ""
-                }
-            }
         }
     ]
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardExtractingKeysPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardExtractingKeysPage.qml
@@ -1,0 +1,106 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+OnboardingPage {
+    id: root
+
+    title: qsTr("Extracting keys from Keycard")
+
+    contentItem: Item {
+        ColumnLayout {
+            anchors.centerIn: parent
+            width: Math.min(350, root.availableWidth)
+            spacing: Theme.halfPadding
+
+            Rectangle {
+                Layout.preferredWidth: 40
+                Layout.preferredHeight: 40
+                Layout.alignment: Qt.AlignHCenter
+
+                color: Theme.palette.baseColor2
+                radius: width/2
+
+                StatusDotsLoadingIndicator {
+                    anchors.centerIn: parent
+                }
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                font.pixelSize: 22
+                font.bold: true
+                wrapMode: Text.WordWrap
+                text: root.title
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            StatusBaseText {
+                id: subtitle
+
+                Layout.fillWidth: true
+
+                text: qsTr("You will now require this Keycard to log into Status and transact with any accounts derived from this key pair")
+                color: Theme.palette.baseColor1
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            StatusImage {
+                id: image
+
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: Math.min(231, parent.width)
+                Layout.preferredHeight: Math.min(211, height)
+                Layout.topMargin: Theme.bigPadding
+                Layout.bottomMargin: Theme.bigPadding
+                source: Theme.png("onboarding/status_keycard_adding_keypair")
+                mipmap: true
+            }
+
+            StatusBaseText {
+                id: subImageText
+
+                Layout.fillWidth: true
+
+                text: qsTr("Please keep the Keycard plugged in until the extraction is complete")
+
+                color: Theme.palette.baseColor1
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+    }
+
+    Component {
+        id: loadingIndicator
+        Rectangle {
+            color: Theme.palette.baseColor2
+            radius: width/2
+            StatusDotsLoadingIndicator {
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    Component {
+        id: successIcon
+        StatusRoundIcon {
+            asset.name: "check-circle"
+            asset.color: Theme.palette.successColor1
+            asset.bgColor: Theme.palette.successColor2
+        }
+    }
+
+    Component {
+        id: failedIcon
+        StatusRoundIcon {
+            asset.name: "close-circle"
+            asset.color: Theme.palette.dangerColor1
+            asset.bgColor: Theme.palette.dangerColor3
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -14,6 +14,7 @@ KeycardCreatePinPage 1.0 KeycardCreatePinPage.qml
 KeycardEmptyPage 1.0 KeycardEmptyPage.qml
 KeycardEnterPinPage 1.0 KeycardEnterPinPage.qml
 KeycardEnterPukPage 1.0 KeycardEnterPukPage.qml
+KeycardExtractingKeysPage 1.0 KeycardExtractingKeysPage.qml
 KeycardIntroPage 1.0 KeycardIntroPage.qml
 KeycardLostPage 1.0 KeycardLostPage.qml
 KeycardNotEmptyPage 1.0 KeycardNotEmptyPage.qml


### PR DESCRIPTION
### What does the PR do

- separates pin entering and presenting keys extraction progress by using separate pages
- simplifies `KeycardEnterPinPage`, removing states from top level component (https://github.com/Furkanzmc/QML-Coding-Guide?tab=readme-ov-file#st-1-dont-define-top-level-states)
- rework `KeycardEnterPinPage`'s SB page to cover whole API
- fixes StackView inspection in OnboardingFlow
- adds reusable `ProgressSelector` to Storybook
- OnboardingLayout test: introduces inspection if given store method was called

Closes: #17205

### Affected areas
Onboarding

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

`KeycardExtractingKeysPage` needs further alignment to the design (missing design)

- [x] I've checked the design and this PR matches it

[Screencast from 07.02.2025 11:05:18.webm](https://github.com/user-attachments/assets/d704f857-ed3b-446d-be3f-100bfa431cff)

