### PR TITLE
chore: Allow targets without qt webengine to run the app

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/+noWebEngine/WalletConnectSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/+noWebEngine/WalletConnectSDK.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.15
+
+/*
+    Dummy WalletConnectSDK.qml file to avoid WebEngine dependency
+    Preserves the same API as WalletConnectSDK.qml
+*/
+
+WalletConnectSDKBase {
+    id: root
+
+    readonly property bool sdkReady: false
+
+    property string userUID: ""
+    property url url: ""
+}

--- a/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DappsConnectorSDK.qml
@@ -2,9 +2,6 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
-import QtWebEngine 1.10
-import QtWebChannel 1.15
-
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as SQUtils
 import StatusQ.Components 0.1


### PR DESCRIPTION
### What does the PR do

Adding a `noWebEngine` qml variant for `WalletConnectSDK`.

It can be configured by using the `QT_FILE_SELECTORS` env variable when needed.

E.g. qputenv("QT_FILE_SELECTORS", "noWebEngine");