### PR TITLE
Onboarding: Adding new keypair page adjusted

### DIFF
--- a/storybook/pages/KeycardAddKeyPairPagePage.qml
+++ b/storybook/pages/KeycardAddKeyPairPagePage.qml
@@ -1,10 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-import StatusQ.Core.Backpressure 0.1
-
 import AppLayouts.Onboarding2.pages 1.0
-import AppLayouts.Onboarding.enums 1.0
 
 Item {
     id: root
@@ -13,28 +10,17 @@ Item {
         id: progressPage
 
         anchors.fill: parent
-        addKeyPairState: ctrlState.currentValue
 
-        onKeypairAddTryAgainRequested: {
-            console.warn("!!! onKeypairAddTryAgainRequested")
-            ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.ProgressState.InProgress)
-            Backpressure.debounce(root, 2000, function() {
-                console.warn("!!! SIMULATION: SUCCESS")
-                ctrlState.currentIndex = ctrlState.indexOfValue(Onboarding.ProgressState.Success)
-            })()
-        }
-        onKeypairAddContinueRequested: console.warn("!!! onKeypairAddContinueRequested")
-        onCreateProfilePageRequested: console.warn("!!! onCreateProfilePageRequested")
+        inProgress: inProgressCheckBox.checked
     }
 
-    ComboBox {
-        id: ctrlState
-        anchors.right: parent.right
+    CheckBox {
+        id: inProgressCheckBox
+
         anchors.bottom: parent.bottom
-        width: 350
-        textRole: "name"
-        valueRole: "value"
-        model: Onboarding.getModelFromEnum("ProgressState")
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        text: "In progress"
     }
 }
 

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -113,7 +113,7 @@ SplitView {
                 logs.logEvent("OnboardingStore.authorize", ["pin"], arguments)
             }
 
-            function loadMnemonic(mnemonic) { // -> void
+            function loadMnemonic(mnemonic: string) { // -> void
                 logs.logEvent("OnboardingStore.loadMnemonic", ["mnemonic"], arguments)
             }
 
@@ -243,6 +243,8 @@ SplitView {
             visible: onboarding.currentPage instanceof SeedphrasePage
 
             onClicked: {
+                const words = Utils.splitWords(mockDriver.mnemonic)
+
                 for (let i = 1;; i++) {
                     const input = StorybookUtils.findChild(
                                     onboarding.currentPage,
@@ -251,7 +253,7 @@ SplitView {
                     if (input === null)
                         break
 
-                    input.text = "dog"
+                    input.text = words[i - 1]
                 }
             }
         }

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -73,7 +73,7 @@ Item {
                 function authorize(pin: string) {
                     authorizeCalled(pin)
                 }
-                function loadMnemonic(mnemonic) {
+                function loadMnemonic(mnemonic: string) {
                     loadMnemonicCalled()
                 }
                 function exportRecoverKeys() {
@@ -552,13 +552,12 @@ Item {
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
             page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
-            btnContinue = findChild(page, "btnContinue")
-            verify(!!btnContinue)
-            compare(btnContinue.enabled, true)
-            mouseClick(btnContinue)
 
             // PAGE 13: Enable Biometrics
             if (data.biometrics) {
+                dynamicSpy.setup(stack, "currentItemChanged")
+                tryCompare(dynamicSpy, "count", 1)
+
                 page = getCurrentPage(stack, EnableBiometricsPage)
 
                 const enableBioButton = findChild(controlUnderTest, data.bioEnabled ? "btnEnableBiometrics" : "btnDontEnableBiometrics")
@@ -654,13 +653,12 @@ Item {
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
             page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
-            const btnContinue2 = findChild(page, "btnContinue")
-            verify(!!btnContinue2)
-            compare(btnContinue2.enabled, true)
-            mouseClick(btnContinue2)
 
             // PAGE 9: Enable Biometrics
             if (controlUnderTest.biometricsAvailable) {
+                dynamicSpy.setup(stack, "currentItemChanged")
+                tryCompare(dynamicSpy, "count", 1)
+
                 page = getCurrentPage(stack, EnableBiometricsPage)
 
                 const enableBioButton = findChild(controlUnderTest, data.bioEnabled ? "btnEnableBiometrics" : "btnDontEnableBiometrics")
@@ -1261,11 +1259,6 @@ Item {
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
             page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
-
-            btnContinue = findChild(page, "btnContinue")
-            verify(!!btnContinue)
-            compare(btnContinue.enabled, true)
-            mouseClick(btnContinue)
 
             // FINISH
             tryCompare(finishedSpy, "count", 1)

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -31,8 +31,6 @@ SQUtils.QObject {
     signal keycardPinCreated(string pin)
     signal seedphraseSubmitted(string seedphrase)
 
-    signal keypairAddTryAgainRequested
-    signal createProfileWithoutKeycardRequested
     signal authorizationRequested
 
     signal finished(bool withNewSeedphrase)
@@ -194,19 +192,12 @@ SQUtils.QObject {
     Component {
         id: addKeypairPage
 
-        KeycardAddKeyPairPage {
+        KeycardAddKeyPairDelayedPage {
             readonly property bool backAvailableHint: false
 
             addKeyPairState: root.addKeyPairState
 
-            onKeypairAddContinueRequested: root.finished(d.withNewSeedphrase)
-
-            onKeypairAddTryAgainRequested: {
-                root.stackView.replace(addKeypairPage)
-                root.keypairAddTryAgainRequested()
-            }
-
-            onCreateProfilePageRequested: root.createProfileWithoutKeycardRequested()
+            onFinished: root.finished(d.withNewSeedphrase)
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -110,19 +110,12 @@ SQUtils.QObject {
     Component {
         id: addKeypairPage
 
-        KeycardAddKeyPairPage {
+        KeycardAddKeyPairDelayedPage {
             readonly property bool backAvailableHint: false
 
             addKeyPairState: root.addKeyPairState
 
-            onKeypairAddContinueRequested: root.finished()
-
-            onKeypairAddTryAgainRequested: {
-                root.stackView.replace(addKeypairPage)
-                root.loadMnemonicRequested()
-            }
-
-            onCreateProfilePageRequested: root.createProfileWithoutKeycardRequested()
+            onFinished: root.finished()
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -273,16 +273,7 @@ SQUtils.QObject {
         onLoadMnemonicRequested: root.loadMnemonicRequested()
         onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
-        onKeypairAddTryAgainRequested: root.loadMnemonicRequested()
         onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
-
-        onCreateProfileWithoutKeycardRequested: {
-            const page = stackView.find(
-                           item => item instanceof HelpUsImproveStatusPage)
-
-            stackView.replace(page, createProfilePage, StackView.PopTransition)
-        }
-
         onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
 
         onFinished: (withNewSeedphrase) => {

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairDelayedPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairDelayedPage.qml
@@ -1,0 +1,50 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import AppLayouts.Onboarding.enums 1.0
+
+/*!
+   \qmltype KeycardAddKeyPairDelayedPage
+   \inherits KeycardAddKeyPairPage
+   \brief It wraps KeycardAddKeyPairPaget and controls it using addKeyPairState
+    property and adding minimal times of displaying particular states.
+*/
+KeycardAddKeyPairPage {
+    id: root
+
+    property int addKeyPairState
+
+    inProgress: d.addKeyPairState !== Onboarding.ProgressState.Success
+
+    signal finished
+
+    QtObject {
+        id: d
+
+        property int addKeyPairState: root.addKeyPairState
+
+        readonly property int inProgressMinimalTime: 2000
+        readonly property int successMinimalTime: 2000
+
+        Binding on addKeyPairState {
+            when: extendingInProgressStateTimer.running
+            value: Onboarding.ProgressState.InProgress
+        }
+    }
+
+    Timer {
+        id: extendingInProgressStateTimer
+
+        interval: d.inProgressMinimalTime
+        running: true
+    }
+
+    Timer {
+        id: extendingSuccessStateTimer
+
+        running: root.addKeyPairState === Onboarding.ProgressState.Success
+        interval: d.successMinimalTime
+
+        onTriggered: root.finished()
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairPage.qml
@@ -1,101 +1,46 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
-import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
-
-import AppLayouts.Onboarding2.controls 1.0
-import AppLayouts.Onboarding.enums 1.0
 
 OnboardingPage {
     id: root
 
-    required property int addKeyPairState // Onboarding.ProgressState.xxx
+    property bool inProgress
 
-    signal keypairAddContinueRequested()
-    signal keypairAddTryAgainRequested()
-    signal createProfilePageRequested()
+    title: qsTr("Adding key pair to Keycard")
 
-    states: [
-        State {
-            name: "inprogress"
-            when: root.addKeyPairState === Onboarding.ProgressState.InProgress ||
-                  root.addKeyPairState === Onboarding.ProgressState.Idle
-            PropertyChanges {
-                target: root
-                title: qsTr("Adding key pair to Keycard")
-            }
-            PropertyChanges {
-                target: iconLoader
-                sourceComponent: loadingIndicator
-            }
-            PropertyChanges {
-                target: subImageText
-                text: qsTr("Please keep the Keycard plugged in until the migration is complete")
-                visible: true
-            }
-            PropertyChanges {
-                target: image
-                source: Theme.png("onboarding/status_keycard_adding_keypair")
-            }
-        },
-        State {
-            name: "success"
-            when: root.addKeyPairState === Onboarding.ProgressState.Success
+    StateGroup {
+        states: State {
+            when: !root.inProgress
+
             PropertyChanges {
                 target: root
                 title: qsTr("Key pair added to Keycard")
-            }
-            PropertyChanges {
-                target: subtitle
-                text: qsTr("You will now require this Keycard to log into Status and transact with any accounts derived from this key pair")
             }
             PropertyChanges {
                 target: iconLoader
                 sourceComponent: successIcon
             }
             PropertyChanges {
-                target: continueButton
-                visible: true
-            }
-            PropertyChanges {
                 target: image
                 source: Theme.png("onboarding/status_keycard_adding_keypair_success")
             }
-        },
-        State {
-            name: "failed"
-            when: root.addKeyPairState === Onboarding.ProgressState.Failed
             PropertyChanges {
-                target: root
-                title: "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Failed to add key pair to Keycard") + "</font>"
-            }
-            PropertyChanges {
-                target: subtitle
-                text: qsTr("Something went wrong...")
-            }
-            PropertyChanges {
-                target: iconLoader
-                sourceComponent: failedIcon
-            }
-            PropertyChanges {
-                target: buttonColumn
-                visible: true
-            }
-            PropertyChanges {
-                target: image
-                source: Theme.png("onboarding/status_keycard_adding_keypair_failed")
+                target: subImageText
+                text: qsTr("You will now require this Keycard to log into Status\nand transact with accounts derived from this key pair")
             }
         }
-    ]
+    }
 
     contentItem: Item {
         ColumnLayout {
-            anchors.centerIn: parent
-            width: Math.min(350, root.availableWidth)
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            anchors.verticalCenter: parent.verticalCenter
             spacing: Theme.halfPadding
 
             Loader {
@@ -103,6 +48,14 @@ OnboardingPage {
                 Layout.preferredHeight: 40
                 Layout.alignment: Qt.AlignHCenter
                 id: iconLoader
+
+                sourceComponent: Rectangle {
+                    color: Theme.palette.baseColor2
+                    radius: width/2
+                    StatusDotsLoadingIndicator {
+                        anchors.centerIn: parent
+                    }
+                }
             }
 
             StatusBaseText {
@@ -124,6 +77,7 @@ OnboardingPage {
 
             StatusImage {
                 id: image
+
                 Layout.alignment: Qt.AlignHCenter
                 Layout.preferredWidth: Math.min(231, parent.width)
                 Layout.preferredHeight: Math.min(211, height)
@@ -135,71 +89,24 @@ OnboardingPage {
 
             StatusBaseText {
                 id: subImageText
+
                 Layout.fillWidth: true
+
+                text: qsTr("Please keep the Keycard plugged in until the migration\nis complete")
                 color: Theme.palette.baseColor1
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignHCenter
-                visible: false
-            }
-
-            StatusButton {
-                objectName: "btnContinue"
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 240
-                id: continueButton
-                text: qsTr("Continue")
-                visible: false
-                onClicked: root.keypairAddContinueRequested()
-            }
-
-            Column {
-                id: buttonColumn
-                Layout.preferredWidth: 280
-                Layout.alignment: Qt.AlignHCenter
-                spacing: 12
-                visible: false
-
-                StatusButton {
-                    width: parent.width
-                    text: qsTr("Try again")
-                    onClicked: root.keypairAddTryAgainRequested()
-                }
-                StatusButton {
-                    text: qsTr("Create profile without Keycard")
-                    width: parent.width
-                    isOutline: true
-                    onClicked: root.createProfilePageRequested()
-                }
-            }
-        }
-    }
-
-    Component {
-        id: loadingIndicator
-        Rectangle {
-            color: Theme.palette.baseColor2
-            radius: width/2
-            StatusDotsLoadingIndicator {
-                anchors.centerIn: parent
             }
         }
     }
 
     Component {
         id: successIcon
+
         StatusRoundIcon {
             asset.name: "check-circle"
             asset.color: Theme.palette.successColor1
             asset.bgColor: Theme.palette.successColor2
-        }
-    }
-
-    Component {
-        id: failedIcon
-        StatusRoundIcon {
-            asset.name: "close-circle"
-            asset.color: Theme.palette.dangerColor1
-            asset.bgColor: Theme.palette.dangerColor3
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardEnterPinPage.qml
@@ -31,8 +31,6 @@ KeycardBasePage {
     }
 
     StateGroup {
-        //state: "entering"
-
         states: [
             State {
                 name: "entering"

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardExtractingKeysPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardExtractingKeysPage.qml
@@ -74,33 +74,4 @@ OnboardingPage {
             }
         }
     }
-
-    Component {
-        id: loadingIndicator
-        Rectangle {
-            color: Theme.palette.baseColor2
-            radius: width/2
-            StatusDotsLoadingIndicator {
-                anchors.centerIn: parent
-            }
-        }
-    }
-
-    Component {
-        id: successIcon
-        StatusRoundIcon {
-            asset.name: "check-circle"
-            asset.color: Theme.palette.successColor1
-            asset.bgColor: Theme.palette.successColor2
-        }
-    }
-
-    Component {
-        id: failedIcon
-        StatusRoundIcon {
-            asset.name: "close-circle"
-            asset.color: Theme.palette.dangerColor1
-            asset.bgColor: Theme.palette.dangerColor3
-        }
-    }
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -8,6 +8,7 @@ CreatePasswordPage 1.0 CreatePasswordPage.qml
 CreateProfilePage 1.0 CreateProfilePage.qml
 EnableBiometricsPage 1.0 EnableBiometricsPage.qml
 HelpUsImproveStatusPage 1.0 HelpUsImproveStatusPage.qml
+KeycardAddKeyPairDelayedPage 1.0 KeycardAddKeyPairDelayedPage.qml
 KeycardAddKeyPairPage 1.0 KeycardAddKeyPairPage.qml
 KeycardBasePage 1.0 KeycardBasePage.qml
 KeycardCreatePinPage 1.0 KeycardCreatePinPage.qml

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -50,7 +50,7 @@ QtObject {
     }
 
     readonly property int addKeyPairState: d.onboardingModuleInst.addKeyPairState // cf. enum Onboarding.ProgressState
-    function loadMnemonic(mnemonic) { // -> void
+    function loadMnemonic(mnemonic: string) { // -> void
         d.onboardingModuleInst.loadMnemonic(mnemonic)
     }
     function exportRecoverKeys() { // -> void


### PR DESCRIPTION
### What does the PR do

- Adjusts `KeycardAddKeyPairPage` to have 2 states with minimal times of displaying them to the user
- restores mnemonic auto-fill button in OnboardingLayout's SB pge
- adds post-review amendments mistakenly skipped in https://github.com/status-im/status-desktop/issues/17205

Closes: #17233

### Affected areas
Onboarding

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Screencast from 10.02.2025 21:11:51.webm](https://github.com/user-attachments/assets/5a4c9c6b-c4a8-42b0-9d07-6c39b278615b)

[Screencast from 10.02.2025 21:10:29.webm](https://github.com/user-attachments/assets/7af060c2-aadc-4bd3-a72b-23a410d2d6de)

[Screencast from 10.02.2025 21:12:33.webm](https://github.com/user-attachments/assets/c2ec613d-ae37-4e58-a9eb-7d25eceb3a8d)

