### PR TITLE
chore(@e2e): enable messaging tests in PRs

### DIFF
--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
@@ -17,14 +17,12 @@ import configs.testpath
 from constants import RandomUser, UserAccount
 from gui.main_window import MainWindow
 from scripts.utils.generators import random_text_message
-from scripts.utils.parsers import remove_tags
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703087', '1-1 Chat')
 @pytest.mark.case(703087, 738732, 738734, 738742, 738744, 738745)
-# @pytest.mark.critical
-# @pytest.mark.smoke
-@pytest.mark.skip(reason="tests are running very long because of long login time")
+@pytest.mark.critical
+@pytest.mark.smoke
 def test_1x1_chat_add_contact_in_settings(multiple_instances):
     user_one: UserAccount = RandomUser()
     user_two: UserAccount = RandomUser()

--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_group_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_group_chat.py
@@ -21,7 +21,6 @@ from scripts.utils.generators import random_text_message
 @pytest.mark.timeout(timeout=315)
 @pytest.mark.critical
 @pytest.mark.smoke
-@pytest.mark.skip(reason="temp skip until timeouts are fixed")
 @pytest.mark.parametrize('community_name, domain_link, domain_link_2',
                          [pytest.param('Status', 'status.app', 'github.com')
                           ])


### PR DESCRIPTION
### What does the PR do

bring back messaging tests (1x1 and group chat tests)