### PR TITLE
fix: Remain pre-selected asset even if not owned

### DIFF
--- a/storybook/pages/SimpleSendModalPage.qml
+++ b/storybook/pages/SimpleSendModalPage.qml
@@ -133,6 +133,7 @@ SplitView {
 
         accountsModel: accountsSelectorAdaptor.processedWalletAccounts
         assetsModel: assetsSelectorViewAdaptor.outputAssetsModel
+        flatAssetsModel: d.walletAssetStore.walletTokensStore.plainTokensBySymbolModel
         flatCollectiblesModel: collectiblesSelectionAdaptor.filteredFlatModel
         collectiblesModel: collectiblesSelectionAdaptor.model
         networksModel: d.filteredNetworksModel

--- a/storybook/qmlTests/tests/tst_SimpleSendModal.qml
+++ b/storybook/qmlTests/tests/tst_SimpleSendModal.qml
@@ -168,6 +168,31 @@ Item {
                 ]
                 Component.onCompleted: append(data)
             }
+
+            flatAssetsModel: ListModel {
+                readonly property var data: [
+                    {
+                        "addressPerChain":[
+                            {address:"0x0000000000000000000000000000000000000000","chainId":1},
+                            {address:"0x0000000000000000000000000000000000000000","chainId":5},
+                            {address:"0x0000000000000000000000000000000000000000","chainId":10},
+                            {address:"0x0000000000000000000000000000000000000000","chainId":11155420},
+                            {address:"0x0000000000000000000000000000000000000000","chainId":42161},
+                            {address:"0x0000000000000000000000000000000000000000","chainId":421614},
+                            {address:"0x0000000000000000000000000000000000000000","chainId":11155111}],
+                        "key":"ETH",
+                    },
+                    {
+                        "addressPerChain":[
+                            {address:"0x6b175474e89094c44da98b954eedeac495271d0f","chainId":1},
+                            {address:"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1","chainId":10},
+                        ],
+                        "key":"DAI",
+                    }
+                ]
+                Component.onCompleted: append(data)
+            }
+
             flatCollectiblesModel: ListModel {
                 readonly property var data: [
                     // collection 2

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -422,6 +422,7 @@ QtObject {
 
             accountsModel: handler.accountsSelectorAdaptor.processedWalletAccounts
             assetsModel: handler.assetsSelectorViewAdaptor.outputAssetsModel
+            flatAssetsModel: root.plainTokensBySymbolModel
             flatCollectiblesModel: handler.collectiblesSelectionAdaptor.filteredFlatModel
             collectiblesModel: handler.collectiblesSelectionAdaptor.model
             networksModel: root.filteredFlatNetworksModel


### PR DESCRIPTION
Cherrypick of https://github.com/status-im/status-desktop/pull/17485 to master

I've modified a fix a little by moving the network check inside the modal.

Why separate model isn't used directly?
Collectible have nice solution with flat model that is unfiltered and used directly. We cannot do that for assets because the chainId and account filtering is hidden deep in submodels. New whole model would need to be created with a lot of duplicated logic for this single use case. I think this solution is really nice compromise between performance hit of another model and code readability.