### PR TITLE
fix(Onboarding): Better handling of login errors

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -428,7 +428,6 @@ proc startupDidLoad*(self: AppController) =
   self.initializeQmlContext()
 
 proc onboardingDidLoad*(self: AppController) =
-  debug "NEW ONBOARDING LOADED"
   self.initializeQmlContext()
 
 proc switchToOldOnboarding*(self: AppController) =

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -170,7 +170,7 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
         # New user with a seedphrase we showed them
         let keycardEvent = self.view.getKeycardEvent()
         err = self.controller.restoreAccountAndLogin(
-          password = "", # For keycard it will be substituted with`encryption.publicKey` in status-go
+          password = "", # For keycard it will be substituted with `encryption.publicKey` in status-go
           seedPhrase,
           recoverAccount = false,
           keycardInstanceUID = keycardEvent.keycardInfo.instanceUID,
@@ -179,7 +179,7 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
         # New user who entered their own seed phrase
         let keycardEvent = self.view.getKeycardEvent()
         err = self.controller.restoreAccountAndLogin(
-          password = "", # For keycard it will be substituted with`encryption.publicKey` in status-go
+          password = "", # For keycard it will be substituted with `encryption.publicKey` in status-go
           seedPhrase,
           recoverAccount = false,
           keycardInstanceUID = keycardEvent.keycardInfo.instanceUID,
@@ -208,7 +208,7 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
           recoverAccount = true
           )
       else:
-        raise newException(ValueError, "Unknown flow: " & $self.onboardingFlow)
+        raise newException(ValueError, "Unknown onboarding flow: " & $self.onboardingFlow)
 
     return err
   except Exception as e:
@@ -229,7 +229,7 @@ method loginRequested*[T](self: Module[T], keyUid: string, loginFlow: int, dataJ
         self.authorize(data["pin"].str)
         # We will continue the flow when the card is authorized in onKeycardStateUpdated
       else:
-        raise newException(ValueError, "Unknown flow: " & $self.onboardingFlow)
+        raise newException(ValueError, "Unknown login flow: " & $self.loginFlow)
 
   except Exception as e:
     error "Error finishing Login Flow", msg = e.msg

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -23,34 +23,7 @@ SplitView {
         // keycard
         property int keycardState: Onboarding.KeycardState.NoPCSCService
         property int keycardRemainingPinAttempts: 3
-        property int keycardRemainingPukAttempts: 3
-
-        function setPin(pin: string) { // -> bool
-            logs.logEvent("setPin", ["pin"], arguments)
-            const valid = pin === ctrlPin.text
-            if (!valid)
-                keycardRemainingPinAttempts-- // SIMULATION: decrease the remaining PIN attempts
-            if (keycardRemainingPinAttempts <= 0) { // SIMULATION: "block" the keycard
-                keycardState = Onboarding.KeycardState.BlockedPIN
-                keycardRemainingPinAttempts = 0
-            }
-            return valid
-        }
-
-        function setPuk(puk) { // -> bool
-            logs.logEvent("setPuk", ["puk"], arguments)
-            const valid = puk === ctrlPuk.text
-            if (!valid)
-                keycardRemainingPukAttempts-- // SIMULATION: decrease the remaining PUK attempts
-            if (keycardRemainingPukAttempts <= 0) { // SIMULATION: "block" the keycard
-                keycardState = Onboarding.KeycardState.BlockedPUK
-                keycardRemainingPukAttempts = 0
-            }
-            return valid
-        }
-
-        // password signals
-        signal accountLoginError(string error, bool wrongPassword)
+        property int keycardRemainingPukAttempts: 5
     }
 
     LoginScreen {
@@ -62,34 +35,38 @@ SplitView {
 
         keycardState: driver.keycardState
 
-        tryToSetPinFunction: (pin) => driver.setPin(pin)
         keycardRemainingPinAttempts: driver.keycardRemainingPinAttempts
         keycardRemainingPukAttempts: driver.keycardRemainingPukAttempts
 
         biometricsAvailable: ctrlBiometrics.checked
-        isBiometricsLogin: localAccountSettings.storeToKeychainValue === Constants.keychain.storedValue.store
+        isBiometricsLogin: ctrlTouchIdUser.checked
 
         onBiometricsRequested: biometricsPopup.open()
+        onDismissBiometricsRequested: biometricsPopup.close()
 
         onLoginRequested: (keyUid, method, data) => {
                               logs.logEvent("onLoginRequested", ["keyUid", "method", "data"], arguments)
 
-                              // SIMULATION: emit an error in case of wrong password
+                              // SIMULATION: emit an error in case of wrong password/PIN
                               if (method === Onboarding.LoginMethod.Password && data.password !== ctrlPassword.text) {
-                                  driver.accountLoginError("The impossible has happened", Math.random() < 0.5)
+                                  setAccountLoginError("", true)
+                              } else if (method === Onboarding.LoginMethod.Keycard && data.pin !== ctrlPin.text) {
+                                  driver.keycardRemainingPinAttempts-- // SIMULATION: decrease the remaining PIN attempts
+                                  if (driver.keycardRemainingPinAttempts <= 0) { // SIMULATION: "block" the keycard
+                                      driver.keycardState = Onboarding.KeycardState.BlockedPIN
+                                      driver.keycardRemainingPinAttempts = 0
+                                  }
+                                  setAccountLoginError("", true)
                               }
                           }
+
+        onSelectedProfileKeyIdChanged: driver.keycardState = Onboarding.KeycardState.NoPCSCService
+
         onOnboardingCreateProfileFlowRequested: logs.logEvent("onOnboardingCreateProfileFlowRequested")
         onOnboardingLoginFlowRequested: logs.logEvent("onOnboardingLoginFlowRequested")
         onUnblockWithSeedphraseRequested: logs.logEvent("onUnblockWithSeedphraseRequested")
         onUnblockWithPukRequested: logs.logEvent("onUnblockWithPukRequested")
         onLostKeycard: logs.logEvent("onLostKeycard")
-
-        // mocks
-        QtObject {
-            id: localAccountSettings
-            readonly property string storeToKeychainValue: ctrlTouchIdUser.checked ? Constants.keychain.storedValue.store : ""
-        }
     }
 
     BiometricsPopup {
@@ -106,16 +83,41 @@ SplitView {
     LogsAndControlsPanel {
         id: logsAndControlsPanel
 
-        SplitView.minimumHeight: 180
-        SplitView.preferredHeight: 180
+        SplitView.minimumHeight: 230
+        SplitView.preferredHeight: 230
 
         logsView.logText: logs.logText
 
         ColumnLayout {
             anchors.fill: parent
 
-            Label {
-                text: "Selected user ID: %1".arg(loginScreen.selectedProfileKeyId || "N/A")
+            RowLayout {
+                Label {
+                    text: "Selected profile ID: %1".arg(loginScreen.selectedProfileKeyId || "N/A")
+                }
+                ToolSeparator {}
+                Button {
+                    focusPolicy: Qt.NoFocus
+                    text: loginScreen.selectedProfileIsKeycard ? "Simulate wrong PIN" : "Simulate wrong password"
+                    onClicked: {
+                        if (loginScreen.selectedProfileIsKeycard) {
+                            driver.keycardRemainingPinAttempts-- // SIMULATION: decrease the remaining PIN attempts
+                            if (driver.keycardRemainingPinAttempts <= 0) { // SIMULATION: "block" the keycard
+                                driver.keycardState = Onboarding.KeycardState.BlockedPIN
+                                driver.keycardRemainingPinAttempts = 0
+                            }
+                        }
+
+                        loginScreen.setAccountLoginError("", true)
+                    }
+                    enabled: loginScreen.selectedProfileIsKeycard ? driver.keycardState === Onboarding.KeycardState.NotEmpty : true
+                }
+                Button {
+                    focusPolicy: Qt.NoFocus
+                    text: "Simulate other login error"
+                    onClicked: loginScreen.setAccountLoginError("The impossible error has just happened", false)
+                    enabled: loginScreen.selectedProfileIsKeycard ? driver.keycardState === Onboarding.KeycardState.NotEmpty : true
+                }
             }
 
             RowLayout {
@@ -137,7 +139,7 @@ SplitView {
                 Switch {
                     id: ctrlTouchIdUser
                     text: "Touch ID login"
-                    enabled: ctrlBiometrics.checked
+                    visible: ctrlBiometrics.checked
                     checked: ctrlBiometrics.checked
                 }
             }
@@ -162,18 +164,37 @@ SplitView {
                     inputMask: "999999999999"
                     selectByMouse: true
                 }
+            }
+            RowLayout {
+                Layout.fillWidth: true
                 Label {
-                    text: "State:"
+                    text: "Keycard state:"
                 }
-                ComboBox {
-                    Layout.preferredWidth: 300
-                    id: ctrlKeycardState
-                    focusPolicy: Qt.NoFocus
-                    textRole: "name"
-                    valueRole: "value"
-                    model: Onboarding.getModelFromEnum("KeycardState")
-                    onActivated: driver.keycardState = currentValue
-                    Component.onCompleted: currentIndex = Qt.binding(() => indexOfValue(driver.keycardState))
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 2
+
+                    ButtonGroup {
+                        id: keycardStateButtonGroup
+                    }
+
+                    Repeater {
+                        model: Onboarding.getModelFromEnum("KeycardState")
+
+                        RoundButton {
+                            focusPolicy: Qt.NoFocus
+                            text: modelData.name
+                            checkable: true
+                            checked: driver.keycardState === modelData.value
+
+                            ButtonGroup.group: keycardStateButtonGroup
+
+                            onClicked: {
+                                driver.keycardState = modelData.value
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/storybook/pages/ProgressSelector.qml
+++ b/storybook/pages/ProgressSelector.qml
@@ -40,6 +40,7 @@ Control {
                 model: Onboarding.getModelFromEnum("ProgressState")
 
                 RoundButton {
+                    focusPolicy: Qt.NoFocus
                     text: modelData.name
                     checkable: true
                     checked: root.value === modelData.value

--- a/ui/StatusQ/include/StatusQ/keychain.h
+++ b/ui/StatusQ/include/StatusQ/keychain.h
@@ -17,7 +17,7 @@ class Keychain : public QObject {
 
 public:
     explicit Keychain(QObject *parent = nullptr);
-    ~Keychain();
+    ~Keychain() override;
 
     enum Status {
         StatusSuccess = 0,

--- a/ui/StatusQ/include/StatusQ/modelutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/modelutilsinternal.h
@@ -32,8 +32,9 @@ public:
                                     const QString& filterRoleName,
                                     const QVariant& filterValue) const;
 
-    Q_INVOKABLE int indexOf(QAbstractItemModel* model, const QString& roleName,
-                            const QVariant& value);
+    Q_INVOKABLE int indexOf(QAbstractItemModel *model,
+                            const QString &roleName,
+                            const QVariant &value) const;
 
     Q_INVOKABLE QPersistentModelIndex persistentIndex(QAbstractItemModel* model,
                                                       int index);

--- a/ui/StatusQ/src/keychain_other.cpp
+++ b/ui/StatusQ/src/keychain_other.cpp
@@ -9,7 +9,7 @@ void Keychain::requestSaveCredential(const QString &reason, const QString &accou
 
     qWarning() << "Keychain::requestSaveCredential is intended to be called only on MacOS.";
 
-    emit this->saveCredentialRequestCompleted(Keychain::StatusNotSupported);
+    emit saveCredentialRequestCompleted(Keychain::StatusNotSupported);
 }
 
 void Keychain::requestDeleteCredential(const QString &reason, const QString &account)
@@ -27,7 +27,7 @@ void Keychain::requestGetCredential(const QString &reason, const QString &accoun
 
     qWarning() << "Keychain::requestGetCredential is intended to be called only on MacOS.";
 
-    emit getCredentialRequestCompleted(Keychain::StatusNotSupported, "");
+    emit getCredentialRequestCompleted(Keychain::StatusNotSupported, {});
 }
 
 void Keychain::cancelActiveRequest()

--- a/ui/StatusQ/src/modelutilsinternal.cpp
+++ b/ui/StatusQ/src/modelutilsinternal.cpp
@@ -95,7 +95,7 @@ QVariantList ModelUtilsInternal::getAll(QAbstractItemModel* model,
  * compared to string "4" will give a positive result.
  */
 int ModelUtilsInternal::indexOf(QAbstractItemModel* model,
-                                const QString& roleName, const QVariant& value)
+                                const QString& roleName, const QVariant& value) const
 {
     auto role = roleByName(model, roleName);
 
@@ -118,7 +118,9 @@ int ModelUtilsInternal::indexOf(QAbstractItemModel* model,
 QPersistentModelIndex ModelUtilsInternal::persistentIndex(
         QAbstractItemModel* model, int row)
 {
-    return QPersistentModelIndex(model->index(row, 0));
+    if (!model)
+        return {};
+    return {model->index(row, 0)};
 }
 
 bool ModelUtilsInternal::contains(QAbstractItemModel* model,

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -38,7 +38,6 @@ SQUtils.QObject {
     required property var passwordStrengthScoreFunction
     required property var isSeedPhraseValid
     required property var validateConnectionString
-    required property var tryToSetPinFunction
     required property var tryToSetPukFunction
 
     signal biometricsRequested(string profileId)
@@ -143,8 +142,6 @@ SQUtils.QObject {
             id: loginScreen
 
             keycardState: root.keycardState
-            tryToSetPinFunction: root.tryToSetPinFunction
-
             keycardRemainingPinAttempts: root.remainingPinAttempts
             keycardRemainingPukAttempts: root.remainingPukAttempts
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -177,7 +177,6 @@ Page {
         passwordStrengthScoreFunction: root.onboardingStore.getPasswordStrengthScore
         isSeedPhraseValid: root.onboardingStore.validMnemonic
         validateConnectionString: root.onboardingStore.validateLocalPairingConnectionString
-        tryToSetPinFunction: root.onboardingStore.setPin
         tryToSetPukFunction: root.onboardingStore.setPuk
         remainingPinAttempts: root.onboardingStore.keycardRemainingPinAttempts
         remainingPukAttempts: root.onboardingStore.keycardRemainingPukAttempts

--- a/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
@@ -91,12 +91,14 @@ Control {
             spacing: 12
             visible: false
             MaybeOutlineButton {
+                objectName: "btnUnblockWithPUK"
                 width: parent.width
                 visible: root.keycardState === Onboarding.KeycardState.BlockedPIN && root.keycardRemainingPukAttempts > 0
                 text: qsTr("Unblock with PUK")
                 onClicked: root.unblockWithPukRequested()
             }
             MaybeOutlineButton {
+                objectName: "btnUnblockWithSeedphrase"
                 width: parent.width
                 visible: root.keycardState === Onboarding.KeycardState.BlockedPIN || root.keycardState === Onboarding.KeycardState.BlockedPUK
                 text: qsTr("Unblock with recovery phrase")

--- a/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
@@ -25,6 +25,8 @@ Control {
 
     signal pinEditedManually()
 
+    signal detailedErrorPopupRequested()
+
     signal unblockWithSeedphraseRequested()
     signal unblockWithPukRequested()
 
@@ -77,6 +79,11 @@ Control {
             horizontalAlignment: Qt.AlignHCenter
             elide: Text.ElideRight
             color: Theme.palette.baseColor1
+            linkColor: hoveredLink ? Theme.palette.hoverColor(color) : color
+            HoverHandler {
+                cursorShape: !!parent.hoveredLink ? Qt.PointingHandCursor : undefined
+            }
+            onLinkActivated: root.detailedErrorPopupRequested()
         }
         Column {
             id: lockedButtons
@@ -191,7 +198,7 @@ Control {
             PropertyChanges {
                 target: infoText
                 color: Theme.palette.dangerColor1
-                text: qsTr("The inserted Keycard is empty.<br>Remove card and insert the correct one.")
+                text: qsTr("The inserted Keycard is empty.<br>Insert the correct Keycard for this profile.")
             }
         },
         State {
@@ -205,13 +212,12 @@ Control {
             }
         },
         State {
-            // TODO this is a deadend. We should never end up here, but I still don't know what it should look like
             name: "errorDuringLogin"
             when: !!root.loginError
             PropertyChanges {
                 target: infoText
                 color: Theme.palette.dangerColor1
-                text: qsTr("Error during login: %1").arg(root.loginError)
+                text: qsTr("Login failed. %1").arg("<a href='#details'>" + qsTr("Show details.") + "</a>")
             }
         },
         // exit states

--- a/ui/app/AppLayouts/Onboarding2/components/LoginPasswordBox.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/LoginPasswordBox.qml
@@ -6,9 +6,7 @@ import QtQml.Models 2.15
 import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
-import StatusQ.Core.Backpressure 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Onboarding2.controls 1.0
@@ -26,6 +24,8 @@ Control {
 
     property alias password: txtPassword.text
     signal passwordEditedManually()
+
+    signal detailedErrorPopupRequested()
 
     signal biometricsRequested()
     signal loginRequested(string password)
@@ -71,7 +71,7 @@ Control {
                 if (link.startsWith("#password"))
                   forgottenPassInstructionsPopupComp.createObject(root).open()
                 else
-                  detailedErrorPopupComp.createObject(root).open()
+                  root.detailedErrorPopupRequested()
             }
         }
         StatusButton {
@@ -167,36 +167,6 @@ Control {
                             wrapMode: Text.Wrap
                             text: qsTr("Enter a new password and you’re all set! You will be able to use your new password")
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    Component {
-        id: detailedErrorPopupComp
-        StatusSimpleTextPopup {
-            objectName: "passwordDetailsPopup"
-            title: qsTr("Login failed")
-            width: 480
-            destroyOnClose: true
-            content.color: Theme.palette.dangerColor1
-            content.text: root.detailedError
-            footer: StatusDialogFooter {
-                spacing: Theme.padding
-                rightButtons: ObjectModel {
-                    StatusFlatButton {
-                        icon.name: "copy"
-                        text: qsTr("Copy error message")
-                        onClicked: {
-                            icon.name = "tiny/checkmark"
-                            ClipboardUtils.setText(root.detailedError)
-                            Backpressure.debounce(this, 1500, () => icon.name = "copy")()
-                        }
-                    }
-                    StatusButton {
-                        text: qsTr("Close")
-                        onClicked: close()
                     }
                 }
             }

--- a/ui/app/AppLayouts/Onboarding2/controls/LoginUserSelector.qml
+++ b/ui/app/AppLayouts/Onboarding2/controls/LoginUserSelector.qml
@@ -7,6 +7,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Core.Utils 0.1
 
 import SortFilterProxyModel 0.2
 
@@ -24,7 +25,11 @@ Control {
     signal onboardingLoginFlowRequested()
 
     function setSelection(keyUid: string) {
-        currentEntry.value = keyUid === "" ? (proxyModel.get(0, "keyUid") ?? "") : keyUid
+        let selection = keyUid
+        if (!ModelUtils.contains(root.model, "keyUid", selection)) // get first item if not existing (or empty)
+            selection = ModelUtils.get(root.model, 0, "keyUid")
+
+        currentEntry.value = selection
     }
 
     QtObject {


### PR DESCRIPTION
### What does the PR do

- remove `tryToSetPinFunction` and correct `setPin` functions; those were not used in LoginScreen
- consistently report login errors to the LoginScreen, including details for the keycard profiles
- display error details in a popup (extracted from `LoginKeycardBox` to `LoginScreen`) for both password and keycard profiles
- add login error simulation buttons to SB pages

Fixes #17258

Separate commit to fix an issue with empty entries in `LoginUserSelector` and extend the QML tests

Fixes #17271

### Affected areas

Onboarding/LoginScreen

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/7e57bef0-a030-4d51-8d84-47095853d600
