### PR TITLE
Onboarding: `KeycardEnterPinPage` cleanup

### DIFF
--- a/storybook/pages/KeycardEnterPinPagePage.qml
+++ b/storybook/pages/KeycardEnterPinPagePage.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import AppLayouts.Onboarding2.pages 1.0
-import AppLayouts.Onboarding.enums 1.0
 
 Item {
     id: root
@@ -14,7 +13,8 @@ Item {
         id: page
         anchors.fill: parent
 
-        authorizationState: authorizationProgressSelector.value
+        state: KeycardEnterPinPage.State.Idle
+
         remainingAttempts: remainingAttemptsSpinBox.value
 
         unblockWithPukAvailable: ctrlUnblockWithPUK.checked
@@ -59,10 +59,34 @@ Item {
             }
         }
 
-        ProgressSelector {
-            id: authorizationProgressSelector
+        RowLayout {
+            id: statesRow
 
-            label: "Authorization progress"
+            ButtonGroup {
+                buttons: statesRow.children
+            }
+
+            Button {
+                checkable: true
+                checked: true
+                text: "Idle"
+                onClicked: page.state = KeycardEnterPinPage.State.Idle
+            }
+            Button {
+                checkable: true
+                text: "InProgress"
+                onClicked: page.state = KeycardEnterPinPage.State.InProgress
+            }
+            Button {
+                checkable: true
+                text: "Success"
+                onClicked: page.state = KeycardEnterPinPage.State.Success
+            }
+            Button {
+                checkable: true
+                text: "WrongPin"
+                onClicked: page.state = KeycardEnterPinPage.State.WrongPin
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -79,7 +79,20 @@ SQUtils.QObject {
         KeycardEnterPinPage {
             id: page
 
-            authorizationState: root.authorizationState
+            state: {
+                switch (root.authorizationState) {
+                case Onboarding.ProgressState.Success:
+                    return KeycardEnterPinPage.State.Success
+                case Onboarding.ProgressState.InProgress:
+                    return KeycardEnterPinPage.State.InProgress
+                // workaround by mapping all failures as wrong pin (#17289)
+                case Onboarding.ProgressState.Failed:
+                    return KeycardEnterPinPage.State.WrongPin
+                }
+
+                return KeycardEnterPinPage.State.Idle
+            }
+
             remainingAttempts: root.remainingPinAttempts
             unblockWithPukAvailable: root.remainingPukAttempts > 0
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -132,7 +132,7 @@ SQUtils.QObject {
 
         function onAuthorizationStateChanged() {
             // workaround for entering pin because currently there is not possible
-            // to distinguish invalid pin and failed pin entering operation
+            // to distinguish invalid pin and failed pin entering operation (#17289)
             if (root.stackView.currentItem instanceof KeycardEnterPinPage)
                 return
 


### PR DESCRIPTION
### What does the PR do

- removes unused internal components from `KeycardEnterPinPage`
- removes dependency on `authorizationState`, exposes `state` property taking own self-defined enum
- mapping authorization failed state to wrong pin state until #17289 is solved

### Affected areas
`KeycardEnterPinPage`
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)