### PR TITLE
fix: Provide a general safe decoding for Json

### DIFF
--- a/src/app/core/signals/remote_signals/base.nim
+++ b/src/app/core/signals/remote_signals/base.nim
@@ -1,4 +1,4 @@
-import json_serialization
+import app_service/common/safe_json_serialization
 import signal_type
 
 import ../../eventemitter

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, chronicles, json_serialization
+import NimQml, json, strutils, chronicles
 import ../eventemitter
 
 include types

--- a/src/app/core/tasks/common.nim
+++ b/src/app/core/tasks/common.nim
@@ -1,10 +1,10 @@
 import
-  json_serialization#, stint
+  app_service/common/safe_json_serialization#, stint
 from eth/common/eth_types_json_serialization import writeValue, readValue
 
 export writeValue, readValue
 
-export json_serialization
+export safe_json_serialization
 
 type
   Task* = proc(arg: string): void {.gcsafe, nimcall.}
@@ -12,7 +12,7 @@ type
     tptr* {.dontSerialize.}: Task # Only used during task creation (don't access in tasks)
 
 proc decode*[T](arg: string): T =
-  Json.decode(arg, T, allowUnknownFields = true)
+  Json.safeDecode(arg, T, allowUnknownFields = true)
 
 proc encode*[T](arg: T): string =
   arg.toJson(typeAnnotations = true)

--- a/src/app_service/common/activity_center.nim
+++ b/src/app_service/common/activity_center.nim
@@ -1,4 +1,4 @@
-import json, json_serialization
+import json, app_service/common/safe_json_serialization
 import ../../app/core/eventemitter
 
 include json_utils

--- a/src/app_service/common/safe_json_serialization.nim
+++ b/src/app_service/common/safe_json_serialization.nim
@@ -1,0 +1,29 @@
+## Safe JSON Serialization Module
+## ===========================
+##
+## This module provides safe JSON serialization and deserialization utilities.
+## It ensures input strings remain alive during the entire decode operation,
+## preventing potential memory issues.
+
+import
+  json_serialization,
+  faststreams/inputs,
+  chronicles
+
+export json_serialization
+
+proc safeDecode*(Format: distinct type, input: string, T: type, allowUnknownFields = false, requireAllFields = false): T =
+  ## Safely decodes a JSON string into the specified type T.
+  ## This version ensures the input string remains alive during the entire decode operation.
+  result = Format.decode(input, T, allowUnknownFields = allowUnknownFields, requireAllFields = requireAllFields)
+  ## Warning: Don't remove `input` reference here to keep it alive during the decode operation.
+  if input.len == 0:
+    error "Cannot decode empty input"
+
+proc safeDecode*(Format: distinct type, input: openArray[byte], T: type, allowUnknownFields = false, requireAllFields = false): T =
+  ## Safely decodes a JSON string into the specified type T.
+  ## This version ensures the input string remains alive during the entire decode operation.
+  result = Format.decode(input, T, allowUnknownFields = allowUnknownFields, requireAllFields = requireAllFields)
+  ## Warning: Don't remove `input` reference here to keep it alive during the decode operation.
+  if input.len == 0:
+    error "Cannot decode empty input"

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -1,4 +1,4 @@
-import "json_serialization"
+import "app_service/common/safe_json_serialization"
 
 type
   ContentType* {.pure.} = enum

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -1,5 +1,5 @@
 import NimQml, Tables, os, json, stew/shims/strformat, sequtils, strutils, times, std/options
-import json_serialization, chronicles
+import app_service/common/safe_json_serialization, chronicles
 
 import ../../../app/global/global_singleton
 import ./dto/accounts as dto_accounts
@@ -522,7 +522,7 @@ QtObject:
   proc onConvertRegularProfileKeypairToKeycard*(self: Service, response: string) {.slot.} =
     var result = false
     try:
-      let rpcResponse = Json.decode(response, RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode(response, RpcResponse[JsonNode])
       if(rpcResponse.result.contains("error")):
         let errMsg = rpcResponse.result["error"].getStr
         if(errMsg.len == 0):
@@ -550,7 +550,7 @@ QtObject:
   proc onConvertKeycardProfileKeypairToRegular*(self: Service, response: string) {.slot.} =
     var result = false
     try:
-      let rpcResponse = Json.decode(response, RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode(response, RpcResponse[JsonNode])
       if(rpcResponse.result.contains("error")):
         let errMsg = rpcResponse.result["error"].getStr
         if(errMsg.len == 0):

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, stew/shims/strformat, strutils, stint, json_serialization
+import json, stew/shims/strformat, strutils, stint, app_service/common/safe_json_serialization
 import ../../message/dto/message
 import ../../contacts/dto/contacts
 import token_data

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, chronicles, strutils, strutils, stint, sugar, tables, json_serialization
+import NimQml, json, sequtils, chronicles, strutils, strutils, stint, sugar, tables, app_service/common/safe_json_serialization
 
 import ../../../app/core/eventemitter
 import ../../../app/core/[main]

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -115,7 +115,7 @@ type
 const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncSendImagesTaskArg](argEncoded)
   try:
-    var images = Json.decode(arg.imagePathsJson, seq[string])
+    var images = Json.safeDecode(arg.imagePathsJson, seq[string])
     var imagePaths: seq[string] = @[]
 
     for imagePathOrSource in images.mitems:

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -455,7 +455,7 @@ QtObject:
       if errorString != "":
         raise newException(CatchableError, errorString)
 
-      let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode($rpcResponseObj["response"], RpcResponse[JsonNode])
 
       discard self.processMessengerResponse(rpcResponse)
     except Exception as e:
@@ -505,7 +505,7 @@ QtObject:
       if errorString != "":
         raise newException(CatchableError, errorString)
 
-      let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode($rpcResponseObj["response"], RpcResponse[JsonNode])
       
       let (chats, messages) = self.processMessengerResponse(rpcResponse)
       if chats.len == 0 or messages.len == 0:
@@ -738,7 +738,7 @@ QtObject:
     try:
       let rpcResponseObj = rpcResponse.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        let error = Json.decode($rpcResponseObj["error"], RpcError)
+        let error = Json.safeDecode($rpcResponseObj["error"], RpcError)
         error "Error checking community channel permissions", msg = error.message
         return
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, sequtils, sugar, tables, strutils, json_serialization, strformat
+import json, sequtils, sugar, tables, strutils, app_service/common/safe_json_serialization, strformat
 
 import ../../../../backend/communities
 include ../../../common/json_utils

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1,6 +1,7 @@
-import NimQml, Tables, json, sequtils, std/sets, std/algorithm, stew/shims/strformat, strutils, chronicles, json_serialization, sugar, times
-import json_serialization/std/tables as ser_tables
+import NimQml, Tables, json, sequtils, std/sets, std/algorithm, stew/shims/strformat, strutils, chronicles, sugar, times
+import std/tables as ser_tables
 
+import app_service/common/safe_json_serialization
 import ./dto/community as community_dto
 import ./dto/sign_params as sign_params_dto
 import ../community_tokens/dto/community_token as community_token_dto
@@ -890,7 +891,7 @@ QtObject:
       let response = status_go.isDisplayNameDupeOfCommunityMember(displayName)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error scanning communities for member name: " & error.message)
 
       if response.result.kind != JNull:
@@ -1026,7 +1027,7 @@ QtObject:
       let response = status_go.spectateCommunity(communityId)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error joining community: " & error.message)
 
       if response.result == nil or response.result.kind == JNull:
@@ -1075,7 +1076,7 @@ QtObject:
       let response = status_go.leaveCommunity(communityId)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error leaving community: " & error.message)
 
       if response.result == nil or response.result.kind == JNull:
@@ -1133,7 +1134,7 @@ QtObject:
         fromTimestamp)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error importing discord community: " & error.message)
 
     except Exception as e:
@@ -1161,7 +1162,7 @@ QtObject:
           fromTimestamp)
 
         if response.error != nil:
-          let error = Json.decode($response.error, RpcError)
+          let error = Json.safeDecode($response.error, RpcError)
           raise newException(RpcException, "Error importing discord channel: " & error.message)
 
       except Exception as e:
@@ -1203,7 +1204,7 @@ QtObject:
         $bannerJson)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error creating community: " & error.message)
 
       if response.result != nil and response.result.kind != JNull:
@@ -1263,7 +1264,7 @@ QtObject:
         pinMessageAllMembersEnabled)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error editing community: " & error.message)
 
       if response.result != nil and response.result.kind != JNull:
@@ -1292,7 +1293,7 @@ QtObject:
         viewersCanPostReactions, hideIfPermissionsNotMet)
 
       if not response.error.isNil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error creating community channel: " & error.message)
 
       if response.result.isNil or response.result.kind == JNull:
@@ -1345,7 +1346,7 @@ QtObject:
       )
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error editing community channel: " & error.message)
 
       if response.result.isNil or response.result.kind == JNull:
@@ -1383,7 +1384,7 @@ QtObject:
         position)
 
       if not response.error.isNil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error reordering community channel: " & error.message)
 
       if response.result.isNil or response.result.kind == JNull:
@@ -1424,7 +1425,7 @@ QtObject:
     try:
       let response = status_go.deleteCommunityChat(communityId, chatId)
       if not response.error.isNil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error deleting community chat: " & error.message)
 
       if response.result.isNil or response.result.kind == JNull:
@@ -1447,7 +1448,7 @@ QtObject:
     try:
       let response = status_go.createCommunityCategory(communityId, name, channels)
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error creating community category: " & error.message)
 
       if response.result != nil and response.result.kind != JNull:
@@ -1495,7 +1496,7 @@ QtObject:
         raise newException(CatchableError, rpcResponseObj["error"].getStr)
 
       if rpcResponseObj["response"]{"error"}.kind != JNull:
-        let error = Json.decode(rpcResponseObj["response"]["error"].getStr, RpcError)
+        let error = Json.safeDecode(rpcResponseObj["response"]["error"].getStr, RpcError)
         raise newException(RpcException, error.message)
     except Exception as e:
       error "Error toggling collapsed community category", msg = e.msg
@@ -1509,7 +1510,7 @@ QtObject:
     try:
       let response = status_go.editCommunityCategory(communityId, categoryId, name, channels)
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error creating community category: " & error.message)
 
       if response.result != nil and response.result.kind != JNull:
@@ -1548,7 +1549,7 @@ QtObject:
       let response = status_go.deleteCommunityCategory(communityId, categoryId)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error deleting community category: " & error.message)
 
       # Update communities objects
@@ -1583,7 +1584,7 @@ QtObject:
         position)
 
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error reordering community category: " & error.message)
 
       let updatedCommunity = response.result["communities"][0].toCommunityDto()
@@ -1729,7 +1730,7 @@ QtObject:
       if (rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != ""):
         raise newException(CatchableError, rpcResponseObj{"error"}.getStr)
 
-      let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode($rpcResponseObj["response"], RpcResponse[JsonNode])
       checkAndEmitACNotificationsFromResponse(self.events, rpcResponse.result{"activityCenterNotifications"})
 
       if not self.processRequestsToJoinCommunity(rpcResponse.result):
@@ -1821,7 +1822,7 @@ QtObject:
       self.events.emit(SIGNAL_COMMUNITY_MEMBER_APPROVED,
         CommunityMemberArgs(communityId: communityId, pubKey: userKey, requestId: requestId))
 
-      let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode($rpcResponseObj["response"], RpcResponse[JsonNode])
       checkAndEmitACNotificationsFromResponse(self.events, rpcResponse.result{"activityCenterNotifications"})
 
     except Exception as e:
@@ -1923,7 +1924,7 @@ QtObject:
     try:
       let response = status_go.speedupArchivesImport()
       if (response.error != nil):
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, fmt"err: {error.message}")
     except Exception as e:
       error "Error speeding up archives import: ", msg = e.msg
@@ -1932,7 +1933,7 @@ QtObject:
     try:
       let response = status_go.slowdownArchivesImport()
       if (response.error != nil):
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, fmt"err: {error.message}")
     except Exception as e:
       error "Error slowing down archives import: ", msg = e.msg
@@ -2131,7 +2132,7 @@ QtObject:
         raise newException(RpcException, rpcResponseObj["error"].getStr)
 
       if rpcResponseObj["response"]{"error"}.kind != JNull:
-        let error = Json.decode(rpcResponseObj["response"]["error"].getStr, RpcError)
+        let error = Json.safeDecode(rpcResponseObj["response"]["error"].getStr, RpcError)
         raise newException(RpcException, error.message)
 
       let memberPubkey = rpcResponseObj{"pubKey"}.getStr()
@@ -2321,7 +2322,7 @@ QtObject:
         raise newException(RpcException, rpcResponseObj["error"].getStr)
 
       if rpcResponseObj["response"]{"error"}.kind != JNull:
-        let error = Json.decode(rpcResponseObj["response"]["error"].getStr, RpcError)
+        let error = Json.safeDecode(rpcResponseObj["response"]["error"].getStr, RpcError)
         raise newException(RpcException, error.message)
 
       let revealedAccounts = rpcResponseObj["response"]["result"].toRevealedAccounts()
@@ -2351,7 +2352,7 @@ QtObject:
         raise newException(RpcException, rpcResponseObj["error"].getStr)
 
       if rpcResponseObj["response"]{"error"}.kind != JNull:
-        let error = Json.decode(rpcResponseObj["response"]["error"].getStr, RpcError)
+        let error = Json.safeDecode(rpcResponseObj["response"]["error"].getStr, RpcError)
         raise newException(RpcException, error.message)
 
       let revealedAccounts = rpcResponseObj["response"]["result"].toMembersRevealedAccounts
@@ -2398,7 +2399,7 @@ QtObject:
       if (rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != ""):
         raise newException(CatchableError, rpcResponseObj{"error"}.getStr)
 
-      let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode($rpcResponseObj["response"], RpcResponse[JsonNode])
       let community = rpcResponse.result["communities"][0].toCommunityDto()
 
       self.handleCommunityUpdates(@[community], @[], @[])
@@ -2412,7 +2413,7 @@ QtObject:
     try:
       let response = status_go.promoteSelfToControlNode(communityId)
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, error.message)
 
       if response.result == nil or response.result.kind == JNull or response.result["communities"].kind == JNull or
@@ -2446,7 +2447,7 @@ QtObject:
     try:
       let response = status_go.markAllReadInCommunity(communityId)
       if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, error.message)
 
       self.chatService.parseChatResponseAndEmit(response)

--- a/src/app_service/service/contacts/dto/profile_showcase.nim
+++ b/src/app_service/service/contacts/dto/profile_showcase.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, stew/shims/strformat
+import json, app_service/common/safe_json_serialization, stew/shims/strformat
 
 include ../../../common/json_utils
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -632,7 +632,7 @@ QtObject:
       else:
         let responseError = rpcResponseObj{"response"}{"error"}
         if responseError.kind != JNull:
-          error = Json.decode($responseError, RpcError).message
+          error = Json.safeDecode($responseError, RpcError).message
 
       if len(error) != 0:
         error "error requesting contact info", msg = error, publicKey

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -142,7 +142,7 @@ QtObject:
     try:
       let response = status_installations.setInstallationName(installationId, name)
       if response.error != nil:
-        let e = Json.decode($response.error, RpcError)
+        let e = Json.safeDecode($response.error, RpcError)
         error "error: ", errorDescription = e.message
         return
       let data = UpdateInstallationNameArgs(installationId: installationId, name: name)
@@ -375,7 +375,7 @@ QtObject:
     try:
       let response = status_installations.finishPairingThroughSeedPhraseProcess(installationId)
       if response.error != nil:
-        let e = Json.decode($response.error, RpcError)
+        let e = Json.safeDecode($response.error, RpcError)
         raise newException(CatchableError, e.message)
     except Exception as e:
       error "error: ", desription = e.msg
@@ -384,7 +384,7 @@ QtObject:
     try:
       let response = status_installations.enableInstallationAndSync(installationId)
       if response.error != nil:
-        let e = Json.decode($response.error, RpcError)
+        let e = Json.safeDecode($response.error, RpcError)
         raise newException(CatchableError, e.message)
       # Parse AC notif
       checkAndEmitACNotificationsFromResponse(self.events, response.result{"activityCenterNotifications"})

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -1,5 +1,5 @@
 import NimQml, Tables, json, sequtils, strutils, stint, sugar, chronicles
-import web3/ethtypes, stew/byteutils, nimcrypto, json_serialization
+import web3/ethtypes, stew/byteutils, nimcrypto, app_service/common/safe_json_serialization
 
 import app/core/eventemitter
 import app/core/tasks/[qt, threadpool]

--- a/src/app_service/service/eth/dto/coder.nim
+++ b/src/app_service/service/eth/dto/coder.nim
@@ -1,7 +1,7 @@
 import tables, strutils, stint, macros
 import
   web3/[encoding, ethtypes], stew/byteutils, nimcrypto, json_serialization, chronicles
-import json, tables, json_serialization
+import json, tables, app_service/common/safe_json_serialization
 
 include  ../../../common/json_utils
 

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, os, chronicles, strutils, random, json_serialization
+import NimQml, Tables, json, os, chronicles, strutils, random, app_service/common/safe_json_serialization
 import app/global/feature_flags
 import app/global/global_singleton
 import app/core/eventemitter
@@ -146,7 +146,7 @@ QtObject:
       let response = callRPC($KeycardAction.Stop)
       let rpcResponseObj = response.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-          let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+          let error = Json.safeDecode(rpcResponseObj["error"].getStr, RpcError)
           raise newException(RpcException, error.message)
     except Exception as e:
       error "error stop", err=e.msg
@@ -156,7 +156,7 @@ QtObject:
       let response = callRPC($KeycardAction.GenerateMnemonic, %*{"length": length})
       let rpcResponseObj = response.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-          let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+          let error = Json.safeDecode(rpcResponseObj["error"].getStr, RpcError)
           raise newException(RpcException, error.message)
 
       let indexes = rpcResponseObj["result"]["indexes"]
@@ -171,7 +171,7 @@ QtObject:
       let response = callRPC($KeycardAction.GetMetadata)
       let rpcResponseObj = response.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-        let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+        let error = Json.safeDecode(rpcResponseObj["error"].getStr, RpcError)
         raise newException(RpcException, error.message)
       return rpcResponseObj["result"].toCardMetadataDto()
     except Exception as e:
@@ -259,7 +259,7 @@ QtObject:
       let response = callRPC($KeycardAction.StoreMetadata, %*{"name": name, "paths": paths})
       let rpcResponseObj = response.parseJson
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
-          let error = Json.decode(rpcResponseObj["error"].getStr, RpcError)
+          let error = Json.safeDecode(rpcResponseObj["error"].getStr, RpcError)
           raise newException(RpcException, error.message)
     except Exception as e:
       error "error storing metadata", err=e.msg

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -685,7 +685,7 @@ QtObject:
       result = GetMessageResult()
       let msgResponse = status_go.getMessageByMessageId(messageId)
       if not msgResponse.error.isNil:
-        let error = Json.decode($msgResponse.error, RpcError)
+        let error = Json.safeDecode($msgResponse.error, RpcError)
         raise newException(RpcException, "Error resending chat message: " & error.message)
 
       result.message = msgResponse.result.toMessageDto()
@@ -1193,7 +1193,7 @@ proc resendChatMessage*(self: Service, messageId: string): string =
     let response = status_go.resendChatMessage(messageId)
 
     if response.error != nil:
-        let error = Json.decode($response.error, RpcError)
+        let error = Json.safeDecode($response.error, RpcError)
         raise newException(RpcException, "Error resending chat message: " & error.message)
 
     return

--- a/src/app_service/service/network/service.nim
+++ b/src/app_service/service/network/service.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, chronicles, sugar, sequtils
+import json, app_service/common/safe_json_serialization, chronicles, sugar, sequtils
 
 import ../../../app/core/eventemitter
 import backend/network as backend
@@ -40,7 +40,7 @@ proc fetchNetworks(self: Service) =
     let errDescription = response.error.message
     error "error getting networks: ", errDescription
   let networksDto = if response.result.isNil or response.result.kind == JNull: @[]
-            else: Json.decode($response.result, seq[NetworkDto], allowUnknownFields = true)
+            else: Json.safeDecode($response.result, seq[NetworkDto], allowUnknownFields = true)
   self.flatNetworks = networksDto.map(n => networkDtoToItem(n))
   self.rpcProviders = @[]
   for network in self.flatNetworks:

--- a/src/app_service/service/profile/dto/profile_showcase_preferences.nim
+++ b/src/app_service/service/profile/dto/profile_showcase_preferences.nim
@@ -1,4 +1,4 @@
-import json, strutils, stew/shims/strformat, stint, sequtils, json_serialization
+import json, strutils, stew/shims/strformat, stint, sequtils, app_service/common/safe_json_serialization
 
 include ../../../common/json_utils
 include ../../../common/utils

--- a/src/app_service/service/ramp/dto.nim
+++ b/src/app_service/service/ramp/dto.nim
@@ -1,5 +1,5 @@
 
-import json, json_serialization, stew/shims/strformat
+import json, app_service/common/safe_json_serialization, stew/shims/strformat
 import options
 
 include app_service/common/json_utils
@@ -54,7 +54,7 @@ proc toCryptoRampDto*(jsonObj: JsonNode): CryptoRampDto =
   for chainID in jsonObj["supportedChainIds"].getElems():
     result.supportedChainIds.add(chainID.getInt())
   for token in jsonObj["supportedTokens"].getElems():
-    let tokenDto = Json.decode($token, TokenDto, allowUnknownFields = true)
+    let tokenDto = Json.safeDecode($token, TokenDto, allowUnknownFields = true)
     result.supportedTokens.add(tokenDto)
   discard jsonObj.getProp("urlsNeedParameters", result.urlsNeedParameters)
 

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -63,7 +63,7 @@ proc installStickerPackTask(argEncoded: string) {.gcsafe, nimcall.} =
     if installResponse.error == nil:
       installed = true
     else:
-      let err = Json.decode($installResponse.error, RpcError)
+      let err = Json.safeDecode($installResponse.error, RpcError)
       error "Error installing stickers", message = err.message
   except RpcException:
     error "Error installing stickers", message = getCurrentExceptionMsg()

--- a/src/app_service/service/stickers/dto/stickers.nim
+++ b/src/app_service/service/stickers/dto/stickers.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, stew/shims/strformat, strutils, stint, json_serialization, chronicles
+import json, stew/shims/strformat, strutils, stint, app_service/common/safe_json_serialization, chronicles
 
 include ../../../common/json_utils
 include ../../../common/utils

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -3,7 +3,7 @@ import NimQml, Tables, json, sequtils, chronicles, strutils, sets, stint
 import app/core/[main]
 import app/core/tasks/[qt, threadpool]
 
-import web3/ethtypes, web3/conversions, stew/byteutils, nimcrypto, json_serialization
+import web3/ethtypes, web3/conversions, stew/byteutils, nimcrypto, app_service/common/safe_json_serialization
 
 import backend/stickers as status_stickers
 import backend/chat as status_chat
@@ -172,7 +172,7 @@ QtObject:
       self.updateStickersPack(args.sentTransaction.hash, args.status)
 
   proc setMarketStickerPacks*(self: Service, strickersJSON: string) {.slot.} =
-    let stickersResult = Json.decode(strickersJSON, tuple[packs: seq[StickerPackDto], error: string])
+    let stickersResult = Json.safeDecode(strickersJSON, tuple[packs: seq[StickerPackDto], error: string])
 
     if stickersResult.error != "":
       self.events.emit(SIGNAL_ALL_STICKER_PACKS_LOAD_FAILED, Args())
@@ -308,7 +308,7 @@ QtObject:
     self.threadpool.start(arg)
 
   proc onStickerPackInstalled*(self: Service, installedPackJson: string) {.slot.} =
-    let installedPack = Json.decode(installedPackJson, tuple[packId: string, installed: bool])
+    let installedPack = Json.safeDecode(installedPackJson, tuple[packId: string, installed: bool])
     if installedPack.installed:
       if self.marketStickerPacks.hasKey(installedPack.packId):
         self.marketStickerPacks[installedPack.packId].status = StickerPackStatus.Installed
@@ -351,7 +351,7 @@ QtObject:
       if errorString != "":
         raise newException(CatchableError, errorString)
 
-      let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
+      let rpcResponse = Json.safeDecode($rpcResponseObj["response"], RpcResponse[JsonNode])
       discard self.chatService.processMessengerResponse(rpcResponse)
     except Exception as e:
       error "Error sending sticker", msg = e.msg

--- a/src/app_service/service/token/dto.nim
+++ b/src/app_service/service/token/dto.nim
@@ -2,7 +2,7 @@ import json, stew/shims/strformat
 
 include app_service/common/json_utils
 
-import json_serialization
+import app_service/common/safe_json_serialization
 
 const WEEKLY_TIME_RANGE* = 0
 const MONTHLY_TIME_RANGE* = 1

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -12,6 +12,7 @@ import app/core/signals/types
 import app_service/common/cache
 import app_service/common/wallet_constants
 import ./dto, ./service_items, ./utils
+import app_service/common/safe_json_serialization
 
 export dto, service_items
 
@@ -132,7 +133,7 @@ QtObject:
         return
 
       for (symbol, marketValuesObj) in tokensResult.pairs:
-        let marketValuesDto = Json.decode($marketValuesObj, dto.TokenMarketValuesDto, allowUnknownFields = true)
+        let marketValuesDto = Json.safeDecode($marketValuesObj, dto.TokenMarketValuesDto, allowUnknownFields = true)
         self.tokenMarketValuesTable[symbol] = TokenMarketValuesItem(
           marketCap: marketValuesDto.marketCap,
           highDay: marketValuesDto.highDay,
@@ -174,7 +175,7 @@ QtObject:
         return
 
       for (symbol, tokenDetailsObj) in tokensResult.pairs:
-        let tokenDetailsDto = Json.decode($tokenDetailsObj, dto.TokenDetailsDto, allowUnknownFields = true)
+        let tokenDetailsDto = Json.safeDecode($tokenDetailsObj, dto.TokenDetailsDto, allowUnknownFields = true)
         self.tokenDetailsTable[symbol] = TokenDetailsItem(
           description: tokenDetailsDto.description,
           assetWebsiteUrl: tokenDetailsDto.assetWebsiteUrl)
@@ -285,7 +286,7 @@ QtObject:
       # Create a copy of the tokenResultStr to avoid exceptions in `decode`
       # Workaround for https://github.com/status-im/status-desktop/issues/17398
       let tokenResultStr = $tokensResult
-      let tokenList =  Json.decode(tokenResultStr, TokenListDto, allowUnknownFields = true)
+      let tokenList =  Json.safeDecode(tokenResultStr, TokenListDto, allowUnknownFields = true)
 
       self.tokenListUpdatedAt = tokenList.updatedAt
 
@@ -535,7 +536,7 @@ QtObject:
 
       self.tokenPreferencesJson = $response.result
       for preferences in response.result:
-        let dto = Json.decode($preferences, TokenPreferencesDto, allowUnknownFields = true)
+        let dto = Json.safeDecode($preferences, TokenPreferencesDto, allowUnknownFields = true)
         self.tokenPreferencesTable[dto.key] = TokenPreferencesItem(
           key: dto.key,
           position: dto.position,
@@ -567,7 +568,7 @@ QtObject:
       var tokenPreferences: seq[TokenPreferencesDto]
       if preferencesJson.kind == JArray:
         for preferences in preferencesJson:
-          add(tokenPreferences, Json.decode($preferences, TokenPreferencesDto, allowUnknownFields = false))
+          add(tokenPreferences, Json.safeDecode($preferences, TokenPreferencesDto, allowUnknownFields = false))
       let response = backend.updateTokenPreferences(tokenPreferences)
       if not response.error.isNil:
         raise newException(CatchableError, response.error.message)

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -1,4 +1,4 @@
-import json, strutils, stint, json_serialization, stew/shims/strformat
+import json, strutils, stint, app_service/common/safe_json_serialization, stew/shims/strformat
 import Tables, sequtils
 
 import
@@ -297,8 +297,8 @@ proc `$`*(self: TransactionPathDto): string =
 proc convertToTransactionPathDto*(jsonObj: JsonNode): TransactionPathDto =
   result = TransactionPathDto()
   discard jsonObj.getProp("bridgeName", result.bridgeName)
-  result.fromNetwork = Json.decode($jsonObj["fromNetwork"], NetworkDto, allowUnknownFields = true)
-  result.toNetwork = Json.decode($jsonObj["toNetwork"], NetworkDto, allowUnknownFields = true)
+  result.fromNetwork = Json.safeDecode($jsonObj["fromNetwork"], NetworkDto, allowUnknownFields = true)
+  result.toNetwork = Json.safeDecode($jsonObj["toNetwork"], NetworkDto, allowUnknownFields = true)
   result.gasFees = decodeSuggestedFeesDto(jsonObj["gasFees"])
   discard jsonObj.getProp("cost", result.cost)
   discard jsonObj.getProp("tokenFees", result.tokenFees)

--- a/src/app_service/service/transaction/dtoV2.nim
+++ b/src/app_service/service/transaction/dtoV2.nim
@@ -1,10 +1,10 @@
-# import json, json_serialization, stint
+# import json, app_service/common/safe_json_serialization, stint
 
 # import ../network/dto, ../token/dto
 
 # include  app_service/common/json_utils
 
-import json, strutils, stint, json_serialization
+import json, strutils, stint, app_service/common/safe_json_serialization, chronicles
 import sequtils, sugar
 
 import
@@ -100,10 +100,10 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   result = TransactionPathDtoV2()
   discard jsonObj.getProp("RouterInputParamsUuid", result.routerInputParamsUuid)
   discard jsonObj.getProp("ProcessorName", result.processorName)
-  result.fromChain = Json.decode($jsonObj["FromChain"], NetworkDto, allowUnknownFields = true)
-  result.toChain = Json.decode($jsonObj["ToChain"], NetworkDto, allowUnknownFields = true)
-  result.fromToken = Json.decode($jsonObj["FromToken"], TokenDto, allowUnknownFields = true)
-  result.toToken = Json.decode($jsonObj["ToToken"], TokenDto, allowUnknownFields = true)
+  result.fromChain = Json.safeDecode($jsonObj["FromChain"], NetworkDto, allowUnknownFields = true)
+  result.toChain = Json.safeDecode($jsonObj["ToChain"], NetworkDto, allowUnknownFields = true)
+  result.fromToken = Json.safeDecode($jsonObj["FromToken"], TokenDto, allowUnknownFields = true)
+  result.toToken = Json.safeDecode($jsonObj["ToToken"], TokenDto, allowUnknownFields = true)
   result.amountIn = stint.fromHex(UInt256, jsonObj{"AmountIn"}.getStr)
   discard jsonObj.getProp("AmountInLocked", result.amountInLocked)
   result.amountOut = stint.fromHex(UInt256, jsonObj{"AmountOut"}.getStr)

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, chronicles, strutils, std/os
+import json, app_service/common/safe_json_serialization, chronicles, strutils, std/os
 import ./core, ../app_service/common/utils
 import ../app_service/service/wallet_account/dto/account_dto
 import ../app_service/service/accounts/dto/login_request
@@ -195,7 +195,7 @@ proc generateAlias*(publicKey: string): RpcResponse[JsonNode] =
 
 proc isAlias*(value: string): bool =
   let response = status_go.isAlias(value)
-  let r = Json.decode(response, JsonNode)
+  let r = Json.safeDecode(response, JsonNode)
   return r["result"].getBool()
 
 proc getRandomMnemonic*(): RpcResponse[JsonNode] =
@@ -232,7 +232,7 @@ proc createAccountFromMnemonicAndDeriveAccountsForPaths*(mnemonic: string, paths
 
   try:
     let response = status_go.createAccountFromMnemonicAndDeriveAccountsForPaths($payload)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error doing rpc request", methodName = "createAccountFromMnemonicAndDeriveAccountsForPaths", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -252,7 +252,7 @@ proc createAccountFromPrivateKey*(privateKey: string): RpcResponse[JsonNode] =
   let payload = %* {"privateKey": privateKey}
   try:
     let response = status_go.createAccountFromPrivateKey($payload)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error doing rpc request", methodName = "createAccountFromPrivateKey", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -299,7 +299,7 @@ proc createAccountAndLogin*(request: CreateAccountRequest): RpcResponse[JsonNode
   try:
     let payload = request.toJson()
     let response = status_go.createAccountAndLogin($payload)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
 
   except RpcException as e:
     error "error doing rpc request", methodName = "createAccountAndLogin", exception=e.msg
@@ -309,7 +309,7 @@ proc restoreAccountAndLogin*(request: RestoreAccountRequest): RpcResponse[JsonNo
   try:
     let payload = request.toJson()
     let response = status_go.restoreAccountAndLogin($payload)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
 
   except RpcException as e:
     error "error doing rpc request", methodName = "restoreAccountAndLogin", exception=e.msg
@@ -319,7 +319,7 @@ proc convertRegularProfileKeypairToKeycard*(account: JsonNode, settings: JsonNod
   RpcResponse[JsonNode] =
   try:
     let response = status_go.convertToKeycardAccount($account, $settings, keycardUid, password, newPassword)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error doing rpc request", methodName = "convertRegularProfileKeypairToKeycard", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -328,7 +328,7 @@ proc convertKeycardProfileKeypairToRegular*(mnemonic: string, currPassword: stri
   RpcResponse[JsonNode] =
   try:
     let response = status_go.convertToRegularAccount(mnemonic, currPassword, newPassword)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error doing rpc request", methodName = "convertKeycardProfileKeypairToRegular", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -337,7 +337,7 @@ proc loginAccount*(request: LoginAccountRequest): RpcResponse[JsonNode] =
   try:
     let payload = request.toJson()
     let response = status_go.loginAccount($payload)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
 
   except RpcException as e:
     error "loginAccount failed", exception=e.msg
@@ -347,7 +347,7 @@ proc verifyAccountPassword*(address: string, hashedPassword: string, keystoreDir
   RpcResponse[JsonNode] =
   try:
     let response = status_go.verifyAccountPassword(keystoreDir, address, hashedPassword)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
 
   except RpcException as e:
     error "error doing rpc request", methodName = "verifyAccountPassword", exception=e.msg
@@ -357,7 +357,7 @@ proc verifyDatabasePassword*(keyuid: string, hashedPassword: string):
   RpcResponse[JsonNode] =
   try:
     let response = status_go.verifyDatabasePassword(keyuid, hashedPassword)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
 
   except RpcException as e:
     error "error doing rpc request", methodName = "verifyDatabasePassword", exception=e.msg

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -1,5 +1,5 @@
 import times, stew/shims/strformat, options, chronicles
-import json, json_serialization
+import json, app_service/common/safe_json_serialization
 import core, response_type
 import stint
 

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, stew/shims/strformat
+import json, app_service/common/safe_json_serialization, stew/shims/strformat
 import hashes
 import ./core, ./response_type
 import app_service/service/saved_address/dto as saved_address_dto

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, json_serialization
+import json, stew/shims/strformat, app_service/common/safe_json_serialization
 import stint, Tables, options, strutils
 import community_tokens_types
 

--- a/src/backend/connector.nim
+++ b/src/backend/connector.nim
@@ -1,5 +1,5 @@
 import options
-import json, json_serialization
+import json, app_service/common/safe_json_serialization
 import core, response_type
 
 from gen import rpc

--- a/src/backend/core.nim
+++ b/src/backend/core.nim
@@ -1,6 +1,7 @@
-import json, json_serialization, stew/shims/strformat, chronicles
+import json, stew/shims/strformat, chronicles
 import status_go
 import response_type
+import app_service/common/safe_json_serialization
 
 export response_type
 
@@ -26,7 +27,7 @@ proc makePrivateRpcCall*(
   try:
     debug "NewBE_callPrivateRPC", rpc_method=methodName
     let rpcResponseRaw = status_go.callPrivateRPC($inputJSON)
-    result = Json.decode(rpcResponseRaw, RpcResponse[JsonNode])
+    result = Json.safeDecode(rpcResponseRaw, RpcResponse[JsonNode])
     if(not result.error.isNil):
       var err = "\nstatus-go error ["
       err &= fmt"methodName:{methodName}, "

--- a/src/backend/general.nim
+++ b/src/backend/general.nim
@@ -1,4 +1,4 @@
-import json, strutils, json_serialization, chronicles
+import json, strutils, app_service/common/safe_json_serialization, chronicles
 import core, ../app_service/common/utils
 import response_type
 
@@ -12,7 +12,7 @@ logScope:
 proc validateMnemonic*(mnemonic: string): RpcResponse[JsonNode] =
   try:
     let response = status_go.validateMnemonic(mnemonic.strip())
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
 
   except RpcException as e:
     error "error doing rpc request", methodName = "validateMnemonic", exception=e.msg
@@ -25,7 +25,7 @@ proc startMessenger*(): RpcResponse[JsonNode] =
 proc logout*(): RpcResponse[JsonNode] =
   try:
     let response = status_go.logout()
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error logging out", methodName = "logout", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -58,7 +58,7 @@ proc getPasswordStrengthScore*(password: string, userInputs: seq[string]): RpcRe
   let params = %* {"password": password, "userInputs": userInputs}
   try:
     let response = status_go.getPasswordStrengthScore($(params))
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error", methodName = "getPasswordStrengthScore", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -66,7 +66,7 @@ proc getPasswordStrengthScore*(password: string, userInputs: seq[string]): RpcRe
 proc generateImages*(imagePath: string, aX, aY, bX, bY: int): RpcResponse[JsonNode] =
   try:
     let response = status_go.generateImages(imagePath, aX, aY, bX, bY)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error", methodName = "generateImages", exception=e.msg
     raise newException(RpcException, e.msg)
@@ -74,7 +74,7 @@ proc generateImages*(imagePath: string, aX, aY, bX, bY: int): RpcResponse[JsonNo
 proc initKeystore*(keystoreDir: string): RpcResponse[JsonNode] =
   try:
     let response = status_go.initKeystore(keystoreDir)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error", methodName = "initKeystore", exception=e.msg
     raise newException(RpcException, e.msg)

--- a/src/backend/network_types.nim
+++ b/src/backend/network_types.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, stew/shims/strformat
+import json, app_service/common/safe_json_serialization, stew/shims/strformat
 
 type RpcProviderType* {.pure.} = enum
   EmbeddedProxy = "embedded-proxy"

--- a/src/backend/node_config.nim
+++ b/src/backend/node_config.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, chronicles
+import json, app_service/common/safe_json_serialization, chronicles
 import ./core
 import ./response_type
 import ../app_service/common/utils
@@ -23,7 +23,7 @@ proc switchFleet*(fleet: string, nodeConfig: JsonNode): RpcResponse[JsonNode] =
   try:
     info "switching fleet", fleet
     let response = status_go.switchFleet(fleet, $nodeConfig)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error doing rpc request", methodName = "switchFleet", exception=e.msg
     raise newException(RpcException, e.msg)

--- a/src/backend/privacy.nim
+++ b/src/backend/privacy.nim
@@ -1,4 +1,4 @@
-import json, json_serialization, chronicles
+import json, app_service/common/safe_json_serialization, chronicles
 import response_type
 
 import status_go
@@ -12,7 +12,7 @@ proc changeDatabasePassword*(keyUID: string, oldHashedPassword: string, newHashe
   =
   try:
     let response = status_go.changeDatabasePassword(keyUID, oldHashedPassword, newHashedPassword)
-    result.result = Json.decode(response, JsonNode)
+    result.result = Json.safeDecode(response, JsonNode)
   except RpcException as e:
     error "error", methodName = "changeDatabasePassword", exception=e.msg
     raise newException(RpcException, e.msg)

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -1,4 +1,4 @@
-import Tables, json, json_serialization, stew/shims/strformat, chronicles
+import Tables, json, app_service/common/safe_json_serialization, stew/shims/strformat, chronicles
 
 import ./core as core
 

--- a/src/backend/visual_identity.nim
+++ b/src/backend/visual_identity.nim
@@ -1,4 +1,4 @@
-import json, json_serialization
+import json, app_service/common/safe_json_serialization
 import response_type
 
 import status_go
@@ -6,10 +6,10 @@ import status_go
 export response_type
 
 proc emojiHashOf*(pubkey: string): RpcResponse[JsonNode] =
-    result = Json.decode(status_go.emojiHash(pubkey), RpcResponse[JsonNode])
+    result = Json.safeDecode(status_go.emojiHash(pubkey), RpcResponse[JsonNode])
 
 proc colorHashOf*(pubkey: string): RpcResponse[JsonNode] =
-    result = Json.decode(status_go.colorHash(pubkey), RpcResponse[JsonNode])
+    result = Json.safeDecode(status_go.colorHash(pubkey), RpcResponse[JsonNode])
 
 proc colorIdOf*(pubkey: string): RpcResponse[JsonNode] =
-    result = Json.decode(status_go.colorID(pubkey), RpcResponse[JsonNode])
+    result = Json.safeDecode(status_go.colorID(pubkey), RpcResponse[JsonNode])

--- a/src/backend/wallet.nim
+++ b/src/backend/wallet.nim
@@ -1,4 +1,4 @@
-import json, tables, json_serialization, chronicles
+import json, tables, app_service/common/safe_json_serialization, chronicles
 import core, response_type
 from ./gen import rpc
 
@@ -105,7 +105,7 @@ proc sendTransactionWithSignature*(resultOut: var JsonNode, chainId: int, txType
 proc hashTypedData*(resultOut: var JsonNode, data: string): string =
   try:
     let rawResponse = status_go.hashTypedData(data)
-    var response = Json.decode(rawResponse, RpcResponse[JsonNode])
+    var response = Json.safeDecode(rawResponse, RpcResponse[JsonNode])
     return prepareResponse(resultOut, response)
   except Exception as e:
     warn "error hashing data", err = e.msg
@@ -114,7 +114,7 @@ proc hashTypedData*(resultOut: var JsonNode, data: string): string =
 proc hashTypedDataV4*(resultOut: var JsonNode, data: string): string =
   try:
     let rawResponse = status_go.hashTypedDataV4(data)
-    var response = Json.decode(rawResponse, RpcResponse[JsonNode])
+    var response = Json.safeDecode(rawResponse, RpcResponse[JsonNode])
     return prepareResponse(resultOut, response)
   except Exception as e:
     warn "error hashing data v4", err = e.msg

--- a/src/backend/wallet_connect.nim
+++ b/src/backend/wallet_connect.nim
@@ -1,5 +1,5 @@
 import options, chronicles
-import json, json_serialization
+import json, app_service/common/safe_json_serialization
 import core, response_type
 
 from gen import rpc
@@ -60,7 +60,7 @@ proc getDapps*(validAtEpoch: int64, testChains: bool): string =
   try:
     let params = %*[validAtEpoch, testChains]
     let rpcResRaw = callPrivateRPCNoDecode("wallet_getWalletConnectDapps", params)
-    let rpcRes = Json.decode(rpcResRaw, RpcResponse[JsonNode])
+    let rpcRes = Json.safeDecode(rpcResRaw, RpcResponse[JsonNode])
     if(not rpcRes.error.isNil):
       return ""
 


### PR DESCRIPTION
### What does the PR do

This is a follow-up of https://github.com/status-im/status-desktop/pull/17594 that's closing the door for the json decode issues on all usages and all platforms.

There's been another attempt here https://github.com/status-im/status-desktop/pull/17606, but it's not efficient on Windows and other platforms. It only works on MacOs asa far as I can tell.

Changes:
`Json.decode` has been replaced with `Json.safeDecode`. The difference here is that the `input` lifetime is forcefully extended by checking the `len` after `decode`. This ensures the GC still has a positive refc for the `input` and won't be collected when the GC cycle is triggered in `decode`.

