### PR TITLE
feat: lost keycard flow - convert keycard account to regular

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -39,7 +39,7 @@ import app_service/service/metrics/service as metrics_service
 import app/modules/shared_modules/keycard_popup/module as keycard_shared_module
 import app/modules/startup/module as startup_module
 import app/modules/onboarding/module as onboarding_module
-import app/modules/onboarding/post_onboarding/[keycard_replacement_task]
+import app/modules/onboarding/post_onboarding/[keycard_replacement_task, keycard_convert_account]
 import app/modules/main/module as main_module
 import app/core/notifications/notifications_manager
 import app/global/[global_singleton, feature_flags]
@@ -621,6 +621,8 @@ proc runPostOnboardingTasks(self: AppController) =
       case task.kind:
       of kPostOnboardingTaskKeycardReplacement:
         KeycardReplacementTask(task).run(self.walletAccountService, self.keycardServiceV2)
+      of kConvertKeycardAccountToRegular:
+        KeycardConvertAccountTask(task).run(self.accountsService)
       else:
         error "unknown post onboarding task"
 

--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -39,7 +39,7 @@ import app_service/service/metrics/service as metrics_service
 import app/modules/shared_modules/keycard_popup/module as keycard_shared_module
 import app/modules/startup/module as startup_module
 import app/modules/onboarding/module as onboarding_module
-import app/modules/onboarding/post_onboarding/[keycard_replacement_task, keycard_convert_account]
+import app/modules/onboarding/post_onboarding/[keycard_replacement_task, keycard_convert_account, save_biometrics_task]
 import app/modules/main/module as main_module
 import app/core/notifications/notifications_manager
 import app/global/[global_singleton, feature_flags]
@@ -455,6 +455,7 @@ proc mainDidLoad*(self: AppController) =
   if not self.onboardingModule.isNil:
     self.switchToOldOnboarding()
     self.runPostOnboardingTasks()
+
 proc start*(self: AppController) =
   if self.shouldUseTheNewOnboardingModule():
     self.keycardServiceV2.init()
@@ -621,8 +622,6 @@ proc runPostOnboardingTasks(self: AppController) =
       case task.kind:
       of kPostOnboardingTaskKeycardReplacement:
         KeycardReplacementTask(task).run(self.walletAccountService, self.keycardServiceV2)
-      of kConvertKeycardAccountToRegular:
-        KeycardConvertAccountTask(task).run(self.accountsService)
       else:
         error "unknown post onboarding task"
 

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -116,6 +116,19 @@ proc init*(self: Controller) =
     self.delegate.onAccountLoginError(args.error)
   self.connectionIds.add(handlerId)
 
+  handlerId = self.events.onWithUUID(SignalType.DBReEncryptionStarted.event) do(e: Args):
+    self.delegate.onReencryptionProcessStarted()
+  self.connectionIds.add(handlerId)
+
+  handlerId = self.events.onWithUUID(SignalType.DBReEncryptionFinished.event) do(e: Args):
+    self.delegate.onReencryptionProcessFinished()
+  self.connectionIds.add(handlerId)
+
+  handlerId = self.events.onWithUUID(SIGNAL_CONVERTING_PROFILE_KEYPAIR) do(e: Args):
+    let args = ResultArgs(e)
+    self.delegate.onKeycardAccountConverted(args.success)
+  self.connectionIds.add(handlerId)
+
 proc initialize*(self: Controller, pin: string) =
   let puk = keycard_serviceV2.generateRandomPUK()
   self.keycardServiceV2.asyncInitialize(pin, puk)

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -117,11 +117,11 @@ proc init*(self: Controller) =
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SignalType.DBReEncryptionStarted.event) do(e: Args):
-    self.delegate.onReencryptionProcessStarted()
+    debug "reencryption process started"
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SignalType.DBReEncryptionFinished.event) do(e: Args):
-    self.delegate.onReencryptionProcessFinished()
+    debug "reencryption process finished"
   self.connectionIds.add(handlerId)
 
   handlerId = self.events.onWithUUID(SIGNAL_CONVERTING_PROFILE_KEYPAIR) do(e: Args):

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -94,10 +94,13 @@ method startKeycardFactoryReset*(self: AccessInterface) {.base.} =
 method getPostOnboardingTasks*(self: AccessInterface): seq[PostOnboardingTask] {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getPostLoginTasks*(self: AccessInterface): seq[PostOnboardingTask] {.base.} =
+method onKeycardAccountConverted* (self: AccessInterface, success: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onKeycardAccountConverted* (self: AccessInterface, success: bool) {.base.} =
+method requestSaveBiometrics*(self: AccessInterface, account: string, credential: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method requestDeleteBiometrics*(self: AccessInterface, account: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -97,12 +97,6 @@ method getPostOnboardingTasks*(self: AccessInterface): seq[PostOnboardingTask] {
 method getPostLoginTasks*(self: AccessInterface): seq[PostOnboardingTask] {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onReencryptionProcessStarted*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onReencryptionProcessFinished*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onKeycardAccountConverted* (self: AccessInterface, success: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -94,6 +94,18 @@ method startKeycardFactoryReset*(self: AccessInterface) {.base.} =
 method getPostOnboardingTasks*(self: AccessInterface): seq[PostOnboardingTask] {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getPostLoginTasks*(self: AccessInterface): seq[PostOnboardingTask] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onReencryptionProcessStarted*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onReencryptionProcessFinished*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardAccountConverted* (self: AccessInterface, success: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -339,7 +339,6 @@ method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settin
   for i in 0..<self.postOnboardingTasks.len:
     let task = self.postOnboardingTasks[i]
     if task.kind == kConvertKeycardAccountToRegular:
-      debug "skippiig finishAppLoading2"
       return
 
   self.finishAppLoading2()
@@ -407,12 +406,6 @@ method onKeycardExportLoginKeysSuccess*[T](self: Module[T], exportedKeys: Keycar
     publicEncryptionKey = exportedKeys.encryptionKey.publicKey,
     privateWhisperKey = exportedKeys.whisperKey.privateKey,
   )
-
-method onReencryptionProcessStarted*[T](self: Module[T]) =
-  self.view.setReencryptingDatabase(true)
-
-method onReencryptionProcessFinished*[T](self: Module[T]) =
-  self.view.setReencryptingDatabase(false)
 
 method onKeycardAccountConverted*[T](self: Module[T], success: bool) =
   let state = if success: ProgressState.Success else: ProgressState.Failed

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -195,10 +195,15 @@ method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string)
           recoverAccount = true
         )
       of OnboardingFlow.LoginWithLostKeycardSeedphrase:
-        # TODO:
-        # 1. Call LoginAccount with `mnemonic` set
-        # 2. Schedule `convertToRegularAccount` for post-onboarding
-        error "LoginWithLostKeycardSeedphrase not implemented"
+        # TODO: 
+        # 1. Schedule `convertToRegularAccount` for post-onboarding
+
+        # 2. Call LoginAccount with `mnemonic` set
+        self.loginRequested(
+          keyUid = keyUid,
+          LoginMethod.Mnemonic.int,
+          $ %*{ "mnemonic": mnemonic },
+        )
       of OnboardingFlow.LoginWithRestoredKeycard:
         self.postOnboardingTasks.add(newKeycardReplacementTask(
           keycardInfo.keyUID,
@@ -230,6 +235,8 @@ method loginRequested*[T](self: Module[T], keyUid: string, loginFlow: int, dataJ
       of LoginMethod.Keycard:
         self.authorize(data["pin"].str)
         # We will continue the flow when the card is authorized in onKeycardStateUpdated
+      of LoginMethod.Mnemonic:
+        self.controller.login(account, password = "", mnemonic = data["mnemonic"].str)
       else:
         raise newException(ValueError, "Unknown login flow: " & $self.loginFlow)
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -426,10 +426,10 @@ method getPostOnboardingTasks*[T](self: Module[T]): seq[PostOnboardingTask] =
   return self.postOnboardingTasks
 
 method requestSaveBiometrics*[T](self: Module[T], account: string, credential: string) =
-  self.view.requestSaveBiometrics(account, credential)
+  self.view.saveBiometricsRequested(account, credential)
 
 method requestDeleteBiometrics*[T](self: Module[T], account: string) =
-  self.view.requestDeleteBiometrics(account)
+  self.view.deleteBiometricsRequested(account)
 
 proc runPostLoginTasks*[T](self: Module[T]) =
   let tasks = self.postLoginTasks

--- a/src/app/modules/onboarding/post_onboarding/keycard_convert_account.nim
+++ b/src/app/modules/onboarding/post_onboarding/keycard_convert_account.nim
@@ -1,0 +1,33 @@
+import task
+import chronicles
+
+export task
+
+import app_service/service/accounts/service as accounts_service
+
+type KeycardConvertAccountTask* = ref object of PostOnboardingTask
+  mnemonic: string
+  newPassword*: string
+
+proc newKeycardConvertAccountTask*(mnemonic: string,
+                                newPassword: string): KeycardConvertAccountTask =
+  result = KeycardConvertAccountTask(
+    kind: kConvertKeycardAccountToRegular,
+    mnemonic: mnemonic,
+    newPassword: newPassword,
+  )
+
+proc run*(self: KeycardConvertAccountTask, accountsService: accounts_service.Service) =
+
+  debug "running kConvertKeycardAccountToRegular"
+
+  # TODO: Implement V2 endpoint in status-go which automatically calculates current password
+  let account = accountsService.createAccountFromMnemonic(self.mnemonic, includeEncryption = true)
+  let currentPassword = account.derivedAccounts.encryption.publicKey
+
+  accountsService.convertKeycardProfileKeypairToRegular(
+      self.mnemonic,
+      currentPassword,
+      self.newPassword)
+
+  # WARNING: If biometrics were enabled, save the new passsword to it, instead of the pin

--- a/src/app/modules/onboarding/post_onboarding/keycard_convert_account.nim
+++ b/src/app/modules/onboarding/post_onboarding/keycard_convert_account.nim
@@ -1,25 +1,35 @@
 import task
 import chronicles
+import ../io_interface
 
 export task
 
 import app_service/service/accounts/service as accounts_service
 
 type KeycardConvertAccountTask* = ref object of PostOnboardingTask
+  keyUid: string
   mnemonic: string
   newPassword*: string
 
-proc newKeycardConvertAccountTask*(mnemonic: string,
-                                newPassword: string): KeycardConvertAccountTask =
+proc newKeycardConvertAccountTask*(keyUid: string,
+                                   mnemonic: string,
+                                   newPassword: string): KeycardConvertAccountTask =
   result = KeycardConvertAccountTask(
     kind: kConvertKeycardAccountToRegular,
+    keyUid: keyUid,
     mnemonic: mnemonic,
     newPassword: newPassword,
   )
 
-proc run*(self: KeycardConvertAccountTask, accountsService: accounts_service.Service) =
+proc run*(self: KeycardConvertAccountTask,
+          accountsService: accounts_service.Service,
+          onboardingModule: AccessInterface) =
 
-  debug "running kConvertKeycardAccountToRegular"
+  debug "running post-onboarding kConvertKeycardAccountToRegular"
+
+  # Remove PIN from Keychain for this account, as it won't be a valid database password after re-encryption.
+  # If needed, the new password will be saved as part of SaveBiometricsTask.
+  onboardingModule.requestDeleteBiometrics(self.keyUid)
 
   # TODO: Implement V2 endpoint in status-go which automatically calculates current password
   let account = accountsService.createAccountFromMnemonic(self.mnemonic, includeEncryption = true)
@@ -29,5 +39,3 @@ proc run*(self: KeycardConvertAccountTask, accountsService: accounts_service.Ser
       self.mnemonic,
       currentPassword,
       self.newPassword)
-
-  # WARNING: If biometrics were enabled, save the new passsword to it, instead of the pin

--- a/src/app/modules/onboarding/post_onboarding/keycard_replacement_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/keycard_replacement_task.nim
@@ -24,7 +24,7 @@ proc run*(self: KeycardReplacementTask,
 
   # NOTE: This implementation was taken from `doKeycardReplacement` in `app_controller.nim`
 
-  debug "running post-onbaording KeycardReplacementTask"
+  debug "running post-onboarding KeycardReplacementTask"
 
   let keypair = walletAccountService.getKeypairByKeyUid(self.keyUid)
   if keypair.isNil:

--- a/src/app/modules/onboarding/post_onboarding/save_biometrics_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/save_biometrics_task.nim
@@ -16,7 +16,7 @@ proc newSaveBiometricsTask*(credential: string): SaveBiometricsTask =
     )
 
 proc run*(self: SaveBiometricsTask, accountsService: accounts_service.Service, onboardingModule: AccessInterface) =
-  debug "running post-onbaording SaveBiometricsTask"
+  debug "running post-onboarding SaveBiometricsTask"
 
   let keyUid = accountsService.getLoggedInAccount().keyUid
   onboardingModule.requestSaveBiometrics(keyUid, self.credential)

--- a/src/app/modules/onboarding/post_onboarding/save_biometrics_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/save_biometrics_task.nim
@@ -1,0 +1,23 @@
+import chronicles
+import task
+import ../io_interface
+
+import app_service/service/accounts/service as accounts_service
+
+export task
+
+type SaveBiometricsTask* = ref object of PostOnboardingTask
+  credential*: string
+
+proc newSaveBiometricsTask*(credential: string): SaveBiometricsTask =
+  result = SaveBiometricsTask(
+      kind: kPostOnboardingTaskSaveBiometrics,
+      credential: credential,
+    )
+
+proc run*(self: SaveBiometricsTask, accountsService: accounts_service.Service, onboardingModule: AccessInterface) =
+  debug "running post-onbaording SaveBiometricsTask"
+
+  let keyUid = accountsService.getLoggedInAccount().keyUid
+  onboardingModule.requestSaveBiometrics(keyUid, self.credential)
+

--- a/src/app/modules/onboarding/post_onboarding/task.nim
+++ b/src/app/modules/onboarding/post_onboarding/task.nim
@@ -13,11 +13,19 @@ type PostOnboardingTaskKind* = enum
 
   kConvertKeycardAccountToRegular = 3
 
+type ExecutionMoment* = enum
+  PostLogin = 0
+  PostOnboarding = 1
+
 type PostOnboardingTask* = ref object of RootObj
   kind*: PostOnboardingTaskKind
+  moment*: ExecutionMoment
 
 # NOTE: In theory we could define a `run` {.base.} method here.
 # But for now there are not many task kinds, and they require different arguments.
 
 proc kind*(self: PostOnboardingTask): PostOnboardingTaskKind =
   return self.kind
+
+proc moment*(self: PostOnboardingTask): ExecutionMoment =
+  return self.moment

--- a/src/app/modules/onboarding/post_onboarding/task.nim
+++ b/src/app/modules/onboarding/post_onboarding/task.nim
@@ -10,22 +10,17 @@ type PostOnboardingTaskKind* = enum
   #       Comparing to the `KeycardReplacementTask` which is used when the keycard is lost and a new one is being used. Theoretically the old keycard can still be found and used. # WARNING: But is this secure?
   kPostOnboardingUpdateKeycardUid = 2 # Onboarding V1 name: changedKeycardUids
 
+  # This task is scheduled if the user agreed to use biometrics.
+  kPostOnboardingTaskSaveBiometrics = 3
 
-  kConvertKeycardAccountToRegular = 3
-
-type ExecutionMoment* = enum
-  PostLogin = 0
-  PostOnboarding = 1
+  # This task is scheduled in LoginWithLostKeycardSeedphrase to convert the keycard account to a regular account.
+  kConvertKeycardAccountToRegular = 4
 
 type PostOnboardingTask* = ref object of RootObj
   kind*: PostOnboardingTaskKind
-  moment*: ExecutionMoment
 
 # NOTE: In theory we could define a `run` {.base.} method here.
 # But for now there are not many task kinds, and they require different arguments.
 
 proc kind*(self: PostOnboardingTask): PostOnboardingTaskKind =
   return self.kind
-
-proc moment*(self: PostOnboardingTask): ExecutionMoment =
-  return self.moment

--- a/src/app/modules/onboarding/post_onboarding/task.nim
+++ b/src/app/modules/onboarding/post_onboarding/task.nim
@@ -10,6 +10,9 @@ type PostOnboardingTaskKind* = enum
   #       Comparing to the `KeycardReplacementTask` which is used when the keycard is lost and a new one is being used. Theoretically the old keycard can still be found and used. # WARNING: But is this secure?
   kPostOnboardingUpdateKeycardUid = 2 # Onboarding V1 name: changedKeycardUids
 
+
+  kConvertKeycardAccountToRegular = 3
+
 type PostOnboardingTask* = ref object of RootObj
   kind*: PostOnboardingTaskKind
 

--- a/src/app/modules/onboarding/states.nim
+++ b/src/app/modules/onboarding/states.nim
@@ -17,6 +17,7 @@ type LoginMethod* {.pure} = enum
   Unknown = 0,
   Password,
   Keycard,
+  Mnemonic,
 
 type ProgressState* {.pure.} = enum
   Idle,

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -37,6 +37,8 @@ QtObject:
 
   proc appLoaded*(self: View, keyUid: string) {.signal.}
   proc accountLoginError*(self: View, error: string, wrongPassword: bool) {.signal.}
+  proc saveBiometricsRequested*(self: View, account: string, credential: string) {.signal.}
+  proc deleteBiometricsRequested*(self: View, account: string) {.signal.}
 
   ### QtProperties ###
 
@@ -141,6 +143,12 @@ QtObject:
   QtProperty[int] convertKeycardAccountState:
     read = getConvertKeycardAccountState
     notify = convertKeycardAccountStateChanged
+
+  proc requestSaveBiometrics*(self: View, account: string, credential: string) =
+    self.saveBiometricsRequested(account, credential)
+
+  proc requestDeleteBiometrics*(self: View, account: string) =
+    self.deleteBiometricsRequested(account)
 
   ### slots ###
 

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -20,7 +20,6 @@ QtObject:
       loginAccountsModel: login_acc_model.Model
       loginAccountsModelVariant: QVariant
       convertKeycardAccountState: ProgressState
-      reencryptingDatabase: bool
 
   proc delete*(self: View) =
     self.QObject.delete
@@ -33,7 +32,6 @@ QtObject:
     result.delegate = delegate
     result.loginAccountsModel = login_acc_model.newModel()
     result.loginAccountsModelVariant = newQVariant(result.loginAccountsModel)
-    result.reencryptingDatabase = false
 
   ### QtSignals ###
 
@@ -143,18 +141,6 @@ QtObject:
   QtProperty[int] convertKeycardAccountState:
     read = getConvertKeycardAccountState
     notify = convertKeycardAccountStateChanged
-
-  proc reencryptingDatabaseChanged*(self: View) {.signal.}
-  proc getReencryptingDatabase(self: View): bool {.slot.} =
-    return self.reencryptingDatabase
-  proc setReencryptingDatabase*(self: View, value: bool) =
-    if self.reencryptingDatabase == value:
-      return
-    self.reencryptingDatabase = value
-    self.reencryptingDatabaseChanged()
-  QtProperty[bool] reencryptingDatabase:
-    read = getReencryptingDatabase
-    notify = reencryptingDatabaseChanged
 
   ### slots ###
 

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -19,6 +19,8 @@ QtObject:
       restoreKeysExportState: int
       loginAccountsModel: login_acc_model.Model
       loginAccountsModelVariant: QVariant
+      convertKeycardAccountState: ProgressState
+      reencryptingDatabase: bool
 
   proc delete*(self: View) =
     self.QObject.delete
@@ -31,6 +33,7 @@ QtObject:
     result.delegate = delegate
     result.loginAccountsModel = login_acc_model.newModel()
     result.loginAccountsModelVariant = newQVariant(result.loginAccountsModel)
+    result.reencryptingDatabase = false
 
   ### QtSignals ###
 
@@ -128,6 +131,30 @@ QtObject:
   QtProperty[QVariant] loginAccountsModel:
     read = getLoginAccountsModel
     notify = loginAccountsModelChanged
+
+  proc convertKeycardAccountStateChanged*(self: View) {.signal.}
+  proc getConvertKeycardAccountState(self: View): int {.slot.} =
+    return self.convertKeycardAccountState.int
+  proc setConvertKeycardAccountState*(self: View, value: ProgressState) =
+    if self.convertKeycardAccountState == value:
+      return
+    self.convertKeycardAccountState = value
+    self.convertKeycardAccountStateChanged()
+  QtProperty[int] convertKeycardAccountState:
+    read = getConvertKeycardAccountState
+    notify = convertKeycardAccountStateChanged
+
+  proc reencryptingDatabaseChanged*(self: View) {.signal.}
+  proc getReencryptingDatabase(self: View): bool {.slot.} =
+    return self.reencryptingDatabase
+  proc setReencryptingDatabase*(self: View, value: bool) =
+    if self.reencryptingDatabase == value:
+      return
+    self.reencryptingDatabase = value
+    self.reencryptingDatabaseChanged()
+  QtProperty[bool] reencryptingDatabase:
+    read = getReencryptingDatabase
+    notify = reencryptingDatabaseChanged
 
   ### slots ###
 

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -144,12 +144,6 @@ QtObject:
     read = getConvertKeycardAccountState
     notify = convertKeycardAccountStateChanged
 
-  proc requestSaveBiometrics*(self: View, account: string, credential: string) =
-    self.saveBiometricsRequested(account, credential)
-
-  proc requestDeleteBiometrics*(self: View, account: string) =
-    self.deleteBiometricsRequested(account)
-
   ### slots ###
 
   proc setPin(self: View, pin: string) {.slot.} =

--- a/storybook/pages/ConvertKeycardAccountPagePage.qml
+++ b/storybook/pages/ConvertKeycardAccountPagePage.qml
@@ -1,0 +1,33 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Backpressure 0.1
+
+import AppLayouts.Onboarding2.pages 1.0
+import AppLayouts.Onboarding.enums 1.0
+
+Item {
+    id: root
+
+    ConvertKeycardAccountPage {
+        id: progressPage
+        anchors.fill: parent
+        convertKeycardAccountState: ctrlState.currentValue
+    }
+
+    ComboBox {
+        id: ctrlState
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        width: 300
+        textRole: "name"
+        valueRole: "value"
+        model: Onboarding.getModelFromEnum("ProgressState")
+    }
+}
+
+// category: Onboarding
+// status: good
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=221-23716&node-type=frame&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=224-20891&node-type=frame&m=dev
+// https://www.figma.com/design/Lw4nPYQcZOPOwTgETiiIYo/Desktop-Onboarding-Redesign?node-id=221-23788&node-type=frame&m=dev

--- a/storybook/pages/ConvertKeycardAccountPagePage.qml
+++ b/storybook/pages/ConvertKeycardAccountPagePage.qml
@@ -1,18 +1,49 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+import Qt.labs.settings 1.0
+
 import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
+import Storybook 1.0
+
 Item {
     id: root
 
-    ConvertKeycardAccountPage {
-        id: progressPage
+    Logs {
+        id: logs
+    }
+
+    SplitView {
         anchors.fill: parent
-        convertKeycardAccountState: ctrlState.currentValue
+        orientation: Qt.Vertical
+
+        ConvertKeycardAccountPage {
+            id: progressPage
+
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            convertKeycardAccountState: ctrlState.currentValue
+            onRestartRequested: {
+                logs.logEvent("restartRequested")
+            }
+            onBackToLoginRequested: {
+                logs.logEvent("backToLoginRequested")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            logsView.logText: logs.logText
+        }
     }
 
     ComboBox {
@@ -23,6 +54,10 @@ Item {
         textRole: "name"
         valueRole: "value"
         model: Onboarding.getModelFromEnum("ProgressState")
+    }
+
+    Settings {
+        property alias convertKeycardAccountPageState: ctrlState.currentIndex
     }
 }
 

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -397,10 +397,12 @@ SplitView {
 
         ConvertKeycardAccountPage {
             convertKeycardAccountState: store.convertKeycardAccountState
-            onQuitRequested: {
-                Qt.quit()
+            onRestartRequested: {
+                logs.logEvent("restartRequested")
+                onboarding.unwindToLoginScreen()
             }
-            onTryAgainRequested: {
+            onBackToLoginRequested: {
+                logs.logEvent("backToLoginRequested")
                 onboarding.unwindToLoginScreen()
             }
         }

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -172,7 +172,7 @@ SplitView {
             // (test) error handler
             onAccountLoginError: function (error, wrongPassword) {
                 ctrlLoginResult.result = "<font color='red'>⛔</font>"
-                onboarding.unwindToLoginScreen()
+                onboarding.restartFlow()
             }
         }
 

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -82,7 +82,6 @@ SplitView {
             property int convertKeycardAccountState: Onboarding.ProgressState.Idle
             property int syncState: Onboarding.ProgressState.Idle
             property var loginAccountsModel: ctrlLoginScreen.checked ? loginAccountsModel : emptyModel
-            readonly property bool reencryptingDatabase: ctrlReencryptingDatabase.checked
 
             property int keycardRemainingPinAttempts: Constants.onboarding.defaultPinAttempts
             property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
@@ -484,12 +483,6 @@ SplitView {
                     visible: ctrlLoginScreen.checked
                     enabled: ctrlBiometrics.checked
                     checked: ctrlBiometrics.checked
-                }
-
-                Switch {
-                    id: ctrlReencryptingDatabase
-                    text: "Reencrypting database"
-                    visible: ctrlLoginScreen.checked
                 }
 
                 Text {

--- a/ui/StatusQ/src/keychain_osx.mm
+++ b/ui/StatusQ/src/keychain_osx.mm
@@ -86,7 +86,7 @@ Keychain::Status authenticate(const QString &reason, LAContext **context)
     }
 
     *context = [[LAContext alloc] init];
-    (*context).localizedFallbackTitle = QObject::tr("Use Status password...").toNSString();
+    (*context).localizedFallbackTitle = QObject::tr("Use Status profile password").toNSString();
 
     QEventLoop loop;
     auto loopPtr = &loop;

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -54,6 +54,7 @@ public:
         Unknown,
         Password,
         Keycard,
+        Mnemonic,
     };
 
     // NOTE: Keep in sync with KeycardState in src/app_service/service/keycardV2/dto.nim

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -9,6 +9,8 @@ import StatusQ.Core.Utils 0.1 as SQUtils
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
+import mainui 1.0
+
 OnboardingStackView {
     id: root
 
@@ -20,6 +22,8 @@ OnboardingStackView {
     required property int restoreKeysExportState
     required property int addKeyPairState
     required property int syncState
+    required property bool reencryptingDatabase
+    required property var generateMnemonic
     required property int remainingPinAttempts
     required property int remainingPukAttempts
 
@@ -126,6 +130,18 @@ OnboardingStackView {
 
         function onAddKeyPairStateChanged() {
             d.handleKeycardProgressFailedState(addKeyPairState)
+        }
+    }
+
+    Connections {
+        target: root
+
+        function onReencryptingDatabaseChanged() {
+            if (root.reencryptingDatabase) {
+                root.push(reencryptingDatabaseScreen, StackView.Immediate)
+            } else {
+                root.pop(StackView.Immediate)
+            }
         }
     }
 
@@ -532,4 +548,16 @@ OnboardingStackView {
             onLinkActivated: (link) => root.linkActivated(link)
         }
     }
+
+    Component {
+        id: reencryptingDatabaseScreen
+
+        SplashScreen {
+            anchors.centerIn: parent
+            text: qsTr("Database re-encryption in progress. Please do NOT close the app.\nThis may take up to 30 minutes. Sorry for the inconvenience.")
+            secondaryText: qsTr("This process is a one time thing and is necessary for the proper functioning of the application.")
+            infiniteLoading: true
+        }
+    }
+
 }

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -22,8 +22,6 @@ OnboardingStackView {
     required property int restoreKeysExportState
     required property int addKeyPairState
     required property int syncState
-    required property bool reencryptingDatabase
-    required property var generateMnemonic
     required property int remainingPinAttempts
     required property int remainingPukAttempts
 
@@ -130,18 +128,6 @@ OnboardingStackView {
 
         function onAddKeyPairStateChanged() {
             d.handleKeycardProgressFailedState(addKeyPairState)
-        }
-    }
-
-    Connections {
-        target: root
-
-        function onReencryptingDatabaseChanged() {
-            if (root.reencryptingDatabase) {
-                root.push(reencryptingDatabaseScreen, StackView.Immediate)
-            } else {
-                root.pop(StackView.Immediate)
-            }
         }
     }
 
@@ -546,17 +532,6 @@ OnboardingStackView {
             destroyOnClose: true
             onOpened: content.text = SQUtils.StringUtils.readTextFile(Qt.resolvedUrl("../../../imports/assets/docs/terms-of-use.mdwn"))
             onLinkActivated: (link) => root.linkActivated(link)
-        }
-    }
-
-    Component {
-        id: reencryptingDatabaseScreen
-
-        SplashScreen {
-            anchors.centerIn: parent
-            text: qsTr("Database re-encryption in progress. Please do NOT close the app.\nThis may take up to 30 minutes. Sorry for the inconvenience.")
-            secondaryText: qsTr("This process is a one time thing and is necessary for the proper functioning of the application.")
-            infiniteLoading: true
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -9,8 +9,6 @@ import StatusQ.Core.Utils 0.1 as SQUtils
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-import mainui 1.0
-
 OnboardingStackView {
     id: root
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -133,7 +133,6 @@ Page {
         restoreKeysExportState: root.onboardingStore.restoreKeysExportState
         syncState: root.onboardingStore.syncState
         addKeyPairState: root.onboardingStore.addKeyPairState
-        reencryptingDatabase: root.onboardingStore.reencryptingDatabase
 
         displayKeycardPromoBanner: !d.settings.keycardPromoShown
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -133,6 +133,7 @@ Page {
         restoreKeysExportState: root.onboardingStore.restoreKeysExportState
         syncState: root.onboardingStore.syncState
         addKeyPairState: root.onboardingStore.addKeyPairState
+        reencryptingDatabase: root.onboardingStore.reencryptingDatabase
 
         displayKeycardPromoBanner: !d.settings.keycardPromoShown
 

--- a/ui/app/AppLayouts/Onboarding2/pages/ConvertKeycardAccountPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/ConvertKeycardAccountPage.qml
@@ -4,17 +4,18 @@ import QtQuick.Layouts 1.15
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
 
 import AppLayouts.Onboarding.enums 1.0
-import AppLayouts.Onboarding2.controls 1.0
 
 OnboardingPage {
     id: root
 
+    readonly property bool backAvailableHint: false
     required property int convertKeycardAccountState
 
-    signal quitRequested()
-    signal tryAgainRequested()
+    signal restartRequested()
+    signal backToLoginRequested()
 
     StateGroup {
         states: [
@@ -23,7 +24,7 @@ OnboardingPage {
 
                 PropertyChanges {
                     target: root
-                    title: qsTr("Converting Keycard Account")
+                    title: qsTr("Re-encrypting your profile data")
                 }
                 PropertyChanges {
                     target: iconLoader
@@ -31,7 +32,11 @@ OnboardingPage {
                 }
                 PropertyChanges {
                     target: subtitle
-                    text: qsTr("in progress")
+                    text: qsTr("Your data must be re-encrypted with your new password which may take some time.")
+                }
+                PropertyChanges {
+                    target: warningText
+                    visible: true
                 }
                 PropertyChanges {
                     target: btnQuit
@@ -47,7 +52,7 @@ OnboardingPage {
 
                 PropertyChanges {
                     target: root
-                    title: qsTr("Keycard account converted")
+                    title: qsTr("Re-encryption complete")
                 }
                 PropertyChanges {
                     target: iconLoader
@@ -55,7 +60,11 @@ OnboardingPage {
                 }
                 PropertyChanges {
                     target: subtitle
-                    text: qsTr("<done>")
+                    text: qsTr("Your data was successfully re-encrypted with your new password. You can now restart Status and log in to your profile using the password you just created.")
+                }
+                PropertyChanges {
+                    target: warningText
+                    visible: false
                 }
                 PropertyChanges {
                     target: btnQuit
@@ -71,7 +80,7 @@ OnboardingPage {
 
                 PropertyChanges {
                     target: root
-                    title: qsTr("Failed to convert keycard account")
+                    title: qsTr("Re-encryption failed")
                 }
                 PropertyChanges {
                     target: iconLoader
@@ -79,7 +88,11 @@ OnboardingPage {
                 }
                 PropertyChanges {
                     target: subtitle
-                    text: qsTr("<details>")
+                    text: qsTr("Your data must be re-encrypted with your new password which may take some time.")
+                }
+                PropertyChanges {
+                    target: warningText
+                    visible: true
                 }
                 PropertyChanges {
                     target: btnQuit
@@ -97,9 +110,9 @@ OnboardingPage {
         ColumnLayout {
             anchors.left: parent.left
             anchors.right: parent.right
-
             anchors.verticalCenter: parent.verticalCenter
-            spacing: Theme.halfPadding
+
+            spacing: Theme.bigPadding
 
             Loader {
                 Layout.preferredWidth: 40
@@ -124,48 +137,47 @@ OnboardingPage {
                 text: root.title
                 horizontalAlignment: Text.AlignHCenter
             }
+
             StatusBaseText {
                 id: subtitle
                 Layout.fillWidth: true
+                Layout.maximumWidth: 388
+                Layout.alignment: Qt.AlignCenter
                 color: Theme.palette.baseColor1
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignHCenter
                 visible: !!text
             }
 
-            Rectangle {
-                id: image
-
-                color: "red"
-                implicitWidth: 231
-                implicitHeight: 231
-                radius: Math.max(width, height) / 2
-
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: Math.min(231, parent.width)
-                Layout.preferredHeight: Layout.preferredWidth
-                Layout.topMargin: Theme.bigPadding
-                Layout.bottomMargin: Theme.bigPadding + 100
+            StatusBaseText {
+                id: warningText
+                Layout.fillWidth: true
+                Layout.maximumWidth: 388
+                Layout.alignment: Qt.AlignCenter
+                color: Theme.palette.dangerColor1
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Do not quit Status or turn off your device. Doing so will lead to loss of profile and inability to restart the app.")
             }
 
-            MaybeOutlineButton {
+            StatusButton {
                 id: btnQuit
 
                 visible: false
                 isOutline: false
-                text: qsTr("Quit and login with new password")
+                text: qsTr("Restart Status and log in with new password")
                 Layout.alignment: Qt.AlignHCenter
-                onClicked: root.quitRequested()
+                onClicked: root.restartRequested()
             }
 
-            MaybeOutlineButton {
+            StatusButton {
                 id: btnTryAgain
 
                 visible: false
                 isOutline: false
-                text: qsTr("Try again")
+                text: qsTr("Back to login")
                 Layout.alignment: Qt.AlignHCenter
-                onClicked: root.tryAgainRequested()
+                onClicked: root.backToLoginRequested()
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding2/pages/ConvertKeycardAccountPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/ConvertKeycardAccountPage.qml
@@ -1,0 +1,202 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+import AppLayouts.Onboarding.enums 1.0
+import AppLayouts.Onboarding2.controls 1.0
+
+OnboardingPage {
+    id: root
+
+    required property int convertKeycardAccountState
+
+    signal quitRequested()
+    signal tryAgainRequested()
+
+    StateGroup {
+        states: [
+            State {
+                when: root.convertKeycardAccountState === Onboarding.ProgressState.InProgress
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Converting Keycard Account")
+                }
+                PropertyChanges {
+                    target: iconLoader
+                    sourceComponent: loadingIndicator
+                }
+                PropertyChanges {
+                    target: subtitle
+                    text: qsTr("in progress")
+                }
+                PropertyChanges {
+                    target: btnQuit
+                    visible: false
+                }
+                PropertyChanges {
+                    target: btnTryAgain
+                    visible: false
+                }
+            },
+            State {
+                when: root.convertKeycardAccountState === Onboarding.ProgressState.Success
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Keycard account converted")
+                }
+                PropertyChanges {
+                    target: iconLoader
+                    sourceComponent: successIcon
+                }
+                PropertyChanges {
+                    target: subtitle
+                    text: qsTr("<done>")
+                }
+                PropertyChanges {
+                    target: btnQuit
+                    visible: true
+                }
+                PropertyChanges {
+                    target: btnTryAgain
+                    visible: false
+                }
+            },
+            State {
+                when: root.convertKeycardAccountState === Onboarding.ProgressState.Failed
+
+                PropertyChanges {
+                    target: root
+                    title: qsTr("Failed to convert keycard account")
+                }
+                PropertyChanges {
+                    target: iconLoader
+                    sourceComponent: failedIcon
+                }
+                PropertyChanges {
+                    target: subtitle
+                    text: qsTr("<details>")
+                }
+                PropertyChanges {
+                    target: btnQuit
+                    visible: false
+                }
+                PropertyChanges {
+                    target: btnTryAgain
+                    visible: true
+                }
+            }
+        ]
+    }
+
+    contentItem: Item {
+        ColumnLayout {
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Theme.halfPadding
+
+            Loader {
+                Layout.preferredWidth: 40
+                Layout.preferredHeight: 40
+                Layout.alignment: Qt.AlignHCenter
+                id: iconLoader
+
+                sourceComponent: Rectangle {
+                    color: Theme.palette.baseColor2
+                    radius: width/2
+                    StatusDotsLoadingIndicator {
+                        anchors.centerIn: parent
+                    }
+                }
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                font.pixelSize: 22
+                font.bold: true
+                wrapMode: Text.WordWrap
+                text: root.title
+                horizontalAlignment: Text.AlignHCenter
+            }
+            StatusBaseText {
+                id: subtitle
+                Layout.fillWidth: true
+                color: Theme.palette.baseColor1
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                visible: !!text
+            }
+
+            Rectangle {
+                id: image
+
+                color: "red"
+                implicitWidth: 231
+                implicitHeight: 231
+                radius: Math.max(width, height) / 2
+
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: Math.min(231, parent.width)
+                Layout.preferredHeight: Layout.preferredWidth
+                Layout.topMargin: Theme.bigPadding
+                Layout.bottomMargin: Theme.bigPadding + 100
+            }
+
+            MaybeOutlineButton {
+                id: btnQuit
+
+                visible: false
+                isOutline: false
+                text: qsTr("Quit and login with new password")
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: root.quitRequested()
+            }
+
+            MaybeOutlineButton {
+                id: btnTryAgain
+
+                visible: false
+                isOutline: false
+                text: qsTr("Try again")
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: root.tryAgainRequested()
+            }
+        }
+    }
+
+    Component {
+        id: loadingIndicator
+        Rectangle {
+            color: Theme.palette.baseColor2
+            radius: width/2
+            StatusDotsLoadingIndicator {
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    Component {
+        id: successIcon
+
+        StatusRoundIcon {
+            asset.name: "check-circle"
+            asset.color: Theme.palette.successColor1
+            asset.bgColor: Theme.palette.successColor2
+        }
+    }
+
+    Component {
+        id: failedIcon
+        StatusRoundIcon {
+            asset.name: "close-circle"
+            asset.color: Theme.palette.dangerColor1
+            asset.bgColor: Theme.palette.dangerColor3
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -3,6 +3,7 @@ BackupSeedphraseIntro 1.0 BackupSeedphraseIntro.qml
 BackupSeedphraseOutro 1.0 BackupSeedphraseOutro.qml
 BackupSeedphraseReveal 1.0 BackupSeedphraseReveal.qml
 BackupSeedphraseVerify 1.0 BackupSeedphraseVerify.qml
+ConvertKeycardAccountPage 1.0 ConvertKeycardAccountPage.qml
 CreateKeycardProfilePage 1.0 CreateKeycardProfilePage.qml
 CreatePasswordPage 1.0 CreatePasswordPage.qml
 CreateProfilePage 1.0 CreateProfilePage.qml

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -8,6 +8,8 @@ QtObject {
     id: root
 
     signal appLoaded(string keyUid)
+    signal saveBiometricsRequested(string keyUid, string credential)
+    signal deleteBiometricsRequested(string keyUid)
 
     readonly property QtObject d: StatusQUtils.QObject {
         id: d
@@ -16,6 +18,8 @@ QtObject {
         Component.onCompleted: {
             d.onboardingModuleInst.appLoaded.connect(root.appLoaded)
             d.onboardingModuleInst.accountLoginError.connect(root.accountLoginError)
+            d.onboardingModuleInst.saveBiometricsRequested.connect(root.saveBiometricsRequested)
+            d.onboardingModuleInst.deleteBiometricsRequested.connect(root.deleteBiometricsRequested)
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -88,7 +88,4 @@ QtObject {
     function inputConnectionStringForBootstrapping(connectionString: string) { // -> void
         d.onboardingModuleInst.inputConnectionStringForBootstrapping(connectionString)
     }
-
-    // reencryption
-    readonly property bool reencryptingDatabase: d.onboardingModuleInst.reencryptingDatabase
 }

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -26,6 +26,7 @@ QtObject {
     readonly property int pinSettingState: d.onboardingModuleInst.pinSettingState // cf. enum Onboarding.ProgressState
     readonly property int authorizationState: d.onboardingModuleInst.authorizationState // cf. enum Onboarding.AuthorizationState
     readonly property int restoreKeysExportState: d.onboardingModuleInst.restoreKeysExportState // cf. enum Onboarding.AuthorizationState
+    readonly property int convertKeycardAccountState: d.onboardingModuleInst.convertKeycardAccountState // cf. enum Onboarding.ProgressState
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
     readonly property int keycardRemainingPukAttempts: d.onboardingModuleInst.keycardRemainingPukAttempts
 
@@ -87,4 +88,7 @@ QtObject {
     function inputConnectionStringForBootstrapping(connectionString: string) { // -> void
         d.onboardingModuleInst.inputConnectionStringForBootstrapping(connectionString)
     }
+
+    // reencryption
+    readonly property bool reencryptingDatabase: d.onboardingModuleInst.reencryptingDatabase
 }

--- a/ui/app/mainui/SplashScreen.qml
+++ b/ui/app/mainui/SplashScreen.qml
@@ -6,11 +6,15 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 import utils 1.0
+import shared 1.0
 
 Item {
+    id: root
+
     property alias text: loadingText.text
     property alias secondaryText: secondaryText.text
     property alias progress: progressBar.value
+    property bool infiniteLoading: false
 
     ColumnLayout {
         anchors.centerIn: parent
@@ -45,7 +49,14 @@ Item {
             Layout.preferredHeight: 4
             Layout.bottomMargin: 100
             fillColor: Theme.palette.primaryColor1
-            opacity: progress > 0 ? 1 : 0
+            visible: !root.infiniteLoading
+        }
+        LoadingAnimation {
+            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+            Layout.preferredHeight: 25
+            Layout.preferredWidth: 25
+            Layout.bottomMargin: 100
+            visible: root.infiniteLoading
         }
     }
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -16,8 +16,10 @@ import shared.stores 1.0
 import mainui 1.0
 import AppLayouts.stores 1.0 as AppStores
 import AppLayouts.Onboarding 1.0
+import AppLayouts.Onboarding.enums 1.0
 import AppLayouts.Onboarding2 1.0 as Onboarding2
 import AppLayouts.Onboarding2.stores 1.0
+import AppLayouts.Onboarding2.pages 1.0
 
 import StatusQ 0.1
 import StatusQ.Core.Theme 0.1
@@ -372,9 +374,13 @@ StatusWindow {
         active: false
         sourceComponent: DidYouKnowSplashScreen {
             objectName: "splashScreen"
-            NumberAnimation on progress { from: 0.0; to: 1; duration: 30000; running: runningProgressAnimation }
-            onProgressChanged: {
-                if (progress === 1) {
+
+            NumberAnimation on progress {
+                from: 0.0
+                to: 1
+                duration: 30000
+                running: runningProgressAnimation
+                onFinished: {
                     appLoadingAnimation.active = false
                     mainModule.fakeLoadingScreenFinished()
                 }
@@ -485,6 +491,12 @@ StatusWindow {
                     console.error("!!! ONBOARDING FINISHED WITH ERROR:", error)
                     return
                 }
+
+                if (flow === Onboarding.OnboardingFlow.LoginWithLostKeycardSeedphrase) {
+                    stack.push(convertingKeycardAccountPage)
+                    return
+                }
+
                 stack.push(splashScreenV2, { runningProgressAnimation: true })
 
                 if (!data.enableBiometrics)
@@ -507,6 +519,17 @@ StatusWindow {
                 }
             }
             onCurrentPageNameChanged: Global.addCentralizedMetricIfEnabled("navigation", {viewId: currentPageName})
+
+            Component {
+                id: convertingKeycardAccountPage
+
+                ConvertKeycardAccountPage {
+                    convertKeycardAccountState: onboardingStore.convertKeycardAccountState
+                    onQuitRequested: {
+                        Qt.quit()
+                    }
+                }
+            }
         }
     }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -13,7 +13,6 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.stores 1.0
 
-import mainui 1.0
 import AppLayouts.stores 1.0 as AppStores
 import AppLayouts.Onboarding 1.0
 import AppLayouts.Onboarding.enums 1.0
@@ -528,7 +527,7 @@ StatusWindow {
                 ConvertKeycardAccountPage {
                     convertKeycardAccountState: onboardingStore.convertKeycardAccountState
                     onRestartRequested: {
-                        Qt.quit()
+                        SystemUtils.restartApplication()
                     }
                     onBackToLoginRequested: {
                         onboardingLayout.unwindToLoginScreen()

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -479,6 +479,12 @@ StatusWindow {
                 onAccountLoginError: function (error, wrongPassword) {
                     onboardingLayout.unwindToLoginScreen() // error handled internally
                 }
+                // onSaveBiometricsRequested: (account, credential) => {
+                //     appKeychain.saveCredential(account, credential)
+                // }
+                // onDeleteBiometricsRequested: (account) => {
+                //     appKeychain.deleteCredential(account)
+                // }
             }
 
             keychain: appKeychain
@@ -492,19 +498,15 @@ StatusWindow {
                     return
                 }
 
+                // We use a custom handler for LoginWithLostKeycardSeedphrase flow.
+                // At the moment of implementation, this was the simplest move to make it work in the given code.
+                // Ideally, ConvertKeycardAccountPage should be created inside the OnboardingLayout and not here,
+                // but this would require more changes and eventually give more inconsistencies.
                 if (flow === Onboarding.OnboardingFlow.LoginWithLostKeycardSeedphrase) {
                     stack.push(convertingKeycardAccountPage)
-                    return
+                } else {
+                    stack.push(splashScreenV2, {runningProgressAnimation: true})
                 }
-
-                stack.push(splashScreenV2, { runningProgressAnimation: true })
-
-                if (!data.enableBiometrics)
-                    return
-
-                onboardingStore.appLoaded.connect((keyUid) => {
-                    appKeychain.saveCredential(keyUid, data.password || data.keycardPin)
-                })
             }
 
             onLoginRequested: function (keyUid, method, data) {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -13,6 +13,7 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.stores 1.0
 
+import mainui 1.0
 import AppLayouts.stores 1.0 as AppStores
 import AppLayouts.Onboarding 1.0
 import AppLayouts.Onboarding.enums 1.0
@@ -21,6 +22,7 @@ import AppLayouts.Onboarding2.stores 1.0
 import AppLayouts.Onboarding2.pages 1.0
 
 import StatusQ 0.1
+import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 StatusWindow {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -479,12 +479,12 @@ StatusWindow {
                 onAccountLoginError: function (error, wrongPassword) {
                     onboardingLayout.unwindToLoginScreen() // error handled internally
                 }
-                // onSaveBiometricsRequested: (account, credential) => {
-                //     appKeychain.saveCredential(account, credential)
-                // }
-                // onDeleteBiometricsRequested: (account) => {
-                //     appKeychain.deleteCredential(account)
-                // }
+                onSaveBiometricsRequested: (account, credential) => {
+                    appKeychain.saveCredential(account, credential)
+                }
+                onDeleteBiometricsRequested: (account) => {
+                    appKeychain.deleteCredential(account)
+                }
             }
 
             keychain: appKeychain

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -373,13 +373,9 @@ StatusWindow {
         active: false
         sourceComponent: DidYouKnowSplashScreen {
             objectName: "splashScreen"
-
-            NumberAnimation on progress {
-                from: 0.0
-                to: 1
-                duration: 30000
-                running: runningProgressAnimation
-                onFinished: {
+            NumberAnimation on progress { from: 0.0; to: 1; duration: 30000; running: runningProgressAnimation }
+            onProgressChanged: {
+                if (progress === 1) {
                     appLoadingAnimation.active = false
                     mainModule.fakeLoadingScreenFinished()
                 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -525,8 +525,11 @@ StatusWindow {
 
                 ConvertKeycardAccountPage {
                     convertKeycardAccountState: onboardingStore.convertKeycardAccountState
-                    onQuitRequested: {
+                    onRestartRequested: {
                         Qt.quit()
+                    }
+                    onBackToLoginRequested: {
+                        onboardingLayout.unwindToLoginScreen()
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17284

# Description

Nim-side:

1. Implemented `LoginWithLostKeycardSeedphrase`
2. Implemented `KeycardConvertAccountTask`
3. Added handling of keycard account conversion result 
4. Added handling of re-encryption signals
5. Introduce `moment` for post-onboarding tasks
To distinguish, should one be executed after login or when main module loaded.
6. Implemented login using mnemonic
7. Re-implement save biometrics as a post-onboarding task

QML:

1. Implemented `ConvertKeycardAccountPage` (with an according storybook page)
   - This requires conversation with design team.
2. Added re-ecnryption splash screen
   - This requires conversation with design team. I reused the standard `SplashScreen` for this. 
   - I'm not sure if the way I used `StackView` is correct, perhaps there is a better approah.
3. Added `infiniteLoading` option for `SplashScreen`.
   - This is used for the re-encryption screen.

# Screenshot

## Pre-step: create keycard account (with biometrics enabled)

https://github.com/user-attachments/assets/bdf57fae-f6fe-4576-96d8-b00eb713aa14

## Convert keycard account to regular

https://github.com/user-attachments/assets/2d96420b-10bd-4f2d-ae1a-19920c6ab466


