### PR TITLE
chore: workaround for QTBUG-135039

### DIFF
--- a/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingLayout.qml
@@ -86,7 +86,7 @@ Page {
             d.selectedProfileKeyId = ""
         }
 
-        readonly property Settings settings: Settings {
+        readonly property var settings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
             property bool keycardPromoShown // whether we've seen the keycard promo banner on KeycardIntroPage
 
             function reset() {

--- a/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/LoginScreen.qml
@@ -103,7 +103,7 @@ OnboardingPage {
             }
         }
 
-        readonly property Settings settings: Settings {
+        readonly property var settings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
             category: "Login"
             property string lastKeyUid
         }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -275,13 +275,13 @@ RightTabBaseView {
                         Component.onCompleted: refreshSortSettings()
                         Component.onDestruction: saveSortSettings()
 
-                        readonly property Settings walletSettings: Settings {
+                        readonly property var walletSettings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
                             id: walletSettings
                             category: "walletSettings-" + root.contactsStore.myPublicKey
                             property var assetsViewCustomOrderApplyTimestamp
                         }
 
-                        readonly property Settings settings: Settings {
+                        readonly property var settings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
                             id: settings
                             property int currentSortValue: SortOrderComboBox.TokenOrderDateAdded
                             property var sortOrderUpdateTimestamp
@@ -390,7 +390,7 @@ RightTabBaseView {
                         Component.onCompleted: refreshSortSettings()
                         Component.onDestruction: saveSortSettings()
 
-                        readonly property Settings settings: Settings {
+                        readonly property var settings: Settings { /* https://bugreports.qt.io/browse/QTBUG-135039 */
                             id: settings
                             property int currentSortValue: SortOrderComboBox.TokenOrderDateAdded
                             property real sortOrderUpdateTimestamp: 0


### PR DESCRIPTION
### What does the PR do

Workaround for qt bug affecting Qt 6 build (https://bugreports.qt.io/browse/QTBUG-135039).

Closes: #17645

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`OnboardingLayout`, `LoginScreen`, `RightTabView` (no visual changes)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

No impact