### PR TITLE
fix: Adding `fno-omit-frame-pointer` to overcome a nim bug where the …

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -50,6 +50,8 @@ else:
 --define:chronicles_line_numbers # useful when debugging=
 switch("define", "chronicles_timestamps=RfcUtcTime")
 
+switch("passC", "-fno-omit-frame-pointer")
+switch("passL", "-fno-omit-frame-pointer")
 # The compiler doth protest too much, methinks, about all these cases where it can't
 # do its (N)RVO pass: https://github.com/nim-lang/RFCs/issues/230
 switch("warning", "ObservableStores:off")


### PR DESCRIPTION
### What does the PR do

Adding `fno-omit-frame-pointer` compiler option to avoid issues where the pointer is prematurely collected.

This seems to be a good fix for MacOs at least. Unfortunately the problem seems to persist on Windows.

See https://github.com/nim-lang/Nim/issues/10625 and https://github.com/status-im/status-desktop/issues/17398