### PR TITLE
fix/17291: Fix sending 0 eth & review send after reject enabled

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -279,7 +279,8 @@ StatusDialog {
         })
 
         readonly property var debounceSetSelectedAmount: Backpressure.debounce(root, 1000, function() {
-            if(amountToSend.amount !== "0" && amountToSend.amount !== root.selectedRawAmount)
+            if(!(amountToSend.amount === "0" && amountToSend.empty)
+                    && amountToSend.amount !== root.selectedRawAmount)
                 root.selectedRawAmount = amountToSend.amount
         })
 
@@ -522,6 +523,12 @@ StatusDialog {
                     onVisibleChanged: if(visible) forceActiveFocus()
 
                     onAmountChanged: d.debounceSetSelectedAmount()
+                    onTextChanged: {
+                        // Only needed to assign value when amount in entered first time
+                        if(!root.selectedRawAmount) {
+                            d.debounceSetSelectedAmount()
+                        }
+                    }
 
                     bottomRightComponent: MaxSendButton {
                         id: maxButton

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -589,6 +589,14 @@ QtObject {
                     }
                 }
 
+                function handleReject() {
+                    if (handler.approvalForTxPathUnderReviewReviewed) {
+                        handler.approvalForTxPathUnderReviewReviewed = false
+                    } else {
+                        handler.indexOfTxPathUnderReview--
+                    }
+                }
+
                 function routesFetched(returnedUuid, pathModel, errCode, errDescription) {
                     simpleSendModal.routesLoading = false
                     if(returnedUuid !== handler.uuid) {
@@ -608,6 +616,7 @@ QtObject {
                         return
                     }
                     if (!!error) {
+                        handleReject()
                         if (error.includes(Constants.walletSection.authenticationCanceled)) {
                             return
                         }
@@ -855,7 +864,10 @@ QtObject {
                     fnGetOpenSeaExplorerUrl: root.fnGetOpenSeaUrl
 
                     onOpened: handler.sendMetricsEvent("sign modal opened")
-                    onRejected: handler.sendMetricsEvent("sign modal rejected")
+                    onRejected:{
+                        handler.sendMetricsEvent("sign modal rejected")
+                        handler.handleReject()
+                    }
                     onAccepted: {
                         handler.sendMetricsEvent("sign modal accepted")
                         if (handler.reviewingLastTxPath) {


### PR DESCRIPTION
### What does the PR do

This PR fixes below issues-
1. Sending 0 eth or any ERC20 is now working
2. Sending after rejecting review send is now enabled 

### Affected areas

Simple Send

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

https://github.com/user-attachments/assets/b16ad795-562c-44b2-83a6-dab509da381b

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
