### PR TITLE
fix(IntroduceYourselfPopup): only show when the display name is empty

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -815,7 +815,7 @@ Item {
         }
 
         function maybeDisplayIntroduceYourselfPopup() {
-            if (!appMainLocalSettings.introduceYourselfPopupSeen && featureFlagsStore.onboardingV2Enabled)
+            if (!appMainLocalSettings.introduceYourselfPopupSeen && featureFlagsStore.onboardingV2Enabled && allContacsAdaptor.selfDisplayName === "")
                 introduceYourselfPopupComponent.createObject(appMain).open()
         }
 


### PR DESCRIPTION
### What does the PR do

- extend the check for showing the Introduce yourself popup with the empty display name condition

Fixes #17596

### Affected areas

AppMain/IntroduceYourselfPopup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

