### PR TITLE
feat(qt5 -> 6 - SQ/StatusFileDialog): Created new `StatusSaveFileDialog` component

### DIFF
--- a/storybook/pages/StatusSaveFileDialogPage.qml
+++ b/storybook/pages/StatusSaveFileDialogPage.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+import StatusQ.Popups.Dialog 0.1
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Rectangle {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        color: "lightgray"
+
+        Button {
+            anchors.centerIn: parent
+            text: "Download"
+            onClicked: dlgSave.open()
+        }
+
+        StatusSaveFileDialog {
+            id: dlgSave
+
+            title: titleText.text
+            acceptLabel: qsTr("Save")
+            selectedFile: documentsLocation + "/messages.json"
+            defaultSuffix: "json"
+
+            onAccepted: {
+                logs.logEvent("StatusFileDialog::onAccepted - dlgSave --> Selected File " + dlgSave.selectedFile)
+            }
+            onRejected: logs.logEvent("StatusFileDialog::onRejected - dlgSave")
+            onTitleChanged: logs.logEvent("StatusFileDialog::onTitleChanged - dlgSave --> " + dlgSave.title)
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 300
+        SplitView.preferredHeight: 300
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            width: parent.width
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                Label {
+                    text: "Title:\t"
+                }
+
+                TextField {
+                    id: titleText
+
+                    text: "Choose files to import"
+                }
+            }
+        }
+    }
+}
+
+// category: Dialogs
+// status: good

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/+qt6/StatusSaveFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/+qt6/StatusSaveFileDialog.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import QtQuick.Dialogs
+import QtCore
+
+import StatusQ.Core.Utils 0.1
+
+QObject {
+    id: root
+
+    property alias title: dlg.title
+    property alias selectedFile: dlg.selectedFile
+    property alias acceptLabel: dlg.acceptLabel
+    property alias defaultSuffix: dlg.defaultSuffix
+
+    readonly property string picturesShortcut: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
+    readonly property string documentsLocation: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+
+    signal accepted
+    signal rejected
+
+    function open() {
+        dlg.open()
+    }
+
+    function close() {
+        dlg.close()
+    }
+
+    FileDialog {
+        id: dlg
+
+        fileMode: FileDialog.SaveFile
+
+        onAccepted: root.accepted()
+        onRejected: root.rejected()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusSaveFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusSaveFileDialog.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.15
+import Qt.labs.platform 1.1
+
+// Since this is a temporal component, it will be wrapped into this visual item since wrapping the
+// FileDialog into a SQUtils.QObject it does not open the dialog in macos
+Item {
+    id: root
+
+    property alias title: dlg.title
+    property alias selectedFile: dlg.currentFile
+    property alias acceptLabel: dlg.acceptLabel
+    property alias defaultSuffix: dlg.defaultSuffix
+
+    readonly property string picturesShortcut: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
+    readonly property string documentsLocation: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+
+    signal accepted
+    signal rejected
+
+    function open() {
+        dlg.open()
+    }
+
+    function close() {
+        dlg.close()
+    }
+
+    FileDialog {
+        id: dlg
+
+        fileMode: FileDialog.SaveFile
+
+        onAccepted: root.accepted()
+        onRejected: root.rejected()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/qmldir
@@ -11,3 +11,4 @@ StatusTitleSubtitle 0.1 StatusTitleSubtitle.qml
 StatusDialogBackground 0.1 StatusDialogBackground.qml
 
 StatusMessageDialog 0.1 StatusMessageDialog.qml
+StatusSaveFileDialog 0.1 StatusSaveFileDialog.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -272,5 +272,7 @@
         <file>StatusQ/Popups/Dialog/StatusFolderDialog.qml</file>
         <file>StatusQ/Popups/Dialog/+qt6/StatusFileDialog.qml</file>
         <file>StatusQ/Popups/Dialog/StatusFileDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/StatusSaveFileDialog.qml</file>
+        <file>StatusQ/Popups/Dialog/+qt6/StatusSaveFileDialog.qml</file>
     </qresource>
 </RCC>

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -1,10 +1,10 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
 
 import StatusQ 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import AppLayouts.Communities.popups 1.0
 import shared.controls.chat.menuItems 1.0
@@ -224,16 +224,15 @@ StatusMenu {
         }
     }
 
-    FileDialog {
+    StatusSaveFileDialog {
         id: downloadDialog
         acceptLabel: qsTr("Save")
-        fileMode: FileDialog.SaveFile
         title: qsTr("Download messages")
-        currentFile: StandardPaths.writableLocation(StandardPaths.DocumentsLocation) + "/messages.json"
+        selectedFile: documentsLocation + "/messages.json"
         defaultSuffix: "json"
 
         onAccepted: {
-            root.downloadMessages(downloadDialog.currentFile)
+            root.downloadMessages(downloadDialog.selectedFile)
         }
     }
 


### PR DESCRIPTION
Closes #17633

### What does the PR do

Although this is not an issue for migrating to qt6, it's been done for consistency with https://github.com/status-im/status-desktop/issues/17561.

- Created `StatusSaveFileDialog` component with basic interface working in both Qt5 and Qt6.
- Created `storybook` page to test the new component.

### Affected areas

`ChatContextMenuView`

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

No impact

### How to test

- There is a `storybook` page
- In the app: Go to a 1:1 chat, right click the user / `Download` option in the context menu
