### PR TITLE
fix(Qt5->6): Fix relative url resolution

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusContactVerificationIcons.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusContactVerificationIcons.qml
@@ -23,7 +23,7 @@ Row {
         bgColor: Theme.palette.primaryColor1
         // Only used to get implicit width and height from the actual image
         property Image dummyImage: Image {
-            source: mutualConnectionIcon.name ? "../../assets/img/icons/" + mutualConnectionIcon.name + ".svg": ""
+            source: mutualConnectionIcon.name ? Qt.resolvedUrl("../../assets/img/icons/" + mutualConnectionIcon.name + ".svg"): ""
             visible: false
             cache: false
         }
@@ -42,7 +42,7 @@ Row {
         bgColor: root.trustIndicator === StatusContactVerificationIcons.TrustedType.Verified ? Theme.palette.successColor1 : Theme.palette.dangerColor1
         // Only used to get implicit width and height from the actual image
         property Image dummyImage: Image {
-            source: trustContactIcon.name ? "../../assets/img/icons/" + trustContactIcon.name + ".svg": ""
+            source: trustContactIcon.name ? Qt.resolvedUrl("../../assets/img/icons/" + trustContactIcon.name + ".svg"): ""
             visible: false
             cache: false
         }
@@ -58,7 +58,7 @@ Row {
         bgRadius: bgWidth / 2
         // Only used to get implicit width and height from the actual image
         property Image dummyImage: Image {
-            source: blockedContactIcon.name ? "../../assets/img/icons/" + blockedContactIcon.name + ".svg": ""
+            source: blockedContactIcon.name ? Qt.resolvedUrl("../../assets/img/icons/" + blockedContactIcon.name + ".svg"): ""
             visible: false
             cache: false
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusEmoji.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusEmoji.qml
@@ -11,5 +11,5 @@ Image {
     fillMode: Image.PreserveAspectFit
     mipmap: true
     antialiasing: true
-    source: emojiId ? `../../assets/twemoji/svg/${emojiId}.svg` : ""
+    source: emojiId ? Qt.resolvedUrl(`../../assets/twemoji/svg/${emojiId}.svg`) : ""
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusListPickerProxies.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListPickerProxies.qml
@@ -23,7 +23,7 @@ QtObject {
     property var name: (model) => model.name
     property var shortName: (model) => model.shortName
     property var symbol: (model) => model.symbol
-    property var imageSource: (model) => model.imageSource
+    property var imageSource: (model) => Qt.resolvedUrl(model.imageSource)
     property var category: (model) => model.category
     property var selected: (model) => model.selected
     property var setSelected: (model, val) => model.selected = val

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml
@@ -36,7 +36,7 @@ RowLayout {
        This is a property function used to acquire image source for given token.
     */
     property var tokenImageSourceGetter: function (token) {
-        return "../../assets/img/icons/%1.png".arg(token)
+        return Qt.resolvedUrl("../../assets/img/icons/%1.png".arg(token))
     }
 
     signal triggered(real amount, string token)

--- a/ui/StatusQ/src/StatusQ/Platform/StatusMacNotification.qml
+++ b/ui/StatusQ/src/StatusQ/Platform/StatusMacNotification.qml
@@ -52,7 +52,7 @@ Rectangle {
     Component {
         id: statusIdenticon
         Image {
-            source: "../../assets/png/status-logo-icon.png"
+            source: Qt.resolvedUrl("../../assets/png/status-logo-icon.png")
             width: 40
             height: 40
             sourceSize.width: width * 2

--- a/ui/StatusQ/src/StatusQ/Platform/StatusMacTrafficLights.qml
+++ b/ui/StatusQ/src/StatusQ/Platform/StatusMacTrafficLights.qml
@@ -41,8 +41,8 @@ MouseArea {
             Image {
                 anchors.centerIn: parent
                 visible: statusMacTrafficLights.containsMouse
-                source: closeSensor.pressed ? "../../assets/img/icons/traffic_lights/close_pressed.png"
-                                            : "../../assets/img/icons/traffic_lights/close.png"
+                source: Qt.resolvedUrl(closeSensor.pressed ? "../../assets/img/icons/traffic_lights/close_pressed.png"
+                                            : "../../assets/img/icons/traffic_lights/close.png")
                 scale: 0.25
             }
 
@@ -71,8 +71,8 @@ MouseArea {
                 anchors.centerIn: parent
                 anchors.verticalCenterOffset: -0.25
                 visible: statusMacTrafficLights.containsMouse
-                source: miniSensor.pressed ? "../../assets/img/icons/traffic_lights/minimise_pressed.png"
-                                           : "../../assets/img/icons/traffic_lights/minimise.png"
+                source: Qt.resolvedUrl(miniSensor.pressed ? "../../assets/img/icons/traffic_lights/minimise_pressed.png"
+                                           : "../../assets/img/icons/traffic_lights/minimise.png")
                 scale: 0.27
             }
 
@@ -99,8 +99,8 @@ MouseArea {
             Image {
                 anchors.centerIn: parent
                 visible: statusMacTrafficLights.containsMouse
-                source:   maxiSensor.pressed ?"../../assets/img/icons/traffic_lights/maximize_pressed.png"
-                                             :"../../assets/img/icons/traffic_lights/maximize.png"
+                source: Qt.resolvedUrl(maxiSensor.pressed ?"../../assets/img/icons/traffic_lights/maximize_pressed.png"
+                                             :"../../assets/img/icons/traffic_lights/maximize.png")
                 scale: 0.25
             }
 


### PR DESCRIPTION
Closes #17451

### What does the PR do

In Qt 5, relative urls were directly resolved, especially when assigned to an url property. In Qt 6 this is no longer the case. In order to continue with the old behavior, `Qt.resolvedUrl` is used.

### Affected areas

SQ components: `StatusContactVerificationIcons`, `StatusEmoji`, `StatusListPickerProxies` (`CurrenciesModel`), `StatusTokenInlineSelector`, `StatusMacNotification` and `StatusMacTrafficLights`.

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

No impact