### PR TITLE
feat(communities): Add clarification text to the community intro an outro labels

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/OutroMessageInput.qml
+++ b/ui/app/AppLayouts/Communities/controls/OutroMessageInput.qml
@@ -10,7 +10,7 @@ import StatusQ.Controls.Validators 0.1
 StatusInput {
     id: root
 
-    label: qsTr("Leaving community message")
+    label: qsTr("Leaving community message (you can edit this later)")
     charLimit: 80
 
     placeholderText: qsTr("The message a member will see when they leave your community")
@@ -20,7 +20,7 @@ StatusInput {
         StatusMinLengthValidator {
             minLength: 1
             errorMessage: Utils.getErrorMessage(root.errors,
-                                                qsTr("community intro message"))
+                                                qsTr("community outro message"))
         }
     ]
 }

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -415,7 +415,7 @@ StatusStackModal {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                label: qsTr("Community introduction and rules")
+                label: qsTr("Community introduction and rules (you can edit this later)")
             }
 
             OutroMessageInput {


### PR DESCRIPTION
Close #17753

### What does the PR do

Added clarification text to the community intro and outro labels.

### Affected areas

Community Creation popup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

![Screenshot 2025-04-09 at 15 16 04](https://github.com/user-attachments/assets/5a469635-2de4-4e73-b661-780cfeb351bc)

### Impact on end user

No impact, just a clarification message to the user

### How to test

- Create community flow