### PR TITLE
feat: collect `KeyUID` during `LoginWithLostKeycardSeedphrase`

### DIFF
--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -66,7 +66,9 @@ SplitView {
         onOnboardingLoginFlowRequested: logs.logEvent("onOnboardingLoginFlowRequested")
         onUnblockWithSeedphraseRequested: logs.logEvent("onUnblockWithSeedphraseRequested")
         onUnblockWithPukRequested: logs.logEvent("onUnblockWithPukRequested")
-        onLostKeycard: logs.logEvent("onLostKeycard")
+        onLostKeycard: (keyUid) =>{
+                           logs.logEvent("onLostKeycard", ["keyUid"], arguments)
+                       }
     }
 
     BiometricsPopup {

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -66,8 +66,8 @@ SplitView {
         onOnboardingLoginFlowRequested: logs.logEvent("onOnboardingLoginFlowRequested")
         onUnblockWithSeedphraseRequested: logs.logEvent("onUnblockWithSeedphraseRequested")
         onUnblockWithPukRequested: logs.logEvent("onUnblockWithPukRequested")
-        onLostKeycard: (keyUid) =>{
-                           logs.logEvent("onLostKeycard", ["keyUid"], arguments)
+        onLostKeycardFlowRequested: () => {
+                           logs.logEvent("onLostKeycardFlowRequested")
                        }
     }
 

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -1177,6 +1177,7 @@ Item {
             compare(resultData.enableBiometrics, false)
             compare(resultData.keycardPin, "")
             compare(resultData.seedphrase, mockDriver.mnemonic)
+            compare(resultData.keyUid, keyUid)
         }
 
         function test_loginScreenLostKeycardCreateReplacementFlow() {

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -155,8 +155,8 @@ SQUtils.QObject {
             onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
             onOnboardingCreateProfileFlowRequested: root.stackView.push(createProfilePage)
             onOnboardingLoginFlowRequested: root.stackView.push(loginPage)
-            onLostKeycard: (keyUid) => {
-                               root.keyUidSubmitted(keyUid)
+            onLostKeycardFlowRequested: () => {
+                               root.keyUidSubmitted(loginScreen.selectedProfileKeyId)
                                root.stackView.push(keycardLostPage)
                            }
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -48,6 +48,7 @@ SQUtils.QObject {
     signal shareUsageDataRequested(bool enabled)
     signal syncProceedWithConnectionString(string connectionString)
     signal seedphraseSubmitted(string seedphrase)
+    signal keyUidSubmitted(string keyUid)
     signal setPasswordRequested(string password)
     signal exportKeysRequested
     signal loadMnemonicRequested
@@ -154,7 +155,11 @@ SQUtils.QObject {
             onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
             onOnboardingCreateProfileFlowRequested: root.stackView.push(createProfilePage)
             onOnboardingLoginFlowRequested: root.stackView.push(loginPage)
-            onLostKeycard: root.stackView.push(keycardLostPage)
+            onLostKeycard: (keyUid) => {
+                               root.keyUidSubmitted(keyUid)
+                               root.stackView.push(keycardLostPage)
+                           }
+
             onUnblockWithSeedphraseRequested: unblockWithSeedphraseFlow.init()
             onUnblockWithPukRequested: unblockWithPukFlow.init()
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -67,6 +67,7 @@ Page {
         property string keycardPin
         property bool enableBiometrics
         property string seedphrase
+        property string keyUid // Used in LoginWithLostKeycardSeedphrase
 
         // login screen state
         property string selectedProfileKeyId
@@ -76,6 +77,7 @@ Page {
             d.keycardPin = ""
             d.enableBiometrics = false
             d.seedphrase = ""
+            d.keyUid = ""
             d.selectedProfileKeyId = ""
         }
 
@@ -92,6 +94,7 @@ Page {
                 password: d.password,
                 keycardPin: d.keycardPin,
                 seedphrase: d.seedphrase,
+                keyUid: d.keyUid,
                 enableBiometrics: d.enableBiometrics
             }
 
@@ -197,6 +200,7 @@ Page {
         onSyncProceedWithConnectionString: (connectionString) =>
             root.onboardingStore.inputConnectionStringForBootstrapping(connectionString)
         onSeedphraseSubmitted: (seedphrase) => d.seedphrase = seedphrase
+        onKeyUidSubmitted: (keyUid) => d.keyUid = keyUid
         onSetPasswordRequested: (password) => d.password = password
         onEnableBiometricsRequested: (enabled) => d.enableBiometrics = enabled
         onLinkActivated: (link) => Qt.openUrlExternally(link)

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -82,7 +82,7 @@ OnboardingPage {
     signal onboardingLoginFlowRequested()
     signal unblockWithSeedphraseRequested()
     signal unblockWithPukRequested()
-    signal lostKeycard()
+    signal lostKeycard(string keyUid)
 
     QtObject {
         id: d
@@ -279,7 +279,7 @@ OnboardingPage {
                 visible: d.currentProfileIsKeycard
                 text: qsTr("Lost this Keycard?")
 
-                onClicked: root.lostKeycard()
+                onClicked: root.lostKeycard(d.settings.lastKeyUid)
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -82,7 +82,7 @@ OnboardingPage {
     signal onboardingLoginFlowRequested()
     signal unblockWithSeedphraseRequested()
     signal unblockWithPukRequested()
-    signal lostKeycard(string keyUid)
+    signal lostKeycardFlowRequested()
 
     QtObject {
         id: d
@@ -279,7 +279,7 @@ OnboardingPage {
                 visible: d.currentProfileIsKeycard
                 text: qsTr("Lost this Keycard?")
 
-                onClicked: root.lostKeycard(d.settings.lastKeyUid)
+                onClicked: root.lostKeycardFlowRequested()
             }
         }
     }


### PR DESCRIPTION
Required for https://github.com/status-im/status-desktop/pull/17273

# Description

When going to `Lost keycard` flow, we need to collect the selected profile `KeyUID`. This is further needed for:
1. To call backend with proper `KeyUID` (done in https://github.com/status-im/status-desktop/pull/17273)
2. Enable to check is seed phrase matches the profile and show [this screen](https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=999-46476&m=dev)