### PR TITLE
fix: Remain pre-selected asset even if not owned

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -178,6 +178,9 @@ StatusDialog {
 
     /** Input function to resolve Ens Name **/
     required property var fnResolveENS
+
+    property bool selectedAssetAvailableInSelectedNetwork: true
+
     /** Output function to set resolved ens name values **/
     function ensNameResolved(resolvedPubKey, resolvedAddress, uuid) {
         recipientsPanel.ensNameResolved(resolvedPubKey, resolvedAddress, uuid)
@@ -217,6 +220,7 @@ StatusDialog {
         // Holds if the asset entry is valid
         readonly property bool selectedAssetEntryValid: (selectedAssetEntry.itemRemovedFromModel ||
                                                          selectedAssetEntry.available) &&
+                                                        root.selectedAssetAvailableInSelectedNetwork &&
                                                         !!selectedAssetEntry.item
 
         // Used to set selected asset in token selector
@@ -281,6 +285,8 @@ StatusDialog {
                 // reset token selector in case selected tokens doesnt exist in either models
                 d.setTokenOnBothHeaders("", "", "")
                 root.selectedTokenKey = ""
+                root.selectedRawAmount = ""
+                amountToSend.clear()
             }
         })
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -208,13 +208,15 @@ StatusDialog {
         readonly property var selectedAssetEntry: ModelEntry {
             sourceModel: root.assetsModel
             key: "tokensKey"
+            cacheOnRemoval: true
             value: root.selectedTokenKey
             onItemChanged: d.setAssetInTokenSelector()
             onAvailableChanged: d.setAssetInTokenSelector()
         }
 
         // Holds if the asset entry is valid
-        readonly property bool selectedAssetEntryValid: selectedAssetEntry.available &&
+        readonly property bool selectedAssetEntryValid: (selectedAssetEntry.itemRemovedFromModel ||
+                                                         selectedAssetEntry.available) &&
                                                         !!selectedAssetEntry.item
 
         // Used to set selected asset in token selector
@@ -667,7 +669,7 @@ StatusDialog {
                 Item {
                     id: bottomSpacer
                     Layout.fillWidth: true
-                    Layout.preferredHeight: (scrollView.contentHeight < scrollView.height + Theme.padding) ? 0 : Theme.bigPadding
+                    Layout.preferredHeight: Theme.bigPadding
                 }
             }
         }

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -437,6 +437,7 @@ QtObject {
             currentCurrency: root.currentCurrency
             fnFormatCurrencyAmount: root.fnFormatCurrencyAmount
             fnResolveENS: root.fnResolveENS
+            selectedAssetAvailableInSelectedNetwork: handler.isAssetAvailableInSelectedNetwork(selectedTokenKey, selectedChainId)
 
             onOpened: {
                 if(isValidParameter(root.simpleSendParams.interactive)) {
@@ -677,6 +678,21 @@ QtObject {
                     }
                 }
 
+                function isAssetAvailableInSelectedNetwork(tokensKey, chainId) {
+                    if (!tokensKey || !chainId || !root.plainTokensBySymbolModel)
+                        return false
+
+                    const addressPerChain = SQUtils.ModelUtils.getByKey(root.plainTokensBySymbolModel, "key", tokensKey, "addressPerChain")
+                    if (!addressPerChain)
+                        return false
+
+                    return !!SQUtils.ModelUtils.getFirstModelEntryIf(
+                                addressPerChain,
+                                (addPerChain) => {
+                                    return chainId === addPerChain.chainId
+                                })
+                }
+
                 readonly property var recipientViewAdaptor: RecipientViewAdaptor {
                     savedAddressesModel: root.savedAddressesModel
                     accountsModel: root.walletAccountsModel
@@ -702,6 +718,7 @@ QtObject {
                 readonly property var assetsSelectorViewAdaptor: TokenSelectorViewAdaptor {
                     assetsModel: root.groupedAccountAssetsModel
                     flatNetworksModel: root.flatNetworksModel
+                    plainTokensBySymbolModel: root.plainTokensBySymbolModel
 
                     currentCurrency: root.currentCurrency
                     showCommunityAssets: root.showCommunityAssetsInSend


### PR DESCRIPTION
Closes #17472 

### What does the PR do

* Cache the selected asset so it is still showed even if another account doesn't have it

### Affected areas

Send modal

### Architecture compliance

- [X] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it https://www.figma.com/design/RfsBP6hKbUvaAjQUrpvMq5/Send?node-id=1-53813&t=VnI94XwPYoQzhMxi-4

