### PR TITLE
17430 platform abstraction guard keycard dependency with compilation flag

### DIFF
--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -1,16 +1,61 @@
 import NimQml
-import os
+import os, macros, strutils
 
-const DEFAULT_FLAG_DAPPS_ENABLED = true
-const DEFAULT_FLAG_SWAP_ENABLED = true
-const DEFAULT_FLAG_CONNECTOR_ENABLED* = true
-const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED = true
+proc boolToEnv*(defaultValue: bool): string =
+  return if defaultValue: "1" else: "0"
+
+# The `featureFlag` macro defines a feature flag based on an environment variable.
+# If the `buildFlag` variable is true, the feature flag is determined at compile time.
+# Otherwise, it is determined at runtime.
+macro featureFlag(name: string, defaultValue: bool, buildFlag: static bool = false): untyped =
+  let flagName = newIdentNode(name.strVal)
+  if `buildFlag`:
+    return quote do:
+      const `flagName`* = static(getEnv("FLAG_" & `name`.toUpper, boolToEnv(`defaultValue`)) != "0")
+  else:
+    return quote do:
+      let `flagName`* = getEnv("FLAG_" & `name`.toUpper, boolToEnv(`defaultValue`)) != "0"
+
+const DEFAULT_FLAG_DAPPS_ENABLED  = true
+const DEFAULT_FLAG_SWAP_ENABLED  = true
+const DEFAULT_FLAG_CONNECTOR_ENABLED  = true
+const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED  = true
 const DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED = true
 const DEFAULT_FLAG_SIMPLE_SEND_ENABLED = true
 const DEFAULT_FLAG_ONBOARDING_V2_ENABLED = false
 
-proc boolToEnv*(defaultValue: bool): string =
-  return if defaultValue: "1" else: "0"
+# Compile time feature flags
+const DEFAULT_FLAG_KEYCARD_ENABLED = true
+
+# Public feature flags
+featureFlag("DAPPS_ENABLED",                  DEFAULT_FLAG_DAPPS_ENABLED)
+featureFlag("SWAP_ENABLED",                   DEFAULT_FLAG_SWAP_ENABLED)
+featureFlag("CONNECTOR_ENABLED",              DEFAULT_FLAG_CONNECTOR_ENABLED)
+featureFlag("SEND_VIA_PERSONAL_CHAT_ENABLED", DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED)
+featureFlag("PAYMENT_REQUEST_ENABLED",        DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED)
+featureFlag("SIMPLE_SEND_ENABLED",            DEFAULT_FLAG_SIMPLE_SEND_ENABLED)
+featureFlag("ONBOARDING_V2_ENABLED",          DEFAULT_FLAG_ONBOARDING_V2_ENABLED)
+featureFlag("KEYCARD_ENABLED",                DEFAULT_FLAG_KEYCARD_ENABLED, true)
+
+# The `featureGuard` macro conditionally replaces the guarded code
+# There are two main usages:
+# 1. With a statement list:
+#    featureGuard(FEATURE_FLAG):
+#      echo "Feature is enabled"
+# 2. As a pragma:
+#    proc myProc(): void {.featureGuard(FEATURE_FLAG).} = echo "Feature is enabled"
+macro featureGuard*(flag: static bool, n: untyped): untyped =
+  if not flag:
+    result = n
+    if n.kind == nnkProcDef:
+      n[6] = newStmtList(
+        newCall(bindSym"echo", newLit("Warning! Calling a disabled feature")),
+        newTree(nnkDiscardStmt, newEmptyNode())
+      ) # Replace body with `discard`
+    else:
+      result = newStmtList()
+  else:
+    result = n
 
 QtObject:
   type FeatureFlags* = ref object of QObject
@@ -21,16 +66,18 @@ QtObject:
     paymentRequestEnabled: bool
     simpleSendEnabled: bool
     onboardingV2Enabled: bool
+    keycardEnabled: bool
 
   proc setup(self: FeatureFlags) =
     self.QObject.setup()
-    self.dappsEnabled = getEnv("FLAG_DAPPS_ENABLED", boolToEnv(DEFAULT_FLAG_DAPPS_ENABLED)) != "0"
-    self.swapEnabled = getEnv("FLAG_SWAP_ENABLED", boolToEnv(DEFAULT_FLAG_SWAP_ENABLED)) != "0"
-    self.connectorEnabled = getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
-    self.sendViaPersonalChatEnabled = getEnv("FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED", boolToEnv(DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED)) != "0"
-    self.paymentRequestEnabled = getEnv("FLAG_PAYMENT_REQUEST_ENABLED", boolToEnv(DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED)) != "0"
-    self.simpleSendEnabled = getEnv("FLAG_SIMPLE_SEND_ENABLED", boolToEnv(DEFAULT_FLAG_SIMPLE_SEND_ENABLED)) != "0"
-    self.onboardingV2Enabled = getEnv("FLAG_ONBOARDING_V2_ENABLED", boolToEnv(DEFAULT_FLAG_ONBOARDING_V2_ENABLED)) != "0"
+    self.dappsEnabled = DAPPS_ENABLED
+    self.swapEnabled = SWAP_ENABLED
+    self.connectorEnabled = CONNECTOR_ENABLED
+    self.sendViaPersonalChatEnabled = SEND_VIA_PERSONAL_CHAT_ENABLED
+    self.paymentRequestEnabled = PAYMENT_REQUEST_ENABLED
+    self.simpleSendEnabled = SIMPLE_SEND_ENABLED
+    self.onboardingV2Enabled = ONBOARDING_V2_ENABLED
+    self.keycardEnabled = KEYCARD_ENABLED
 
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
@@ -80,3 +127,9 @@ QtObject:
 
   QtProperty[bool] onboardingV2Enabled:
     read = getOnboardingV2Enabled
+
+  QtProperty[bool] keycardEnabled:
+    read = getKeycardEnabled
+
+  proc getKeycardEnabled*(self: FeatureFlags): bool {.slot.} =
+    return self.keycardEnabled

--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -16,31 +16,31 @@ macro featureFlag(name: string, defaultValue: bool, buildFlag: static bool = fal
     return quote do:
       let `flagName`* = getEnv("FLAG_" & `name`.toUpper, boolToEnv(`defaultValue`)) != "0"
 
-const DEFAULT_FLAG_DAPPS_ENABLED  = true
 const DEFAULT_FLAG_SWAP_ENABLED  = true
-const DEFAULT_FLAG_CONNECTOR_ENABLED  = true
 const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED  = true
 const DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED = true
 const DEFAULT_FLAG_SIMPLE_SEND_ENABLED = true
 const DEFAULT_FLAG_ONBOARDING_V2_ENABLED = false
 
 # Compile time feature flags
+const DEFAULT_FLAG_DAPPS_ENABLED  = true
+const DEFAULT_FLAG_CONNECTOR_ENABLED  = true
 const DEFAULT_FLAG_KEYCARD_ENABLED = true
 const DEFAULT_FLAG_THREADPOOL_ENABLED = true
 const DEFAULT_FLAG_SINGLE_STATUS_INSTANCE_ENABLED = true
 
 # Public feature flags
-featureFlag("DAPPS_ENABLED",                  DEFAULT_FLAG_DAPPS_ENABLED)
 featureFlag("SWAP_ENABLED",                   DEFAULT_FLAG_SWAP_ENABLED)
-featureFlag("CONNECTOR_ENABLED",              DEFAULT_FLAG_CONNECTOR_ENABLED)
 featureFlag("SEND_VIA_PERSONAL_CHAT_ENABLED", DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED)
 featureFlag("PAYMENT_REQUEST_ENABLED",        DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED)
 featureFlag("SIMPLE_SEND_ENABLED",            DEFAULT_FLAG_SIMPLE_SEND_ENABLED)
 featureFlag("ONBOARDING_V2_ENABLED",          DEFAULT_FLAG_ONBOARDING_V2_ENABLED)
+
+featureFlag("DAPPS_ENABLED",                  DEFAULT_FLAG_DAPPS_ENABLED, true)
+featureFlag("CONNECTOR_ENABLED",              DEFAULT_FLAG_CONNECTOR_ENABLED, true)
 featureFlag("KEYCARD_ENABLED",                DEFAULT_FLAG_KEYCARD_ENABLED, true)
 featureFlag("THREADPOOL_ENABLED",             DEFAULT_FLAG_THREADPOOL_ENABLED, true)
 featureFlag("SINGLE_STATUS_INSTANCE_ENABLED", DEFAULT_FLAG_SINGLE_STATUS_INSTANCE_ENABLED, true)
-
 # The `featureGuard` macro conditionally replaces the guarded code
 # There are two main usages:
 # 1. With a statement list:

--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -27,6 +27,7 @@ const DEFAULT_FLAG_ONBOARDING_V2_ENABLED = false
 # Compile time feature flags
 const DEFAULT_FLAG_KEYCARD_ENABLED = true
 const DEFAULT_FLAG_THREADPOOL_ENABLED = true
+const DEFAULT_FLAG_SINGLE_STATUS_INSTANCE_ENABLED = true
 
 # Public feature flags
 featureFlag("DAPPS_ENABLED",                  DEFAULT_FLAG_DAPPS_ENABLED)
@@ -38,6 +39,7 @@ featureFlag("SIMPLE_SEND_ENABLED",            DEFAULT_FLAG_SIMPLE_SEND_ENABLED)
 featureFlag("ONBOARDING_V2_ENABLED",          DEFAULT_FLAG_ONBOARDING_V2_ENABLED)
 featureFlag("KEYCARD_ENABLED",                DEFAULT_FLAG_KEYCARD_ENABLED, true)
 featureFlag("THREADPOOL_ENABLED",             DEFAULT_FLAG_THREADPOOL_ENABLED, true)
+featureFlag("SINGLE_STATUS_INSTANCE_ENABLED", DEFAULT_FLAG_SINGLE_STATUS_INSTANCE_ENABLED, true)
 
 # The `featureGuard` macro conditionally replaces the guarded code
 # There are two main usages:

--- a/src/app/global/global_singleton.nim
+++ b/src/app/global/global_singleton.nim
@@ -16,6 +16,7 @@ export user_profile
 export utils
 export global_events
 export loader_deactivator
+export feature_flags
 
 type
   GlobalSingleton = object

--- a/src/app_service/service/keycardV2/rpc.nim
+++ b/src/app_service/service/keycardV2/rpc.nim
@@ -1,9 +1,12 @@
 import json
-import keycard_go
+import app/global/feature_flags
+
+featureGuard KEYCARD_ENABLED:
+  import keycard_go
 
 var rpcCounter: int = 0
 
-proc callRPC*(methodName: string, params: JsonNode = %*{}): string  =
+proc callRPC*(methodName: string, params: JsonNode = %*{}): string  {.featureGuard(KEYCARD_ENABLED).}=
     rpcCounter.inc
     let request = %*{
       "id": rpcCounter,

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -1,11 +1,14 @@
 import NimQml, json, os, chronicles, strutils, random, json_serialization
-import keycard_go
+import app/global/feature_flags
 import app/global/global_singleton
 import app/core/eventemitter
 import app/core/tasks/[qt, threadpool]
 import backend/response_type
-import constants as status_const
 import ./dto, rpc
+
+featureGuard KEYCARD_ENABLED:
+  import keycard_go
+  import constants as status_const
 
 export dto
 
@@ -92,16 +95,16 @@ QtObject:
 
   include queued_async_calls
 
-  proc init*(self: Service) =
+  proc init*(self: Service) {.featureGuard(KEYCARD_ENABLED).} =
     debug "KeycardServiceV2 init"
     self.initializeRPC()
     self.asyncStart(status_const.KEYCARDPAIRINGDATAFILE)
     discard
 
-  proc initializeRPC(self: Service) {.slot.} =
+  proc initializeRPC(self: Service) {.slot, featureGuard(KEYCARD_ENABLED).} =
     var response = keycard_go.keycardInitializeRPC()
 
-  proc receiveKeycardSignalV2(self: Service, signal: string) {.slot.} =
+  proc receiveKeycardSignalV2(self: Service, signal: string) {.slot, featureGuard(KEYCARD_ENABLED).} =
     try:
       # Since only one service can register to signals, we pass the signal to the old service too
       var jsonSignal = signal.parseJson
@@ -112,20 +115,20 @@ QtObject:
     except Exception as e:
       error "error receiving a keycard signal", err=e.msg, data = signal
 
-  proc asyncStart(self: Service, storageDir: string) =
+  proc asyncStart(self: Service, storageDir: string) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{
       "storageFilePath": storageDir,
       "logEnabled": KEYCARD_LOGS_ENABLED,
       "logFilePath": KEYCARD_LOG_FILE_PATH,
     }
-    self.asyncCallRPC(KeycardAction.Start, params, proc (responseObj: JsonNode, err: string) =
+    self.asyncCallRPC(KeycardAction.Start, params, proc (responseObj: JsonNode, err: string) {.featureGuard(KEYCARD_ENABLED).} =
       if err.len > 0:
         error "error starting keycard", err=err
         return
       debug "keycard started"
     )
 
-  proc asyncStop*(self: Service) =
+  proc asyncStop*(self: Service)  {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{}
     self.asyncCallRPC(KeycardAction.Stop, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -134,7 +137,7 @@ QtObject:
       debug "keycard stopped"
     )
 
-  proc stop*(self: Service) =
+  proc stop*(self: Service)  {.featureGuard(KEYCARD_ENABLED).} =
     try:
       let response = callRPC($KeycardAction.Stop)
       let rpcResponseObj = response.parseJson
@@ -144,7 +147,7 @@ QtObject:
     except Exception as e:
       error "error stop", err=e.msg
 
-  proc generateMnemonic*(self: Service, length: int): string =
+  proc generateMnemonic*(self: Service, length: int): string {.featureGuard(KEYCARD_ENABLED).} =
     try:
       let response = callRPC($KeycardAction.GenerateMnemonic, %*{"length": length})
       let rpcResponseObj = response.parseJson
@@ -159,7 +162,7 @@ QtObject:
     except Exception as e:
       error "error generating mnemonic", err=e.msg
 
-  proc getMetadata*(self: Service): CardMetadataDto =
+  proc getMetadata*(self: Service): CardMetadataDto {.featureGuard(KEYCARD_ENABLED).} =
     try:
       let response = callRPC($KeycardAction.GetMetadata)
       let rpcResponseObj = response.parseJson
@@ -170,7 +173,7 @@ QtObject:
     except Exception as e:
       error "error getting metadata", err=e.msg
 
-  proc asyncLoadMnemonic*(self: Service, mnemonic: string) =
+  proc asyncLoadMnemonic*(self: Service, mnemonic: string) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{"mnemonic": mnemonic}
     self.asyncCallRPC(KeycardAction.LoadMnemonic, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -181,7 +184,7 @@ QtObject:
       self.events.emit(SIGNAL_KEYCARD_LOAD_MNEMONIC_SUCCESS, KeycardKeyUIDArg(keyUID: keyUID))
     )
 
-  proc asyncAuthorize*(self: Service, pin: string) =
+  proc asyncAuthorize*(self: Service, pin: string) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{"pin": pin}
     self.asyncCallRPC(KeycardAction.Authorize, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -197,7 +200,7 @@ QtObject:
       self.events.emit(SIGNAL_KEYCARD_AUTHORIZE_FINISHED, event)
     )
 
-  proc asyncInitialize*(self: Service, pin: string, puk: string) =
+  proc asyncInitialize*(self: Service, pin: string, puk: string) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{"pin": pin, "puk": puk}
     self.asyncCallRPC(KeycardAction.Initialize, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -207,7 +210,7 @@ QtObject:
       debug "keycard initialized"
     )
 
-  proc asyncExportRecoverKeys*(self: Service) =
+  proc asyncExportRecoverKeys*(self: Service) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{}
     self.asyncCallRPC(KeycardAction.ExportRecoverKeys, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -218,7 +221,7 @@ QtObject:
       self.events.emit(SIGNAL_KEYCARD_EXPORT_RESTORE_KEYS_SUCCESS, KeycardExportedKeysArg(exportedKeys: keys))
     )
 
-  proc asyncExportLoginKeys*(self: Service) =
+  proc asyncExportLoginKeys*(self: Service) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{}
     self.asyncCallRPC(KeycardAction.ExportLoginKeys, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -229,7 +232,7 @@ QtObject:
       self.events.emit(SIGNAL_KEYCARD_EXPORT_LOGIN_KEYS_SUCCESS, KeycardExportedKeysArg(exportedKeys: keys))
     )
 
-  proc asyncFactoryReset*(self: Service) =
+  proc asyncFactoryReset*(self: Service) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{}
     self.asyncCallRPC(KeycardAction.FactoryReset, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -238,7 +241,7 @@ QtObject:
       debug "factory reset"
     )
 
-  proc asyncStoreMetadata*(self: Service, name: string, paths: seq[string]) =
+  proc asyncStoreMetadata*(self: Service, name: string, paths: seq[string]) {.featureGuard(KEYCARD_ENABLED).} =
     let params = %*{"name": name, "paths": paths}
     self.asyncCallRPC(KeycardAction.StoreMetadata, params, proc (responseObj: JsonNode, err: string) =
       if err.len > 0:
@@ -247,7 +250,7 @@ QtObject:
       debug "metadata stored"
     )
 
-  proc storeMetadata*(self: Service, name: string, paths: seq[string]) =
+  proc storeMetadata*(self: Service, name: string, paths: seq[string]) {.featureGuard(KEYCARD_ENABLED).} =
     try:
       let response = callRPC($KeycardAction.StoreMetadata, %*{"name": name, "paths": paths})
       let rpcResponseObj = response.parseJson

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -276,12 +276,12 @@ type StatusDesktopConfig = object
     name: "USE_MOCKED_KEYCARD"
     abbr: "use-mocked-keycard" .}: bool
   httpApiEnabled* {.
-    defaultValue: getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
+    defaultValue: CONNECTOR_ENABLED
     desc: "Enable HTTP RPC API"
     name: "HTTP_API"
     abbr: "http-api" .}: bool
   wsApiEnabled* {.
-    defaultValue: getEnv("FLAG_CONNECTOR_ENABLED", boolToEnv(DEFAULT_FLAG_CONNECTOR_ENABLED)) != "0"
+    defaultValue: CONNECTOR_ENABLED
     desc: "Enable WebSocket RPC API"
     name: "WS_API"
     abbr: "ws-api" .}: bool

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -241,10 +241,11 @@ proc mainProc() =
     singleInstance.delete()
     app.delete()
 
-  # Checks below must be always after "defer", in case anything fails destructors will freed a memory.
-  if singleInstance.secondInstance():
-    info "Terminating the app as the second instance"
-    quit()
+  featureGuard SINGLE_STATUS_INSTANCE_ENABLED:
+    # Checks below must be always after "defer", in case anything fails destructors will freed a memory.
+    if singleInstance.secondInstance():
+      info "Terminating the app as the second instance"
+      quit()
 
   # We need these global variables in order to be able to access the application
   # from the non-closure callback passed to `statusgo_backend.setSignalEventCallback`

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -176,6 +176,7 @@ SplitView {
 
         biometricsAvailable: ctrlBiometrics.checked
         isBiometricsLogin: ctrlTouchIdUser.checked
+        isKeycardEnabled: ctrlKeycard.checked
 
         onBiometricsRequested: (profileId) => biometricsPopup.open()
         onDismissBiometricsRequested: biometricsPopup.close()
@@ -444,6 +445,12 @@ SplitView {
                     checked: true
                 }
 
+                Switch {
+                    id: ctrlKeycard
+                    text: "Keycard enabled"
+                    checked: true
+                }
+
                 ToolSeparator {}
 
                 Switch {
@@ -663,6 +670,7 @@ SplitView {
         property alias useBiometrics: ctrlBiometrics.checked
         property alias showLoginScreen: ctrlLoginScreen.checked
         property alias useTouchId: ctrlTouchIdUser.checked
+        property alias keycardEnabled: ctrlKeycard.checked
     }
 }
 

--- a/storybook/pages/SettingsLeftTabViewPage.qml
+++ b/storybook/pages/SettingsLeftTabViewPage.qml
@@ -22,6 +22,7 @@ SplitView {
         SplitView.fillHeight: true
 
         model: SettingsEntriesModel {
+            isKeycardEnabled: ctrlIsKeycardEnabled.checked
             showWalletEntries: ctrlShowWalletEntries.checked
             showBackUpSeed: ctrlShowBackUpSeed.checked
             syncingBadgeCount: ctrlSyncingBadgeCount.value
@@ -70,6 +71,11 @@ SplitView {
                 id: ctrlShowWalletEntries
                 checked: true
                 text: "Show wallet entries"
+            }
+            Switch {
+                id: ctrlIsKeycardEnabled
+                checked: true
+                text: "Is keycard enabled"
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -20,6 +20,7 @@ OnboardingBasePage {
 
     property StartupStore startupStore: StartupStore {}
     property UtilsStore utilsStore
+    property bool isKeycardEnabled: false
 
     backButtonVisible: root.startupStore.currentStartupState ? root.startupStore.currentStartupState.displayBackButton
                                                              : false
@@ -234,6 +235,7 @@ following the \"Add existing Status user\" flow, using your recovery phrase.")
         id: keysMainViewComponent
         KeysMainView {
             startupStore: root.startupStore
+            isKeycardEnabled: root.isKeycardEnabled
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
@@ -22,6 +22,7 @@ Item {
     id: root
 
     property StartupStore startupStore
+    property bool isKeycardEnabled: true
 
     Component.onCompleted: {
         if (button1.visible) {
@@ -245,7 +246,7 @@ Item {
             objectName: "iDontHaveOtherDeviceButton"
             Layout.alignment: Qt.AlignHCenter
             visible: text !== ""
-            color: Theme.palette.primaryColor1
+            color: enabled ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
             font.pixelSize: Constants.onboarding.fontSize3
             MouseArea {
                 anchors.fill: parent
@@ -383,6 +384,7 @@ Item {
             PropertyChanges {
                 target: button2
                 text: qsTr("Login with Keycard")
+                enabled: root.isKeycardEnabled
             }
             PropertyChanges {
                 target: button3
@@ -418,6 +420,7 @@ Item {
             PropertyChanges {
                 target: button2
                 text: qsTr("Generate keys for a new Keycard")
+                enabled: root.isKeycardEnabled
             }
             PropertyChanges {
                 target: button3

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -25,6 +25,7 @@ OnboardingStackView {
     required property int remainingPukAttempts
 
     required property bool isBiometricsLogin // FIXME should come from the loginAccountsModel for each profile separately?
+    property bool isKeycardEnabled: true
 
     required property bool biometricsAvailable
     required property bool displayKeycardPromoBanner
@@ -194,6 +195,7 @@ OnboardingStackView {
             loginAccountsModel: root.loginAccountsModel
             biometricsAvailable: root.biometricsAvailable
             isBiometricsLogin: root.isBiometricsLogin
+            isKeycardEnabled: root.isKeycardEnabled
 
             onBiometricsRequested: (profileId) => {
                 if (visible)
@@ -239,6 +241,8 @@ OnboardingStackView {
         id: createProfilePage
 
         CreateProfilePage {
+            isKeycardEnabled: root.isKeycardEnabled
+
             onCreateProfileWithPasswordRequested: root.push(createNewProfileFlow)
             onCreateProfileWithSeedphraseRequested: {
                 d.flow = Onboarding.OnboardingFlow.CreateProfileWithSeedphrase
@@ -254,6 +258,7 @@ OnboardingStackView {
 
         NewAccountLoginPage {
             networkChecksEnabled: root.networkChecksEnabled
+            isKeycardEnabled: root.isKeycardEnabled
 
             onLoginWithSyncingRequested: root.push(logInBySyncingFlow)
             onLoginWithKeycardRequested: root.push(loginWithKeycardFlow)

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -19,6 +19,8 @@ Page {
 
     property bool biometricsAvailable: Qt.platform.os === Constants.mac
 
+    property bool isKeycardEnabled: true
+
     property bool isBiometricsLogin // FIXME should come from the loginAccountsModel for each profile separately?
 
     property bool networkChecksEnabled: true
@@ -149,6 +151,7 @@ Page {
 
         displayKeycardPromoBanner: !d.settings.keycardPromoShown
         isBiometricsLogin: root.isBiometricsLogin
+        isKeycardEnabled: root.isKeycardEnabled
         biometricsAvailable: root.biometricsAvailable
         networkChecksEnabled: root.networkChecksEnabled
 

--- a/ui/app/AppLayouts/Onboarding2/controls/ListItemButton.qml
+++ b/ui/app/AppLayouts/Onboarding2/controls/ListItemButton.qml
@@ -18,7 +18,12 @@ AbstractButton {
     icon.height: 32
 
     background: Rectangle {
-        color: root.hovered ? Theme.palette.backgroundHover : "transparent"
+        color: {
+            if (root.disabled) {
+                return Theme.palette.baseColor2
+            }
+            return root.hovered ? Theme.palette.backgroundHover : "transparent"
+        }
         HoverHandler {
             cursorShape: root.hovered ? Qt.PointingHandCursor : undefined
         }
@@ -41,6 +46,7 @@ AbstractButton {
                 text: root.text
                 font.pixelSize: Theme.additionalTextSize
                 font.weight: Font.Medium
+                color: root.enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
                 lineHeightMode: Text.FixedHeight
                 lineHeight: 18
             }
@@ -48,7 +54,7 @@ AbstractButton {
                 Layout.fillWidth: true
                 text: root.subTitle
                 font.pixelSize: Theme.additionalTextSize
-                color: Theme.palette.baseColor1
+                color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.baseColor2
                 visible: !!text
                 lineHeightMode: Text.FixedHeight
                 lineHeight: 18
@@ -59,7 +65,7 @@ AbstractButton {
             Layout.preferredWidth: 16
             Layout.preferredHeight: 16
             icon: "tiny/chevron-right"
-            color: Theme.palette.baseColor1
+            color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.baseColor1
         }
     }
 }

--- a/ui/app/AppLayouts/Onboarding2/pages/CreateProfilePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/CreateProfilePage.qml
@@ -15,6 +15,8 @@ import utils 1.0
 OnboardingPage {
     id: root
 
+    property bool isKeycardEnabled: true
+
     title: qsTr("Create profile")
 
     signal createProfileWithPasswordRequested()
@@ -109,6 +111,7 @@ OnboardingPage {
                         subTitle: qsTr("Store your new profile keys on Keycard")
                         icon.source: Theme.png("onboarding/create_profile_keycard")
                         onClicked: root.createProfileWithEmptyKeycardRequested()
+                        enabled: root.isKeycardEnabled
                     }
                 }
             }

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -33,6 +33,7 @@ OnboardingPage {
 
     property bool biometricsAvailable: Qt.platform.os === Constants.mac
     required property bool isBiometricsLogin // FIXME should come from the loginAccountsModel for each profile separately?
+    property bool isKeycardEnabled: true
 
     readonly property string selectedProfileKeyId: loginUserSelector.selectedProfileKeyId
     readonly property bool selectedProfileIsKeycard: d.currentProfileIsKeycard
@@ -90,7 +91,7 @@ OnboardingPage {
         property bool biometricsSuccessful
         property bool biometricsFailed
 
-        readonly property bool currentProfileIsKeycard: loginUserSelector.keycardCreatedAccount
+        readonly property bool currentProfileIsKeycard: loginUserSelector.keycardCreatedAccount && root.isKeycardEnabled
 
         readonly property Settings settings: Settings {
             category: "Login"

--- a/ui/app/AppLayouts/Onboarding2/pages/NewAccountLoginPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/NewAccountLoginPage.qml
@@ -20,6 +20,8 @@ OnboardingPage {
 
     required property bool networkChecksEnabled
 
+    property bool isKeycardEnabled: true
+
     title: qsTr("Log in")
 
     signal loginWithSeedphraseRequested()
@@ -114,6 +116,7 @@ OnboardingPage {
                         subTitle: qsTr("If your profile keys are stored on a Keycard")
                         icon.source: Theme.png("onboarding/create_profile_keycard")
                         onClicked: root.loginWithKeycardRequested()
+                        enabled: root.isKeycardEnabled
                     }
                 }
             }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -54,6 +54,8 @@ StatusSectionLayout {
     required property SharedStores.CurrenciesStore currencyStore
     required property SharedStores.NetworksStore networksStore
 
+    property bool isKeycardEnabled: true
+
     property var mutualContactsModel
     property var blockedContactsModel
     property var pendingContactsModel
@@ -115,6 +117,7 @@ StatusSectionLayout {
 
         showWalletEntries: root.store.walletMenuItemEnabled
         showBackUpSeed: !root.store.privacyStore.mnemonicBackedUp
+        isKeycardEnabled: root.isKeycardEnabled
 
         syncingBadgeCount: root.store.devicesStore.devicesModel.count -
                            root.store.devicesStore.devicesModel.pairedCount
@@ -299,6 +302,7 @@ StatusSectionLayout {
                 contentWidth: d.contentWidth
 
                 settingsSubSubsection: root.settingsSubSubsection
+                isKeycardEnabled: root.isKeycardEnabled
 
                 rootStore: root.store
                 tokensStore: root.tokensStore

--- a/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
+++ b/ui/app/AppLayouts/Profile/helpers/SettingsEntriesModel.qml
@@ -30,6 +30,9 @@ SortFilterProxyModel {
     // Determines if back up seed phrase entry should be included
     property bool showBackUpSeed
 
+    // Determines if keycard-related entries should be included
+    property bool isKeycardEnabled: true
+
     // Badge count for the syncing entry
     property int syncingBadgeCount: 0
 
@@ -170,6 +173,8 @@ SortFilterProxyModel {
                         return root.showWalletEntries
                     case Constants.settingsSubsection.backUpSeed:
                         return root.showBackUpSeed
+                    case Constants.settingsSubsection.keycard:
+                        return root.isKeycardEnabled
 
                     default: return true
                 }

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -56,6 +56,8 @@ SettingsContentBase {
     readonly property string walletSectionTitle: qsTr("Wallet")
     readonly property string networksSectionTitle: qsTr("Networks")
 
+    property bool isKeycardEnabled: true
+
     function resetStack() {
         if(stackContainer.currentIndex === root.editNetworksViewIndex) {
             networksView.overrideInitialTabIndex(editNetwork.network.isTest ? networksView.testnetTabIndex : networksView.mainnetTabIndex)
@@ -213,6 +215,7 @@ SettingsContentBase {
 
             walletStore: root.walletStore
             emojiPopup: root.emojiPopup
+            isKeycardEnabled: root.isKeycardEnabled
 
             onGoToNetworksView: {
                 stackContainer.currentIndex = networksViewIndex

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -21,6 +21,8 @@ Column {
     property WalletStore walletStore
     property var emojiPopup
 
+    property bool isKeycardEnabled: true
+
     signal goToNetworksView()
     signal goToAccountOrderView()
     signal goToAccountView(var account)
@@ -101,6 +103,7 @@ Column {
         asynchronous: true
 
         sourceComponent: AddAccountPopup {
+            isKeycardEnabled: root.isKeycardEnabled
             store.emojiPopup: root.emojiPopup
             store.addAccountModule: walletSection.addAccountModule
         }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -47,6 +47,8 @@ Item {
 
     property var dAppsModel
 
+    property bool isKeycardEnabled: true
+
     signal dappListRequested()
     signal dappConnectRequested()
     signal dappDisconnectRequested(string dappUrl)
@@ -300,6 +302,7 @@ Item {
             anchors.fill: parent
             emojiPopup: root.emojiPopup
             networkConnectionStore: root.networkConnectionStore
+            isKeycardEnabled: root.isKeycardEnabled
 
             changeSelectedAccount: function(address) {
                 d.displayAddress(address)

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -35,6 +35,8 @@ Rectangle {
     property var selectSavedAddresses: function(){}
     property var emojiPopup: null
 
+    property bool isKeycardEnabled: true
+
     color: Theme.palette.secondaryMenuBackground
 
     Component.onCompleted: {
@@ -52,6 +54,7 @@ Rectangle {
         asynchronous: true
 
         sourceComponent: AddAccountPopup {
+            isKeycardEnabled: root.isKeycardEnabled
             store.emojiPopup: root.emojiPopup
             store.addAccountModule: walletSection.addAccountModule
         }

--- a/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
+++ b/ui/app/AppLayouts/stores/FeatureFlagsStore.qml
@@ -8,4 +8,5 @@ QtObject {
     property bool paymentRequestEnabled
     property bool simpleSendEnabled
     property bool onboardingV2Enabled
+    property bool keycardEnabled
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1973,7 +1973,7 @@ Item {
                             dAppsVisible: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
                             dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.isServiceOnline : false
                             dAppsModel: dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
-
+                            isKeycardEnabled: featureFlagsStore.keycardEnabled
                             onDappListRequested: () => dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppListOpened)
                             onDappConnectRequested: () => {
                                 dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppConnectInitiated)
@@ -2021,6 +2021,7 @@ Item {
                             pendingContactsModel: contactsModelAdaptor.pendingContacts
                             pendingReceivedContactsCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
                             dismissedReceivedRequestContactsModel: contactsModelAdaptor.dimissedReceivedRequestContacts
+                            isKeycardEnabled: featureFlagsStore.keycardEnabled
 
                             Binding on settingsSubsection {
                                 value: profileLoader.settingsSubsection

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -20,6 +20,8 @@ StatusModal {
 
     property AddAccountStore store: AddAccountStore { }
 
+    property bool isKeycardEnabled: true
+
     width: Constants.addAccountPopup.popupWidth
 
     closePolicy: root.store.disablePopup? Popup.NoAutoClose : Popup.CloseOnEscape | Popup.CloseOnPressOutside
@@ -219,6 +221,7 @@ StatusModal {
             Component {
                 id: selectMasterKeyComponent
                 SelectMasterKey {
+                    isKeycardEnabled: root.isKeycardEnabled
                     height: Constants.addAccountPopup.contentHeight1
                     store: root.store
                     onContinueOnKeycard: {

--- a/ui/imports/shared/popups/addaccount/states/SelectMasterKey.qml
+++ b/ui/imports/shared/popups/addaccount/states/SelectMasterKey.qml
@@ -15,6 +15,9 @@ Item {
     id: root
 
     property AddAccountStore store
+
+    property bool isKeycardEnabled: true
+
     signal continueOnKeycard()
 
     Column {
@@ -96,6 +99,7 @@ Item {
 
         StatusListItem {
             title: qsTr("Use Keycard")
+            enabled: root.isKeycardEnabled
             sensor.enabled: false
             sensor.hoverEnabled: false
             statusListItemIcon.enabled: false

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -40,6 +40,7 @@ StatusWindow {
         // TODO get rid of direct access when the new login is available
         // We need this to make sure the module is loaded before we can use it
         onboardingV2Enabled: featureFlags && featureFlags.onboardingV2Enabled && typeof onboardingModule !== "undefined"
+        keycardEnabled: featureFlags ? featureFlags.keycardEnabled : false
     }
 
     property MetricsStore metricsStore: MetricsStore {}
@@ -437,6 +438,7 @@ StatusWindow {
             anchors.fill: parent
 
             utilsStore: applicationWindow.utilsStore
+            isKeycardEnabled: featureFlagsStore.keycardEnabled
         }
     }
 
@@ -451,6 +453,7 @@ StatusWindow {
 
             // FIXME, https://github.com/status-im/status-desktop/issues/17240
             isBiometricsLogin: Qt.platform.os === Constants.mac
+            isKeycardEnabled: featureFlagsStore.keycardEnabled
 
             networkChecksEnabled: true
             biometricsAvailable: Qt.platform.os === Constants.mac


### PR DESCRIPTION
### What does the PR do

Closes #17430 
Needs https://github.com/status-im/nimqml/pull/60

Adding a new compile time flag to disable the Keycard support on platforms where PCSC-lite is not available.
This should be a temporary solution, but in a state where it could be released.

Changes:
- Adding a new `featureFlag` macro to create public feature flags. This macro can read the feature flag at compile time or at run time, based on configuration.
Usage:
```
# Creating a new public feature flag `KEYCARD_ENABLED`. The second argument specifies that the feature flag should be determined at compile time 
featureFlag("KEYCARD_ENABLED", DEFAULT_FLAG_KEYCARD_ENABLED, true)
```
- Adding a `featureGuard` macro to guard the code based on a feature flag. There are two main usages for this featureGuard: To guard a statement list (in this case it just drops the statement list), to guard a `proc` (in this case the proc just returns `discard`). I've kept the proc symbols because otherwise the changes would be much larger.
- Guarding the main entry points for keycard in nim.
- Guarding the main QML entry points for keycard by disabling or hiding the options
    - Login - disable keycard login
    - Onboarding - disable the option to recover account from keycard or create a new keycard account
    - Settings - hide the keycard settings page
    - Wallet - disable the option to add accounts to keycard