### PR TITLE
StatusQ: Set file selector for qt6 along with types registration

### DIFF
--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -56,10 +56,6 @@ int main(int argc, char *argv[])
 
     QQmlApplicationEngine engine;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    engine.setExtraFileSelectors({"qt6"});
-#endif
-
     const QStringList additionalImportPaths {
         STATUSQ_MODULE_IMPORT_PATH,
         QML_IMPORT_ROOT + QStringLiteral("/../ui/app"),

--- a/ui/StatusQ/sandbox/sandboxapp.cpp
+++ b/ui/StatusQ/sandbox/sandboxapp.cpp
@@ -53,10 +53,6 @@ void SandboxApp::restartEngine()
     m_engine = std::make_unique<QQmlApplicationEngine>();
     m_engine->addImportPath(STATUSQ_MODULE_IMPORT_PATH);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    m_engine->setExtraFileSelectors({"qt6"});
-#endif
-
     if (firstRun)
         qDebug() << "QQmlEngine import paths: " << m_engine->importPathList();
 

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -40,6 +40,12 @@
 #include "onboarding/enums.h"
 
 void registerStatusQTypes() {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QByteArrayList selectors = qgetenv("QT_FILE_SELECTORS").split(',');
+    selectors << QByteArrayLiteral("qt6");
+    qputenv("QT_FILE_SELECTORS", selectors.join(","));
+#endif
+
     qmlRegisterType<StatusWindow>("StatusQ", 0, 1, "StatusWindow");
     qmlRegisterType<StatusSyntaxHighlighter>("StatusQ", 0, 1, "StatusSyntaxHighlighter");
     qmlRegisterType<RXValidator>("StatusQ", 0, 1, "RXValidator");


### PR DESCRIPTION
### What does the PR do

- sets file selector for StatusQ
- removes per-app selectors from storybook/sanbox

Closes: #17650

### Affected areas
`StatusQ` types registration

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
