### PR TITLE
Onboarding: Flows based on own StackView

### DIFF
--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -64,10 +64,10 @@ SplitView {
         SplitView.fillHeight: true
 
         readonly property Item currentPage: {
-            if (stack.currentItem instanceof Loader)
-                return stack.currentItem.item
+            if (stack.topLevelItem instanceof Loader)
+                return stack.topLevelItem.item
 
-            return stack.currentItem
+            return stack.topLevelItem
         }
 
         onboardingStore: OnboardingStore {
@@ -386,21 +386,29 @@ SplitView {
             TextField {
                 Layout.fillWidth: true
 
+                function stackToText(stack) {
+                    let content = ""
+
+                    for (let i = 0; i < stack.depth; i++) {
+                        const stackEntry = stack.get(i, StackView.ForceLoad)
+
+                        if (stackEntry instanceof StackView)
+                            content += " [" + InspectionUtils.baseName(stackEntry) + ": " + stackToText(stackEntry) + "]"
+                        else
+                            content += " " + InspectionUtils.baseName(stackEntry instanceof Loader
+                                                                    ? stackEntry.item : stackEntry)
+                    }
+
+                    return content
+                }
+
                 text: {
                     const stack = onboarding.stack
 
                     // trigger change when only curret item changes on replace
-                    stack.currentItem
+                    stack.topLevelItem
 
-                    let content = `Stack (${stack.depth}):`
-
-                    for (let i = 0; i < stack.depth; i++) {
-                        const stackEntry = stack.get(i, StackView.ForceLoad)
-                        content += " " + InspectionUtils.baseName(stackEntry instanceof Loader
-                                                                  ? stackEntry.item : stackEntry)
-                    }
-
-                    return content
+                    return `Stack (${stack.totalDepth}): ${stackToText(stack)}`
                 }
 
                 background: null

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -156,17 +156,25 @@ Item {
         name: "OnboardingLayout"
         when: windowShown
 
-        function init() {
-            controlUnderTest = createTemporaryObject(componentUnderTest, root)
-
-            // disable animated transitions to speed-up tests
-            const stack = findChild(controlUnderTest, "stack")
+        function disableTransitions(stack) {
             stack.pushEnter = null
             stack.pushExit = null
             stack.popEnter = null
             stack.popExit = null
             stack.replaceEnter = null
             stack.replaceExit = null
+        }
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+
+            // disable animated transitions to speed-up tests
+            const stack = controlUnderTest.stack
+
+            disableTransitions(stack)
+            stack.topLevelStackChanged.connect(() => {
+                disableTransitions(stack.topLevelStack)
+            })
         }
 
         function cleanup() {
@@ -191,15 +199,15 @@ Item {
             if (!stack || !pageClass)
                 fail("getCurrentPage: expected param 'stack' or 'pageClass' empty")
             verify(!!stack)
-            tryCompare(stack, "busy", false) // wait for page transitions to stop
+            tryCompare(stack, "topLevelStackBusy", false) // wait for page transitions to stop
 
-            if (stack.currentItem instanceof Loader) {
-                verify(stack.currentItem.item instanceof pageClass)
-                return stack.currentItem.item
+            if (stack.topLevelItem instanceof Loader) {
+                verify(stack.topLevelItem.item instanceof pageClass)
+                return stack.topLevelItem.item
             }
 
-            verify(stack.currentItem instanceof pageClass)
-            return stack.currentItem
+            verify(stack.topLevelItem instanceof pageClass)
+            return stack.topLevelItem
         }
 
         // common variant data for all flow related TDD tests
@@ -226,7 +234,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.biometricsAvailable = data.biometrics
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -338,7 +346,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.biometricsAvailable = data.biometrics
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -435,7 +443,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.biometricsAvailable = data.biometrics
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -482,7 +490,7 @@ Item {
             mockDriver.authorizationState = Onboarding.AuthorizationState.Authorized
 
             // PAGE 7: Backup your recovery phrase (intro)
-            dynamicSpy.setup(stack, "currentItemChanged")
+            dynamicSpy.setup(stack, "topLevelItemChanged")
             tryCompare(dynamicSpy, "count", 1)
             page = getCurrentPage(stack, BackupSeedphraseIntro)
             const btnBackupSeedphrase = findChild(page, "btnBackupSeedphrase")
@@ -553,7 +561,7 @@ Item {
 
             // PAGE 13: Enable Biometrics
             if (data.biometrics) {
-                dynamicSpy.setup(stack, "currentItemChanged")
+                dynamicSpy.setup(stack, "topLevelItemChanged")
                 tryCompare(dynamicSpy, "count", 1)
 
                 page = getCurrentPage(stack, EnableBiometricsPage)
@@ -581,7 +589,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.biometricsAvailable = data.biometrics
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -640,7 +648,7 @@ Item {
             mockDriver.authorizationState = Onboarding.AuthorizationState.Authorized
 
             // PAGE 8: Adding key pair to Keycard
-            dynamicSpy.setup(stack, "currentItemChanged")
+            dynamicSpy.setup(stack, "topLevelItemChanged")
             tryCompare(dynamicSpy, "count", 1)
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
@@ -648,7 +656,7 @@ Item {
 
             // PAGE 9: Enable Biometrics
             if (controlUnderTest.biometricsAvailable) {
-                dynamicSpy.setup(stack, "currentItemChanged")
+                dynamicSpy.setup(stack, "topLevelItemChanged")
                 tryCompare(dynamicSpy, "count", 1)
 
                 page = getCurrentPage(stack, EnableBiometricsPage)
@@ -676,7 +684,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.biometricsAvailable = data.biometrics
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -769,7 +777,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.biometricsAvailable = data.biometrics
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -862,7 +870,7 @@ Item {
             controlUnderTest.biometricsAvailable = data.biometrics
             mockDriver.existingPin = "123456"
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Welcome
@@ -909,7 +917,7 @@ Item {
 
             // PAGE 7: Enable Biometrics
             if (data.biometrics) {
-                dynamicSpy.setup(stack, "currentItemChanged")
+                dynamicSpy.setup(stack, "topLevelItemChanged")
                 tryCompare(dynamicSpy, "count", 1)
 
                 page = getCurrentPage(stack, EnableBiometricsPage)
@@ -1100,7 +1108,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.onboardingStore.loginAccountsModel = loginAccountsModel
 
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             // PAGE 1: Login screen
@@ -1185,7 +1193,7 @@ Item {
             controlUnderTest.onboardingStore.loginAccountsModel = loginAccountsModel
 
             // PAGE 1: Login screen
-            const stack = findChild(controlUnderTest, "stack")
+            const stack = controlUnderTest.stack
             verify(!!stack)
 
             let page = getCurrentPage(stack, LoginScreen)
@@ -1240,7 +1248,7 @@ Item {
             mockDriver.authorizationState = Onboarding.AuthorizationState.Authorized
 
             // PAGE 6: Adding key pair to Keycard
-            dynamicSpy.setup(stack, "currentItemChanged")
+            dynamicSpy.setup(stack, "topLevelItemChanged")
             tryCompare(dynamicSpy, "count", 1)
             page = getCurrentPage(stack, KeycardAddKeyPairPage)
             tryCompare(page, "addKeyPairState", Onboarding.ProgressState.InProgress)
@@ -1290,7 +1298,7 @@ Item {
             mouseClick(button)
 
             tryVerify(() => {
-                const currentPage = controlUnderTest.stack.currentItem
+                const currentPage = controlUnderTest.stack.topLevelItem
                 return !!currentPage && currentPage instanceof data.landingPage
             })
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/RecursiveStackView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/RecursiveStackView.qml
@@ -10,7 +10,7 @@ import QtQuick.Controls 2.15
     a convenient way.
 */
 StackView {
-    // this stack of nested one if currentItem is RecursiveStackView, recusively
+    // this stack or nested one if currentItem is RecursiveStackView, recusively
     readonly property RecursiveStackView topLevelStack: {
         if (currentItem instanceof RecursiveStackView)
             return currentItem.topLevelStack
@@ -18,11 +18,11 @@ StackView {
         return this
     }
 
-    // busy flag of this stack of nested one if currentItem is
+    // busy flag of this stack or nested one if currentItem is
     // RecursiveStackView, recusively
     readonly property bool topLevelStackBusy: topLevelStack.busy
 
-    // currentItem of this stack of the nested stack if currentItem is
+    // currentItem of this stack or the nested stack if currentItem is
     // RecursiveStackView, recursively
     readonly property Item topLevelItem: {
         if (currentItem instanceof RecursiveStackView)
@@ -31,7 +31,7 @@ StackView {
         return currentItem
     }
 
-    // total depth taking into account depth of nested stacks
+    // total depth, taking into account depth of nested stacks
     readonly property int totalDepth: {
         if (currentItem instanceof RecursiveStackView)
             return depth - 1 + currentItem.depth

--- a/ui/StatusQ/src/StatusQ/Core/Utils/RecursiveStackView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/RecursiveStackView.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+/*!
+   \qmltype RecursiveStackView
+   \inherits StackView
+   \inqmlmodule StatusQ.Core.Utils
+
+   \brief A utility wrapper over StackView allowing to compose StackViews in
+    a convenient way.
+*/
+StackView {
+    // this stack of nested one if currentItem is RecursiveStackView, recusively
+    readonly property RecursiveStackView topLevelStack: {
+        if (currentItem instanceof RecursiveStackView)
+            return currentItem.topLevelStack
+
+        return this
+    }
+
+    // busy flag of this stack of nested one if currentItem is
+    // RecursiveStackView, recusively
+    readonly property bool topLevelStackBusy: topLevelStack.busy
+
+    // currentItem of this stack of the nested stack if currentItem is
+    // RecursiveStackView, recursively
+    readonly property Item topLevelItem: {
+        if (currentItem instanceof RecursiveStackView)
+            return currentItem.topLevelItem
+
+        return currentItem
+    }
+
+    // total depth taking into account depth of nested stacks
+    readonly property int totalDepth: {
+        if (currentItem instanceof RecursiveStackView)
+            return depth - 1 + currentItem.depth
+
+        return depth
+    }
+
+    // pops from the current stack or nested one
+    function popTopLevelItem(operation = StackView.Transition) {
+        if (topLevelStack.depth === 1)
+            topLevelStack.StackView.view.pop(operation)
+        else
+            topLevelStack.pop(operation)
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -11,6 +11,7 @@ ModelChangeTracker 0.1 ModelChangeTracker.qml
 ModelEntryChangeTracker 0.1 ModelEntryChangeTracker.qml
 ModelsComparator 0.1 ModelsComparator.qml
 QObject 0.1 QObject.qml
+RecursiveStackView 0.1 RecursiveStackView.qml
 SearchFilter 0.1 SearchFilter.qml
 StackViewStates 0.1 StackViewStates.qml
 StatesStack 0.1 StatesStack.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -206,6 +206,7 @@
         <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
         <file>StatusQ/Core/Utils/OperatorsUtils.qml</file>
         <file>StatusQ/Core/Utils/QObject.qml</file>
+        <file>StatusQ/Core/Utils/RecursiveStackView.qml</file>
         <file>StatusQ/Core/Utils/SearchFilter.qml</file>
         <file>StatusQ/Core/Utils/StackViewStates.qml</file>
         <file>StatusQ/Core/Utils/StatesStack.qml</file>

--- a/ui/app/AppLayouts/Onboarding2/CreateNewProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/CreateNewProfileFlow.qml
@@ -1,30 +1,17 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
-
-import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Onboarding2.pages 1.0
 
-
-SQUtils.QObject {
+OnboardingStackView {
     id: root
 
-    required property StackView stackView
     required property var passwordStrengthScoreFunction
 
     signal finished(string password)
 
-    function init() {
-        root.stackView.push(createPasswordPage)
-    }
+    initialItem: CreatePasswordPage {
+        passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
 
-    Component {
-        id: createPasswordPage
-
-        CreatePasswordPage {
-            passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
-
-            onSetPasswordRequested: root.finished(password)
-        }
+        onSetPasswordRequested: root.finished(password)
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -1,18 +1,11 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
-
-import StatusQ.Core.Utils 0.1 as SQUtils
-import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-import utils 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
-
-    required property StackView stackView
 
     required property int keycardState
     required property int pinSettingState
@@ -32,12 +25,9 @@ SQUtils.QObject {
     signal seedphraseSubmitted(string seedphrase)
 
     signal authorizationRequested
-
     signal finished(bool withNewSeedphrase)
 
-    function init() {
-        root.stackView.push(d.initialComponent())
-    }
+    initialItem: d.initialComponent()
 
     QtObject {
         id: d
@@ -65,8 +55,8 @@ SQUtils.QObject {
             factoryResetAvailable: true
 
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-            onEmptyKeycardDetected: root.stackView.replace(createKeycardProfilePage)
-            onNotEmptyKeycardDetected: root.stackView.replace(keycardNotEmptyPage)
+            onEmptyKeycardDetected: root.replace(createKeycardProfilePage)
+            onNotEmptyKeycardDetected: root.replace(keycardNotEmptyPage)
         }
     }
 
@@ -76,11 +66,11 @@ SQUtils.QObject {
         CreateKeycardProfilePage {
             onCreateKeycardProfileWithNewSeedphrase: {
                 d.withNewSeedphrase = true
-                root.stackView.push(keycardCreatePinPage)
+                root.push(keycardCreatePinPage)
             }
             onCreateKeycardProfileWithExistingSeedphrase: {
                 d.withNewSeedphrase = false
-                root.stackView.push(seedphrasePage)
+                root.push(seedphrasePage)
             }
         }
     }
@@ -98,7 +88,7 @@ SQUtils.QObject {
         id: backupSeedIntroPage
 
         BackupSeedphraseIntro {
-            onBackupSeedphraseRequested: root.stackView.push(backupSeedAcksPage)
+            onBackupSeedphraseRequested: root.push(backupSeedAcksPage)
         }
     }
 
@@ -106,7 +96,7 @@ SQUtils.QObject {
         id: backupSeedAcksPage
 
         BackupSeedphraseAcks {
-            onBackupSeedphraseContinue: root.stackView.push(backupSeedRevealPage)
+            onBackupSeedphraseContinue: root.push(backupSeedRevealPage)
         }
     }
 
@@ -118,7 +108,7 @@ SQUtils.QObject {
 
             onBackupSeedphraseConfirmed: {
                 root.seedphraseSubmitted(d.mnemonic)
-                root.stackView.push(backupSeedVerifyPage)
+                root.push(backupSeedVerifyPage)
             }
         }
     }
@@ -128,7 +118,7 @@ SQUtils.QObject {
         BackupSeedphraseVerify {
             mnemonic: d.mnemonic
             countToVerify: 4
-            onBackupSeedphraseVerified: root.stackView.push(backupSeedOutroPage)
+            onBackupSeedphraseVerified: root.push(backupSeedOutroPage)
         }
     }
 
@@ -138,7 +128,7 @@ SQUtils.QObject {
         BackupSeedphraseOutro {
             onBackupSeedphraseRemovalConfirmed: {
                 root.loadMnemonicRequested()
-                root.stackView.push(addKeypairPage)
+                root.push(addKeypairPage)
             }
         }
     }
@@ -152,7 +142,7 @@ SQUtils.QObject {
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
-                root.stackView.push(keycardCreatePinPage)
+                root.push(keycardCreatePinPage)
             }
         }
     }
@@ -171,10 +161,10 @@ SQUtils.QObject {
 
             onFinished: {
                 if (d.withNewSeedphrase) {
-                    root.stackView.replace(backupSeedIntroPage)
+                    root.replace(backupSeedIntroPage)
                 } else {
                     root.loadMnemonicRequested()
-                    root.stackView.push(addKeypairPage)
+                    root.push(addKeypairPage)
                 }
             }
         }

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -1,16 +1,10 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
-
-import StatusQ.Core.Utils 0.1 as SQUtils
-import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
-
-    required property StackView stackView
 
     required property int keycardState
     required property int addKeyPairState
@@ -33,22 +27,14 @@ SQUtils.QObject {
 
     signal finished
 
-    function init() {
-        root.stackView.push(d.initialComponent())
-    }
+    initialItem: {
+        if (root.keycardState === Onboarding.KeycardState.Empty)
+            return seedphrasePage
 
-    QtObject {
-        id: d
+        if (root.keycardState === Onboarding.KeycardState.NotEmpty)
+            return keycardNotEmptyPage
 
-        function initialComponent() {
-            if (root.keycardState === Onboarding.KeycardState.Empty)
-                return seedphrasePage
-
-            if (root.keycardState === Onboarding.KeycardState.NotEmpty)
-                return keycardNotEmptyPage
-
-            return keycardIntroPage
-        }
+        return keycardIntroPage
     }
 
     Component {
@@ -59,8 +45,8 @@ SQUtils.QObject {
             displayPromoBanner: root.displayKeycardPromoBanner
 
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
-            onEmptyKeycardDetected: root.stackView.replace(seedphrasePage)
-            onNotEmptyKeycardDetected: root.stackView.replace(keycardNotEmptyPage)
+            onEmptyKeycardDetected: root.replace(seedphrasePage)
+            onNotEmptyKeycardDetected: root.replace(keycardNotEmptyPage)
         }
     }
 
@@ -82,7 +68,7 @@ SQUtils.QObject {
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
-                root.stackView.push(keycardCreatePinPage)
+                root.push(keycardCreatePinPage)
             }
         }
     }
@@ -101,7 +87,7 @@ SQUtils.QObject {
 
             onFinished: {
                 root.loadMnemonicRequested()
-                root.stackView.push(addKeypairPage)
+                root.push(addKeypairPage)
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding2/KeycardFactoryResetFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardFactoryResetFlow.qml
@@ -1,41 +1,25 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
 
-    required property StackView stackView
     required property int keycardState
+    property bool fromLoginScreen
 
     signal performKeycardFactoryResetRequested
 
     signal finished
 
-    function init(fromLoginScreen = false) {
-        d.fromLoginScreen = fromLoginScreen
-        root.stackView.push(d.initialComponent())
-    }
-
-    QtObject {
-        id: d
-
-        property bool fromLoginScreen
-
-        function initialComponent() {
-            if (root.keycardState === Onboarding.KeycardState.FactoryResetting)
-                return keycardResetPageComponent
-            return keycardResetAcks
-        }
-    }
+    initialItem: root.keycardState === Onboarding.KeycardState.FactoryResetting
+                 ? keycardResetPageComponent : keycardResetAcks
 
     Component {
         id: keycardResetAcks
@@ -64,7 +48,7 @@ SQUtils.QObject {
                     enabled: ack.checked
                     onClicked: {
                         root.performKeycardFactoryResetRequested()
-                        root.stackView.replace(null, keycardResetPageComponent)
+                        root.replace(null, keycardResetPageComponent)
                     }
                 }
             ]
@@ -99,7 +83,8 @@ SQUtils.QObject {
                     visible: !keycardResetPage.resetting
                     anchors.horizontalCenter: parent.horizontalCenter
                     width: 320
-                    text: d.fromLoginScreen ? qsTr("Back to Login screen") : qsTr("Log in or Create profile")
+                    text: root.fromLoginScreen ? qsTr("Back to Login screen")
+                                               : qsTr("Log in or Create profile")
                     onClicked: root.finished()
                 }
             ]

--- a/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginBySyncingFlow.qml
@@ -1,15 +1,12 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-import StatusQ.Core.Utils 0.1 as SQUtils
-
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
 
-    required property StackView stackView
     required property var validateConnectionString
     required property int syncState
 
@@ -17,20 +14,12 @@ SQUtils.QObject {
     signal loginWithSeedphraseRequested
     signal finished
 
-    function init() {
-        root.stackView.push(loginBySyncPage)
-    }
+    initialItem: LoginBySyncingPage {
+        validateConnectionString: root.validateConnectionString
 
-    Component {
-        id: loginBySyncPage
-
-        LoginBySyncingPage {
-            validateConnectionString: root.validateConnectionString
-
-            onSyncProceedWithConnectionString: {
-                root.syncProceedWithConnectionString(connectionString)
-                root.stackView.push(syncProgressPage)
-            }
+        onSyncProceedWithConnectionString: {
+            root.syncProceedWithConnectionString(connectionString)
+            root.push(syncProgressPage)
         }
     }
 
@@ -44,7 +33,7 @@ SQUtils.QObject {
             syncState: root.syncState
 
             onLoginToAppRequested: root.finished()
-            onRestartSyncRequested: root.stackView.pop()
+            onRestartSyncRequested: root.pop()
 
             onLoginWithSeedphraseRequested: root.loginWithSeedphraseRequested()
         }

--- a/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/LoginWithKeycardFlow.qml
@@ -1,16 +1,13 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
-
-    required property StackView stackView
 
     required property int keycardState
     required property int authorizationState
@@ -30,22 +27,14 @@ SQUtils.QObject {
     signal exportKeysRequested
     signal finished
 
-    function init() {
-        root.stackView.push(d.initialComponent())
-    }
+    initialItem: {
+        if (root.keycardState === Onboarding.KeycardState.Empty)
+            return keycardEmptyPage
 
-    QtObject {
-        id: d
+        if (root.keycardState === Onboarding.KeycardState.NotEmpty)
+            return keycardEnterPinPage
 
-        function initialComponent() {
-            if (root.keycardState === Onboarding.KeycardState.Empty)
-                return keycardEmptyPage
-
-            if (root.keycardState === Onboarding.KeycardState.NotEmpty)
-                return keycardEnterPinPage
-
-            return keycardIntroPage
-        }
+        return keycardIntroPage
     }
 
     Component {
@@ -60,8 +49,8 @@ SQUtils.QObject {
             onKeycardFactoryResetRequested: root.keycardFactoryResetRequested()
             onUnblockWithSeedphraseRequested: root.unblockWithSeedphraseRequested()
             onUnblockWithPukRequested: root.unblockWithPukRequested()
-            onEmptyKeycardDetected: root.stackView.replace(keycardEmptyPage)
-            onNotEmptyKeycardDetected: root.stackView.replace(keycardEnterPinPage)
+            onEmptyKeycardDetected: root.replace(keycardEmptyPage)
+            onNotEmptyKeycardDetected: root.replace(keycardEnterPinPage)
         }
     }
 
@@ -109,7 +98,7 @@ SQUtils.QObject {
 
                     const doNext = () => {
                         root.exportKeysRequested()
-                        root.stackView.replace(keycardExtractingKeysPage)
+                        root.replace(keycardExtractingKeysPage)
                     }
 
                     Backpressure.debounce(page, root.keycardPinInfoPageDelay,

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -9,10 +9,8 @@ import StatusQ.Core.Utils 0.1 as SQUtils
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
-
-    required property StackView stackView
 
     required property var loginAccountsModel
 
@@ -61,8 +59,8 @@ SQUtils.QObject {
 
     signal finished(int flow)
 
-    function init() {
-        root.stackView.push(entryPage)
+    function restart() {
+        replace(null, initialComponent)
     }
 
     function setBiometricResponse(secret: string, error = "",
@@ -85,18 +83,18 @@ SQUtils.QObject {
 
         function pushOrSkipBiometricsPage() {
             if (root.biometricsAvailable) {
-                root.stackView.replace(null, enableBiometricsPage)
+                root.replace(null, enableBiometricsPage)
             } else {
                 root.finished(d.flow)
             }
         }
 
         function openPrivacyPolicyPopup() {
-            privacyPolicyPopup.createObject(root.stackView).open()
+            privacyPolicyPopup.createObject(root).open()
         }
 
         function openTermsOfUsePopup() {
-            termsOfUsePopup.createObject(root.stackView).open()
+            termsOfUsePopup.createObject(root).open()
         }
 
         function handleKeycardProgressFailedState(state) {
@@ -110,28 +108,12 @@ SQUtils.QObject {
         }
 
         function handleKeycardFailedState() {
-            // find index of first page in the flow
-            let idx = 0
-            const entryItem = stackView.find((item, index) => {
-                idx = index
-                // Loader is the type of first page (wrapping welcome page or login screen)
-                return item instanceof Loader
-            })
-
-            // when the initial page is not found, because e.g. the flow is not initialized
-            // or the stack was cleared
-            if (!entryItem)
-                return
-
-            // replace the second page in the flow
-            stackView.replace(stackView.get(idx + 1), errorPage)
+            root.replace(root.get(1), errorPage)
         }
     }
 
     Connections {
-        enabled: !(root.stackView.currentItem instanceof Loader) &&
-                 !(root.stackView.currentItem instanceof KeycardErrorPage) &&
-                 !(root.stackView.currentItem instanceof EnableBiometricsPage)
+        enabled: root.depth > 1 && !(root.currentItem instanceof KeycardErrorPage)
 
         function onPinSettingStateChanged() {
             d.handleKeycardProgressFailedState(pinSettingState)
@@ -150,8 +132,10 @@ SQUtils.QObject {
         }
     }
 
+    initialItem: initialComponent
+
     Component {
-        id: entryPage
+        id: initialComponent
 
         Loader {
             sourceComponent: loginAccountsModel.ModelCount.empty ? welcomePage
@@ -165,8 +149,8 @@ SQUtils.QObject {
         KeycardErrorPage {
             readonly property bool backAvailableHint: false
 
-            onTryAgainRequested: root.stackView.pop()
-            onFactoryResetRequested: keycardFactoryResetFlow.init()
+            onTryAgainRequested: root.pop()
+            onFactoryResetRequested: root.push(keycardFactoryResetFlow)
         }
     }
 
@@ -176,13 +160,13 @@ SQUtils.QObject {
         WelcomePage {
             function pushWithProxy(component) {
                 if (d.seenUsageDataPrompt) { // don't ask for "Share usage data" a second time (e.g. after a factory reset)
-                    root.stackView.push(component)
+                    root.push(component)
                 } else {
-                    const page = root.stackView.push(helpUsImproveStatusPage)
+                    const page = root.push(helpUsImproveStatusPage)
 
                     page.shareUsageDataRequested.connect(enabled => {
                         root.shareUsageDataRequested(enabled)
-                        root.stackView.push(component)
+                        root.push(component)
                         d.seenUsageDataPrompt = true
                     })
                 }
@@ -213,15 +197,15 @@ SQUtils.QObject {
             onBiometricsRequested: (profileId) => root.biometricsRequested(profileId)
             onDismissBiometricsRequested: root.dismissBiometricsRequested()
             onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
-            onOnboardingCreateProfileFlowRequested: root.stackView.push(createProfilePage)
-            onOnboardingLoginFlowRequested: root.stackView.push(loginPage)
+            onOnboardingCreateProfileFlowRequested: root.push(createProfilePage)
+            onOnboardingLoginFlowRequested: root.push(loginPage)
             onLostKeycardFlowRequested: () => {
                                root.keyUidSubmitted(loginScreen.selectedProfileKeyId)
-                               root.stackView.push(keycardLostPage)
+                               root.push(keycardLostPage)
                            }
 
-            onUnblockWithSeedphraseRequested: unblockWithSeedphraseFlow.init()
-            onUnblockWithPukRequested: unblockWithPukFlow.init()
+            onUnblockWithSeedphraseRequested: root.push(unblockWithSeedphraseFlow)
+            onUnblockWithPukRequested: root.push(unblockWithPukFlow)
 
             onVisibleChanged: {
                 if (!visible)
@@ -251,12 +235,13 @@ SQUtils.QObject {
         id: createProfilePage
 
         CreateProfilePage {
-            onCreateProfileWithPasswordRequested: createNewProfileFlow.init()
+            onCreateProfileWithPasswordRequested: root.push(createNewProfileFlow)
             onCreateProfileWithSeedphraseRequested: {
                 d.flow = Onboarding.OnboardingFlow.CreateProfileWithSeedphrase
-                useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.NewProfile)
+                root.push(useRecoveryPhraseFlow,
+                          { type: UseRecoveryPhraseFlow.Type.NewProfile })
             }
-            onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
+            onCreateProfileWithEmptyKeycardRequested: root.push(keycardCreateProfileFlow)
         }
     }
 
@@ -266,12 +251,13 @@ SQUtils.QObject {
         NewAccountLoginPage {
             networkChecksEnabled: root.networkChecksEnabled
 
-            onLoginWithSyncingRequested: logInBySyncingFlow.init()
-            onLoginWithKeycardRequested: loginWithKeycardFlow.init()
+            onLoginWithSyncingRequested: root.push(logInBySyncingFlow)
+            onLoginWithKeycardRequested: root.push(loginWithKeycardFlow)
 
             onLoginWithSeedphraseRequested: {
                 d.flow = Onboarding.OnboardingFlow.LoginWithSeedphrase
-                useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.Login)
+                root.push(useRecoveryPhraseFlow,
+                          { type: UseRecoveryPhraseFlow.Type.Login })
             }
         }
     }
@@ -282,219 +268,225 @@ SQUtils.QObject {
         KeycardLostPage {
             onCreateReplacementKeycardRequested: {
                 d.flow = Onboarding.OnboardingFlow.LoginWithRestoredKeycard
-                keycardCreateReplacementFlow.init()
+                root.push(keycardCreateReplacementFlow)
             }
 
             onUseProfileWithoutKeycardRequested: {
                 d.flow = Onboarding.OnboardingFlow.LoginWithLostKeycardSeedphrase
-                useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.KeycardRecovery)
+                root.push(useRecoveryPhraseFlow,
+                          { type: UseRecoveryPhraseFlow.Type.KeycardRecovery })
             }
         }
     }
 
-    CreateNewProfileFlow {
+    Component {
         id: createNewProfileFlow
 
-        stackView: root.stackView
-        passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
+        CreateNewProfileFlow {
+            passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
 
-        onFinished: (password) => {
-            root.setPasswordRequested(password)
-            d.flow = Onboarding.OnboardingFlow.CreateProfileWithPassword
-            d.pushOrSkipBiometricsPage()
-        }
-    }
-
-    UseRecoveryPhraseFlow {
-        id: useRecoveryPhraseFlow
-
-        stackView: root.stackView
-        isSeedPhraseValid: root.isSeedPhraseValid
-        passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
-
-        onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
-        onSetPasswordRequested: (password) => root.setPasswordRequested(password)
-        onFinished: d.pushOrSkipBiometricsPage()
-    }
-
-    KeycardCreateProfileFlow {
-        id: keycardCreateProfileFlow
-
-        stackView: root.stackView
-        keycardState: root.keycardState
-        pinSettingState: root.pinSettingState
-        authorizationState: root.authorizationState
-        addKeyPairState: root.addKeyPairState
-        generateMnemonic: root.generateMnemonic
-        displayKeycardPromoBanner: root.displayKeycardPromoBanner
-        isSeedPhraseValid: root.isSeedPhraseValid
-
-        keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
-
-        onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
-        onLoadMnemonicRequested: root.loadMnemonicRequested()
-        onSetPinRequested: (pin) => root.setPinRequested(pin)
-        onLoginWithKeycardRequested: loginWithKeycardFlow.init()
-        onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
-        onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
-
-        onFinished: (withNewSeedphrase) => {
-            d.flow = withNewSeedphrase
-                        ? Onboarding.OnboardingFlow.CreateProfileWithKeycardNewSeedphrase
-                        : Onboarding.OnboardingFlow.CreateProfileWithKeycardExistingSeedphrase
-
-            d.pushOrSkipBiometricsPage()
-        }
-    }
-
-    LoginBySyncingFlow {
-        id: logInBySyncingFlow
-
-        stackView: root.stackView
-        validateConnectionString: root.validateConnectionString
-        syncState: root.syncState
-
-        onSyncProceedWithConnectionString: (connectionString) =>
-                                           root.syncProceedWithConnectionString(connectionString)
-
-        onLoginWithSeedphraseRequested: {
-            d.flow = Onboarding.OnboardingFlow.LoginWithSeedphrase
-            useRecoveryPhraseFlow.init(UseRecoveryPhraseFlow.Type.Login)
-        }
-
-        onFinished: {
-            d.flow = Onboarding.OnboardingFlow.LoginWithSyncing
-            d.pushOrSkipBiometricsPage()
-        }
-    }
-
-    LoginWithKeycardFlow {
-        id: loginWithKeycardFlow
-
-        stackView: root.stackView
-        keycardState: root.keycardState
-        authorizationState: root.authorizationState
-        restoreKeysExportState: root.restoreKeysExportState
-        remainingPinAttempts: root.remainingPinAttempts
-        remainingPukAttempts: root.remainingPukAttempts
-        displayKeycardPromoBanner: root.displayKeycardPromoBanner
-        onAuthorizationRequested: root.authorizationRequested(pin)
-
-        keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
-
-        onCreateProfileWithEmptyKeycardRequested: keycardCreateProfileFlow.init()
-        onExportKeysRequested: root.exportKeysRequested()
-        onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
-        onUnblockWithSeedphraseRequested: unblockWithSeedphraseFlow.init()
-        onUnblockWithPukRequested: unblockWithPukFlow.init()
-
-        onFinished: {
-            d.flow = Onboarding.OnboardingFlow.LoginWithKeycard
-            d.pushOrSkipBiometricsPage()
-        }
-    }
-
-    UnblockWithSeedphraseFlow {
-        id: unblockWithSeedphraseFlow
-
-        property string pin
-
-        stackView: root.stackView
-
-        isSeedPhraseValid: root.isSeedPhraseValid
-        pinSettingState: root.pinSettingState
-
-        onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
-
-        onSetPinRequested: (pin) => {
-            unblockWithSeedphraseFlow.pin = pin
-            root.setPinRequested(pin)
-        }
-
-        onFinished: {
-            if (root.loginScreen) {
-                root.loginRequested(root.loginScreen.selectedProfileKeyId,
-                                    Onboarding.LoginMethod.Keycard, { pin })
-            } else {
-                d.flow = Onboarding.SecondaryFlow.LoginWithKeycard
+            onFinished: (password) => {
+                root.setPasswordRequested(password)
+                d.flow = Onboarding.OnboardingFlow.CreateProfileWithPassword
                 d.pushOrSkipBiometricsPage()
             }
         }
     }
 
-    UnblockWithPukFlow {
-        id: unblockWithPukFlow
+    Component {
+        id: useRecoveryPhraseFlow
 
-        property string pin
+        UseRecoveryPhraseFlow {
+            isSeedPhraseValid: root.isSeedPhraseValid
+            passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
 
-        stackView: root.stackView
-        keycardState: root.keycardState
-        pinSettingState: root.pinSettingState
-        tryToSetPukFunction: root.tryToSetPukFunction
-        remainingAttempts: root.remainingPukAttempts
-
-        onSetPinRequested: (pin) => {
-            unblockWithPukFlow.pin = pin
-            root.setPinRequested(pin)
+            onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
+            onSetPasswordRequested: (password) => root.setPasswordRequested(password)
+            onFinished: d.pushOrSkipBiometricsPage()
         }
-        onKeycardFactoryResetRequested: keycardFactoryResetFlow.init()
+    }
 
-        onFinished: (success) => {
-            if (!success)
-               return
-            if (root.loginScreen) {
-                root.loginRequested(root.loginScreen.selectedProfileKeyId,
-                                    Onboarding.LoginMethod.Keycard, { pin })
-            } else {
+    Component {
+        id: keycardCreateProfileFlow
+
+        KeycardCreateProfileFlow {
+            keycardState: root.keycardState
+            pinSettingState: root.pinSettingState
+            authorizationState: root.authorizationState
+            addKeyPairState: root.addKeyPairState
+            generateMnemonic: root.generateMnemonic
+            displayKeycardPromoBanner: root.displayKeycardPromoBanner
+            isSeedPhraseValid: root.isSeedPhraseValid
+
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+
+            onKeycardFactoryResetRequested: root.push(keycardFactoryResetFlow)
+            onLoadMnemonicRequested: root.loadMnemonicRequested()
+            onSetPinRequested: (pin) => root.setPinRequested(pin)
+            onLoginWithKeycardRequested: root.push(loginWithKeycardFlow)
+            onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
+            onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
+
+            onFinished: (withNewSeedphrase) => {
+                d.flow = withNewSeedphrase
+                            ? Onboarding.OnboardingFlow.CreateProfileWithKeycardNewSeedphrase
+                            : Onboarding.OnboardingFlow.CreateProfileWithKeycardExistingSeedphrase
+
+                d.pushOrSkipBiometricsPage()
+            }
+        }
+    }
+
+    Component {
+        id: logInBySyncingFlow
+
+        LoginBySyncingFlow {
+            validateConnectionString: root.validateConnectionString
+            syncState: root.syncState
+
+            onSyncProceedWithConnectionString:
+                (connectionString) => root.syncProceedWithConnectionString(connectionString)
+
+            onLoginWithSeedphraseRequested: {
+                d.flow = Onboarding.OnboardingFlow.LoginWithSeedphrase
+
+                root.push(useRecoveryPhraseFlow,
+                          { type: UseRecoveryPhraseFlow.Type.Login })
+            }
+
+            onFinished: {
+                d.flow = Onboarding.OnboardingFlow.LoginWithSyncing
+                d.pushOrSkipBiometricsPage()
+            }
+        }
+    }
+
+    Component {
+        id: loginWithKeycardFlow
+
+        LoginWithKeycardFlow {
+            keycardState: root.keycardState
+            authorizationState: root.authorizationState
+            restoreKeysExportState: root.restoreKeysExportState
+            remainingPinAttempts: root.remainingPinAttempts
+            remainingPukAttempts: root.remainingPukAttempts
+            displayKeycardPromoBanner: root.displayKeycardPromoBanner
+            onAuthorizationRequested: root.authorizationRequested(pin)
+
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+
+            onCreateProfileWithEmptyKeycardRequested: root.push(keycardCreateProfileFlow)
+            onExportKeysRequested: root.exportKeysRequested()
+            onKeycardFactoryResetRequested: root.push(keycardFactoryResetFlow)
+            onUnblockWithSeedphraseRequested: root.push(unblockWithSeedphraseFlow)
+            onUnblockWithPukRequested: root.push(unblockWithPukFlow)
+
+            onFinished: {
                 d.flow = Onboarding.OnboardingFlow.LoginWithKeycard
                 d.pushOrSkipBiometricsPage()
             }
         }
     }
 
-    KeycardCreateReplacementFlow {
-        id: keycardCreateReplacementFlow
+    Component {
+        id: unblockWithSeedphraseFlow
 
-        stackView: root.stackView
+        UnblockWithSeedphraseFlow {
+            property string pin
 
-        keycardState: root.keycardState
-        pinSettingState: root.pinSettingState
-        authorizationState: root.authorizationState
-        addKeyPairState: root.addKeyPairState
+            isSeedPhraseValid: root.isSeedPhraseValid
+            pinSettingState: root.pinSettingState
 
-        displayKeycardPromoBanner: root.displayKeycardPromoBanner
-        isSeedPhraseValid: root.isSeedPhraseValid
+            onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
 
-        keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+            onSetPinRequested: (pin) => {
+                unblockWithSeedphraseFlow.pin = pin
+                root.setPinRequested(pin)
+            }
 
-        onKeycardFactoryResetRequested: keycardFactoryResetFlow.init(true)
-        onSetPinRequested: (pin) => root.setPinRequested(pin)
-        onLoginWithKeycardRequested: loginWithKeycardFlow.init()
-        onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
-        onLoadMnemonicRequested: root.loadMnemonicRequested()
-
-        onCreateProfileWithoutKeycardRequested: {
-            const page = stackView.find(
-                           item => item instanceof HelpUsImproveStatusPage)
-
-            stackView.replace(page, createProfilePage, StackView.PopTransition)
+            onFinished: {
+                if (root.loginScreen) {
+                    root.loginRequested(root.loginScreen.selectedProfileKeyId,
+                                        Onboarding.LoginMethod.Keycard, { pin })
+                } else {
+                    d.flow = Onboarding.SecondaryFlow.LoginWithKeycard
+                    d.pushOrSkipBiometricsPage()
+                }
+            }
         }
-
-        onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
-
-        onFinished: d.pushOrSkipBiometricsPage()
     }
 
-    KeycardFactoryResetFlow {
+    Component {
+        id: unblockWithPukFlow
+
+        UnblockWithPukFlow {
+            property string pin
+
+            keycardState: root.keycardState
+            pinSettingState: root.pinSettingState
+            tryToSetPukFunction: root.tryToSetPukFunction
+            remainingAttempts: root.remainingPukAttempts
+
+            onSetPinRequested: (pin) => {
+                unblockWithPukFlow.pin = pin
+                root.setPinRequested(pin)
+            }
+            onKeycardFactoryResetRequested: root.push(keycardFactoryResetFlow)
+
+            onFinished: (success) => {
+                if (!success)
+                   return
+                if (root.loginScreen) {
+                    root.loginRequested(root.loginScreen.selectedProfileKeyId,
+                                        Onboarding.LoginMethod.Keycard, { pin })
+                } else {
+                    d.flow = Onboarding.OnboardingFlow.LoginWithKeycard
+                    d.pushOrSkipBiometricsPage()
+                }
+            }
+        }
+    }
+
+    Component {
+        id: keycardCreateReplacementFlow
+
+        KeycardCreateReplacementFlow {
+            keycardState: root.keycardState
+            pinSettingState: root.pinSettingState
+            authorizationState: root.authorizationState
+            addKeyPairState: root.addKeyPairState
+
+            displayKeycardPromoBanner: root.displayKeycardPromoBanner
+            isSeedPhraseValid: root.isSeedPhraseValid
+
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
+
+            onKeycardFactoryResetRequested: root.push(keycardFactoryResetFlow,
+                                                      { fromLoginScreen: true })
+            onSetPinRequested: (pin) => root.setPinRequested(pin)
+            onLoginWithKeycardRequested: root.push(loginWithKeycardFlow)
+            onAuthorizationRequested: root.authorizationRequested("") // Pin was saved locally already
+            onLoadMnemonicRequested: root.loadMnemonicRequested()
+
+            onCreateProfileWithoutKeycardRequested: {
+                const page = root.find(item => item instanceof HelpUsImproveStatusPage)
+                root.replace(page, createProfilePage, StackView.PopTransition)
+            }
+
+            onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
+
+            onFinished: d.pushOrSkipBiometricsPage()
+        }
+    }
+
+    Component {
         id: keycardFactoryResetFlow
 
-        stackView: root.stackView
-        keycardState: root.keycardState
+        KeycardFactoryResetFlow {
+            keycardState: root.keycardState
 
-        onPerformKeycardFactoryResetRequested: root.performKeycardFactoryResetRequested()
-        onFinished: {
-            stackView.clear()
-            root.init()
+            onPerformKeycardFactoryResetRequested: root.performKeycardFactoryResetRequested()
+            onFinished: root.pop(null)
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingStackView.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingStackView.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
+import StatusQ.Core.Utils 0.1
 import StatusQ.Core.Theme 0.1
 
-StackView {
+RecursiveStackView {
     id: root
 
-    readonly property bool backAvailable: currentItem ? (currentItem.backAvailableHint ?? true)
-                                                      : false
+    readonly property bool backAvailable:
+        topLevelItem ? (topLevelItem.backAvailableHint ?? true) : false
 
     QtObject {
         id: d

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
@@ -1,17 +1,13 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
-
-    required property StackView stackView
 
     required property int keycardState
     required property int pinSettingState
@@ -22,8 +18,11 @@ SQUtils.QObject {
     signal keycardFactoryResetRequested
     signal finished(bool success)
 
-    function init() {
-        root.stackView.push(d.initialComponent())
+    initialItem: d.initialComponent()
+
+    function reset() {
+        clear()
+        push(d.initialComponent())
     }
 
     QtObject {
@@ -53,9 +52,9 @@ SQUtils.QObject {
             unblockUsingSeedphraseAvailable: true
             factoryResetAvailable: !unblockWithPukAvailable
             onKeycardFactoryResetRequested: d.finishWithFactoryReset()
-            onEmptyKeycardDetected: root.stackView.replace(keycardUnblockedPage)
-            onNotEmptyKeycardDetected: root.stackView.replace(keycardUnblockedPage)
-            onUnblockWithPukRequested: root.stackView.push(keycardEnterPukPage)
+            onEmptyKeycardDetected: root.replace(keycardUnblockedPage)
+            onNotEmptyKeycardDetected: root.replace(keycardUnblockedPage)
+            onUnblockWithPukRequested: root.push(keycardEnterPukPage)
         }
     }
 
@@ -65,7 +64,7 @@ SQUtils.QObject {
         KeycardEnterPukPage {
             tryToSetPukFunction: root.tryToSetPukFunction
             remainingAttempts: root.remainingAttempts
-            onKeycardPukEntered: (puk) => root.stackView.replace(keycardCreatePinPage)
+            onKeycardPukEntered: (puk) => root.replace(keycardCreatePinPage)
             onKeycardFactoryResetRequested: d.finishWithFactoryReset()
         }
     }
@@ -78,8 +77,8 @@ SQUtils.QObject {
             authorizationState: Onboarding.AuthorizationState.Authorized // authorization not needed
 
             onSetPinRequested: root.setPinRequested(pin)
-            onFinished: root.stackView.replace(keycardUnblockedPage,
-                                               { title: qsTr("Unblock successful") })
+            onFinished: root.replace(keycardUnblockedPage,
+                                     { title: qsTr("Unblock successful") })
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithSeedphraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithSeedphraseFlow.qml
@@ -1,15 +1,11 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-import StatusQ.Core.Utils 0.1 as SQUtils
-
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
-
-    required property StackView stackView
 
     required property var isSeedPhraseValid
     required property int pinSettingState
@@ -18,22 +14,14 @@ SQUtils.QObject {
     signal setPinRequested(string pin)
     signal finished
 
-    function init() {
-        root.stackView.push(seedphrasePage)
-    }
+    initialItem: SeedphrasePage {
+        title: qsTr("Unblock Keycard using the recovery phrase")
+        btnContinueText: qsTr("Unblock Keycard")
+        isSeedPhraseValid: root.isSeedPhraseValid
 
-    Component {
-        id: seedphrasePage
-
-        SeedphrasePage {
-            title: qsTr("Unblock Keycard using the recovery phrase")
-            btnContinueText: qsTr("Unblock Keycard")
-            isSeedPhraseValid: root.isSeedPhraseValid
-
-            onSeedphraseSubmitted: (seedphrase) => {
-                root.seedphraseSubmitted(seedphrase)
-                root.stackView.push(keycardCreatePinPage)
-            }
+        onSeedphraseSubmitted: (seedphrase) => {
+            root.seedphraseSubmitted(seedphrase)
+            root.push(keycardCreatePinPage)
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -1,12 +1,9 @@
 import QtQuick 2.15
-import QtQuick.Controls 2.15
-
-import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding.enums 1.0
 
-SQUtils.QObject {
+OnboardingStackView {
     id: root
 
     enum Type {
@@ -15,7 +12,8 @@ SQUtils.QObject {
         Login
     }
 
-    required property StackView stackView
+    // https://bugreports.qt.io/browse/QTBUG-84269, required can be restored on Qt6
+    /*required*/ property int type
 
     required property var passwordStrengthScoreFunction
     required property var isSeedPhraseValid
@@ -24,34 +22,31 @@ SQUtils.QObject {
     signal setPasswordRequested(string password)
     signal finished
 
-    function init(type = UseRecoveryPhraseFlow.Type.NewProfile) {
-        let title = ""
+    initialItem: SeedphrasePage {
+        isSeedPhraseValid: root.isSeedPhraseValid
 
-        if (type === UseRecoveryPhraseFlow.Type.NewProfile)
-            title = qsTr("Create profile using a recovery phrase")
-        else if (type === UseRecoveryPhraseFlow.Type.KeycardRecovery)
-            title = qsTr("Enter recovery phrase of lost Keycard")
-        else if (type === UseRecoveryPhraseFlow.Type.Login)
-            title = qsTr("Log in with your Status recovery phrase")
-
-        root.stackView.push(seedphrasePage, { title })
-    }
-
-    Component {
-        id: seedphrasePage
-
-        SeedphrasePage {
-            isSeedPhraseValid: root.isSeedPhraseValid
-
-            onSeedphraseSubmitted: (seedphrase) => {
-                root.seedphraseSubmitted(seedphrase)
-                root.stackView.push(createPasswordPage)
+        title: {
+            switch (root.type) {
+            case UseRecoveryPhraseFlow.Type.NewProfile:
+                return qsTr("Create profile using a recovery phrase")
+            case UseRecoveryPhraseFlow.Type.KeycardRecovery:
+                return qsTr("Enter recovery phrase of lost Keycard")
+            case UseRecoveryPhraseFlow.Type.Login:
+                return qsTr("Log in with your Status recovery phrase")
             }
+
+            return ""
+        }
+
+        onSeedphraseSubmitted: (seedphrase) => {
+            root.seedphraseSubmitted(seedphrase)
+            root.push(createPasswordPage)
         }
     }
 
     Component {
         id: createPasswordPage
+
         CreatePasswordPage {
             passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
 


### PR DESCRIPTION
### What does the PR do

- introduces utility component to StatusQ - `RecursiveStackView` for easy nesting multiple `StackView`s
- alters the structure of onboarding from single shared `StackView` to multiple `StackView`s, one per flow. This approach simplifies the flow management because every flow handles freely it's own stack.
- consistent handling of single pages and flows by pushing/replacing/popping on the stack
- no need for custom `init` function to start the flow
- flows instantiated on demand and disposed whenever not needed
- flows are self-contained, no need to provide external stack view to run on
- handier inspection into the flow in Storybook (both pages and flows are listed)

Closes: #17304

### Affected areas

`Onboarding`

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
