### PR TITLE
fix(@desktop/wallet): Send Modal - Switcher icon's position is incorrect

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PaymentRequestModal.qml
+++ b/ui/app/AppLayouts/Chat/popups/PaymentRequestModal.qml
@@ -148,7 +148,10 @@ StatusDialog {
                                    amount, root.selectedTokenKey)
 
             dividerVisible: true
-            selectedSymbol: d.isSelectedHoldingValidAsset ? d.selectedHolding.item.symbol : ""
+            selectedSymbol:  amountToSendInput.fiatMode ?
+                                 root.currentCurrency:
+                                 d.isSelectedHoldingValidAsset ?
+                                     d.selectedHolding.item.symbol : ""
             amountInputRightPadding: holdingSelector.width + Theme.padding
 
             AssetSelector {

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -298,7 +298,6 @@ Control {
 
                 objectName: "bottomItemText"
 
-                Layout.fillWidth: true
                 Layout.preferredWidth: contentWidth
 
                 text: {


### PR DESCRIPTION
Also fixes switching fiat<->crypto symbol in Payment request modal

fixes #17497

### What does the PR do

Fixes -
1.Switcher icon's position in Send Modal
2.  fixes switching fiat<->crypto symbol in Payment request modal

### Affected areas

SimpleSendModal.qml
PaymentRequestModal.qml

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->


https://github.com/user-attachments/assets/eb46a133-5902-439b-b014-64c1b99ce32b


https://github.com/user-attachments/assets/bf3a00ed-ffe5-46ea-b710-8aafa2c45ac0


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
