### PR TITLE
fix(Qt 5->6): Clicking X button on native window closes app

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -214,11 +214,11 @@ StatusWindow {
             } else {
                 if (loader.sourceComponent != app) {
                     Qt.quit();
-                }
-                else if (loader.sourceComponent == app) {
+                } else if (loader.sourceComponent == app) {
                     if (localAccountSensitiveSettings.quitOnClose) {
                         Qt.quit();
                     } else {
+                        close.accepted = false
                         applicationWindow.visible = false;
                     }
                 }


### PR DESCRIPTION
### What does the PR do

- reject the close event when the "Minimize on close" option is active

Fixes #17694

### Affected areas

AppMain

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

TBD