### PR TITLE
fix(Onboarding): prevent importing the same seedphrase twice

### DIFF
--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -124,9 +124,11 @@ proc getPasswordStrengthScore*(self: Controller, password, userName: string): in
 
 proc validMnemonic*(self: Controller, mnemonic: string): bool =
   let (_, err) = self.accountsService.validateMnemonic(mnemonic)
-  if err.len == 0:
-    return true
-  return false
+  return err.len == 0
+
+proc isMnemonicDuplicate*(self: Controller, mnemonic: string): bool =
+  let (keyUID, err) = self.accountsService.validateMnemonic(mnemonic)
+  return self.accountsService.openedAccountsContainsKeyUid(keyUID)
 
 proc loadMnemonic*(self: Controller, mnemonic: string) =
   self.keycardServiceV2.loadMnemonic(mnemonic)

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -31,6 +31,9 @@ method getPasswordStrengthScore*(self: AccessInterface, password, userName: stri
 method validMnemonic*(self: AccessInterface, mnemonic: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method isMnemonicDuplicate*(self: AccessInterface, mnemonic: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method generateMnemonic*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -108,6 +108,9 @@ method getPasswordStrengthScore*[T](self: Module[T], password, userName: string)
 method validMnemonic*[T](self: Module[T], mnemonic: string): bool =
   self.controller.validMnemonic(mnemonic)
 
+method isMnemonicDuplicate*[T](self: Module[T], mnemonic: string): bool =
+  self.controller.isMnemonicDuplicate(mnemonic)
+
 method generateMnemonic*[T](self: Module[T]): string =
   return self.controller.generateMnemonic(SupportedMnemonicLength12)
 

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -145,6 +145,9 @@ QtObject:
   proc validMnemonic(self: View, mnemonic: string): bool {.slot.} =
     return self.delegate.validMnemonic(mnemonic)
 
+  proc isMnemonicDuplicate(self: View, mnemonic: string): bool {.slot.} =
+    return self.delegate.isMnemonicDuplicate(mnemonic)
+
   proc generateMnemonic(self: View): string {.slot.} =
     return self.delegate.generateMnemonic()
 

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -145,6 +145,11 @@ SplitView {
                 return mnemonic === mockDriver.mnemonic
             }
 
+            function isMnemonicDuplicate(mnemonic: string) { // -> bool
+                logs.logEvent("OnboardingStore.isMnemonicDuplicate", ["mnemonic"], arguments)
+                return false
+            }
+
             function generateMnemonic() { // -> string
                 logs.logEvent("OnboardingStore.generateMnemonic()")
                 return mockDriver.mnemonic

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -91,10 +91,15 @@ Item {
                 }
 
                 // seedphrase/mnemonic
-                function validMnemonic(mnemonic: string) {
+                function validMnemonic(mnemonic: string) { // -> bool
                     return mnemonic === mockDriver.mnemonic
                 }
-                function generateMnemonic() {
+
+                function isMnemonicDuplicate(mnemonic: string) { // -> bool
+                    return false
+                }
+
+                function generateMnemonic() { // -> string
                     return mockDriver.mnemonic
                 }
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -35,6 +35,7 @@ OnboardingStackView {
     // functions
     required property var passwordStrengthScoreFunction
     required property var isSeedPhraseValid
+    required property var isSeedPhraseDuplicate
     required property var validateConnectionString
     required property var tryToSetPukFunction
 
@@ -298,6 +299,7 @@ OnboardingStackView {
 
         UseRecoveryPhraseFlow {
             isSeedPhraseValid: root.isSeedPhraseValid
+            isSeedPhraseDuplicate: root.isSeedPhraseDuplicate
             passwordStrengthScoreFunction: root.passwordStrengthScoreFunction
 
             onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -144,6 +144,7 @@ Page {
 
         passwordStrengthScoreFunction: root.onboardingStore.getPasswordStrengthScore
         isSeedPhraseValid: root.onboardingStore.validMnemonic
+        isSeedPhraseDuplicate: root.onboardingStore.isMnemonicDuplicate
         validateConnectionString: root.onboardingStore.validateLocalPairingConnectionString
         tryToSetPukFunction: root.onboardingStore.setPuk
         remainingPinAttempts: root.onboardingStore.keycardRemainingPinAttempts

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -15,8 +15,10 @@ OnboardingStackView {
     // https://bugreports.qt.io/browse/QTBUG-84269, required can be restored on Qt6
     /*required*/ property int type
 
-    required property var passwordStrengthScoreFunction
-    required property var isSeedPhraseValid
+    // functions
+    required property var passwordStrengthScoreFunction // (string) => int
+    required property var isSeedPhraseValid // (string) => bool
+    required property var isSeedPhraseDuplicate // (string) => bool
 
     signal seedphraseSubmitted(string seedphrase)
     signal setPasswordRequested(string password)
@@ -36,6 +38,21 @@ OnboardingStackView {
             }
 
             return ""
+        }
+
+        onSeedphraseUpdated: (valid, seedphrase) => {
+            if (root.type === UseRecoveryPhraseFlow.Type.KeycardRecovery) {
+                if (!valid)
+                    setWrongSeedPhraseMessage(qsTr("Recovery phrase doesn’t match the profile of an existing Keycard user on this device"))
+                else
+                    setWrongSeedPhraseMessage("")
+            } else {  // different error messages when trying to import a duplicate seedphrase
+                if (valid && root.isSeedPhraseDuplicate(seedphrase)) {
+                    setWrongSeedPhraseMessage(qsTr("The entered recovery phrase is already added"))
+                } else if (valid) {
+                    setWrongSeedPhraseMessage("")
+                }
+            }
         }
 
         onSeedphraseSubmitted: (seedphrase) => {

--- a/ui/app/AppLayouts/Onboarding2/pages/SeedphrasePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SeedphrasePage.qml
@@ -21,6 +21,11 @@ OnboardingPage {
     property var isSeedPhraseValid: (mnemonic) => { console.error("isSeedPhraseValid IMPLEMENT ME"); return false }
 
     signal seedphraseSubmitted(string seedphrase)
+    signal seedphraseUpdated(bool valid, string seedphrase)
+
+    function setWrongSeedPhraseMessage(err: string) {
+        seedPanel.setWrongSeedPhraseMessage(err)
+    }
 
     contentItem: Item {
         ColumnLayout {
@@ -51,6 +56,7 @@ OnboardingPage {
                 Layout.alignment: Qt.AlignHCenter
                 isSeedPhraseValid: root.isSeedPhraseValid
                 onSubmitSeedPhrase: root.seedphraseSubmitted(getSeedPhraseAsString())
+                onSeedPhraseUpdated: (valid, seedphrase) => root.seedphraseUpdated(valid, seedphrase)
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -72,6 +72,9 @@ QtObject {
     function validMnemonic(mnemonic: string) { // -> bool
         return d.onboardingModuleInst.validMnemonic(mnemonic)
     }
+    function isMnemonicDuplicate(mnemonic: string) { // -> bool
+        return d.onboardingModuleInst.isMnemonicDuplicate(mnemonic)
+    }
     function generateMnemonic() { // -> string as per BIP-39 (space-separated list of words)
         return d.onboardingModuleInst.generateMnemonic()
     }


### PR DESCRIPTION
### What does the PR do

- adds a new NIM method `isMnemonicDuplicate` which checks for duplicate mnemonics
- use it in the "seedphrase recovery flows"
- in case of a duplicate seedphrase, present the user with a more suitable error message (other than a plan "Invalid seedphrase")
- fixes re-importing the same seed leading to an infinite splash screen loop due to an "account already exists" error

Fixes #17248

### Affected areas

Onboarding/seed flows

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/a33a990b-b978-4ad1-9ede-a51cea4ad1dd)

Storybook:

Wrong seed:
![image](https://github.com/user-attachments/assets/fd9edeb5-6811-471b-a6db-80d29a8f5724)

Duplicate seed:
![image](https://github.com/user-attachments/assets/91612a27-bd25-4121-8f30-fe10fd6ed345)

