### PR TITLE
feat(Communities): Add info banner in Community Creation Flow

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusSelectableText.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSelectableText.qml
@@ -14,6 +14,7 @@ Item {
     property bool multiline: false
     property string text: ""
     property string hoveredLinkColor: Theme.palette.directColor1
+    property color defaultLinkColor: Theme.palette.baseColor1
 
     property alias selectedText: edit.selectedText
     property alias selectedTextColor: edit.selectedTextColor
@@ -87,7 +88,7 @@ Item {
 
                 onLinkActivated: statusSelectableText.linkActivated(link)
 
-                text: "<style>a:link { color: " + (!!hoveredLink ? statusSelectableText.hoveredLinkColor : Theme.palette.baseColor1) + "; }</style>" + statusSelectableText.text
+                text: "<style>a:link { color: " + (!!hoveredLink ? statusSelectableText.hoveredLinkColor : statusSelectableText.defaultLinkColor) + "; }</style>" + statusSelectableText.text
             }
 
         }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
@@ -33,11 +33,11 @@ Control {
     padding: 16
 
     /*!
-        \qmlproperty alias StatusWarningBox::text
+        \qmlproperty string StatusWarningBox::text
         This property holds a reference to the StatusBaseText component's text property and displays the
         warning text.
     */
-    property alias text: warningText.text
+    property string text
     /*!
         \qmlproperty string StatusWarningBox::icon
         This property sets the StatusWarningBox icon.
@@ -48,6 +48,11 @@ Control {
         This property sets the StatusWarningBox icon color.
     */
     property color iconColor: "transparent"
+    /*!
+        \qmlproperty var StatusWarningBox::iconAlignment
+        This property allows setting the position of the icon inside the warning box component.
+    */
+    property int iconAlignment: Qt.AlignTop
     /*!
         \qmlproperty color StatusWarningBox::bgColor
         This property sets the StatusWarningBox background color.
@@ -68,12 +73,16 @@ Control {
         This property sets the StatusWarningBox text pixel size
     */
     property int textSize: Theme.primaryTextFontSize
-
+    /*!
+        \qmlproperty bool StatusWarningBox::isRowLayout
+        This property sets the StatusWarningBox layout as row or column.
+    */
+    property bool isRowLayout: true
     /*!
         \qmlproperty Component StatusWarningBox::extraContentComponent
         This property lets you add some extra component on the trailing side (like a button)
     */
-    property alias extraContentComponent: extraContent.sourceComponent
+    property Component extraContentComponent
 
     background: Rectangle {
         radius: 8
@@ -91,19 +100,47 @@ Control {
     contentItem: RowLayout {
         spacing: 8
         StatusIcon {
-            Layout.alignment: Qt.AlignTop
+            Layout.alignment: root.iconAlignment
             icon: root.icon
             color: root.iconColor
         }
-        StatusBaseText {
-            id: warningText
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-            font.pixelSize: root.textSize
-            color: root.textColor
-        }
         Loader {
-            id: extraContent
+            Layout.fillWidth: true
+            sourceComponent: root.isRowLayout ? rowLayoutComponent : columnLayoutComponent
+        }
+    }
+
+    Component {
+        id: rowLayoutComponent
+        RowLayout {
+            StatusBaseText {
+                id: warningText
+                Layout.fillWidth: true
+                text: root.text
+                wrapMode: Text.WordWrap
+                font.pixelSize: root.textSize
+                color: root.textColor
+            }
+            Loader {
+                sourceComponent: extraContentComponent
+            }
+        }
+    }
+
+    Component {
+        id: columnLayoutComponent
+        ColumnLayout {
+            StatusBaseText {
+                id: warningText
+                Layout.fillWidth: true
+                text: root.text
+                wrapMode: Text.WordWrap
+                font.pixelSize: root.textSize
+                color: root.textColor
+            }
+            Loader {
+                sourceComponent: extraContentComponent
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/controls/Options.qml
+++ b/ui/app/AppLayouts/Communities/controls/Options.qml
@@ -25,6 +25,7 @@ ColumnLayout {
         id: d
         readonly property int optionHeight: 64
         readonly property string aboutHistoryServiceLink: Constants.statusHelpLinkPrefix + "communities/about-the-community-history-service"
+        readonly property string aboutPermissionsLink: Constants.statusHelpLinkPrefix + "communities/set-up-your-community-permissions"
     }
 
     ColumnLayout {
@@ -108,6 +109,46 @@ ColumnLayout {
             text: qsTr("Any member can pin a message")
         }
     }
+
+    StatusWarningBox {
+        Layout.fillWidth: true
+        Layout.bottomMargin: Theme.padding
+        borderColor: Theme.palette.baseColor2
+        textColor: Theme.palette.directColor1
+        icon: Theme.svg("token")
+        iconColor: Theme.palette.directColor1
+        iconAlignment: Qt.AlignVCenter
+        isRowLayout: false
+        text: qsTr("You can token-gate your community and channels anytime after creation using existing tokens or by minting new ones in the community admin area.")
+        extraContentComponent: RowLayout {
+            spacing: 0
+            StatusSelectableText {
+                Layout.fillWidth: true
+                defaultLinkColor: Theme.palette.primaryColor1
+                hoveredLinkColor: Theme.palette.primaryColor1
+                text: "<p><a style='text-decoration:none' href=' '>%1</a></p>".arg(qsTr("Learn more about token-gating"))
+
+                onLinkActivated: Global.openLinkWithConfirmation(d.aboutPermissionsLink,
+                                                                 StatusQUtils.StringUtils.extractDomainFromLink(d.aboutPermissionsLink))
+            }
+
+            StatusIcon {
+                icon: "external-link"
+                color: Theme.palette.primaryColor1
+                Layout.preferredWidth: 16
+                Layout.preferredHeight: 16
+
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+
+                    onClicked: Global.openLinkWithConfirmation(d.aboutPermissionsLink,
+                                                               StatusQUtils.StringUtils.extractDomainFromLink(d.aboutPermissionsLink))
+                }
+            }
+        }
+    }
+
 
     Component {
         id: messageHistoryInfoPopupComponent


### PR DESCRIPTION
Closes #17752

### What does the PR do
- Add info banner to ensure users know token gating and mint tokens flows can be reached after community is created.
- `SQ/StatusSelectableText`: Added `defaultLinkColor` property.
- `SQ/StatusWarningBox`: Added new property to setup the `extraContent` layout as column or row format.

### Affected areas

- Create community popup flow
- `StatusSelectableText` component
- `StatusWarningBox` component

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/720581a9-6439-4a1f-aeea-b542ea2a3477

### Impact on end user

During `Create Community Flow` there's a new info box to add more clarification to the user about the gated communities. 

### How to test
- Open create community flow and scroll to the options section.