### PR TITLE
fix: solve race condition in swap payPanel

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -253,8 +253,10 @@ StatusDialog {
 
                     onRawValueChanged: {
                         if(root.swapInputParamsForm.fromTokensKey === selectedHoldingId) {
-                            const amount = !tokenAmount && value === 0 ? "" :
-                                                                         SQUtils.AmountsArithmetic.div(SQUtils.AmountsArithmetic.fromString(rawValue),
+                            const zero = SQUtils.AmountsArithmetic.fromString("0")
+                            const bigIntRawValue = SQUtils.AmountsArithmetic.fromString(rawValue)
+                            const amount = !tokenAmount && SQUtils.AmountsArithmetic.cmp(bigIntRawValue, zero) === 0 ? "" :
+                                                                         SQUtils.AmountsArithmetic.div(bigIntRawValue,
                                                                                                        SQUtils.AmountsArithmetic.fromNumber(1, rawValueMultiplierIndex)).toString()
                             root.swapInputParamsForm.fromTokenAmount = amount
                         }


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/17347 and https://github.com/status-im/status-desktop/issues/17471

`amount`, used in the `fromTokenAmount` calculation, is calculated using a bunch of properties that might be updated before or after `rawValue` changes. In unlucky conditions, `value` would be 0 even though the user had entered a valid amount, causing the value in `swapInputParamsForm` to not be properly updated.

This PR avoids using `amount` in that calculation, using `rawAmount` instead.


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Swap

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
