### PR TITLE
Onboarding: `KeycardCreatePinPage` and `SeedphrasePage` refactored to be pure UI components

### DIFF
--- a/storybook/pages/KeycardCreatePinPagePage.qml
+++ b/storybook/pages/KeycardCreatePinPagePage.qml
@@ -1,16 +1,27 @@
 import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import AppLayouts.Onboarding2.pages 1.0
-import AppLayouts.Onboarding.enums 1.0
 
 Item {
     id: root
 
     KeycardCreatePinPage {
         anchors.fill: parent
-        pinSettingState: Onboarding.ProgressState.Idle
-        authorizationState: Onboarding.ProgressState.Idle
-        onKeycardPinCreated: (pin) => console.warn("!!! PIN CREATED:", pin)
+
+        success: successCheckBox.checked
+
+        onSetPinRequested: console.log("Set pin requested:", pin)
+    }
+
+    CheckBox {
+        id: successCheckBox
+
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.margins: 10
+
+        text: "Success"
     }
 }
 

--- a/storybook/pages/UnblockWithPukFlowPage.qml
+++ b/storybook/pages/UnblockWithPukFlowPage.qml
@@ -82,7 +82,7 @@ SplitView {
         tryToSetPukFunction: mockDriver.setPuk
         remainingAttempts: mockDriver.keycardRemainingPukAttempts
         keycardPinInfoPageDelay: 1000
-        onKeycardPinCreated: (pin) => {
+        onSetPinRequested: (pin) => {
                                  logs.logEvent("keycardPinCreated", ["pin"], arguments)
                                  console.warn("!!! PIN CREATED:", pin)
                              }

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -474,18 +474,16 @@ Item {
             // PAGE 6: Create new Keycard PIN
             const newPin = "123321"
             page = getCurrentPage(stack, KeycardCreatePinPage)
-            tryCompare(page, "state", "creating")
-            dynamicSpy.setup(page, "keycardPinCreated")
-            keyClickSequence(newPin)
-            tryCompare(page, "state", "repeating")
-            keyClickSequence(newPin)
+            dynamicSpy.setup(page, "setPinRequested")
+            keyClickSequence(newPin + newPin) // set and repeat
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], newPin)
-            dynamicSpy.setup(page, "keycardAuthorized")
+            mockDriver.pinSettingState = Onboarding.ProgressState.Success
             mockDriver.authorizationState = Onboarding.ProgressState.Success
-            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 7: Backup your recovery phrase (intro)
+            dynamicSpy.setup(stack, "currentItemChanged")
+            tryCompare(dynamicSpy, "count", 1)
             page = getCurrentPage(stack, BackupSeedphraseIntro)
             const btnBackupSeedphrase = findChild(page, "btnBackupSeedphrase")
             verify(!!btnBackupSeedphrase)
@@ -635,21 +633,15 @@ Item {
             // PAGE 7: Create new Keycard PIN
             const newPin = "123321"
             page = getCurrentPage(stack, KeycardCreatePinPage)
-            tryCompare(page, "state", "creating")
-            dynamicSpy.setup(page, "keycardPinCreated")
-            keyClickSequence(newPin)
-            tryCompare(page, "state", "repeating")
-            keyClickSequence(newPin)
-            tryCompare(dynamicSpy, "count", 1)
+            dynamicSpy.setup(page, "setPinRequested")
+            keyClickSequence(newPin + newPin) // set and repeat
             compare(dynamicSpy.signalArguments[0][0], newPin)
-            dynamicSpy.setup(page, "keycardPinSuccessfullySet")
             mockDriver.pinSettingState = Onboarding.ProgressState.Success
-            tryCompare(dynamicSpy, "count", 1)
-            dynamicSpy.setup(page, "keycardAuthorized")
             mockDriver.authorizationState = Onboarding.ProgressState.Success
-            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 8: Adding key pair to Keycard
+            dynamicSpy.setup(stack, "currentItemChanged")
+            tryCompare(dynamicSpy, "count", 1)
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
             page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION
@@ -1244,18 +1236,16 @@ Item {
             // PAGE 5: Create new Keycard PIN
             const newPin = "123321"
             page = getCurrentPage(stack, KeycardCreatePinPage)
-            tryCompare(page, "state", "creating")
-            dynamicSpy.setup(page, "keycardPinCreated")
-            keyClickSequence(newPin)
-            tryCompare(page, "state", "repeating")
-            keyClickSequence(newPin)
+            dynamicSpy.setup(page, "setPinRequested")
+            keyClickSequence(newPin + newPin) // set and repeat
             tryCompare(dynamicSpy, "count", 1)
             compare(dynamicSpy.signalArguments[0][0], newPin)
-            dynamicSpy.setup(page, "keycardAuthorized")
+            mockDriver.pinSettingState = Onboarding.ProgressState.Success
             mockDriver.authorizationState = Onboarding.ProgressState.Success
-            tryCompare(dynamicSpy, "count", 1)
 
             // PAGE 6: Adding key pair to Keycard
+            dynamicSpy.setup(stack, "currentItemChanged")
+            tryCompare(dynamicSpy, "count", 1)
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
             page.addKeyPairState = Onboarding.ProgressState.Success // SIMULATION

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -28,7 +28,7 @@ SQUtils.QObject {
     signal loginWithKeycardRequested
     signal keycardFactoryResetRequested
     signal loadMnemonicRequested
-    signal keycardPinCreated(string pin)
+    signal setPinRequested(string pin)
     signal seedphraseSubmitted(string seedphrase)
 
     signal authorizationRequested
@@ -153,7 +153,6 @@ SQUtils.QObject {
         SeedphrasePage {
             title: qsTr("Create profile on empty Keycard using a recovery phrase")
 
-            authorizationState: root.authorizationState
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
@@ -165,20 +164,14 @@ SQUtils.QObject {
     Component {
         id: keycardCreatePinPage
 
-        KeycardCreatePinPage {
-            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+        KeycardCreatePinDelayedPage {
             pinSettingState: root.pinSettingState
             authorizationState: root.authorizationState
-            onKeycardPinCreated: (pin) => {
-                root.keycardPinCreated(pin)
-            }
-            onKeycardPinSuccessfullySet: {
-                if (d.withNewSeedphrase) {
-                    // Need to authorize before getting a seedphrase
-                    root.authorizationRequested()
-                }
-            }
-            onKeycardAuthorized: {
+
+            onSetPinRequested: (pin) => root.setPinRequested(pin)
+            onAuthorizationRequested: root.authorizationRequested()
+
+            onFinished: {
                 if (d.withNewSeedphrase) {
                     root.stackView.push(backupSeedIntroPage)
                 } else {

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -24,7 +24,7 @@ SQUtils.QObject {
 
     signal loginWithKeycardRequested
     signal keycardFactoryResetRequested
-    signal keycardPinCreated(string pin)
+    signal setPinRequested(string pin)
     signal authorizationRequested()
     signal seedphraseSubmitted(string seedphrase)
 
@@ -79,7 +79,6 @@ SQUtils.QObject {
         SeedphrasePage {
             title: qsTr("Enter recovery phrase of lost Keycard")
 
-            authorizationState: root.authorizationState
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
@@ -91,16 +90,14 @@ SQUtils.QObject {
     Component {
         id: keycardCreatePinPage
 
-        KeycardCreatePinPage {
-            pinSettingState: root.pinSettingState
+        KeycardCreatePinDelayedPage {
             authorizationState: root.authorizationState
-            onKeycardPinCreated: (pin) => {
-                root.keycardPinCreated(pin)
-            }
-            onKeycardPinSuccessfullySet: {
-                root.authorizationRequested()
-            }
-            onKeycardAuthorized: {
+            pinSettingState: root.pinSettingState
+
+            onSetPinRequested: (pin) => root.setPinRequested(pin)
+            onAuthorizationRequested: root.authorizationRequested()
+
+            onFinished: {
                 root.loadMnemonicRequested()
                 root.stackView.push(addKeypairPage)
             }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -44,7 +44,7 @@ SQUtils.QObject {
     signal biometricsRequested(string profileId)
     signal dismissBiometricsRequested
     signal loginRequested(string keyUid, int method, var data)
-    signal keycardPinCreated(string pin)
+    signal setPinRequested(string pin)
     signal enableBiometricsRequested(bool enable)
     signal shareUsageDataRequested(bool enabled)
     signal syncProceedWithConnectionString(string connectionString)
@@ -271,7 +271,7 @@ SQUtils.QObject {
 
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
         onLoadMnemonicRequested: root.loadMnemonicRequested()
-        onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
+        onSetPinRequested: (pin) => root.setPinRequested(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
         onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
         onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
@@ -341,8 +341,8 @@ SQUtils.QObject {
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
         onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
-        onKeycardPinCreated: (pin) => {
-            root.keycardPinCreated(pin)
+        onSetPinRequested: (pin) => {
+            root.setPinRequested(pin)
 
             if (root.loginScreen) {
                 root.loginRequested(root.loginScreen.selectedProfileKeyId,
@@ -366,9 +366,9 @@ SQUtils.QObject {
 
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
-        onKeycardPinCreated: (pin) => {
+        onSetPinRequested: (pin) => {
             unblockWithPukFlow.pin = pin
-            root.keycardPinCreated(pin)
+            root.setPinRequested(pin)
         }
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
 
@@ -401,7 +401,7 @@ SQUtils.QObject {
         keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
         onKeycardFactoryResetRequested: keycardFactoryResetFlow.init(true)
-        onKeycardPinCreated: (pin) => root.keycardPinCreated(pin)
+        onSetPinRequested: (pin) => root.setPinRequested(pin)
         onLoginWithKeycardRequested: loginWithKeycardFlow.init()
         onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
         onLoadMnemonicRequested: root.loadMnemonicRequested()

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -186,7 +186,7 @@ Page {
         onDismissBiometricsRequested: root.dismissBiometricsRequested()
         onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
 
-        onKeycardPinCreated: (pin) => {
+        onSetPinRequested: (pin) => {
             d.keycardPin = pin
             root.onboardingStore.setPin(pin)
         }

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
@@ -20,7 +20,7 @@ SQUtils.QObject {
 
     required property int keycardPinInfoPageDelay
 
-    signal keycardPinCreated(string pin)
+    signal setPinRequested(string pin)
     signal keycardFactoryResetRequested
     signal finished(bool success)
 
@@ -75,9 +75,9 @@ SQUtils.QObject {
         id: keycardCreatePinPage
 
         KeycardCreatePinPage {
-            onKeycardPinCreated: (pin) => {
+            onSetPinRequested: (pin) => {
                 Backpressure.debounce(root, root.keycardPinInfoPageDelay, () => {
-                    root.keycardPinCreated(pin)
+                    root.setPinRequested(pin)
                     root.stackView.replace(keycardUnblockedPage, {title: qsTr("Unblock successful")})
                 })()
             }

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithSeedphraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithSeedphraseFlow.qml
@@ -18,7 +18,7 @@ SQUtils.QObject {
     required property int keycardPinInfoPageDelay
 
     signal seedphraseSubmitted(string seedphrase)
-    signal keycardPinCreated(string pin)
+    signal setPinRequested(string pin)
 
     function init() {
         root.stackView.push(seedphrasePage)
@@ -31,6 +31,7 @@ SQUtils.QObject {
             title: qsTr("Unblock Keycard using the recovery phrase")
             btnContinueText: qsTr("Unblock Keycard")
             isSeedPhraseValid: root.isSeedPhraseValid
+
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
                 root.stackView.push(keycardCreatePinPage)
@@ -42,9 +43,9 @@ SQUtils.QObject {
         id: keycardCreatePinPage
 
         KeycardCreatePinPage {
-            onKeycardPinCreated: (pin) => {
+            onSetPinRequested: (pin) => {
                 Backpressure.debounce(root, root.keycardPinInfoPageDelay, () => {
-                    root.keycardPinCreated(pin)
+                    root.setPinRequested(pin)
                 })()
             }
         }

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -42,7 +42,6 @@ SQUtils.QObject {
 
         SeedphrasePage {
             isSeedPhraseValid: root.isSeedPhraseValid
-            authorizationState: Onboarding.ProgressState.Idle
 
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairDelayedPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardAddKeyPairDelayedPage.qml
@@ -12,7 +12,7 @@ import AppLayouts.Onboarding.enums 1.0
 KeycardAddKeyPairPage {
     id: root
 
-    property int addKeyPairState
+    required property int addKeyPairState
 
     inProgress: d.addKeyPairState !== Onboarding.ProgressState.Success
 

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinDelayedPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinDelayedPage.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import AppLayouts.Onboarding.enums 1.0
+
+/*!
+   \qmltype KeycardCreatePinDelayedPage
+   \inherits KeycardCreatePinPage
+   \brief It wraps KeycardCreatePinPage and controls it using authorizationState
+    and pinSettingState properties and adding minimal time of displaying a success
+    state.
+*/
+KeycardCreatePinPage {
+    id: root
+
+    required property int pinSettingState
+    required property int authorizationState
+
+    success: root.authorizationState === Onboarding.ProgressState.Success &&
+             root.pinSettingState === Onboarding.ProgressState.Success
+
+    signal finished
+    signal authorizationRequested
+
+    Timer {
+        interval: 2000
+        running: root.success
+
+        onTriggered: root.finished()
+    }
+
+    Connections {
+        target: root
+
+        function onPinSettingStateChanged() {
+            if (root.pinSettingState === Onboarding.ProgressState.Success)
+                root.authorizationRequested()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
@@ -1,200 +1,163 @@
 import QtQuick 2.15
-import QtQuick.Layouts 1.15
-import QtQml 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Onboarding2.controls 1.0
-import AppLayouts.Onboarding.enums 1.0
-
-import utils 1.0
 
 KeycardBasePage {
     id: root
 
-    property int keycardPinInfoPageDelay: 1000
-    required property int pinSettingState
-    required property int authorizationState
+    property bool success
 
-    signal keycardPinCreated(string pin)
-    signal keycardPinSuccessfullySet()
-    signal keycardAuthorized()
+    signal setPinRequested(string pin)
 
     image.source: Theme.png("onboarding/keycard/reading")
-
-    QtObject {
-        id: d
-        property string pin
-        property string pin2
-
-        function setPins() {
-            if (pinInput.valid) {
-                if (root.state === "creating")
-                    d.pin = pinInput.pinInput
-                else if (root.state === "repeating" || root.state === "mismatch")
-                    d.pin2 = pinInput.pinInput
-
-                if (root.state === "mismatch")
-                    pinInput.statesInitialization()
-            }
-        }
-    }
 
     buttons: [
         StatusPinInput {
             id: pinInput
+
             anchors.horizontalCenter: parent.horizontalCenter
+
             validator: StatusIntValidator { bottom: 0; top: 999999 }
+
+            onPinInputChanged: Qt.callLater(d.setPins)
+
             Component.onCompleted: {
                 statesInitialization()
                 forceFocus()
             }
-            onPinInputChanged: {
-                Qt.callLater(d.setPins)
-            }
         },
+
         StatusBaseText {
             id: errorText
+
             anchors.horizontalCenter: parent.horizontalCenter
+            visible: false
+
             text: qsTr("PINs don't match")
             font.pixelSize: Theme.tertiaryTextFontSize
             color: Theme.palette.dangerColor1
-            visible: false
         },
+
         StatusLoadingIndicator {
             id: loadingIndicator
+
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.topMargin: Theme.halfPadding
             visible: false
         }
     ]
 
-    state: "creating"
+    StateGroup {
+        id: d
 
-    states: [
-        State {
-            name: "creating"
-            PropertyChanges {
-                target: root
-                title: qsTr("Create new Keycard PIN")
-            }
-        },
-        State {
-            name: "mismatch"
-            extend: "repeating"
-            when: !!d.pin && !!d.pin2 && d.pin !== d.pin2
-            PropertyChanges {
-                target: errorText
-                visible: true
-            }
-            PropertyChanges {
-                target: root
-                image.source: Theme.png("onboarding/keycard/error")
-            }
-        },
-        State {
-            name: "error"
-            when: root.pinSettingState === Onboarding.ProgressState.Failed || root.authorizationState === Onboarding.ProgressState.Failed
-            PropertyChanges {
-                target: errorText
-                visible: true
-                text: qsTr("Error setting pin")
-            }
-            PropertyChanges {
-                target: root
-                image.source: Theme.png("onboarding/keycard/error")
-            }
-        },
-        State {
-            name: "authorized"
-            when: root.authorizationState === Onboarding.ProgressState.Success
-            PropertyChanges {
-                target: root
-                title: qsTr("PIN set")
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: root
-                image.source: Theme.png("onboarding/keycard/success")
-            }
-            StateChangeScript {
-                script: {
-                    Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
-                        root.keycardAuthorized()
-                    })()
-                }
-            }
-        },
-        State {
-            name: "success"
-            when: root.pinSettingState === Onboarding.ProgressState.Success
-            PropertyChanges {
-                target: root
-                title: qsTr("PIN set")
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: root
-                image.source: Theme.png("onboarding/keycard/success")
-            }
-            StateChangeScript {
-                script: {
-                    root.keycardPinSuccessfullySet()
-                }
-            }
-        },
-        State {
-            name: "settingPin"
-            extend: "repeating"
-            when: !!d.pin && !!d.pin2 && d.pin === d.pin2 && (root.pinSettingState === Onboarding.ProgressState.Idle || root.pinSettingState === Onboarding.ProgressState.InProgress)
-            PropertyChanges {
-                target: root
-                title: qsTr("Setting Keycard PIN")
-            }
-            PropertyChanges {
-                target: pinInput
-                enabled: false
-            }
-            PropertyChanges {
-                target: loadingIndicator
-                visible: true
-            }
-            PropertyChanges {
-                target: root
-                image.source: Theme.png("onboarding/keycard/success")
-            }
-            StateChangeScript {
-                script: {
-                    Backpressure.debounce(root, keycardPinInfoPageDelay, function() {
-                        pinInput.setPin(d.pin)
-                        root.keycardPinCreated(d.pin)
-                    })()
-                }
-            }
-        },
-        State {
-            name: "repeating"
-            when: d.pin !== ""
-            PropertyChanges {
-                target: root
-                title: qsTr("Repeat Keycard PIN")
-            }
-            StateChangeScript {
-                script: {
-                    pinInput.statesInitialization()
-                }
-            }
+        state: "creating"
+
+        property string pin
+        property string pin2
+
+        readonly property bool matchingPinsProvided: pin && pin2 && pin === pin2
+
+        function setPins() {
+            if (!pinInput.valid)
+                return
+
+            if (d.state === "creating")
+                d.pin = pinInput.pinInput
+            else if (d.state === "repeating" || d.state === "mismatch")
+                d.pin2 = pinInput.pinInput
+
+            if (d.state === "mismatch")
+                pinInput.statesInitialization()
         }
-    ]
+
+        states: [
+            State {
+                name: "creating"
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Create new Keycard PIN")
+                }
+            },
+            State {
+                name: "repeating"
+                when: d.pin !== "" && d.pin2 === ""
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Repeat Keycard PIN")
+                }
+                StateChangeScript {
+                    script: {
+                        pinInput.statesInitialization()
+                    }
+                }
+            },
+            State {
+                name: "mismatch"
+                extend: "repeating"
+                when: !!d.pin && !!d.pin2 && d.pin !== d.pin2
+
+                PropertyChanges {
+                    target: errorText
+                    visible: true
+                }
+                PropertyChanges {
+                    target: root
+                    image.source: Theme.png("onboarding/keycard/error")
+                }
+            },
+            State {
+                name: "settingInProgress"
+                extend: "repeating"
+                when: d.matchingPinsProvided && !root.success
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Setting Keycard PIN")
+                }
+                PropertyChanges {
+                    target: pinInput
+                    enabled: false
+                }
+                PropertyChanges {
+                    target: loadingIndicator
+                    visible: true
+                }
+                PropertyChanges {
+                    target: root
+                    image.source: Theme.png("onboarding/keycard/success")
+                }
+                StateChangeScript {
+                    script: {
+                        pinInput.setPin(d.pin)
+                        root.setPinRequested(d.pin)
+                    }
+                }
+            },
+            State {
+                name: "success"
+                when: d.matchingPinsProvided && root.success
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("PIN set")
+                }
+                PropertyChanges {
+                    target: pinInput
+                    enabled: false
+                }
+                PropertyChanges {
+                    target: root
+                    image.source: Theme.png("onboarding/keycard/success")
+                }
+            }
+        ]
+    }
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/SeedphrasePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SeedphrasePage.qml
@@ -18,12 +18,9 @@ OnboardingPage {
     property string subtitle: qsTr("Enter your 12, 18 or 24 word recovery phrase")
     property alias btnContinueText: btnContinue.text
 
-    required property int authorizationState
-
     property var isSeedPhraseValid: (mnemonic) => { console.error("isSeedPhraseValid IMPLEMENT ME"); return false }
 
     signal seedphraseSubmitted(string seedphrase)
-    signal keycardAuthorized()
 
     contentItem: Item {
         ColumnLayout {
@@ -67,30 +64,4 @@ OnboardingPage {
             }
         }
     }
-
-    state: "creating"
-
-    states: [
-        State {
-            name: "creating"
-        },
-        State {
-            name: "authorized"
-            when: root.authorizationState === Onboarding.ProgressState.Success
-            StateChangeScript {
-                script: {
-                    root.keycardAuthorized()
-                }
-            }
-        },
-        State {
-            name: "loadingMnemonic"
-            when: root.authorizationState === Onboarding.ProgressState.InProgress
-
-            PropertyChanges {
-                target: btnContinue
-                loading: true
-            }
-        }
-    ]
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -11,6 +11,7 @@ HelpUsImproveStatusPage 1.0 HelpUsImproveStatusPage.qml
 KeycardAddKeyPairDelayedPage 1.0 KeycardAddKeyPairDelayedPage.qml
 KeycardAddKeyPairPage 1.0 KeycardAddKeyPairPage.qml
 KeycardBasePage 1.0 KeycardBasePage.qml
+KeycardCreatePinDelayedPage 1.0 KeycardCreatePinDelayedPage.qml
 KeycardCreatePinPage 1.0 KeycardCreatePinPage.qml
 KeycardEmptyPage 1.0 KeycardEmptyPage.qml
 KeycardEnterPinPage 1.0 KeycardEnterPinPage.qml


### PR DESCRIPTION
### What does the PR do

- Restores the initial design of the onboarding, removing hacks used for fast initial integration (at least in the touched area)
- `KeycardCreatePinPage` and `SeedphrasePage` components made not aware of any logic in the upper layer, making the flows more structured and easier to follow.
- fixes the unlock with seedphrase flow (page was not loading because required property not set)

Required for: #17232

### Affected areas
`Onboarding`


### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
