### PR TITLE
chore(@e2e): temp disable step with resolving wallet address in chat

### DIFF
--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
@@ -131,10 +131,10 @@ def test_1x1_chat_add_contact_in_settings(multiple_instances):
             message = chat.find_message_by_text(chat_message1, 0)
             additional_text = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(1, 21))
             time.sleep(5)
-
-        with step(f'User {user_one.name}, click address / ens link in message and verify send modal appears'):
-            send_modal = chat.open_send_modal_from_link(chat_message1)
-            assert str(send_modal.send_modal_recipient_panel.object.selectedRecipientAddress) == chat_message1
+        # TODO: https://github.com/status-im/status-desktop/issues/17757
+        # with step(f'User {user_one.name}, click address / ens link in message and verify send modal appears'):
+        #     send_modal = chat.open_send_modal_from_link(chat_message1)
+        #     assert str(send_modal.send_modal_recipient_panel.object.selectedRecipientAddress) == chat_message1
             left_panel_chat.click()
 
         with step(f'User {user_one.name}, edit message and verify it was changed'):

--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_group_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_group_chat.py
@@ -233,17 +233,17 @@ def test_group_chat_add_contact_in_ac(multiple_instances, community_name, domain
                     lambda: domain_link_2 == message_object.get_link_domain(),
                     configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
-            # with step(f'Paste link to status community'):
-            #     message_community = link_to_status_community
-            #     messages_screen.group_chat.type_message(message_community)
-            #
-            # with step('Verify title and subtitle of preview are correct and close button exists'):
-            #     assert driver.waitFor(
-            #         lambda: community_name == messages_screen.group_chat.get_link_preview_bubble_title(),
-            #         configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
-            #     assert driver.waitFor(
-            #         lambda: domain_link == messages_screen.group_chat.get_link_preview_bubble_description(),
-            #         configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+            with step(f'Paste link to status community'):
+                message_community = link_to_status_community
+                messages_screen.group_chat.type_message(message_community)
+
+            with step('Verify title and subtitle of preview are correct and close button exists'):
+                assert driver.waitFor(
+                    lambda: community_name == messages_screen.group_chat.get_link_preview_bubble_title(),
+                    configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+                assert driver.waitFor(
+                    lambda: domain_link == messages_screen.group_chat.get_link_preview_bubble_description(),
+                    configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
             with step('Close link preview options popup and send a message'):
                 messages_screen.group_chat.confirm_sending_message()


### PR DESCRIPTION
### What does the PR do

- bring back step of sending community link in chat
- disable step of checking wallet address to link functionality
