### PR TITLE
ci: use xcode 16.2

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -7,7 +7,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.22 && xcode-15.1"
+    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.22 && xcode-16.2"
   }
 
   parameters {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -65,8 +65,9 @@ pipeline {
     PLATFORM = "macos/${getArch()}"
     /* Improve make performance */
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
-    /* WARNING: Qt 5.15.8 installed via Brew. */
-    QTDIR = '/opt/homebrew/opt/qt@5'
+    QT_VERSION="5.15.16_1"
+    BREW_PREFIX = sh(script: "brew --prefix", returnStdout: true).trim()
+    QTDIR="${BREW_PREFIX}/Cellar/qt@5/${QT_VERSION}"
     /* Enforce Go version installed infra-role-golang. */
     PATH = "${env.QTDIR}/bin:${env.HOME}/go/bin:/usr/local/go/bin:${env.PATH}"
     /* Avoid weird bugs caused by stale cache. */


### PR DESCRIPTION
## Summary
I've upgraded all CI hosts to Xcode 16.
After this PR is merged we can finally switch the labels in Jenkins.
