### PR TITLE
chore: Add sleep to prevent crash on Intel MacOS during init

### DIFF
--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -94,6 +94,11 @@ QtObject:
 
   proc init*(self: Service) =
     debug "KeycardServiceV2 init"
+    # Do not remove the sleep 700, this sleep prevents a crash on intel MacOS
+    # with errors like bad flushGen 12 in prepareForSweep; sweepgen 0
+    # More details: https://github.com/status-im/status-desktop/pull/15194
+    if status_const.IS_MACOS and status_const.IS_INTEL:
+      sleep 700
     self.initializeRPC()
     self.asyncStart(status_const.KEYCARDPAIRINGDATAFILE)
     discard


### PR DESCRIPTION
Copy https://github.com/status-im/status-desktop/pull/15194 hotfix to `KeycardServiceV2`