### PR TITLE
fix(Post Onboarding): unbreak showing of `IntroduceYourselfPopup`

### DIFF
--- a/storybook/pages/IntroduceYourselfPopupPage.qml
+++ b/storybook/pages/IntroduceYourselfPopupPage.qml
@@ -15,7 +15,6 @@ Item {
     IntroduceYourselfPopup {
         id: popup
         visible: true
-        closePolicy: Popup.NoAutoClose
 
         pubKey: "zQ3shW234234EA4545545rhf"
         colorId: 0

--- a/test/e2e/gui/components/community/create_community_popups.py
+++ b/test/e2e/gui/components/community/create_community_popups.py
@@ -7,7 +7,6 @@ import allure
 import configs
 import driver
 from constants import CommunityData
-from gui.components.base_popup import BasePopup
 from gui.components.community.color_select_popup import ColorSelectPopup
 from gui.components.community.tags_select_popup import TagsSelectPopup
 from gui.components.picture_edit_popup import PictureEditPopup
@@ -22,21 +21,21 @@ from gui.screens.community import CommunityScreen
 LOG = logging.getLogger(__name__)
 
 
-class CreateCommunitiesBanner(BasePopup):
+class CreateCommunitiesBanner(QObject):
 
     def __init__(self):
-        super().__init__()
-        self._crete_community_button = Button(names.create_new_StatusButton)
+        super().__init__(names.create_new_StatusButton)
+        self.create_new_button = Button(names.create_new_StatusButton)
 
     def open_create_community_popup(self) -> 'CreateCommunityPopup':
-        self._crete_community_button.click()
+        self.create_new_button.click()
         return CreateCommunityPopup().wait_until_appears()
 
 
-class CreateCommunityPopup(BasePopup):
+class CreateCommunityPopup(QObject):
 
     def __init__(self):
-        super().__init__()
+        super().__init__(names.createCommunityNameInput_TextEdit)
         self._scroll = Scroll(names.generalView_StatusScrollView)
         self._name_text_edit = TextEdit(names.createCommunityNameInput_TextEdit)
         self._description_text_edit = TextEdit(names.createCommunityDescriptionInput_TextEdit)

--- a/test/e2e/gui/components/introduce_yourself_popup.py
+++ b/test/e2e/gui/components/introduce_yourself_popup.py
@@ -1,0 +1,11 @@
+from gui.elements.button import Button
+from gui.elements.object import QObject
+from gui.objects_map import names
+
+
+class IntroduceYourselfPopup(QObject):
+    def __init__(self):
+        super().__init__(names.introduceYourselfEditProfileButton)
+
+        self.skip_button = Button(names.introduceYourselfSkipButton)
+        self.edit_profile_button = Button(names.introduceYourselfEditProfileButton)

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -8,6 +8,7 @@ import configs
 import driver
 from constants import UserAccount, CommunityData
 from gui.components.community.invite_contacts import InviteContactsPopup
+from gui.components.introduce_yourself_popup import IntroduceYourselfPopup
 from gui.components.onboarding.share_usage_data_popup import ShareUsageDataPopup
 from gui.components.context_menu import ContextMenu
 from gui.components.onboarding.before_started_popup import BeforeStartedPopUp
@@ -108,14 +109,19 @@ class LeftPanel(QObject):
 
     @allure.step('Open community portal')
     def open_communities_portal(self, attempts: int = 2) -> CommunitiesPortal:
-        self._communities_portal_button.click()
-        try:
-            return CommunitiesPortal().wait_until_appears()
-        except Exception as ex:
-            if attempts:
-                self.open_communities_portal(attempts - 1)
-            else:
-                raise ex
+        for _ in range(attempts):
+            self._communities_portal_button.click()
+            introduce_yourself_popup = IntroduceYourselfPopup()
+            if introduce_yourself_popup.is_visible:
+                introduce_yourself_popup.skip_button.click()
+                introduce_yourself_popup.wait_until_hidden()
+            time.sleep(0.2)
+            try:
+                return CommunitiesPortal().wait_until_appears()
+            except Exception:
+                pass  # Retry if attempts remain
+        raise Exception(f"Failed to open Communities Portal after {attempts} attempts")
+
 
     def _get_community(self, name: str):
         community_names = []

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -216,6 +216,10 @@ unpinButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow_overl
 headerActionsCloseButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "headerActionsCloseButton", "type": "StatusFlatRoundButton", "visible": True}
 o_StatusPinMessageDetails = {"container": statusDesktop_mainWindow_overlay, "type": "StatusPinMessageDetails", "unnamed": 1, "visible": True}
 
+# Introduce Yourself popup
+introduceYourselfSkipButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "introduceSkipStatusFlatButton", "type": "StatusFlatButton", "visible": True}
+introduceYourselfEditProfileButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "introduceEditStatusFlatButton", "type": "StatusButton", "visible": True}
+
 """ Settings """
 
 # Send Contact Request

--- a/test/e2e/gui/screens/community_portal.py
+++ b/test/e2e/gui/screens/community_portal.py
@@ -1,3 +1,5 @@
+import time
+
 import allure
 
 import driver
@@ -11,14 +13,15 @@ class CommunitiesPortal(QObject):
 
     def __init__(self):
         super().__init__(communities_names.mainWindow_communitiesPortalLayout_CommunitiesPortalLayout)
-        self._create_community_button = Button(communities_names.mainWindow_Create_New_Community_StatusButton)
+        self.create_community_from_portal_button = Button(communities_names.mainWindow_Create_New_Community_StatusButton)
 
     @allure.step('Open create community popup')
     def open_create_community_popup(self) -> CreateCommunityPopup:
-        self._create_community_button.click()
-        try:
-            assert driver.waitForObjectExists(CreateCommunitiesBanner().real_name, 5000), \
-                f'Create community banner is not present within 5 seconds'
-        except (Exception, AssertionError) as ex:
-            raise ex
-        return CreateCommunitiesBanner().open_create_community_popup()
+        for i in range(2):
+            self.create_community_from_portal_button.click()
+            time.sleep(0.1)
+            try:
+                return CreateCommunitiesBanner().wait_until_appears().open_create_community_popup()
+            except Exception:
+                pass
+        raise LookupError(f'Create Communities banner is not displayed')

--- a/ui/imports/shared/popups/IntroduceYourselfPopup.qml
+++ b/ui/imports/shared/popups/IntroduceYourselfPopup.qml
@@ -120,10 +120,12 @@ StatusDialog {
         spacing: Theme.padding
         rightButtons: ObjectModel {
             StatusFlatButton {
+                objectName: "introduceSkipStatusFlatButton"
                 text: qsTr("Skip")
                 onClicked: root.close()
             }
             StatusButton {
+                objectName: "introduceEditStatusFlatButton"
                 icon.name: "settings"
                 text: qsTr("Edit Profile in Settings")
                 onClicked: root.accept()

--- a/ui/imports/shared/popups/IntroduceYourselfPopup.qml
+++ b/ui/imports/shared/popups/IntroduceYourselfPopup.qml
@@ -24,6 +24,8 @@ StatusDialog {
     padding: Theme.smallPadding*2
     topPadding: Theme.xlPadding
 
+    closePolicy: Popup.NoAutoClose
+
     title: qsTr("Introduce yourself")
 
     contentItem: ColumnLayout {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -39,9 +39,7 @@ StatusWindow {
         sendViaPersonalChatEnabled: featureFlags ? featureFlags.sendViaPersonalChatEnabled : false
         paymentRequestEnabled: featureFlags ? featureFlags.paymentRequestEnabled : false
         simpleSendEnabled: featureFlags ? featureFlags.simpleSendEnabled : false
-        // TODO get rid of direct access when the new login is available
-        // We need this to make sure the module is loaded before we can use it
-        onboardingV2Enabled: featureFlags && featureFlags.onboardingV2Enabled && typeof onboardingModule !== "undefined"
+        onboardingV2Enabled: featureFlags ? featureFlags.onboardingV2Enabled : false
     }
 
     property MetricsStore metricsStore: MetricsStore {}
@@ -120,6 +118,10 @@ StatusWindow {
 
     QtObject {
         id: d
+        // TODO get rid of direct access when the new login is available
+        // We need this to make sure the module is loaded before we can use it
+        readonly property bool onboardingV2Enabled: featureFlagsStore.onboardingV2Enabled && typeof onboardingModule !== "undefined"
+
         property int previousApplicationState: -1
 
         property var mockedKeycardControllerWindow
@@ -205,8 +207,8 @@ StatusWindow {
 
     //TODO remove direct backend access
     Connections {
-        enabled: !featureFlagsStore.onboardingV2Enabled
-        target: !featureFlagsStore.onboardingV2Enabled && typeof startupModule !== "undefined" ? startupModule : null
+        enabled: !d.onboardingV2Enabled
+        target: !d.onboardingV2Enabled && typeof startupModule !== "undefined" ? startupModule : null
 
         function onStartUpUIRaised() {
             applicationWindow.appIsReady = true;
@@ -420,7 +422,7 @@ StatusWindow {
         id: startupOnboardingLoader
         anchors.fill: parent
         sourceComponent: {
-            if (featureFlagsStore.onboardingV2Enabled) {
+            if (d.onboardingV2Enabled) {
                 return onboardingV2
             }
             return onboardingV1


### PR DESCRIPTION
### What does the PR do

- the problem was that the feature flag (`onboardingV2Enabled`) was incorrect due to a nasty side effect of mixing it with the check for `onboardingModule`
- this was true only inside main.qml; once propagated down to AppMain, where the popup resides, it became `false` because the `onboardingModule` gets unloaded

Fixes #17498

NEEDS_BACKPORT

### Affected areas

Onboarding/main

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2025-03-06 11-40-47](https://github.com/user-attachments/assets/bc43e64e-b84c-4707-8e8c-f8498aa72874)

