### PR TITLE
fix(AccountSelector): incorrectly rendering header on Qt 6

### DIFF
--- a/storybook/pages/AccountSelectorPage.qml
+++ b/storybook/pages/AccountSelectorPage.qml
@@ -132,8 +132,8 @@ SplitView {
         tokensBySymbolModel: d.assetsStore.walletTokensStore.plainTokensBySymbolModel
         filteredFlatNetworksModel: d.filteredFlatNetworksModel
 
-        selectedTokenKey: selectedTokenComboBox.currentValue
-        selectedNetworkChainId: networksComboBox.currentValue
+        selectedTokenKey: selectedTokenComboBox.currentValue ?? ""
+        selectedNetworkChainId: networksComboBox.currentValue ?? -1
 
         fnFormatCurrencyAmountFromBigInt: function(balance, symbol, decimals, options = null) {
             return d.currencyStore.formatCurrencyAmountFromBigInt(balance, symbol, decimals, options)

--- a/storybook/pages/SwapModalPage.qml
+++ b/storybook/pages/SwapModalPage.qml
@@ -135,7 +135,7 @@ SplitView {
                     if (!number)
                         return "N/A"
                     if (!symbol)
-                        symbol = root.currentCurrency
+                        symbol = "USD"
                     let options = {}
                     if (!!noSymbolOption)
                         options = {noSymbol: true}
@@ -143,7 +143,13 @@ SplitView {
                 }
             }
             networksStore: SharedStores.NetworksStore {
-                readonly property var activeNetworks: NetworksModel.flatNetworks
+                readonly property SortFilterProxyModel activeNetworks: SortFilterProxyModel {
+                    sourceModel: NetworksModel.flatNetworks
+                    filters: [
+                        ValueFilter { roleName: "isTest"; value: areTestNetworksEnabledCheckbox.checked },
+                        ValueFilter { roleName: "isActive"; value: true }
+                    ]
+                }
             }
             swapFormData: SwapInputParamsForm {
                 onSelectedAccountAddressChanged: {
@@ -224,7 +230,13 @@ SplitView {
                 id: accountComboBox
                 textRole: "name"
                 valueRole: "address"
-                model: adaptor.nonWatchAccounts
+                model: SortFilterProxyModel {
+                    sourceModel: dSwapStore.accounts
+                    filters: ValueFilter {
+                        roleName: "canSend"
+                        value: true
+                    }
+                }
                 currentIndex: 0
             }
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -453,9 +453,6 @@ StatusDialog {
         id: sendModalcontentItem
 
         anchors.fill: parent
-        anchors.top: parent.top
-
-        implicitWidth: parent.width
 
         // Floating account Selector
         AccountSelectorHeader {
@@ -463,8 +460,7 @@ StatusDialog {
 
             objectName: "accountSelector"
 
-            anchors.top: parent.top
-            anchors.topMargin: -accountSelector.height - Theme.padding
+            y: -height - Theme.bigPadding
             anchors.left: parent.left
             anchors.leftMargin: -Theme.xlPadding
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -125,12 +125,8 @@ StatusDialog {
     }
 
     header: Item {
-        implicitHeight: selector.implicitHeight
-        implicitWidth: selector.implicitWidth
-        anchors.top: parent.top
-        anchors.topMargin: -height - 18
         AccountSelectorHeader {
-            id: selector
+            y: -height - Theme.padding
             control.popup.width: 512
             model: d.accountsSelectorAdaptor.processedWalletAccounts
             selectedAddress: root.swapInputParamsForm.selectedAccountAddress

--- a/ui/imports/shared/controls/AccountSelector.qml
+++ b/ui/imports/shared/controls/AccountSelector.qml
@@ -144,7 +144,7 @@ StatusComboBox {
 
     QtObject {
         id: d
-        property string currentAccountSelection: root.selectedAddress || root.currentValue
+        property string currentAccountSelection
 
         Binding on currentAccountSelection {
             value: root.selectedAddress || root.currentValue

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -331,13 +331,9 @@ StatusDialog {
     }
 
     header: Item {
-        implicitHeight: accountSelector.implicitHeight
-        implicitWidth: accountSelector.implicitWidth
-        anchors.top: parent.top
-        anchors.topMargin: -height - 18
-
         AccountSelectorHeader {
             id: accountSelector
+            y: -height - 18
             model: SortFilterProxyModel {
                 sourceModel: popup.store.accounts
 


### PR DESCRIPTION
### What does the PR do

- unbreak the binding loops, use absolute `y` position in the header style
- some SB page fixes

### Affected areas

AccountSelector

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/b621190d-b93a-4a65-b370-1541dc30438f

SwapModal under Qt6:
![image](https://github.com/user-attachments/assets/246297db-14bd-4b9f-b9bc-8ff3698b9d0c)

SwapModal under Qt5:
![image](https://github.com/user-attachments/assets/ff20a5da-0b40-4bd5-87fa-9784d7b04db2)


