### PR TITLE
Implement News Feed popup

### DIFF
--- a/storybook/pages/ActivityNotificationNewsMessagePage.qml
+++ b/storybook/pages/ActivityNotificationNewsMessagePage.qml
@@ -19,8 +19,8 @@ SplitView {
         property string id: "1"
         property string title: "Swaps around the corner!"
         property string description: "Status Desktop’s next release brings the app up-to-speed with Status Mobile. That means: SWAPS!"
-        property int timestamp: Date.now()
-        property int previousTimestamp: 0
+        property double timestamp: Date.now()
+        property double previousTimestamp: 0
         property bool read: false
         property bool dismissed: false
         property bool accepted: false
@@ -39,7 +39,7 @@ SplitView {
 
             notification: notificationMock
 
-            onLearnMoreClicked: logs.logEvent("ActivityNotificationNewsMessages::onLearnMoreClicked")
+            onReadMoreClicked: logs.logEvent("ActivityNotificationNewsMessage::onReadMoreClicked")
         }
 
     }

--- a/storybook/pages/NewsMessagePopupPage.qml
+++ b/storybook/pages/NewsMessagePopupPage.qml
@@ -1,48 +1,73 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import Storybook 1.0
 
+import StatusQ.Controls 0.1
+
 import shared.popups 1.0
 
-Item {
-    Button {
-        anchors.centerIn: parent
-        text: "Reopen"
-        onClicked: popup.open()
-    }
-
+SplitView {
     Logs { id: logs }
+    orientation: Qt.Vertical
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
 
-    QtObject {
-        id: notificationMock
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+            onClicked: popup.open()
+        }
 
-        property string id: "1"
-        property string title: "Swaps around the corner!"
-        property string description: "Status Desktop’s next release brings the app up-to-speed with Status Mobile. That means: SWAPS!"
-        property string content: "Status Desktop’s next release brings the app up-to-speed with Status Mobile. That means: SWAPS! Now you can trade Ethereum, Arbitrum and Optimism tokens directly in-app. Status leverages Paraswap so you always benefit from the best prices and fastest settlements!"
-        property string link: "https://status.app/"
-        property string linkLabel: "Read our blog post"
-        property string imageUrl: "https://picsum.photos/438/300"
-        property double timestamp: Date.now()
-        property double previousTimestamp: 0
-        property bool read: false
-        property bool dismissed: false
-        property bool accepted: false
+
+        QtObject {
+            id: notificationMock
+
+            property string id: "1"
+            property string title: "Swaps around the corner!"
+            property string description: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS!"
+            property string content: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS! Now you can trade Ethereum, Arbitrum and Optimism tokens directly in-app. Status leverages Paraswap so you always benefit from the best prices and fastest settlements!"
+            property string link: "https://status.app/"
+            property string linkLabel: linkLabelInput.text
+            property string imageUrl: hasImage.checked ? "https://picsum.photos/438/300" : ""
+            property double timestamp: Date.now()
+            property double previousTimestamp: 0
+            property bool read: false
+            property bool dismissed: false
+            property bool accepted: false
+        }
+
+        NewsMessagePopup {
+            id: popup
+            visible: true
+            notification: notificationMock
+            onLinkClicked: logs.logEvent("NewsMessagesPopup::onLinkClicked")
+        }
     }
-
-    NewsMessagePopup {
-        id: popup
-        visible: true
-        notification: notificationMock
-        onLinkClicked: logs.logEvent("NewsMessagesPopup::onLinkClicked")
-    }
-
+   
     LogsAndControlsPanel {
         SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 160
+        SplitView.preferredHeight: 200
 
         logsView.logText: logs.logText
+
+        RowLayout {
+            spacing: 4
+
+            CheckBox {
+                id: hasImage
+                text: "Has Image"
+                checked: true
+            }
+
+            StatusInput {
+                id: linkLabelInput
+                label: "linkLabel"
+                text: "Read our blog post"
+            }
+        }
     }
 }
 

--- a/storybook/pages/NewsMessagePopupPage.qml
+++ b/storybook/pages/NewsMessagePopupPage.qml
@@ -1,0 +1,50 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import Storybook 1.0
+
+import shared.popups 1.0
+
+Item {
+    Button {
+        anchors.centerIn: parent
+        text: "Reopen"
+        onClicked: popup.open()
+    }
+
+    Logs { id: logs }
+
+    QtObject {
+        id: notificationMock
+
+        property string id: "1"
+        property string title: "Swaps around the corner!"
+        property string description: "Status Desktop’s next release brings the app up-to-speed with Status Mobile. That means: SWAPS!"
+        property string content: "Status Desktop’s next release brings the app up-to-speed with Status Mobile. That means: SWAPS! Now you can trade Ethereum, Arbitrum and Optimism tokens directly in-app. Status leverages Paraswap so you always benefit from the best prices and fastest settlements!"
+        property string link: "https://status.app/"
+        property string linkLabel: "Read our blog post"
+        property string imageUrl: "https://picsum.photos/438/300"
+        property double timestamp: Date.now()
+        property double previousTimestamp: 0
+        property bool read: false
+        property bool dismissed: false
+        property bool accepted: false
+    }
+
+    NewsMessagePopup {
+        id: popup
+        visible: true
+        notification: notificationMock
+        onLinkClicked: logs.logEvent("NewsMessagesPopup::onLinkClicked")
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 160
+
+        logsView.logText: logs.logText
+    }
+}
+
+// category: Popups
+// status: good

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
@@ -23,7 +23,6 @@ StatusRoundedComponent {
     isLoading: image.isLoading
     isError: image.isError
     border.width: 0
-    radius: 10
 
     StatusImage {
         id: image

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
@@ -23,6 +23,7 @@ StatusRoundedComponent {
     isLoading: image.isLoading
     isError: image.isError
     border.width: 0
+    radius: 10
 
     StatusImage {
         id: image

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -115,7 +115,7 @@ QtObject {
 
     property var currentPopup
     function openPopup(popupComponent, params = {}, cb = null) {
-        if (activePopupComponents.includes(popupComponent)) {
+        if (root.activePopupComponents.includes(popupComponent)) {
             return
         }
 
@@ -124,12 +124,12 @@ QtObject {
         if (cb)
             cb(root.currentPopup)
 
-        activePopupComponents.push(popupComponent)
+        root.activePopupComponents.push(popupComponent)
 
         root.currentPopup.closed.connect(() => {
-            const removeIndex = activePopupComponents.indexOf(popupComponent)
+            const removeIndex = root.activePopupComponents.indexOf(popupComponent)
             if (removeIndex !== -1) {
-                activePopupComponents.splice(removeIndex, 1)
+                root.activePopupComponents.splice(removeIndex, 1)
             }
         })
     }

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -9,6 +9,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Backpressure 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 import shared 1.0
 import shared.popups 1.0
@@ -369,7 +370,14 @@ Popup {
             notification: parent.notification
             store: root.store
             activityCenterStore: root.activityCenterStore
-            onReadMoreClicked: console.log("ActivityNotificationNewsMessage::onReadMoreClicked")
+            onReadMoreClicked: {
+                root.close()
+                Global.openPopup(newsMessagePopup, {
+                    notification: parent.notification
+                })
+                Global.addCentralizedMetricIfEnabled("news-info-opened", {"news-link": parent.notification.link})
+
+            }
             onCloseActivityCenter: root.close()
         }
     }
@@ -515,6 +523,14 @@ Popup {
                 }
             }
             footer: null
+        }
+    }
+
+    Component {
+        id: newsMessagePopup
+
+        NewsMessagePopup {
+            onLinkClicked: Global.openLinkWithConfirmation(link, StatusQUtils.StringUtils.extractDomainFromLink(link));
         }
     }
 }

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -369,6 +369,7 @@ Popup {
             notification: parent.notification
             store: root.store
             activityCenterStore: root.activityCenterStore
+            onReadMoreClicked: console.log("ActivityNotificationNewsMessage::onReadMoreClicked")
             onCloseActivityCenter: root.close()
         }
     }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationNewsMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationNewsMessage.qml
@@ -11,7 +11,7 @@ import shared.panels 1.0
 ActivityNotificationBase {
     id: root
 
-    signal learnMoreClicked
+    signal readMoreClicked
 
     bodyComponent: RowLayout {
         spacing: 8
@@ -49,9 +49,9 @@ ActivityNotificationBase {
 
     ctaComponent: StatusFlatButton {
         size: StatusBaseButton.Size.Small
-        text: qsTr("Learn more")
+        text: qsTr("Read more")
         onClicked: {
-            root.learnMoreClicked()
+            root.readMoreClicked()
         }
     }
 }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -8,7 +8,6 @@ import StatusQ.Popups.Dialog 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
-import StatusQ.Core.Utils 0.1 as CoreUtils
 
 import shared 1.0
 import utils 1.0
@@ -17,9 +16,8 @@ StatusDialog {
     id: root
 
     required property var notification
-    signal linkClicked()
+    signal linkClicked(string link)
 
-    anchors.centerIn: parent
     width: 480
     padding: Theme.bigPadding
 
@@ -41,21 +39,27 @@ StatusDialog {
     }
 
     ColumnLayout {
-        spacing: 16
         width: parent.width
 
-        StatusRoundedImage {
-            Layout.fillWidth: true
-            Layout.preferredHeight: 300
+        Loader {
+            active: !!notification.imageUrl
 
-            image.source: notification.imageUrl
-            color: "transparent"
-            border.color: root.backgroundColor
-            border.width: 1
+            Layout.bottomMargin: active ? Theme.bigPadding : 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: active ? 300 : 0
+
+            sourceComponent: StatusRoundedImage {
+
+                image.source: notification.imageUrl
+                color: "transparent"
+                border.color: root.backgroundColor
+                border.width: 1
+                radius: 10
+            }
         }
 
         StatusBaseText {
-            text: notification.content
+            text: notification.content || notification.description
             Layout.fillWidth: true
             Layout.fillHeight: true
             wrapMode: Text.WordWrap
@@ -64,9 +68,9 @@ StatusDialog {
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
-                text: notification.linkLabel
+                text: !!notification.linkLabel ? notification.linkLabel : qsTr("Visit the website")
                 icon.name: "external"
-                onClicked: root.linkClicked()
+                onClicked: root.linkClicked(root.notification.link)
             }
         }
     }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Utils 0.1 as CoreUtils
+
+import shared 1.0
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    required property var notification
+    signal linkClicked()
+
+    anchors.centerIn: parent
+    width: 480
+    padding: Theme.bigPadding
+
+    header: StatusDialogHeader {
+        StatusDateGroupLabel {
+            id: dateGroupLabel
+            messageTimestamp: notification ? notification.timestamp : 0
+            // Hidden label to get the string
+            visible: false
+        }
+
+        headline.title: notification.title
+        headline.subtitle: dateGroupLabel.text
+        actions.closeButton.onClicked: root.close()
+        leftComponent: StatusSmartIdenticon {
+            asset.name: Theme.png("status-logo-icon")
+            asset.isImage: true
+        }
+    }
+
+    ColumnLayout {
+        spacing: 16
+        width: parent.width
+
+        StatusRoundedImage {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 300
+
+            image.source: notification.imageUrl
+            color: "transparent"
+            border.color: root.backgroundColor
+            border.width: 1
+        }
+
+        StatusBaseText {
+            text: notification.content
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            wrapMode: Text.WordWrap
+        }
+    }
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusButton {
+                text: notification.linkLabel
+                icon.name: "external"
+                onClicked: root.linkClicked()
+            }
+        }
+    }
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -20,6 +20,7 @@ MarkAsIDVerifiedDialog 1.0 MarkAsIDVerifiedDialog.qml
 MarkAsUntrustedPopup 1.0 MarkAsUntrustedPopup.qml
 MetricsEnablePopup 1.0 MetricsEnablePopup.qml
 ModalPopup 1.0 ModalPopup.qml
+NewsMessagePopup 1.0 NewsMessagePopup.qml
 NicknamePopup 1.0 NicknamePopup.qml
 NoPermissionsToJoinPopup 1.0 NoPermissionsToJoinPopup.qml
 OutgoingContactVerificationRequestPopup 1.0 OutgoingContactVerificationRequestPopup.qml


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/17691

Based on top of https://github.com/status-im/status-desktop/pull/17719
Status-go PR: https://github.com/status-im/status-go/pull/6487

The first commit is the component alone and storybook elements
The second one is the hooking to the rest + metrics

### Affected areas

AC

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

Again, it doesn't follow the Design exactly, because I use the current component and I also used Hacker news so there is no image and the text is not truncated yet (it will be done in another issue/PR)

[news-popup.webm](https://github.com/user-attachments/assets/161c5879-2a04-4398-897f-1bfc59ebe162)

Storybook: 
![image](https://github.com/user-attachments/assets/bc2fbf37-a85a-4fa5-bc06-2c0e78502fb3)


### Impact on end user
Let's users see the details of a News message and go to the link

### How to test

- Enable the status-go feature flag and run the app
- Go to the AC

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

It's behind a feature flag and also it's just a new AC popup
