### PR TITLE
fix: Don't load the command line arguments for lib or staticLib

### DIFF
--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -296,8 +296,11 @@ type StatusDesktopConfig = object
 # serial number (PSN) as -psn_... command-line argument, which we remove before
 # processing the arguments with nim-confutils.
 # Credit: https://github.com/bitcoin/bitcoin/blame/b6e34afe9735faf97d6be7a90fafd33ec18c0cbb/src/util/system.cpp#L383-L389
+when appType == "lib" or appType == "staticlib":
+  var cliParams: seq[string] = @[]
+else:
+  var cliParams = commandLineParams()
 
-var cliParams = commandLineParams()
 if defined(macosx):
   cliParams.keepIf(proc(p: string): bool = not p.startsWith("-psn_"))
 


### PR DESCRIPTION
Closes #17380

Don't try to load the commandLineParams if the app is built as lib or staticLib