### PR TITLE
fix: send metrics event with proper login flow

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -271,11 +271,10 @@ proc syncAppAndKeycardState[T](self: Module[T]) =
 proc finishAppLoading2[T](self: Module[T]) =
   self.delegate.appReady()
 
-  var eventType = "user-logged-in"
-  if self.loginFlow == LoginMethod.Unknown:
-    eventType = "onboarding-completed"
-  singletonInstance.globalEvents.addCentralizedMetricIfEnabled(eventType,
-    $(%*{"flowType": repr(self.onboardingFlow)}))
+  let isOnboarding = self.loginFlow == LoginMethod.Unknown
+  let eventType = if isOnboarding: "onboarding-completed" else: "user-logged-in"
+  let flowType = if isOnboarding: repr(self.onboardingFlow) else : repr(self.loginFlow)
+  singletonInstance.globalEvents.addCentralizedMetricIfEnabled(eventType, $(%*{"flowType": flowType}))
 
   self.syncAppAndKeycardState()
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17350

# Testing note

But I couldn't confirm that it works. I can see that the metrics are enabled:
```
2025-02-26T18:52:39.383Z	DEBUG	RequestLogger	call	{"method": "centralizedMetricsInfo", "duration": "77.875µs", "request": null, "response": {"enabled":true,"userConfirmed":true}}
```

But I don't see `Add metric flow` log in the logs, which should be done here:
https://github.com/status-im/status-desktop/blob/42a95304520b41b3333432f54e4b9b64903d07d6/src/app_service/service/metrics/async_tasks.nim#L21

But... maybe I'm doing something wrong 🤷 