### PR TITLE
chore: Remove `browsers` module dependency and replace it with QT API

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, browsers, strutils
+import NimQml, tables, json, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, strutils
 
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model
@@ -1924,7 +1924,7 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   let urlData = self.sharedUrlsModule.parseSharedUrl(statusDeepLink)
   if urlData.notASupportedStatusLink:
     # Just open it in the browser
-    openDefaultBrowser(statusDeepLink)
+    self.view.emitOpenUrlSignal(statusDeepLink)
     return
   if urlData.channel.uuid != "":
     self.onStatusUrlRequested(StatusUrlAction.OpenCommunityChannel, urlData.community.communityId, urlData.channel.uuid,

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -417,3 +417,7 @@ QtObject:
 
   proc stopTokenHoldersManagement*(self: View) {.slot.} =
     self.delegate.stopTokenHoldersManagement()
+
+  proc openUrl*(self: View, url: string) {.signal.}
+  proc emitOpenUrlSignal*(self: View, url: string) =
+    self.openUrl(url)

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -166,6 +166,17 @@ QtObject {
         id: d
 
         readonly property var userProfileInst: userProfile
+        readonly property Connections mainModuleConnections: Connections {
+            target: root.mainModuleInst
+            
+            function onResolvedENS(resolvedPubKey, resolvedAddress, uuid) {
+                root.ensNameResolved(resolvedPubKey, resolvedAddress, uuid)
+            }
+
+            function onOpenUrl(url) {
+                root.openUrl(url)
+            }
+        }
     }
 
     function getEtherscanTxLink(chainID) {
@@ -259,7 +270,5 @@ QtObject {
     }
 
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
-    Component.onCompleted: {
-        mainModuleInst.resolvedENS.connect(ensNameResolved)
-    }
+    signal openUrl(string link)
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -68,7 +68,11 @@ Item {
 
     readonly property SharedStores.NetworksStore networksStore: SharedStores.NetworksStore {}
     
-    readonly property AppStores.RootStore rootStore: AppStores.RootStore {}
+    readonly property AppStores.RootStore rootStore: AppStores.RootStore {
+        onOpenUrl: {
+            Global.openLinkWithConfirmation(link, SQUtils.StringUtils.extractDomainFromLink(link))
+        }
+    }
     readonly property ProfileStores.ProfileSectionStore profileSectionStore: rootStore.profileSectionStore
     readonly property ProfileStores.ProfileStore profileStore: profileSectionStore.profileStore
 

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -760,10 +760,24 @@ QtObject {
                     }
                 }
 
-                Component.onCompleted: {
-                    root.ensNameResolved.connect(ensNameResolved)
-                    root.transactionStoreNew.suggestedRoutesReady.connect(routesFetched)
-                    root.transactionStoreNew.transactionSent.connect(transactionSent)
+                readonly property Connections rootConnections: Connections {
+                    target: root
+                    function onEnsNameResolved(resolvedPubKey, resolvedAddress, uuid) {
+                        simpleSendModal.ensNameResolved(resolvedPubKey, resolvedAddress, uuid)
+                    }
+                }
+
+                readonly property Connections storeConnections: Connections {
+                    target: root.transactionStoreNew
+
+                    function onSuggestedRoutesReady(uuid, pathModel, errCode, errDescription) {
+                        handler.routesFetched(uuid, pathModel, errCode, errDescription)
+                    }
+
+                    function onTransactionSent(uuid, chainId, approvalTx, txHash, error) {
+                        handler.transactionSent(uuid, chainId, approvalTx, txHash, error)
+                    }
+
                 }
 
                 function resetRouterValues() {


### PR DESCRIPTION
### What does the PR do

Closes #17410 

Replace nim `browsers` module with QML API.

Motivation: The browsers module is using `c_system` calls to start the browser. This call has been deprecated on some platforms.
