### PR TITLE
CMake configs for Storybook supporting both Qt 5 & 6

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -18,10 +18,15 @@ if (APPLE)
     set(MACOS_VERSION_MIN_FLAGS -mmacosx-version-min=11.0)
 endif()
 
-find_package(
-  Qt5
-  COMPONENTS Core Gui Quick QuickControls2 Test QuickTest Qml WebView
-  REQUIRED)
+find_package(Qt6 COMPONENTS Core QUIET)
+if (Qt6_FOUND)
+    set(QT_VERSION_MAJOR 6)
+else()
+    set(QT_VERSION_MAJOR 5)
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Quick QuickControls2 Test
+    QuickTest Qml WebView REQUIRED)
 
 set(STATUSQ_BUILD_SANDBOX OFF)
 set(STATUSQ_BUILD_SANITY_CHECKER OFF)
@@ -76,7 +81,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
     )
 
 target_link_libraries(
-    ${PROJECT_LIB} PUBLIC Qt5::Core Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::WebView StatusQ)
+    ${PROJECT_LIB} PUBLIC Qt::Core Qt::Gui Qt::Quick Qt::QuickControls2 Qt::WebView StatusQ)
 
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE ${PROJECT_LIB})
@@ -89,7 +94,7 @@ add_executable(
 )
 
 target_link_libraries(
-    PagesValidator PUBLIC Qt5::Core Qt5::Gui Qt5::Quick Qt5::QuickControls2 Qt5::WebView StatusQ)
+    PagesValidator PUBLIC Qt::Core Qt::Gui Qt::Quick Qt::QuickControls2 Qt::WebView StatusQ)
 
 target_compile_definitions(PagesValidator PRIVATE
         QML_IMPORT_ROOT="${CMAKE_CURRENT_LIST_DIR}"
@@ -99,11 +104,11 @@ target_compile_definitions(PagesValidator PRIVATE
 add_test(NAME PagesValidator COMMAND PagesValidator)
 
 add_executable(SectionsDecoratorModelTest tests/tst_SectionsDecoratorModel.cpp)
-target_link_libraries(SectionsDecoratorModelTest PRIVATE Qt5::Test ${PROJECT_LIB})
+target_link_libraries(SectionsDecoratorModelTest PRIVATE Qt::Test ${PROJECT_LIB})
 add_test(NAME SectionsDecoratorModelTest COMMAND SectionsDecoratorModelTest)
 
 add_executable(DirectoryFilesWatcherTest tests/tst_DirectoryFilesWatcher.cpp)
-target_link_libraries(DirectoryFilesWatcherTest PRIVATE Qt5::Test ${PROJECT_LIB})
+target_link_libraries(DirectoryFilesWatcherTest PRIVATE Qt::Test ${PROJECT_LIB})
 add_test(NAME DirectoryFilesWatcherTest COMMAND DirectoryFilesWatcherTest)
 
 add_executable(QmlTests
@@ -114,7 +119,7 @@ target_compile_definitions(QmlTests PRIVATE
         QML_IMPORT_ROOT="${CMAKE_CURRENT_LIST_DIR}"
         STATUSQ_MODULE_IMPORT_PATH="${STATUSQ_MODULE_IMPORT_PATH}"
         QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qmlTests")
-target_link_libraries(QmlTests PRIVATE Qt5::QuickTest Qt5::Qml ${PROJECT_LIB} SortFilterProxyModel)
+target_link_libraries(QmlTests PRIVATE Qt::QuickTest Qt::Qml ${PROJECT_LIB} SortFilterProxyModel)
 add_test(NAME QmlTests COMMAND QmlTests -platform offscreen)
 
 set(OVERRIDE_STORE_PATHS_WITH_STUBS_IN_QTCREATOR OFF CACHE BOOL

--- a/storybook/src/Storybook/FigmaPreviewWindow.qml
+++ b/storybook/src/Storybook/FigmaPreviewWindow.qml
@@ -75,9 +75,9 @@ ApplicationWindow {
                 count: imagesSwipeView.count
                 currentIndex: imagesSwipeView.currentIndex
 
-                onUp: topSwipeView.decrementCurrentIndex()
-                onLeft: imagesSwipeView.decrementCurrentIndex()
-                onRight: imagesSwipeView.incrementCurrentIndex()
+                onMoveUp: topSwipeView.decrementCurrentIndex()
+                onMoveLeft: imagesSwipeView.decrementCurrentIndex()
+                onMoveRight: imagesSwipeView.incrementCurrentIndex()
             }
         }
     }

--- a/storybook/src/Storybook/ImagesNavigationLayout.qml
+++ b/storybook/src/Storybook/ImagesNavigationLayout.qml
@@ -8,9 +8,9 @@ ColumnLayout {
     property alias count: indicator.count
     property alias currentIndex: indicator.currentIndex
 
-    signal up
-    signal left
-    signal right
+    signal moveUp
+    signal moveLeft
+    signal moveRight
 
     RowLayout {
         Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
### What does the PR do

- Updates Storybook's CMakeListst.txt to handle both Qt 5 and 6 seamlessly
- Introduces workaround for the qt bug reported there: https://bugreports.qt.io/browse/QTBUG-134074

### Affected areas
`Storybook`

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

