### PR TITLE
feat(Onboarding): Implement re-enryption warning screen 

### DIFF
--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -183,7 +183,12 @@ SplitView {
             logs.logEvent("onFinished", ["flow", "data"], arguments)
 
             if (flow === Onboarding.OnboardingFlow.LoginWithLostKeycardSeedphrase) {
+                store.convertKeycardAccountState = Onboarding.ProgressState.InProgress // SIMULATION
                 stack.push(convertingKeycardAccountPage)
+                Backpressure.debounce(root, 3000, () => {
+                    console.warn("!!! SIMULATION: CONVERTING KEYCARD")
+                    store.convertKeycardAccountState = Onboarding.ProgressState.Success // SIMULATION
+                })()
                 return
             }
 
@@ -399,11 +404,11 @@ SplitView {
             convertKeycardAccountState: store.convertKeycardAccountState
             onRestartRequested: {
                 logs.logEvent("restartRequested")
-                onboarding.unwindToLoginScreen()
+                root.restart()
             }
             onBackToLoginRequested: {
                 logs.logEvent("backToLoginRequested")
-                onboarding.unwindToLoginScreen()
+                root.restart()
             }
         }
     }

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -1118,6 +1118,10 @@ Item {
                       })
         }
 
+        function test_loginScreenLostKeycardSeedphraseLoginFlow_data() {
+            return [{ tag: "lost keycard: start using without keycard" }] // dummy to skip global data, and run just once
+        }
+
         function test_loginScreenLostKeycardSeedphraseLoginFlow() {
             verify(!!controlUnderTest)
             controlUnderTest.onboardingStore.loginAccountsModel = loginAccountsModel
@@ -1146,7 +1150,14 @@ Item {
             verify(!!startUsingWithoutKeycardButton)
             mouseClick(startUsingWithoutKeycardButton)
 
-            // PAGE 3: Seedphrase
+            // PAGE 3: Conversion acks page
+            page = getCurrentPage(stack, ConvertKeycardAccountAcksPage)
+
+            const continueButton = findChild(page, "continueButton")
+            verify(!!continueButton)
+            mouseClick(continueButton)
+
+            // PAGE 4: Seedphrase
             page = getCurrentPage(stack, SeedphrasePage)
 
             const btnContinue = findChild(page, "btnContinue")
@@ -1161,7 +1172,7 @@ Item {
             compare(btnContinue.enabled, true)
             mouseClick(btnContinue)
 
-            // PAGE 4: Create password
+            // PAGE 5: Create password
             page = getCurrentPage(stack, CreatePasswordPage)
 
             const btnConfirmPassword = findChild(page, "btnConfirmPassword")
@@ -1200,6 +1211,10 @@ Item {
             compare(resultData.keycardPin, "")
             compare(resultData.seedphrase, mockDriver.mnemonic)
             compare(resultData.keyUid, keyUid)
+        }
+
+        function test_loginScreenLostKeycardCreateReplacementFlow_data() {
+            return [{ tag: "lost keycard: create replacement keycard" }] // dummy to skip global data, and run just once
         }
 
         function test_loginScreenLostKeycardCreateReplacementFlow() {

--- a/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UseRecoveryPhraseFlow.qml
@@ -24,40 +24,52 @@ OnboardingStackView {
     signal setPasswordRequested(string password)
     signal finished
 
-    initialItem: SeedphrasePage {
-        isSeedPhraseValid: root.isSeedPhraseValid
+    initialItem: type === UseRecoveryPhraseFlow.Type.KeycardRecovery ? conversionAckPage : seedPhrasePage
 
-        title: {
-            switch (root.type) {
-            case UseRecoveryPhraseFlow.Type.NewProfile:
-                return qsTr("Create profile using a recovery phrase")
-            case UseRecoveryPhraseFlow.Type.KeycardRecovery:
-                return qsTr("Enter recovery phrase of lost Keycard")
-            case UseRecoveryPhraseFlow.Type.Login:
-                return qsTr("Log in with your Status recovery phrase")
+    Component {
+        id: conversionAckPage
+        ConvertKeycardAccountAcksPage {
+            onContinueRequested: root.push(seedPhrasePage)
+        }
+    }
+
+    Component {
+        id: seedPhrasePage
+        SeedphrasePage {
+            isSeedPhraseValid: root.isSeedPhraseValid
+
+            title: {
+                switch (root.type) {
+                case UseRecoveryPhraseFlow.Type.NewProfile:
+                    return qsTr("Create profile using a recovery phrase")
+                case UseRecoveryPhraseFlow.Type.KeycardRecovery:
+                    return qsTr("Enter recovery phrase of lost Keycard")
+                case UseRecoveryPhraseFlow.Type.Login:
+                    return qsTr("Log in with your Status recovery phrase")
+                }
+
+                return ""
             }
 
-            return ""
-        }
-
-        onSeedphraseUpdated: (valid, seedphrase) => {
-            if (root.type === UseRecoveryPhraseFlow.Type.KeycardRecovery) {
-                if (!valid)
-                    setWrongSeedPhraseMessage(qsTr("Recovery phrase doesn’t match the profile of an existing Keycard user on this device"))
-                else
-                    setWrongSeedPhraseMessage("")
-            } else {  // different error messages when trying to import a duplicate seedphrase
-                if (valid && root.isSeedPhraseDuplicate(seedphrase)) {
-                    setWrongSeedPhraseMessage(qsTr("The entered recovery phrase is already added"))
-                } else if (valid) {
-                    setWrongSeedPhraseMessage("")
+            onSeedphraseUpdated: function(valid, seedphrase) {
+                if (root.type === UseRecoveryPhraseFlow.Type.KeycardRecovery) {
+                    if (!valid)
+                        setWrongSeedPhraseMessage(qsTr("Recovery phrase doesn’t match the profile of an existing Keycard user on this device"))
+                    else
+                        setWrongSeedPhraseMessage("")
+                } else {  // different error messages when trying to import a duplicate seedphrase
+                    if (valid && root.isSeedPhraseDuplicate(seedphrase)) {
+                        setWrongSeedPhraseMessage(qsTr("The entered recovery phrase is already added"))
+                    } else if (valid) {
+                        setWrongSeedPhraseMessage("")
+                    }
                 }
             }
-        }
 
-        onSeedphraseSubmitted: (seedphrase) => {
-            root.seedphraseSubmitted(seedphrase)
-            root.push(createPasswordPage)
+            onSeedphraseSubmitted: function(seedphrase) {
+                root.seedphraseSubmitted(seedphrase)
+                root.push(createPasswordPage)
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding2/pages/ConvertKeycardAccountAcksPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/ConvertKeycardAccountAcksPage.qml
@@ -1,0 +1,66 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+OnboardingPage {
+    id: root
+
+    title: qsTr("Are you sure you want to migrate this profile keypair to Status?")
+
+    signal continueRequested()
+
+    contentItem: Item {
+        ColumnLayout {
+            anchors.centerIn: parent
+            width: Math.min(390, root.availableWidth)
+            spacing: 20
+
+            StatusRoundIcon {
+                Layout.preferredWidth: 40
+                Layout.preferredHeight: 40
+                Layout.alignment: Qt.AlignHCenter
+                asset.name: "warning"
+                asset.color: Theme.palette.warningColor1
+                asset.bgColor: Theme.palette.warningColor2
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                font.pixelSize: 22
+                font.bold: true
+                wrapMode: Text.WordWrap
+                text: root.title
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignCenter
+                color: Theme.palette.warningColor1
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("This profile and its accounts will be less secure, as Keycard will no longer be required to transact or login.")
+            }
+
+            StatusBaseText {
+                id: subtitle
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignCenter
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Your data will also be re-encrypted, restricting access to Status for up to 30 mins. Do you wish to continue?")
+            }
+
+            StatusButton {
+                objectName: "continueButton"
+                text: qsTr("Continue")
+                Layout.alignment: Qt.AlignHCenter
+                onClicked: root.continueRequested()
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardLostPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardLostPage.qml
@@ -18,14 +18,12 @@ KeycardBasePage {
     buttons: [
         StatusButton {
             objectName: "createReplacementButton"
-            width: 486
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Create replacement Keycard using the same recovery phrase")
             onClicked: root.createReplacementKeycardRequested()
         },
         StatusButton {
             objectName: "startUsingWithoutKeycardButton"
-            width: 486
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Start using this profile without Keycard")
             onClicked: root.useProfileWithoutKeycardRequested()

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardLostPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardLostPage.qml
@@ -18,18 +18,16 @@ KeycardBasePage {
     buttons: [
         StatusButton {
             objectName: "createReplacementButton"
-
+            width: 486
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Create replacement Keycard using the same recovery phrase")
             onClicked: root.createReplacementKeycardRequested()
         },
         StatusButton {
             objectName: "startUsingWithoutKeycardButton"
-
-            isOutline: true
-
-            text: qsTr("Start using this profile without Keycard")
+            width: 486
             anchors.horizontalCenter: parent.horizontalCenter
+            text: qsTr("Start using this profile without Keycard")
             onClicked: root.useProfileWithoutKeycardRequested()
         }
     ]

--- a/ui/app/AppLayouts/Onboarding2/pages/qmldir
+++ b/ui/app/AppLayouts/Onboarding2/pages/qmldir
@@ -4,6 +4,7 @@ BackupSeedphraseOutro 1.0 BackupSeedphraseOutro.qml
 BackupSeedphraseReveal 1.0 BackupSeedphraseReveal.qml
 BackupSeedphraseVerify 1.0 BackupSeedphraseVerify.qml
 ConvertKeycardAccountPage 1.0 ConvertKeycardAccountPage.qml
+ConvertKeycardAccountAcksPage 1.0 ConvertKeycardAccountAcksPage.qml
 CreateKeycardProfilePage 1.0 CreateKeycardProfilePage.qml
 CreatePasswordPage 1.0 CreatePasswordPage.qml
 CreateProfilePage 1.0 CreateProfilePage.qml


### PR DESCRIPTION
### What does the PR do

- `Lost keycard -> Start using this profile without Keycard` has a new screen (`KeycardRecovery` type in `UseRecoveryPhraseFlow`)
- adjust the QML tests to take the extra page into account
- 2 small extra commits for a better simulation in SB

Fixes https://github.com/status-im/status-desktop/issues/17415

### Affected areas

Onboarding/LoginScreen/LostKeycard

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/f9f7758c-fa8c-4e49-a216-cebb83729ab3


