### PR TITLE
fix(login): move to main only when the chat is loaded

### DIFF
--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -42,6 +42,7 @@ type
 const SIGNAL_STATUS_URL_ACTIVATED* = "statusUrlActivated"
 const FAKE_LOADING_SCREEN_FINISHED* = "fakeLoadingScreenFinished"
 
+const SIGNAL_MAIN_LOADED* = "signalMainLoaded"
 
 type
   WalletAddressesArgs* = ref object of Args

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -5,7 +5,7 @@ import ephemeral_notification_item, ephemeral_notification_model
 import app/modules/shared_models/[user_item, member_item, member_model, section_item, section_model, section_details]
 import app/modules/shared_models/[color_hash_item, color_hash_model]
 import app/modules/shared_modules/keycard_popup/module as keycard_shared_module
-import app/global/app_sections_config as conf
+import app/global/app_sections_config
 import app/global/app_signals
 import app/global/[global_singleton, feature_flags]
 import app/global/utils as utils
@@ -698,34 +698,18 @@ method load*[T](
 
   var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
-  if activeSectionId == "" or activeSectionId == conf.SETTINGS_SECTION_ID:
-    activeSectionId = conf.WALLET_SECTION_ID
-
-  let loadingItem = initItem(
-    LOADING_SECTION_ID,
-    SectionType.LoadingSection,
-    conf.LOADING_SECTION_NAME,
-    memberRole = MemberRole.Owner,
-    description = "",
-    image = "",
-    icon = conf.LOADING_SECTION_ICON,
-    color = "",
-    hasNotification = false,
-    notificationsCount = 0,
-    active = false,
-    enabled = true,
-  )
-  self.view.model().addItem(loadingItem)
+  if activeSectionId == "" or activeSectionId == SETTINGS_SECTION_ID:
+    activeSectionId = WALLET_SECTION_ID
 
   # Communities Portal Section
   let communitiesPortalSectionItem = initItem(
-    conf.COMMUNITIESPORTAL_SECTION_ID,
+    COMMUNITIESPORTAL_SECTION_ID,
     SectionType.CommunitiesPortal,
-    conf.COMMUNITIESPORTAL_SECTION_NAME,
+    COMMUNITIESPORTAL_SECTION_NAME,
     memberRole = MemberRole.Owner,
     description = "",
     image = "",
-    icon = conf.COMMUNITIESPORTAL_SECTION_ICON,
+    icon = COMMUNITIESPORTAL_SECTION_ICON,
     color = "",
     hasNotification = false,
     notificationsCount = 0,
@@ -738,15 +722,15 @@ method load*[T](
 
   # Wallet Section
   let walletSectionItem = initItem(
-    conf.WALLET_SECTION_ID,
+    WALLET_SECTION_ID,
     SectionType.Wallet,
-    conf.WALLET_SECTION_NAME,
+    WALLET_SECTION_NAME,
     memberRole = MemberRole.Owner,
     description = "",
     introMessage = "",
     outroMessage = "",
     image = "",
-    icon = conf.WALLET_SECTION_ICON,
+    icon = WALLET_SECTION_ICON,
     color = "",
     hasNotification = false,
     notificationsCount = 0,
@@ -759,15 +743,15 @@ method load*[T](
 
   # Node Management Section
   let nodeManagementSectionItem = initItem(
-    conf.NODEMANAGEMENT_SECTION_ID,
+    NODEMANAGEMENT_SECTION_ID,
     SectionType.NodeManagement,
-    conf.NODEMANAGEMENT_SECTION_NAME,
+    NODEMANAGEMENT_SECTION_NAME,
     memberRole = MemberRole.Owner,
     description = "",
     introMessage = "",
     outroMessage = "",
     image = "",
-    icon = conf.NODEMANAGEMENT_SECTION_ICON,
+    icon = NODEMANAGEMENT_SECTION_ICON,
     color = "",
     hasNotification = false,
     notificationsCount = 0,
@@ -780,15 +764,15 @@ method load*[T](
 
   # Profile Section
   let profileSettingsSectionItem = initItem(
-    conf.SETTINGS_SECTION_ID,
+    SETTINGS_SECTION_ID,
     SectionType.ProfileSettings,
-    conf.SETTINGS_SECTION_NAME,
+    SETTINGS_SECTION_NAME,
     memberRole = MemberRole.Owner,
     description = "",
     introMessage = "",
     outroMessage = "",
     image = "",
-    icon = conf.SETTINGS_SECTION_ICON,
+    icon = SETTINGS_SECTION_ICON,
     color = "",
     hasNotification = self.calculateProfileSectionHasNotification(),
     notificationsCount = 0,
@@ -802,15 +786,15 @@ method load*[T](
   if singletonInstance.featureFlags().getTradingCenterEnabled():
     # Trading center Section
     let tradingCenterItem = initItem(
-      conf.TRADING_CENTER_SECTION_ID,
+      TRADING_CENTER_SECTION_ID,
       SectionType.TradingCenter,
-      conf.TRADING_CENTER_SECTION_NAME,
+      TRADING_CENTER_SECTION_NAME,
       memberRole = MemberRole.Owner,
       description = "",
       introMessage = "",
       outroMessage = "",
       image = "",
-      icon = conf.TRADING_CENTER_SECTION_ICON,
+      icon = TRADING_CENTER_SECTION_ICON,
       color = "",
       hasNotification = false,
       notificationsCount = 0,
@@ -823,15 +807,15 @@ method load*[T](
   else:
     # Swap Section
     let swapSectionItem = initItem(
-      conf.SWAP_SECTION_ID,
+      SWAP_SECTION_ID,
       SectionType.Swap,
-      conf.SWAP_SECTION_NAME,
+      SWAP_SECTION_NAME,
       memberRole = MemberRole.Owner,
       description = "",
       introMessage = "",
       outroMessage = "",
       image = "",
-      icon = conf.SWAP_SECTION_ICON,
+      icon = SWAP_SECTION_ICON,
       color = "",
       hasNotification = false,
       notificationsCount = 0,
@@ -855,11 +839,8 @@ method load*[T](
   self.sharedUrlsModule.load()
 
   # Set active section on app start
-  # If section is empty or profile then open the loading section until chats are loaded
-  if activeSection.isEmpty() or activeSection.sectionType == SectionType.ProfileSettings:
-    # Set bogus Item as active until the chat is loaded
-    self.setActiveSection(loadingItem, skipSavingInSettings = true)
-  else:
+  # If section is empty or profile wait until chats are loaded
+  if not activeSection.isEmpty() and activeSection.sectionType != SectionType.ProfileSettings:
     self.setActiveSection(activeSection)
 
 proc isEverythingLoaded[T](self: Module[T]): bool =
@@ -916,8 +897,8 @@ method onChatsLoaded*[T](
   let personalChatSectionItem = initItem(
     myPubKey,
     sectionType = SectionType.Chat,
-    name = conf.CHAT_SECTION_NAME,
-    icon = conf.CHAT_SECTION_ICON,
+    name = CHAT_SECTION_NAME,
+    icon = CHAT_SECTION_ICON,
     hasNotification = unviewedMessagesCount > 0 or unviewedMentionsCount > 0,
     notificationsCount = unviewedMentionsCount,
     active = self.getActiveSectionId() == myPubKey,
@@ -964,18 +945,17 @@ method onChatsLoaded*[T](
 
   self.view.model().addItems(items)
 
+  self.checkIfWeHaveNotifications()
+
+  self.events.emit(SIGNAL_MAIN_LOADED, Args())
+
   # Set active section if it is one of the channel sections
   if not activeSection.isEmpty():
     self.setActiveSection(activeSection)
 
-  # Remove old loading section
-  self.view.model().removeItem(LOADING_SECTION_ID)
-
   self.view.sectionsLoaded()
   if self.statusDeepLinkToActivate != "":
     self.activateStatusDeepLink(self.statusDeepLinkToActivate)
-
-  self.checkIfWeHaveNotifications()
 
 method onCommunityDataLoaded*[T](
   self: Module[T],
@@ -1176,13 +1156,13 @@ method activeSectionSet*[T](self: Module[T], sectionId: string, skipSavingInSett
     return
 
   case sectionId:
-    of conf.COMMUNITIESPORTAL_SECTION_ID:
+    of COMMUNITIESPORTAL_SECTION_ID:
       self.communitiesModule.onActivated()
 
   # If metrics are enabled, send a navigation event
   var sectionIdToSend = sectionId
   if sectionId == singletonInstance.userProfile.getPubKey():
-    sectionIdToSend = conf.CHAT_SECTION_NAME
+    sectionIdToSend = CHAT_SECTION_NAME
   elif sectionId.startsWith("0x"):
     # This is a community
     sectionIdToSend = "community"
@@ -1638,7 +1618,7 @@ method calculateProfileSectionHasNotification*[T](self: Module[T]): bool =
 
 method mnemonicBackedUp*[T](self: Module[T]) =
   self.view.model().updateNotifications(
-    conf.SETTINGS_SECTION_ID,
+    SETTINGS_SECTION_ID,
     self.calculateProfileSectionHasNotification(),
     notificationsCount = 0)
 

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -4,6 +4,7 @@ import uuids
 
 import app/core/eventemitter
 import app/core/signals/types
+import app/global/app_signals
 import app_service/service/general/service as general_service
 import app_service/service/accounts/service as accounts_service
 import app_service/service/accounts/dto/image_crop_rectangle
@@ -127,6 +128,10 @@ proc init*(self: Controller) =
   handlerId = self.events.onWithUUID(SIGNAL_CONVERTING_PROFILE_KEYPAIR) do(e: Args):
     let args = ResultArgs(e)
     self.delegate.onKeycardAccountConverted(args.success)
+  self.connectionIds.add(handlerId)
+
+  handlerId = self.events.onWithUUID(SIGNAL_MAIN_LOADED) do(e: Args):
+    self.delegate.onMainLoaded()
   self.connectionIds.add(handlerId)
 
 proc initialize*(self: Controller, pin: string) =

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -13,6 +13,9 @@ method delete*(self: AccessInterface) {.base.} =
 method onAppLoaded*(self: AccessInterface, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onMainLoaded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onNodeLogin*(self: AccessInterface, error: string, account: AccountDto, settings: SettingsDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -76,7 +76,11 @@ method delete*[T](self: Module[T]) =
   self.controller.delete
 
 method onAppLoaded*[T](self: Module[T], keyUid: string) =
-  self.view.appLoaded(keyUid)
+  # Doesn't do anything since we wait for the Main section to be loaded
+  discard
+
+method onMainLoaded*[T](self: Module[T]) =
+  self.view.appLoaded()
   singletonInstance.engine.setRootContextProperty("onboardingModule", newQVariant())
   self.view.delete
   self.view = nil

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -32,7 +32,7 @@ QtObject:
 
   ### QtSignals ###
 
-  proc appLoaded*(self: View, keyUid: string) {.signal.}
+  proc appLoaded*(self: View) {.signal.}
   proc accountLoginError*(self: View, error: string, wrongPassword: bool) {.signal.}
   proc saveBiometricsRequested*(self: View, account: string, credential: string) {.signal.}
   proc deleteBiometricsRequested*(self: View, account: string) {.signal.}

--- a/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding2/stores/OnboardingStore.qml
@@ -7,7 +7,7 @@ import AppLayouts.Onboarding.enums 1.0
 QtObject {
     id: root
 
-    signal appLoaded(string keyUid)
+    signal appLoaded()
     signal saveBiometricsRequested(string keyUid, string credential)
     signal deleteBiometricsRequested(string keyUid)
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -201,9 +201,7 @@ StatusWindow {
 
         d.runMockedKeycardControllerWindow()
 
-        Backpressure.debounce(applicationWindow, 3000, function() {
-            startupOnboardingLoader.active = false
-        })()
+        startupOnboardingLoader.active = false
     }
 
     //! Workaround for custom QQuickWindow


### PR DESCRIPTION
### What does the PR do

Fixes #17629

Only moves to the main screen when the chats are loaded to avoid showing the "loading sections" message. Also removes the loadingSection as it will never have a chance to be shown again. Removes the 3 second debounce when switching to main as the loading should be all finished by that point anyway

### Affected areas

Login and onboarding too technically, but there is nothing to load

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

This just shows that everything works as expected. It's slow because it's not on top of my speed up branch

[move-to-app-main.webm](https://github.com/user-attachments/assets/76a6484d-b3bc-4d85-be10-0140c579bdca)


### Impact on end user

Makes sure to never sow the !loading sections" section. With the speed up PR, it makes the login a little faster too since there is no debounce

### How to test

- login and make sure the last section works

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Worst case the last section is no respected
