### PR TITLE
feat(Onboarding): enable analytics screen from login screen too

### DIFF
--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -1103,7 +1103,7 @@ Item {
             verify(!!controlUnderTest)
             controlUnderTest.onboardingStore.loginAccountsModel = loginAccountsModel
 
-            const page = getCurrentPage(controlUnderTest.stack, LoginScreen)
+            let page = getCurrentPage(controlUnderTest.stack, LoginScreen)
 
             const loginUserSelector = findChild(page, "loginUserSelector")
             verify(!!loginUserSelector)
@@ -1119,10 +1119,20 @@ Item {
             mouseClick(menuDelegate)
             tryCompare(dynamicSpy, "count", 1)
 
+            // PAGE 2: Help us improve
+            page = getCurrentPage(controlUnderTest.stack, HelpUsImproveStatusPage)
+
+            const shareButton = findChild(controlUnderTest, "btnShare")
+            dynamicSpy.setup(page, "shareUsageDataRequested")
+            mouseClick(shareButton)
+            tryCompare(dynamicSpy, "count", 1)
+            compare(dynamicSpy.signalArguments[0][0], true)
+
+            // PAGE 3: CreateProfilePage or NewAccountLoginPage
             tryVerify(() => {
-                          const currentPage = controlUnderTest.stack.currentItem
-                          return !!currentPage && currentPage instanceof data.landingPage
-                      })
+                const currentPage = controlUnderTest.stack.currentItem
+                return !!currentPage && currentPage instanceof data.landingPage
+            })
         }
 
         function test_loginScreenLostKeycardSeedphraseLoginFlow_data() {

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -819,6 +819,7 @@ class ReturningLoginView(QObject):
     def add_existing_status_user(self):
         self.user_selector_button.click()
         OnboardingLoginUsersPopup().create_profile_button.click()
+        HelpUsImproveStatusView().not_now_button.click()
         return CreateYourProfileViewOnboarding().wait_until_appears()
 
     @allure.step('Select user by name')

--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -78,8 +78,6 @@ OnboardingStackView {
         property int flow
         property LoginScreen loginScreen: null
 
-        property bool seenUsageDataPrompt
-
         function pushOrSkipBiometricsPage() {
             if (root.biometricsAvailable) {
                 root.replace(null, enableBiometricsPage)
@@ -153,26 +151,20 @@ OnboardingStackView {
         }
     }
 
+    function startWithProxy(component) {
+        const page = root.push(helpUsImproveStatusPage)
+
+        page.shareUsageDataRequested.connect(enabled => {
+            root.push(component)
+        })
+    }
+
     Component {
         id: welcomePage
 
         WelcomePage {
-            function pushWithProxy(component) {
-                if (d.seenUsageDataPrompt) { // don't ask for "Share usage data" a second time (e.g. after a factory reset)
-                    root.push(component)
-                } else {
-                    const page = root.push(helpUsImproveStatusPage)
-
-                    page.shareUsageDataRequested.connect(enabled => {
-                        root.shareUsageDataRequested(enabled)
-                        root.push(component)
-                        d.seenUsageDataPrompt = true
-                    })
-                }
-            }
-
-            onCreateProfileRequested: pushWithProxy(createProfilePage)
-            onLoginRequested: pushWithProxy(loginPage)
+            onCreateProfileRequested: startWithProxy(createProfilePage)
+            onLoginRequested: startWithProxy(loginPage)
 
             onPrivacyPolicyRequested: d.openPrivacyPolicyPopup()
             onTermsOfUseRequested: d.openTermsOfUsePopup()
@@ -201,8 +193,8 @@ OnboardingStackView {
             }
             onDismissBiometricsRequested: root.dismissBiometricsRequested()
             onLoginRequested: (keyUid, method, data) => root.loginRequested(keyUid, method, data)
-            onOnboardingCreateProfileFlowRequested: root.push(createProfilePage)
-            onOnboardingLoginFlowRequested: root.push(loginPage)
+            onOnboardingCreateProfileFlowRequested: startWithProxy(createProfilePage)
+            onOnboardingLoginFlowRequested: startWithProxy(loginPage)
             onLostKeycardFlowRequested: {
                 root.keyUidSubmitted(loginScreen.selectedProfileKeyId)
                 root.push(keycardLostPage)
@@ -232,6 +224,7 @@ OnboardingStackView {
 
         HelpUsImproveStatusPage {
             onPrivacyPolicyRequested: d.openPrivacyPolicyPopup()
+            onShareUsageDataRequested: (enabled) => root.shareUsageDataRequested(enabled)
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- show the HelpUsImprovePage too, when creating a new profile from the login screen's context menu
- adjust the tests for the new expected page in the flow

Fixes #17658

### Affected areas

Onboarding/Login

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/5348c59b-e34d-4a60-bd2d-aee503243979


