### PR TITLE
feat(wallet): auto-refresh tokens lists

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -11,6 +11,7 @@ type SignalType* {.pure.} = enum
   WalletRouterTransactionsSent = "wallet.router.transactions-sent"
   WalletTransactionStatusChanged = "wallet.transaction.status-changed"
   WalletSuggestedRoutes = "wallet.suggested.routes"
+  WalletTokensListsUpdated = "wallet.token-lists.updated"
   NodeReady = "node.ready"
   NodeCrashed = "node.crashed"
   NodeStarted = "node.started"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -85,7 +85,8 @@ QtObject:
         SignalType.WalletRouterSignTransactions,
         SignalType.WalletRouterTransactionsSent,
         SignalType.WalletTransactionStatusChanged,
-        SignalType.WalletSuggestedRoutes:
+        SignalType.WalletSuggestedRoutes,
+        SignalType.WalletTokensListsUpdated:
           WalletSignal.fromEvent(signalType, jsonSignal)
       of SignalType.NodeReady,
         SignalType.NodeCrashed,

--- a/src/app/modules/main/wallet_section/all_tokens/controller.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/controller.nim
@@ -79,8 +79,8 @@ proc getTokenBySymbolList*(self: Controller): var seq[TokenBySymbolItem] =
 proc getTokenDetails*(self: Controller, symbol: string): TokenDetailsItem =
   return self.tokenService.getTokenDetails(symbol)
 
-proc getTokenListUpdatedAt*(self: Controller): int64 =
-  return self.tokenService.getTokenListUpdatedAt()
+proc getLastTokensUpdate*(self: Controller): int64 =
+  return self.settingsService.getLastTokensUpdate()
 
 proc getMarketValuesBySymbol*(self: Controller, symbol: string): TokenMarketValuesItem =
   return self.tokenService.getMarketValuesBySymbol(symbol)
@@ -140,3 +140,9 @@ proc getDisplayAssetsBelowBalanceThreshold*(self: Controller): CurrencyAmount =
 
 proc setDisplayAssetsBelowBalanceThreshold*(self: Controller, threshold: int64): bool =
   return self.settingsService.setDisplayAssetsBelowBalanceThreshold(threshold)
+
+proc getAutoRefreshTokensLists*(self: Controller): bool =
+  return self.settingsService.getAutoRefreshTokens()
+
+proc toggleAutoRefreshTokensLists*(self: Controller): bool =
+  return self.settingsService.toggleAutoRefreshTokens()

--- a/src/app/modules/main/wallet_section/all_tokens/io_interface.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/io_interface.nim
@@ -106,3 +106,12 @@ method getDisplayAssetsBelowBalanceThreshold*(self: AccessInterface): CurrencyAm
 
 method setDisplayAssetsBelowBalanceThreshold*(self: AccessInterface, threshold: int64): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getLastTokensUpdate*(self: AccessInterface): int64 {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getAutoRefreshTokensLists*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method toggleAutoRefreshTokensLists*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/all_tokens/view.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/view.nim
@@ -9,7 +9,6 @@ QtObject:
       marketHistoryIsLoading: bool
       balanceHistoryIsLoading: bool
 
-      tokenListUpdatedAt: int64
       # This contains the different sources for the tokens list
       # ex. uniswap list, status tokens list
       sourcesOfTokensModel: SourcesOfTokensModel
@@ -53,11 +52,10 @@ QtObject:
     read = getMarketHistoryIsLoading
     notify = marketHistoryIsLoadingChanged
 
-  proc tokenListUpdatedAtChanged*(self: View) {.signal.}
   proc getTokenListUpdatedAt(self: View): QVariant {.slot.} =
-    return newQVariant(self.tokenListUpdatedAt)
-  proc setTokenListUpdatedAt*(self: View, updatedAt: int64) =
-    self.tokenListUpdatedAt = updatedAt
+    return newQVariant(self.delegate.getLastTokensUpdate())
+  proc tokenListUpdatedAtChanged(self: View) {.signal.}
+  proc emitTokenListUpdatedAtSignal*(self: View) =
     self.tokenListUpdatedAtChanged()
   QtProperty[QVariant] tokenListUpdatedAt:
     read = getTokenListUpdatedAt
@@ -220,3 +218,16 @@ QtObject:
   QtProperty[QVariant] displayAssetsBelowBalanceThreshold:
     read = getDisplayAssetsBelowBalanceThreshold
     notify = displayAssetsBelowBalanceThresholdChanged
+
+
+  proc autoRefreshTokensListsChanged(self: View) {.signal.}
+  proc emitAutoRefreshTokensListsChanged*(self: View) =
+    self.autoRefreshTokensListsChanged()
+  proc getAutoRefreshTokensLists(self: View): bool {.slot.} =
+    return self.delegate.getAutoRefreshTokensLists()
+  proc toggleAutoRefreshTokensLists(self: View) {.slot.} =
+    self.delegate.toggleAutoRefreshTokensLists()
+    self.autoRefreshTokensListsChanged()
+  QtProperty[bool] autoRefreshTokensLists:
+    read = getAutoRefreshTokensLists
+    notify = autoRefreshTokensListsChanged

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -1,9 +1,11 @@
-import Tables, json, options, tables, strutils
+import Tables, json, options, tables, strutils, times, chronicles
 import ../../stickers/dto/stickers
 
 include ../../../common/json_utils
 from ../../../common/types import StatusType
 from ../../../common/conversion import intToEnum
+
+const DateTimeFormat* = "yyyy-MM-dd'T'HH:mm:sszzz"
 
 # Setting keys:
 const KEY_ADDRESS* = "address"
@@ -52,6 +54,8 @@ const KEY_COLLECTIBLE_GROUP_BY_COMMUNITY* = "collectible-group-by-community?"
 const KEY_COLLECTIBLE_GROUP_BY_COLLECTION* = "collectible-group-by-collection?"
 const PROFILE_MIGRATION_NEEDED* = "profile-migration-needed"
 const KEY_URL_UNFURLING_MODE* = "url-unfurling-mode"
+const KEY_AUTO_REFRESH_TOKENS* = "auto-refresh-tokens-enabled"
+const KEY_LAST_TOKENS_UPDATE* = "last-tokens-update"
 
 # Notifications Settings Values
 const VALUE_NOTIF_SEND_ALERTS* = "SendAlerts"
@@ -162,6 +166,8 @@ type
     collectibleGroupByCommunity*: bool
     collectibleGroupByCollection*: bool
     urlUnfurlingMode*: UrlUnfurlingMode
+    autoRefreshTokens*: bool
+    lastTokensUpdate*: int64
 
 proc toPinnedMailserver*(jsonObj: JsonNode): PinnedMailserver =
   # we maintain pinned mailserver per fleet
@@ -221,6 +227,15 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_COLLECTIBLE_GROUP_BY_COMMUNITY, result.collectibleGroupByCommunity)
   discard jsonObj.getProp(KEY_COLLECTIBLE_GROUP_BY_COLLECTION, result.collectibleGroupByCollection)
   discard jsonObj.getProp(PROFILE_MIGRATION_NEEDED, result.profileMigrationNeeded)
+  discard jsonObj.getProp(KEY_AUTO_REFRESH_TOKENS, result.autoRefreshTokens)
+
+  var lastTokensUpdate: string
+  discard jsonObj.getProp(KEY_LAST_TOKENS_UPDATE, lastTokensUpdate)
+  try:
+    let dateTime = parse(lastTokensUpdate, DateTimeFormat)
+    result.lastTokensUpdate = dateTime.toTime().toUnix()
+  except ValueError:
+    warn "Failed to parse lastTokensUpdate: ", lastTokensUpdate
 
   var urlUnfurlingMode: int
   discard jsonObj.getProp(KEY_URL_UNFURLING_MODE, urlUnfurlingMode)

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -384,6 +384,8 @@ QtObject:
         of "wallet-tick-reload":
           self.rebuildMarketData()
     # update and populate internal list and then emit signal when new custom token detected?
+    self.events.on(SignalType.WalletTokensListsUpdated.event) do(e:Args):
+      self.events.emit(SIGNAL_TOKENS_LIST_UPDATED, Args())
 
   proc getCurrency*(self: Service): string =
     return self.settingsService.getCurrency()

--- a/src/backend/settings.nim
+++ b/src/backend/settings.nim
@@ -92,3 +92,6 @@ proc deleteExemptions*(id: string): RpcResponse[JsonNode] =
 
 proc mnemonicWasShown*(): RpcResponse[JsonNode] =
   return core.callPrivateRPC("settings_mnemonicWasShown")
+
+proc lastTokensUpdate*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("settings_lastTokensUpdate")

--- a/ui/app/AppLayouts/Profile/panels/SupportedTokenListsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/SupportedTokenListsPanel.qml
@@ -95,15 +95,7 @@ StatusListView {
                 updatedAt: delegate.updatedAt
                 tokensCount: delegate.tokensCount
 
-                title: {
-                    // Similar to Constants.getSupportedTokenSourceImage
-                    if (delegate.name === Constants.supportedTokenSources.uniswap ||
-                            delegate.name === Constants.supportedTokenSources.aave ||
-                            delegate.name === Constants.supportedTokenSources.status)
-                        return delegate.name;
-
-                    return qsTr("%1 Token List").arg(delegate.name)
-                }
+                title: delegate.name
 
                 tokensListModel: SortFilterProxyModel {
                     sourceModel: root.tokensListModel

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -161,12 +161,15 @@ Item {
                     if (rawAmount !== thresholdCurrency.amount) {
                         root.tokensStore.setDisplayAssetsBelowBalanceThreshold(rawAmount)
                     }
+                    if (autoRefreshTokensListsSwitch.checked !== root.tokensStore.autoRefreshTokensLists)
+                        root.tokensStore.toggleAutoRefreshTokensLists()
                     dirty = false
                 }
 
                 function resetChanges() {
                     showCommunityAssetsSwitch.checked = root.tokensStore.showCommunityAssetsInSend
                     displayThresholdSwitch.checked = root.tokensStore.displayAssetsBelowBalance
+                    autoRefreshTokensListsSwitch.checked = root.tokensStore.autoRefreshTokensLists
                     currencyAmount.value = getDisplayThresholdAmount()
                     dirty = false
                 }
@@ -245,6 +248,30 @@ Item {
                 StatusDialogDivider {
                     Layout.fillWidth: true
                 }
+                StatusListItem {
+                    Layout.fillWidth: true
+                    title: qsTr("Auto-refresh tokens lists")
+
+                    components: [
+                        StatusSwitch {
+                            id: autoRefreshTokensListsSwitch
+                            checked: root.tokensStore.autoRefreshTokensLists
+                            onCheckedChanged: {
+                                if (!advancedSettings.dirty && checked === root.tokensStore.autoRefreshTokensLists) {
+                                    // Skipping initial value
+                                    return
+                                }
+                                advancedSettings.dirty = true
+                            }
+                        }
+                    ]
+                    onClicked: {
+                        autoRefreshTokensListsSwitch.checked = !autoRefreshTokensListsSwitch.checked
+                    }
+                }
+                StatusDialogDivider {
+                    Layout.fillWidth: true
+                }
                 RowLayout {
                     Layout.fillWidth: true
                     Layout.preferredHeight: 64
@@ -257,7 +284,7 @@ Item {
                     }
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: qsTr("Last fetched %1").arg(LocaleUtils.getTimeDifference(new Date(root.tokenListUpdatedAt * 1000), new Date()))
+                        text: qsTr("Last check %1").arg(LocaleUtils.getTimeDifference(new Date(root.tokenListUpdatedAt * 1000), new Date()))
                         font.pixelSize: Theme.additionalTextSize
                         color: Theme.palette.darkGrey
                     }

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -123,6 +123,7 @@ QtObject {
     // Temporarily disabled, refer to https://github.com/status-im/status-desktop/issues/15955 for details.
     readonly property bool showCommunityAssetsInSend: true //root._allTokensModule.showCommunityAssetWhenSendingTokens
     readonly property bool displayAssetsBelowBalance: root._allTokensModule.displayAssetsBelowBalance
+    readonly property bool autoRefreshTokensLists: root._allTokensModule.autoRefreshTokensLists
 
     signal displayAssetsBelowBalanceThresholdChanged()
 
@@ -154,6 +155,10 @@ QtObject {
 
     function toggleDisplayAssetsBelowBalance() {
         root._allTokensModule.toggleDisplayAssetsBelowBalance()
+    }
+
+    function toggleAutoRefreshTokensLists() {
+        root._allTokensModule.toggleAutoRefreshTokensLists()
     }
 
     readonly property Connections allTokensConnections: Connections {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -785,8 +785,8 @@ QtObject {
     }
 
     readonly property QtObject supportedTokenSources: QtObject {
-        readonly property string uniswap: "Uniswap Labs Default Token List"
-        readonly property string aave: "Aave Token List"
+        readonly property string uniswap: "Uniswap Labs Default"
+        readonly property string aave: "Aave token list"
         readonly property string status: "Status Token List"
         readonly property string custom: "custom"
     }


### PR DESCRIPTION
Corresponding `statusgo` PRs:
- https://github.com/status-im/status-go/pull/6399
- https://github.com/status-im/status-go/pull/6398

Changes:
- added toggle for enabling disabling tokens auto-refresh
- tokens lists updated at regular intervals

By default, new lists are fetched every 30 minutes. Once new tokens are fetched, the token lists and available tokens in the app will be updated with any newly published tokens from those lists. The auto-refresh setting is being synced across paired devices.

Closes #17377

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/150f3113-9637-48fa-b4fd-801acb33d0e3" />

@benjthayer, please look at the screenshot here and let me know if the wording (and design) is acceptable or how to name the "Auto-refresh tokens lists" option? If this is ok, then we will just need to update the related Figma accordingly.