### PR TITLE
[Qt 5->6]: Compilation warnings fixes, `Qt Proxy Models` tests aligned to qt 6

### DIFF
--- a/storybook/figmaio.cpp
+++ b/storybook/figmaio.cpp
@@ -37,7 +37,7 @@ QMap<QString, QStringList> FigmaIO::read(const QString &file)
             QStringList linksList;
             linksList.reserve(links.size());
 
-            for (const QJsonValue &link : qAsConst(links))
+            for (const QJsonValue &link : std::as_const(links))
                 if (link.isString())
                     linksList << link.toString();
 

--- a/storybook/pagesmodel.cpp
+++ b/storybook/pagesmodel.cpp
@@ -16,7 +16,7 @@ PagesModel::PagesModel(const QString &path, QObject *parent)
 {
     m_items = readMetadata(m_pagesWatcher->files());
 
-    for (const auto& item : qAsConst(m_items))
+    for (const auto& item : std::as_const(m_items))
         setFigmaLinks(item.title, item.figmaLinks);
 
     connect(m_pagesWatcher, &DirectoryFilesWatcher::filesChanged,
@@ -120,7 +120,7 @@ void PagesModel::onPagesChanged(const QStringList& added,
 
         auto metadata = readMetadata(added);
 
-        for (const auto& item : qAsConst(metadata))
+        for (const auto& item : std::as_const(metadata))
             setFigmaLinks(item.title, item.figmaLinks);
 
         m_items << metadata;

--- a/storybook/validator_main.cpp
+++ b/storybook/validator_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
                 errorCount++;
                 failedPages << objUrl.toLocalFile();
 
-                for (const auto &warning: qAsConst(warnings))
+                for (const auto &warning: std::as_const(warnings))
                     qWarning() << "    " << warning;
             }
         });

--- a/ui/StatusQ/include/StatusQ/leftjoinmodel.h
+++ b/ui/StatusQ/include/StatusQ/leftjoinmodel.h
@@ -7,6 +7,7 @@
 class LeftJoinModel : public QAbstractListModel, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(QAbstractItemModel* leftModel READ leftModel
                WRITE setLeftModel NOTIFY leftModelChanged)

--- a/ui/StatusQ/src/concatmodel.cpp
+++ b/ui/StatusQ/src/concatmodel.cpp
@@ -487,10 +487,10 @@ void ConcatModel::initRoles()
 
     m_nameRoles.reserve(m_expectedRoles.size() + 1);
 
-    for (const auto& expectedRoleName : qAsConst(m_expectedRoles))
+    for (const auto& expectedRoleName : std::as_const(m_expectedRoles))
         m_nameRoles.try_emplace(expectedRoleName.toUtf8(), m_nameRoles.size());
 
-    for (auto sourceModel : qAsConst(m_sources)) {
+    for (auto sourceModel : std::as_const(m_sources)) {
         auto model = sourceModel->model();
 
         if (model == nullptr)

--- a/ui/StatusQ/src/leftjoinmodel.cpp
+++ b/ui/StatusQ/src/leftjoinmodel.cpp
@@ -74,7 +74,7 @@ void LeftJoinModel::initialize(bool reset)
     if (!namesIntersection.isEmpty()) {
         qWarning().nospace() << "Source models contain conflicting model names: "
                              << QList(namesIntersection.cbegin(),
-                                      namesIntersection.cend())
+                                      namesIntersection.cend()).join()
                              << "!";
         return;
     }

--- a/ui/StatusQ/src/leftjoinmodel.cpp
+++ b/ui/StatusQ/src/leftjoinmodel.cpp
@@ -35,7 +35,7 @@ void LeftJoinModel::initialize(bool reset)
         if (rolesToJoin.indexOf(m_joinRole) == -1)
             rolesToJoin << m_joinRole;
 
-        for (auto& roleName : qAsConst(rolesToJoin)) {
+        for (auto& roleName : std::as_const(rolesToJoin)) {
             auto name = roleName.toUtf8();
             auto roles = rightRoleNames.keys(name);
 

--- a/ui/StatusQ/src/modelentry.cpp
+++ b/ui/StatusQ/src/modelentry.cpp
@@ -342,7 +342,7 @@ void ModelEntry::cacheItem()
 {
     if(!m_cacheOnRemoval) return;
 
-    for(const auto& role : qAsConst(m_roles))
+    for(const auto& role : std::as_const(m_roles))
     {
         auto roleNames = m_sourceModel->roleNames().keys(role.toUtf8());
         if (roleNames.isEmpty()) continue;

--- a/ui/StatusQ/src/objectproxymodel.cpp
+++ b/ui/StatusQ/src/objectproxymodel.cpp
@@ -268,7 +268,7 @@ void ObjectProxyModel::updateRoleNames()
 
     auto maxRoleKey = *maxElementIt;
 
-    for (auto& exposedRole : qAsConst(m_exposedRoles)) {
+    for (auto& exposedRole : std::as_const(m_exposedRoles)) {
 
         auto exposedRoleByteArray = exposedRole.toUtf8();
         auto keys = roles.keys(exposedRoleByteArray);

--- a/ui/StatusQ/src/rolesrenamingmodel.cpp
+++ b/ui/StatusQ/src/rolesrenamingmodel.cpp
@@ -111,7 +111,7 @@ QHash<int, QByteArray> RolesRenamingModel::roleNames() const
     if (!renameMap.isEmpty()) {
         qWarning().nospace()
                 << "RolesRenamingModel: specified source roles not found: "
-                << renameMap.keys() << "!";
+                << renameMap.keys().join(" ") << "!";
     }
 
     m_rolesFetched = true;

--- a/ui/StatusQ/src/statussyntaxhighlighter.cpp
+++ b/ui/StatusQ/src/statussyntaxhighlighter.cpp
@@ -140,7 +140,7 @@ void StatusSyntaxHighlighter::buildRules()
 
 void StatusSyntaxHighlighter::highlightBlock(const QString& text)
 {
-    for(const HighlightingRule& rule : qAsConst(highlightingRules))
+    for(const HighlightingRule& rule : std::as_const(highlightingRules))
     {
         if(rule.pattern.pattern() == QStringLiteral("")) continue;
 
@@ -249,7 +249,7 @@ QRegularExpression StatusSyntaxHighlighter::highlightedHyperlinkRegularExpressio
 QRegularExpression StatusSyntaxHighlighter::hyperlinksRegularExpression() const
 {
     QStringList hyperlinks;
-    for(const QString& hyperlink : qAsConst(m_hyperlinks))
+    for(const QString& hyperlink : std::as_const(m_hyperlinks))
     {
         const auto possibleUrlFormats = getPossibleUrlFormats(QUrl(hyperlink));
         hyperlinks.append(possibleUrlFormats);

--- a/ui/StatusQ/src/statussyntaxhighlighter.cpp
+++ b/ui/StatusQ/src/statussyntaxhighlighter.cpp
@@ -91,7 +91,7 @@ void StatusSyntaxHighlighter::buildRules()
     if (m_features & StatusSyntaxHighlighter::Code)
     {
         //CODE (`foo`)
-        codeFormat.setFontFamily(QStringLiteral("Roboto Mono"));
+        codeFormat.setFontFamilies({ QStringLiteral("Roboto Mono") });
         codeFormat.setBackground(m_codeBackgroundColor);
         codeFormat.setForeground(m_codeForegroundColor);
         rule.id = StatusSyntaxHighlighter::Code;

--- a/ui/StatusQ/tests/src/TestHelpers/modelsignalsspy.cpp
+++ b/ui/StatusQ/tests/src/TestHelpers/modelsignalsspy.cpp
@@ -1,5 +1,7 @@
 #include "modelsignalsspy.h"
 
+#include <QDebug>
+
 namespace {
 
 using QAIM = QAbstractItemModel;
@@ -56,4 +58,46 @@ int ModelSignalsSpy::count() const
             + rowsInsertedSpy.count()
             + rowsMovedSpy.count()
             + rowsRemovedSpy.count();
+}
+
+void ModelSignalsSpy::printDebugSummary() const
+{
+    qDebug() << "TOTAL:" << count();
+
+    if (auto c = columnsAboutToBeInsertedSpy.count())
+        qDebug() << "columnsAboutToBeInserted:" << c;
+    if (auto c = columnsAboutToBeMovedSpy.count())
+        qDebug() << "columnsAboutToBeMoved:" << c;
+    if (auto c = columnsAboutToBeRemovedSpy.count())
+        qDebug() << "columnsAboutToBeRemoved:" << c;
+    if (auto c = columnsInsertedSpy.count())
+        qDebug() << "columnsInserted:" << c;
+    if (auto c = columnsMovedSpy.count())
+        qDebug() << "columnsMoved:" << c;
+    if (auto c = columnsRemovedSpy.count())
+        qDebug() << "columnsRemoved:" << c;
+    if (auto c = dataChangedSpy.count())
+        qDebug() << "dataChanged:" << c;
+    if (auto c = headerDataChangedSpy.count())
+        qDebug() << "headerDataChanged:" << c;
+    if (auto c = layoutAboutToBeChangedSpy.count())
+        qDebug() << "layoutAboutToBeChanged:" << c;
+    if (auto c = layoutChangedSpy.count())
+        qDebug() << "layoutChanged:" << c;
+    if (auto c = modelAboutToBeResetSpy.count())
+        qDebug() << "modelAboutToBeReset:" << c;
+    if (auto c = modelResetSpy.count())
+        qDebug() << "modelReset:" << c;
+    if (auto c = rowsAboutToBeInsertedSpy.count())
+        qDebug() << "rowsAboutToBeInserted:" << c;
+    if (auto c = rowsAboutToBeMovedSpy.count())
+        qDebug() << "rowsAboutToBeMoved:" << c;
+    if (auto c = rowsAboutToBeRemovedSpy.count())
+        qDebug() << "rowsAboutToBeRemoved:" << c;
+    if (auto c = rowsInsertedSpy.count())
+        qDebug() << "rowsInserted:" << c;
+    if (auto c = rowsMovedSpy.count())
+        qDebug() << "rowsMoved:" << c;
+    if (auto c = rowsRemovedSpy.count())
+        qDebug() << "rowsRemoved:" << c;
 }

--- a/ui/StatusQ/tests/src/TestHelpers/modelsignalsspy.h
+++ b/ui/StatusQ/tests/src/TestHelpers/modelsignalsspy.h
@@ -28,4 +28,5 @@ public:
     const QSignalSpy rowsRemovedSpy;
 
     int count() const;
+    void printDebugSummary() const;
 };

--- a/ui/StatusQ/tests/tst_LeftJoinModel.cpp
+++ b/ui/StatusQ/tests/tst_LeftJoinModel.cpp
@@ -83,7 +83,7 @@ private slots:
 
         QTest::ignoreMessage(QtWarningMsg,
                              "Source models contain conflicting model names: "
-                             "(\"name\")!");
+                             "\"name\"!");
 
         model.setJoinRole("communityId");
 

--- a/ui/StatusQ/tests/tst_ObjectProxyModel.cpp
+++ b/ui/StatusQ/tests/tst_ObjectProxyModel.cpp
@@ -386,8 +386,13 @@ private slots:
         QCOMPARE(signalsSpy.rowsAboutToBeRemovedSpy.count(), 1);
         QCOMPARE(signalsSpy.rowsRemovedSpy.count(), 1);
 
-        QTest::qWait(100);
+        QEventLoop().processEvents();
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         QCOMPARE(signalsSpy.count(), 2);
+#else
+        QCOMPARE(signalsSpy.count(), 3);
+        QCOMPARE(signalsSpy.headerDataChangedSpy.count(), 1);
+#endif
     }
 
     void modelResetWhenRoleChangedTest() {
@@ -724,7 +729,7 @@ private slots:
             QCOMPARE(signalsSpy.dataChangedSpy.count(), 2);
         }
 
-        QTest::qWait(100);
+        QEventLoop().processEvents();
         QCOMPARE(signalsSpy.count(), 2);
         QCOMPARE(signalsSpy.dataChangedSpy.count(), 2);
 
@@ -742,7 +747,7 @@ private slots:
             QCOMPARE(signalsSpy.dataChangedSpy.count(), 4);
         }
 
-        QTest::qWait(100);
+        QEventLoop().processEvents();
         QCOMPARE(signalsSpy.count(), 5);
         QCOMPARE(signalsSpy.dataChangedSpy.count(), 5);
     }

--- a/ui/StatusQ/tests/tst_RolesRenamingModel.cpp
+++ b/ui/StatusQ/tests/tst_RolesRenamingModel.cpp
@@ -28,7 +28,7 @@ private slots:
 
         QTest::ignoreMessage(QtWarningMsg,
                              "RolesRenamingModel: specified source roles not "
-                             "found: (\"someIdFrom\")!");
+                             "found: \"someIdFrom\"!");
 
         QHash<int, QByteArray> expectedRoles = {
             {0, "id"}, {1, "name"}, {2, "color"}


### PR DESCRIPTION
### What does the PR do

- fixes various compilation warnings in cpp components
- adds missing `Q_INTERFACE` declaration to `LeftJoinModel`
- fixes tests of `ObjectProxyModel` caused by additional `headerDataChanged` signal emitted only in qt 6.
- fixes tests of `LeftJoinModel` and `RolesRenamingModel` related to changed format of `QList`'s `toString`
- added `printDebugSummary()` method to `ModelSignalsSpy` for debug purpose

Closes: #17665 
Closes: #17664

### Affected areas
`Qt Proxy Models` and other Cpp components.

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

No impact
