### PR TITLE
fix: restore missing testnet mode banner, community settings disable

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1493,7 +1493,7 @@ Item {
                     buttonText: qsTr("Turn off")
                     type: ModuleWarning.Warning
                     iconName: "warning"
-                    active: appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled
+                    active: appMain.networksStore.areTestNetworksEnabled
                     delay: false
                     onClicked: Global.openTestnetPopup()
                     closeBtnVisible: false
@@ -2099,7 +2099,7 @@ Item {
                                 createChatPropertiesStore: appMain.createChatPropertiesStore
                                 communitiesStore: appMain.communitiesStore
                                 communitySettingsDisabled: !chatLayoutComponent.isManageCommunityEnabledInAdvanced &&
-                                                           (production && appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled)
+                                                           (production && appMain.networksStore.areTestNetworksEnabled)
                                 sharedRootStore: appMain.sharedRootStore
                                 utilsStore: appMain.utilsStore
                                 rootStore: ChatStores.RootStore {


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/17346

We were using the old stores for getting the areTestNetworksEnabled property

<img width="1206" alt="image" src="https://github.com/user-attachments/assets/008bcac0-ec93-4465-beaa-bf1e8a24ae6e" />


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
