### PR TITLE
[Qt5->6]: Refactor `StatusQrCodeScanner` to work on both Qt 5/6, OnboardingLayout SB page working on Qt 6

### DIFF
--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -6,7 +6,6 @@
 
 #include <QtWebView>
 
-
 #include "cachecleaner.h"
 #include "directorieswatcher.h"
 #include "figmalinks.h"
@@ -56,6 +55,10 @@ int main(int argc, char *argv[])
     qputenv("QTWEBENGINE_CHROMIUM_FLAGS", chromiumFlags);
 
     QQmlApplicationEngine engine;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    engine.setExtraFileSelectors({"qt6"});
+#endif
 
     const QStringList additionalImportPaths {
         STATUSQ_MODULE_IMPORT_PATH,

--- a/storybook/pages/StatusQrCodeScannerPage.qml
+++ b/storybook/pages/StatusQrCodeScannerPage.qml
@@ -1,0 +1,29 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Components 0.1
+
+Item {
+    id: root
+
+    StatusQrCodeScanner {
+        id: scanner
+
+        anchors.fill: parent
+    }
+
+    Rectangle {
+        anchors.fill: row
+    }
+
+    RowLayout {
+        id: row
+        Label {
+            text: scanner.lastTag
+        }
+    }
+}
+
+// category: Components
+// status: good

--- a/ui/StatusQ/sandbox/DemoApp.qml
+++ b/ui/StatusQ/sandbox/DemoApp.qml
@@ -78,7 +78,7 @@ Rectangle {
         leftPanel: StatusAppNavBar {
             id: navBar
 
-            chatItemsModel: SortFilterProxyModel {
+            topSectionModel: SortFilterProxyModel {
                 sourceModel: Models.demoAppSectionsModel
                 filters: ValueFilter {
                     roleName: "sectionType"
@@ -86,7 +86,7 @@ Rectangle {
                 }
             }
 
-            chatItemDelegate: navButtonComponent
+            topSectionDelegate: navButtonComponent
 
             communityItemsModel: SortFilterProxyModel {
                 sourceModel: Models.demoAppSectionsModel

--- a/ui/StatusQ/sandbox/QrCodeScannerPage.qml
+++ b/ui/StatusQ/sandbox/QrCodeScannerPage.qml
@@ -136,22 +136,5 @@ Rectangle {
                 value: d.rectToString(qrScanner.captureRectangle)
             }
         }
-
-        RowLayout {
-            Layout.fillWidth: true
-            spacing: 10
-
-            ValueIndicator {
-                Layout.fillWidth: true
-                title: "Camera state:"
-                value: qrScanner.camera ? d.cameraStateString(qrScanner.camera.cameraState) : ""
-            }
-
-            ValueIndicator {
-                Layout.fillWidth: true
-                title: "Camera status:"
-                value: qrScanner.camera ? d.cameraStatusString(qrScanner.camera.cameraStatus) : ""
-            }
-        }
     }
 }

--- a/ui/StatusQ/sandbox/sandboxapp.cpp
+++ b/ui/StatusQ/sandbox/sandboxapp.cpp
@@ -53,6 +53,10 @@ void SandboxApp::restartEngine()
     m_engine = std::make_unique<QQmlApplicationEngine>();
     m_engine->addImportPath(STATUSQ_MODULE_IMPORT_PATH);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    m_engine->setExtraFileSelectors({"qt6"});
+#endif
+
     if (firstRun)
         qDebug() << "QQmlEngine import paths: " << m_engine->importPathList();
 

--- a/ui/StatusQ/sanity_checker/main.cpp
+++ b/ui/StatusQ/sanity_checker/main.cpp
@@ -30,6 +30,11 @@ int main(int argc, char *argv[]) {
         if (info.suffix() != QStringLiteral("qml"))
             continue;
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        if (info.path().contains("+qt6"))
+            continue;
+#endif
+
         QFile file(it.filePath());
         file.open(QIODevice::ReadOnly);
 

--- a/ui/StatusQ/src/StatusQ/Components/+qt6/StatusQrCodeCapture.qml
+++ b/ui/StatusQ/src/StatusQ/Components/+qt6/StatusQrCodeCapture.qml
@@ -1,0 +1,103 @@
+import QtQuick
+
+import QtMultimedia
+import QZXing
+
+Item {
+    id: root
+
+    readonly property size sourceSize: Qt.size(videoOutput.sourceRect.width,
+                                               videoOutput.sourceRect.height)
+    readonly property size contentSize: Qt.size(videoOutput.contentRect.width,
+                                                videoOutput.contentRect.height)
+    readonly property real sourceRatio: videoOutput.sourceRect.width
+                                        / videoOutput.sourceRect.height
+
+    readonly property int failsCount: d.failsCount
+    readonly property int tagsCount: d.tagsCount
+    readonly property int decodeTime: d.decodeTime
+    readonly property string lastTag: d.lastTag
+    readonly property string currentTag: d.currentTag
+
+    readonly property alias contentRect: videoOutput.contentRect
+
+    readonly property var availableCameras: {
+        return mediaDevices.videoInputs.map(d => ({
+            deviceId: d.id.toString(),
+            displayName: d.description
+        }))
+    }
+
+    readonly property bool cameraAvailable: camera.active
+    readonly property string cameraError: camera.errorString
+
+    signal tagFound(string tag)
+
+    function setCameraDevice(deviceId: string) {
+        camera.cameraDevice = mediaDevices.videoInputs.find(
+                    d => d.id.toString() === deviceId)
+    }
+
+    MediaDevices {
+        id: mediaDevices
+    }
+
+    QtObject {
+        id: d
+
+        property int failsCount: 0
+        property int tagsCount: 0
+        property int decodeTime: 0
+        property string lastTag
+        property string currentTag
+    }
+
+    Camera {
+        id: camera
+
+        active: true
+        focusMode: Camera.FocusModeAutoNear
+
+        Component.onDestruction: camera.active = false
+    }
+
+    CaptureSession {
+        camera: camera
+        videoOutput: videoOutput
+    }
+
+    VideoOutput {
+        id: videoOutput
+
+        anchors.fill: parent
+        fillMode: VideoOutput.PreserveAspectCrop
+    }
+
+    QZXingFilter {
+        id: zxingFilter
+        videoSink: videoOutput.videoSink
+        orientation: videoOutput.orientation
+
+        captureRect: videoOutput.sourceRect
+
+        decoder {
+            enabledDecoders: QZXing.DecoderFormat_EAN_13 | QZXing.DecoderFormat_CODE_39 | QZXing.DecoderFormat_QR_CODE
+            onTagFound: (tag) => {
+                d.currentTag = tag
+                d.lastTag = tag
+                root.tagFound(tag)
+            }
+            tryHarder: false
+        }
+
+        onDecodingFinished: (succeeded, decodeTime) => {
+            if (succeeded) {
+                ++d.tagsCount
+            } else {
+                ++d.failsCount
+                d.currentTag = ""
+            }
+            d.decodeTime = decodeTime
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/StatusQrCodeCapture.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusQrCodeCapture.qml
@@ -1,0 +1,102 @@
+import QtQuick 2.15
+
+import QtMultimedia 5.15
+import QZXing 3.3
+
+Item {
+    id: root
+
+    readonly property size sourceSize: Qt.size(videoOutput.sourceRect.width,
+                                               videoOutput.sourceRect.height)
+    readonly property real sourceRatio: videoOutput.sourceRect.width
+                                        / videoOutput.sourceRect.height
+    readonly property size contentSize: Qt.size(videoOutput.contentRect.width,
+                                                videoOutput.contentRect.height)
+    readonly property alias contentRect: videoOutput.contentRect
+
+    readonly property int failsCount: d.failsCount
+    readonly property int tagsCount: d.tagsCount
+    readonly property int decodeTime: d.decodeTime
+    readonly property string lastTag: d.lastTag
+    readonly property string currentTag: d.currentTag
+
+    readonly property var availableCameras: d.availableCameras
+    readonly property bool cameraAvailable: camera.availability === Camera.Available
+    readonly property string cameraError: camera.errorString
+
+    function setCameraDevice(deviceId) {
+        camera.deviceId = "" // Workaround for Qt bug. Without this the device changes only first time.
+        camera.deviceId = deviceId
+    }
+
+    signal tagFound(string tag)
+
+    QtObject {
+        id: d
+
+        // NOTE: QtMultimedia.availableCameras also makes a request to OS, if not made previously.
+        //       So we postpone this call until the `Camera` component is loaded
+        property var availableCameras: []
+
+        property int failsCount: 0
+        property int tagsCount: 0
+        property int decodeTime: 0
+        property string lastTag
+        property string currentTag
+
+    }
+
+    VideoOutput {
+        id: videoOutput
+
+        anchors.fill: parent
+
+        source: Camera {
+            id: camera
+
+            focus {
+                focusMode: CameraFocus.FocusContinuous
+                focusPointMode: CameraFocus.FocusPointAuto
+            }
+
+            Component.onCompleted: {
+                d.availableCameras = QtMultimedia.availableCameras
+            }
+        }
+
+        filters: QZXingFilter {
+            id: qzxingFilter
+            orientation: videoOutput.orientation
+            captureRect: {
+                videoOutput.contentRect; videoOutput.sourceRect // bindings
+                const normalizedRectangle = Qt.rect(0, 0, 1, 1)
+                const rectangle = videoOutput.mapNormalizedRectToItem(normalizedRectangle)
+
+                console.log("CAPTURE RECT:", videoOutput.mapRectToSource(rectangle))
+
+                return videoOutput.mapRectToSource(rectangle);
+            }
+
+            decoder {
+                enabledDecoders: QZXing.DecoderFormat_QR_CODE
+                onTagFound: {
+                    d.currentTag = tag
+                    d.lastTag = tag
+                    root.tagFound(tag)
+                }
+            }
+
+            onDecodingFinished: {
+                if (succeeded) {
+                    ++d.tagsCount
+                } else {
+                    ++d.failsCount
+                    d.currentTag = ""
+                }
+                d.decodeTime = decodeTime
+            }
+        }
+
+        fillMode: VideoOutput.PreserveAspectCrop
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -7,7 +7,6 @@ StatusAddressPanel 0.1 StatusAddressPanel.qml
 StatusAnimatedImage 0.1 StatusAnimatedImage.qml
 StatusBadge 0.1 StatusBadge.qml
 StatusBetaTag 0.1 StatusBetaTag.qml
-StatusNewTag 0.1 StatusNewTag.qml
 StatusCard 0.1 StatusCard.qml
 StatusChartPanel 0.1 StatusChartPanel.qml
 StatusChatInfoToolBar 0.1 StatusChatInfoToolBar.qml
@@ -49,8 +48,10 @@ StatusMessageHeader 0.1 StatusMessageHeader.qml
 StatusMessageSenderDetails 0.1 StatusMessageSenderDetails.qml
 StatusNavigationListItem 0.1 StatusNavigationListItem.qml
 StatusNavigationPanelHeadline 0.1 StatusNavigationPanelHeadline.qml
+StatusNewTag 0.1 StatusNewTag.qml
 StatusOnlineBadge 0.1 StatusOnlineBadge.qml
 StatusPageIndicator 0.1 StatusPageIndicator.qml
+StatusQrCodeCapture 0.1 StatusQrCodeCapture.qml
 StatusQrCodeScanner 0.1 StatusQrCodeScanner.qml
 StatusRoundIcon 0.1 StatusRoundIcon.qml
 StatusRoundedComponent 0.1 StatusRoundedComponent.qml

--- a/ui/StatusQ/src/StatusQ/Core/StatusIcon.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusIcon.qml
@@ -17,7 +17,7 @@ ColorImage {
             source = icon
             objectName = "custom-icon"
         } else if (icon !== "") {
-            source = "../../assets/img/icons/" + icon+ ".svg";
+            source = Qt.resolvedUrl("../../assets/img/icons/" + icon+ ".svg");
             objectName = icon + "-icon"
         }
     }

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -51,6 +51,7 @@
         <file>StatusQ/Components/StatusNavigationPanelHeadline.qml</file>
         <file>StatusQ/Components/StatusOnlineBadge.qml</file>
         <file>StatusQ/Components/StatusPageIndicator.qml</file>
+        <file>StatusQ/Components/StatusQrCodeCapture.qml</file>
         <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
         <file>StatusQ/Components/StatusRoundIcon.qml</file>
         <file>StatusQ/Components/StatusRoundedComponent.qml</file>

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -218,7 +218,7 @@ OnboardingPage {
                     }
 
                     Qt.callLater(() => {
-                        if (!isBiometricsLogin)
+                        if (!root || !root.isBiometricsLogin)
                             return
 
                         if (d.currentProfileIsKeycard && root.keycardState !== Onboarding.KeycardState.NotEmpty)

--- a/ui/imports/shared/controls/DecoratedListItem.qml
+++ b/ui/imports/shared/controls/DecoratedListItem.qml
@@ -1,3 +1,4 @@
+import QtQuick 2.15
 import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1

--- a/ui/imports/shared/controls/StatusSyncCodeScan.qml
+++ b/ui/imports/shared/controls/StatusSyncCodeScan.qml
@@ -159,7 +159,7 @@ Column {
     }
 
     StatusBaseText {
-        visible: d.showCamera && cameraLoader.item.camera ? true : false
+        visible: d.showCamera && cameraLoader.item.cameraAvailable
         width: parent.width
         height: visible ? implicitHeight : 0
         wrapMode: Text.WordWrap


### PR DESCRIPTION
### What does the PR do

- Excludes `StatusQrCodeCapture` which is responsible exclusively for qr codes detection from the video input, with no other UI elements. It's the only component related to qr codes depending directly on QZXing and
QtMultimedia. That depenency is removed StatusQrCodeScanner. It gives ability of providing alternative version on the StatusQrCodeCapture for qt 6 via file selector.
- Register file selector for qt6 in `Storybook` and `Sandbox` apps
- Add Qt6 variant of StatusQrCodeCapture. It makes `StatusQrCodeScanner` working on both qt 5 and 6
- Fixes url resolution in `StatusIcon` In Qt6 URLs are no longer automatically resolved on assignment, therefore it's necessary to resolve them explicitely where necessary. It doesn't change the behavior on Qt5.
- Solves some small inconsistencies to make `OnboardingLayout` running in Storybook

Closes: #17397

### Affected areas
`StatusQrCodeScanner`, `StatusIcon` and others

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[Screencast from 28.02.2025 13:17:08.webm](https://github.com/user-attachments/assets/3f6669ae-e9fe-4e9f-8138-b6af553ab290)
