### PR TITLE
fix: only publish onboarding navigation event on non-null page

### DIFF
--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -25,7 +25,14 @@ Page {
     property alias keycardPinInfoPageDelay: onboardingFlow.keycardPinInfoPageDelay
 
     readonly property alias stack: onboardingFlow // TODO remove external stack access
-    readonly property string currentPageName: stack.topLevelItem ? Utils.objectTypeName(stack.topLevelItem) : ""
+    readonly property string currentPageName: {
+        if (!stack.topLevelItem)
+            return ""
+
+        const item = stack.topLevelItem instanceof Loader ? stack.topLevelItem.item
+                                                          : stack.topLevelItem
+        return Utils.objectTypeName(item)
+    }
 
     signal shareUsageDataRequested(bool enabled)
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -517,7 +517,11 @@ StatusWindow {
                     Global.addCentralizedMetricIfEnabled("usage_data_shared", {placement: Constants.metricsEnablePlacement.onboarding})
                 }
             }
-            onCurrentPageNameChanged: Global.addCentralizedMetricIfEnabled("navigation", {viewId: currentPageName})
+            onCurrentPageNameChanged: {
+                if (currentPageName !== "") {
+                    Global.addCentralizedMetricIfEnabled("navigation", {viewId: currentPageName})
+                }
+            }
 
             Component {
                 id: convertingKeycardAccountPage


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17351

## Test notes

I wasn't able to fully reproduce the issue. I got an empty `viewId`, but only as the last navigation event, not in the middle of some flow.

Anyway, from code there seem to be only one possible reason for this. - when there's no page visible. Perhaps there's sometimes a quick glitch when switching pages.
Basically, I just added a condition to skip such events, when the page name is empty 😄 