### PR TITLE
[CHERRY-PICK] fix(IntroduceYourselfPopup): only show when the display name is empty

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -806,7 +806,7 @@ Item {
         }
 
         function maybeDisplayIntroduceYourselfPopup() {
-            if (!appMainLocalSettings.introduceYourselfPopupSeen && featureFlagsStore.onboardingV2Enabled)
+            if (!appMainLocalSettings.introduceYourselfPopupSeen && featureFlagsStore.onboardingV2Enabled && allContacsAdaptor.selfDisplayName === "")
                 introduceYourselfPopupComponent.createObject(appMain).open()
         }
 


### PR DESCRIPTION
Backport of PR https://github.com/status-im/status-desktop/pull/17604 to fix issue https://github.com/status-im/status-desktop/issues/17596

### What does the PR do

- extend the check for showing the Introduce yourself popup with the empty display name condition

Fixes #17596

### Affected areas

AppMain/IntroduceYourselfPopup
