### PR TITLE
fix(onboarding/keycard): keycard being used through the onboarding flows is recognized in the app and synced with the app state

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -179,7 +179,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   # Services
   result.generalService = general_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.keycardService = keycard_service.newService(statusFoundation.events, statusFoundation.threadpool)
-  result.keycardServiceV2 = keycard_serviceV2.newService(statusFoundation.events, statusFoundation.threadpool, result.keycardService)
+  result.keycardServiceV2 = keycard_serviceV2.newService(statusFoundation.events, statusFoundation.threadpool)
   result.nodeConfigurationService = node_configuration_service.newService(statusFoundation.fleetConfiguration,
   result.settingsService, statusFoundation.events)
   result.keychainService = keychain_service.newService(statusFoundation.events)
@@ -259,6 +259,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
       statusFoundation.events,
       result.generalService,
       result.accountsService,
+      result.walletAccountService,
       result.devicesService,
       result.keycardServiceV2,
     )

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -186,6 +186,9 @@ proc finishPairingThroughSeedPhraseProcess*(self: Controller, installationId: st
   self.devicesService.finishPairingThroughSeedPhraseProcess(installationId)
 
 proc stopKeycardService*(self: Controller) =
+  self.keycardServiceV2.stop()
+
+proc stopKeycardServiceAsync*(self: Controller) =
   self.keycardServiceV2.asyncStop()
 
 proc generateMnemonic*(self: Controller, length: int): string =
@@ -241,4 +244,7 @@ proc startKeycardFactoryReset*(self: Controller) =
   self.keycardServiceV2.asyncFactoryReset()
 
 proc storeMetadata*(self: Controller, name: string, paths: seq[string]) =
+  self.keycardServiceV2.storeMetadata(name, paths)
+
+proc storeMetadataAsync*(self: Controller, name: string, paths: seq[string]) =
   self.keycardServiceV2.asyncStoreMetadata(name, paths)

--- a/src/app_service/service/keycardV2/async_tasks.nim
+++ b/src/app_service/service/keycardV2/async_tasks.nim
@@ -1,101 +1,16 @@
-import ./rpc
-
 type
-  AsyncInitializeTaskArg = ref object of QObjectTaskArg
-    pin: string
-    puk: string
+  AsyncRequestArg = ref object of QObjectTaskArg
+    action*: string
+    params*: JsonNode
 
-proc asyncInitializeTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncInitializeTaskArg](argEncoded)
+proc asyncRequestTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncRequestArg](argEncoded)
+  var output = %*{
+    "response": "",
+    "error": ""
+  }
   try:
-    let response = callRPC("Initialize", %*{"pin": arg.pin, "puk": arg.puk})
-    arg.finish(%*{
-      "response": response,
-      "error": ""
-    })
+    output["response"] = %* callRPC(arg.action, arg.params)
   except Exception as e:
-    arg.finish(%* {
-      "error": e.msg,
-    })
-
-type
-  AsyncAuthorizeArg = ref object of QObjectTaskArg
-    pin: string
-
-proc asyncAuthorizeTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncInitializeTaskArg](argEncoded)
-  try:
-    let response = callRPC("Authorize", %*{"pin": arg.pin})
-    arg.finish(%*{
-      "response": response,
-      "error": ""
-    })
-  except Exception as e:
-    arg.finish(%* {
-      "error": e.msg,
-    })
-
-type
-  AsyncLoadMnemonicArg = ref object of QObjectTaskArg
-    mnemonic: string
-
-proc asyncLoadMnemonicTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncLoadMnemonicArg](argEncoded)
-  try:
-    let loadMnemonicResponse = callRPC("LoadMnemonic", %*{"mnemonic": arg.mnemonic})
-    arg.finish(%*{
-      "response": loadMnemonicResponse,
-      "error": ""
-    })
-  except Exception as e:
-    arg.finish(%* {
-      "error": e.msg,
-    })
-
-type
-  AsyncExportRecoverKeysArg = ref object of QObjectTaskArg
-
-proc asyncExportRecoverKeysTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncExportRecoverKeysArg](argEncoded)
-  try:
-    let response = callRPC("ExportRecoverKeys")
-    arg.finish(%*{
-      "response": response,
-      "error": ""
-    })
-  except Exception as e:
-    arg.finish(%* {
-      "error": e.msg,
-    })
-
-type
-  AsyncExportLoginKeysArg = ref object of QObjectTaskArg
-
-proc asyncExportLoginKeysTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncExportLoginKeysArg](argEncoded)
-  try:
-    let response = callRPC("ExportLoginKeys")
-    arg.finish(%*{
-      "response": response,
-      "error": ""
-    })
-  except Exception as e:
-    arg.finish(%* {
-      "error": e.msg,
-    })
-
-type
-  AsyncFactoryResetArg = ref object of QObjectTaskArg
-
-proc asyncFactoryResetTask(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[AsyncFactoryResetArg](argEncoded)
-  try:
-    let response = callRPC("FactoryReset")
-    arg.finish(%*{
-      "response": response,
-      "error": ""
-    })
-  except Exception as e:
-    arg.finish(%* {
-      "error": e.msg,
-    })
+    output["error"] = %* e.msg
+  arg.finish(output)

--- a/src/app_service/service/keycardV2/queued_async_calls.nim
+++ b/src/app_service/service/keycardV2/queued_async_calls.nim
@@ -1,0 +1,49 @@
+proc onAsyncResponse(self: Service, response: string) {.slot.} =
+  try:
+    let responseObj = response.parseJson
+    if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
+      raise newException(CatchableError, responseObj{"error"}.getStr)
+    let rpcResponseObj = responseObj["response"].getStr().parseJson()
+    self.currentRequest.callback(rpcResponseObj, "")
+  except Exception as e:
+    error "onAsyncResponse", err=e.msg
+    self.currentRequest.callback(newJNull(), e.msg)
+  self.requestsQueue.del(0)
+  self.currentRequest = nil
+
+proc onTimeout(self: Service, reason: string) {.slot.} =
+  if not self.currentRequest.isNil:
+    self.runTimer()
+    return
+  if self.requestsQueue.len == 0:
+    return
+  self.currentRequest = self.requestsQueue[0]
+  let arg = AsyncRequestArg(
+    tptr: asyncRequestTask,
+    vptr: cast[uint](self.vptr),
+    slot: "onAsyncResponse",
+    action: $self.currentRequest.action,
+    params: self.currentRequest.params,
+  )
+  self.threadpool.start(arg)
+
+proc runTimer(self: Service) =
+  let arg = TimerTaskArg(
+    tptr: timerTask,
+    vptr: cast[uint](self.vptr),
+    slot: "onTimeout",
+    timeoutInMilliseconds: KeycardLibCallsInterval,
+  )
+  self.threadpool.start(arg)
+
+proc asyncCallRPC(self: Service, action: KeycardAction, params: JsonNode, callback: proc (responseObj: JsonNode, err: string)) =
+  let request = KeycardRequest(
+    action: action,
+    params: params,
+    callback: callback
+  )
+  self.requestsQueue.add(request)
+  if self.currentRequest.isNil:
+    self.onTimeout("")
+    return
+  self.runTimer()

--- a/src/app_service/service/keycardV2/rpc.nim
+++ b/src/app_service/service/keycardV2/rpc.nim
@@ -4,7 +4,7 @@ import keycard_go
 var rpcCounter: int = 0
 
 proc callRPC*(methodName: string, params: JsonNode = %*{}): string  =
-    rpcCounter += 1
+    rpcCounter.inc
     let request = %*{
       "id": rpcCounter,
       "method": "keycard." & methodName,

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -130,6 +130,16 @@ QtObject:
       debug "keycard stopped"
     )
 
+  proc stop*(self: Service) =
+    try:
+      let response = callRPC($KeycardAction.Stop)
+      let rpcResponseObj = response.parseJson
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+          let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+          raise newException(RpcException, error.message)
+    except Exception as e:
+      error "error stop", err=e.msg
+
   proc generateMnemonic*(self: Service, length: int): string =
     try:
       let response = callRPC($KeycardAction.GenerateMnemonic, %*{"length": length})
@@ -232,3 +242,13 @@ QtObject:
         return
       debug "metadata stored"
     )
+
+  proc storeMetadata*(self: Service, name: string, paths: seq[string]) =
+    try:
+      let response = callRPC($KeycardAction.StoreMetadata, %*{"name": name, "paths": paths})
+      let rpcResponseObj = response.parseJson
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+          let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+          raise newException(RpcException, error.message)
+    except Exception as e:
+      error "error storing metadata", err=e.msg

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -1,21 +1,21 @@
-import NimQml, json, chronicles, strutils, random, json_serialization
+import NimQml, json, os, chronicles, strutils, random, json_serialization
 import keycard_go
 import app/global/global_singleton
 import app/core/eventemitter
 import app/core/tasks/[qt, threadpool]
-import app_service/service/keycard/service as old_keycard_service
-import ../../../backend/response_type
-import ../../../constants as status_const
-import ./dto
+import backend/response_type
+import constants as status_const
+import ./dto, rpc
 
-include ../../common/mnemonics
-include async_tasks
+export dto
 
 logScope:
   topics = "keycardV2-service"
 
 const SupportedMnemonicLength12* = 12
 const PUKLengthForStatusApp* = 12
+
+const KeycardLibCallsInterval = 500 # 0.5 seconds
 
 const SIGNAL_KEYCARD_STATE_UPDATED* = "keycardStateUpdated"
 const SIGNAL_KEYCARD_SET_PIN_FAILURE* = "keycardSetPinFailure"
@@ -26,6 +26,19 @@ const SIGNAL_KEYCARD_EXPORT_RESTORE_KEYS_FAILURE* = "keycardExportRestoreKeysFai
 const SIGNAL_KEYCARD_EXPORT_RESTORE_KEYS_SUCCESS* = "keycardExportRestoreKeysSuccess"
 const SIGNAL_KEYCARD_EXPORT_LOGIN_KEYS_FAILURE* = "keycardExportLoginKeysFailure"
 const SIGNAL_KEYCARD_EXPORT_LOGIN_KEYS_SUCCESS* = "keycardExportLoginKeysSuccess"
+
+type KeycardAction {.pure.} = enum
+  Start = "Start"
+  Stop = "Stop"
+  GenerateMnemonic = "GenerateMnemonic"
+  LoadMnemonic = "LoadMnemonic"
+  Authorize = "Authorize"
+  Initialize = "Initialize"
+  ExportRecoverKeys = "ExportRecoverKeys"
+  ExportLoginKeys = "ExportLoginKeys"
+  FactoryReset = "FactoryReset"
+  GetMetadata = "GetMetadata"
+  StoreMetadata = "StoreMetadata"
 
 type
   KeycardEventArg* = ref object of Args
@@ -44,53 +57,86 @@ type
   KeycardExportedKeysArg* = ref object of Args
     exportedKeys*: KeycardExportedKeysDto
 
+include utils
+include app_service/common/async_tasks
+include async_tasks
+
+type
+  KeycardRequest = ref object
+    action*: KeycardAction
+    params*: JsonNode
+    callback: proc (responseObj: JsonNode, err: string)
+
 QtObject:
   type Service* = ref object of QObject
     events: EventEmitter
     threadpool: ThreadPool
-    oldKeyCardService: old_keycard_service.Service
+    requestsQueue: seq[KeycardRequest]
+    currentRequest: KeycardRequest
+
+  ## Forward declaration
+  proc initializeRPC(self: Service)
+  proc asyncStart*(self: Service, storageDir: string)
+  proc runTimer(self: Service)
+  proc onTimeout(self: Service, reason: string) {.slot.}
+  proc onAsyncResponse(self: Service, response: string) {.slot.}
 
   proc delete*(self: Service) =
     self.QObject.delete
 
-  proc newService*(events: EventEmitter, threadpool: ThreadPool, oldKeyCardService: old_keycard_service.Service): Service =
+  proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
     new(result, delete)
     result.QObject.setup
     result.events = events
     result.threadpool = threadpool
-    result.oldKeyCardService = oldKeyCardService
 
-  proc initializeRPC(self: Service)
-  proc start*(self: Service, storageDir: string)
+  include queued_async_calls
 
   proc init*(self: Service) =
     debug "KeycardServiceV2 init"
     self.initializeRPC()
-    self.start(status_const.KEYCARDPAIRINGDATAFILE)
+    self.asyncStart(status_const.KEYCARDPAIRINGDATAFILE)
     discard
 
   proc initializeRPC(self: Service) {.slot.} =
     var response = keycard_go.keycardInitializeRPC()
 
-  proc start*(self: Service, storageDir: string) =
-    discard callRPC("Start", %*{"storageFilePath": storageDir})
+  proc receiveKeycardSignalV2(self: Service, signal: string) {.slot.} =
+    try:
+      # Since only one service can register to signals, we pass the signal to the old service too
+      var jsonSignal = signal.parseJson
+      if jsonSignal["type"].getStr == "status-changed":
+        let keycardEvent = jsonSignal["event"].toKeycardEventDto()
 
-  proc stop*(self: Service) =
-    discard callRPC("Stop")
-  
-  proc buildSeedPhrasesFromIndexes*(seedPhraseIndexes: JsonNode): seq[string] =
-    var seedPhrase: seq[string]
-    for ind in seedPhraseIndexes.items:
-      seedPhrase.add(englishWords[ind.getInt])
-    return seedPhrase
+        self.events.emit(SIGNAL_KEYCARD_STATE_UPDATED, KeycardEventArg(keycardEvent: keycardEvent))
+    except Exception as e:
+      error "error receiving a keycard signal", err=e.msg, data = signal
+
+  proc asyncStart(self: Service, storageDir: string) =
+    let params = %*{"storageFilePath": storageDir}
+    self.asyncCallRPC(KeycardAction.Start, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error starting keycard", err=err
+        return
+      debug "keycard started"
+    )
+
+  proc asyncStop*(self: Service) =
+    let params = %*{}
+    self.asyncCallRPC(KeycardAction.Stop, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error stopping keycard", err=err
+        return
+      debug "keycard stopped"
+    )
 
   proc generateMnemonic*(self: Service, length: int): string =
     try:
-      let response = callRPC("GenerateMnemonic", %*{"length": length})
+      let response = callRPC($KeycardAction.GenerateMnemonic, %*{"length": length})
       let rpcResponseObj = response.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
           let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
-          raise newException(RpcException, "Error loading mnemonic: " & error.message)
+          raise newException(RpcException, error.message)
 
       let indexes = rpcResponseObj["result"]["indexes"]
       let words = buildSeedPhrasesFromIndexes(indexes)
@@ -99,170 +145,90 @@ QtObject:
     except Exception as e:
       error "error generating mnemonic", err=e.msg
 
-  proc loadMnemonic*(self: Service, mnemonic: string) =
-    let arg = AsyncLoadMnemonicArg(
-      tptr: asyncLoadMnemonicTask,
-      vptr: cast[uint](self.vptr),
-      slot: "onAsyncLoadMnemonicResponse",
-      mnemonic: mnemonic,
-    )
-    self.threadpool.start(arg)
-    
-  proc onAsyncLoadMnemonicResponse(self: Service, response: string) {.slot.} =
+  proc getMetadata*(self: Service): CardMetadataDto =
     try:
-      let responseObj = response.parseJson
-      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
-        raise newException(CatchableError, responseObj{"error"}.getStr)
-
-      let rpcResponseObj = responseObj["response"].getStr().parseJson()
-
+      let response = callRPC($KeycardAction.GetMetadata)
+      let rpcResponseObj = response.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
         let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
-        raise newException(RpcException, "Error loading mnemonic: " & error.message)
-
-      self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_SUCCESS, KeycardKeyUIDArg(keyUID: rpcResponseObj["result"]["keyUID"].getStr))
+        raise newException(RpcException, error.message)
+      return rpcResponseObj["result"].toCardMetadataDto()
     except Exception as e:
-      error "error loading mnemonic", err=e.msg
-      self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_FAILURE, KeycardErrorArg(error: e.msg))
+      error "error getting metadata", err=e.msg
+
+  proc asyncLoadMnemonic*(self: Service, mnemonic: string) =
+    let params = %*{"mnemonic": mnemonic}
+    self.asyncCallRPC(KeycardAction.LoadMnemonic, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error loading mnemonic", err=err
+        self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_FAILURE, KeycardErrorArg(error: err))
+        return
+      let keyUID = responseObj["result"]["keyUID"].getStr
+      self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_SUCCESS, KeycardKeyUIDArg(keyUID: keyUID))
+    )
 
   proc asyncAuthorize*(self: Service, pin: string) =
-    let arg = AsyncAuthorizeArg(
-      tptr: asyncAuthorizeTask,
-      vptr: cast[uint](self.vptr),
-      slot: "onAsyncAuthorizeResponse",
-      pin: pin,
-    )
-    self.threadpool.start(arg)
-
-  proc onAsyncAuthorizeResponse*(self: Service, response: string) {.slot.} =
-    try:
-      let responseObj = response.parseJson
-
-      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
-        raise newException(CatchableError, responseObj{"error"}.getStr)
-
-      let rpcResponseObj = responseObj["response"].getStr().parseJson()
-      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        raise newException(RpcException, rpcResponseObj["error"].getStr)
-      let resultObj = rpcResponseObj{"result"}
+    let params = %*{"pin": pin}
+    self.asyncCallRPC(KeycardAction.Authorize, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error authorizing", err=err
+        let event = KeycardAuthorizeEvent(error: err, authorized: false)
+        self.events.emit(SIGNAL_KEYCARD_AUTHORIZE_FINISHED, event)
+        return
+      let resultObj = responseObj{"result"}
       let event = KeycardAuthorizeEvent(
         error: "",
         authorized: resultObj{"authorized"}.getBool(),
       )
       self.events.emit(SIGNAL_KEYCARD_AUTHORIZE_FINISHED, event)
-    except Exception as e:
-      error "error during authorize: ", msg = e.msg
-      let event = KeycardAuthorizeEvent(error: e.msg, authorized: false)
-      self.events.emit(SIGNAL_KEYCARD_AUTHORIZE_FINISHED, event)
-
-  proc receiveKeycardSignalV2(self: Service, signal: string) {.slot.} =
-    try:
-      # Since only one service can register to signals, we pass the signal to the old service too
-      var jsonSignal = signal.parseJson
-
-      if jsonSignal["type"].getStr == "status-changed":
-        let keycardEvent = jsonSignal["event"].toKeycardEventDto()
-        
-        self.events.emit(SIGNAL_KEYCARD_STATE_UPDATED, KeycardEventArg(keycardEvent: keycardEvent))
-    except Exception as e:
-      error "error receiving a keycard signal", err=e.msg, data = signal
-
-  proc initialize*(self: Service, pin: string, puk: string) =
-    let arg = AsyncInitializeTaskArg(
-      tptr: asyncInitializeTask,
-      vptr: cast[uint](self.vptr),
-      slot: "onAsyncInitializeResponse",
-      pin: pin,
-      puk: puk,
     )
-    self.threadpool.start(arg)
 
-  proc onAsyncInitializeResponse*(self: Service, response: string) {.slot.} =
-    try:
-      let responseObj = response.parseJson
-
-      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
-        raise newException(CatchableError, responseObj{"error"}.getStr)
-
-      let rpcResponseObj = responseObj["response"].getStr().parseJson()
-      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
-        raise newException(RpcException, "Error authorizing: " & error.message)
-    except Exception as e:
-      error "error set pin: ", msg = e.msg
-      self.events.emit(SIGNAL_KEYCARD_SET_PIN_FAILURE, KeycardErrorArg(error: e.msg))
-
-  proc generateRandomPUK*(self: Service): string =
-    randomize()
-    for i in 0 ..< PUKLengthForStatusApp:
-      result = result & $rand(0 .. 9)
+  proc asyncInitialize*(self: Service, pin: string, puk: string) =
+    let params = %*{"pin": pin, "puk": puk}
+    self.asyncCallRPC(KeycardAction.Initialize, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error initializing keycard", err=err
+        self.events.emit(SIGNAL_KEYCARD_SET_PIN_FAILURE, KeycardErrorArg(error: err))
+        return
+      debug "keycard initialized"
+    )
 
   proc asyncExportRecoverKeys*(self: Service) =
-    let arg = AsyncExportRecoverKeysArg(
-      tptr: asyncExportRecoverKeysTask,
-      vptr: cast[uint](self.vptr),
-      slot: "onAsyncExportRecoverKeys",
-    )
-    self.threadpool.start(arg)
-
-  proc onAsyncExportRecoverKeys*(self: Service, response: string) {.slot.} =
-    try:
-      let responseObj = response.parseJson
-
-      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
-        raise newException(CatchableError, responseObj{"error"}.getStr)
-
-      let rpcResponseObj = responseObj["response"].getStr().parseJson()
-      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
-        raise newException(RpcException, "Error authorizing: " & error.message)
-
-      let keys = rpcResponseObj["result"]["keys"].toKeycardExportedKeysDto()
+    let params = %*{}
+    self.asyncCallRPC(KeycardAction.ExportRecoverKeys, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error exporting recover keys", err=err
+        self.events.emit(SIGNAL_KEYCARD_EXPORT_RESTORE_KEYS_FAILURE, KeycardErrorArg(error: err))
+        return
+      let keys = responseObj["result"]["keys"].toKeycardExportedKeysDto()
       self.events.emit(SIGNAL_KEYCARD_EXPORT_RESTORE_KEYS_SUCCESS, KeycardExportedKeysArg(exportedKeys: keys))
-    except Exception as e:
-      error "error exporting recover keys", msg = e.msg
-      self.events.emit(SIGNAL_KEYCARD_EXPORT_RESTORE_KEYS_FAILURE, KeycardErrorArg(error: e.msg))
+    )
 
   proc asyncExportLoginKeys*(self: Service) =
-    let arg = AsyncExportLoginKeysArg(
-      tptr: asyncExportLoginKeysTask,
-      vptr: cast[uint](self.vptr),
-      slot: "onAsyncExportLoginKeys",
-    )
-    self.threadpool.start(arg)
-
-  proc onAsyncExportLoginKeys*(self: Service, response: string) {.slot.} =
-    try:
-      let responseObj = response.parseJson
-
-      if responseObj{"error"}.kind != JNull and responseObj{"error"}.getStr != "":
-        raise newException(CatchableError, responseObj{"error"}.getStr)
-
-      let rpcResponseObj = responseObj["response"].getStr().parseJson()
-      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
-        raise newException(RpcException, "Error authorizing: " & error.message)
-
-      let keys = rpcResponseObj["result"]["keys"].toKeycardExportedKeysDto()
+    let params = %*{}
+    self.asyncCallRPC(KeycardAction.ExportLoginKeys, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error exporting login keys", err=err
+        self.events.emit(SIGNAL_KEYCARD_EXPORT_LOGIN_KEYS_FAILURE, KeycardErrorArg(error: err))
+        return
+      let keys = responseObj["result"]["keys"].toKeycardExportedKeysDto()
       self.events.emit(SIGNAL_KEYCARD_EXPORT_LOGIN_KEYS_SUCCESS, KeycardExportedKeysArg(exportedKeys: keys))
-    except Exception as e:
-      error "error exporting login keys", msg = e.msg
-      self.events.emit(SIGNAL_KEYCARD_EXPORT_LOGIN_KEYS_FAILURE, KeycardErrorArg(error: e.msg))
+    )
 
   proc asyncFactoryReset*(self: Service) =
-    let arg = AsyncFactoryResetArg(
-      tptr: asyncFactoryResetTask,
-      vptr: cast[uint](self.vptr),
-      slot: "onAsyncFactoryReset",
+    let params = %*{}
+    self.asyncCallRPC(KeycardAction.FactoryReset, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error factory reset", err=err
+        return
+      debug "factory reset"
     )
-    self.threadpool.start(arg)
 
-  proc onAsyncFactoryReset*(self: Service) =
-    try:
-      let response = callRPC("FactoryReset")
-      let rpcResponseObj = response.parseJson
-      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
-        raise newException(RpcException, "Error factory reset: " & error.message)
-    except Exception as e:
-      error "error factory reset", err=e.msg
+  proc asyncStoreMetadata*(self: Service, name: string, paths: seq[string]) =
+    let params = %*{"name": name, "paths": paths}
+    self.asyncCallRPC(KeycardAction.StoreMetadata, params, proc (responseObj: JsonNode, err: string) =
+      if err.len > 0:
+        error "error storing metadata", err=err
+        return
+      debug "metadata stored"
+    )

--- a/src/app_service/service/keycardV2/utils.nim
+++ b/src/app_service/service/keycardV2/utils.nim
@@ -1,0 +1,12 @@
+include app_service/common/mnemonics
+
+proc generateRandomPUK*(): string =
+  randomize()
+  for i in 0 ..< PUKLengthForStatusApp:
+    result = result & $rand(0 .. 9)
+
+proc buildSeedPhrasesFromIndexes*(seedPhraseIndexes: JsonNode): seq[string] =
+  var seedPhrase: seq[string]
+  for ind in seedPhraseIndexes.items:
+    seedPhrase.add(englishWords[ind.getInt])
+  return seedPhrase

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -55,6 +55,10 @@ proc getKeypairByKeyUid*(self: Service, keyUid: string): KeypairDto =
     return
   return self.keypairs[keyUid]
 
+# This one should be used in a very rare cases, when we need to get keypair from db before service is initialized
+proc getKeypairByKeyUidFromDb*(self: Service, keyUid: string): KeypairDto =
+  return getKeypairByKeyUidFromDb(keyUid)
+
 proc getKeypairByAccountAddress*(self: Service, address: string): KeypairDto =
   for _, kp in self.keypairs:
     for acc in kp.accounts:


### PR DESCRIPTION
Changes done in this PR:
- Due to inability (because of the hardware limitations/speed) to call one keycard flow immediately after another a queued mechanism of calls is added
- All functions from the keycard service that do the async keycard calls follow the pattern "asyncFunctionName"
- New functions added to keycard service:
- getMetadata
- asyncStoreMetadata
- Keycard's metadata updated and synced with the app state
- The app updated appropriately that keycard accounts are marked with the keycard icon and keycard is now visible in the settings' keycards section
- By default if there is no name for the profile key pair "Status Keycard" is used for the keycard name


Closes: https://github.com/status-im/status-desktop/issues/17128


https://github.com/user-attachments/assets/47a302e4-ef42-41e4-9139-50e6c5be9422

