### PR TITLE
ci: fix qt formulae download location

### DIFF
--- a/scripts/macos_build_setup.sh
+++ b/scripts/macos_build_setup.sh
@@ -28,8 +28,9 @@ function install_qt {
   echo "Detected Homebrew prefix: ${BREW_PREFIX}"
   echo "Qt will be installed to: ${QT_INSTALL_DIR}"
 
-  curl -o qt@5.rb "${QT_FORMULA_URL}"
-  brew install ./qt@5.rb
+  curl -o /tmp/qt@5.rb "${QT_FORMULA_URL}"
+  brew install /tmp/qt@5.rb
+  rm /tmp/qt@5.rb
 }
 
 function get_go_arch {


### PR DESCRIPTION
## Summary

Fix the qt installation script else it may fail like this: 

```
TASK [status-desktop-setup : Install Qt SDK] ********************************************************
fatal: [maci7-03.ms-eu-dublin.ci.devel]: FAILED! => {
    "changed": true,
    "cmd": ". ~/.profile\n. /Users/jenkins/macos_build_setup.sh;\ninstall_qt\n",
    "delta": "0:00:00.250556",
    "end": "2025-04-04 14:57:05.388782",
    "rc": 56,
    "start": "2025-04-04 14:57:05.138226"
}

STDOUT:

Installing QT 5.15.16_1
Detected Homebrew prefix: /usr/local
Qt will be installed to: /usr/local/Cellar/qt@5/5.15.16_1


STDERR:

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the
   file qt@5.rb: Permission denied
  0 14552    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) Failure writing output to destination, passed 824 returned 4294967295


MSG:

non-zero return code
```

