### PR TITLE
UserStatusContextMenu: icon property renamed to avoid conflict on Qt 6

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1452,7 +1452,7 @@ Item {
                     colorHash: appMain.profileStore.colorHash
                     colorId: appMain.profileStore.colorId
                     name: appMain.profileStore.name
-                    icon: appMain.profileStore.icon
+                    headerIcon: appMain.profileStore.icon
                     isEnsVerified: !!appMain.profileStore.preferredName
 
                     currentUserStatus: appMain.profileStore.currentUserStatus

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -11,7 +11,7 @@ StatusMenu {
     property alias compressedPubKey: header.compressedPubKey
     property alias emojiHash: header.emojiHash
     property alias name: header.displayName
-    property alias icon: header.icon
+    property alias headerIcon: header.icon
     property alias colorHash: header.colorHash
     property alias colorId: header.colorId
 


### PR DESCRIPTION
### What does the PR do

In Qt 6 Menu component has final `icon` properly what was conflicting with `icon` property alias defined in UserStatusContextMenu.

Closes: #17647

### Impact on end user
No impact
