### PR TITLE
feat(Qt5 -> 6): support parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -571,6 +571,24 @@ else
  NIM_STATUS_CLIENT := bin/nim_status_client
 endif
 
+# Writing the QMAKE variable to a file to compare its value from the previous
+# make call and forcing linking of NIM_STATUS_CLIENT if the value has changed.
+
+# Define the file to store the previous QMAKE value
+QMAKE_PREVIOUS := .qmake_previous
+
+# Check if the QMAKE value has changed
+QMAKE_CHANGED := $(shell [ -f $(QMAKE_PREVIOUS) ] && [ "$$(cat $(QMAKE_PREVIOUS))" = "$(QMAKE)" ] && echo "no" || echo "yes")
+
+# Target to store the current QMAKE value
+update-qmake-previous:
+	@echo $(QMAKE) > $(QMAKE_PREVIOUS)
+
+# Add a dependency on update-qmake-previous if QMAKE has changed
+ifeq ($(QMAKE_CHANGED),yes)
+$(NIM_STATUS_CLIENT): update-qmake-previous
+endif
+
 $(NIM_STATUS_CLIENT): NIM_PARAMS += $(RESOURCES_LAYOUT)
 $(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSGO) $(STATUSKEYCARDGO) $(QRCODEGEN) $(FLEETS_FILE) rcc compile-translations deps
 	echo -e $(BUILD_MSG) "$@"

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -266,6 +266,8 @@ StatusWindow {
     }
 
     Component.onCompleted: {
+        console.info(">>> %1 %2 started, using Qt version %3".arg(Qt.application.name).arg(Qt.application.version).arg(SystemUtils.qtRuntimeVersion()))
+
         Theme.changeTheme(Universal.System, systemPalette.isCurrentSystemThemeDark());
 
         restoreAppState();


### PR DESCRIPTION
### What does the PR do

TLDR: make it possible to build against multiple Qt versions at will; Windows use a dll so should be fine

- add separate build dirs, based on Qt version being used
- do not hardcode/repeat the `DOTHERSIDE_LIBFILE`
- use the respective `CMAKE_PREFIX_PATH` when building the Qt parts
- output Qt runtime version on app start to ease debugging/verifying the correct Qt version is used at runtime for QML
- store `QMAKE` variable to a file in order to compare current and previous invocation and therefore detect need of re-linking

Fixes #17738
Needs: https://github.com/status-im/dotherside/pull/92

### Affected areas

Makefile

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Qt 6 build:
![Snímek obrazovky z 2025-04-04 14-39-50](https://github.com/user-attachments/assets/4978e58d-0eff-4882-957f-398e323f3777)

Qt 5 build:
![Snímek obrazovky z 2025-04-04 14-53-25](https://github.com/user-attachments/assets/a39f6eb4-f8e3-4b5d-a816-2bfa3dfce5a9)

