### PR TITLE
fix(Onboarding/Login): missing state for incorrect keycard during login

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -105,7 +105,7 @@ method load*[T](self: Module[T]) =
   self.delegate.onboardingDidLoad()
 
 method initialize*[T](self: Module[T], pin: string) =
-  self.view.setPinSettingState(ProgressState.InProgress.int)
+  self.view.setPinSettingState(ProgressState.InProgress)
   self.controller.initialize(pin)
 
 method authorize*[T](self: Module[T], pin: string) =
@@ -131,7 +131,7 @@ method inputConnectionStringForBootstrapping*[T](self: Module[T], connectionStri
   self.controller.inputConnectionStringForBootstrapping(connectionString)
 
 method loadMnemonic*[T](self: Module[T], mnemonic: string) =
-  self.view.setAddKeyPairState(ProgressState.InProgress.int)
+  self.view.setAddKeyPairState(ProgressState.InProgress)
   self.controller.loadMnemonic(mnemonic)
 
 method finishOnboardingFlow*[T](self: Module[T], flowInt: int, dataJson: string): string =
@@ -359,14 +359,14 @@ method onKeycardStateUpdated*[T](self: Module[T], keycardEvent: KeycardEventDto)
 
   if keycardEvent.state == KeycardState.NotEmpty and self.view.getPinSettingState() == ProgressState.InProgress.int:
     # We just finished setting the pin
-    self.view.setPinSettingState(ProgressState.Success.int)
+    self.view.setPinSettingState(ProgressState.Success)
 
-  if keycardEvent.state == KeycardState.Authorized and self.view.getAuthorizationState() == ProgressState.InProgress.int:
+  if keycardEvent.state == KeycardState.Authorized and self.view.getAuthorizationState() == AuthorizationState.InProgress.int:
     # We just finished authorizing
     self.view.setAuthorizationState(AuthorizationState.Authorized)
 
 method onKeycardSetPinFailure*[T](self: Module[T], error: string) =
-  self.view.setPinSettingState(ProgressState.Failed.int)
+  self.view.setPinSettingState(ProgressState.Failed)
 
 method onKeycardAuthorizeFinished*[T](self: Module[T], error: string, authorized: bool) =
   if error != "":
@@ -382,17 +382,17 @@ method onKeycardAuthorizeFinished*[T](self: Module[T], error: string, authorized
     self.view.accountLoginError(error, not authorized)
 
 method onKeycardLoadMnemonicFailure*[T](self: Module[T], error: string) =
-  self.view.setAddKeyPairState(ProgressState.Failed.int)
+  self.view.setAddKeyPairState(ProgressState.Failed)
 
 method onKeycardLoadMnemonicSuccess*[T](self: Module[T], keyUID: string) =
-  self.view.setAddKeyPairState(ProgressState.Success.int)
+  self.view.setAddKeyPairState(ProgressState.Success)
 
 method onKeycardExportRestoreKeysFailure*[T](self: Module[T], error: string) =
-  self.view.setRestoreKeysExportState(ProgressState.Failed.int)
+  self.view.setRestoreKeysExportState(ProgressState.Failed)
 
 method onKeycardExportRestoreKeysSuccess*[T](self: Module[T], exportedKeys: KeycardExportedKeysDto) =
   self.exportedKeys = exportedKeys
-  self.view.setRestoreKeysExportState(ProgressState.Success.int)
+  self.view.setRestoreKeysExportState(ProgressState.Success)
 
 method onKeycardExportLoginKeysFailure*[T](self: Module[T], error: string) =
   self.view.accountLoginError(error, wrongPassword = false)
@@ -415,7 +415,7 @@ method onKeycardAccountConverted*[T](self: Module[T], success: bool) =
   self.generalService.logout()
 
 method exportRecoverKeys*[T](self: Module[T]) =
-  self.view.setRestoreKeysExportState(ProgressState.InProgress.int)
+  self.view.setRestoreKeysExportState(ProgressState.InProgress)
   self.controller.exportRecoverKeysFromKeycard()
 
 method startKeycardFactoryReset*[T](self: Module[T]) =

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -13,10 +13,10 @@ QtObject:
       delegate: io_interface.AccessInterface
       keycardEvent: KeycardEventDto
       syncState: LocalPairingState
-      addKeyPairState: int
-      pinSettingState: int
+      addKeyPairState: ProgressState
+      pinSettingState: ProgressState
       authorizationState: AuthorizationState
-      restoreKeysExportState: int
+      restoreKeysExportState: ProgressState
       loginAccountsModel: login_acc_model.Model
       loginAccountsModelVariant: QVariant
       convertKeycardAccountState: ProgressState
@@ -49,16 +49,20 @@ QtObject:
     read = getSyncState
     notify = syncStateChanged
   proc setSyncState*(self: View, syncState: LocalPairingState) =
+    if self.syncState == syncState:
+      return
     self.syncState = syncState
     self.syncStateChanged()
 
   proc pinSettingStateChanged*(self: View) {.signal.}
   proc getPinSettingState*(self: View): int {.slot.} =
-    return self.pinSettingState
+    return self.pinSettingState.int
   QtProperty[int] pinSettingState:
     read = getPinSettingState
     notify = pinSettingStateChanged
-  proc setPinSettingState*(self: View, pinSettingState: int) =
+  proc setPinSettingState*(self: View, pinSettingState: ProgressState) =
+    if self.pinSettingState == pinSettingState:
+      return
     self.pinSettingState = pinSettingState
     self.pinSettingStateChanged()
 
@@ -69,16 +73,20 @@ QtObject:
     read = getAuthorizationState
     notify = authorizationStateChanged
   proc setAuthorizationState*(self: View, authorizationState: AuthorizationState) =
+    if self.authorizationState == authorizationState:
+      return
     self.authorizationState = authorizationState
     self.authorizationStateChanged()
 
   proc restoreKeysExportStateChanged*(self: View) {.signal.}
   proc getRestoreKeysExportState*(self: View): int {.slot.} =
-    return self.restoreKeysExportState
+    return self.restoreKeysExportState.int
   QtProperty[int] restoreKeysExportState:
     read = getRestoreKeysExportState
     notify = restoreKeysExportStateChanged
-  proc setRestoreKeysExportState*(self: View, restoreKeysExportState: int) =
+  proc setRestoreKeysExportState*(self: View, restoreKeysExportState: ProgressState) =
+    if self.restoreKeysExportState == restoreKeysExportState:
+      return
     self.restoreKeysExportState = restoreKeysExportState
     self.restoreKeysExportStateChanged()
 
@@ -88,6 +96,13 @@ QtObject:
   QtProperty[int] keycardState:
     read = getKeycardState
     notify = keycardStateChanged
+
+  proc keycardUIDChanged*(self: View) {.signal.}
+  proc getKeycardUID(self: View): string {.slot.} =
+    return self.keycardEvent.keycardInfo.keyUID
+  QtProperty[string] keycardUID:
+    read = getKeycardUID
+    notify = keycardUIDChanged
 
   proc keycardRemainingPinAttemptsChanged*(self: View) {.signal.}
   proc getKeycardRemainingPinAttempts(self: View): int {.slot.} =
@@ -105,17 +120,20 @@ QtObject:
 
   proc addKeyPairStateChanged*(self: View) {.signal.}
   proc getAddKeyPairState(self: View): int {.slot.} =
-    return self.addKeyPairState
+    return self.addKeyPairState.int
   QtProperty[int] addKeyPairState:
     read = getAddKeyPairState
     notify = addKeyPairStateChanged
-  proc setAddKeyPairState*(self: View, addKeyPairState: int) =
+  proc setAddKeyPairState*(self: View, addKeyPairState: ProgressState) =
+    if self.addKeyPairState == addKeyPairState:
+      return
     self.addKeyPairState = addKeyPairState
     self.addKeyPairStateChanged()
 
   proc setKeycardEvent*(self: View, keycardEvent: KeycardEventDto) =
     self.keycardEvent = keycardEvent
     self.keycardStateChanged()
+    self.keycardUIDChanged()
     self.keycardRemainingPinAttemptsChanged()
     self.keycardRemainingPukAttemptsChanged()
 
@@ -177,9 +195,9 @@ QtObject:
     self.delegate.exportRecoverKeys()
 
   proc finishOnboardingFlow(self: View, flowInt: int, dataJson: string): string {.slot.} =
-    self.delegate.finishOnboardingFlow(flowInt, dataJson)
+    return self.delegate.finishOnboardingFlow(flowInt, dataJson)
 
-  proc loginRequested(self: View, keyUid: string, loginFlow: int, dataJson: string): string {.slot.} =
+  proc loginRequested(self: View, keyUid: string, loginFlow: int, dataJson: string) {.slot.} =
     self.delegate.loginRequested(keyUid, loginFlow, dataJson)
 
   proc startKeycardFactoryReset(self: View) {.slot.} =

--- a/src/app_service/service/keycardV2/dto.nim
+++ b/src/app_service/service/keycardV2/dto.nim
@@ -26,7 +26,6 @@ type KeycardState* = enum
   PluginReader,
   InsertKeycard,
   ReadingKeycard,
-  WrongKeycard,
   NotKeycard,
   MaxPairingSlotsReached,
   BlockedPIN,

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -23,6 +23,7 @@ SplitView {
 
         // keycard
         property int keycardState: Onboarding.KeycardState.NoPCSCService
+        readonly property string keycardUID: "uid_4"
         property int keycardRemainingPinAttempts: Constants.onboarding.defaultPinAttempts
         property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
 
@@ -38,7 +39,7 @@ SplitView {
         loginAccountsModel: LoginAccountsModel {}
 
         keycardState: driver.keycardState
-
+        keycardUID: driver.keycardUID
         keycardRemainingPinAttempts: driver.keycardRemainingPinAttempts
         keycardRemainingPukAttempts: driver.keycardRemainingPukAttempts
 

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -75,6 +75,7 @@ SplitView {
             id: store
 
             property int keycardState: Onboarding.KeycardState.NoPCSCService
+            readonly property string keycardUID: "uid_4"
             property int addKeyPairState: Onboarding.ProgressState.Idle
             property int pinSettingState: Onboarding.ProgressState.Idle
             property int authorizationState: Onboarding.AuthorizationState.Idle

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -61,6 +61,7 @@ Item {
 
             onboardingStore: OnboardingStore {
                 readonly property int keycardState: mockDriver.keycardState // enum Onboarding.KeycardState
+                readonly property string keycardUID: "uid_4"
                 readonly property int pinSettingState: mockDriver.pinSettingState // enum Onboarding.ProgressState
                 readonly property int authorizationState: mockDriver.authorizationState // enum Onboarding.AuthorizationState
                 readonly property int restoreKeysExportState: mockDriver.restoreKeysExportState // enum Onboarding.ProgressState

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -27,12 +27,6 @@ public:
         return result;
     }
 
-    enum class PrimaryFlow {
-        Unknown,
-        CreateProfile,
-        Login
-    };
-
     // NOTE: Keep in sync with OnboardingFlow in src/app/modules/onboarding/module.nim
     enum class OnboardingFlow {
         Unknown,
@@ -100,7 +94,6 @@ public:
     };
 
 private:
-    Q_ENUM(PrimaryFlow)
     Q_ENUM(OnboardingFlow)
     Q_ENUM(LoginMethod)
     Q_ENUM(KeycardState)

--- a/ui/StatusQ/src/onboarding/enums.h
+++ b/ui/StatusQ/src/onboarding/enums.h
@@ -58,7 +58,6 @@ public:
         InsertKeycard,
         ReadingKeycard,
         // error states
-        WrongKeycard,
         NotKeycard,
         MaxPairingSlotsReached,
         BlockedPIN, // PIN remaining attempts == 0

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -15,6 +15,7 @@ OnboardingStackView {
     required property var loginAccountsModel
 
     required property int keycardState
+    required property string keycardUID
     required property int pinSettingState
     required property int authorizationState
     required property int restoreKeysExportState
@@ -184,6 +185,7 @@ OnboardingStackView {
             id: loginScreen
 
             keycardState: root.keycardState
+            keycardUID: root.keycardUID
             keycardRemainingPinAttempts: root.remainingPinAttempts
             keycardRemainingPukAttempts: root.remainingPukAttempts
 

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -6,7 +6,6 @@ import StatusQ 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 
-import AppLayouts.Onboarding2.pages 1.0
 import AppLayouts.Onboarding2.stores 1.0
 import AppLayouts.Onboarding.enums 1.0
 
@@ -135,6 +134,7 @@ Page {
 
         loginAccountsModel: root.onboardingStore.loginAccountsModel
         keycardState: root.onboardingStore.keycardState
+        keycardUID: root.onboardingStore.keycardUID
         pinSettingState: root.onboardingStore.pinSettingState
         authorizationState: root.onboardingStore.authorizationState
         restoreKeysExportState: root.onboardingStore.restoreKeysExportState

--- a/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding2/components/LoginKeycardBox.qml
@@ -14,6 +14,7 @@ Control {
     id: root
 
     required property int keycardState
+    required property bool isWrongKeycard
     required property int keycardRemainingPinAttempts
     required property int keycardRemainingPukAttempts
     property string loginError
@@ -48,7 +49,8 @@ Control {
         pinInputField.setPin(pin)
     }
 
-    padding: 12
+    horizontalPadding: Theme.padding
+    verticalPadding: 20
 
     QtObject {
         id: d
@@ -162,7 +164,7 @@ Control {
         },
         State {
             name: "wrongKeycard"
-            when: root.keycardState === Onboarding.KeycardState.WrongKeycard
+            when: root.isWrongKeycard
             PropertyChanges {
                 target: infoText
                 color: Theme.palette.dangerColor1

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardIntroPage.qml
@@ -147,8 +147,7 @@ KeycardBasePage {
         // error states
         State {
             name: "notKeycard"
-            when: root.keycardState === Onboarding.KeycardState.WrongKeycard ||
-                  root.keycardState === Onboarding.KeycardState.NotKeycard
+            when: root.keycardState === Onboarding.KeycardState.NotKeycard
             PropertyChanges {
                 target: root
                 title: qsTr("Oops this isn’t a Keycard")

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -24,7 +24,7 @@ OnboardingPage {
     id: root
 
     required property int keycardState
-
+    required property string keycardUID
     required property int keycardRemainingPinAttempts
     required property int keycardRemainingPukAttempts
 
@@ -89,6 +89,7 @@ OnboardingPage {
         property bool biometricsFailed
 
         readonly property bool currentProfileIsKeycard: loginUserSelector.keycardCreatedAccount
+        readonly property bool isWrongKeycard: !!root.keycardUID && loginUserSelector.selectedProfileKeyId !== root.keycardUID
 
         readonly property Settings settings: Settings {
             category: "Login"
@@ -259,6 +260,7 @@ OnboardingPage {
                 biometricsSuccessful: d.biometricsSuccessful
                 biometricsFailed: d.biometricsFailed
                 keycardState: root.keycardState
+                isWrongKeycard: d.isWrongKeycard
                 keycardRemainingPinAttempts: root.keycardRemainingPinAttempts
                 keycardRemainingPukAttempts: root.keycardRemainingPukAttempts
                 onUnblockWithSeedphraseRequested: root.unblockWithSeedphraseRequested()

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -27,6 +27,7 @@ QtObject {
 
     // keycard
     readonly property int keycardState: d.onboardingModuleInst.keycardState // cf. enum Onboarding.KeycardState
+    readonly property string keycardUID: d.onboardingModuleInst.keycardUID
     readonly property int pinSettingState: d.onboardingModuleInst.pinSettingState // cf. enum Onboarding.ProgressState
     readonly property int authorizationState: d.onboardingModuleInst.authorizationState // cf. enum Onboarding.AuthorizationState
     readonly property int restoreKeysExportState: d.onboardingModuleInst.restoreKeysExportState // cf. enum Onboarding.AuthorizationState
@@ -34,7 +35,7 @@ QtObject {
     readonly property int keycardRemainingPinAttempts: d.onboardingModuleInst.keycardRemainingPinAttempts
     readonly property int keycardRemainingPukAttempts: d.onboardingModuleInst.keycardRemainingPukAttempts
 
-    function finishOnboardingFlow(flow: int, data: Object) { // -> bool
+    function finishOnboardingFlow(flow: int, data: Object) { // -> string
         return d.onboardingModuleInst.finishOnboardingFlow(flow, JSON.stringify(data))
     }
 


### PR DESCRIPTION
### What does the PR do

- expose `keycardUID` from keycard info
- compare it with the `selectedProfileKeyId` to determine whether it's the matching (or wrong) keycard for the selected profile
- use native `ProgressState` types internally in onboarding/view.nim instead of a generic `int`
- removed unused "WrongKeycard" dto state

Fixes #17391

### Affected areas

Onboarding/Login

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/41a3d0bd-78ab-425a-a99c-0ef5586ec8ab)

