### PR TITLE
fix: Show SignPhraseModal only when the appMain is visible

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -207,7 +207,7 @@ Item {
         id: signPhrasePopup
         onRemindLaterClicked: hideSignPhraseModal = true
         onAcceptClicked: { RootStore.setHideSignPhraseModal(true); }
-        visible: !root.hideSignPhraseModal && !RootStore.hideSignPhraseModal
+        visible: !root.hideSignPhraseModal && !RootStore.hideSignPhraseModal && root.appMainVisible
     }
 
     SeedPhraseBackupWarning {


### PR DESCRIPTION
### What does the PR do

Closes #17321

Show SignPhraseModal only when the appMain is visible

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/dd817ce8-e374-4847-935c-c898a8802bf7
