### PR TITLE
chore: Use QProcess only when Qt is configured to support the feature

### DIFF
--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -18,7 +18,9 @@ QString SystemUtilsInternal::qtRuntimeVersion() const {
 
 void SystemUtilsInternal::restartApplication() const
 {
+#if QT_CONFIG(process)
     QProcess::startDetached(QCoreApplication::applicationFilePath(), {});
+#endif
     QMetaObject::invokeMethod(QCoreApplication::instance(), "quit", Qt::QueuedConnection);
 }
 

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -365,7 +365,9 @@ void dos_qguiapplication_quit()
 
 void dos_qguiapplication_restart()
 {
+#if QT_CONFIG(process)
     QProcess::startDetached(QCoreApplication::applicationFilePath(), {});
+#endif
     dos_qguiapplication_quit();
 }
 


### PR DESCRIPTION
### What does the PR do

Closes #17477 

Guarding QProcess so that it's used only when the Qt build supports this feature.
