### PR TITLE
feat(Swap): display the exchange rate approximation in swap

### DIFF
--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -11,7 +11,7 @@ SplitView {
 
     QtObject {
         id: d
-        readonly property var sizesModel: [StatusBaseButton.Size.Tiny, StatusBaseButton.Size.Small, StatusBaseButton.Size.Large]
+        readonly property var sizesModel: [StatusBaseButton.Size.XSmall, StatusBaseButton.Size.Tiny, StatusBaseButton.Size.Small, StatusBaseButton.Size.Large]
 
         readonly property string effectiveEmoji: ctrlEmojiEnabled.checked ? ctrlEmoji.text : ""
         readonly property int effectiveTextPosition: ctrlTextPosLeft.checked ? StatusBaseButton.TextPosition.Left
@@ -30,16 +30,17 @@ SplitView {
                 anchors.centerIn: parent
                 rowSpacing: 10
                 columnSpacing: 10
-                columns: 4
+                columns: 5
 
                 Label { text: "" }
+                Label { text: "XSmall" }
                 Label { text: "Tiny" }
                 Label { text: "Small" }
                 Label { text: "Large" }
 
                 Label {
                     text: "StatusButton"
-                    Layout.columnSpan: 4
+                    Layout.columnSpan: 5
                     font.bold: true
                 }
 
@@ -128,7 +129,7 @@ SplitView {
 
                 Label {
                     text: "StatusFlatButton"
-                    Layout.columnSpan: 4
+                    Layout.columnSpan: 5
                     font.bold: true
                 }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -11,6 +11,7 @@ Button {
     id: root
 
     enum Size {
+        XSmall,
         Tiny,
         Small,
         Large
@@ -72,6 +73,8 @@ Button {
         readonly property bool iconOnly: root.display === AbstractButton.IconOnly || root.text === ""
         readonly property int iconSize: {
             switch(root.size) {
+            case StatusBaseButton.Size.XSmall:
+                return 13
             case StatusBaseButton.Size.Tiny:
                 return 16
             case StatusBaseButton.Size.Small:
@@ -94,6 +97,8 @@ Button {
         }
         if (root.icon.name) {
             switch (size) {
+            case StatusBaseButton.Size.XSmall:
+                return 6
             case StatusBaseButton.Size.Tiny:
                 return Theme.halfPadding
             case StatusBaseButton.Size.Small:
@@ -110,6 +115,8 @@ Button {
             return isRoundIcon ? 8 : spacing
         }
         switch (size) {
+        case StatusBaseButton.Size.XSmall:
+            return 3
         case StatusBaseButton.Size.Tiny:
             return 5
         case StatusBaseButton.Size.Small:


### PR DESCRIPTION
### What does the PR do

Closes #17199 

Show the exchange rate approximation in swap. The exchange rate shows when the swap input is valid. It has 3 states:
1. invisibile - when the pay/receive input is empty
2. visible and loading - while fetching the routes. Happens whenever the swap input changes AND the input is valid
3. visible, with data - once the routes have been fetched


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Swap
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)


https://github.com/user-attachments/assets/310e6614-df7e-47fe-a33a-5130681e37ce


- [x] I've checked the design and this PR matches it

### User stories

https://www.notion.so/b68de7395a0245909ad3b8755c460015?v=9d95d86c162944b68c8d55c7499f1140&p=1928f96fb65c80348476d907c236d704&pm=s

