### PR TITLE
fix(StatusInput): Chat search is overlapped

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQml 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -414,9 +415,16 @@ Control {
         readonly property int inputHeight: statusBaseInput.multiline || (root.minimumHeight > 0) || (root.maximumHeight > 0)?
                                   Math.min(Math.max(statusBaseInput.topPadding + statusBaseInput.bottomPadding, 44,
                                                     root.minimumHeight), root.maximumHeight) : 44
+        readonly property real noPadding: -0.1
     }
 
     implicitWidth: 448
+
+    // to distinguish from the builtin 0; has no real effect otherwise
+    leftPadding: internal.noPadding
+    rightPadding: internal.noPadding
+    topPadding: internal.noPadding
+    bottomPadding: internal.noPadding
 
     Component.onCompleted: {
         validate()
@@ -436,7 +444,6 @@ Control {
     }
 
     contentItem: ColumnLayout {
-        id: inputLayout
         spacing: 0
 
         RowLayout {
@@ -500,7 +507,8 @@ Control {
             Layout.preferredHeight: internal.inputHeight
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignTop
-            Layout.topMargin: (topRow.height > 0) ? labelPadding : 0
+            Layout.topMargin: topRow.height > 0 ? labelPadding : 0
+            Layout.bottomMargin: bottomRow.height > 0 ? labelPadding : 0
             maximumLength: root.charLimit
             font: root.font
             onTextChanged: root.validate()
@@ -515,13 +523,33 @@ Control {
             onEditingFinished: {
                 root.editingFinished()
             }
+
+            // use the default padding values from StatusBaseInput, but forward any explicitly set values from outside
+            Binding on topPadding {
+                value: root.topPadding
+                when: root.topPadding !== internal.noPadding && root.topPadding !== statusBaseInput.topPadding
+                restoreMode: Binding.RestoreBinding
+            }
+            Binding on bottomPadding {
+                value: root.bottomPadding
+                when: root.bottomPadding !== internal.noPadding && root.bottomPadding !== statusBaseInput.bottomPadding
+                restoreMode: Binding.RestoreBinding
+            }
+            Binding on leftPadding {
+                value: root.leftPadding
+                when: root.leftPadding !== internal.noPadding && root.leftPadding !== statusBaseInput.leftPadding
+                restoreMode: Binding.RestoreBinding
+            }
+            Binding on rightPadding {
+                value: root.rightPadding
+                when: root.rightPadding !== internal.noPadding && root.rightPadding !== statusBaseInput.rightPadding
+                restoreMode: Binding.RestoreBinding
+            }
         }
 
         RowLayout {
             id: bottomRow
-            Layout.topMargin: Theme.halfPadding
             Layout.fillWidth: true
-            Layout.preferredHeight: Math.max(bottomLabelMessageLeft.height, errorMessage.height, bottomLabelMessageLeft.height)
 
             StatusBaseText {
                 id: bottomLabelMessageLeft

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -96,11 +96,9 @@ Item {
             Layout.fillWidth: true
             Layout.leftMargin: Theme.padding
             Layout.rightMargin: Theme.padding
-            Layout.preferredHeight: 36
-            maximumHeight: 36
-            leftPadding: 10
-            topPadding: 4
-            bottomPadding: 4
+            Layout.preferredHeight: 40
+            input.topPadding: 4
+            input.bottomPadding: 4
             MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true


### PR DESCRIPTION
### What does the PR do

- propagate the real (internal) paddings to the StatusBaseInput
- do not inflate the overall height with the bottomRow when empty

Fixes #17399

### Affected areas

StatusInput (and search fields in general)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Messages search field:
![Snímek obrazovky z 2025-02-26 18-19-49](https://github.com/user-attachments/assets/a41262eb-51cf-4c84-ab76-7c4bd74148bb)

Search popup:
![Snímek obrazovky z 2025-02-26 18-19-53](https://github.com/user-attachments/assets/01f8119a-140e-4c3c-a47e-2ba8a11db456)

Collectibles view filter:
![image](https://github.com/user-attachments/assets/1c76841e-8b8c-4c3d-8369-0e071c8c1cdd)

Search in assets panel:
![image](https://github.com/user-attachments/assets/23fe057f-3bdc-441c-a868-705bb9d5b6b2)

