### PR TITLE
fix(TransactionSettings): fix component height jumping around

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusFeeOption.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusFeeOption.qml
@@ -167,8 +167,8 @@ Control {
             StatusImage {
                 id: image
                 visible: root.selected || root.hovered
-                width: 22
-                height: 22
+                width: 20
+                height: 20
                 source: root.icon
             }
         }

--- a/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
@@ -160,7 +160,7 @@ Rectangle {
         ColumnLayout {
             Layout.margins: 20
 
-            spacing: 16
+            spacing: Theme.padding
 
             StatusBaseText {
                 Layout.preferredWidth: parent.width
@@ -210,7 +210,7 @@ Rectangle {
                     selected: root.selectedFeeMode === StatusFeeOption.Type.Custom
                     showSubText: !!selected
                     showAdditionalText: !!selected
-                    unselectedText: "Set your own fees & nonce"
+                    unselectedText: qsTr("Set your own fees & nonce")
 
                     onClicked: root.selectedFeeMode = StatusFeeOption.Type.Custom
                 }
@@ -242,7 +242,7 @@ Rectangle {
 
                         readonly property bool displayLowBaseFeeWarning: {
                             if (!customBaseFeeInput.text) {
-                                return
+                                return false
                             }
                             const weiCurrentValue = SQUtils.AmountsArithmetic.fromString(root.currentBaseFee)
                             const decreasedCurrentValue = SQUtils.AmountsArithmetic.times(weiCurrentValue, SQUtils.AmountsArithmetic.fromString("0.9")) // up to -10% is acceptable
@@ -252,7 +252,7 @@ Rectangle {
 
                         readonly property bool displayHighBaseFeeWarning: {
                             if (!customBaseFeeInput.text) {
-                                return
+                                return false
                             }
                             const weiCurrentValue = SQUtils.AmountsArithmetic.fromString(root.currentBaseFee)
                             const increasedCurrentValue = SQUtils.AmountsArithmetic.times(weiCurrentValue, SQUtils.AmountsArithmetic.fromString("1.2")) // up to 20% higher value is acceptable
@@ -401,7 +401,7 @@ Rectangle {
                                                               : qsTr("Current: %1").arg(root.currentGasAmount)
                         rightPadding: leftPadding
                         input.rightComponent: StatusBaseText {
-                            text: "UNITS"
+                            text: qsTr("UNITS")
                             color: Theme.palette.baseColor1
                         }
 


### PR DESCRIPTION
### What does the PR do

- use the correct icon size
- fix some forgotten `qsTr()`
- silence some warnings; a plain `return` returns `undefined` whereas a `bool` is expected

### Affected areas

TransactionSettings

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/ca3dc68d-b2b2-4b0b-9498-875508359014


