### PR TITLE
fix(Onboarding): skip PIN creation a second time

### DIFF
--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -89,6 +89,9 @@ SplitView {
 
             function setPin(pin: string) {
                 logs.logEvent("OnboardingStore.setPin", ["pin"], arguments)
+
+                pinSettingState = Onboarding.ProgressState.InProgress
+
                 ctrlLoginResult.result = "🯄"
                 const valid = pin === mockDriver.pin
                 if (!valid)

--- a/storybook/pages/UnblockWithPukFlowPage.qml
+++ b/storybook/pages/UnblockWithPukFlowPage.qml
@@ -33,6 +33,7 @@ SplitView {
             pinSettingState: pinSettingStateSelector.value
             tryToSetPukFunction: mockDriver.setPuk
             remainingAttempts: mockDriver.keycardRemainingPukAttempts
+            keycardPinInfoPageDelay: 2000
             onSetPinRequested: (pin) => {
                 logs.logEvent("setPinRequested", ["pin"], arguments)
                 console.warn("!!! SET PIN REQUESTED:", pin)

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateProfileFlow.qml
@@ -34,6 +34,7 @@ OnboardingStackView {
 
         property bool withNewSeedphrase
         property string mnemonic
+        property bool pinAlreadySet
 
         function initialComponent() {
             if (root.keycardState === Onboarding.KeycardState.Empty)
@@ -43,6 +44,19 @@ OnboardingStackView {
                 return keycardNotEmptyPage
 
             return keycardIntroPage
+        }
+
+        function handleCreatePINPage() {
+            if (d.pinAlreadySet) { // skip the create PIN page and move forward
+                if (d.withNewSeedphrase) {
+                    root.push(backupSeedIntroPage)
+                } else {
+                    root.loadMnemonicRequested()
+                    root.push(addKeypairPage)
+                }
+            } else {
+                root.push(keycardCreatePinPage)
+            }
         }
     }
 
@@ -66,7 +80,7 @@ OnboardingStackView {
         CreateKeycardProfilePage {
             onCreateKeycardProfileWithNewSeedphrase: {
                 d.withNewSeedphrase = true
-                root.push(keycardCreatePinPage)
+                d.handleCreatePINPage()
             }
             onCreateKeycardProfileWithExistingSeedphrase: {
                 d.withNewSeedphrase = false
@@ -142,7 +156,7 @@ OnboardingStackView {
             isSeedPhraseValid: root.isSeedPhraseValid
             onSeedphraseSubmitted: (seedphrase) => {
                 root.seedphraseSubmitted(seedphrase)
-                root.push(keycardCreatePinPage)
+                d.handleCreatePINPage()
             }
         }
     }
@@ -155,11 +169,13 @@ OnboardingStackView {
 
             pinSettingState: root.pinSettingState
             authorizationState: root.authorizationState
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
             onSetPinRequested: (pin) => root.setPinRequested(pin)
             onAuthorizationRequested: root.authorizationRequested()
 
             onFinished: {
+                d.pinAlreadySet = true
                 if (d.withNewSeedphrase) {
                     root.replace(backupSeedIntroPage)
                 } else {

--- a/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardCreateReplacementFlow.qml
@@ -81,6 +81,7 @@ OnboardingStackView {
 
             authorizationState: root.authorizationState
             pinSettingState: root.pinSettingState
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
             onSetPinRequested: (pin) => root.setPinRequested(pin)
             onAuthorizationRequested: root.authorizationRequested()

--- a/ui/app/AppLayouts/Onboarding2/KeycardFactoryResetFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/KeycardFactoryResetFlow.qml
@@ -60,9 +60,10 @@ OnboardingStackView {
 
         KeycardBasePage {
             id: keycardResetPage
+            readonly property bool backAvailableHint: false
             readonly property bool resetting: root.keycardState === Onboarding.KeycardState.FactoryResetting
 
-            image.source: resetting ? Theme.png("onboarding/keycard/empty") // FIXME correct image
+            image.source: resetting ? Theme.png("onboarding/keycard/empty")
                                     : Theme.png("onboarding/keycard/success")
             title: resetting ? qsTr("Reseting Keycard") : qsTr("Keycard successfully factory reset")
             subtitle: resetting ? "" : qsTr("You can now use this Keycard like it's a brand-new, empty Keycard")

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -399,6 +399,7 @@ OnboardingStackView {
 
             isSeedPhraseValid: root.isSeedPhraseValid
             pinSettingState: root.pinSettingState
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
             onSeedphraseSubmitted: (seedphrase) => root.seedphraseSubmitted(seedphrase)
 
@@ -429,6 +430,7 @@ OnboardingStackView {
             pinSettingState: root.pinSettingState
             tryToSetPukFunction: root.tryToSetPukFunction
             remainingAttempts: root.remainingPukAttempts
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
             onSetPinRequested: (pin) => {
                 unblockWithPukFlow.pin = pin

--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -52,14 +52,11 @@ Page {
         d.resetState()
     }
 
-    // clear the stack down to the LoginScreen, or recreate it
+    // clear the stack and load the LoginScreen
     // the purpose is to return from main/splash screen in case of a late stage error
     // and use the below error handler (onAccountLoginError)
     function unwindToLoginScreen() {
-        onboardingFlow.pop(null, StackView.Immediate)
-        if (!onboardingFlow.loginScreen) {
-            restartFlow()
-        }
+        restartFlow()
     }
 
     QtObject {

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithPukFlow.qml
@@ -13,6 +13,7 @@ OnboardingStackView {
     required property int pinSettingState
     required property var tryToSetPukFunction
     required property int remainingAttempts
+    required property int keycardPinInfoPageDelay
 
     signal setPinRequested(string pin)
     signal keycardFactoryResetRequested
@@ -75,6 +76,7 @@ OnboardingStackView {
         KeycardCreatePinDelayedPage {
             pinSettingState: root.pinSettingState
             authorizationState: Onboarding.AuthorizationState.Authorized // authorization not needed
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
             onSetPinRequested: root.setPinRequested(pin)
             onFinished: root.replace(keycardUnblockedPage,

--- a/ui/app/AppLayouts/Onboarding2/UnblockWithSeedphraseFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/UnblockWithSeedphraseFlow.qml
@@ -9,6 +9,7 @@ OnboardingStackView {
 
     required property var isSeedPhraseValid
     required property int pinSettingState
+    required property int keycardPinInfoPageDelay
 
     signal seedphraseSubmitted(string seedphrase)
     signal setPinRequested(string pin)
@@ -31,6 +32,7 @@ OnboardingStackView {
         KeycardCreatePinDelayedPage {
             pinSettingState: root.pinSettingState
             authorizationState: Onboarding.AuthorizationState.Authorized // authorization not needed
+            keycardPinInfoPageDelay: root.keycardPinInfoPageDelay
 
             onSetPinRequested: root.setPinRequested(pin)
             onFinished: root.finished()

--- a/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinDelayedPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/KeycardCreatePinDelayedPage.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.15
-import QtQuick.Layouts 1.15
 
 import AppLayouts.Onboarding.enums 1.0
 
@@ -15,6 +14,7 @@ KeycardCreatePinPage {
 
     required property int pinSettingState
     required property int authorizationState
+    required property int keycardPinInfoPageDelay
 
     success: root.authorizationState === Onboarding.ProgressState.Success &&
              root.pinSettingState === Onboarding.ProgressState.Success
@@ -23,7 +23,7 @@ KeycardCreatePinPage {
     signal authorizationRequested
 
     Timer {
-        interval: 2000
+        interval: root.keycardPinInfoPageDelay
         running: root.success
 
         onTriggered: root.finished()


### PR DESCRIPTION
### What does the PR do

- when creating a keycard profile, we can't set the PIN twice w/o finishing the flow
- skip the PIN creation screen a second time when going back and forth
- correctly propagate and consistently use the delay interval to display the final success state to the user

Plus two smaller fixes for other flows

Fixes https://github.com/status-im/status-desktop/issues/17494

### Affected areas

Onboarding/Create profile with empty keycard

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/c3a9dae4-a595-4f56-91d1-62a2fa30d827

