### PR TITLE
Swap and Send - notifications - Unknown displays on the notification instead of the corresponding chain explorer

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -312,6 +312,7 @@ Item {
             let toastLoading = false
             let toastType = Constants.ephemeralNotificationType.normal
             let toastLink = ""
+            let blockExplorerUrl = ""
 
             const sender = !!fromName? fromName : SQUtils.Utils.elideAndFormatWalletAddress(fromAddr)
             let senderChainName = qsTr("unknown")
@@ -329,14 +330,10 @@ Item {
             let sentCommunityAmount1 = ""
             let sentCommunityAmount2 = ""
 
-            if (!!txHash) {
-                toastLink = "%1/%2".arg(appMain.rootStore.getEtherscanTxLink(fromChainId)).arg(txHash)
-                toastSubtitle = qsTr("View on %1").arg(senderChainName)
-            }
-
-            const fromChainName = SQUtils.ModelUtils.getByKey(appMain.networksStore.activeNetworks, "chainId", fromChainId, "chainName")
-            if (!!fromChainName) {
-                senderChainName = fromChainName
+            const fromChain = SQUtils.ModelUtils.getByKey(appMain.networksStore.activeNetworks, "chainId", fromChainId)
+            if (!!fromChain) {
+                senderChainName = fromChain.chainName
+                blockExplorerUrl = fromChain.blockExplorerURL
             }
             const toChainName = SQUtils.ModelUtils.getByKey(appMain.networksStore.activeNetworks, "chainId", toChainId, "chainName")
             if (!!toChainName) {
@@ -351,6 +348,11 @@ Item {
             const toToken = SQUtils.ModelUtils.getByKey(appMain.tokensStore.plainTokensBySymbolModel, "key", toAsset)
             if (!!toToken) {
                 receivedAmount = currencyStore.formatCurrencyAmountFromBigInt(toAmount, toToken.symbol, toToken.decimals)
+            }
+
+            if (!!txHash) {
+                toastLink = "%1/tx/%2".arg(blockExplorerUrl).arg(txHash)
+                toastSubtitle = qsTr("View on %1").arg(senderChainName)
             }
 
             if (txType === Constants.SendType.ERC721Transfer || txType === Constants.SendType.ERC1155Transfer) {


### PR DESCRIPTION
fixes #17530 

### What does the PR do

Corrects the chain name being set  when sending notifications

### Affected areas

Swap, Send Notifications

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->


https://github.com/user-attachments/assets/fdcb9472-5494-402e-ba10-d298276ea349


https://github.com/user-attachments/assets/0026a922-1fee-4dc6-bc30-2a398d87b16a


https://github.com/user-attachments/assets/03b5c021-8bc3-4304-a4b7-e95eeb112bd6


<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
