### PR TITLE
fix(Onboarding): Incorrect Navigation Flow for 'Use existing phrase' subflow

### DIFF
--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -620,7 +620,20 @@ Item {
             verify(!!btnCreateWithExistingSeedphrase)
             mouseClick(btnCreateWithExistingSeedphrase)
 
-            // PAGE 6: Create new Keycard PIN
+            // PAGE 6: Create profile on empty Keycard using a recovery phrase
+            page = getCurrentPage(stack, SeedphrasePage)
+            const btnContinue = findChild(page, "btnContinue")
+            verify(!!btnContinue)
+            compare(btnContinue.enabled, false)
+            const firstInput = findChild(page, "enterSeedPhraseInputField1")
+            verify(!!firstInput)
+            tryCompare(firstInput, "activeFocus", true)
+            ClipboardUtils.setText(mockDriver.mnemonic)
+            keySequence(StandardKey.Paste)
+            compare(btnContinue.enabled, true)
+            mouseClick(btnContinue)
+
+            // PAGE 7: Create new Keycard PIN
             const newPin = "123321"
             page = getCurrentPage(stack, KeycardCreatePinPage)
             tryCompare(page, "state", "creating")
@@ -633,20 +646,6 @@ Item {
             dynamicSpy.setup(page, "keycardPinSuccessfullySet")
             mockDriver.pinSettingState = Onboarding.ProgressState.Success
             tryCompare(dynamicSpy, "count", 1)
-
-
-            // PAGE 7: Create profile on empty Keycard using a recovery phrase
-            page = getCurrentPage(stack, SeedphrasePage)
-            const btnContinue = findChild(page, "btnContinue")
-            verify(!!btnContinue)
-            compare(btnContinue.enabled, false)
-            const firstInput = findChild(page, "enterSeedPhraseInputField1")
-            verify(!!firstInput)
-            tryCompare(firstInput, "activeFocus", true)
-            ClipboardUtils.setText(mockDriver.mnemonic)
-            keySequence(StandardKey.Paste)
-            compare(btnContinue.enabled, true)
-            mouseClick(btnContinue)
             dynamicSpy.setup(page, "keycardAuthorized")
             mockDriver.authorizationState = Onboarding.ProgressState.Success
             tryCompare(dynamicSpy, "count", 1)

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -82,7 +82,7 @@ SQUtils.QObject {
             }
             onCreateKeycardProfileWithExistingSeedphrase: {
                 d.withNewSeedphrase = false
-                root.stackView.push(keycardCreatePinPage)
+                root.stackView.push(seedphrasePage)
             }
         }
     }
@@ -153,20 +153,13 @@ SQUtils.QObject {
         id: seedphrasePage
 
         SeedphrasePage {
-            id: seedphrasePage
             title: qsTr("Create profile on empty Keycard using a recovery phrase")
 
             authorizationState: root.authorizationState
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
-                root.authorizationRequested()
-            }
-            onKeycardAuthorized: {
-                if (!d.withNewSeedphrase) {
-                    root.loadMnemonicRequested()
-                    root.stackView.push(addKeypairPage)
-                }
+                root.stackView.push(keycardCreatePinPage)
             }
         }
     }
@@ -175,8 +168,6 @@ SQUtils.QObject {
         id: keycardCreatePinPage
 
         KeycardCreatePinPage {
-            id: createPinPage
-
             keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
             pinSettingState: root.pinSettingState
             authorizationState: root.authorizationState
@@ -187,13 +178,14 @@ SQUtils.QObject {
                 if (d.withNewSeedphrase) {
                     // Need to authorize before getting a seedphrase
                     root.authorizationRequested()
-                } else {
-                    root.stackView.push(seedphrasePage)
                 }
             }
             onKeycardAuthorized: {
                 if (d.withNewSeedphrase) {
                     root.stackView.push(backupSeedIntroPage)
+                } else {
+                    root.loadMnemonicRequested()
+                    root.stackView.push(addKeypairPage)
                 }
             }
         }

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -95,7 +95,7 @@ SQUtils.QObject {
             pinSettingState: root.pinSettingState
             authorizationState: root.authorizationState
             onKeycardPinCreated: (pin) => {
-                    root.keycardPinCreated(pin)
+                root.keycardPinCreated(pin)
             }
             onKeycardPinSuccessfullySet: {
                 root.authorizationRequested()

--- a/ui/app/AppLayouts/Onboarding2/components/SeedphraseVerifyInput.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/SeedphraseVerifyInput.qml
@@ -18,7 +18,7 @@ StatusTextField {
     placeholderText: qsTr("Enter word")
 
     leftPadding: Theme.padding
-    rightPadding: Theme.padding + rightIcon.width + d.contentSpacing
+    rightPadding: Theme.padding + clearIcon.width + d.contentSpacing
     topPadding: Theme.smallPadding
     bottomPadding: Theme.smallPadding
 

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
@@ -22,7 +22,8 @@ OnboardingPage {
     states: [
         State {
             name: "inprogress"
-            when: root.addKeyPairState === Onboarding.ProgressState.InProgress
+            when: root.addKeyPairState === Onboarding.ProgressState.InProgress ||
+                  root.addKeyPairState === Onboarding.ProgressState.Idle
             PropertyChanges {
                 target: root
                 title: qsTr("Adding key pair to Keycard")


### PR DESCRIPTION
### What does the PR do

- changes the order of the "Create profile on empty Keycard" flow to match Figma (seedphrase -> create pin -> add key pair)
- fixup tests to match the order

Fixes #17216

### Affected areas

Onboarding -> Create Profile -> Empty Keycard -> Existing seedphrase

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/30d70df0-16a1-42a4-b51a-4360abcbc978)
