### PR TITLE
feat(Communities): Updated community creation archive protocol flow with new design

### DIFF
--- a/storybook/pages/EnableFullMessageHistoryPopupPage.qml
+++ b/storybook/pages/EnableFullMessageHistoryPopupPage.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Communities.popups 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            EnableFullMessageHistoryPopup {
+                id: dialog
+
+                anchors.centerIn: parent
+
+                onAccepted: logs.logEvent("EnableFullMessageHistoryPopup::onAccepted")
+                onClosed: logs.logEvent("EnableFullMessageHistoryPopup::onClosed")
+
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+    }
+}
+
+// category: Popups

--- a/ui/app/AppLayouts/Communities/controls/EditCommunitySettingsForm.qml
+++ b/ui/app/AppLayouts/Communities/controls/EditCommunitySettingsForm.qml
@@ -146,13 +146,13 @@ Control {
         StatusModalDivider {
             Layout.fillWidth: true
             Layout.topMargin: 2
-            Layout.bottomMargin: -root.spacing
+            Layout.bottomMargin: 2
         }
 
         Options {
             id: options
             Layout.fillWidth: true
-            Layout.topMargin: 4
+            Layout.topMargin: -parent.spacing
             Layout.bottomMargin: 4
         }
     }

--- a/ui/app/AppLayouts/Communities/controls/Options.qml
+++ b/ui/app/AppLayouts/Communities/controls/Options.qml
@@ -5,6 +5,11 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
+import AppLayouts.Communities.popups 1.0
+
+import utils 1.0
 
 ColumnLayout {
     id: root
@@ -12,7 +17,6 @@ ColumnLayout {
     property alias archiveSupportEnabled: archiveSupportToggle.checked
     property alias requestToJoinEnabled: requestToJoinToggle.checked
     property alias pinMessagesEnabled: pinMessagesToggle.checked
-
     property alias archiveSupporVisible: archiveSupport.visible
 
     spacing: 0
@@ -20,56 +24,22 @@ ColumnLayout {
     QtObject {
         id: d
         readonly property int optionHeight: 64
-    }
-
-    Item {
-        id: archiveSupport
-
-        Layout.preferredWidth: parent.width
-        Layout.preferredHeight: visible ? d.optionHeight : 0
-
-        StatusCheckBox {
-            id: archiveSupportToggle
-            width: (parent.width-12)
-            leftSide: false
-            padding: 0
-            anchors.verticalCenter: parent.verticalCenter
-            text: qsTr("Community history service")
-
-            StatusToolTip {
-                text: qsTr('For this Community Setting to work, you also need to activate "Archive Protocol Enabled" in Advanced Settings')
-                visible: parent.hovered
-            }
-        }
-    }
-
-    Item {
-        Layout.preferredWidth: parent.width
-        Layout.preferredHeight: d.optionHeight
-
-        StatusCheckBox {
-            id: pinMessagesToggle
-            width: (parent.width-12)
-            leftSide: false
-            padding: 0
-            anchors.verticalCenter: parent.verticalCenter
-            text: qsTr("Any member can pin a message")
-        }
+        readonly property string aboutHistoryServiceLink: Constants.statusHelpLinkPrefix + "communities/about-the-community-history-service"
     }
 
     ColumnLayout {
-        Layout.preferredWidth: parent.width
-        Layout.topMargin: 22
+        Layout.fillWidth: true
         spacing: 4
+
         StatusCheckBox {
             id: requestToJoinToggle
             Layout.fillWidth: true
-            Layout.preferredHeight: 22
+            Layout.preferredHeight: d.optionHeight
             Layout.alignment: Qt.AlignVCenter
-            Layout.rightMargin: 12
             text: qsTr("Request to join required")
             leftSide: false
             padding: 0
+            spacing: 0
         }
 
         StatusBaseText {
@@ -80,6 +50,70 @@ ColumnLayout {
             text: qsTr("Warning: Only token gated communities (or token gated channels inside non-token gated community) are encrypted")
             font.pixelSize: Theme.tertiaryTextFontSize
             color: Theme.palette.warningColor1
+        }
+    }
+
+    Item {
+        id: archiveSupport
+
+        Layout.fillWidth: true
+        Layout.preferredHeight: visible ? d.optionHeight : 0
+
+        StatusCheckBox {
+            id: archiveSupportToggle
+
+            width: parent.width
+            leftSide: false
+            padding: 0
+            anchors.verticalCenter: parent.verticalCenter
+
+            contentItem: Item {
+                width: archiveSupportToggle.availableWidth
+
+                StatusFlatButton {
+                    id: infoBtn
+
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: archiveSupportToggle.indicator.width + Theme.halfPadding
+                    anchors.left: parent.left
+                    textColor: Theme.palette.directColor5
+                    textHoverColor: Theme.palette.primaryColor1
+                    icon.name: "info"
+                    onClicked: Global.openPopup(messageHistoryInfoPopupComponent)
+                }
+
+                StatusBaseText {
+                    width: parent.width - infoBtn.width - archiveSupportToggle.indicator.width - Theme.halfPadding
+                    text: qsTr("New members can see full message history")
+                    font: archiveSupportToggle.font
+                    verticalAlignment: Text.AlignVCenter
+                    wrapMode: Text.WordWrap
+                    lineHeight: 1.2
+                }
+            }
+        }
+    }
+
+    Item {
+        Layout.fillWidth: true
+        Layout.preferredHeight: d.optionHeight
+
+        StatusCheckBox {
+            id: pinMessagesToggle
+
+            width: parent.width
+            leftSide: false
+            padding: 0
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("Any member can pin a message")
+        }
+    }
+
+    Component {
+        id: messageHistoryInfoPopupComponent
+
+        EnableFullMessageHistoryPopup {
+            onAccepted: Global.openLinkWithConfirmation(d.aboutHistoryServiceLink, StatusQUtils.StringUtils.extractDomainFromLink(d.aboutHistoryServiceLink))
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -19,11 +19,13 @@ import StatusQ.Popups.Dialog 0.1
 import AppLayouts.Communities.controls 1.0
 import AppLayouts.Communities.panels 1.0
 import AppLayouts.Communities.stores 1.0
+import AppLayouts.Profile.stores 1.0
 
 StatusStackModal {
     id: root
 
     property CommunitiesStore store
+    property AdvancedStore advancedStore
     property bool isDiscordImport // creating new or importing from discord?
     property bool isDevBuild
 
@@ -457,11 +459,19 @@ StatusStackModal {
         }
 
         function createCommunity() {
+            // Step 1: Proceed with community creation
             const error = root.store.createCommunity(_getCommunityConfig())
             if (error) {
                 errorDialog.text = error.error
                 errorDialog.open()
+                return
             }
+            // Step 2: Automatically set the archive protocol global property if it's been checked as
+            // an option during community creation process. It's a more user friendly process
+            else if(generalViewLayout.options.archiveSupportEnabled) {
+                root.advancedStore.enableArchiveProtocolProperty()
+            }
+
             root.close()
         }
 

--- a/ui/app/AppLayouts/Communities/popups/EnableFullMessageHistoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/EnableFullMessageHistoryPopup.qml
@@ -1,0 +1,56 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups.Dialog 0.1
+
+StatusDialog {
+    id: root
+
+    width: 440
+    padding: Theme.smallPadding*2
+    topPadding: Theme.xlPadding
+    bottomPadding: Theme.xlPadding
+
+    closePolicy: Popup.NoAutoClose
+
+    title: qsTr("Enable full message history")
+
+    contentItem: ColumnLayout {
+        spacing: Theme.xlPadding
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            text: qsTr("Enabling the Community History Service ensures every member can view the complete message history for all channels they have permission to view. Without this feature, message history will be limited to the last 30 days. Your computer, which is the control node for the community, must remain online for this to work.")
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            color: Theme.palette.directColor5
+            text: qsTr("This service operates using the Archive Protocol, which will be automatically enabled.")
+        }
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Theme.padding
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                objectName: "readMoreStatusFlatButton"
+                icon.name: "external-link"
+                text: qsTr("Read more")
+                onClicked: root.accept()
+            }
+
+            StatusButton {
+                objectName: "gotItStatusFlatButton"
+                text: qsTr("Got it")
+                onClicked: root.close()
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -6,6 +6,7 @@ CreateCategoryPopup 1.0 CreateCategoryPopup.qml
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CreateCommunityPopup 1.0 CreateCommunityPopup.qml
 DiscordImportProgressDialog 1.0 DiscordImportProgressDialog.qml
+EnableFullMessageHistoryPopup 1.0 EnableFullMessageHistoryPopup.qml
 EnableShardingPopup 1.0 EnableShardingPopup.qml
 ExportControlNodePopup 1.0 ExportControlNodePopup.qml
 FinaliseOwnershipDeclinePopup 1.0 FinaliseOwnershipDeclinePopup.qml

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -151,6 +151,15 @@ QtObject {
         }
     }
 
+    function enableArchiveProtocolProperty() {
+        if(!advancedModule)
+            return
+
+        if (!root.archiveProtocolEnabled) {
+            advancedModule.enableCommunityHistoryArchiveSupport()
+        }
+    }
+
     function toggleEnsCommunityPermissionsEnabled() {
         localAccountSensitiveSettings.ensCommunityPermissionsEnabled = !root.ensCommunityPermissionsEnabled
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -866,6 +866,7 @@ Item {
         buyCryptoStore: appMain.buyCryptoStore
         networkConnectionStore: appMain.networkConnectionStore
         networksStore: appMain.networksStore
+        advancedStore: appMain.profileSectionStore.advancedStore
 
         allContactsModel: allContacsAdaptor.allContactsModel
         mutualContactsModel: contactsModelAdaptor.mutualContacts

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -53,6 +53,7 @@ QtObject {
     property WalletStores.CollectiblesStore walletCollectiblesStore
     property NetworkConnectionStore networkConnectionStore
     property WalletStores.BuyCryptoStore buyCryptoStore
+    property ProfileStores.AdvancedStore advancedStore
 
     property var allContactsModel
     property var mutualContactsModel
@@ -840,6 +841,7 @@ QtObject {
             id: createCommunitiesPopupComponent
             CreateCommunityPopup {
                 store: root.communitiesStore
+                advancedStore: root.advancedStore
                 isDevBuild: root.isDevBuild
                 onClosed: {
                     destroy()


### PR DESCRIPTION
Closes #17751

### What does the PR do
- `Options` component reordering.
- Archive protocol related checkbox renamed.
- Created new information popup `EnableFullMessageHistoryPopup` and its corresponding `storybook` page.

### Affected areas

Create New Community Popup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

**App running on Qt5:**

https://github.com/user-attachments/assets/7ec583bc-6850-4b66-8e3d-da3cbaec5082

**Storybook running on Qt6:**

https://github.com/user-attachments/assets/a02e59fe-00c3-4e7d-8161-a2284eb7b24b

### Impact on end user

No impact, just more information about the archive protocol checkbox.

### How to test

- Opening the `Create New Community` popup.
- Using `storybook`.