### PR TITLE
feat(StatusQ): create a standard `StatusMessageDialog` component

### DIFF
--- a/storybook/pages/StatusMessageDialogPage.qml
+++ b/storybook/pages/StatusMessageDialogPage.qml
@@ -1,0 +1,145 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ.Popups.Dialog 0.1
+
+import Models 1.0
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Rectangle {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        color: "lightgray"
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+            onClicked: dlg.open()
+        }
+
+        StatusMessageDialog {
+            id: dlg
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+            anchors.centerIn: parent
+            text: ctrlText.text
+            standardButtons: sampleModel.count > 0 ? sampleModel.get(ctrlCombo.currentIndex).buttons : Dialog.Ok
+            informativeText: ctrlInfoText.text
+            detailedText: ctrlDetailedText.text
+            icon: ctrlCombo.currentValue
+            onAccepted: console.info("accepted")
+            onRejected: console.info("rejected")
+            onApplied: console.info("applied")
+            onDiscarded: console.info("discarded")
+            onReset: console.info("reset")
+            onHelpRequested: console.info("helpRequested")
+
+            Binding on title {
+                value: ctrlTitle.text
+                when: ctrlTitle.text !== ""
+                restoreMode: Binding.RestoreBindingOrValue
+            }
+        }
+    }
+
+    ListModel {
+        id: sampleModel
+        Component.onCompleted: append(data)
+        readonly property var data: [
+            { title: "NoIcon", value: StatusMessageDialog.StandardIcon.NoIcon, buttons: Dialog.Yes | Dialog.No | Dialog.Help },
+            { title: "Question", value: StatusMessageDialog.StandardIcon.Question, buttons: Dialog.Yes | Dialog.YesToAll | Dialog.No | Dialog.NoToAll },
+            { title: "Information", value: StatusMessageDialog.StandardIcon.Information, buttons:  Dialog.Ok | Dialog.Apply | Dialog.Cancel },
+            { title: "Warning", value: StatusMessageDialog.StandardIcon.Warning, buttons: Dialog.Abort | Dialog.Ignore | Dialog.Discard },
+            { title: "Critical", value: StatusMessageDialog.StandardIcon.Critical, buttons: Dialog.Reset | Dialog.Close | Dialog.Ok }
+        ]
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 300
+        SplitView.preferredHeight: 300
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            width: parent.width
+
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: "Type:\t"
+                }
+                ComboBox {
+                    Layout.preferredWidth: 300
+                    id: ctrlCombo
+                    model: sampleModel
+                    textRole: "title"
+                    valueRole: "value"
+                    currentIndex: 0
+                    onCurrentIndexChanged: if (!dlg.visible) dlg.open()
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: "Title:\t"
+                }
+                TextField {
+                    Layout.preferredWidth: 300
+                    id: ctrlTitle
+                    placeholderText: "Empty == default title"
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: "Text:\t"
+                }
+                TextField {
+                    Layout.preferredWidth: 300
+                    id: ctrlText
+                    placeholderText: "Empty == default title"
+                    text: "Do you want to proceed?"
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: "Info text:\t"
+                }
+                TextField {
+                    Layout.preferredWidth: 300
+                    id: ctrlInfoText
+                    placeholderText: "Empty == default title"
+                    text: "If you click Yes, the file will be deleted"
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: "Detailed text:\t"
+                }
+                TextField {
+                    Layout.preferredWidth: 300
+                    id: ctrlDetailedText
+                    placeholderText: "Empty == default title"
+                    text: "This is an optional detailed text"
+                }
+            }
+        }
+    }
+}
+
+// category: Dialogs
+// status: good

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -37,7 +37,7 @@ Dialog {
 
     anchors.centerIn: Overlay.overlay
 
-    padding: 16
+    padding: Theme.padding
     // by design
     margins: root.contentItem.Window.height <= 780 ? 28 : 64
     modal: true

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogBackground.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.14
+import QtQuick 2.15
 import StatusQ.Core.Theme 0.1
 
 Rectangle {
     color: Theme.palette.statusModal.backgroundColor
-    radius: 8
+    radius: Theme.radius
 }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogHeader.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
@@ -22,7 +22,7 @@ Rectangle {
     signal closeInternalPopup()
 
     color: Theme.palette.statusModal.backgroundColor
-    radius: 8
+    radius: Theme.radius
 
     implicitHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
     implicitWidth: layout.implicitWidth + layout.anchors.leftMargin + layout.anchors.rightMargin
@@ -42,10 +42,10 @@ Rectangle {
 
         anchors {
             fill: parent
-            margins: 16
+            margins: Theme.padding
         }
 
-        spacing: 8
+        spacing: Theme.halfPadding
 
         Loader {
             id: leftComponentLoader

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusMessageDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusMessageDialog.qml
@@ -1,0 +1,135 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    id: root
+
+    property string text
+    property string informativeText
+    property string detailedText
+
+    enum StandardIcon {
+        NoIcon,
+        Question,
+        Information,
+        Warning,
+        Critical
+    }
+
+    property int icon: StatusMessageDialog.StandardIcon.NoIcon
+
+    readonly property string defaultTitle: {
+        switch (root.icon) {
+        case StatusMessageDialog.StandardIcon.Question:
+            return qsTr("Question")
+        case StatusMessageDialog.StandardIcon.Information:
+            return qsTr("Information")
+        case StatusMessageDialog.StandardIcon.Warning:
+            return qsTr("Warning")
+        case StatusMessageDialog.StandardIcon.Critical:
+            return qsTr("Error")
+        case StatusMessageDialog.StandardIcon.NoIcon:
+        default:
+            return ""
+        }
+    }
+
+    standardButtons: Dialog.Ok
+
+    header: StatusDialogHeader {
+        visible: headline.title || root.subtitle
+        headline.title: root.title || root.defaultTitle
+        headline.subtitle: root.subtitle
+        leftComponent: root.icon !== StatusMessageDialog.StandardIcon.NoIcon ? iconComponent : null
+        actions.closeButton.onClicked: root.closeHandler()
+    }
+
+    footer: DialogButtonBox {
+        spacing: Theme.halfPadding
+        padding: Theme.padding
+
+        standardButtons: root.standardButtons
+        delegate: StatusButton {
+            type: (DialogButtonBox.buttonRole & DialogButtonBox.DestructiveRole) ? StatusButton.Type.Danger
+                                                                                 : StatusButton.Type.Normal
+        }
+
+        background: Rectangle {
+            color: Theme.palette.statusModal.backgroundColor
+            radius: Theme.radius
+
+            // cover for the top rounded corners
+            Rectangle {
+                width: parent.width
+                height: parent.radius
+                anchors.top: parent.top
+                color: parent.color
+            }
+
+            StatusDialogDivider {
+                anchors.top: parent.top
+                width: parent.width
+            }
+        }
+    }
+
+    ColumnLayout {
+        width: root.availableWidth
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            text: root.text
+            font.weight: Font.DemiBold
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.topMargin: 4
+            wrapMode: Text.Wrap
+            text: root.informativeText
+            visible: !!text
+            font.pixelSize: Theme.secondaryTextFontSize
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            text: root.detailedText
+            visible: !!text
+            font.pixelSize: Theme.additionalTextSize
+        }
+    }
+
+    Component {
+        id: iconComponent
+        StatusIcon {
+            icon: {
+                switch (root.icon) {
+                case StatusMessageDialog.StandardIcon.Question:
+                    return "help"
+                case StatusMessageDialog.StandardIcon.Information:
+                    return "info"
+                case StatusMessageDialog.StandardIcon.Warning:
+                    return "warning"
+                case StatusMessageDialog.StandardIcon.Critical:
+                    return "caution"
+                case StatusMessageDialog.StandardIcon.NoIcon:
+                default:
+                    return ""
+                }
+            }
+
+            Binding on color {
+                when: root.icon === StatusMessageDialog.StandardIcon.Warning || root.icon === StatusMessageDialog.StandardIcon.Critical
+                value: root.icon === StatusMessageDialog.StandardIcon.Critical ? Theme.palette.dangerColor1 : Theme.palette.warningColor1
+                restoreMode: Binding.RestoreBindingOrValue
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusTitleSubtitle.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusTitleSubtitle.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -25,7 +25,7 @@ Item {
             Layout.fillWidth: true
 
             font {
-                pixelSize: 17
+                pixelSize: Theme.secondaryAdditionalTextSize
                 bold: true
             }
             elide: Text.ElideMiddle

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
@@ -7,3 +7,5 @@ StatusDialogHeader 0.1 StatusDialogHeader.qml
 StatusHeaderActions 0.1 StatusHeaderActions.qml
 StatusTitleSubtitle 0.1 StatusTitleSubtitle.qml
 StatusDialogBackground 0.1 StatusDialogBackground.qml
+
+StatusMessageDialog 0.1 StatusMessageDialog.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -240,6 +240,7 @@
         <file>StatusQ/Popups/Dialog/StatusDialogHeader.qml</file>
         <file>StatusQ/Popups/Dialog/StatusHeaderActions.qml</file>
         <file>StatusQ/Popups/Dialog/StatusTitleSubtitle.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusMessageDialog.qml</file>
         <file>StatusQ/Popups/Dialog/qmldir</file>
         <file>StatusQ/Popups/StatusAction.qml</file>
         <file>StatusQ/Popups/StatusColorDialog.qml</file>

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -2,13 +2,13 @@ import QtQuick 2.15
 import QtQml 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Backpressure 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared 1.0
@@ -414,13 +414,12 @@ Item {
         onHeaderChanged: chatLogView.positionViewAtBeginning()
     }
 
-    MessageDialog {
+    StatusMessageDialog {
         property string error
 
         id: sendingMsgFailedPopup
-        standardButtons: StandardButton.Ok
         text: qsTr("Failed to send message.\n" + error)
-        icon: StandardIcon.Critical
+        icon: StatusMessageDialog.StandardIcon.Critical
     }
 
     Component {

--- a/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
@@ -1,6 +1,5 @@
-import QtQuick 2.12
-import QtQuick.Controls 2.3
-import QtQuick.Dialogs 1.3
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -9,6 +8,7 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared.popups 1.0
@@ -235,12 +235,10 @@ StatusModal {
         }
     ]
 
-    MessageDialog {
+    StatusMessageDialog {
         id: categoryError
-        title: isEdit ?
-                qsTr("Error editing the category") :
-                qsTr("Error creating the category")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
+        title: isEdit ? qsTr("Error editing the category")
+                      : qsTr("Error creating the category")
+        icon: StatusMessageDialog.StandardIcon.Critical
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -1,13 +1,12 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.3
+import QtQuick.Dialogs 1.3 // TODO Remove with FileDialog
 import QtQml 2.15
 import QtQml.Models 2.15
 
 import utils 1.0
 import shared.panels 1.0
-
 
 import StatusQ 0.1
 import StatusQ.Core 0.1
@@ -17,6 +16,7 @@ import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Communities.views 1.0
 import AppLayouts.Communities.panels 1.0
@@ -966,10 +966,9 @@ StatusStackModal {
         }
     ]
 
-    MessageDialog {
+    StatusMessageDialog {
         id: creatingError
         title: qsTr("Error creating the channel")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
+        icon: StatusMessageDialog.StandardIcon.Critical
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
+import QtQuick.Dialogs 1.3 // TODO remove with FileDialog
 
 import utils 1.0
 import shared.panels 1.0
@@ -14,6 +14,7 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Communities.controls 1.0
 import AppLayouts.Communities.panels 1.0
@@ -479,11 +480,10 @@ StatusStackModal {
         }
     }
 
-    MessageDialog {
+    StatusMessageDialog {
         id: errorDialog
 
         title: qsTr("Error creating the community")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
+        icon: StatusMessageDialog.StandardIcon.Critical
     }
 }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.3
 import QtGraphicalEffects 1.15
 import QtQuick.Layouts 1.15
 
@@ -9,6 +8,7 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared 1.0
@@ -641,10 +641,9 @@ Item {
         }
     }
 
-    MessageDialog {
+    StatusMessageDialog {
         id: deleteError
         title: qsTr("Error deleting the category")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
+        icon: StatusMessageDialog.StandardIcon.Critical
     }
 }

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
-import QtQuick.Dialogs 1.3
 
 import SortFilterProxyModel 0.2
 
@@ -12,6 +11,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 import StatusQ.Layout 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import shared.panels 1.0
 import shared.popups 1.0
@@ -718,12 +718,11 @@ StatusSectionLayout {
         }
     }
 
-    MessageDialog {
+    StatusMessageDialog {
         id: errorDialog
 
         title: qsTr("Error editing the community")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
+        icon: StatusMessageDialog.StandardIcon.Critical
     }
 
     Component {

--- a/ui/app/AppLayouts/Profile/popups/RenameAccontModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/RenameAccontModal.qml
@@ -1,12 +1,12 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
@@ -120,11 +120,10 @@ StatusModal {
                       accountColorInput.selectedColorIndex >= 0 && accountColorInput.selectedColor !== popup.account.color ||
                       accountNameInput.input.asset.emoji !== popup.account.emoji)
 
-            MessageDialog {
+            StatusMessageDialog {
                 id: changeError
                 title: qsTr("Changing settings failed")
-                icon: StandardIcon.Critical
-                standardButtons: StandardButton.Ok
+                icon: StatusMessageDialog.StandardIcon.Critical
             }
 
             onClicked : {


### PR DESCRIPTION
### What does the PR do

- (almost) a dropin replacement for the QtQuick.1 `MessageDialog`, preserving the same API
- based on `StatusDialog` to get the default look'n'feel
- works on both Qt5/Qt6 using native Status components
- some smaller fixes/alignments to the underlying StatusDialog
- add a dedicated StoryBook page

Fixes #17562

### Affected areas

StatusMessageDialog

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/3a236eff-0dbc-452b-9b39-0f6ca1e2831f)

