### PR TITLE
chore(community): show Create Community button for everyone

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -168,19 +168,6 @@ QtObject:
     write = setRefreshTokenEnabled
     notify = refreshTokenEnabledChanged
 
-  proc createCommunityEnabledChanged*(self: LocalAppSettings) {.signal.}
-  proc getCreateCommunityEnabled*(self: LocalAppSettings): bool {.slot.} =
-    self.settings.value(LAS_KEY_CREATE_COMMUNITIES_ENABLED, newQVariant(DEFAULT_LAS_KEY_CREATE_COMMUNITIES_ENABLED)).boolVal
-
-  proc setCreateCommunityEnabled*(self: LocalAppSettings, enabled: bool) {.slot.} =
-    self.settings.setValue(LAS_KEY_CREATE_COMMUNITIES_ENABLED, newQVariant(enabled))
-    self.createCommunityEnabledChanged()
-
-  QtProperty[bool] createCommunityEnabled:
-    read = getCreateCommunityEnabled
-    write = setCreateCommunityEnabled
-    notify = createCommunityEnabledChanged
-
   proc wakuV2ShardedCommunitiesEnabledChanged*(self: LocalAppSettings) {.signal.}
   proc getWakuV2ShardedCommunitiesEnabled*(self: LocalAppSettings): bool {.slot.} =
     self.settings.value(LAS_KEY_SHARDED_COMMUNITIES_ENABLED, newQVariant(DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED)).boolVal

--- a/test/e2e/gui/screens/settings_advanced.py
+++ b/test/e2e/gui/screens/settings_advanced.py
@@ -14,7 +14,6 @@ class AdvancedSettingsView(QObject):
         self._scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self._manage_community_on_testnet_button = Button(
             settings_names.manageCommunitiesOnTestnetButton_StatusSettingsLineButton)
-        self._enable_creation_community_button = Button(settings_names.enableCreateCommunityButton_StatusSettingsLineButton)
         self._light_mode_button = Button(settings_names.settingsContentBaseScrollViewLightWakuModeBloomSelectorButton)
         self._relay_mode_button = Button(settings_names.settingsContentBaseScrollViewRelayWakuModeBloomSelectorButton)
 
@@ -22,11 +21,6 @@ class AdvancedSettingsView(QObject):
     def switch_manage_on_community(self):
         self._scroll.vertical_scroll_down(self._manage_community_on_testnet_button)
         self._manage_community_on_testnet_button.click()
-
-    @allure.step('Enable creation of communities')
-    def enable_creation_of_communities(self):
-        self._scroll.vertical_scroll_down(self._enable_creation_community_button)
-        self._enable_creation_community_button.click()
 
     @allure.step('Switch waku mode')
     def switch_waku_mode(self, mode):

--- a/test/e2e/helpers/SettingsHelper.py
+++ b/test/e2e/helpers/SettingsHelper.py
@@ -7,12 +7,6 @@ def enable_testnet_mode(main_window):
         wallet_settings.open_networks().switch_testnet_mode_toggle().turn_on_button.click()
 
 
-def enable_community_creation(main_screen):
-    with step('Enable creation of community option'):
-        settings = main_screen.left_panel.open_settings()
-        settings.left_panel.open_advanced_settings().enable_creation_of_communities()
-
-
 def enable_managing_communities_toggle(main_window):
     with step('Switch manage community on testnet option'):
         settings = main_window.left_panel.open_settings()

--- a/test/e2e/tests/communities/test_communities_categories.py
+++ b/test/e2e/tests/communities/test_communities_categories.py
@@ -8,7 +8,6 @@ import constants
 from allure_commons._allure import step
 
 from constants import RandomCommunity
-from helpers.SettingsHelper import enable_community_creation
 from tests import test_data
 from gui.components.context_menu import ContextMenu
 from gui.main_window import MainWindow
@@ -56,8 +55,6 @@ def test_member_role_cannot_add_edit_or_delete_category(main_screen, user_data, 
                          [pytest.param('Category in general', True)])
 @pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/17395')
 def test_clicking_community_category(main_screen: MainWindow, category_name, general_checkbox):
-    enable_community_creation(main_screen)
-
     with step('Create community and select it'):
         community = RandomCommunity()
         main_screen.create_community(community_data=community)

--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -12,7 +12,6 @@ import driver
 from constants import UserAccount, RandomCommunity
 from gui.main_window import MainWindow
 from gui.screens.messages import MessagesScreen
-from helpers.SettingsHelper import enable_community_creation
 from scripts.utils.parsers import remove_tags
 
 
@@ -29,8 +28,6 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
                                               channel_emoji_image,
                                               channel_color, new_channel_name, new_channel_description,
                                               new_channel_emoji):
-    enable_community_creation(main_screen)
-
     with step('Create community and select it'):
         community = RandomCommunity()
         main_screen.create_community(community_data=community)

--- a/test/e2e/tests/communities/test_communities_kick_ban.py
+++ b/test/e2e/tests/communities/test_communities_kick_ban.py
@@ -8,7 +8,6 @@ import driver
 from constants import UserAccount, RandomUser, RandomCommunity, CommunityData
 from constants.community import ToastMessages
 from gui.screens.community import Members
-from helpers.SettingsHelper import enable_community_creation
 from scripts.utils.generators import random_text_message
 import configs.testpath
 from gui.main_window import MainWindow
@@ -60,7 +59,6 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             contacts_settings.accept_contact_request(user_one.name)
 
         with step(f'User {user_two.name}, create community and invite {user_one.name}'):
-            enable_community_creation(main_screen)
             main_screen.create_community(community_data=community)
             community_screen = main_screen.left_panel.select_community(community.name)
             add_members = community_screen.left_panel.open_add_members_popup()

--- a/test/e2e/tests/communities/test_communities_limit_to_5_permissions.py
+++ b/test/e2e/tests/communities/test_communities_limit_to_5_permissions.py
@@ -7,7 +7,6 @@ import driver
 from constants import permission_data_member, RandomCommunity
 from constants.community import LimitWarnings
 from gui.main_window import MainWindow
-from helpers.SettingsHelper import enable_community_creation
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/739309',
@@ -15,7 +14,6 @@ from helpers.SettingsHelper import enable_community_creation
 @pytest.mark.case(739309)
 @pytest.mark.communities
 def test_add_5_member_role_permissions(main_screen: MainWindow):
-    enable_community_creation(main_screen)
 
     with step('Create community and select it'):
         community = RandomCommunity()

--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -7,7 +7,6 @@ from allure_commons._allure import step
 import driver
 from gui.components.community.pinned_messages_popup import PinnedMessagesPopup
 from gui.main_window import MainWindow
-from helpers.SettingsHelper import enable_community_creation
 from scripts.utils.generators import random_text_message
 import configs
 from constants import ColorCodes, UserAccount, RandomUser, RandomCommunity
@@ -63,8 +62,6 @@ def test_join_community_and_pin_unpin_message(multiple_instances):
             contacts_settings.accept_contact_request(user_one.name)
 
         with step(f'User {user_two.name}, create community and invite {user_one.name}'):
-            enable_community_creation(main_screen)
-
             with step('Create community and select it'):
                 community = RandomCommunity()
                 main_screen.create_community(community_data=community)

--- a/test/e2e/tests/communities/test_communities_screens_overview.py
+++ b/test/e2e/tests/communities/test_communities_screens_overview.py
@@ -3,7 +3,6 @@ import pytest
 from allure_commons._allure import step
 
 from constants import RandomCommunity
-from helpers.SettingsHelper import enable_community_creation
 
 from constants.community import AirdropsElements, TokensElements, PermissionsElements
 from constants.images_paths import AIRDROPS_WELCOME_IMAGE_PATH, TOKENS_WELCOME_IMAGE_PATH, PERMISSION_WELCOME_IMAGE_PATH
@@ -18,8 +17,6 @@ from gui.main_window import MainWindow
                  'Manage community: Manage Airdrops screen overview')
 @pytest.mark.case(703198, 703199, 703200)
 def test_manage_community_screens_overview(main_screen: MainWindow):
-    enable_community_creation(main_screen)
-
     with step('Create community and select it'):
         community = RandomCommunity()
         main_screen.create_community(community_data=community)

--- a/test/e2e/tests/communities/test_communities_send_accept_decline_request_from_profile.py
+++ b/test/e2e/tests/communities/test_communities_send_accept_decline_request_from_profile.py
@@ -6,7 +6,6 @@ import driver
 from gui.components.profile_popup import ProfilePopupFromMembers
 from gui.components.remove_contact_popup import RemoveContactPopup
 from gui.main_window import MainWindow
-from helpers.SettingsHelper import enable_community_creation
 from scripts.utils.generators import random_text_message
 import configs
 from constants import UserAccount, RandomUser, RandomCommunity
@@ -91,7 +90,6 @@ def test_communities_send_accept_decline_request_remove_contact_from_profile(mul
         with step(f'User {user_two.name}, creates community and invites {user_one.name} and {user_three.name}'):
             aut_two.attach()
             main_screen.prepare()
-            enable_community_creation(main_screen)
 
             with step('Create community and select it'):
                 community = RandomCommunity()

--- a/test/e2e/tests/crtitical_tests_prs/test_community_category_add_edit_delete.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_community_category_add_edit_delete.py
@@ -4,7 +4,6 @@ from allure_commons._allure import step
 
 from constants import RandomCommunity
 from gui.main_window import MainWindow
-from helpers.SettingsHelper import enable_community_creation
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703226', 'Add category')
@@ -22,8 +21,6 @@ from helpers.SettingsHelper import enable_community_creation
 def test_create_edit_remove_community_category(main_screen: MainWindow, category_name, general_checkbox, channel_name,
                                  channel_description, channel_emoji, second_channel_name, second_channel_description,
                                  second_channel_emoji):
-    enable_community_creation(main_screen)
-
     with step('Create community and select it'):
         community = RandomCommunity()
         main_screen.create_community(community_data=community)

--- a/test/e2e/tests/crtitical_tests_prs/test_community_create_edit_share_link.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_community_create_edit_share_link.py
@@ -4,7 +4,6 @@ from allure_commons._allure import step
 
 from constants import RandomCommunity
 from constants.community import Channel
-from helpers.SettingsHelper import enable_community_creation
 from scripts.utils.browser import get_response, get_page_content
 from scripts.utils.generators import random_community_name, random_community_description, random_community_introduction, \
     random_community_leave_message
@@ -18,8 +17,6 @@ from gui.main_window import MainWindow
 @pytest.mark.critical
 @pytest.mark.smoke
 def test_create_edit_community(main_screen: MainWindow):
-    enable_community_creation(main_screen)
-
     with step('Open create community popup'):
         communities_portal = main_screen.left_panel.open_communities_portal()
         create_community_form = communities_portal.open_create_community_popup()

--- a/test/e2e/tests/crtitical_tests_prs/test_community_permissions_add_edit_delete_duplicate.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_community_permissions_add_edit_delete_duplicate.py
@@ -11,7 +11,6 @@ from constants.community import ToastMessages, PermissionsElements
 from gui.components.changes_detected_popup import PermissionsChangesDetectedToastMessage
 from gui.main_window import MainWindow
 from gui.screens.community_settings import PermissionsIntroView
-from helpers.SettingsHelper import enable_community_creation
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703632',
@@ -20,8 +19,6 @@ from helpers.SettingsHelper import enable_community_creation
 # @pytest.mark.critical
 @pytest.mark.skip(reason='The test is broken itself, need to fix it')
 def test_add_edit_remove_duplicate_permissions(main_screen: MainWindow):
-    enable_community_creation(main_screen)
-
     with step('Create community and select it'):
         community = RandomCommunity()
         main_screen.create_community(community_data=community)

--- a/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
+++ b/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
@@ -11,7 +11,7 @@ from configs import WALLET_SEED
 from constants import ReturningUser, RandomCommunity
 from helpers.OnboardingHelper import open_generate_new_keys_view, open_import_seed_view_and_do_import, \
     finalize_onboarding_and_login
-from helpers.SettingsHelper import enable_testnet_mode, enable_community_creation, enable_managing_communities_toggle
+from helpers.SettingsHelper import enable_testnet_mode, enable_managing_communities_toggle
 from constants.community import MintOwnerTokensElements
 from gui.screens.community_settings_tokens import MintedTokensView
 
@@ -30,7 +30,6 @@ def test_mint_owner_and_tokenmaster_tokens(main_window, user_account):
     finalize_onboarding_and_login(profile_view, user_account)
 
     enable_testnet_mode(main_window)
-    enable_community_creation(main_window)
     enable_managing_communities_toggle(main_window)
 
     with step('Create community and select it'):

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -129,25 +129,19 @@ StatusSectionLayout {
                 Item { Layout.fillWidth: true }
 
                 StatusButton {
-                    id: importBtn
                     Layout.preferredHeight: 38
                     text: qsTr("Import community")
                     verticalPadding: 0
                     onClicked: Global.importCommunityPopupRequested()
                 }
 
-                Loader {
-                    Layout.preferredHeight: active ? 38 : 0
-                    active: communitiesStore.createCommunityEnabled || communitiesStore.testEnvironment
-                    sourceComponent: StatusButton {
-                        id: createBtn
-                        objectName: "createCommunityButton"
-                        height: parent.height
-                        verticalPadding: 0
-                        text: qsTr("Create community")
-                        onClicked: {
-                            Global.openPopup(chooseCommunityCreationTypePopupComponent)
-                        }
+                StatusButton {
+                    objectName: "createCommunityButton"
+                    Layout.preferredHeight: 38
+                    verticalPadding: 0
+                    text: qsTr("Create community")
+                    onClicked: {
+                        Global.openPopup(chooseCommunityCreationTypePopupComponent)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -35,7 +35,6 @@ QtObject {
     property bool downloadingCommunityHistoryArchives: root.communitiesModuleInst.downloadingCommunityHistoryArchives
     property var advancedModule: profileSectionModule.advancedModule
 
-    readonly property bool createCommunityEnabled: localAppSettings.createCommunityEnabled ?? false
     readonly property bool testEnvironment: localAppSettings.testEnvironment ?? false
 
     property string communityTags: communitiesModuleInst.tags

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -24,7 +24,6 @@ QtObject {
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
     readonly property bool isFakeLoadingScreenEnabled: localAppSettings.fakeLoadingScreenEnabled ?? false
-    readonly property bool createCommunityEnabled: localAppSettings.createCommunityEnabled ?? false
     property bool isManageCommunityOnTestModeEnabled: false
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string communities: "communities"
@@ -139,13 +138,6 @@ QtObject {
             return
 
         localAppSettings.fakeLoadingScreenEnabled = !localAppSettings.fakeLoadingScreenEnabled
-    }
-
-    function toggleCreateCommunityEnabled() {
-        if(!localAppSettings)
-            return
-
-        localAppSettings.createCommunityEnabled = !localAppSettings.createCommunityEnabled
     }
 
     function toggleArchiveProtocolEnabled() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -152,18 +152,6 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
-                objectName: "enableCreateCommunityButton"
-                text: qsTr("Enable Community Creation")
-                isSwitch: true
-                switchChecked: root.advancedStore.createCommunityEnabled
-                onClicked: {
-                    root.advancedStore.toggleCreateCommunityEnabled()
-                }
-            }
-
-            StatusSettingsLineButton {
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
                 text: qsTr("Archive Protocol Enabled")
                 isSwitch: true
                 switchChecked: root.advancedStore.archiveProtocolEnabled


### PR DESCRIPTION
### What does the PR do

Fixes #17671

Makes the Create Community button visible and available to everyone regardless of the setting. The setting switch and Nim code for it has been removed.

### Affected areas

Community portal and settings

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

![image](https://github.com/user-attachments/assets/f92e1a9d-7a14-4217-87ce-aa6cab81627b)

![image](https://github.com/user-attachments/assets/9227f89e-3356-4576-aabb-0abc318c935d)

### Impact on end user

Everyone has access to the create community buttons now

### How to test

- Open the portal and the settings

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Not much risk here
