### PR TITLE
feat(qt5->6): Create a `StatusFolderDialog` wrapper component for both qt5 and qt6 versions and refactor the existing code

### DIFF
--- a/storybook/pages/StatusFolderDialogPage.qml
+++ b/storybook/pages/StatusFolderDialogPage.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ.Popups.Dialog 0.1
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Rectangle {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        color: "lightgray"
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+            onClicked: dlg.open()
+        }
+
+        StatusFolderDialog {
+            id: dlg
+
+            visible: true
+            title: titleText.text
+            onAccepted: logs.logEvent("StatusFolderDialog::onAccepted --> Selected File: " + dlg.selectedFolder)
+            onRejected: logs.logEvent("StatusFolderDialog::onRejected")
+            onTitleChanged: logs.logEvent("StatusFolderDialog::onTitleChanged --> " + dlg.title)
+            onCurrentFolderChanged: logs.logEvent("StatusFolderDialog::onCurrentFolderChanged --> " + dlg.currentFolder)
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 300
+        SplitView.preferredHeight: 300
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+             width: parent.width
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Label {
+                    text: "Title:\t"
+                }
+
+                TextField {
+                    id: titleText
+
+                    text: "Choose folder to import"
+                }
+            }
+        }
+    }
+}
+
+// category: Dialogs
+// status: good

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/+qt6/StatusFolderDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/+qt6/StatusFolderDialog.qml
@@ -1,0 +1,32 @@
+import QtQuick
+import QtQuick.Dialogs
+
+import StatusQ.Core.Utils 0.1
+
+QObject {
+
+    id: root
+
+    property alias title: dlg.title
+    property alias selectedFolder: dlg.selectedFolder
+    property alias modality: dlg.modality
+    property alias currentFolder: dlg.currentFolder
+
+    signal accepted
+    signal rejected
+
+    function open() {
+        dlg.open()
+    }
+
+    function close() {
+        dlg.close()
+    }
+
+    FolderDialog {
+        id: dlg
+
+        onAccepted: root.accepted()
+        onRejected: root.rejected()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFolderDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFolderDialog.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.15
+import QtQuick.Dialogs 1.3
+
+// Since this is a temporal component, it will be wrapped into this visual item since wrapping the
+// FileDialog into a SQUtils.QObject it does not open the dialog in macos
+Item {
+
+    id: root
+
+    property alias title: dlg.title
+    property alias selectedFolder: dlg.fileUrl
+    property alias modality: dlg.modality
+    property alias currentFolder: dlg.folder
+
+    signal accepted
+    signal rejected
+
+    function open() {
+        dlg.open()
+    }
+
+    function close() {
+        dlg.close()
+    }
+
+    FileDialog {
+        id: dlg
+
+        selectFolder: true
+        selectExisting: true
+        selectMultiple: false
+
+        onAccepted: root.accepted()
+        onRejected: root.rejected()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
@@ -4,6 +4,7 @@ StatusDialog 0.1 StatusDialog.qml
 StatusDialogDivider 0.1 StatusDialogDivider.qml
 StatusDialogFooter 0.1 StatusDialogFooter.qml
 StatusDialogHeader 0.1 StatusDialogHeader.qml
+StatusFolderDialog 0.1 StatusFolderDialog.qml
 StatusHeaderActions 0.1 StatusHeaderActions.qml
 StatusTitleSubtitle 0.1 StatusTitleSubtitle.qml
 StatusDialogBackground 0.1 StatusDialogBackground.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -268,5 +268,7 @@
         <file>StatusQ/Components/+qt6/StatusQrCodeCapture.qml</file>
         <file>StatusQ/Components/+qt6/StatusSoundEffect.qml</file>
         <file>StatusQ/Components/+qt6/StatusVideo.qml</file>
+        <file>StatusQ/Popups/Dialog/+qt6/StatusFolderDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusFolderDialog.qml</file>
     </qresource>
 </RCC>

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
-import QtQuick.Dialogs 1.3
 import QtQml.Models 2.15
 import QtQml 2.15
 
@@ -864,15 +863,15 @@ QtObject {
 
         Component {
             id: downloadImageDialogComponent
-            FileDialog {
+
+            StatusFolderDialog {
                 property string imageSource
+
                 title: qsTr("Please choose a directory")
-                selectFolder: true
-                selectExisting: true
-                selectMultiple: false
                 modality: Qt.NonModal
+
                 onAccepted: {
-                    SystemUtils.downloadImageByUrl(imageSource, fileUrl)
+                    SystemUtils.downloadImageByUrl(imageSource, selectedFolder)
                     destroy()
                 }
                 onRejected: {


### PR DESCRIPTION
Closes #17544

### What does the PR do

- It creates a basic `StatusFolderDialog` wrapper for both qt versions. In case of qt5 it uses `FileDialog` as a source, in case of qt6, it uses `FolderDialog`.
- It creates a `storybook` page to test the new component.
- It replaces existing `FileDialog` by new `StatusFolderDialog` component, compatible with qt5 and qt6.

### Affected areas

Popups / downloadImageDialogComponent

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

**- qt5 version:**

https://github.com/user-attachments/assets/ff076092-fca1-4017-a326-ac44c39e3816

**- qt6 version:**

https://github.com/user-attachments/assets/cdd2ddd9-725c-4299-8b60-8d6702324f3b

### Impact on end user

No impact

### How to test

- Go through the flow where you can right click a gif and download it into a folder from a chat / channel.