### PR TITLE
feat(wallet): Adjust scrolling behavior

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -195,10 +195,10 @@ StatusDialog {
 
         readonly property real scrollViewContentY: scrollView.flickable.contentY
         onScrollViewContentYChanged: {
-            const buffer = sendModalHeader.height + scrollViewLayout.spacing
+            const buffer = sendModalHeader.height + scrollViewLayout.spacing * 2
             if (scrollViewContentY > buffer) {
                 d.stickyHeaderVisible = true
-            } else if (scrollViewContentY === 0) {
+            } else if (scrollViewContentY < buffer) {
                 d.stickyHeaderVisible = false
             }
         }


### PR DESCRIPTION
Closes #17265

### What does the PR do

Updating scrolling size and speed didn't give good result.
Only possible way to imitate the design bahevior  was to adjust the buffer, so the sticky header will show later and hide earlier.

### Affected areas

Send modal

### Architecture compliance

- [X] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

Design video:

https://www.figma.com/proto/RfsBP6hKbUvaAjQUrpvMq5/Send?node-id=1-67434&t=fhiFhshyyICkquvY-0&scaling=min-zoom&content-scaling=fixed&page-id=1%3A20&starting-point-node-id=1%3A75261


https://github.com/user-attachments/assets/8a68974f-67e7-42d5-911f-ef803942a63d

