### PR TITLE
fix(onboarding): Incorrect Back Navigation and Button Visibility on PIN Screens

### DIFF
--- a/storybook/pages/BackupSeedphraseFlowPage.qml
+++ b/storybook/pages/BackupSeedphraseFlowPage.qml
@@ -1,10 +1,8 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
 
 import StatusQ 0.1
 import StatusQ.Core 0.1
-import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
@@ -31,12 +29,13 @@ Item {
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.BackButton
-        enabled: stack.depth > 1 && !stack.busy
+        enabled: backButton.visible
         cursorShape: undefined // fall thru
         onClicked: stack.pop()
     }
 
     StatusBackButton {
+        id: backButton
         width: 44
         height: 44
         anchors.left: parent.left

--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -5,6 +5,8 @@ import QtQuick.Layouts 1.15
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
+import utils 1.0
+
 Item {
     id: root
 
@@ -54,8 +56,8 @@ Item {
                 id: remainingAttemptsSpinBox
 
                 from: 0
-                to: 3
-                value: 3
+                to: Constants.onboarding.defaultPinAttempts
+                value: Constants.onboarding.defaultPinAttempts
             }
         }
 

--- a/storybook/pages/KeycardEnterPukPagePage.qml
+++ b/storybook/pages/KeycardEnterPukPagePage.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls 2.15
 
 import AppLayouts.Onboarding2.pages 1.0
 
+import utils 1.0
+
 Item {
     id: root
 
@@ -11,7 +13,7 @@ Item {
     KeycardEnterPukPage {
         id: page
         anchors.fill: parent
-        remainingAttempts: 3
+        remainingAttempts: Constants.onboarding.defaultPukAttempts
         tryToSetPukFunction: (puk) => {
                                  console.warn("!!! ATTEMPTED PUK:", puk)
                                  const valid = puk === root.existingPuk
@@ -28,7 +30,7 @@ Item {
             console.warn("onKeycardFactoryResetRequested")
             console.warn("!!! RESETTING FLOW")
             state = "entering"
-            remainingAttempts = 3
+            remainingAttempts = Constants.onboarding.defaultPukAttempts
         }
     }
 

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -22,8 +22,8 @@ SplitView {
 
         // keycard
         property int keycardState: Onboarding.KeycardState.NoPCSCService
-        property int keycardRemainingPinAttempts: 3
-        property int keycardRemainingPukAttempts: 5
+        property int keycardRemainingPinAttempts: Constants.onboarding.defaultPinAttempts
+        property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
     }
 
     LoginScreen {

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -43,8 +43,8 @@ SplitView {
         store.authorizationState = Onboarding.ProgressState.Idle
         store.restoreKeysExportState = Onboarding.ProgressState.Idle
         store.syncState = Onboarding.ProgressState.Idle
-        store.keycardRemainingPinAttempts = 3
-        store.keycardRemainingPukAttempts = 5
+        store.keycardRemainingPinAttempts = Constants.onboarding.defaultPinAttempts
+        store.keycardRemainingPukAttempts = Constants.onboarding.defaultPukAttempts
 
         onboarding.restartFlow()
     }
@@ -81,8 +81,8 @@ SplitView {
             property int syncState: Onboarding.ProgressState.Idle
             property var loginAccountsModel: ctrlLoginScreen.checked ? loginAccountsModel : emptyModel
 
-            property int keycardRemainingPinAttempts: 3
-            property int keycardRemainingPukAttempts: 5
+            property int keycardRemainingPinAttempts: Constants.onboarding.defaultPinAttempts
+            property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
 
             function setPin(pin: string) {
                 logs.logEvent("OnboardingStore.setPin", ["pin"], arguments)

--- a/storybook/pages/UnblockWithPukFlowPage.qml
+++ b/storybook/pages/UnblockWithPukFlowPage.qml
@@ -83,16 +83,16 @@ SplitView {
         tryToSetPukFunction: mockDriver.setPuk
         remainingAttempts: mockDriver.keycardRemainingPukAttempts
         onSetPinRequested: (pin) => {
-                                 logs.logEvent("keycardPinCreated", ["pin"], arguments)
-                                 console.warn("!!! PIN CREATED:", pin)
-                             }
+            logs.logEvent("setPinRequested", ["pin"], arguments)
+            console.warn("!!! SET PIN REQUESTED:", pin)
+        }
         onKeycardFactoryResetRequested: {
             logs.logEvent("keycardFactoryResetRequested", ["pin"], arguments)
             console.warn("!!! FACTORY RESET REQUESTED")
         }
-        onFinished: {
-            console.warn("!!! UNLOCK WITH PUK FINISHED")
-            logs.logEvent("finished")
+        onFinished: (success) => {
+            console.warn("!!! UNLOCK WITH PUK FINISHED:", success)
+            logs.logEvent("finished", ["success"], arguments)
             console.warn("!!! RESTARTING FLOW")
 
             stackView.clear()
@@ -106,11 +106,11 @@ SplitView {
 
         function reset() {
             keycardState = Onboarding.KeycardState.NoPCSCService
-            keycardRemainingPukAttempts = 3
+            keycardRemainingPukAttempts = Constants.onboarding.defaultPukAttempts
         }
 
         property int keycardState: Onboarding.KeycardState.NoPCSCService
-        property int keycardRemainingPukAttempts: 3
+        property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
 
         function setPuk(puk) { // -> bool
             logs.logEvent("setPuk", ["puk"], arguments)

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -59,8 +59,8 @@ Item {
                 readonly property int pinSettingState: mockDriver.pinSettingState // enum Onboarding.ProgressState
                 readonly property int authorizationState: mockDriver.authorizationState // enum Onboarding.ProgressState
                 readonly property int restoreKeysExportState: mockDriver.restoreKeysExportState // enum Onboarding.ProgressState
-                property int keycardRemainingPinAttempts: 3
-                property int keycardRemainingPukAttempts: 5
+                property int keycardRemainingPinAttempts: Constants.onboarding.defaultPinAttempts
+                property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
                 property var loginAccountsModel: emptyModel
 
                 function setPin(pin: string) {

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -43,7 +43,7 @@ SQUtils.QObject {
         id: d
 
         property bool withNewSeedphrase
-        property var mnemonic
+        property string mnemonic
 
         function initialComponent() {
             if (root.keycardState === Onboarding.KeycardState.Empty)
@@ -113,17 +113,13 @@ SQUtils.QObject {
     Component {
         id: backupSeedRevealPage
         BackupSeedphraseReveal {
-            Component.onCompleted: {
-                try {
-                    d.mnemonic = root.generateMnemonic()
-                    root.seedphraseSubmitted(d.mnemonic)
-                } catch (e) {
-                    console.error('failed to generate mnemonic', e)
-                }
-            }
+            Component.onCompleted: d.mnemonic = root.generateMnemonic()
             mnemonic: d.mnemonic
 
-            onBackupSeedphraseConfirmed: root.stackView.push(backupSeedVerifyPage)
+            onBackupSeedphraseConfirmed: {
+                root.seedphraseSubmitted(d.mnemonic)
+                root.stackView.push(backupSeedVerifyPage)
+            }
         }
     }
 
@@ -165,6 +161,8 @@ SQUtils.QObject {
         id: keycardCreatePinPage
 
         KeycardCreatePinDelayedPage {
+            readonly property bool backAvailableHint: !success && !pinSettingInProgress
+
             pinSettingState: root.pinSettingState
             authorizationState: root.authorizationState
 
@@ -173,7 +171,7 @@ SQUtils.QObject {
 
             onFinished: {
                 if (d.withNewSeedphrase) {
-                    root.stackView.push(backupSeedIntroPage)
+                    root.stackView.replace(backupSeedIntroPage)
                 } else {
                     root.loadMnemonicRequested()
                     root.stackView.push(addKeypairPage)

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -91,6 +91,8 @@ SQUtils.QObject {
         id: keycardCreatePinPage
 
         KeycardCreatePinDelayedPage {
+            readonly property bool backAvailableHint: !success && !pinSettingInProgress
+
             authorizationState: root.authorizationState
             pinSettingState: root.pinSettingState
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -135,11 +135,12 @@ Page {
         anchors.fill: parent
         acceptedButtons: Qt.BackButton
         cursorShape: undefined // don't override the cursor coming from the stack
-        enabled: stack.depth > 1 && !stack.busy
+        enabled: backButton.visible
         onClicked: stack.pop()
     }
 
     StatusBackButton {
+        id: backButton
         width: 44
         height: 44
         anchors.left: parent.left

--- a/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
@@ -128,8 +128,7 @@ Control {
         // normal/intro states
         State {
             name: "plugin"
-            when: root.keycardState === Onboarding.KeycardState.PluginReader ||
-                  root.keycardState === -1
+            when: root.keycardState === Onboarding.KeycardState.PluginReader
             PropertyChanges {
                 target: infoText
                 text: qsTr("Plug in Keycard reader...")
@@ -163,21 +162,22 @@ Control {
         },
         State {
             name: "wrongKeycard"
-            when: root.keycardState === Onboarding.KeycardState.WrongKeycard ||
-                  root.keycardState === Onboarding.KeycardState.MaxPairingSlotsReached
+            when: root.keycardState === Onboarding.KeycardState.WrongKeycard
             PropertyChanges {
                 target: infoText
                 color: Theme.palette.dangerColor1
-                text: qsTr("Wrong Keycard for this profile inserted.<br>Remove card and insert the correct one.")
+                text: qsTr("Wrong Keycard for this profile inserted")
             }
         },
         State {
-            name: "noService"
-            when: root.keycardState === Onboarding.KeycardState.NoPCSCService
+            name: "genericError"
+            when: root.keycardState === -1 ||
+                  root.keycardState === Onboarding.KeycardState.NoPCSCService ||
+                  root.keycardState === Onboarding.KeycardState.MaxPairingSlotsReached // TODO add a generic/fallback keycard error here too
             PropertyChanges {
                 target: infoText
                 color: Theme.palette.dangerColor1
-                text: qsTr("Smartcard reader service unavailable")
+                text: qsTr("Issue detecting Keycard.<br>Remove and re-insert reader and Keycard.")
             }
         },
         State {

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinPage.qml
@@ -13,6 +13,8 @@ KeycardBasePage {
 
     property bool success
 
+    readonly property bool pinSettingInProgress: d.state === "settingInProgress"
+
     signal setPinRequested(string pin)
 
     image.source: Theme.png("onboarding/keycard/reading")
@@ -129,10 +131,6 @@ KeycardBasePage {
                 PropertyChanges {
                     target: loadingIndicator
                     visible: true
-                }
-                PropertyChanges {
-                    target: root
-                    image.source: Theme.png("onboarding/keycard/success")
                 }
                 StateChangeScript {
                     script: {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -418,6 +418,9 @@ QtObject {
                 readonly property string watchOnlyAccounts: "watchOnlyAccounts"
             }
         }
+
+        readonly property int defaultPinAttempts: 3
+        readonly property int defaultPukAttempts: 5
     }
 
     readonly property QtObject onlineStatus: QtObject{


### PR DESCRIPTION
### What does the PR do

For the PIN pages:
- add a `pinSettingInProgress` bool hint to `KeycardCreatePinPage` when setting/authorizing the PIN is in progress to be able to correctly display the Back button
- don't display the "success" image yet when in progress
- use the hint in related flows

For the backup seed phrase sequence:
- the mnemonic is a string and gets submitted when exiting the BackupSeedphraseReveal, not right after its (re)creation
- when starting the flow (going from `KeycardCreatePinDelayedPage`), replace instead of push, so that Back skips the PIN page
- fixup the related SB pages

Fixes https://github.com/status-im/status-desktop/issues/17218

### Affected areas

Onboarding/Create profile on empty Keycard

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/c0013078-db04-403b-8c5a-198d574413f7

