### PR TITLE
feat: Update interactive states in simple send modal

### DIFF
--- a/storybook/qmlTests/tests/tst_RecipientView.qml
+++ b/storybook/qmlTests/tests/tst_RecipientView.qml
@@ -69,6 +69,7 @@ Item {
             compare(view.model.ModelCount.count, 0)
             compare(view.searchPattern, "")
             compare(view.selectedRecipientAddress, "")
+            verify(view.interactive)
             compare(view.item.objectName, "RecipientView_SendRecipientInput")
         }
 
@@ -139,17 +140,26 @@ Item {
         }
 
         function test_prefillSelectedRecipientAddress() {
-            const view = createTemporaryObject(testComponent, root)
+            const view = createTemporaryObject(testComponent, root, { selectedRecipientAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240" })
             verify(view)
-
-            compare(view.selectedRecipientAddress, "")
-            compare(view.item.objectName, "RecipientView_SendRecipientInput")
-
-            view.selectedRecipientAddress = "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
 
             compare(view.selectedRecipientAddress, "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240")
             compare(view.item.objectName, "RecipientView_RecipientViewDelegate")
             compare(view.item.address, "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240")
+        }
+
+        function test_interactive() {
+            const view = createTemporaryObject(testComponent, root, { selectedRecipientAddress: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0Fd864dd", interactive: false })
+            verify(view)
+
+            const clearButton = findChild(view, "RecipientView_clearButton")
+            verify(clearButton)
+
+            verify(!view.interactive)
+            verify(!clearButton.visible)
+
+            view.interactive = true
+            verify(clearButton.visible)
         }
     }
 }

--- a/storybook/qmlTests/tests/tst_SimpleSendModal.qml
+++ b/storybook/qmlTests/tests/tst_SimpleSendModal.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtTest 1.15
 
+import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as SQUtils
 
@@ -868,10 +869,10 @@ Item {
             verify(!!recipientsPanel)
 
             verify(!stickyHeaderTokenSelector.enabled)
-            verify(!stickyHeaderNetworkFilter.selectionAllowed)
+            verify(!stickyHeaderNetworkFilter.interactive)
 
             verify(!tokenSelector.enabled)
-            verify(!networkFilter.selectionAllowed)
+            verify(!networkFilter.interactive)
 
             verify(!amountToSend.interactive)
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -23,6 +23,8 @@ Item {
     readonly property alias currentValue: comboBox.currentValue
     readonly property alias currentText: comboBox.currentText
 
+    /** Property disable combobox same as enabled, but doesn't change opacity of whole StatusComboBox  **/
+    property bool interactive: true
     property alias label: labelItem.text
     property alias validationError: validationErrorItem.text
     property bool forceError: false
@@ -100,7 +102,7 @@ Item {
             Layout.fillHeight: true
             Layout.topMargin: labelItem.visible ? 7 : 0
 
-            enabled: root.enabled
+            enabled: root.enabled && root.interactive
 
             font.family: Theme.baseFont.name
             font.pixelSize: root.size === StatusComboBox.Size.Large ? Theme.secondaryTextFontSize : 13

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -55,12 +55,14 @@ StatusComboBox {
 
     control.background: SQP.StatusComboboxBackground {
         height: 38
+        opacity: root.interactive ? 1 : 0.5
         active: root.control.down || root.control.hovered
     }
 
     control.indicator: SQP.StatusComboboxIndicator {
         x: root.control.mirrored ? root.control.horizontalPadding : root.width - width - root.control.horizontalPadding
         y: root.control.topPadding + (root.control.availableHeight - height) / 2
+        opacity: root.interactive ? 1 : 0.5
         visible: !d.selectionUnavailable && root.selectionAllowed
     }
 

--- a/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SendModalHeader.qml
@@ -157,7 +157,7 @@ RowLayout {
         multiSelection: false
         showSelectionIndicator: false
         showTitle: false
-        selectionAllowed: root.interactive
+        interactive: root.interactive
 
         Binding on selection {
             value: [root.selectedChainId]

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -319,14 +319,14 @@ StatusDialog {
         }
 
         function setSelectedCollectible(key) {
-            let tokenType = SQUtils.ModelUtils.getByKey(root.flatCollectiblesModel, "symbol", key, "tokenType")
-               if(tokenType === Constants.TokenType.ERC1155) {
-                   root.sendType =  Constants.SendType.ERC1155Transfer
-               } else if(tokenType === Constants.TokenType.ERC721) {
-                   root.sendType =  Constants.SendType.ERC721Transfer
-               }
-               root.selectedRawAmount = "1"
-               root.selectedTokenKey = key
+            const tokenType = SQUtils.ModelUtils.getByKey(root.flatCollectiblesModel, "symbol", key, "tokenType")
+            if(tokenType === Constants.TokenType.ERC1155) {
+               root.sendType =  Constants.SendType.ERC1155Transfer
+            } else if(tokenType === Constants.TokenType.ERC721) {
+               root.sendType =  Constants.SendType.ERC721Transfer
+            }
+            root.selectedRawAmount = "1"
+            root.selectedTokenKey = key
         }
 
         function setSelectedAsset(key) {
@@ -629,7 +629,7 @@ StatusDialog {
         }
     }
 
-    footer: SendModalFooter {        
+    footer: SendModalFooter {
         objectName: "sendModalFooter"
 
         width: root.width

--- a/ui/app/AppLayouts/Wallet/views/RecipientView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RecipientView.qml
@@ -136,7 +136,6 @@ Loader {
             width: parent.width
             height: visible ? implicitHeight: 0
 
-            interactive: root.interactive
             checkMarkVisible: !d.isBeingEvaluated && d.isValidAddress
             loading: d.isBeingEvaluated
             input.edit.textFormat: Text.AutoText
@@ -184,7 +183,9 @@ Loader {
 
             components: [
                 StatusClearButton {
+                    objectName: "RecipientView_clearButton"
                     anchors.verticalCenter: parent.verticalCenter
+                    visible: root.interactive
                     onClicked: d.clearValues()
                 }
             ]


### PR DESCRIPTION
Closes #17186

### What does the PR do

* Added non-interactive state for network filter
* Updated non-interactive state for simple send modal

### Affected areas

Simple send modal

### Architecture compliance

- [X] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/576b09f4-e5b1-4136-9aee-a1ecfd7ff5a1

