### PR TITLE
fix(LoginScreen): set account selector initial selection

### DIFF
--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -140,15 +140,12 @@ QtObject:
   proc getKeycardEvent*(self: View): KeycardEventDto =
     return self.keycardEvent
 
-  proc loginAccountsModelChanged*(self: View) {.signal.}
   proc getLoginAccountsModel(self: View): QVariant {.slot.} =
     return self.loginAccountsModelVariant
   proc setLoginAccountsModelItems*(self: View, accounts: seq[login_acc_item.Item]) =
     self.loginAccountsModel.setItems(accounts)
-    self.loginAccountsModelChanged()
   QtProperty[QVariant] loginAccountsModel:
     read = getLoginAccountsModel
-    notify = loginAccountsModelChanged
 
   proc convertKeycardAccountStateChanged*(self: View) {.signal.}
   proc getConvertKeycardAccountState(self: View): int {.slot.} =

--- a/storybook/pages/LoginScreenPage.qml
+++ b/storybook/pages/LoginScreenPage.qml
@@ -31,12 +31,16 @@ SplitView {
         property int loginResult: Onboarding.ProgressState.Idle // NB abusing the tristate enum here a bit :)
     }
 
+    LoginAccountsModel {
+        id: accModel
+    }
+
     LoginScreen {
         id: loginScreen
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        loginAccountsModel: LoginAccountsModel {}
+        loginAccountsModel: accModel
 
         keycardState: driver.keycardState
         keycardUID: driver.keycardUID

--- a/storybook/pages/OnboardingLayoutPage.qml
+++ b/storybook/pages/OnboardingLayoutPage.qml
@@ -82,7 +82,7 @@ SplitView {
             property int restoreKeysExportState: Onboarding.ProgressState.Idle
             property int convertKeycardAccountState: Onboarding.ProgressState.Idle
             property int syncState: Onboarding.ProgressState.Idle
-            property var loginAccountsModel: ctrlLoginScreen.checked ? loginAccountsModel : emptyModel
+            readonly property var loginAccountsModel: ctrlLoginScreen.checked ? loginAccountsModel : emptyModel
 
             property int keycardRemainingPinAttempts: Constants.onboarding.defaultPinAttempts
             property int keycardRemainingPukAttempts: Constants.onboarding.defaultPukAttempts
@@ -175,6 +175,7 @@ SplitView {
 
             // (test) error handler
             onAccountLoginError: function (error, wrongPassword) {
+                logs.logEvent("OnboardingStore.accountLoginError", ["error", "wrongPassword"], arguments)
                 ctrlLoginResult.result = "<font color='red'>⛔</font>"
                 onboarding.restartFlow()
             }

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -959,6 +959,8 @@ Item {
               { tag: "correct password+biometrics", keyUid: "uid_1", password: mockDriver.dummyNewPassword, biometrics: true },
               { tag: "wrong password", keyUid: "uid_1", password: "foobar", biometrics: false },
               { tag: "wrong password+biometrics", keyUid: "uid_1", password: "foobar", biometrics: true },
+              { tag: "non existing user", keyUid: "uid_xxx", password: "foobar", biometrics: false },
+              { tag: "empty user", keyUid: "", password: "foobar", biometrics: false },
               // keycard based profile ("uid_4")
               { tag: "correct PIN", keyUid: "uid_4", pin: "111111", biometrics: false },
               { tag: "correct PIN+biometrics", keyUid: "uid_4", pin: "111111", biometrics: true },
@@ -978,6 +980,10 @@ Item {
             const userSelector = findChild(page, "loginUserSelector")
             verify(!!userSelector)
             userSelector.setSelection(data.keyUid) // select the right profile, keycard or regular one (password)
+
+            expectFail("non existing user")
+            expectFail("empty user")
+
             tryCompare(userSelector, "selectedProfileKeyId", data.keyUid)
             tryCompare(userSelector, "keycardCreatedAccount", !!data.pin && data.pin !== "")
 

--- a/ui/app/AppLayouts/Onboarding2/controls/LoginUserSelector.qml
+++ b/ui/app/AppLayouts/Onboarding2/controls/LoginUserSelector.qml
@@ -133,6 +133,7 @@ Control {
             }
             StatusMenuSeparator {
                 Layout.fillWidth: true
+                visible: proxyModel.count > 0
             }
             LoginUserSelectorDelegate {
                 Layout.fillWidth: true

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -92,6 +92,17 @@ OnboardingPage {
         readonly property bool currentProfileIsKeycard: loginUserSelector.keycardCreatedAccount && root.isKeycardEnabled
         readonly property bool isWrongKeycard: !!root.keycardUID && loginUserSelector.selectedProfileKeyId !== root.keycardUID
 
+        readonly property int loginModelCount: root.loginAccountsModel.ModelCount.count
+        onLoginModelCountChanged: setSelectedLoginUser()
+
+        function setSelectedLoginUser() {
+            if (loginModelCount > 0) {
+                loginUserSelector.setSelection(d.settings.lastKeyUid)
+                if (!d.currentProfileIsKeycard)
+                    passwordBox.forceActiveFocus()
+            }
+        }
+
         readonly property Settings settings: Settings {
             category: "Login"
             property string lastKeyUid
@@ -106,14 +117,14 @@ OnboardingPage {
             if (password.length === 0)
                 return
 
-            root.loginRequested(d.settings.lastKeyUid, Onboarding.LoginMethod.Password, { password })
+            root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Password, { password })
         }
 
         function doKeycardLogin(pin: string) {
             if (pin.length === 0)
                 return
 
-            root.loginRequested(d.settings.lastKeyUid, Onboarding.LoginMethod.Keycard, { pin })
+            root.loginRequested(root.selectedProfileKeyId, Onboarding.LoginMethod.Keycard, { pin })
         }
     }
 
@@ -128,9 +139,7 @@ OnboardingPage {
     }
 
     Component.onCompleted: {
-        loginUserSelector.setSelection(d.settings.lastKeyUid)
-        if (!d.currentProfileIsKeycard)
-            passwordBox.forceActiveFocus()
+        d.setSelectedLoginUser()
     }
 
     // login errors reporting


### PR DESCRIPTION
### What does the PR do

- set the current item in CTOR only iff the model is not empty
- and then again anytime the model contents/count changes
- remove the separator with just 1 model entry

Fixes #17597

### Affected areas

Onboarding/Login

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/bfdd552b-5774-4d97-9369-3d98c94b3a61)
