### PR TITLE
[Qt 5->6]: Onboarding: stack clearing before onboarding deactivation removed

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -202,7 +202,6 @@ StatusWindow {
         d.runMockedKeycardControllerWindow()
 
         Backpressure.debounce(applicationWindow, 3000, function() {
-            startupOnboardingLoader.item.unload()
             startupOnboardingLoader.active = false
         })()
     }


### PR DESCRIPTION
### What does the PR do

It's not necessary to clear the stack (via unload()) as the whole stack is unloaded in the next line. It's especially important that clearing the stack in this situation was leading to crash on Qt 6 because https://bugreports.qt.io/browse/QTBUG-135295.

Closes: #17679

### Affected areas
`main.qml`

### Screenshot of functionality (including design for comparison)

[Screencast from 28.03.2025 13:38:45.webm](https://github.com/user-attachments/assets/b379de4c-9e61-401d-9922-6ce323015953)

### Impact on end user

No impact

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
