### PR TITLE
chore(DOtherSide): remove image resizing (`dos_image_resizer`)

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -125,7 +125,7 @@ proc resetLinkPreviews(self: Controller) =
   self.delegate.setAskToEnableLinkPreview(false)
 
 proc sendImages*(self: Controller,
-                 imagePathsAndDataJson: string,
+                 imagePathsJson: string,
                  msg: string,
                  replyTo: string,
                  preferredUsername: string = "",
@@ -134,7 +134,7 @@ proc sendImages*(self: Controller,
   self.resetLinkPreviews()
   self.chatService.asyncSendImages(
     self.chatId,
-    imagePathsAndDataJson,
+    imagePathsJson,
     msg,
     replyTo,
     preferredUsername,

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -66,8 +66,8 @@ method getModuleAsVariant*(self: Module): QVariant =
 proc getChatId*(self: Module): string =
   return self.controller.getChatId()
 
-method sendImages*(self: Module, imagePathsAndDataJson: string, msg: string, replyTo: string, linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) =
-  self.controller.sendImages(imagePathsAndDataJson, msg, replyTo, singletonInstance.userProfile.getPreferredName(), linkPreviews, paymentRequests)
+method sendImages*(self: Module, imagePathsJson: string, msg: string, replyTo: string, linkPreviews: seq[LinkPreview], paymentRequests: seq[PaymentRequest]) =
+  self.controller.sendImages(imagePathsJson, msg, replyTo, singletonInstance.userProfile.getPreferredName(), linkPreviews, paymentRequests)
 
 method sendChatMessage*(
     self: Module,

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -67,11 +67,11 @@ QtObject:
     self.delegate.setText(msg, false)
     self.delegate.sendChatMessage(msg, replyTo, contentType, self.linkPreviewModel.getUnfuledLinkPreviews(), self.payment_request_model.getPaymentRequests())
 
-  proc sendImages*(self: View, imagePathsAndDataJson: string, msg: string, replyTo: string) {.slot.} =
+  proc sendImages*(self: View, imagePathsJson: string, msg: string, replyTo: string) {.slot.} =
     # FIXME: Update this when `setText` is async.
     self.setSendingInProgress(true)
     self.delegate.setText(msg, false)
-    self.delegate.sendImages(imagePathsAndDataJson, msg, replyTo, self.linkPreviewModel.getUnfuledLinkPreviews(), self.payment_request_model.getPaymentRequests())
+    self.delegate.sendImages(imagePathsJson, msg, replyTo, self.linkPreviewModel.getUnfuledLinkPreviews(), self.payment_request_model.getPaymentRequests())
 
   proc acceptAddressRequest*(self: View, messageId: string , address: string) {.slot.} =
     self.delegate.acceptRequestAddressForTransaction(messageId, address)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -16,7 +16,6 @@ import ../../../backend/chatCommands as status_chat_commands
 import ../../../app/global/global_singleton
 import ../../../app/core/eventemitter
 import ../../../app/core/signals/types
-import ../../../constants
 
 import ../../common/message as message_common
 from ../../common/account_constants import ZERO_ADDRESS
@@ -419,7 +418,7 @@ QtObject:
 
   proc asyncSendImages*(self: Service,
                    chatId: string,
-                   imagePathsAndDataJson: string,
+                   imagePathsJson: string,
                    msg: string,
                    replyTo: string,
                    preferredUsername: string = "",
@@ -433,8 +432,7 @@ QtObject:
         vptr: cast[uint](self.vptr),
         slot: "onAsyncSendImagesDone",
         chatId: chatId,
-        imagePathsAndDataJson: imagePathsAndDataJson,
-        tempDir: TMPDIR,
+        imagePathsJson: imagePathsJson,
         msg: msg,
         replyTo: replyTo,
         preferredUsername: preferredUsername,

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -55,7 +55,7 @@ if (NOT DEFINED STATUSQ_SHADOW_BUILD)
     #
     #   This is an option that defaults to OFF in Debug mode and ON otherwise.
     #   When ON:
-    #     - resources are compiled into a a shared library
+    #     - resources are compiled into a shared library
     #   When OFF:
     #     - no resources are compiled, it's expected to use QML/JS sources
     #

--- a/ui/StatusQ/include/StatusQ/urlutils.h
+++ b/ui/StatusQ/include/StatusQ/urlutils.h
@@ -16,6 +16,9 @@ public:
     Q_INVOKABLE bool isValidImageUrl(const QUrl &url) const;
     Q_INVOKABLE static qint64 getFileSize(const QUrl &url);
 
+    Q_INVOKABLE QString convertUrlToLocalPath(const QString& url) const;
+    Q_INVOKABLE QStringList convertUrlsToLocalPaths(const QStringList& urls) const;
+
 private:
     QMimeDatabase m_mimeDb;
 

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -52,7 +52,7 @@ void registerStatusQTypes() {
 
     qmlRegisterUncreatableType<QValidator>(
                 "StatusQ", 0, 1,
-                "Validator", "This is abstract type, cannot be created directly.");
+                "Validator", QStringLiteral("This is abstract type, cannot be created directly."));
     qmlRegisterType<GenericValidator>("StatusQ", 0, 1, "GenericValidator");
 
     qmlRegisterType<ManageTokensController>("StatusQ.Models", 0, 1, "ManageTokensController");
@@ -94,7 +94,7 @@ void registerStatusQTypes() {
     qRegisterMetaType<Keychain::Status>();
 
     qmlRegisterUncreatableType<ModelCount>("StatusQ", 0, 1,
-                                           "ModelCount", "This is attached type, cannot be created directly.");
+                                           "ModelCount", QStringLiteral("This is attached type, cannot be created directly."));
 
     // Workaround for https://bugreports.qt.io/browse/QTBUG-86428
     qmlRegisterAnonymousType<QAbstractItemModel>("StatusQ", 1);

--- a/ui/StatusQ/src/urlutils.cpp
+++ b/ui/StatusQ/src/urlutils.cpp
@@ -44,3 +44,21 @@ qint64 UrlUtils::getFileSize(const QUrl& url)
 
     return 0;
 }
+
+QString UrlUtils::convertUrlToLocalPath(const QString &url) const {
+    const auto localFileOrUrl = QUrl::fromUserInput(url); // accept both "file:/foo/bar" and "/foo/bar"
+    if (localFileOrUrl.isLocalFile()) {
+        return localFileOrUrl.toLocalFile();
+    }
+    return {};
+}
+
+QStringList UrlUtils::convertUrlsToLocalPaths(const QStringList &urls) const {
+    QStringList result;
+    for (const auto& url: urls) {
+        const auto localPath = convertUrlToLocalPath(url);
+        if (!localPath.isEmpty())
+            result << localPath;
+    }
+    return result;
+}

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -252,9 +252,9 @@ QtObject {
         }
 
         if (fileUrlsAndSources.length > 0) {
-            chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrlsAndSources), textMsg.trim(), replyMessageId)
+            const convertedImagePaths = UrlUtils.convertUrlsToLocalPaths(fileUrlsAndSources)
+            chatContentModule.inputAreaModule.sendImages(JSON.stringify(convertedImagePaths), textMsg.trim(), replyMessageId)
             result = true
-
         } else {
             if (textMsg.trim() !== "") {
                 chatContentModule.inputAreaModule.sendMessage(
@@ -272,7 +272,7 @@ QtObject {
 
     function openCloseCreateChatView() {
         if (root.openCreateChat) {
-             Global.closeCreateChatView()
+            Global.closeCreateChatView()
         } else {
             Global.openCreateChatView()
         }

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -6,6 +6,7 @@ import utils 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
@@ -241,10 +242,7 @@ StatusStackModal {
                 nameFilters: [qsTr("JSON files (%1)").arg("*.json")]
                 onAccepted: {
                     if (fileDialog.selectedFiles.length > 0) {
-                        let files = []
-                        for (let i = 0; i < fileDialog.selectedFiles.length; i++)
-                            files.push(decodeURI(fileDialog.selectedFiles[i].toString()))
-                        root.store.setFileListItems(files)
+                        root.store.setFileListItems(UrlUtils.convertUrlsToLocalPaths(fileDialog.selectedFiles))
                     }
                 }
             }

--- a/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
+++ b/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
@@ -116,8 +116,6 @@ DOS_API char * DOS_CALL dos_escape_html(char* input);
 
 DOS_API void DOS_CALL dos_qncm_delete(DosQNetworkConfigurationManager *vptr);
 
-DOS_API char * DOS_CALL dos_image_resizer(const char* imagePathOrData, int maxSize, const char* tmpDirPath);
-
 DOS_API char * DOS_CALL dos_qurl_fromUserInput(char* input);
 
 DOS_API char * DOS_CALL dos_qurl_host(char* host);


### PR DESCRIPTION
### What does the PR do

- just use the intrinsic resizing done by status-go, only convert the image paths from local URLs to local file paths

Needs https://github.com/status-im/nimqml/pull/63

Fixes #17580

### Affected areas

DOtherSide
Chat/Send image(s)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2025-03-24 17-24-58](https://github.com/user-attachments/assets/1079ac9b-1c51-4ded-a768-43d5d0fd9fe6)

