### PR TITLE
feat(@desktop/wallet): Adapt changes for estimated time and fee mode in the single network SendModal

### DIFF
--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -157,22 +157,22 @@ SplitView {
                     normalPrice: "1.45 EUR"
                     normalBaseFee: "10000"
                     normalPriorityFee: "1000"
-                    normalTime: "~60s"
+                    normalTime: 60
                     fastPrice: "1.65 EUR"
                     fastBaseFee: "100000"
                     fastPriorityFee: "10000"
-                    fastTime: "~40s"
+                    fastTime: 40
                     urgentPrice: "1.85 EUR"
                     urgentBaseFee: "1000000"
                     urgentPriorityFee: "100000"
-                    urgentTime: "~15s"
+                    urgentTime: 15
 
                     customBaseFee: "10000"
                     customPriorityFee: "1000"
                     customGasAmount: "35000"
                     customNonce: 22
 
-                    selectedFeeMode: StatusFeeOption.Type.Normal
+                    selectedFeeMode: Constants.FeePriorityModeType.Normal
 
                     fnGetPriceInCurrencyForFee: function(feeInWei) {
                         return "0.25 USD"
@@ -184,7 +184,7 @@ SplitView {
 
                     fiatFees: formatBigNumber(42.542567, "EUR")
                     cryptoFees: formatBigNumber(0.06, "ETH")
-                    estimatedTime: qsTr("> 5 minutes")
+                    estimatedTime: qsTr("~60s")
 
                     isCollectibleLoading: isCollectibleLoadingCheckbox.checked
                     isCollectible: isCollectibleCheckbox.checked

--- a/storybook/pages/StatusFeeOptionPage.qml
+++ b/storybook/pages/StatusFeeOptionPage.qml
@@ -7,6 +7,9 @@ import StatusQ.Core.Theme 0.1
 
 import Storybook 1.0
 
+import AppLayouts.Wallet 1.0
+import utils 1.0
+
 SplitView {
     orientation: Qt.Horizontal
 
@@ -23,6 +26,9 @@ SplitView {
         StatusFeeOption {
             id: feeOption
             anchors.centerIn: parent
+            type: feeModeCombobox.currentValue
+            mainText: WalletUtils.getFeeTextForFeeMode(type)
+            icon: WalletUtils.getIconForFeeMode(type)
 
             onClicked: {
                 console.warn("control clicked...")
@@ -41,19 +47,16 @@ SplitView {
             anchors.fill: parent
 
             ComboBox {
+                id: feeModeCombobox
                 model: [
-                    {testCase: StatusFeeOption.Type.Normal, name: "Normal"},
-                    {testCase: StatusFeeOption.Type.Fast, name: "Fast"},
-                    {testCase: StatusFeeOption.Type.Urgent, name: "Urgent"},
-                    {testCase: StatusFeeOption.Type.Custom, name: "Custom"}
+                    {testCase: Constants.FeePriorityModeType.Normal, name: "Normal"},
+                    {testCase: Constants.FeePriorityModeType.Fast, name: "Fast"},
+                    {testCase: Constants.FeePriorityModeType.Urgent, name: "Urgent"},
+                    {testCase: Constants.FeePriorityModeType.Custom, name: "Custom"}
                 ]
 
                 textRole: "name"
                 valueRole: "testCase"
-                onCurrentValueChanged: {
-                    console.warn("valueRole: ", currentValue)
-                    feeOption.type = currentValue
-                }
             }
 
             RowLayout {

--- a/storybook/pages/TransactionSettingsPanelPage.qml
+++ b/storybook/pages/TransactionSettingsPanelPage.qml
@@ -46,7 +46,7 @@ SplitView {
                 customGasAmount: "35000"
                 customNonce: "22"
 
-                selectedFeeMode: StatusFeeOption.Type.Normal
+                selectedFeeMode: Constants.FeePriorityModeType.Normal
 
                 fnGetPriceInCurrencyForFee: function(feeInWei) {
                     return "0.25 USD"
@@ -59,7 +59,7 @@ SplitView {
                 onConfirmClicked: {
                     logs.logEvent("confirm clicked...")
                     logs.logEvent(`selected fee mode: ${txSettings.selectedFeeMode}`)
-                    if (selectedFeeMode === StatusFeeOption.Type.Custom) {
+                    if (selectedFeeMode === Constants.FeePriorityModeType.Custom) {
                         logs.logEvent(`selected customBaseFee...${txSettings.customBaseFee}`)
                         logs.logEvent(`selected customPriorityFee...${txSettings.customPriorityFee}`)
                         logs.logEvent(`selected customGasAmount...${txSettings.customGasAmount}`)

--- a/storybook/qmlTests/tests/tst_SendSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SendSignModal.qml
@@ -9,6 +9,7 @@ import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
+import AppLayouts.Wallet 1.0
 import AppLayouts.Wallet.popups.simpleSend 1.0
 
 import utils 1.0
@@ -54,22 +55,22 @@ Item {
             normalPrice: "1.45 EUR"
             normalBaseFee: "10000"
             normalPriorityFee: "1000"
-            normalTime: "~60s"
+            normalTime: 60
             fastPrice: "1.65 EUR"
             fastBaseFee: "100000"
             fastPriorityFee: "10000"
-            fastTime: "~40s"
+            fastTime: 40
             urgentPrice: "1.85 EUR"
             urgentBaseFee: "1000000"
             urgentPriorityFee: "100000"
-            urgentTime: "~15s"
+            urgentTime: 15
 
             customBaseFee: "10000"
             customPriorityFee: "1000"
             customGasAmount: "35000"
             customNonce: 22
 
-            selectedFeeMode: StatusFeeOption.Type.Normal
+            selectedFeeMode: Constants.FeePriorityModeType.Normal
 
             fnGetPriceInCurrencyForFee: function(feeInWei) {
                 return "0.25 USD"
@@ -562,9 +563,21 @@ Item {
             verify(!!fiatFeesText)
             compare(fiatFeesText.text, controlUnderTest.fiatFees)
 
+            const footerFiatFeesLabel = findChild(controlUnderTest.footer, "footerFiatFeesLabel")
+            verify(!!footerFiatFeesLabel)
+            compare(footerFiatFeesLabel.text, "Max fees")
+
             const footerEstTimeText = findChild(controlUnderTest.footer, "footerEstTimeText")
             verify(!!footerEstTimeText)
             compare(footerEstTimeText.text, controlUnderTest.estimatedTime)
+
+            const footerEstTimeLabel = findChild(controlUnderTest.footer, "footerEstTimeLabel")
+            verify(!!footerEstTimeLabel)
+            compare(footerEstTimeLabel.text, WalletUtils.getFeeTextForFeeMode(controlUnderTest.selectedFeeMode))
+
+            const footerEstTimeIcon = findChild(controlUnderTest.footer, "footerEstTimeIcon")
+            verify(!!footerEstTimeIcon)
+            compare(footerEstTimeIcon.source, WalletUtils.getIconForFeeMode(controlUnderTest.selectedFeeMode))
         }
 
         function test_signButton() {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusFeeOption.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusFeeOption.qml
@@ -40,30 +40,11 @@ import StatusQ.Core.Theme 0.1
 Control {
     id: root
 
-    enum Type {
-        Normal,
-        Fast,
-        Urgent,
-        Custom
-    }
-
-    property int type: StatusFeeOption.Type.Normal
+    required property int type
 
     property bool selected: false
 
-    property string mainText: {
-        switch(type) {
-        case StatusFeeOption.Type.Fast:
-            return qsTr("Fast")
-        case StatusFeeOption.Type.Urgent:
-            return qsTr("Urgent")
-        case StatusFeeOption.Type.Custom:
-            return qsTr("Custom")
-        case StatusFeeOption.Type.Normal:
-        default:
-            return qsTr("Normal")
-        }
-    }
+    required property string mainText
 
     property string subText
     property bool showSubText
@@ -73,19 +54,7 @@ Control {
 
     property string unselectedText
 
-    property string icon: {
-        switch(type) {
-        case StatusFeeOption.Type.Fast:
-            return Theme.png("wallet/car")
-        case StatusFeeOption.Type.Urgent:
-            return Theme.png("wallet/rocket")
-        case StatusFeeOption.Type.Custom:
-            return Theme.png("wallet/handwrite")
-        case StatusFeeOption.Type.Normal:
-        default:
-            return Theme.png("wallet/clock")
-        }
-    }
+    required property string icon
 
     signal clicked()
 

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -78,7 +78,10 @@ QtObject {
     }
 
     function formatEstimatedTime(estimatedTime) {
-        if (estimatedTime == 0 || estimatedTime >= 60) {
+        if (estimatedTime === 0 ) {
+            return qsTr("Unknown")
+        }
+        if (estimatedTime >= 60) {
             return qsTr(">60s")
         }
         return qsTr("~%1").arg(estimatedTime)
@@ -330,6 +333,34 @@ QtObject {
             return qsTr("no positive balance for your account across chains")
         default:
             return ""
+        }
+    }
+
+    function getFeeTextForFeeMode(feeMode) {
+        switch(feeMode) {
+        case Constants.FeePriorityModeType.Fast:
+            return qsTr("Fast")
+        case Constants.FeePriorityModeType.Urgent:
+            return qsTr("Urgent")
+        case Constants.FeePriorityModeType.Custom:
+            return qsTr("Custom")
+        case Constants.FeePriorityModeType.Normal:
+        default:
+            return qsTr("Normal")
+        }
+    }
+
+    function getIconForFeeMode(feeMode) {
+        switch(feeMode) {
+        case Constants.FeePriorityModeType.Fast:
+            return Theme.png("wallet/car")
+        case Constants.FeePriorityModeType.Urgent:
+            return Theme.png("wallet/rocket")
+        case Constants.FeePriorityModeType.Custom:
+            return Theme.png("wallet/handwrite")
+        case Constants.FeePriorityModeType.Normal:
+        default:
+            return Theme.png("wallet/clock")
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -78,7 +78,7 @@ StatusDialog {
                 id: closeButton
                 visible: root.hasExpiryDate && countdownPill.isExpired
                 text: root.closeButtonText
-                onClicked: root.close()
+                onClicked: root.closeHandler()
             }
         }
     }
@@ -120,7 +120,7 @@ StatusDialog {
         headline.title: root.title
         headline.subtitle: root.subtitle
         actions.closeButton.visible: root.headerActionsCloseButtonVisible
-        actions.closeButton.onClicked: root.close()
+        actions.closeButton.onClicked: root.closeHandler()
 
         leftComponent: root.headerIconComponent
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
@@ -8,6 +8,7 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
+import AppLayouts.Wallet 1.0
 import AppLayouts.Wallet.panels 1.0
 import AppLayouts.Wallet.views 1.0
 import AppLayouts.Wallet.popups 1.0
@@ -95,15 +96,15 @@ SignTransactionModalBase {
     required property string normalPrice
     required property string normalBaseFee
     required property string normalPriorityFee
-    required property string normalTime
+    required property int normalTime
 
     required property string fastPrice
-    required property string fastTime
+    required property int fastTime
     required property string fastBaseFee
     required property string fastPriorityFee
 
     required property string urgentPrice
-    required property string urgentTime
+    required property int urgentTime
     required property string urgentBaseFee
     required property string urgentPriorityFee
 
@@ -199,10 +200,20 @@ SignTransactionModalBase {
             spacing: Theme.bigPadding
             ColumnLayout {
                 spacing: 2
-                StatusBaseText {
-                    text: qsTr("Est time")
-                    color: Theme.palette.baseColor1
-                    font.pixelSize: Theme.additionalTextSize
+                RowLayout {
+                    StatusBaseText {
+                        objectName: "footerEstTimeLabel"
+                        text: WalletUtils.getFeeTextForFeeMode(root.selectedFeeMode)
+                        color: Theme.palette.baseColor1
+                        font.pixelSize: Theme.additionalTextSize
+                    }
+                    StatusImage {
+                        objectName: "footerEstTimeIcon"
+                        Layout.alignment: Qt.AlignVCenter
+                        Layout.preferredWidth: 22
+                        Layout.preferredHeight: 22
+                        source: WalletUtils.getIconForFeeMode(root.selectedFeeMode)
+                    }
                 }
                 StatusTextWithLoadingState {
                     objectName: "footerEstTimeText"
@@ -213,6 +224,7 @@ SignTransactionModalBase {
             ColumnLayout {
                 spacing: 2
                 StatusBaseText {
+                    objectName: "footerFiatFeesLabel"
                     text: qsTr("Max fees")
                     color: Theme.palette.baseColor1
                     font.pixelSize: Theme.additionalTextSize
@@ -224,9 +236,12 @@ SignTransactionModalBase {
                 }
             }
             StatusFlatButton {
+                Layout.preferredWidth: 44
+                Layout.preferredHeight: 44
                 tooltip.text: qsTr("Edit transaction settings")
                 icon.name: "settings-advance"
                 textColor: hovered? Theme.palette.directColor1 : Theme.palette.baseColor1
+                size: StatusBaseButton.Size.Small
                 onClicked: {
                     root.internalPopupActive = true
                 }
@@ -256,7 +271,7 @@ SignTransactionModalBase {
 
         function updateCustomFields() {
             // by default custom follows normal fee option
-            if (selectedFeeMode !== StatusFeeOption.Type.Custom) {
+            if (selectedFeeMode !== Constants.FeePriorityModeType.Custom) {
                 customBaseFee = ""
                 customPriorityFee = ""
                 customGasAmount = ""
@@ -303,7 +318,7 @@ SignTransactionModalBase {
 
         Component.onCompleted: {
             d.refreshTxSettings.connect(updateCustomFields)
-            if (root.selectedFeeMode === StatusFeeOption.Type.Custom) {
+            if (root.selectedFeeMode === Constants.FeePriorityModeType.Custom) {
                 updateCustomFields()
                 recalculateCustomPrice()
             }
@@ -320,7 +335,7 @@ SignTransactionModalBase {
         onConfirmClicked: {
             let priorityFee = ""
             let maxFeesPerGas = ""
-            if (selectedFeeMode === StatusFeeOption.Type.Custom) {
+            if (selectedFeeMode === Constants.FeePriorityModeType.Custom) {
                 if (!!customPriorityFee && !!customBaseFee) {
                     const baseFeeWei = Utils.gweiToWei(customBaseFee)
                     const priorityFeeWei = Utils.gweiToWei(customPriorityFee)

--- a/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
@@ -14,6 +14,8 @@ import shared.controls 1.0
 import shared.popups 1.0
 import utils 1.0
 
+import AppLayouts.Wallet 1.0
+
 Rectangle {
     id: root
 
@@ -72,7 +74,7 @@ Rectangle {
     QtObject {
         id: d
 
-        readonly property bool customMode: root.selectedFeeMode === StatusFeeOption.Type.Custom
+        readonly property bool customMode: root.selectedFeeMode === Constants.FeePriorityModeType.Custom
 
         function showAlert(title, text, note, url) {
             infoBox.title = title
@@ -176,43 +178,51 @@ Rectangle {
 
                 StatusFeeOption {
                     id: optionNormal
-                    type: StatusFeeOption.Type.Normal
-                    selected: root.selectedFeeMode === StatusFeeOption.Type.Normal
+                    type: Constants.FeePriorityModeType.Normal
+                    mainText: WalletUtils.getFeeTextForFeeMode(type)
+                    icon: WalletUtils.getIconForFeeMode(type)
+                    selected: root.selectedFeeMode === Constants.FeePriorityModeType.Normal
                     showSubText: true
                     showAdditionalText: true
 
-                    onClicked: root.selectedFeeMode = StatusFeeOption.Type.Normal
+                    onClicked: root.selectedFeeMode = Constants.FeePriorityModeType.Normal
                 }
 
                 StatusFeeOption {
                     id: optionFast
-                    type: StatusFeeOption.Type.Fast
-                    selected: root.selectedFeeMode === StatusFeeOption.Type.Fast
+                    type: Constants.FeePriorityModeType.Fast
+                    mainText: WalletUtils.getFeeTextForFeeMode(type)
+                    icon: WalletUtils.getIconForFeeMode(type)
+                    selected: root.selectedFeeMode === Constants.FeePriorityModeType.Fast
                     showSubText: true
                     showAdditionalText: true
 
-                    onClicked: root.selectedFeeMode = StatusFeeOption.Type.Fast
+                    onClicked: root.selectedFeeMode = Constants.FeePriorityModeType.Fast
                 }
 
                 StatusFeeOption {
                     id: optionUrgent
-                    type: StatusFeeOption.Type.Urgent
-                    selected: root.selectedFeeMode === StatusFeeOption.Type.Urgent
+                    type: Constants.FeePriorityModeType.Urgent
+                    mainText: WalletUtils.getFeeTextForFeeMode(type)
+                    icon: WalletUtils.getIconForFeeMode(type)
+                    selected: root.selectedFeeMode === Constants.FeePriorityModeType.Urgent
                     showSubText: true
                     showAdditionalText: true
 
-                    onClicked: root.selectedFeeMode = StatusFeeOption.Type.Urgent
+                    onClicked: root.selectedFeeMode = Constants.FeePriorityModeType.Urgent
                 }
 
                 StatusFeeOption {
                     id: optionCustom
-                    type: StatusFeeOption.Type.Custom
-                    selected: root.selectedFeeMode === StatusFeeOption.Type.Custom
+                    type: Constants.FeePriorityModeType.Custom
+                    mainText: WalletUtils.getFeeTextForFeeMode(type)
+                    icon: WalletUtils.getIconForFeeMode(type)
+                    selected: root.selectedFeeMode === Constants.FeePriorityModeType.Custom
                     showSubText: !!selected
                     showAdditionalText: !!selected
                     unselectedText: "Set your own fees & nonce"
 
-                    onClicked: root.selectedFeeMode = StatusFeeOption.Type.Custom
+                    onClicked: root.selectedFeeMode = Constants.FeePriorityModeType.Custom
                 }
             }
 

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -756,7 +756,7 @@ QtObject {
                     aggregateFunction: (aggr, value) => aggr < value? value : aggr
 
                     onValueChanged: {
-                        simpleSendModal.estimatedTime = WalletUtils.getLabelForEstimatedTxTime(value)
+                        simpleSendModal.estimatedTime = WalletUtils.formatEstimatedTime(value)
                     }
                 }
 
@@ -829,7 +829,7 @@ QtObject {
                             }
                             return txPathUnderReviewEntry.item.txGasFeeMode
                         }
-                        return StatusFeeOption.Type.Normal
+                        return Constants.FeePriorityModeType.Normal
                     }
 
                     currentBaseFee: !!txPathUnderReviewEntry.item? txPathUnderReviewEntry.item.currentBaseFee : ""
@@ -1000,11 +1000,11 @@ QtObject {
                     estimatedTime: {
                         if (!!txPathUnderReviewEntry.item) {
                             if (handler.reviewApprovalForTxPathUnderReview) {
-                                return WalletUtils.getLabelForEstimatedTxTime(txPathUnderReviewEntry.item.approvalEstimatedTime)
+                                return WalletUtils.formatEstimatedTime(txPathUnderReviewEntry.item.approvalEstimatedTime)
                             }
-                            return WalletUtils.getLabelForEstimatedTxTime(txPathUnderReviewEntry.item.txEstimatedTime)
+                            return WalletUtils.formatEstimatedTime(txPathUnderReviewEntry.item.txEstimatedTime)
                         }
-                        return Constants.TransactionEstimatedTime.Unknown
+                        return WalletUtils.formatEstimatedTime(0)
                     }
 
                     loginType: root.loginType
@@ -1028,10 +1028,9 @@ QtObject {
                     }
 
                     onOpened: handler.sendMetricsEvent("sign modal opened")
-
-                    onRejected:{
-                        handler.sendMetricsEvent("sign modal rejected")
+                    closeHandler: function() {
                         handler.handleReject()
+                        close()
                     }
 
                     onUpdateTxSettings: {
@@ -1042,7 +1041,7 @@ QtObject {
                             chainId = txPathUnderReviewEntry.item.fromChain
                         }
 
-                        if (selectedFeeMode === StatusFeeOption.Type.Custom) {
+                        if (selectedFeeMode === Constants.FeePriorityModeType.Custom) {
                             root.transactionStoreNew.setCustomTxDetails(customNonce,
                                                                         customGasAmount,
                                                                         maxFeesPerGas,
@@ -1061,6 +1060,11 @@ QtObject {
                                                             chainId,
                                                             handler.reviewApprovalForTxPathUnderReview,
                                                             "")
+                    }
+
+                    onRejected: {
+                        handler.sendMetricsEvent("sign modal rejected")
+                        handler.handleReject()
                     }
 
                     onAccepted: {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1041,6 +1041,13 @@ QtObject {
         Unknown
     }
 
+    enum FeePriorityModeType {
+        Normal,
+        Fast,
+        Urgent,
+        Custom
+    }
+
     enum ErrorType {
         SendAmountExceedsBalance,
         NoRoute,


### PR DESCRIPTION
fixes #17446 

### What does the PR do

Cherry-pick of https://github.com/status-im/status-desktop/pull/17331.

### Affected areas

SimpleSend

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://github.com/user-attachments/assets/b0f693dd-d2e5-4c1b-b893-7478fd47304b

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
