### PR TITLE
feat: keycard log to file and only in development

### DIFF
--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -113,7 +113,11 @@ QtObject:
       error "error receiving a keycard signal", err=e.msg, data = signal
 
   proc asyncStart(self: Service, storageDir: string) =
-    let params = %*{"storageFilePath": storageDir}
+    let params = %*{
+      "storageFilePath": storageDir,
+      "logEnabled": KEYCARD_LOGS_ENABLED,
+      "logFilePath": KEYCARD_LOG_FILE_PATH,
+    }
     self.asyncCallRPC(KeycardAction.Start, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
         error "error starting keycard", err=err

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -31,7 +31,9 @@ let
   ROOTKEYSTOREDIR* = joinPath(baseDir, "data", "keystore")
   TMPDIR* = joinPath(baseDir, "tmp") & sep
   LOGDIR* = joinPath(baseDir, "logs") & sep
-  KEYCARDPAIRINGDATAFILE* = joinPath(baseDir, "data", "keycard", "pairings.json")
+  KEYCARD_DATA_DIR* = joinPath(baseDir, "data", "keycard")
+  KEYCARD_LOG_FILE_PATH* = joinPath(KEYCARD_DATA_DIR, "keycard.log")
+  KEYCARDPAIRINGDATAFILE* = joinPath(KEYCARD_DATA_DIR, "pairings.json")
 
   # runtime variables
   TEST_MODE_ENABLED* = desktopConfig.testMode
@@ -73,6 +75,7 @@ let
   SENTRY_DSN_STATUS_GO* = BUILD_SENTRY_DSN_STATUS_GO
   SENTRY_DSN_STATUS_GO_DESKTOP* = BUILD_SENTRY_DSN_STATUS_DESKTOP
   API_LOGGING* = desktopConfig.apiLogging
+  KEYCARD_LOGS_ENABLED* = if defined(production): false else: true
 
 proc hasLogLevelOption*(): bool =
   for p in cliParams:


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17364
Requires https://github.com/status-im/status-desktop/pull/17355
Based on top of https://github.com/status-im/status-desktop/pull/17337

# Description

1. Update dependency to get https://github.com/keycard-tech/status-keycard-go/pull/22
2. Only write keycard logs in development builds. 
3. Write keycard logs to `Status/data/keycard/keycardl.log` file, instead of console (because the format doesn't match and logs are not synced)

### Affected areas

Onboarding, Logs

### How to test

1. Run development build, ensure:
    - no keycard logs in console
    - `Status/data/keycard/keycardl.log` file,
2. Run production build, ensure:
    - no keycard logs in both console and files

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.