### PR TITLE
Qt 5->6: Adjust `GraphicalEffects` imports to work on both qt 5/6

### DIFF
--- a/storybook/pages/StatusImageCropPanelPage.qml
+++ b/storybook/pages/StatusImageCropPanelPage.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Dialogs 1.3
 import QtQml 2.14
-import QtGraphicalEffects 1.14
+import QtGraphicalEffects 1.15
 
 import Storybook 1.0
 import Models 1.0

--- a/ui/StatusQ/sandbox/pages/StatusImageCropPanelPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusImageCropPanelPage.qml
@@ -7,7 +7,7 @@ import QtQml 2.14
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
-import QtGraphicalEffects 1.14
+import QtGraphicalEffects 1.15
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Layouts 1.14
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatInfoToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatInfoToolBar.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.13
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusColorSpace.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusColorSpace.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.14
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -5,7 +5,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
-import QtGraphicalEffects 1.14
+import QtGraphicalEffects 1.15
 
 import "private"
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusListPicker.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListPicker.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import QtMultimedia 5.15
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedComponent.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedComponent.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.13
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusTagSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusTagSelector.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
@@ -2,7 +2,7 @@ import QtQuick 2.14
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusImageMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusImageMessage.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.3
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.13
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 import QtQuick.Layouts 1.14
 
 import StatusQ.Controls 0.1

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusPinMessageDetails.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusPinMessageDetails.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.15
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
 
-import QtGraphicalEffects 1.1
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core.Utils 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSelect.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSelect.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSlider.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSlider.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.14
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/StatusQ/Platform/StatusMacNotification.qml
+++ b/ui/StatusQ/src/StatusQ/Platform/StatusMacNotification.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -113,6 +113,14 @@ void registerStatusQTypes() {
                                                   return new OnboardingEnums;
                                               });
 
+// create import alias from QtGraphicalEffects 1.15 to Qt5Compat.GraphicalEffects
+// in order to satisfy both Qt 5/6, relying the same version of qml code
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    qmlRegisterModule("QtGraphicalEffects", 1, 15);
+    qmlRegisterModuleImport("QtGraphicalEffects", QQmlModuleImportModuleAny,
+                            "Qt5Compat.GraphicalEffects", QQmlModuleImportLatest);
+#endif
+
     QZXing::registerQMLTypes();
     qqsfpm::registerTypes();
 }

--- a/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
@@ -2,7 +2,7 @@ import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
 import QtQuick.Dialogs 1.3
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import utils 1.0
 import shared.panels 1.0

--- a/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
@@ -2,7 +2,7 @@ import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
 import QtQuick.Dialogs 1.3
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import utils 1.0
 import shared.panels 1.0

--- a/ui/app/AppLayouts/Communities/panels/ControlNodeOfflineCenterPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ControlNodeOfflineCenterPanel.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/app/AppLayouts/Communities/panels/JoinCommunityCenterPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinCommunityCenterPanel.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/app/AppLayouts/Communities/panels/JoinCommunityHeaderPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/JoinCommunityHeaderPanel.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/app/AppLayouts/Communities/panels/PrivilegedTokenArtworkPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PrivilegedTokenArtworkPanel.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/app/AppLayouts/Communities/panels/TokenInfoPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TokenInfoPanel.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.0
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/app/AppLayouts/Wallet/controls/AccountHeaderGradient.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AccountHeaderGradient.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.13
-import QtGraphicalEffects 1.12
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core.Theme 0.1
 

--- a/ui/app/mainui/activitycenter/controls/CommunityBadge.qml
+++ b/ui/app/mainui/activitycenter/controls/CommunityBadge.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.3
 import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.13
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core 0.1

--- a/ui/imports/shared/panels/SeedPhrase.qml
+++ b/ui/imports/shared/panels/SeedPhrase.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.14
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1


### PR DESCRIPTION
### What does the PR do

- Creates import alias for Qt 6 by
  - registering dummy `QtGraphicalEffects 1.15`
  - registering module import `Qt5Compat.GraphicalEffects` for the dummy module to load the actual module
- Replaces all occurences of `import QtGraphicalEffects 1.* ` to
  ```
  import QtGraphicalEffects 1.15
  ```

Closes: #17388

Script used for replacement:
```bash
#!/bin/bash

# Directory to search in
directory=$1

# Initialize count
count=0

# Find and replace lines in .qml files and count occurrences
while IFS= read -r -d '' file; do
  # Count occurrences that match the pattern but not already "import QtGraphicalEffects 1.15"
  occurrences=$(grep -E 'import QtGraphicalEffects 1\..*' "$file" | grep -v 'import QtGraphicalEffects 1.15' | wc -l)
  if [ "$occurrences" -gt 0 ]; then
    # Replace matching lines with "import QtGraphicalEffects 1.15"
    sed -i -E 's/import QtGraphicalEffects 1\..*/import QtGraphicalEffects 1.15/' "$file"
    count=$((count + occurrences))
  fi
done < <(find "$directory" -type f -name "*.qml" -print0)

# Print the number of occurrences replaced
echo "Replaced $count occurrences."
```

### Affected areas
The whole qml codebase (components using `QtGraphicalEffects`)

