### PR TITLE
fix(wallet): reevaluation of max value for send when switching a chain

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -312,6 +312,7 @@ StatusDialog {
                                                                     selectedCollectibleEntry.item.symbol: ""
 
         readonly property double maxSafeCryptoValue: {
+            root.selectedChainId // reference for binding
             if (selectedCollectibleEntryValid) {
                 let collectibleBalance =  SQUtils.ModelUtils.getByKey(selectedCollectibleEntry.item.ownership, "accountAddress", root.selectedAccountAddress, "balance")
                 return !!collectibleBalance ? collectibleBalance: 0


### PR DESCRIPTION
I cannot reproduce the issue described in #17559 using the accounts I have, but looking at the video there, I see what the issue is and am pretty sure this is the fix. 

@virginiabalducci please have a try with this change.

Fixes #17559