### PR TITLE
ci: add cleanup stage before build

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -32,6 +32,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Build') {
       parallel {
         stage('Linux/x86_64 and E2E') {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -78,6 +78,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -71,6 +71,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Deps') {
       steps { script {
         nix.shell('make update', pure: true)

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -82,6 +82,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -98,6 +98,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Prep') {
       steps { script {
         setNewBuildName()

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -54,6 +54,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -43,6 +43,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Build StatusQ Tests') {
       steps {
         sh 'make statusq-tests'

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -86,6 +86,11 @@ pipeline {
   }
 
   stages {
+    stage('Cleanup Workspace') {
+      steps {
+        sh './scripts/clean-git.sh'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'


### PR DESCRIPTION
## Summary

Sometimes when CI fails in checkout stage, the post cleanup phase does not get executed which could leave Jenkins workspace in a dirty state.

This PR adds another cleanup phase at the beginning of all jobs, to take care of such scenarios.
