### PR TITLE
fix(wallet): import missing keypair button is missing when recovering data from waku

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -84,7 +84,9 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.topMargin: Theme.bigPadding
         Layout.preferredHeight: childrenRect.height
-        visible: !!root.keyPair && root.keyPair.operability === Constants.keypair.operability.nonOperable
+        visible: root.walletStore.walletModule.hasPairedDevices
+                 && !!root.keyPair
+                 && root.keyPair.operability === Constants.keypair.operability.nonOperable
 
         onRunImport: {
             root.runImportMissingKeypairFlow()

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -10,6 +10,7 @@ import StatusQ.Core.Utils 0.1
 import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Wallet.controls 1.0
+import AppLayouts.Wallet.stores 1.0 as WalletStores
 
 import utils 1.0
 import shared.controls 1.0
@@ -134,10 +135,11 @@ RightTabBaseView {
                 Layout.fillWidth: true
                 Layout.topMargin: Theme.bigPadding
                 Layout.preferredHeight: childrenRect.height
-                visible: root.store.walletSectionInst.hasPairedDevices && root.store.walletSectionInst.keypairOperabilityForObservedAccount === Constants.keypair.operability.nonOperable
+                visible: WalletStores.RootStore.walletSectionInst.hasPairedDevices
+                         && WalletStores.RootStore.walletSectionInst.keypairOperabilityForObservedAccount === Constants.keypair.operability.nonOperable
 
                 onRunImport: {
-                    root.store.walletSectionInst.runKeypairImportPopup()
+                    WalletStores.RootStore.walletSectionInst.runKeypairImportPopup()
                 }
             }
 


### PR DESCRIPTION
Related Figma:
- https://www.figma.com/design/idUoxN7OIW2Jpp3PMJ1Rl8/Settings-%7C-Desktop?node-id=18442-539034&m=dev

Closes #17394