### PR TITLE
fix(wallet): set default selected token in buy modal form

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoModal.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.15
 import QtQml.Models 2.15
 import SortFilterProxyModel 0.2
 
+import StatusQ 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
 import StatusQ.Controls 0.1
@@ -10,7 +11,6 @@ import StatusQ.Components 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
-import StatusQ 0.1
 
 import utils 1.0
 
@@ -87,7 +87,7 @@ StatusStackModal {
         readonly property ModelEntry selectedTokenEntry: ModelEntry {
             sourceModel: root.plainTokensBySymbolModel
             key: "key"
-            value: root.buyCryptoInputParamsForm.selectedTokenKey || Constants.ethToken
+            value: root.buyCryptoInputParamsForm.selectedTokenKey
         }
 
         readonly property ModelEntry selectedProviderEntry: ModelEntry {

--- a/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoParamsForm.qml
+++ b/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoParamsForm.qml
@@ -1,19 +1,22 @@
 import QtQml 2.15
 
+import utils 1.0
 QtObject {
     id: root
 
     property string selectedWalletAddress: ""
     property int selectedNetworkChainId: -1
-    property string selectedTokenKey: ""
+    property string selectedTokenKey: defaultTokenKey
     property string selectedProviderId: ""
 
     readonly property bool filledCorrectly: !!selectedWalletAddress && !!selectedTokenKey && selectedNetworkChainId !== -1
 
+    property string defaultTokenKey: Constants.ethToken
+
     function resetFormData() {
         selectedWalletAddress = ""
         selectedNetworkChainId = -1
-        selectedTokenKey = ""
+        selectedTokenKey = defaultTokenKey
         selectedProviderId = ""
     }
 }


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/17466

The default token was set in `selectedTokenEntry`, while we expect to have the current value in `buyCryptoInputParamsForm.selectedTokenKey`. This PR fixes that

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->
Wallet/Buy

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
