### PR TITLE
chore(wallet): statusProxyEnabled flag removed since it's not in use anymore

### DIFF
--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -45,7 +45,6 @@ type
     keycardInstanceUID*: string
     keycardPairingDataFile*: string
     apiConfig*: APIConfig
-    statusProxyEnabled*: bool
 
 proc toJson*(self: CreateAccountRequest): JsonNode =
   result = %*{
@@ -68,7 +67,6 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
     "apiConfig": self.apiConfig,
     "wakuV2EnableStoreConfirmationForMessagesSent": self.wakuV2EnableStoreConfirmationForMessagesSent,
     "wakuV2EnableMissingMessageVerification": self.wakuV2EnableMissingMessageVerification,
-    "statusProxyEnabled": self.statusProxyEnabled,
   }
 
   if self.logLevel.isSome():

--- a/src/app_service/service/accounts/dto/login_request.nim
+++ b/src/app_service/service/accounts/dto/login_request.nim
@@ -17,7 +17,6 @@ type
     mnemonic*: string
     walletSecretsConfig*: WalletSecretsConfig
     apiConfig*: APIConfig
-    statusProxyEnabled*: bool
 
 proc toJson*(self: LoginAccountRequest): JsonNode =
   result = %* {
@@ -30,7 +29,6 @@ proc toJson*(self: LoginAccountRequest): JsonNode =
     "keycardWhisperPrivateKey": self.keycardWhisperPrivateKey,
     "mnemonic": self.mnemonic,
     "apiConfig": self.apiConfig,
-    "statusProxyEnabled": self.statusProxyEnabled
   }
   for key, value in self.walletSecretsConfig.toJson().pairs():
     result[key] = value

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -201,7 +201,6 @@ QtObject:
         keycardPairingDataFile: main_constants.KEYCARDPAIRINGDATAFILE,
         walletSecretsConfig: buildWalletSecrets(),
         apiConfig: defaultApiConfig(),
-        statusProxyEnabled: true
       )
 
   proc buildCreateAccountRequest(password: string, displayName: string, imagePath: string, imageCropRectangle: ImageCropRectangle): CreateAccountRequest =
@@ -429,7 +428,6 @@ QtObject:
       walletSecretsConfig: buildWalletSecrets(),
       bandwidthStatsEnabled: true,
       apiConfig: defaultApiConfig(),
-      statusProxyEnabled: true # TODO: read from settings
     )
 
     if main_constants.runtimeLogLevelSet():


### PR DESCRIPTION
We don't use `statusProxyEnabled` anywhere on the statusgo side, thus not needed on the client side anymore.

Corresponding `statusgo` PR that removes it:
- https://github.com/status-im/status-go/pull/6434