### PR TITLE
test: auto-login and restart if the wallet is loaded

### DIFF
--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -282,7 +282,9 @@ QtObject:
       if tokensResult.isNil or tokensResult.kind == JNull:
         raise newException(Exception, "Error in response of getting supported tokens list")
 
-      let tokenList =  Json.decode($tokensResult, TokenListDto, allowUnknownFields = true)
+      let tokenResultStr = $tokensResult
+      let tokenList =  Json.decode(tokenResultStr, TokenListDto, allowUnknownFields = true)
+
       self.tokenListUpdatedAt = tokenList.updatedAt
 
       let supportedNetworkChains = self.networkService.getFlatNetworks().map(n => n.chainId)

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -129,6 +129,7 @@ proc logHandlerCallback(messageType: cint, message: cstring, category: cstring, 
       warn "qt message of unknown type", messageType = int(messageType)
 
 proc mainProc() =
+  sleep 1000
 
   when defined(macosx) and defined(arm64):
     var signalStack: cstring = cast[cstring](allocShared(SIGSTKSZ))
@@ -239,7 +240,7 @@ proc mainProc() =
   # Checks below must be always after "defer", in case anything fails destructors will freed a memory.
   if singleInstance.secondInstance():
     info "Terminating the app as the second instance"
-    quit()
+    mainProc()
 
   # We need these global variables in order to be able to access the application
   # from the non-closure callback passed to `statusgo_backend.setSignalEventCallback`

--- a/ui/app/AppLayouts/Onboarding2/controls/LoginPasswordInput.qml
+++ b/ui/app/AppLayouts/Onboarding2/controls/LoginPasswordInput.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Backpressure 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 
@@ -18,6 +19,10 @@ StatusPasswordInput {
     rightPadding: iconsLayout.width + iconsLayout.anchors.rightMargin
     placeholderText: qsTr("Password")
     echoMode: d.showPassword ? TextInput.Normal : TextInput.Password
+    Component.onCompleted: {
+        text = "1234567890"
+        Backpressure.setTimeout(root, 200, () => root.accepted())
+    }
 
     QtObject {
         id: d

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -286,7 +286,11 @@ Control {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            model: root.loading ? loadingModel : regularModel
+            model: {
+                if (!root.loading)
+                    SystemUtils.restartApplication()
+                root.loading ? loadingModel : regularModel
+            }
 
             section {
                 property: "isCommunity"


### PR DESCRIPTION
### What does the PR do

Playground for #17398


It will automatically log-in and restart the application when the wallet is loaded. If the wallet fails to load, it will stop and leave the app open.

Just make sure to use an account with password 1234567890