### PR TITLE
chore: replace deprecated `RegExpValidator` with `RegularExpressionValidator` for qt 6 compat

### DIFF
--- a/ui/imports/shared/views/PasswordConfirmationView.qml
+++ b/ui/imports/shared/views/PasswordConfirmationView.qml
@@ -74,7 +74,7 @@ ColumnLayout {
         Layout.alignment: Qt.AlignHCenter
         placeholderText: qsTr("Confirm your password (again)")
         echoMode: showPassword ? TextInput.Normal : TextInput.Password
-        validator: RegExpValidator { regExp: /^[!-~]+$/ } // That includes NOT extended ASCII printable characters less space
+        validator: RegularExpressionValidator { regularExpression: /^[!-~]+$/ } // That includes NOT extended ASCII printable characters less space
         maximumLength: Constants.maxPasswordLength // a maximum of 100 characters allowed
         rightPadding: showHideCurrentIcon.width + showHideCurrentIcon.anchors.rightMargin + Theme.padding / 2
         onTextChanged: {


### PR DESCRIPTION
### What does the PR do

- Replaces `RegExpValidator` with `RegularExpressionValidator` as the former is deprecated in qt 5 and removed from qt 6.

Closes: #17644

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

