### PR TITLE
feat(qt5->6): Create a `StatusFileDialog` wrapper component for both qt5 and qt6 versions and refactor the existing code

### DIFF
--- a/storybook/pages/StatusFileDialogPage.qml
+++ b/storybook/pages/StatusFileDialogPage.qml
@@ -1,0 +1,118 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ.Popups.Dialog 0.1
+
+import Models 1.0
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Rectangle {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        color: "lightgray"
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+            onClicked: dlg.open()
+        }
+
+        StatusFileDialog {
+            id: dlg
+
+            title: titleText.text
+            selectMultiple: selectMultiple.checked
+            nameFilters: filtersText.text
+            currentFolder: folderText.text
+            onAccepted: {
+                logs.logEvent("StatusFileDialog::onAccepted --> Selected Files: " + dlg.selectedFiles.length)
+                if (dlg.selectedFiles.length > 0) {
+                    for (let i = 0; i < dlg.selectedFiles.length; i++)
+                        logs.logEvent("StatusFileDialog::onAccepted --> " + decodeURI(dlg.selectedFiles[i].toString()))
+                }
+            }
+            onRejected: logs.logEvent("StatusFileDialog::onRejected")
+            onTitleChanged: logs.logEvent("StatusFileDialog::onTitleChanged --> " + dlg.title)
+            onCurrentFolderChanged: logs.logEvent("StatusFileDialog::onCurrentFolderChanged --> " + dlg.currentFolder)
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 300
+        SplitView.preferredHeight: 300
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+             width: parent.width
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Label {
+                    text: "Title:\t"
+                }
+
+                TextField {
+                    id: titleText
+
+                    text: "Choose files to import"
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Label {
+                    text: "Name Filters:\t"
+                }
+
+                TextField {
+                    id: filtersText
+
+                    text: "JSON files (%1)".arg("*.json *.JSON")
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Label {
+                    text: "Multiple Selection:\t"
+                }
+
+                CheckBox {
+                    id: selectMultiple
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Label {
+                    text: "Folder:\t"
+                }
+
+                TextField {
+                    id: folderText
+
+                    text: dlg.picturesShortcut
+                }
+            }
+        }
+    }
+}
+
+// category: Dialogs
+// status: good

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
@@ -1,10 +1,10 @@
 import QtQuick 2.3
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.14
-import QtQuick.Dialogs 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
 
 /*!
    \qmltype StatusImageSelector
@@ -225,11 +225,11 @@ Control {
         }
     }
 
-    FileDialog {
+    StatusFileDialog {
         id: fileDialog
 
-        folder: shortcuts.pictures
+        currentFolder: picturesShortcut
         nameFilters: [ qsTr("Supported image formats (%1)").arg(d.getExtensionsFilterText())]
-        onAccepted: d.loadFile(fileUrls)
+        onAccepted: d.loadFile(selectedFiles)
     }
 }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/+qt6/StatusFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/+qt6/StatusFileDialog.qml
@@ -1,0 +1,40 @@
+import QtQuick
+import QtQuick.Dialogs
+import QtCore
+
+import StatusQ.Core.Utils 0.1
+
+QObject {
+    id: root
+
+    property alias title: dlg.title
+    property alias nameFilters: dlg.nameFilters
+    property alias selectedFile: dlg.selectedFile
+    property alias selectedFiles: dlg.selectedFiles
+    property bool selectMultiple
+
+    property alias modality: dlg.modality
+    property alias currentFolder: dlg.currentFolder
+
+    property string picturesShortcut: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
+
+    signal accepted
+    signal rejected
+
+    function open() {
+        dlg.open()
+    }
+
+    function close() {
+        dlg.close()
+    }
+
+    FileDialog {
+        id: dlg
+
+        fileMode: selectMultiple ? FileDialog.OpenFiles : FileDialog.OpenFile
+
+        onAccepted: root.accepted()
+        onRejected: root.rejected()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.15
+import QtQuick.Dialogs 1.3
+
+// Since this is a temporal component, it will be wrapped into this visual item since wrapping the
+// FileDialog into a SQUtils.QObject it does not open the dialog in macos
+Item {
+    id: root
+
+    property alias title: dlg.title
+    property alias nameFilters: dlg.nameFilters
+    property alias selectedFile: dlg.fileUrl
+    property alias selectedFiles: dlg.fileUrls
+    property alias modality: dlg.modality
+    property alias currentFolder: dlg.folder
+    property alias selectMultiple: dlg.selectMultiple
+
+    readonly property string picturesShortcut: dlg.shortcuts.pictures
+
+    signal accepted
+    signal rejected
+
+    function open() {
+        dlg.open()
+    }
+
+    function close() {
+        dlg.close()
+    }
+
+    FileDialog {
+        id: dlg
+
+        onAccepted: root.accepted()
+        onRejected: root.rejected()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
@@ -5,6 +5,7 @@ StatusDialogDivider 0.1 StatusDialogDivider.qml
 StatusDialogFooter 0.1 StatusDialogFooter.qml
 StatusDialogHeader 0.1 StatusDialogHeader.qml
 StatusFolderDialog 0.1 StatusFolderDialog.qml
+StatusFileDialog 0.1 StatusFileDialog.qml
 StatusHeaderActions 0.1 StatusHeaderActions.qml
 StatusTitleSubtitle 0.1 StatusTitleSubtitle.qml
 StatusDialogBackground 0.1 StatusDialogBackground.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -270,5 +270,7 @@
         <file>StatusQ/Components/+qt6/StatusVideo.qml</file>
         <file>StatusQ/Popups/Dialog/+qt6/StatusFolderDialog.qml</file>
         <file>StatusQ/Popups/Dialog/StatusFolderDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/+qt6/StatusFileDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusFileDialog.qml</file>
     </qresource>
 </RCC>

--- a/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
-import QtQuick.Dialogs 1.3
 import QtGraphicalEffects 1.15
 
 import utils 1.0

--- a/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
-import QtQuick.Dialogs 1.3
 import QtGraphicalEffects 1.15
 
 import utils 1.0

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
-import QtQuick.Dialogs 1.3 // TODO Remove with FileDialog
 import QtQml 2.15
 import QtQml.Models 2.15
 
@@ -517,16 +516,19 @@ StatusStackModal {
                     }
                 }
             }
-            FileDialog {
+            StatusFileDialog {
                 id: fileDialog
                 title: qsTr("Choose files to import")
                 selectMultiple: true
                 nameFilters: [qsTr("JSON files (%1)").arg("*.json *.JSON")]
                 onAccepted: {
-                    if (fileDialog.fileUrls.length > 0) {
+                    if(fileDialog.selectedFiles.length === 0) {
+                        return
+                    }
+                    else if (fileDialog.selectedFiles.length > 0) {
                         const files = []
-                        for (let i = 0; i < fileDialog.fileUrls.length; i++)
-                            files.push(decodeURI(fileDialog.fileUrls[i].toString()))
+                        for (let i = 0; i < fileDialog.selectedFiles.length; i++)
+                            files.push(decodeURI(fileDialog.selectedFiles[i].toString()))
                         root.communitiesStore.setFileListItems(files)
                     }
                 }

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3 // TODO remove with FileDialog
 
 import utils 1.0
 import shared.panels 1.0
@@ -234,17 +233,17 @@ StatusStackModal {
                 }
             }
 
-            FileDialog {
+            StatusFileDialog {
                 id: fileDialog
 
                 title: qsTr("Choose files to import")
                 selectMultiple: true
                 nameFilters: [qsTr("JSON files (%1)").arg("*.json")]
                 onAccepted: {
-                    if (fileDialog.fileUrls.length > 0) {
+                    if (fileDialog.selectedFiles.length > 0) {
                         let files = []
-                        for (let i = 0; i < fileDialog.fileUrls.length; i++)
-                            files.push(decodeURI(fileDialog.fileUrls[i].toString()))
+                        for (let i = 0; i < fileDialog.selectedFiles.length; i++)
+                            files.push(decodeURI(fileDialog.selectedFiles[i].toString()))
                         root.store.setFileListItems(files)
                     }
                 }

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
-import QtQuick.Dialogs 1.3
 
 import StatusQ.Core 0.1
 import StatusQ.Popups.Dialog 0.1

--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
 import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
 
 import StatusQ 0.1
 import StatusQ.Components 0.1
@@ -37,15 +36,15 @@ Item {
         imageCropperModal.open()
     }
 
-    FileDialog {
+    StatusFileDialog {
         id: fileDialog
 
         title: root.imageFileDialogTitle
-        folder: root.userSelectedImage ? imageCropper.source.substr(0, imageCropper.source.lastIndexOf("/")) : shortcuts.pictures
+        currentFolder: root.userSelectedImage ? imageCropper.source.substr(0, imageCropper.source.lastIndexOf("/")) : fileDialog.picturesShortcut
         nameFilters: [qsTr("Supported image formats (%1)").arg(UrlUtils.validImageNameFilters)]
         onAccepted: {
-            if (fileDialog.fileUrls.length > 0) {
-                const url = fileDialog.fileUrls[0]
+            if (fileDialog.selectedFiles.length > 0) {
+                const url = fileDialog.selectedFiles[0]
                 if (Utils.isValidDragNDropImage(url))
                     cropImage(url)
                 else

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Dialogs 1.3
 
 import utils 1.0
 
@@ -22,6 +21,7 @@ import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1 as StatusQ
@@ -993,15 +993,15 @@ Rectangle {
     Component {
         id: imageDialogComponent
 
-        FileDialog {
+        StatusFileDialog {
             title: qsTr("Please choose an image")
-            folder: shortcuts.pictures
+            currentFolder: picturesShortcut
             selectMultiple: true
             nameFilters: [
                 qsTr("Image files (%1)").arg(UrlUtils.validImageNameFilters)
             ]
             onAccepted: {
-                validateImagesAndShowImageArea(fileUrls)
+                validateImagesAndShowImageArea(selectedFiles)
                 messageInputField.forceActiveFocus()
                 destroy()
             }

--- a/ui/imports/shared/status/StatusInputListPopup.qml
+++ b/ui/imports/shared/status/StatusInputListPopup.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.15
-import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1


### PR DESCRIPTION
- It closes the main wrapper component creation: [#17561](https://github.com/status-im/status-desktop/issues/17561)
- It also includes commits for the migration of the needed components: 
[#17547](https://github.com/status-im/status-desktop/issues/17547), [#17534](https://github.com/status-im/status-desktop/issues/17534), [#17535](https://github.com/status-im/status-desktop/issues/17535), [#17541](https://github.com/status-im/status-desktop/issues/17541), [#17542](https://github.com/status-im/status-desktop/issues/17542), [#17538](https://github.com/status-im/status-desktop/issues/17538), [#17537](https://github.com/status-im/status-desktop/issues/17537), [#17546](https://github.com/status-im/status-desktop/issues/17546), [#17532](https://github.com/status-im/status-desktop/issues/17532), [#17545](https://github.com/status-im/status-desktop/issues/17545)

### What does the PR do

- It removes unused `QtQuick.Dialogs` imports in different files.
- It creates `StatusFileDialog` component with basic interface for our current needs working in both `Qt5` and `Qt6`.
- It creates `storybook` page to test the new component.
- It replaces the used `FileDialog` component by the new and compatible with `qt5` and `6` versions `StatusFileDialog` component on all needed app usages.

### Affected areas

`StatusImageSelector`, `CreateChannelPopup`, `CreateCommunityPopup`, `ImageCropWorkflow` and `StatusChatInput`

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)
Here the `storybook` page used to test the new `StatusFileDialog` component:
**- qt5 version:**

https://github.com/user-attachments/assets/b89897d4-564e-4bb0-a7f4-ba888a67c25a

**- qt6 version:**

https://github.com/user-attachments/assets/fceeaea5-4960-4c49-9386-3a3bcfab9034

### Impact on end user

No impact

### How to test
Run the application and use the file dialog functionality in all the listed flows below:
- In a chat, try to attach an image file.
- In a community, try to change the image of the logo or banner by selecting another file and cropping it.
- In the discord import community flow, try to import a new json file via the file dialog.
- In `storybook`, test both, qt5 and qt6 versions of the component.