### PR TITLE
fix: Use mixcase address when sharing the address

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -15,6 +15,7 @@ QtObject:
   proc setup*(self: Item,
     name: string,
     address: string,
+    mixedcaseAddress: string,
     path: string,
     colorId: string,
     walletType: string,
@@ -33,6 +34,7 @@ QtObject:
     self.QObject.setup
     self.WalletAccountItem.setup(name,
       address,
+      mixedcaseAddress,
       colorId,
       emoji,
       walletType,
@@ -55,6 +57,7 @@ QtObject:
   proc newItem*(
     name: string = "",
     address: string = "",
+    mixedcaseAddress: string = "",
     path: string = "",
     colorId: string = "",
     walletType: string = "",
@@ -73,6 +76,7 @@ QtObject:
     new(result, delete)
     result.setup(name,
       address,
+      mixedcaseAddress,
       path,
       colorId,
       walletType,

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -7,6 +7,7 @@ type
   ModelRole {.pure.} = enum
     Name = UserRole + 1,
     Address,
+    MixedcaseAddress,
     Path,
     ColorId,
     WalletType,
@@ -58,6 +59,7 @@ QtObject:
     {
       ModelRole.Name.int:"name",
       ModelRole.Address.int:"address",
+      ModelRole.MixedcaseAddress.int:"mixedcaseAddress",
       ModelRole.Path.int:"path",
       ModelRole.ColorId.int:"colorId",
       ModelRole.WalletType.int:"walletType",
@@ -160,6 +162,8 @@ QtObject:
       result = newQVariant(item.name())
     of ModelRole.Address:
       result = newQVariant(item.address())
+    of ModelRole.MixedcaseAddress:
+      result = newQVariant(item.mixedcaseAddress())
     of ModelRole.Path:
       result = newQVariant(item.path())
     of ModelRole.ColorId:

--- a/src/app/modules/shared/wallet_utils.nim
+++ b/src/app/modules/shared/wallet_utils.nim
@@ -19,6 +19,7 @@ proc walletAccountToWalletAccountItem*(w: WalletAccountDto, keycardAccount: bool
   return newWalletAccountItem(
     w.name,
     w.address,
+    w.mixedcaseAddress,
     w.colorId,
     w.emoji,
     w.walletType,
@@ -37,6 +38,7 @@ proc walletAccountToWalletAccountsItem*(w: WalletAccountDto, isKeycardAccount: b
   return wallet_accounts_item.newItem(
     w.name,
     w.address,
+    w.mixedcaseAddress,
     w.path,
     w.colorId,
     w.walletType,

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -7,6 +7,7 @@ QtObject:
   type WalletAccountItem* = ref object of QObject
     name: string
     address: string
+    mixedcaseAddress: string
     colorId: string
     emoji: string
     walletType: string
@@ -21,6 +22,7 @@ QtObject:
   proc setup*(self: WalletAccountItem,
     name: string = "",
     address: string = "",
+    mixedcaseAddress: string = "",
     colorId: string = "",
     emoji: string = "",
     walletType: string = "",
@@ -35,6 +37,7 @@ QtObject:
       self.QObject.setup
       self.name = name
       self.address = address
+      self.mixedcaseAddress = mixedcaseAddress
       self.colorId = colorId
       self.emoji = emoji
       self.walletType = walletType
@@ -52,6 +55,7 @@ QtObject:
   proc newWalletAccountItem*(
     name: string = "",
     address: string = "",
+    mixedcaseAddress: string = "",
     colorId: string = "",
     emoji: string = "",
     walletType: string = "",
@@ -81,6 +85,7 @@ QtObject:
     result = fmt"""WalletAccountItem(
       name: {self.name},
       address: {self.address},
+      mixedcaseAddress: {self.mixedcaseAddress},
       colorId: {self.colorId},
       emoji: {self.emoji},
       walletType: {self.walletType},
@@ -112,6 +117,14 @@ QtObject:
   QtProperty[string] address:
     read = address
     notify = addressChanged
+
+  proc mixedcaseAddressChanged*(self: WalletAccountItem) {.signal.}
+  proc mixedcaseAddress*(self: WalletAccountItem): string {.slot.} =
+    return self.mixedcaseAddress
+
+  QtProperty[string] mixedcaseAddress:
+    read = mixedcaseAddress
+    notify = mixedcaseAddressChanged
 
   proc colorIdChanged*(self: WalletAccountItem) {.signal.}
   proc colorId*(self: WalletAccountItem): string {.slot.} =

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -33,7 +33,7 @@ StatusModal {
 
     property bool switchingAccounsEnabled: true
 
-    property string qrImageSource: root.store.getQrCode(root.selectedAccount.address)
+    property string qrImageSource: root.store.getQrCode(root.selectedAccount.mixedcaseAddress)
 
     property WalletStores.RootStore store: WalletStores.RootStore
 
@@ -108,7 +108,7 @@ StatusModal {
                     verticalAlignment: Text.AlignVCenter
                     textFormat: TextEdit.RichText
                     wrapMode: Text.WrapAnywhere
-                    text: root.selectedAccount.address
+                    text: root.selectedAccount.mixedcaseAddress
                     font.pixelSize: 15
                     color: Theme.palette.directColor1
                 }
@@ -120,7 +120,7 @@ StatusModal {
                     Layout.preferredWidth: 32
                     Layout.preferredHeight: 32
                     Layout.fillWidth: true
-                    textToCopy: root.selectedAccount.address
+                    textToCopy: root.selectedAccount.mixedcaseAddress
                     successCircleVisible: true
                 }
             }

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -69,7 +69,7 @@ Rectangle {
             address: {
                 if (!account)
                     return ""
-                return account.address
+                return account.mixedcaseAddress
             }
             name: account ? account.name : ""
             walletType: account ? account.walletType : ""


### PR DESCRIPTION
### What does the PR do

Closes #17301

Adding the `MixedcaseAddress` role to accounts model. This role can be used when sharing the address.


### Affected areas

Receive model (QR code, display address, and copy address )
Walet account context menu -> the copy action use the mixcase address
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
