### PR TITLE
fix(Onboarding): Back button appears on loading screen

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -301,6 +301,7 @@ method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settin
   let err2 = self.delegate.userLoggedIn()
   if err2.len != 0:
     error "error from userLoggedIn", err2
+    self.onAccountLoginError(err2)
     return
 
   if self.localPairingStatus != nil and self.localPairingStatus.installation != nil and self.localPairingStatus.installation.id != "":

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -166,6 +166,12 @@ SplitView {
 
             // password signals
             signal accountLoginError(string error, bool wrongPassword)
+
+            // (test) error handler
+            onAccountLoginError: function (error, wrongPassword) {
+                ctrlLoginResult.result = "<font color='red'>⛔</font>"
+                onboarding.unwindToLoginScreen()
+            }
         }
 
         biometricsAvailable: ctrlBiometrics.checked
@@ -179,7 +185,6 @@ SplitView {
             logs.logEvent("onFinished", ["flow", "data"], arguments)
 
             console.warn("!!! SIMULATION: SHOWING SPLASH")
-            stack.clear()
             stack.push(splashScreen, { runningProgressAnimation: true })
         }
 
@@ -188,7 +193,7 @@ SplitView {
 
             // SIMULATION: emit an error in case of wrong password or PIN
             if (method === Onboarding.LoginMethod.Password && data.password !== mockDriver.password) {
-                onboardingStore.accountLoginError("The impossible has happened", Math.random() < 0.5) // randomly fail between a wrong pass and some other error
+                onboardingStore.accountLoginError("", true)
                 ctrlLoginResult.result = "<font color='red'>⛔</font>"
             } else if (method === Onboarding.LoginMethod.Keycard && data.pin !== mockDriver.pin) {
                 onboardingStore.keycardRemainingPinAttempts-- // SIMULATION: decrease the remaining PIN attempts
@@ -200,6 +205,7 @@ SplitView {
                 ctrlLoginResult.result = "<font color='red'>⛔</font>"
             } else {
                 ctrlLoginResult.result = "<font color='green'>✔</font>"
+                stack.push(splashScreen, { runningProgressAnimation: true })
             }
         }
 
@@ -359,6 +365,7 @@ SplitView {
         id: splashScreen
 
         DidYouKnowSplashScreen {
+            readonly property bool backAvailableHint: false
             property bool runningProgressAnimation
 
             NumberAnimation on progress {
@@ -459,6 +466,18 @@ SplitView {
                     property string result: "🯄"
                     visible: ctrlLoginScreen.checked
                     text: "Login result: %1".arg(result)
+                }
+
+                Button {
+                    text: "Unwind"
+                    visible: ctrlLoginScreen.checked && onboarding.stack.depth > 1 && !(onboarding.currentPage instanceof DidYouKnowSplashScreen)
+                    onClicked: onboarding.unwindToLoginScreen()
+                }
+
+                Button {
+                    text: "Simulate login error"
+                    visible: ctrlLoginScreen.checked && onboarding.currentPage instanceof DidYouKnowSplashScreen
+                    onClicked: onboarding.onboardingStore.accountLoginError("SIMULATION: Something bad happened", false)
                 }
             }
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -200,10 +200,10 @@ OnboardingStackView {
             onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
             onOnboardingCreateProfileFlowRequested: root.push(createProfilePage)
             onOnboardingLoginFlowRequested: root.push(loginPage)
-            onLostKeycardFlowRequested: () => {
-                               root.keyUidSubmitted(loginScreen.selectedProfileKeyId)
-                               root.push(keycardLostPage)
-                           }
+            onLostKeycardFlowRequested: {
+                root.keyUidSubmitted(loginScreen.selectedProfileKeyId)
+                root.push(keycardLostPage)
+            }
 
             onUnblockWithSeedphraseRequested: root.push(unblockWithSeedphraseFlow)
             onUnblockWithPukRequested: root.push(unblockWithPukFlow)

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -24,7 +24,7 @@ Page {
     property bool networkChecksEnabled: true
     property alias keycardPinInfoPageDelay: onboardingFlow.keycardPinInfoPageDelay
 
-    readonly property alias stack: onboardingFlow
+    readonly property alias stack: onboardingFlow // TODO remove external stack access
     readonly property string currentPageName: stack.topLevelItem ? Utils.objectTypeName(stack.topLevelItem) : ""
 
     signal shareUsageDataRequested(bool enabled)
@@ -47,6 +47,16 @@ Page {
     function unload() {
         onboardingFlow.clear()
         d.resetState()
+    }
+
+    // clear the stack down to the LoginScreen, or recreate it
+    // the purpose is to return from main/splash screen in case of a late stage error
+    // and use the below error handler (onAccountLoginError)
+    function unwindToLoginScreen() {
+        onboardingFlow.pop(null, StackView.PopTransition)
+        if (!onboardingFlow.loginScreen) {
+            restartFlow()
+        }
     }
 
     function setBiometricResponse(secret: string, error = "",
@@ -216,10 +226,10 @@ Page {
         }
     }
 
+    // error handler for the LoginScreen
     Connections {
         target: root.onboardingStore
 
-        // (password) login
         function onAccountLoginError(error: string, wrongPassword: bool) {
             const loginScreen = onboardingFlow.loginScreen
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -53,7 +53,7 @@ Page {
     // the purpose is to return from main/splash screen in case of a late stage error
     // and use the below error handler (onAccountLoginError)
     function unwindToLoginScreen() {
-        onboardingFlow.pop(null, StackView.PopTransition)
+        onboardingFlow.pop(null, StackView.Immediate)
         if (!onboardingFlow.loginScreen) {
             restartFlow()
         }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -225,8 +225,7 @@ StatusWindow {
                 appLoadingAnimation.active = false
                 appLoadingAnimation.active = true
                 startupOnboardingLoader.item.visible = false
-            }
-            else if(state === Constants.appState.main) {
+            } else if(state === Constants.appState.main) {
                 // We set main module to the Global singleton once user is logged in and we move to the main app.
                 appLoadingAnimation.active = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
                 appLoadingAnimation.runningProgressAnimation = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
@@ -405,6 +404,11 @@ StatusWindow {
                 duration: !!localAppSettings && localAppSettings.fakeLoadingScreenEnabled ? 30000 : 3000
                 running: runningProgressAnimation
             }
+            onProgressChanged: {
+                if (progress === 1) {
+                    mainModule.fakeLoadingScreenFinished()
+                }
+            }
         }
     }
 
@@ -480,7 +484,7 @@ StatusWindow {
             }
 
             onLoginRequested: function (keyUid, method, data) {
-                stack.push(splashScreenV2, { runningProgressAnimation: true })
+                stack.push(splashScreenV2, { runningProgressAnimation: true }, StackView.Immediate) // we unwind on error
                 onboardingStore.loginRequested(keyUid, method, data)
             }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -198,7 +198,7 @@ StatusWindow {
         Theme.changeTheme(localAppSettings.theme, systemPalette.isCurrentSystemThemeDark())
         Theme.changeFontSize(localAccountSensitiveSettings.fontSize)
 
-        d.runMockedKeycardControllerWindow() // FIXME this is run twice with onboardingV1
+        d.runMockedKeycardControllerWindow()
     }
 
     //TODO remove direct backend access
@@ -395,6 +395,7 @@ StatusWindow {
     Component {
         id: splashScreenV2
         DidYouKnowSplashScreen {
+            readonly property bool backAvailableHint: false
             readonly property string pageClassName: "Splash"
             property bool runningProgressAnimation
             messagesEnabled: true
@@ -475,7 +476,6 @@ StatusWindow {
                     console.error("!!! ONBOARDING FINISHED WITH ERROR:", error)
                     return
                 }
-                stack.clear()
                 stack.push(splashScreenV2, { runningProgressAnimation: true })
             }
 
@@ -500,7 +500,7 @@ StatusWindow {
                     moveToAppMain()
                 }
                 onAccountLoginError: function (error, wrongPassword) {
-                    onboardingLayout.stack.pop()
+                    onboardingLayout.unwindToLoginScreen() // error handled internally
                 }
             }
 


### PR DESCRIPTION
### What does the PR do

- don't clear the stack, we might need it to show errors during login (while displaying splash screen)
- use the `backAvailableHint` instead on the splash screen itself to hide the back button
- when a login error happens, unwind (or recreate) the stack to show the LoginScreen page again, together with the error message
- add a simulation of these 2 scenarios to StoryBook, together with showing the splash screen after a login

Fixes https://github.com/status-im/status-desktop/issues/17352

### Affected areas

Onboarding/Splash screen

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/c78882e2-adda-465c-9579-d4720d4d9c6e

