### PR TITLE
fix: simplify nim finalizers

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -49,9 +49,6 @@ QtObject:
     self.settingsService = settingsService
 
   proc delete*(self: NotificationsManager) =
-    if self.notificationSetUp:
-      self.osNotification.delete
-      self.soundManager.delete
     self.QObject.delete
 
   proc newNotificationsManager*(events: EventEmitter, settingsService: settings_service.Service): NotificationsManager =

--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -88,9 +88,6 @@ QtObject:
     self.settingsFileDir = os.joinPath(DATADIR, "qt")
 
   proc delete*(self: LocalAccountSensitiveSettings) =
-    if(not self.settings.isNil):
-      self.settings.delete
-
     self.QObject.delete
 
   proc newLocalAccountSensitiveSettings*():

--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -23,9 +23,6 @@ QtObject:
     self.settingsFileDir = os.joinPath(DATADIR, "qt")
 
   proc delete*(self: LocalAccountSettings) =
-    if(not self.settings.isNil):
-      self.settings.delete
-
     self.QObject.delete
 
   proc newLocalAccountSettings*():

--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -31,8 +31,6 @@ QtObject:
     result.setup
 
   proc setFileName*(self: LocalAccountSettings, fileName: string) =
-    if(not self.settings.isNil):
-      self.settings.delete
     let
       currentFilePath = os.joinPath(self.settingsFileDir, self.currentFileName)
       newFilePath = os.joinPath(self.settingsFileDir, fileName)

--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -38,8 +38,6 @@ QtObject:
     self.QObject.setup
 
   proc delete*(self: LocalAppSettings) =
-    self.settings.delete
-
     self.QObject.delete
 
   proc newLocalAppSettings*(fileName: string): LocalAppSettings =

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -30,7 +30,6 @@ QtObject:
   proc setup(self: Model) = self.QAbstractListModel.setup
 
   proc delete(self: Model) =
-    self.activityCenterNotifications = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/main/app_search/base_item.nim
+++ b/src/app/modules/main/app_search/base_item.nim
@@ -17,9 +17,6 @@ proc initBaseItem*(value, text, image, icon, iconColor: string): BaseItem =
   result = BaseItem()
   result.setup(value, text, image, icon, iconColor)
 
-proc delete*(self: BaseItem) =
-  discard
-
 method value*(self: BaseItem): string {.inline base.} =
   self.value
 

--- a/src/app/modules/main/app_search/location_menu_item.nim
+++ b/src/app/modules/main/app_search/location_menu_item.nim
@@ -11,10 +11,6 @@ proc initItem*(value, text, image, icon, iconColor: string = ""): Item =
   result.setup(value, text, image, icon, iconColor)
   result.subItems = newSubModel()
 
-proc delete*(self: Item) =
-  self.subItems.delete
-  self.BaseItem.delete
-
 proc subItems*(self: Item): SubModel {.inline.} =
   self.subItems
 

--- a/src/app/modules/main/app_search/location_menu_model.nim
+++ b/src/app/modules/main/app_search/location_menu_model.nim
@@ -18,9 +18,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    for i in 0 ..< self.items.len:
-      self.items[i].delete
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/app_search/location_menu_sub_item.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_item.nim
@@ -36,9 +36,6 @@ proc initSubItem*(
   result.colorHash = color_hash_model.newModel()
   result.colorHash.setItems(map(colorHash, x => color_hash_item.initItem(x.len, x.colorIdx)))
 
-proc delete*(self: SubItem) =
-  self.BaseItem.delete
-
 proc `$`*(self: SubItem): string =
   result = fmt"""SearchMenuSubItem(
     value: {self.value},

--- a/src/app/modules/main/app_search/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_model.nim
@@ -22,9 +22,6 @@ QtObject:
       items: seq[SubItem]
 
   proc delete*(self: SubModel) =
-    for i in 0 ..< self.items.len:
-      self.items[i].delete
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: SubModel) =

--- a/src/app/modules/main/app_search/view.nim
+++ b/src/app/modules/main/app_search/view.nim
@@ -10,8 +10,6 @@ QtObject:
       locationMenuModel: location_menu_model.Model
 
   proc delete*(self: View) =
-    self.searchResultModel.delete
-    self.locationMenuModel.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/chat_search_model.nim
+++ b/src/app/modules/main/chat_search_model.nim
@@ -21,7 +21,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
@@ -10,7 +10,6 @@ QtObject:
       items: seq[string]
 
   proc delete*(self: Model) = 
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -27,16 +27,6 @@ QtObject:
 
   proc delete*(self: View) =
     self.QObject.delete
-    self.preservedPropertiesVariant.delete
-    self.preservedProperties.delete
-    self.linkPreviewModelVariant.delete
-    self.linkPreviewModel.delete
-    self.paymentRequestModelVariant.delete
-    self.paymentRequestModel.delete
-    self.urlsModelVariant.delete
-    self.urlsModel.delete
-    self.emojiReactionsModel.delete
-    self.emojiReactionsModelVariant.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -20,8 +20,6 @@ QtObject:
       keepUnread: bool
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/chat_section/chat_content/users/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/view.nim
@@ -12,8 +12,6 @@ QtObject:
       temporaryModelVariant: QVariant
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -19,10 +19,6 @@ QtObject:
   proc chatDetailsChanged*(self:View) {.signal.}
 
   proc delete*(self: View) =
-    self.pinnedMessagesModel.delete
-    self.pinnedMessagesModelVariant.delete
-    self.chatDetails.delete
-    self.chatDetailsVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -49,10 +49,6 @@ QtObject:
       items: seq[Item]
 
   proc delete*(self: Model) =
-    for i in 0 ..< self.items.len:
-      self.items[i].delete
-
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -39,19 +39,6 @@ QtObject:
 
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
-    self.activeItem.delete
-    self.activeItemVariant.delete
-    self.contactRequestsModel.delete
-    self.contactRequestsModelVariant.delete
-    self.editCategoryChannelsModel.delete
-    self.editCategoryChannelsVariant.delete
-    self.tokenPermissionsModel.delete
-    self.tokenPermissionsVariant.delete
-    self.memberMessagesModel.delete
-    self.memberMessagesModelVariant.delete
-
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -29,7 +29,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: CuratedCommunityModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newCuratedCommunityModel*(): CuratedCommunityModel =

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -15,7 +15,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: DiscordCategoriesModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newDiscordCategoriesModel*(): DiscordCategoriesModel =

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -18,7 +18,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: DiscordChannelsModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newDiscordChannelsModel*(): DiscordChannelsModel =

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -17,7 +17,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: DiscordFileListModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newDiscordFileListModel*(): DiscordFileListModel =

--- a/src/app/modules/main/communities/models/discord_import_errors_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_errors_model.nim
@@ -15,7 +15,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: DiscordImportErrorsModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newDiscordDiscordImportErrorsModel*(): DiscordImportErrorsModel =

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -21,7 +21,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: DiscordImportTasksModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newDiscordDiscordImportTasksModel*(): DiscordImportTasksmodel =

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -44,7 +44,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: TokenModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newTokenModel*(): TokenModel =

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -19,7 +19,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: TokenOwnersModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newTokenOwnersModel*(): TokenOwnersModel =

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -63,29 +63,6 @@ QtObject:
       keypairsSigningModelVariant: QVariant
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
-    self.spectatedCommunityPermissionModel.delete
-    self.spectatedCommunityPermissionModelVariant.delete
-    self.curatedCommunitiesModel.delete
-    self.curatedCommunitiesModelVariant.delete
-    self.discordFileListModel.delete
-    self.discordFileListModelVariant.delete
-    self.discordCategoriesModel.delete
-    self.discordCategoriesModelVariant.delete
-    self.discordChannelsModel.delete
-    self.discordChannelsModelVariant.delete
-    self.discordImportTasksModel.delete
-    self.discordImportTasksModelVariant.delete
-    self.tokenListModel.delete
-    self.tokenListModelVariant.delete
-    self.collectiblesListModel.delete
-    self.collectiblesListModelVariant.delete
-    if not self.keypairsSigningModel.isNil:
-      self.keypairsSigningModel.delete
-    if not self.keypairsSigningModelVariant.isNil:
-      self.keypairsSigningModelVariant.delete
-
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/ephemeral_notification_model.nim
+++ b/src/app/modules/main/ephemeral_notification_model.nim
@@ -25,7 +25,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/main/gifs/view.nim
+++ b/src/app/modules/main/gifs/view.nim
@@ -14,9 +14,6 @@ QtObject:
 
   proc delete*(self: View) =
     self.QObject.delete
-    self.gifColumnAModel.delete
-    self.gifColumnBModel.delete
-    self.gifColumnCModel.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/main/network_connection/view.nim
+++ b/src/app/modules/main/network_connection/view.nim
@@ -17,9 +17,6 @@ QtObject:
 
   proc delete*(self: View) =
     self.QObject.delete
-    self.blockchainNetworkConnection.delete
-    self.collectiblesNetworkConnection.delete
-    self.marketValuesNetworkConnection.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_accounts_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_accounts_model.nim
@@ -22,7 +22,6 @@ QtObject:
       items: seq[ShowcaseContactAccountItem]
 
   proc delete(self: ShowcaseContactAccountModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: ShowcaseContactAccountModel) =

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_generic_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_generic_model.nim
@@ -16,7 +16,6 @@ QtObject:
       items: seq[ShowcaseContactGenericItem]
 
   proc delete(self: ShowcaseContactGenericModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: ShowcaseContactGenericModel) =

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_social_links_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_social_links_model.nim
@@ -18,7 +18,6 @@ QtObject:
       items: seq[ShowcaseContactSocialLinkItem]
 
   proc delete(self: ShowcaseContactSocialLinkModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: ShowcaseContactSocialLinkModel) =

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -26,18 +26,6 @@ QtObject:
 
 
   proc delete*(self: View) =
-    self.contactsModel.delete
-    self.contactsModelVariant.delete
-    self.showcaseContactCommunitiesModel.delete
-    self.showcaseContactCommunitiesModelVariant.delete
-    self.showcaseContactAccountsModel.delete
-    self.showcaseContactAccountsModelVariant.delete
-    self.showcaseContactCollectiblesModel.delete
-    self.showcaseContactCollectiblesModelVariant.delete
-    self.showcaseContactAssetsModel.delete
-    self.showcaseContactAssetsModelVariant.delete
-    self.showcaseContactSocialLinksModel.delete
-    self.showcaseContactSocialLinksModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -26,7 +26,6 @@ QtObject:
     self.pairedCount = 0
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/main/profile_section/devices/view.nim
+++ b/src/app/modules/main/profile_section/devices/view.nim
@@ -14,10 +14,7 @@ QtObject:
       localPairingStatus: LocalPairingStatus
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
-    self.localPairingStatus.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -17,7 +17,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -13,8 +13,6 @@ QtObject:
       etherscanAddressLink: string
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/profile_section/keycard/view.nim
+++ b/src/app/modules/main/profile_section/keycard/view.nim
@@ -15,14 +15,6 @@ QtObject:
 
   proc delete*(self: View) =
     self.QObject.delete
-    if not self.keycardModel.isNil:
-      self.keycardModel.delete
-    if not self.keycardModelVariant.isNil:
-      self.keycardModelVariant.delete
-    if not self.keycardDetailsModel.isNil:
-      self.keycardDetailsModel.delete
-    if not self.keycardDetailsModelVariant.isNil:
-      self.keycardDetailsModelVariant.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/main/profile_section/language/model.nim
+++ b/src/app/modules/main/profile_section/language/model.nim
@@ -16,7 +16,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/profile_section/language/view.nim
+++ b/src/app/modules/main/profile_section/language/view.nim
@@ -12,8 +12,6 @@ QtObject:
 
   proc delete*(self: View) =
     self.QObject.delete
-    self.model.delete
-    self.modelVariant.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -23,7 +23,6 @@ QtObject:
       items: seq[Item]
 
   proc delete*(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/profile_section/notifications/view.nim
+++ b/src/app/modules/main/profile_section/notifications/view.nim
@@ -10,8 +10,6 @@ QtObject:
       exemptionsModelVariant: QVariant
       
   proc delete*(self: View) =
-    self.exemptionsModel.delete
-    self.exemptionsModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_generic_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_generic_model.nim
@@ -20,7 +20,6 @@ QtObject:
       items: seq[ShowcasePreferencesGenericItem]
 
   proc delete(self: ShowcasePreferencesGenericModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: ShowcasePreferencesGenericModel) =

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
@@ -18,7 +18,6 @@ QtObject:
       items: seq[ShowcasePreferencesSocialLinkItem]
 
   proc delete(self: ShowcasePreferencesSocialLinkModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: ShowcasePreferencesSocialLinkModel) =

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -22,16 +22,6 @@ QtObject:
       showcasePreferencesSocialLinksModelVariant: QVariant
 
   proc delete*(self: View) =
-    self.showcasePreferencesCommunitiesModel.delete
-    self.showcasePreferencesCommunitiesModelVariant.delete
-    self.showcasePreferencesAccountsModel.delete
-    self.showcasePreferencesAccountsModelVariant.delete
-    self.showcasePreferencesCollectiblesModel.delete
-    self.showcasePreferencesCollectiblesModelVariant.delete
-    self.showcasePreferencesAssetsModel.delete
-    self.showcasePreferencesAssetsModelVariant.delete
-    self.showcasePreferencesSocialLinksModel.delete
-    self.showcasePreferencesSocialLinksModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/profile_section/sync/model.nim
+++ b/src/app/modules/main/profile_section/sync/model.nim
@@ -14,7 +14,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/main/profile_section/sync/view.nim
+++ b/src/app/modules/main/profile_section/sync/view.nim
@@ -9,8 +9,6 @@ QtObject:
       modelVariant: QVariant
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/profile_section/waku/model.nim
+++ b/src/app/modules/main/profile_section/waku/model.nim
@@ -13,7 +13,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/main/profile_section/waku/view.nim
+++ b/src/app/modules/main/profile_section/waku/view.nim
@@ -10,8 +10,6 @@ QtObject:
       modelVariant: QVariant
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -20,7 +20,6 @@ QtObject:
       items: seq[WalletAccountItem]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/profile_section/wallet/accounts/view.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/view.nim
@@ -19,9 +19,6 @@ QtObject:
       selectedAccount: KeyPairAccountItem
 
   proc delete*(self: View) =
-    self.accounts.delete
-    self.accountsVariant.delete
-    self.keyPairModel.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -29,14 +29,6 @@ QtObject:
   proc activeSectionSet*(self: View, item: SectionItem)
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
-    self.activeSection.delete
-    self.activeSectionVariant.delete
-    self.chatSearchModel.delete
-    self.chatSearchModelVariant.delete
-    self.ephemeralNotificationModel.delete
-    self.ephemeralNotificationModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -28,7 +28,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -15,8 +15,6 @@ QtObject:
       accountsVariant: QVariant
 
   proc delete*(self: View) =
-    self.accounts.delete
-    self.accountsVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/wallet_section/activity/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_model.nim
@@ -22,7 +22,6 @@ QtObject:
       hasMore: bool
 
   proc delete(self: CollectiblesModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: CollectiblesModel) =

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -17,7 +17,6 @@ QtObject:
       hasMore: bool
 
   proc delete(self: Model) =
-    self.entries = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
@@ -44,7 +44,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: FlatTokensModel) =
-    self.tokenMarketDetails = @[]
     self.QAbstractListModel.delete
 
   proc newFlatTokensModel*(

--- a/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
@@ -46,8 +46,6 @@ QtObject:
     self.tokenMarketDetails = @[]
 
   proc delete(self: TokensBySymbolModel) =
-    self.addressPerChainModel = @[]
-    self.tokenMarketDetails = @[]
     self.QAbstractListModel.delete
 
   proc newTokensBySymbolModel*(

--- a/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
+++ b/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
@@ -14,7 +14,6 @@ QtObject:
       balancesPerChain: seq[BalancesModel]
 
   proc delete(self: Model) =
-    self.balancesPerChain = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/view.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/view.nim
@@ -16,8 +16,6 @@ QtObject:
       isFetching: bool
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/wallet_section/saved_addresses/model.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/model.nim
@@ -20,7 +20,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/main/wallet_section/saved_addresses/view.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/view.nim
@@ -11,8 +11,6 @@ QtObject:
       modelVariant: QVariant
 
   proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/wallet_section/send/network_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_route_model.nim
@@ -22,7 +22,6 @@ QtObject:
     items*: seq[NetworkRouteItem]
 
   proc delete(self: NetworkRouteModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: NetworkRouteModel) =

--- a/src/app/modules/main/wallet_section/send/suggested_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_model.nim
@@ -12,7 +12,6 @@ QtObject:
       items*: seq[SuggestedRouteItem]
 
   proc delete(self: SuggestedRouteModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: SuggestedRouteModel) =

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -34,9 +34,6 @@ QtObject:
   proc updateNetworksTokenBalance(self: View)
 
   proc delete*(self: View) =
-    self.fromNetworksRouteModel.delete
-    self.toNetworksRouteModel.delete
-    self.transactionRoutes.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/wallet_section/send_new/path_model.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_model.nim
@@ -63,7 +63,6 @@ QtObject:
       items*: seq[PathItem]
 
   proc delete(self: PathModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: PathModel) =

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -15,7 +15,6 @@ QtObject:
       pathModel: PathModel
 
   proc delete*(self: View) =
-    self.pathModel.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -36,9 +36,6 @@ QtObject:
     self.QObject.setup
 
   proc delete*(self: View) =
-    self.wcController.delete
-    self.dappsConnectorController.delete
-
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface,

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -23,8 +23,6 @@ QtObject:
 
   proc delete*(self: View) =
     self.QObject.delete
-    self.loginAccountsModel.delete
-    self.loginAccountsModelVariant.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)

--- a/src/app/modules/shared_models/collectible_ownership_model.nim
+++ b/src/app/modules/shared_models/collectible_ownership_model.nim
@@ -15,7 +15,6 @@ QtObject:
       items: seq[backend.AccountBalance]
 
   proc delete(self: OwnershipModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: OwnershipModel) =

--- a/src/app/modules/shared_models/collectible_trait_model.nim
+++ b/src/app/modules/shared_models/collectible_trait_model.nim
@@ -15,7 +15,6 @@ QtObject:
       items: seq[backend.CollectibleTrait]
 
   proc delete(self: TraitModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: TraitModel) =

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -47,7 +47,6 @@ QtObject:
     if isSome(data.ownership):
       let ownership = data.ownership.get()
       self.ownership.setItems(ownership)
-    self.setup()
 
   proc `$`*(self: CollectiblesEntry): string =
     return fmt"""CollectiblesEntry(

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -37,7 +37,6 @@ QtObject:
       isError: bool
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_models/color_hash_model.nim
+++ b/src/app/modules/shared_models/color_hash_model.nim
@@ -16,7 +16,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_models/contract_model.nim
+++ b/src/app/modules/shared_models/contract_model.nim
@@ -16,7 +16,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newModel*(): Model =

--- a/src/app/modules/shared_models/derived_address_model.nim
+++ b/src/app/modules/shared_models/derived_address_model.nim
@@ -14,7 +14,6 @@ QtObject:
       items: seq[DerivedAddressItem]
 
   proc delete(self: DerivedAddressModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: DerivedAddressModel) =

--- a/src/app/modules/shared_models/emoji_reactions_model.nim
+++ b/src/app/modules/shared_models/emoji_reactions_model.nim
@@ -12,7 +12,6 @@ QtObject:
         items: seq[EmojiReactionItem]
 
     proc delete(self: Model) =
-        self.items = @[]
         self.QAbstractListModel.delete
 
     # TODO : To make this code scale, we can consider a loop similar to

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -16,7 +16,6 @@ QtObject:
       items: seq[KeyPairAccountItem]
 
   proc delete(self: KeyPairAccountModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: KeyPairAccountModel) =

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -15,7 +15,6 @@ QtObject:
       items: seq[KeyPairItem]
 
   proc delete(self: KeyPairModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: KeyPairModel) =

--- a/src/app/modules/shared_models/link_preview_item.nim
+++ b/src/app/modules/shared_models/link_preview_item.nim
@@ -9,9 +9,6 @@ type
     loadingLocalData*: bool
     linkPreview*: LinkPreview
 
-proc delete*(self: Item) =
-  self.linkPreview.delete
-
 proc linkPreview*(self: Item): LinkPreview {.inline.} =
   return self.linkPreview
 

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -42,9 +42,6 @@ QtObject:
       items: seq[Item]
 
   proc delete*(self: Model) = 
-    for i in 0 ..< self.items.len:
-      self.items[i].delete
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -42,7 +42,6 @@ QtObject:
       items: seq[MemberItem]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -84,7 +84,6 @@ QtObject:
       firstUnseenMessageId: string
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -15,7 +15,6 @@ QtObject:
       items: seq[MessageReactionItem]
 
   proc delete(self: MessageReactionModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: MessageReactionModel) =

--- a/src/app/modules/shared_models/payment_request_model.nim
+++ b/src/app/modules/shared_models/payment_request_model.nim
@@ -14,7 +14,6 @@ QtObject:
       items: seq[PaymentRequest]
 
   proc delete*(self: Model) = 
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -53,7 +53,6 @@ QtObject:
       items: seq[SectionItem]
 
   proc delete(self: SectionModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: SectionModel) =

--- a/src/app/modules/shared_models/token_criteria_model.nim
+++ b/src/app/modules/shared_models/token_criteria_model.nim
@@ -22,7 +22,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: TokenCriteriaModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newTokenCriteriaModel*(): TokenCriteriaModel =

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -24,7 +24,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: TokenListModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newTokenListModel*(): TokenListModel =

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -14,7 +14,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: TokenPermissionChatListModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newTokenPermissionChatListModel*(): TokenPermissionChatListModel =

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -23,7 +23,6 @@ QtObject:
     self.QAbstractListModel.setup
 
   proc delete(self: TokenPermissionsModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc newTokenPermissionsModel*(): TokenPermissionsModel =

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -42,7 +42,6 @@ QtObject:
       items: seq[UserItem]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -36,20 +36,6 @@ QtObject:
       disablePopup: bool # unables user to interact with the popup (action buttons are disabled as well as close popup button)
 
   proc delete*(self: View) =
-    self.currentStateVariant.delete
-    self.currentState.delete
-    self.originModel.delete
-    self.originModelVariant.delete
-    self.selectedOrigin.delete
-    self.selectedOriginVariant.delete
-    self.derivedAddressModel.delete
-    self.derivedAddressModelVariant.delete
-    self.selectedDerivedAddress.delete
-    self.selectedDerivedAddressVariant.delete
-    self.watchOnlyAccAddress.delete
-    self.watchOnlyAccAddressVariant.delete
-    self.privateKeyAccAddress.delete
-    self.privateKeyAccAddressVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
@@ -13,7 +13,6 @@ QtObject:
       items: seq[KeycardItem]
 
   proc delete(self: KeycardModel) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: KeycardModel) =

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -23,20 +23,6 @@ QtObject:
       remainingAttempts: int
 
   proc delete*(self: View) =
-    self.currentStateVariant.delete
-    self.currentState.delete
-    if not self.keyPairModel.isNil:
-      self.keyPairModel.delete
-    if not self.keyPairModelVariant.isNil:
-      self.keyPairModelVariant.delete
-    if not self.keyPairHelper.isNil:
-      self.keyPairHelper.delete
-    if not self.keyPairHelperVariant.isNil:
-      self.keyPairHelperVariant.delete
-    if not self.keyPairForProcessing.isNil:
-      self.keyPairForProcessing.delete
-    if not self.keyPairForProcessingVariant.isNil:
-      self.keyPairForProcessingVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/shared_modules/keypair_import/view.nim
+++ b/src/app/modules/shared_modules/keypair_import/view.nim
@@ -20,14 +20,6 @@ QtObject:
       connectionStringError: string
 
   proc delete*(self: View) =
-    self.currentStateVariant.delete
-    self.currentState.delete
-    self.selectedKeypair.delete
-    self.selectedKeypairVariant.delete
-    if not self.keypairModel.isNil:
-      self.keypairModel.delete
-    if not self.keypairModelVariant.isNil:
-      self.keypairModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app/modules/startup/models/fetching_data_model.nim
+++ b/src/app/modules/startup/models/fetching_data_model.nim
@@ -19,7 +19,6 @@ QtObject:
   proc reevaluateAllTotals(self: Model)
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/startup/models/login_account_model.nim
+++ b/src/app/modules/startup/models/login_account_model.nim
@@ -21,7 +21,6 @@ QtObject:
       items: seq[Item]
 
   proc delete(self: Model) =
-    self.items = @[]
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -36,17 +36,6 @@ QtObject:
       localPairingStatus: LocalPairingStatus
 
   proc delete*(self: View) =
-    self.currentStartupStateVariant.delete
-    self.currentStartupState.delete
-    self.selectedLoginAccount.delete
-    self.selectedLoginAccountVariant.delete
-    self.loginAccountsModel.delete
-    self.loginAccountsModelVariant.delete
-    if not self.fetchingDataModel.isNil:
-      self.fetchingDataModel.delete
-    if not self.fetchingDataModelVariant.isNil:
-      self.fetchingDataModelVariant.delete
-    self.localPairingStatus.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -113,9 +113,6 @@ QtObject:
   proc constructContactDetails(self: Service, contactDto: ContactsDto): ContactDetails
 
   proc delete*(self: Service) =
-    self.closingApp = true
-    self.contacts.clear
-    self.contactsStatus.clear
     self.QObject.delete
 
   proc newService*(
@@ -547,8 +544,6 @@ QtObject:
       error "error resolving ENS ", msg=e.msg
 
   proc resolveENS*(self: Service, value: string, uuid: string = "", reason = "") =
-    if(self.closingApp):
-      return
     let arg = LookupContactTaskArg(
       tptr: lookupContactTask,
       vptr: cast[uint](self.vptr),

--- a/src/app_service/service/devices/dto/local_pairing_status.nim
+++ b/src/app_service/service/devices/dto/local_pairing_status.nim
@@ -33,11 +33,8 @@ type
     transferredKeypairs*: seq[string] ## seq[keypair_key_uid]
     error*: string
 
-proc delete*(self: LocalPairingStatus) =
-  discard
-
 proc newLocalPairingStatus*(pairingType: PairingType, mode: LocalPairingMode): LocalPairingStatus =
-  new(result, delete)
+  new(result)
   result.pairingType = pairingType
   result.mode = mode
   result.state = LocalPairingState.Idle

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -63,8 +63,6 @@ QtObject:
 
   proc delete*(self: Service) =
     self.QObject.delete
-    if not self.localPairingStatus.isNil:
-      self.localPairingStatus.delete
 
   proc newService*(events: EventEmitter,
     threadpool: ThreadPool,

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -239,6 +239,7 @@ QtObject:
 
   proc onTimeout(self: Service, response: string) {.slot.} =
     if response == $TimerReason.ReRunCurrentFlowLater:
+      #TODO: Find another way to handle this. The vptr should be invalid by now..
       if(self.closingApp or self.currentFlow == KCSFlowType.NoFlow):
         return
       if self.doLogging:

--- a/src/app_service/service/keychain/service.nim
+++ b/src/app_service/service/keychain/service.nim
@@ -27,7 +27,6 @@ QtObject:
     self.QObject.setup
 
   proc delete*(self: Service) =
-    self.keychainManager.delete
     self.QObject.delete
 
   proc newService*(events: EventEmitter): Service =

--- a/src/app_service/service/message/dto/link_preview.nim
+++ b/src/app_service/service/message/dto/link_preview.nim
@@ -22,16 +22,6 @@ type
     statusCommunityPreview*: StatusCommunityLinkPreview
     statusCommunityChannelPreview*: StatusCommunityChannelLinkPreview
 
-proc delete*(self: LinkPreview) =
-  if self.standardPreview != nil:
-    self.standardPreview.delete
-  if self.statusContactPreview != nil:
-    self.statusContactPreview.delete
-  if self.statusCommunityPreview != nil:
-    self.statusCommunityPreview.delete
-  if self.statusCommunityChannelPreview != nil:
-    self.statusCommunityChannelPreview.delete
-
 proc initLinkPreview*(url: string): LinkPreview =
   result = LinkPreview()
   result.url = url

--- a/src/app_service/service/message/dto/standard_link_preview.nim
+++ b/src/app_service/service/message/dto/standard_link_preview.nim
@@ -29,7 +29,6 @@ QtObject:
 
   proc delete*(self: StandardLinkPreview) =
     self.QObject.delete
-    self.thumbnail.delete
 
   proc newStandardLinkPreview*(hostname: string, title: string, description: string, thumbnail: LinkPreviewThumbnail, linkType: LinkType): StandardLinkPreview =
     new(result, delete)

--- a/src/app_service/service/message/dto/status_community_channel_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_channel_link_preview.nim
@@ -19,7 +19,6 @@ QtObject:
 
   proc delete*(self: StatusCommunityChannelLinkPreview) =
     self.QObject.delete()
-    self.community.delete()
 
   proc channelUuidChanged*(self: StatusCommunityChannelLinkPreview) {.signal.}
   proc getChannelUuid*(self: StatusCommunityChannelLinkPreview): string {.slot.} =

--- a/src/app_service/service/message/dto/status_community_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_link_preview.nim
@@ -24,9 +24,6 @@ QtObject:
 
   proc delete*(self: StatusCommunityLinkPreview) =
     self.QObject.delete()
-    self.icon.delete()
-    self.banner.delete()
-
 
   proc communityIdChanged*(self: StatusCommunityLinkPreview) {.signal.}
   proc getCommunityId*(self: StatusCommunityLinkPreview): string {.slot.} =

--- a/src/app_service/service/message/dto/status_contact_link_preview.nim
+++ b/src/app_service/service/message/dto/status_contact_link_preview.nim
@@ -17,7 +17,6 @@ QtObject:
 
   proc delete*(self: StatusContactLinkPreview) =
     self.QObject.delete()
-    self.icon.delete()
 
   proc newStatusContactLinkPreview*(publicKey: var string, displayName: string, description: string, icon: LinkPreviewThumbnail): StatusContactLinkPreview =
     new(result, delete)

--- a/src/app_service/service/network_connection/service.nim
+++ b/src/app_service/service/network_connection/service.nim
@@ -50,7 +50,6 @@ proc newConnectionStatus(): ConnectionStatus =
 
 QtObject:
   type Service* = ref object of QObject
-    closingApp: bool
     events: EventEmitter
     walletService: wallet_service.Service
     networkService: network_service.Service
@@ -66,7 +65,6 @@ QtObject:
   proc getChainStatusTable(message: string): ConnectionStatusNotification
 
   proc delete*(self: Service) =
-    self.closingApp = true
     self.QObject.delete
 
   proc newService*(
@@ -78,7 +76,6 @@ QtObject:
   ): Service =
     new(result, delete)
     result.QObject.setup
-    result.closingApp = false
     result.events = events
     result.walletService = walletService
     result.networkService = networkService

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -36,7 +36,6 @@ include  ../../common/json_utils
 
 QtObject:
   type Service* = ref object of QObject
-    closingApp: bool
     events: EventEmitter
     threadpool: ThreadPool
     settingsService: settings_service.Service
@@ -72,7 +71,6 @@ QtObject:
   proc onENSNamesFetched*(self: Service, response: string) {.slot.}
 
   proc delete*(self: Service) =
-    self.closingApp = true
     self.QObject.delete
 
   proc newService*(
@@ -86,7 +84,6 @@ QtObject:
   ): Service =
     new(result, delete)
     result.QObject.setup
-    result.closingApp = false
     result.events = events
     result.threadpool = threadpool
     result.settingsService = settingsService


### PR DESCRIPTION
### What does the PR do

Closes: [#17510](https://github.com/status-im/status-desktop/issues/17510)

Remove any extra work done in the finalizers, keeping just the nimqml `delete` that absolutely needed to clean the c++ classes.

Apparently the finalizers are buggy and we need to be really careful about the code we execute there. One thing we know for sure is that it's not supported to allocate any memory in the finalizer.

See this old bug: nim-lang/Nim#4851
