### PR TITLE
[cherry-pick] fix: unbreak OS notifications

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -183,6 +183,8 @@ StatusWindow {
     }
 
     function moveToAppMain() {
+        mainModule.fakeLoadingScreenFinished()
+
         Global.appIsReady = true
 
         loader.sourceComponent = app
@@ -233,9 +235,6 @@ StatusWindow {
                 // We set main module to the Global singleton once user is logged in and we move to the main app.
                 appLoadingAnimation.active = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
                 appLoadingAnimation.runningProgressAnimation = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
-                if (!appLoadingAnimation.runningProgressAnimation) {
-                    mainModule.fakeLoadingScreenFinished()
-                }
                 moveToAppMain()
             } else if(state === Constants.appState.appEncryptionProcess) {
                 loader.sourceComponent = undefined
@@ -381,7 +380,6 @@ StatusWindow {
             onProgressChanged: {
                 if (progress === 1) {
                     appLoadingAnimation.active = false
-                    mainModule.fakeLoadingScreenFinished()
                 }
             }
         }
@@ -409,11 +407,6 @@ StatusWindow {
                 to: 1
                 duration: !!localAppSettings && localAppSettings.fakeLoadingScreenEnabled ? 30000 : 3000
                 running: runningProgressAnimation
-            }
-            onProgressChanged: {
-                if (progress === 1) {
-                    mainModule.fakeLoadingScreenFinished()
-                }
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

- call the `mainModule.fakeLoadingScreenFinished()` when moving to AppMain
- avoids calling it in the splash screen progress handler, since it can get stuck, or completely skipped in dev envs

Fixes #17558

### Affected areas

OS notifications

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/51d2e384-14c7-4016-9958-6266fe6325ad)

