### PR TITLE
Fix/memory issues

### DIFF
--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -31,8 +31,6 @@ QtObject:
     result.setup
 
   proc setFileName*(self: LocalAccountSettings, fileName: string) =
-    if(not self.settings.isNil):
-      self.settings.delete
     let
       currentFilePath = os.joinPath(self.settingsFileDir, self.currentFileName)
       newFilePath = os.joinPath(self.settingsFileDir, fileName)

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -49,8 +49,6 @@ QtObject:
 
     let topLeft = self.createIndex(0, 0, nil)
     let bottomRight = self.createIndex(self.activityCenterNotifications.len - 1, 0, nil)
-    defer: topLeft.delete
-    defer: bottomRight.delete
     self.dataChanged(topLeft, bottomRight, @[NotifRoles.Read.int])
 
   method rowCount*(self: Model, index: QModelIndex = nil): int = self.activityCenterNotifications.len
@@ -126,7 +124,6 @@ QtObject:
 
     self.activityCenterNotifications[i].read = false
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[NotifRoles.Read.int])
 
   proc markActivityCenterNotificationRead*(self: Model, notificationId: string) =
@@ -136,7 +133,6 @@ QtObject:
 
     self.activityCenterNotifications[i].read = true
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[NotifRoles.Read.int])
 
   proc activityCenterNotificationAccepted*(self: Model, notificationId: string) =
@@ -147,7 +143,6 @@ QtObject:
     self.activityCenterNotifications[i].read = true
     self.activityCenterNotifications[i].accepted = true
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[NotifRoles.Accepted.int, NotifRoles.Read.int])
 
   proc activityCenterNotificationDismissed*(self: Model, notificationId: string) =
@@ -158,7 +153,6 @@ QtObject:
     self.activityCenterNotifications[i].read = true
     self.activityCenterNotifications[i].dismissed = true
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[NotifRoles.Dismissed.int, NotifRoles.Read.int])
 
   proc removeNotifications*(self: Model, ids: seq[string]) =
@@ -188,7 +182,6 @@ QtObject:
   proc updateActivityCenterNotification*(self: Model, ind: int, newNotification: Item) =
     self.activityCenterNotifications[ind] = newNotification
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index)
 
   proc upsertActivityCenterNotification*(self: Model, newNotification: Item) =
@@ -212,7 +205,6 @@ QtObject:
     let indexToUpdate = indexToInsert - 2
     if indexToUpdate >= 0 and indexToUpdate < self.activityCenterNotifications.len:
       let index = self.createIndex(indexToUpdate, 0, nil)
-      defer: index.delete
       self.dataChanged(index, index, @[NotifRoles.PreviousTimestamp.int])
 
   proc upsertActivityCenterNotifications*(self: Model, activityCenterNotifications: seq[Item]) =

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -175,7 +175,6 @@ QtObject:
     for index in indexesToDelete:
       let indexUpdated = index - i
       let modelIndex = newQModelIndex()
-      defer: modelIndex.delete
       self.beginRemoveRows(modelIndex, indexUpdated, indexUpdated)
       self.activityCenterNotifications.delete(indexUpdated)
       self.endRemoveRows()
@@ -199,7 +198,6 @@ QtObject:
         return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     var indexToInsert = self.activityCenterNotifications.len
     for i, notification in self.activityCenterNotifications:

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -56,7 +56,7 @@ proc newModule*(
   result.moduleLoaded = false
 
 method delete*(self: Module) =
-  self.view.delete
+  discard
 
 method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("activityCenterModule", self.viewVariant)

--- a/src/app/modules/main/app_search/result_model.nim
+++ b/src/app/modules/main/app_search/result_model.nim
@@ -118,7 +118,6 @@ QtObject:
 
   proc add*(self: Model, item: Item) =
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginInsertRows(modelIndex, self.resultList.len, self.resultList.len)
     self.resultList.add(item)
     self.endInsertRows()

--- a/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
@@ -57,7 +57,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
@@ -85,7 +84,6 @@ QtObject:
 
     if itemsToInsert.len > 0:
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
       self.beginInsertRows(parentModelIndex, self.items.len, self.items.len + itemsToInsert.len - 1)
       self.items = self.items & itemsToInsert
       self.endInsertRows()

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -244,7 +244,6 @@ QtObject:
   # IMPORTANT: if you call this function for a chat with a category, make sure the category is appended first
   proc appendItem*(self: Model, item: Item, ignoreCategory: bool = false) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     var indexToInsertTo = item.position
     if item.isCategory:
@@ -296,7 +295,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, idx, idx)
     self.items.delete(idx)

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -273,7 +273,6 @@ QtObject:
       if self.items[i].categoryId == categoryId:
         self.items[i].categoryOpened = opened
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.CategoryOpened.int])
 
   # This function only refreshes ShouldBeHiddenBecausePermissionsAreNotMet.
@@ -287,7 +286,6 @@ QtObject:
     if not self.items[index].isCategory:
       return
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int])
 
   proc removeItemByIndex(self: Model, idx: int) =
@@ -332,7 +330,6 @@ QtObject:
       return
     self.items[index].hasUnreadMessages = unread
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.HasUnreadMessages.int])
 
   proc setActiveItem*(self: Model, id: string) =
@@ -340,7 +337,6 @@ QtObject:
       let isChannelToSetActive = (self.items[i].id == id)
       if self.items[i].active != isChannelToSetActive:
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         # Set active channel to true and others to false
         self.items[i].active = isChannelToSetActive
         if (isChannelToSetActive):
@@ -364,7 +360,6 @@ QtObject:
 
     self.items[index].locked = locked
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Locked.int])
 
   proc setItemPermissionsRequired*(self: Model, id: string, value: bool) =
@@ -377,7 +372,6 @@ QtObject:
 
     self.items[index].requiresPermissions = value
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.RequiresPermissions.int])
 
   proc getItemPermissionsRequired*(self: Model, id: string): bool =
@@ -395,7 +389,6 @@ QtObject:
       return
     self.items[index].muted = muted
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Muted.int])
 
   proc changeCanPostValues*(self: Model, id: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool) =
@@ -424,7 +417,6 @@ QtObject:
       return
     
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     changedRoles.add(ModelRole.HideIfPermissionsNotMet.int) # depends on canPost, canView
     changedRoles.add(ModelRole.ShouldBeHiddenBecausePermissionsAreNotMet.int) # depends on hideIfPermissionsNotMet
     self.dataChanged(modelIndex, modelIndex, changedRoles)
@@ -433,7 +425,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if self.items[i].categoryId == categoryId and self.items[i].muted != muted:
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].muted = muted
         self.dataChanged(index, index, @[ModelRole.Muted.int])
 
@@ -451,7 +442,6 @@ QtObject:
       return
     self.items[index].blocked = blocked
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Blocked.int])
 
   proc updateItemDetailsById*(self: Model, id, name, icon: string, trustStatus: TrustStatus) =
@@ -463,7 +453,6 @@ QtObject:
     self.items[index].icon = icon
     self.items[index].trustStatus = trustStatus
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.Icon.int,
@@ -480,7 +469,6 @@ QtObject:
     self.items[index].color = color
     self.items[index].hideIfPermissionsNotMet = hideIfPermissionsNotMet
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.Description.int,
@@ -500,7 +488,6 @@ QtObject:
     self.items[index].color = color
     self.items[index].icon = icon
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.Color.int,
@@ -519,7 +506,6 @@ QtObject:
     self.items[categoryIndex].name = newCategoryName
     self.items[categoryIndex].categoryPosition = newCategoryPosition
     let modelIndex = self.createIndex(categoryIndex, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.CategoryPosition.int,
@@ -546,7 +532,6 @@ QtObject:
         item.categoryId = chat.categoryId
         item.categoryPosition = if nowHasCategory: newCategoryPosition else: -1
         let modelIndex = self.createIndex(i, 0, nil)
-        defer: modelIndex.delete
         var roleChanges = @[
           ModelRole.Position.int,
           ModelRole.CategoryId.int,
@@ -579,7 +564,6 @@ QtObject:
         item.categoryPosition = -1
         item.categoryOpened = true
         let modelIndex = self.createIndex(i, 0, nil)
-        defer: modelIndex.delete
         self.dataChanged(modelIndex, modelIndex, @[
           ModelRole.Position.int,
           ModelRole.CategoryId.int,
@@ -596,7 +580,6 @@ QtObject:
       return
     self.items[index].name = newName
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Name.int])
 
   proc renameItemById*(self: Model, id, name: string) =
@@ -607,7 +590,6 @@ QtObject:
       return
     self.items[index].name = name
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Name.int])
 
   proc updateItemOnlineStatusById*(self: Model, id: string, onlineStatus: OnlineStatus) =
@@ -618,7 +600,6 @@ QtObject:
       return
     self.items[index].onlineStatus = onlineStatus
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.OnlineStatus.int])
 
   proc updateNotificationsForItemById*(self: Model, id: string, hasUnreadMessages: bool,
@@ -629,7 +610,6 @@ QtObject:
     self.items[index].hasUnreadMessages = hasUnreadMessages
     self.items[index].notificationsCount = notificationsCount
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.HasUnreadMessages.int, ModelRole.NotificationsCount.int])
 
   proc updateLastMessageTimestampOnItemById*(self: Model, id: string, lastMessageTimestamp: int) =
@@ -640,7 +620,6 @@ QtObject:
       return
     self.items[index].lastMessageTimestamp = lastMessageTimestamp
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.LastMessageTimestamp.int])
 
   proc reorderChats*(
@@ -671,7 +650,6 @@ QtObject:
 
       self.items[index].position = updatedChat.position
       let modelIndex = self.createIndex(index, 0, nil)
-      defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex, roles)
 
   proc reorderCategoryById*(
@@ -687,7 +665,6 @@ QtObject:
         continue
       item.categoryPosition = position
       let modelIndex = self.createIndex(i, 0, nil)
-      defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex, @[ModelRole.CategoryPosition.int])
 
   proc clearItems*(self: Model) =
@@ -710,7 +687,6 @@ QtObject:
     self.items[index].loaderActive = false
     self.items[index].active = false
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Active.int, ModelRole.LoaderActive.int])
 
   proc updateMissingEncryptionKey*(self: Model, id: string, missingEncryptionKey: bool) =
@@ -721,5 +697,4 @@ QtObject:
     if self.items[index].missingEncryptionKey != missingEncryptionKey:
       self.items[index].missingEncryptionKey = missingEncryptionKey
       let modelIndex = self.createIndex(index, 0, nil)
-      defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex, @[ModelRole.MissingEncryptionKey.int])

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -136,7 +136,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
@@ -152,7 +151,6 @@ QtObject:
       self.dataChanged(index, index)
     else:
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
       self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
       self.items.add(item)
       self.endInsertRows()

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -146,7 +146,6 @@ QtObject:
     let idx = self.findIndexById(item.getId())
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       self.items[idx] = item
       self.dataChanged(index, index)
     else:

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -95,7 +95,6 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       self.items[idx].selected = false
       self.dataChanged(index, index, @[ModelRole.Selected.int])
 
@@ -103,13 +102,11 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       self.items[idx].selected = true
       self.dataChanged(index, index, @[ModelRole.Selected.int])
 
   proc selectOneItem*(self: DiscordCategoriesModel, id: string) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
-      defer: index.delete
       self.items[i].selected = self.items[i].getId() == id
       self.dataChanged(index, index, @[ModelRole.Selected.int])

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -78,7 +78,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, idx, idx)
     self.items.delete(idx)
@@ -87,7 +86,6 @@ QtObject:
 
   proc addItem*(self: DiscordCategoriesModel, item: DiscordCategoryItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -156,7 +156,6 @@ QtObject:
     for i in 0 ..< indices.len:
 
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
 
       self.beginRemoveRows(parentModelIndex, indices[i], indices[i])
       self.items.delete(indices[i])
@@ -165,7 +164,6 @@ QtObject:
 
   proc addItem*(self: DiscordChannelsModel, item: DiscordChannelItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -173,7 +173,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getCategoryId() == id):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].selected = false
         self.dataChanged(index, index, @[ModelRole.Selected.int])
     self.hasSelectedItemsChanged()
@@ -182,7 +181,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getCategoryId() == id):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].selected = true
         self.dataChanged(index, index, @[ModelRole.Selected.int])
     self.hasSelectedItemsChanged()
@@ -202,7 +200,6 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       self.items[idx].selected = false
       self.dataChanged(index, index, @[ModelRole.Selected.int])
       self.hasSelectedItemsChanged()
@@ -211,7 +208,6 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       self.items[idx].selected = true
       self.dataChanged(index, index, @[ModelRole.Selected.int])
       self.hasSelectedItemsChanged()
@@ -219,7 +215,6 @@ QtObject:
   proc selectOneItem*(self: DiscordChannelsModel, id: string) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
-      defer: index.delete
       self.items[i].selected = self.items[i].getId() == id
       self.dataChanged(index, index, @[ModelRole.Selected.int])
     self.hasSelectedItemsChanged()

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -153,7 +153,6 @@ QtObject:
   proc setAllValidated*(self: DiscordFileListModel) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
-      defer: index.delete
       self.items[i].validated = true
       self.dataChanged(index, index, @[ModelRole.Validated.int])
     self.selectedFilesValidChanged()
@@ -162,7 +161,6 @@ QtObject:
     let idx = self.findIndexByFilePath(filePath)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       self.items[idx].errorMessage = errorMessage
       self.items[idx].errorCode = errorCode
       self.items[idx].selected = false

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -137,7 +137,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, idx, idx)
     self.items.delete(idx)
@@ -146,7 +145,6 @@ QtObject:
 
   proc addItem*(self: DiscordFileListModel, item: DiscordFileItem) =
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
       self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
       self.items.add(item)
       self.endInsertRows()

--- a/src/app/modules/main/communities/models/discord_import_errors_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_errors_model.nim
@@ -53,7 +53,6 @@ QtObject:
 
   proc addItem*(self: DiscordImportErrorsModel, item: DiscordImportErrorItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -91,7 +91,6 @@ QtObject:
     let idx = self.findIndexByType(item.`type`)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
-      defer: index.delete
       let errorsAndWarningsCount = self.items[idx].warningsCount + self.items[idx].errorsCount
       self.items[idx].progress = item.progress
       self.items[idx].state = item.state

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -77,7 +77,6 @@ QtObject:
 
   proc addItem*(self: DiscordImportTasksModel, item: DiscordImportTaskItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -165,7 +165,6 @@ QtObject:
 
   proc appendItem*(self: TokenModel, item: TokenItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
@@ -178,7 +177,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, itemIdx, itemIdx)
     self.items.delete(itemIdx)

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -63,7 +63,6 @@ QtObject:
 
     self.items[itemIdx].tokenDto.deployState = deployState
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.DeployState.int])
 
   proc updateAddress*(self: TokenModel, chainId: int, oldContractAddress: string, newContractAddress: string) =
@@ -73,7 +72,6 @@ QtObject:
 
     self.items[itemIdx].tokenDto.address = newContractAddress
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.TokenAddress.int])
 
   proc updateBurnState*(self: TokenModel, chainId: int, contractAddress: string, burnState: ContractTransactionStatus) =
@@ -83,7 +81,6 @@ QtObject:
   
     self.items[itemIdx].burnState = burnState
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.BurnState.int])
 
   proc updateRemoteDestructedAddresses*(self: TokenModel, chainId: int, contractAddress: string, remoteDestructedAddresses: seq[string]) =
@@ -93,7 +90,6 @@ QtObject:
 
     self.items[itemIdx].remoteDestructedAddresses = remoteDestructedAddresses
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.RemotelyDestructState.int])
     self.items[itemIdx].tokenOwnersModel.updateRemoteDestructState(remoteDestructedAddresses)
     self.dataChanged(index, index, @[ModelRole.TokenOwnersModel.int])
@@ -107,7 +103,6 @@ QtObject:
       self.items[itemIdx].tokenDto.supply = supply
       self.items[itemIdx].destructedAmount = destructedAmount
       let index = self.createIndex(itemIdx, 0, nil)
-      defer: index.delete
       self.dataChanged(index, index, @[ModelRole.Supply.int])
 
   proc updateRemainingSupply*(self: TokenModel, chainId: int, contractAddress: string, remainingSupply: Uint256) =
@@ -117,7 +112,6 @@ QtObject:
 
     self.items[itemIdx].remainingSupply = remainingSupply
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.RemainingSupply.int])
 
   proc hasTokenHolders*(self: TokenModel, chainId: int, contractAddress: string): bool =
@@ -137,7 +131,6 @@ QtObject:
       result = initTokenOwnersItem(owner.contactId, owner.name, owner.imageSource, 0, owner.collectibleOwner, self.items[itemIdx].remoteDestructedAddresses)
     ))
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.TokenOwnersModel.int, ModelRole.TokenHoldersLoading.int])
 
   proc setCommunityTokenHoldersLoading*(self: TokenModel, chainId: int, contractAddress: string, value: bool) =
@@ -147,7 +140,6 @@ QtObject:
 
     self.items[itemIdx].tokenHoldersLoading = value
     let index = self.createIndex(itemIdx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.TokenHoldersLoading.int])
 
   proc countChanged(self: TokenModel) {.signal.}

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -57,8 +57,6 @@ QtObject:
   proc updateRemoteDestructState*(self: TokenOwnersModel, remoteDestructedAddresses: seq[string]) =
     let indexBegin = self.createIndex(0, 0, nil)
     let indexEnd = self.createIndex(self.items.len - 1, 0, nil)
-    defer: indexBegin.delete
-    defer: indexEnd.delete
     for i in 0 ..< self.items.len:
       self.items[0].remotelyDestructState = remoteDestructTransactionStatus(remoteDestructedAddresses, self.items[0].ownerDetails.address)
     self.dataChanged(indexBegin, indexEnd, @[ModelRole.RemotelyDestructState.int])

--- a/src/app/modules/main/ephemeral_notification_model.nim
+++ b/src/app/modules/main/ephemeral_notification_model.nim
@@ -101,7 +101,6 @@ QtObject:
 
   proc addItem*(self: Model, item: Item) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
@@ -113,7 +112,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -99,7 +99,6 @@ QtObject:
 
   proc addItem*(self: Model, item: Item) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -121,7 +121,6 @@ QtObject:
       return
 
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
 
     self.items[i].installation = installation
     self.dataChanged(index, index, @[
@@ -141,7 +140,6 @@ QtObject:
       return
 
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
 
     self.items[i].installation.metadata.name = name
     self.dataChanged(index, index, @[ModelRole.Name.int])

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -103,5 +103,4 @@ QtObject:
     self.items[ind].isPending = pendingStatus
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.IsPending.int])

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -77,7 +77,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
@@ -90,7 +89,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -161,7 +161,6 @@ QtObject:
     roles.add(ModelRole.Customized.int)
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, roles)
 
   proc updateName*(self: Model, id: string, name: string) =
@@ -172,7 +171,6 @@ QtObject:
     self.items[ind].name = name
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Name.int])
 
   proc updateItem*(self: Model, id, name, image, color: string) =
@@ -190,5 +188,4 @@ QtObject:
       return
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, roles)

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -100,7 +100,6 @@ QtObject:
       position = self.items.len
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, position, position)
     self.items.insert(item, position)
@@ -112,7 +111,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, 0, items.len - 1)
     self.items = items
@@ -133,7 +131,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)

--- a/src/app/modules/main/profile_section/sync/model.nim
+++ b/src/app/modules/main/profile_section/sync/model.nim
@@ -45,7 +45,6 @@ QtObject:
 
   proc addItem*(self: Model, item: Item) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
@@ -56,7 +55,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     let first = self.items.len
     let last = first + items.len - 1

--- a/src/app/modules/main/profile_section/waku/model.nim
+++ b/src/app/modules/main/profile_section/waku/model.nim
@@ -41,7 +41,6 @@ QtObject:
 
   proc addItem*(self: Model, item: Item) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
@@ -52,7 +51,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     let first = self.items.len
     let last = first + items.len - 1

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -113,9 +113,7 @@ QtObject:
       return false
 
     let sourceIndex = newQModelIndex()
-    defer: sourceIndex.delete
     let destIndex = newQModelIndex()
-    defer: destIndex.delete
 
     var destRow = toRow
     if toRow > fromRow:

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -73,7 +73,6 @@ QtObject:
         item.colorId = account.colorId
         item.emoji = account.emoji
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Name.int, ModelRole.ColorId.int, ModelRole.Emoji.int])
         break
       i.inc

--- a/src/app/modules/main/stickers/models/sticker_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_list.nim
@@ -54,7 +54,6 @@ QtObject:
     if(self.stickers.any(proc(existingSticker: Item): bool = return existingSticker.getHash == sticker.getHash)):
       return
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginInsertRows(modelIndex, 0, 0)
     self.stickers.insert(sticker, 0)
     self.endInsertRows()
@@ -70,7 +69,6 @@ QtObject:
     if idx == -1:
       return
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginRemoveRows(modelIndex, idx, idx)
     self.stickers.delete(idx)
     self.endRemoveRows()

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -117,7 +117,6 @@ QtObject:
     if idx == -1:
       return
     let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
     self.packs.apply(proc(it: var StickerPackView) =
       if it.pack.id == packId:
         it.installed = installed

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -101,7 +101,6 @@ QtObject:
 
   proc addStickerPackToList*(self: StickerPackList, pack: PackItem, stickers: StickerList, installed, bought, pending: bool) =
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginInsertRows(modelIndex, 0, 0)
     self.packs.insert((pack: pack, stickers: stickers, installed: installed, bought: bought, pending: pending), 0)
     self.endInsertRows()
@@ -109,7 +108,6 @@ QtObject:
   proc removeStickerPackFromList*(self: StickerPackList, packId: string) =
     let idx = self.findIndexById(packId)
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginRemoveRows(modelIndex, idx, idx)
     self.packs.delete(idx)
     self.endRemoveRows()

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -78,7 +78,6 @@ QtObject:
     if (index < 0 or index >= self.items.len):
       return
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
     self.endRemoveRows()
@@ -87,7 +86,6 @@ QtObject:
     if (index < 0 or index > self.items.len):
       return
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, index, index)
     self.items.insert(item, index)
     self.endInsertRows()

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -117,7 +117,6 @@ QtObject:
       let index = self.findAccountIndex(account)
       if index >= 0:
         let qIndex = self.createIndex(i, 0, nil)
-        defer: qIndex.delete
 
         self.items[index] = account
         self.dataChanged(qIndex, qIndex)
@@ -135,7 +134,6 @@ QtObject:
       if i >= 0:
         self.items[i] = account
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index)
       else:
         self.insertItem(account, self.getCount())
@@ -196,7 +194,6 @@ QtObject:
     self.items[i].setBalance(balance)
     self.items[i].setAssetsLoading(assetsLoading)
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.CurrencyBalance.int, ModelRole.AssetsLoading.int])
 
   proc updateAccountHiddenFromTotalBalance*(self: Model, address: string, hideFromTotalBalance: bool) =
@@ -205,7 +202,6 @@ QtObject:
       return
     self.items[i].setHideFromTotalBalance(hideFromTotalBalance)
     let index = self.createIndex(i, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.HideFromTotalBalance.int])
 
   proc updateAccountsPositions*(self: Model, values: Table[string, int]) =
@@ -216,9 +212,6 @@ QtObject:
       self.items[i].setPosition(position)
     let firstIndex = self.createIndex(0, 0, nil)
     let lastIndex = self.createIndex(self.rowCount() - 1, 0, nil)
-    defer: 
-      firstIndex.delete
-      lastIndex.delete
     self.dataChanged(firstIndex, lastIndex, @[ModelRole.Position.int])
 
   proc deleteAccount*(self: Model, address: string) =

--- a/src/app/modules/main/wallet_section/activity/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_model.nim
@@ -118,7 +118,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     # Start after the current last real item
     let startIdx = self.items.len
@@ -135,7 +134,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
   
     # Start from the beginning
     let startIdx = 0

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -87,7 +87,6 @@ QtObject:
       self.resetModel(newEntries)
     else:
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
 
       if offset != self.entries.len:
         error "offset != self.entries.len"
@@ -102,7 +101,6 @@ QtObject:
 
   proc addNewEntries*(self: Model, newEntries: seq[entry.ActivityEntry], insertPositions: seq[int]) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     for j in countdown(newEntries.high, 0):
       let ae = newEntries[j]

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -135,7 +135,6 @@ QtObject:
       if cmpIgnoreCase(self.entries[i].getSender(), address) == 0 or
         cmpIgnoreCase(self.entries[i].getRecipient(), address) == 0:
           let index = self.createIndex(i, 0, nil)
-          defer: index.delete
           self.dataChanged(index, index, @[ModelRole.ActivityEntryRole.int])
 
   proc refreshAmountCurrency*(self: Model, currencyService: Service) =

--- a/src/app/modules/main/wallet_section/activity/recipients_model.nim
+++ b/src/app/modules/main/wallet_section/activity/recipients_model.nim
@@ -74,7 +74,6 @@ QtObject:
       self.endResetModel()
     else:
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
 
       if offset != self.addresses.len:
         error "offset != self.addresses.len"

--- a/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
@@ -150,8 +150,6 @@ QtObject:
     if self.delegate.getFlatTokensList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getFlatTokensList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.MarketDetails.int, ModelRole.MarketDetailsLoading.int])
 
   proc tokensMarketValuesUpdated*(self: FlatTokensModel) =
@@ -164,8 +162,6 @@ QtObject:
     if self.delegate.getFlatTokensList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getFlatTokensList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Description.int, ModelRole.WebsiteUrl.int, ModelRole.DetailsLoading.int])
 
   proc tokensDetailsAboutToUpdate*(self: FlatTokensModel) =
@@ -182,6 +178,4 @@ QtObject:
     if self.delegate.getFlatTokensList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getFlatTokensList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Visible.int, ModelRole.Position.int])

--- a/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
@@ -154,32 +154,24 @@ QtObject:
       if self.delegate.getTokenBySymbolList().len > 0:
         let index = self.createIndex(0, 0, nil)
         let lastindex = self.createIndex(self.delegate.getTokenBySymbolList().len-1, 0, nil)
-        defer: index.delete
-        defer: lastindex.delete
         self.dataChanged(index, lastindex, @[ModelRole.MarketDetails.int, ModelRole.MarketDetailsLoading.int])
 
   proc tokensMarketValuesAboutToUpdate*(self: TokensBySymbolModel) =
     if self.delegate.getTokenBySymbolList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getTokenBySymbolList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.MarketDetails.int, ModelRole.MarketDetailsLoading.int])
 
   proc tokensDetailsAboutToUpdate*(self: TokensBySymbolModel) =
     if self.delegate.getTokenBySymbolList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getTokenBySymbolList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Description.int, ModelRole.WebsiteUrl.int, ModelRole.DetailsLoading.int])
 
   proc tokensDetailsUpdated*(self: TokensBySymbolModel) =
     if self.delegate.getTokenBySymbolList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getTokenBySymbolList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Description.int, ModelRole.WebsiteUrl.int, ModelRole.DetailsLoading.int])
 
   proc currencyFormatsUpdated*(self: TokensBySymbolModel) =
@@ -190,6 +182,4 @@ QtObject:
     if self.delegate.getTokenBySymbolList().len > 0:
       let index = self.createIndex(0, 0, nil)
       let lastindex = self.createIndex(self.delegate.getTokenBySymbolList().len-1, 0, nil)
-      defer: index.delete
-      defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Visible.int, ModelRole.Position.int])

--- a/src/app/modules/main/wallet_section/send/network_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_route_model.nim
@@ -105,7 +105,6 @@ QtObject:
   proc reset*(self: NetworkRouteModel) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
-      defer: index.delete
       self.items[i].amountIn = ""
       self.items[i].amountOut = ""
       self.items[i].resetToNetworks()
@@ -122,7 +121,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getChainId() == chainId):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].tokenBalance = tokenBalance
         self.dataChanged(index, index, @[ModelRole.TokenBalance.int])
 
@@ -130,7 +128,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if path.getfromNetwork() == self.items[i].getChainId():
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].amountIn = path.getAmountIn()
         self.items[i].toNetworks = path.getToNetwork()
         self.items[i].hasGas = hasGas
@@ -141,7 +138,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if path.getToNetwork() == self.items[i].getChainId():
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         if self.items[i].getAmountOut().len != 0:
           self.items[i].amountOut = $(stint.u256(self.items[i].getAmountOut()) + stint.u256(path.getAmountOut()))
         else:
@@ -151,7 +147,6 @@ QtObject:
   proc resetPathData*(self: NetworkRouteModel) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
-      defer: index.delete
       self.items[i].amountIn = ""
       self.items[i].resetToNetworks()
       self.items[i].hasGas = true
@@ -177,7 +172,6 @@ QtObject:
     try:
       for i in 0 ..< self.items.len:
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].isRoutePreferred = false
         self.items[i].isRouteEnabled = false
         if chainIds.len == 0:
@@ -197,7 +191,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if not self.items[i].getIsRoutePreferred():
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].isRouteEnabled = false
         self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
 
@@ -205,14 +198,12 @@ QtObject:
     for i in 0 ..< self.items.len:
       if not self.items[i].getIsRoutePreferred():
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].isRouteEnabled = true
         self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
 
   proc setAllNetworksAsRoutePreferredChains*(self: NetworkRouteModel) {.slot.} =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
-      defer: index.delete
       self.items[i].isRoutePreferred = true
       self.dataChanged(index, index, @[ModelRole.IsRoutePreferred.int])
 
@@ -220,7 +211,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getChainId() == chainId):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].isRouteEnabled = not self.items[i].getIsRouteEnabled()
         self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
 
@@ -228,7 +218,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getChainId() == chainId):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].isRouteEnabled = not disabled
         self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
 
@@ -244,7 +233,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getChainId() == chainId):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].locked = lock
         self.dataChanged(index, index, @[ModelRole.Locked.int])
         if self.items[i].getLocked():

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -47,7 +47,6 @@ QtObject:
     if isSome(data.ownership):
       let ownership = data.ownership.get()
       self.ownership.setItems(ownership)
-    self.setup()
 
   proc `$`*(self: CollectiblesEntry): string =
     return fmt"""CollectiblesEntry(

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -212,7 +212,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     # Start after the current last real item
     let startIdx = self.items.len
@@ -229,7 +228,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, idx, idx)
     self.items.delete(idx)

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -310,7 +310,6 @@ QtObject:
         let update = updates[j]
         if entry.updateDataIfSameID(update):
           let index = self.createIndex(i, 0, nil)
-          defer: index.delete
           self.dataChanged(index, index)
           anyUpdated = true
           break

--- a/src/app/modules/shared_models/derived_address_model.nim
+++ b/src/app/modules/shared_models/derived_address_model.nim
@@ -90,7 +90,6 @@ QtObject:
         item = self.items[i]
        
         let parentModelIndex = newQModelIndex()
-        defer: parentModelIndex.delete
         self.beginRemoveRows(parentModelIndex, i, i)
         self.items.delete(i)
         self.endRemoveRows()
@@ -106,7 +105,6 @@ QtObject:
       indexToInsertTo.inc
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, indexToInsertTo, indexToInsertTo)
     self.items.insert(
       newDerivedAddressItem(item.getOrder(), item.getAddress(), item.getPublicKey(), item.getPath(), item.getAlreadyCreated(), 

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -68,7 +68,6 @@ QtObject:
 
   proc addItem*(self: KeyPairAccountModel, item: KeyPairAccountItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
@@ -107,7 +106,6 @@ QtObject:
     if (index < 0 or index >= self.items.len):
       return
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
     self.endRemoveRows()

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -64,7 +64,6 @@ QtObject:
 
   proc addItem*(self: KeyPairModel, item: KeyPairItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -170,7 +170,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
@@ -196,9 +195,7 @@ QtObject:
       return
 
     let sourceIndex = newQModelIndex()
-    defer: sourceIndex.delete
     let destIndex = newQModelIndex()
-    defer: destIndex.delete
 
     let currentItem = self.items[fromRow]
     self.beginMoveRows(sourceIndex, fromRow, fromRow, destIndex, to)
@@ -246,7 +243,6 @@ QtObject:
       item.linkPreview = linkPreview
 
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
       self.beginInsertRows(parentModelIndex, i, i)
       self.items.insert(item, i)
       self.endInsertRows()

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -210,7 +210,6 @@ QtObject:
       item.unfurled = true
       item.linkPreview = linkPreviews[item.linkPreview.url]
       let modelIndex = self.createIndex(row, 0, nil)
-      defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex)
 
   proc setUrls*(self: Model, urls: seq[string]) =
@@ -262,7 +261,6 @@ QtObject:
     self.items[index].markAsImmutable()
 
     let modelIndex = self.createIndex(index, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex)
 
   proc removeAllPreviewData*(self: Model) {.slot.} =
@@ -271,8 +269,6 @@ QtObject:
   
     let indexStart = self.createIndex(0, 0, nil)
     let indexEnd = self.createIndex(self.items.len, 0, nil)
-    defer: indexStart.delete
-    defer: indexEnd.delete
     self.dataChanged(indexStart, indexEnd)
       
   proc getLinkPreviewType*(self: Model, url: string): int {.slot.} =
@@ -311,7 +307,6 @@ QtObject:
       return
     item.loadingLocalData = value
     let modelIndex = self.createIndex(row, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.LoadingLocalData.int])
 
   proc setItemIsLocalData(self: Model, row: int, item: Item) = 
@@ -323,7 +318,6 @@ QtObject:
       item.loadingLocalData = false
       roles.add(ModelRole.LoadingLocalData.int)
     let modelIndex = self.createIndex(row, 0, nil)
-    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, roles)
 
   proc setContactInfo*(self: Model, contactDetails: ContactDetails) =

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -257,7 +257,6 @@ QtObject:
       roles.add(ModelRole.PreferredDisplayName.int)
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, roles)
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
@@ -271,7 +270,6 @@ QtObject:
     self.items[ind].icon = icon
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Icon.int])
 
   proc updateItem*(
@@ -335,7 +333,6 @@ QtObject:
 
     if callDataChanged:
       let index = self.createIndex(ind, 0, nil)
-      defer: index.delete
       self.dataChanged(index, index, roles)
 
     return roles
@@ -377,8 +374,6 @@ QtObject:
 
     let startModelIndex = self.createIndex(startIndex, 0, nil)
     let endModelIndex = self.createIndex(endIndex, 0, nil)
-    defer: startModelIndex.delete
-    defer: endModelIndex.delete
     self.dataChanged(startModelIndex, endModelIndex, allRoles)
 
 
@@ -464,7 +459,6 @@ QtObject:
 
     self.items[idx].onlineStatus = onlineStatus
     let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.OnlineStatus.int
     ])
@@ -479,7 +473,6 @@ QtObject:
 
     self.items[idx].airdropAddress = airdropAddress
     let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.AirdropAddress.int
     ])
@@ -505,7 +498,6 @@ QtObject:
 
     self.items[idx].requestToJoinLoading = requestToJoinLoading
     let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.RequestToJoinLoading.int
     ])
@@ -520,7 +512,6 @@ QtObject:
 
     self.items[idx].membershipRequestState = membershipRequestState
     let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.MembershipRequestState.int
     ])

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -172,7 +172,6 @@ QtObject:
 
   proc addItem*(self: Model, item: MemberItem) =
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginInsertRows(modelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
@@ -196,7 +195,6 @@ QtObject:
 
   proc removeItemWithIndex(self: Model, index: int) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
@@ -225,7 +223,6 @@ QtObject:
       return
 
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
 
     let first = self.items.len
     let last = first + items.len - 1

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -394,7 +394,6 @@ QtObject:
 
   proc insertItems(self: Model, position: int, items: seq[Item]) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     # Update replied to messages if there are
     # We update replies before adding, since we do not need to update the new items, they should already be up to date
@@ -489,7 +488,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
@@ -762,7 +760,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
@@ -782,7 +779,6 @@ QtObject:
     let position = index + 1
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, position, position)
     self.items.insert(initNewMessagesMarkerItem(self.items[index].clock, self.items[index].timestamp), position)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -364,7 +364,6 @@ QtObject:
 
   proc updateItemAtIndex(self: Model, index: int) =
     let ind = self.createIndex(index, 0, nil)
-    defer: ind.delete
     self.dataChanged(ind, ind)
 
   proc findIndexForMessageId*(self: Model, messageId: string): int =
@@ -410,7 +409,6 @@ QtObject:
           oldItem.quotedMessageText = newItem.unparsedText
           oldItem.quotedMessageContentType = newItem.contentType
           let index = self.createIndex(i, 0, nil)
-          defer: index.delete
           self.dataChanged(index, index, @[
             ModelRole.QuotedMessageFrom.int,
             ModelRole.QuotedMessageAuthorDisplayName.int,
@@ -471,7 +469,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].responseToMessageWithId == messageId):
         let ind = self.createIndex(i, 0, nil)
-        defer: ind.delete
         var item = self.items[i]
         item.quotedMessageText = ""
         item.quotedMessageParsedText = ""
@@ -509,7 +506,6 @@ QtObject:
       return
 
     let ind = self.createIndex(i, 0, nil)
-    defer: ind.delete
 
     var item = self.items[i]
     item.messageText = ""
@@ -551,7 +547,6 @@ QtObject:
       return
     self.items[ind].outgoingStatus = status
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.OutgoingStatus.int])
 
   proc itemSending*(self: Model, messageId: string) =
@@ -572,7 +567,6 @@ QtObject:
       return
     self.items[ind].resendError = error
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.ResendError.int])
 
   proc addReaction*(self: Model, messageId: string, emojiId: EmojiId, didIReactWithThisEmoji: bool,
@@ -584,7 +578,6 @@ QtObject:
     self.items[ind].addReaction(emojiId, didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Reactions.int])
 
   proc removeReaction*(self: Model, messageId: string, emojiId: EmojiId, reactionId: string, didIRemoveThisReaction: bool) =
@@ -595,7 +588,6 @@ QtObject:
     self.items[ind].removeReaction(emojiId, reactionId, didIRemoveThisReaction)
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Reactions.int])
 
   proc pinUnpinMessage*(self: Model, messageId: string, pinned: bool, pinnedBy: string) =
@@ -610,7 +602,6 @@ QtObject:
     self.items[ind].pinnedBy = pinnedBy
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Pinned.int, ModelRole.PinnedBy.int])
 
   proc getMessageByIdAsJson*(self: Model, messageId: string): JsonNode =
@@ -655,7 +646,6 @@ QtObject:
 
       if(roles.len > 0):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, roles)
 
   proc setEditModeOn*(self: Model, messageId: string)  =
@@ -666,7 +656,6 @@ QtObject:
     self.items[ind].editMode = true
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.EditMode.int])
 
   proc setEditModeOff*(self: Model, messageId: string)  =
@@ -677,7 +666,6 @@ QtObject:
     self.items[ind].editMode = false
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.EditMode.int])
 
   proc updateEditedMsg*(
@@ -705,7 +693,6 @@ QtObject:
     self.items[ind].parsedText = updatedParsedText
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.MessageText.int,
       ModelRole.UnparsedText.int,
@@ -723,7 +710,6 @@ QtObject:
         self.items[i].quotedMessageText = updatedRawMsg
         self.items[i].quotedMessageContentType = contentType
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[
           ModelRole.QuotedMessageText.int,
           ModelRole.QuotedMessageParsedText.int,
@@ -797,7 +783,6 @@ QtObject:
       if not item.seen:
         item.seen = true
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Seen.int])
 
   proc setMessageMarker*(self: Model, messageId: string) =
@@ -813,7 +798,6 @@ QtObject:
       if item.id == messageId and item.seen:
         item.seen = false
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Seen.int])
         break
 
@@ -827,7 +811,6 @@ QtObject:
       if messagesSet.contains(currentItemID):
         self.items[i].seen = true
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Seen.int])
         messagesSet.excl(currentItemID)
 
@@ -856,7 +839,6 @@ QtObject:
         item.albumMessageIds = albumMessagesIds
 
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.AlbumMessageImages.int])
         return true
     return false

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -113,7 +113,6 @@ QtObject:
         return
       self.items[ind].addReaction(didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
       let index = self.createIndex(ind, 0, nil)
-      defer: index.delete
       self.dataChanged(index, index)
     else:
       let parentModelIndex = newQModelIndex()
@@ -144,5 +143,4 @@ QtObject:
       self.countChanged()
     else:
       let index = self.createIndex(ind, 0, nil)
-      defer: index.delete
       self.dataChanged(index, index)

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -117,7 +117,6 @@ QtObject:
       self.dataChanged(index, index)
     else:
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
 
       var item = initMessageReactionItem(emojiId)
       item.addReaction(didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
@@ -138,7 +137,6 @@ QtObject:
     if(self.items[ind].numberOfReactions() == 0):
       # remove item if there are no reactions for this emoji id
       let parentModelIndex = newQModelIndex()
-      defer: parentModelIndex.delete
 
       self.beginRemoveRows(parentModelIndex, ind, ind)
       self.items.delete(ind)

--- a/src/app/modules/shared_models/payment_request_model.nim
+++ b/src/app/modules/shared_models/payment_request_model.nim
@@ -75,7 +75,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
@@ -83,7 +82,6 @@ QtObject:
 
   proc insertItem(self: Model, paymentRequest: PaymentRequest) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(paymentRequest)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -215,7 +215,6 @@ QtObject:
 
   proc addItem*(self: SectionModel, item: SectionItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     if not self.itemExists(item.id):
       self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
@@ -226,7 +225,6 @@ QtObject:
 
   proc addItem*(self: SectionModel, item: SectionItem, index: int) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     if not self.itemExists(item.id):
       self.beginInsertRows(parentModelIndex, index, index)
@@ -240,7 +238,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     let first = self.items.len
     let last = first + items.len - 1
@@ -263,7 +260,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -277,7 +277,6 @@ QtObject:
 
     self.items[index].muted = muted 
     let dataIndex = self.createIndex(index, 0, nil)
-    defer: dataIndex.delete
     self.dataChanged(dataIndex, dataIndex, @[ModelRole.Muted.int])
 
   proc editItem*(self: SectionModel, item: SectionItem) =
@@ -326,7 +325,6 @@ QtObject:
       return
 
     let dataIndex = self.createIndex(ind, 0, nil)
-    defer: dataIndex.delete
     self.dataChanged(dataIndex, dataIndex, roles)
 
   proc updateMemberItemInSections*(
@@ -387,13 +385,11 @@ QtObject:
     for i in 0 ..< self.items.len:
       if self.items[i].active:
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].active = false
         self.dataChanged(index, index, @[ModelRole.Active.int])
 
       if self.items[i].id == id:
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].active = true
 
         self.dataChanged(index, index, @[ModelRole.Active.int])
@@ -409,7 +405,6 @@ QtObject:
           if self.items[i].enabled == value:
             continue
           let index = self.createIndex(i, 0, nil)
-          defer: index.delete
           self.items[i].enabled = value
           self.dataChanged(index, index, @[ModelRole.Enabled.int])
     else:
@@ -425,8 +420,6 @@ QtObject:
 
       let topIndex = self.createIndex(topInd, 0, nil)
       let bottomIndex = self.createIndex(bottomInd, 0, nil)
-      defer: topIndex.delete
-      defer: bottomIndex.delete
       self.dataChanged(topIndex, bottomIndex, @[ModelRole.Enabled.int])
 
     # This signal is emitted to update buttons visibility in the left navigation bar,
@@ -452,7 +445,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if self.items[i].id == id:
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
 
         if self.items[i].isPendingOwnershipRequest == isPending:
           return
@@ -473,7 +465,6 @@ QtObject:
           return
 
         let index = self.createIndex(ind, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, roles)
         self.notificationsCountChanged()
         return
@@ -488,7 +479,6 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].id == id):
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].appendCommunityToken(item)
         return
 

--- a/src/app/modules/shared_models/token_criteria_model.nim
+++ b/src/app/modules/shared_models/token_criteria_model.nim
@@ -88,7 +88,6 @@ QtObject:
 
   proc addItem*(self: TokenCriteriaModel, item: TokenCriteriaItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -72,7 +72,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     let first = self.items.len
     let last = first + items.len - 1
     self.beginInsertRows(parentModelIndex, first, last)

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -70,6 +70,5 @@ QtObject:
       if self.items[i].getKey() == chatId:
         self.items[i] = initTokenPermissionChatListItem(chatId, newName)
         let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.ChannelName.int])
         return

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -51,7 +51,6 @@ QtObject:
 
   proc addItem*(self: TokenPermissionChatListModel, item: TokenPermissionChatListItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -101,7 +101,6 @@ QtObject:
 
   proc addItem*(self: TokenPermissionsModel, item: TokenPermissionItem) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
@@ -122,7 +121,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, idx, idx)
     self.items.delete(idx)

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -149,7 +149,6 @@ QtObject:
     self.items[idx].state = item.state
 
     let index = self.createIndex(idx, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.Type.int,
       ModelRole.TokenCriteria.int,

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -253,7 +253,6 @@ QtObject:
       return
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, roles)
 
   proc setIcon*(self: Model, pubKey: string, icon: string) =
@@ -264,7 +263,6 @@ QtObject:
     self.items[ind].icon = icon
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Icon.int])
 
   proc updateItem*(
@@ -332,7 +330,6 @@ QtObject:
       return
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, roles)
 
   proc updateItem*(
@@ -384,7 +381,6 @@ QtObject:
     self.items[ind].trustStatus = trustStatus
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.TrustStatus.int, ModelRole.IsUntrustworthy.int, ModelRole.IsVerified.int])
 
   proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =
@@ -398,7 +394,6 @@ QtObject:
     self.items[ind].onlineStatus = onlineStatus
 
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.OnlineStatus.int])
 
 

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -179,7 +179,6 @@ QtObject:
       return
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     let first = self.items.len
     let last = first + items.len - 1
@@ -203,7 +202,6 @@ QtObject:
     let position = self.items.len
 
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, position, position)
     self.items.insert(item, position)
@@ -222,7 +220,6 @@ QtObject:
 
   proc removeItemWithIndex(self: Model, index: int) =
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
 
     self.beginRemoveRows(parentModelIndex, index, index)
     let pubKey = self.items[index].pubKey

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
@@ -47,7 +47,6 @@ QtObject:
 
   proc addItem*(self: KeycardModel, item: KeycardItem) =
     let modelIndex = newQModelIndex()
-    defer: modelIndex.delete
     self.beginInsertRows(modelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
@@ -63,7 +62,6 @@ QtObject:
     if (index < 0 or index >= self.items.len):
       return
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
     self.endRemoveRows()

--- a/src/app/modules/startup/models/fetching_data_model.nim
+++ b/src/app/modules/startup/models/fetching_data_model.nim
@@ -132,7 +132,6 @@ QtObject:
     if(ind == -1):
       return
     let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
     self.endRemoveRows()

--- a/src/app/modules/startup/models/fetching_data_model.nim
+++ b/src/app/modules/startup/models/fetching_data_model.nim
@@ -95,7 +95,6 @@ QtObject:
     self.items[ind].receivedMessageAtPosition(position)
     self.reevaluateAllTotals()
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.LoadedMessages.int])
 
   proc evaluateWhetherToProcessReceivedData*(self: Model, backedUpMsgClock: uint64, entities: seq[tuple[entity: string, icon: string]]): bool =
@@ -122,7 +121,6 @@ QtObject:
     self.items[ind].totalMessages = totalMessages
     self.reevaluateAllTotals()
     let index = self.createIndex(ind, 0, nil)
-    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.TotalMessages.int, ModelRole.LoadedMessages.int])
 
   proc removeSection*(self: Model, entity: string) =


### PR DESCRIPTION
### What does the PR do

This PR continues the work done for https://github.com/status-im/status-desktop/pull/17643

Changes:
- Remove explicit delete in case of QModelIndex. It will register its own finalizer
- Fix memory leaks in case of collectibles updates. The `QObject.setup` was called when the data changes
- Avoid double delete on QSettings. This was producing a sanitizer error. The instance will be collected by the GC. 
