### PR TITLE
Implement News Feed Ephemeral notifications

### DIFF
--- a/src/app/core/notifications/details.nim
+++ b/src/app/core/notifications/details.nim
@@ -26,7 +26,8 @@ type
     CommunityTokenPermissionDeletionFailed,
     CommunityMemberKicked,
     CommunityMemberBanned,
-    CommunityMemberUnbanned
+    CommunityMemberUnbanned,
+    NewsFeedMessage,
 
   NotificationDetails* = object
     notificationType*: NotificationType # the default value is `UnknownNotification`

--- a/src/app/core/notifications/details.nim
+++ b/src/app/core/notifications/details.nim
@@ -39,6 +39,7 @@ type
     isOneToOne*: bool
     isGroupChat*: bool
     messageId*: string
+    notificationId*: string
 
 proc isEmpty*(self: NotificationDetails): bool =
   return self.notificationType == NotificationType.UnknownNotification

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -85,6 +85,7 @@ QtObject:
     signalConnect(singletonInstance.globalEvents, "showCommunityMemberKickedNotification(QString, QString, QString)", self, "onShowCommunityMemberKickedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityMemberBannedNotification(QString, QString, QString)", self, "onShowCommunityMemberBannedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityMemberUnbannedNotification(QString, QString, QString)", self, "onShowCommunityMemberUnbannedNotification(QString, QString, QString)", 2)
+    signalConnect(singletonInstance.globalEvents, "showNewsMessageNotification(QString, QString)", self, "onShowNewsMessageNotification(QString, QString)", 2)
 
     self.notificationSetUp = true
 
@@ -143,6 +144,10 @@ QtObject:
       isGroupChat: isGroupChat,
       messageId: messageId)
     self.processNotification(title, message, details)
+
+  proc onShowNewsMessageNotification(self: NotificationsManager, title: string, description: string) {.slot.} =
+    let details = NotificationDetails(notificationType: NotificationType.NewsFeedMessage)
+    self.processNotification(title, description, details)
 
   proc onShowCommunityTokenPermissionCreatedNotification*(self: NotificationsManager, sectionId: string, title: string, message: string) {.slot.} =
     let details = NotificationDetails(notificationType: NotificationType.CommunityTokenPermissionCreated, sectionId: sectionId, isCommunitySection: true)

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -145,9 +145,12 @@ QtObject:
       messageId: messageId)
     self.processNotification(title, message, details)
 
-  proc onShowNewsMessageNotification(self: NotificationsManager, title: string, description: string) {.slot.} =
-    let details = NotificationDetails(notificationType: NotificationType.NewsFeedMessage)
-    self.processNotification(title, description, details)
+  proc onShowNewsMessageNotification(self: NotificationsManager, id: string, title: string) {.slot.} =
+    let details = NotificationDetails(
+      notificationType: NotificationType.NewsFeedMessage,
+      notificationId: id,
+    )
+    self.processNotification(title, message = "", details)
 
   proc onShowCommunityTokenPermissionCreatedNotification*(self: NotificationsManager, sectionId: string, title: string, message: string) {.slot.} =
     let details = NotificationDetails(notificationType: NotificationType.CommunityTokenPermissionCreated, sectionId: sectionId, isCommunitySection: true)

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -57,4 +57,6 @@ QtObject:
 
   proc showCommunityMemberUnbannedNotification*(self: GlobalEvents, sectionId: string, title: string, message: string) {.signal.}
 
+  proc showNewsMessageNotification*(self: GlobalEvents, title: string, description: string) {.signal.}
+
   proc addCentralizedMetricIfEnabled*(self: GlobalEvents, eventName: string, eventValueJson: string) {.signal.}

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -57,6 +57,6 @@ QtObject:
 
   proc showCommunityMemberUnbannedNotification*(self: GlobalEvents, sectionId: string, title: string, message: string) {.signal.}
 
-  proc showNewsMessageNotification*(self: GlobalEvents, title: string, description: string) {.signal.}
+  proc showNewsMessageNotification*(self: GlobalEvents, id: string, title: string) {.signal.}
 
   proc addCentralizedMetricIfEnabled*(self: GlobalEvents, eventName: string, eventValueJson: string) {.signal.}

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -5,8 +5,6 @@ import ../../../../app_service/service/chat/dto/chat
 import ../../../../app_service/service/contacts/dto/contacts
 import ./token_data_item
 
-const CONTACT_REQUEST_PENDING_STATE = 1
-
 type Item* = ref object
   id: string # ID is the id of the chat, for public chats it is the name e.g. status, for one-to-one is the hex encoded public key and for group chats is a random uuid appended with the hex encoded pk of the creator of the chat
   chatId: string
@@ -14,11 +12,12 @@ type Item* = ref object
   membershipStatus: ActivityCenterMembershipStatus
   sectionId: string
   name: string
-  title: string
-  description: string
-  content: string
-  imageUrl: string
-  link: string
+  newsTitle: string
+  newsDescription: string
+  newsContent: string
+  newsImageUrl: string
+  newsLink: string
+  newsLinkLabel: string
   author: string
   notificationType: ActivityCenterNotificationType
   timestamp: int64
@@ -38,11 +37,12 @@ proc initItem*(
   membershipStatus: ActivityCenterMembershipStatus,
   sectionId: string,
   name: string,
-  title: string,
-  description: string,
-  content: string,
-  imageUrl: string,
-  link: string,
+  newsTitle: string,
+  newsDescription: string,
+  newsContent: string,
+  newsImageUrl: string,
+  newsLink: string,
+  newsLinkLabel: string,
   author: string,
   notificationType: ActivityCenterNotificationType,
   timestamp: int64,
@@ -62,11 +62,12 @@ proc initItem*(
   result.membershipStatus = membershipStatus
   result.sectionId = sectionId
   result.name = name
-  result.title = title
-  result.description = description
-  result.content = content
-  result.imageUrl = imageUrl
-  result.link = link
+  result.newsTitle = newsTitle
+  result.newsDescription = newsDescription
+  result.newsContent = newsContent
+  result.newsImageUrl = newsImageUrl
+  result.newsLink = newsLink
+  result.newsLinkLabel = newsLinkLabel
   result.author = author
   result.notificationType = notificationType
   result.timestamp = timestamp
@@ -83,11 +84,12 @@ proc `$`*(self: Item): string =
   result = fmt"""activity_center/Item(
     id: {self.id},
     name: {$self.name},
-    title: {$self.title},
-    description: {$self.description},
-    content: {$self.content},
-    imageUrl: {$self.imageUrl},
-    link: {$self.link},
+    newsTitle: {$self.newsTitle},
+    newsDescription: {$self.newsDescription},
+    newsContent: {$self.newsContent},
+    newsImageUrl: {$self.newsImageUrl},
+    newsLink: {$self.newsLink},
+    newsLinkLabel: {$self.newsLinkLabel},
     chatId: {$self.chatId},
     communityId: {$self.communityId},
     membershipStatus: {$self.membershipStatus.int},
@@ -110,20 +112,23 @@ proc id*(self: Item): string =
 proc name*(self: Item): string =
   return self.name
 
-proc title*(self: Item): string =
-  return self.title
+proc newsTitle*(self: Item): string =
+  return self.newsTitle
 
-proc description*(self: Item): string =
-  return self.description
+proc newsDescription*(self: Item): string =
+  return self.newsDescription
 
-proc content*(self: Item): string =
-  return self.content
+proc newsContent*(self: Item): string =
+  return self.newsContent
 
-proc imageUrl*(self: Item): string =
-  return self.imageUrl
+proc newsImageUrl*(self: Item): string =
+  return self.newsImageUrl
 
-proc link*(self: Item): string =
-  return self.link
+proc newsLink*(self: Item): string =
+  return self.newsLink
+
+proc newsLinkLabel*(self: Item): string =
+  return self.newsLinkLabel
 
 proc author*(self: Item): string =
   return self.author

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -9,11 +9,12 @@ type
     MembershipStatus
     SectionId
     Name
-    Title
-    Description
-    Content
-    ImageUrl
-    Link
+    NewsTitle
+    NewsDescription
+    NewsContent
+    NewsImageUrl
+    NewsLink
+    NewsLinkLabel
     NotificationType
     Message
     Timestamp
@@ -75,11 +76,12 @@ QtObject:
       of NotifRoles.MembershipStatus: result = newQVariant(activityNotificationItem.membershipStatus.int)
       of NotifRoles.SectionId: result = newQVariant(activityNotificationItem.sectionId)
       of NotifRoles.Name: result = newQVariant(activityNotificationItem.name)
-      of NotifRoles.Title: result = newQVariant(activityNotificationItem.title)
-      of NotifRoles.Description: result = newQVariant(activityNotificationItem.description)
-      of NotifRoles.Content: result = newQVariant(activityNotificationItem.content)
-      of NotifRoles.ImageUrl: result = newQVariant(activityNotificationItem.imageUrl)
-      of NotifRoles.Link: result = newQVariant(activityNotificationItem.link)
+      of NotifRoles.NewsTitle: result = newQVariant(activityNotificationItem.newsTitle)
+      of NotifRoles.NewsDescription: result = newQVariant(activityNotificationItem.newsDescription)
+      of NotifRoles.NewsContent: result = newQVariant(activityNotificationItem.newsContent)
+      of NotifRoles.NewsImageUrl: result = newQVariant(activityNotificationItem.newsImageUrl)
+      of NotifRoles.NewsLink: result = newQVariant(activityNotificationItem.newsLink)
+      of NotifRoles.NewsLinkLabel: result = newQVariant(activityNotificationItem.newsLinkLabel)
       of NotifRoles.Author: result = newQVariant(activityNotificationItem.author)
       of NotifRoles.NotificationType: result = newQVariant(activityNotificationItem.notificationType.int)
       of NotifRoles.Message: result = if not activityNotificationItem.messageItem.isNil:
@@ -94,7 +96,10 @@ QtObject:
       of NotifRoles.Read: result = newQVariant(activityNotificationItem.read.bool)
       of NotifRoles.Dismissed: result = newQVariant(activityNotificationItem.dismissed.bool)
       of NotifRoles.Accepted: result = newQVariant(activityNotificationItem.accepted.bool)
-      of NotifRoles.RepliedMessage: result = newQVariant(activityNotificationItem.repliedMessageItem)
+      of NotifRoles.RepliedMessage: result = if not activityNotificationItem.repliedMessageItem.isNil:
+                                        newQVariant(activityNotificationItem.repliedMessageItem)
+                                      else:
+                                        newQVariant()
       of NotifRoles.ChatType: result = newQVariant(activityNotificationItem.chatType.int)
       of NotifRoles.TokenData: result = newQVariant(activityNotificationItem.tokenDataItem)
       of NotifRoles.InstallationId: result = newQVariant(activityNotificationItem.installationId)
@@ -107,11 +112,12 @@ QtObject:
       NotifRoles.MembershipStatus.int: "membershipStatus",
       NotifRoles.SectionId.int: "sectionId",
       NotifRoles.Name.int: "name",
-      NotifRoles.Title.int: "title",
-      NotifRoles.Description.int: "description",
-      NotifRoles.Content.int: "content",
-      NotifRoles.ImageUrl.int: "imageUrl",
-      NotifRoles.Link.int: "link",
+      NotifRoles.NewsTitle.int: "newsTitle",
+      NotifRoles.NewsDescription.int: "newsDescription",
+      NotifRoles.NewsContent.int: "newsContent",
+      NotifRoles.NewsImageUrl.int: "newsImageUrl",
+      NotifRoles.NewsLink.int: "newsLink",
+      NotifRoles.NewsLinkLabel.int: "newsLinkLabel",
       NotifRoles.Author.int: "author",
       NotifRoles.NotificationType.int: "notificationType",
       NotifRoles.Message.int: "message",
@@ -126,7 +132,7 @@ QtObject:
       NotifRoles.InstallationId.int: "installationId",
     }.toTable
 
-  proc findNotificationIndex(self: Model, notificationId: string): int =
+  proc findNotificationIndex(self: Model, notificationId: string): int {.slot.} =
     if notificationId.len == 0:
       return -1
     for i in 0 ..< self.activityCenterNotifications.len:

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -210,6 +210,13 @@ method markAsSeenActivityCenterNotifications*(self: Module) =
   self.controller.markAsSeenActivityCenterNotifications()
 
 method addActivityCenterNotifications*(self: Module, activityCenterNotifications: seq[ActivityCenterNotificationDto]) =
+  for notif in activityCenterNotifications:
+    if notif.notificationType == ActivityCenterNotificationTypeNews:
+      # Show an AC or OS notification for News Feed notifications
+      singletonInstance.globalEvents.showNewsMessageNotification(
+        notif.title,
+        notif.description,
+      )
   self.view.addActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
   self.view.hasUnseenActivityCenterNotificationsChanged()
 

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -171,11 +171,12 @@ method convertToItems*(
         notification.membershipStatus,
         sectionId,
         notification.name,
-        notification.title,
-        notification.description,
-        notification.content,
-        notification.imageUrl,
-        notification.link,
+        notification.newsTitle,
+        notification.newsDescription,
+        notification.newsContent,
+        notification.newsImageUrl,
+        notification.newsLink,
+        notification.newsLinkLabel,
         notification.author,
         notification.notificationType,
         notification.timestamp,
@@ -214,8 +215,8 @@ method addActivityCenterNotifications*(self: Module, activityCenterNotifications
     if notif.notificationType == ActivityCenterNotificationTypeNews:
       # Show an AC or OS notification for News Feed notifications
       singletonInstance.globalEvents.showNewsMessageNotification(
-        notif.title,
-        notif.description,
+        notif.id,
+        notif.newsTitle,
       )
   self.view.addActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
   self.view.hasUnseenActivityCenterNotificationsChanged()

--- a/src/app/modules/main/ephemeral_notification_item.nim
+++ b/src/app/modules/main/ephemeral_notification_item.nim
@@ -13,6 +13,7 @@ type EphemeralActionType* {.pure} = enum
   OpenSendModalPopup
   ViewTransactionDetails
   OpenFirstCommunityTokenPopup
+  OpenNewsMessagePopup
 
 type
   Item* = object

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -215,16 +215,20 @@ method displayEphemeralNotification*(self: AccessInterface, title: string, subTi
   {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method displayEphemeralNotification*(self: AccessInterface, title: string, subTitle: string, icon: string, loading: bool,
-    ephNotifType: int, url: string, details = NotificationDetails()) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method displayEphemeralWithActionNotification*(self: AccessInterface, title: string, subTitle: string, icon: string, iconColor: string, loading: bool,
-    ephNotifType: int, actionType: int, actionData: string, details = NotificationDetails()) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method displayEphemeralImageWithActionNotification*(self: AccessInterface, title: string, subTitle: string, image: string,
-    ephNotifType: int, actionType: int, actionData: string, details = NotificationDetails()) {.base.} =
+method displayEphemeralNotification*(
+    self: AccessInterface,
+    title: string,
+    subTitle: string,
+    image: string,
+    icon: string,
+    iconColor: string,
+    loading: bool,
+    ephNotifType: int,
+    actionType: int,
+    actionData: string,
+    url: string,
+    details = NotificationDetails(),
+  ) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method removeEphemeralNotification*(self: AccessInterface, id: int64) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1467,11 +1467,22 @@ method resolveENS*[T](self: Module[T], ensName: string, uuid: string, reason: st
   self.controller.resolveENS(ensName, uuid, reason)
 
 method resolvedENS*[T](self: Module[T], publicKey: string, address: string, uuid: string, reason: string) =
-  if(reason.len > 0 and publicKey.len == 0):
-    self.displayEphemeralNotification("Unexisting contact", "Wrong public key or ens name", "", false, EphemeralNotificationType.Default.int, "")
+  if reason.len > 0 and publicKey.len == 0:
+    self.displayEphemeralNotification(
+      title = "Unexisting contact",
+      subTitle = "Wrong public key or ens name",
+      image = "",
+      icon = "",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Default.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+    )
     return
 
-  if(reason == STATUS_URL_ENS_RESOLVE_REASON & $StatusUrlAction.DisplayUserProfile):
+  if reason == STATUS_URL_ENS_RESOLVE_REASON & $StatusUrlAction.DisplayUserProfile:
     self.switchToContactOrDisplayUserProfile(publicKey)
   else:
     self.view.emitResolvedENSSignal(publicKey, address, uuid)
@@ -1657,84 +1668,160 @@ method communityMembershipRequestCanceled*[T](self: Module[T], communityId: stri
 method meMentionedCountChanged*[T](self: Module[T], allMentions: int) =
   singletonInstance.globalEvents.meMentionedIconBadgeNotification(allMentions)
 
-method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle: string, icon: string, loading: bool,
-  ephNotifType: int, url: string, details = NotificationDetails()) =
+method displayEphemeralNotification*[T](
+    self: Module[T],
+    title: string,
+    subTitle: string,
+    image: string,
+    icon: string,
+    iconColor: string,
+    loading: bool,
+    ephNotifType: int,
+    actionType: int,
+    actionData: string,
+    url: string,
+    details = NotificationDetails()
+  ) =
   let now = getTime()
   let id = now.toUnix * 1000000000 + now.nanosecond
   var finalEphNotifType = EphemeralNotificationType.Default
-  if(ephNotifType == EphemeralNotificationType.Success.int):
+  if ephNotifType == EphemeralNotificationType.Success.int:
     finalEphNotifType = EphemeralNotificationType.Success
-  elif(ephNotifType == EphemeralNotificationType.Danger.int):
+  elif ephNotifType == EphemeralNotificationType.Danger.int:
     finalEphNotifType = EphemeralNotificationType.Danger
 
-  let item = ephemeral_notification_item.initItem(id, title, TOAST_MESSAGE_VISIBILITY_DURATION_IN_MS, subTitle, "", icon, "",
-  loading, finalEphNotifType, url, EphemeralActionType.None, "", details)
-  self.view.ephemeralNotificationModel().addItem(item)
-
-# TO UNIFY with the one above.
-# Further refactor will be done in a next step
-method displayEphemeralWithActionNotification*[T](self: Module[T], title: string, subTitle: string, icon: string, iconColor: string, loading: bool,
-  ephNotifType: int, actionType: int, actionData: string, details = NotificationDetails()) =
-  let now = getTime()
-  let id = now.toUnix * 1000000000 + now.nanosecond
-  var finalEphNotifType = EphemeralNotificationType.Default
-  if(ephNotifType == EphemeralNotificationType.Success.int):
-    finalEphNotifType = EphemeralNotificationType.Success
-  elif(ephNotifType == EphemeralNotificationType.Danger.int):
-    finalEphNotifType = EphemeralNotificationType.Danger
-
-  let item = ephemeral_notification_item.initItem(id, title, TOAST_MESSAGE_VISIBILITY_DURATION_IN_MS, subTitle, "", icon, iconColor,
-  loading, finalEphNotifType, "", EphemeralActionType(actionType), actionData, details)
-  self.view.ephemeralNotificationModel().addItem(item)
-
-# TO UNIFY with the one above.
-# Further refactor will be done in a next step
-method displayEphemeralImageWithActionNotification*[T](self: Module[T], title: string, subTitle: string, image: string, ephNotifType: int,
-    actionType: int, actionData: string, details = NotificationDetails()) =
-  let now = getTime()
-  let id = now.toUnix * 1000000000 + now.nanosecond
-  var finalEphNotifType = EphemeralNotificationType.Default
-  if(ephNotifType == EphemeralNotificationType.Success.int):
-    finalEphNotifType = EphemeralNotificationType.Success
-  elif(ephNotifType == EphemeralNotificationType.Danger.int):
-    finalEphNotifType = EphemeralNotificationType.Danger
-
-
-  let item = ephemeral_notification_item.initItem(id, title, TOAST_MESSAGE_VISIBILITY_DURATION_IN_MS, subTitle, image, "", "", false,
-  finalEphNotifType, "", EphemeralActionType(actionType), actionData, details)
+  let item = ephemeral_notification_item.initItem(
+    id,
+    title,
+    TOAST_MESSAGE_VISIBILITY_DURATION_IN_MS,
+    subTitle,
+    image,
+    icon,
+    iconColor,
+    loading,
+    finalEphNotifType,
+    url,
+    EphemeralActionType(actionType),
+    actionData,
+    details
+  )
   self.view.ephemeralNotificationModel().addItem(item)
 
 method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle: string, details: NotificationDetails) =
   if details.notificationType == NotificationType.NewMessage or
-    details.notificationType == NotificationType.NewMessageWithPersonalMention or
-    details.notificationType == NotificationType.CommunityTokenPermissionCreated or
-    details.notificationType == NotificationType.CommunityTokenPermissionUpdated or
-    details.notificationType == NotificationType.CommunityTokenPermissionDeleted or
-    details.notificationType == NotificationType.CommunityTokenPermissionCreationFailed or
-    details.notificationType == NotificationType.CommunityTokenPermissionUpdateFailed or
-    details.notificationType == NotificationType.CommunityTokenPermissionDeletionFailed or
-    details.notificationType == NotificationType.NewMessageWithGlobalMention:
-    self.displayEphemeralNotification(title, subTitle, "", false, EphemeralNotificationType.Default.int, "", details)
+      details.notificationType == NotificationType.NewMessageWithPersonalMention or
+      details.notificationType == NotificationType.CommunityTokenPermissionCreated or
+      details.notificationType == NotificationType.CommunityTokenPermissionUpdated or
+      details.notificationType == NotificationType.CommunityTokenPermissionDeleted or
+      details.notificationType == NotificationType.CommunityTokenPermissionCreationFailed or
+      details.notificationType == NotificationType.CommunityTokenPermissionUpdateFailed or
+      details.notificationType == NotificationType.CommunityTokenPermissionDeletionFailed or
+      details.notificationType == NotificationType.NewMessageWithGlobalMention:
+    self.displayEphemeralNotification(
+      title,
+      subTitle,
+      image = "",
+      icon = "",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Default.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+      details,
+    )
 
   elif details.notificationType == NotificationType.NewContactRequest or
-    details.notificationType == NotificationType.IdentityVerificationRequest or
-    details.notificationType == NotificationType.ContactRemoved:
-    self.displayEphemeralNotification(title, subTitle, "contact", false, EphemeralNotificationType.Default.int, "", details)
+      details.notificationType == NotificationType.IdentityVerificationRequest or
+      details.notificationType == NotificationType.ContactRemoved:
+    self.displayEphemeralNotification(
+      title,
+      subTitle,
+      image = "",
+      icon = "contact",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Default.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+      details,
+    )
 
   elif details.notificationType == NotificationType.AcceptedContactRequest:
-    self.displayEphemeralNotification(title, subTitle, "checkmark-circle", false, EphemeralNotificationType.Success.int, "", details)
+    self.displayEphemeralNotification(
+      title,
+      subTitle,
+      image = "",
+      icon = "checkmark-circle",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Success.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+      details,
+    )
 
   elif details.notificationType == NotificationType.CommunityMemberKicked:
-    self.displayEphemeralNotification(title, subTitle, "communities", false, EphemeralNotificationType.Danger.int, "", details)
+    self.displayEphemeralNotification(
+      title,
+      subTitle,
+      image = "",
+      icon = "communities",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Danger.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+      details,
+    )
 
   elif details.notificationType == NotificationType.CommunityMemberBanned:
-    self.displayEphemeralNotification(title, subTitle, "communities", false, EphemeralNotificationType.Danger.int, "", details)
+    self.displayEphemeralNotification(
+      title,
+      subTitle,
+      image = "",
+      icon = "communities",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Danger.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+      details,
+    )
 
   elif details.notificationType == NotificationType.CommunityMemberUnbanned:
-    self.displayEphemeralWithActionNotification(title, "Visit community" , "communities", "", false, EphemeralNotificationType.Success.int, EphemeralActionType.NavigateToCommunityAdmin.int, details.sectionId)
+    self.displayEphemeralNotification(
+      title,
+      subTitle = "Visit community",
+      image = "",
+      icon = "communities",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Success.int,
+      actionType = EphemeralActionType.NavigateToCommunityAdmin.int,
+      actionData = details.sectionId,
+      url = "",
+      details,
+    )
 
   else:
-    self.displayEphemeralNotification(title, subTitle, "", false, EphemeralNotificationType.Default.int, "", details)
+    self.displayEphemeralNotification(
+      title,
+      subTitle,
+      image = "",
+      icon = "",
+      iconColor = "",
+      loading = false,
+      ephNotifType = EphemeralNotificationType.Default.int,
+      actionType = EphemeralActionType.None.int,
+      actionData = "",
+      url = "",
+      details,
+    )
 
 method removeEphemeralNotification*[T](self: Module[T], id: int64) =
   self.view.ephemeralNotificationModel().removeItemWithId(id)
@@ -1751,7 +1838,18 @@ method ephemeralNotificationClicked*[T](self: Module[T], id: int64) =
     self.osNotificationClicked(item.details)
 
 method onMyRequestAdded*[T](self: Module[T]) =
-  self.displayEphemeralNotification("Your Request has been submitted", "" , "checkmark-circle", false, EphemeralNotificationType.Success.int, "")
+  self.displayEphemeralNotification(
+    title = "Your Request has been submitted",
+    subTitle = "",
+    image = "",
+    icon = "checkmark-circle",
+    iconColor = "",
+    loading = false,
+    ephNotifType = EphemeralNotificationType.Success.int,
+    actionType = EphemeralActionType.None.int,
+    actionData = "",
+    url = "",
+  )
 
 proc switchToContactOrDisplayUserProfile[T](self: Module[T], publicKey: string) =
   let contact = self.controller.getContact(publicKey)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1808,6 +1808,9 @@ method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle
       details,
     )
 
+  elif details.notificationType == NotificationType.NewsFeedMessage:
+    self.view.newsFeedEphemeralNotification(title, details.notificationId)
+
   else:
     self.displayEphemeralNotification(
       title,

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -106,21 +106,30 @@ QtObject:
     read = getEphemeralNotificationModel
     notify = ephemeralNotificationModelChanged
 
-  proc displayEphemeralNotification*(self: View, title: string, subTitle: string, icon: string, loading: bool,
-    ephNotifType: int, url: string) {.slot.} =
-    self.delegate.displayEphemeralNotification(title, subTitle, icon, loading, ephNotifType, url)
-
-  # TO UNIFY with the one above. Now creating a specific method for not introuducing regression.
-  # Further refactor will be done in a next step
-  proc displayEphemeralWithActionNotification*(self: View, title: string, subTitle: string, icon: string, iconColor: string, loading: bool,
-    ephNotifType: int, actionType: int, actionData: string) {.slot.} =
-    self.delegate.displayEphemeralWithActionNotification(title, subTitle, icon, iconColor, loading, ephNotifType, actionType, actionData)
-
-  # TO UNIFY with the one above.
-  # Further refactor will be done in a next step
-  proc displayEphemeralImageWithActionNotification*(self: View, title: string, subTitle: string, image: string, ephNotifType: int,
-    actionType: int, actionData: string) {.slot.} =
-    self.delegate.displayEphemeralImageWithActionNotification(title, subTitle, image, ephNotifType, actionType, actionData)
+  proc displayEphemeralNotification*(self: View,
+      title: string,
+      subTitle: string,
+      image: string,
+      icon: string,
+      iconColor: string,
+      loading: bool,
+      ephNotifType: int,
+      actionType: int,
+      actionData: string,
+      url: string
+    ) {.slot.} =
+    self.delegate.displayEphemeralNotification(
+      title,
+      subTitle,
+      image,
+      icon,
+      iconColor,
+      loading,
+      ephNotifType,
+      actionType,
+      actionData,
+      url,
+    )
 
   proc removeEphemeralNotification*(self: View, id: string) {.slot.} =
     self.delegate.removeEphemeralNotification(id.parseInt)

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -410,6 +410,8 @@ QtObject:
   proc addressWasShown*(self: View, address: string) {.slot.} =
     self.delegate.addressWasShown(address)
 
+  proc newsFeedEphemeralNotification*(self:View, newsTitle: string, notificationId: string) {.signal.}
+  
   proc communityMemberStatusEphemeralNotification*(self:View, communityName: string, memberName: string, membershipState: int) {.signal.}
 
   proc emitCommunityMemberStatusEphemeralNotification*(self:View, communityName: string, memberName: string,

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -71,11 +71,12 @@ type ActivityCenterNotificationDto* = ref object of RootObj
   communityId*: string
   membershipStatus*: ActivityCenterMembershipStatus
   name*: string
-  title*: string
-  description*: string
-  content*: string
-  imageUrl*: string
-  link*: string
+  newsTitle*: string
+  newsDescription*: string
+  newsContent*: string
+  newsImageUrl*: string
+  newsLink*: string
+  newsLinkLabel*: string
   author*: string
   installationId*: string
   notificationType*: ActivityCenterNotificationType
@@ -95,11 +96,12 @@ proc `$`*(self: ActivityCenterNotificationDto): string =
     chatId: {self.chatId},
     communityId: {self.communityId},
     name: {self.name},
-    title: {self.title},
-    description: {self.description},
-    content: {self.content},
-    imageUrl: {self.imageUrl},
-    link: {self.link},
+    newsTitle: {self.newsTitle},
+    newsDescription: {self.newsDescription},
+    newsContent: {self.newsContent},
+    newsImageUrl: {self.newsImageUrl},
+    newsLink: {self.newsLink},
+    newsLinkLabel: {self.newsLinkLabel},
     membershipStatus: {self.membershipStatus},
     author: {self.author},
     installationId: {self.installationId},
@@ -120,11 +122,12 @@ proc toActivityCenterNotificationDto*(jsonObj: JsonNode): ActivityCenterNotifica
   discard jsonObj.getProp("chatId", result.chatId)
   discard jsonObj.getProp("communityId", result.communityId)
   discard jsonObj.getProp("name", result.name)
-  discard jsonObj.getProp("title", result.title)
-  discard jsonObj.getProp("description", result.description)
-  discard jsonObj.getProp("content", result.content)
-  discard jsonObj.getProp("imageUrl", result.imageUrl)
-  discard jsonObj.getProp("link", result.link)
+  discard jsonObj.getProp("newsTitle", result.newsTitle)
+  discard jsonObj.getProp("newsDescription", result.newsDescription)
+  discard jsonObj.getProp("newsContent", result.newsContent)
+  discard jsonObj.getProp("newsImageUrl", result.newsImageUrl)
+  discard jsonObj.getProp("newsLink", result.newsLink)
+  discard jsonObj.getProp("newsLinkLabel", result.newsLinkLabel)
 
   result.membershipStatus = ActivityCenterMembershipStatus.Idle
   var membershipStatusInt: int

--- a/storybook/pages/NewsMessagePopupPage.qml
+++ b/storybook/pages/NewsMessagePopupPage.qml
@@ -26,12 +26,12 @@ SplitView {
             id: notificationMock
 
             property string id: "1"
-            property string title: "Swaps around the corner!"
-            property string description: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS!"
-            property string content: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS! Now you can trade Ethereum, Arbitrum and Optimism tokens directly in-app. Status leverages Paraswap so you always benefit from the best prices and fastest settlements!"
-            property string link: "https://status.app/"
-            property string linkLabel: linkLabelInput.text
-            property string imageUrl: hasImage.checked ? "https://picsum.photos/438/300" : ""
+            property string newsTitle: "Swaps around the corner!"
+            property string newsDescription: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS!"
+            property string newsContent: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS! Now you can trade Ethereum, Arbitrum and Optimism tokens directly in-app. Status leverages Paraswap so you always benefit from the best prices and fastest settlements!"
+            property string newsLink: "https://status.app/"
+            property string newsLinkLabel: linkLabelInput.text
+            property string newsImageUrl: hasImage.checked ? "https://picsum.photos/438/300" : ""
             property double timestamp: Date.now()
             property double previousTimestamp: 0
             property bool read: false

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -867,6 +867,7 @@ Item {
         buyCryptoStore: appMain.buyCryptoStore
         networkConnectionStore: appMain.networkConnectionStore
         networksStore: appMain.networksStore
+        activityCenterStore: appMain.activityCenterStore
         advancedStore: appMain.profileSectionStore.advancedStore
 
         allContactsModel: allContacsAdaptor.allContactsModel

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -23,6 +23,7 @@ import AppLayouts.Wallet.popups 1.0
 import AppLayouts.Wallet.adaptors 1.0
 import AppLayouts.Communities.stores 1.0
 import AppLayouts.Profile.helpers 1.0
+import mainui.activitycenter.stores 1.0
 
 import AppLayouts.Wallet.stores 1.0 as WalletStores
 import AppLayouts.Chat.stores 1.0 as ChatStores
@@ -54,6 +55,7 @@ QtObject {
     property NetworkConnectionStore networkConnectionStore
     property WalletStores.BuyCryptoStore buyCryptoStore
     property ProfileStores.AdvancedStore advancedStore
+    property ActivityCenterStore activityCenterStore
 
     property var allContactsModel
     property var mutualContactsModel
@@ -111,6 +113,7 @@ QtObject {
         Global.privacyPolicyRequested.connect(() => openPopup(privacyPolicyPopupComponent))
         Global.openPaymentRequestModalRequested.connect(openPaymentRequestModal)
         Global.termsOfUseRequested.connect(() => openPopup(termsOfUsePopupComponent))
+        Global.openNewsMessagePopupRequested.connect(openNewsMessagePopup)
     }
 
     property var currentPopup
@@ -413,6 +416,10 @@ QtObject {
 
     function openPaymentRequestModal(callback) {
         openPopup(paymentRequestModalComponent, {callback: callback})
+    }
+
+    function openNewsMessagePopup(notification, notificationId) {
+        openPopup(newsMessageComponent, {notification: notification, notificationId: notificationId})
     }
 
     readonly property list<Component> _components: [
@@ -1330,6 +1337,14 @@ QtObject {
                     callback(selectedAccountAddress, amount, selectedTokenKey, selectedNetworkChainId)
                 }
                 destroyOnClose: true
+            }
+        },
+        Component {
+            id: newsMessageComponent
+
+            NewsMessagePopup {
+                activityCenterNotifications: root.activityCenterStore.activityCenterNotifications
+                onLinkClicked: Global.openLinkWithConfirmation(link, StatusQUtils.StringUtils.extractDomainFromLink(link));
             }
         }
     ]

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -9,6 +9,7 @@ import AppLayouts.Wallet 1.0
 import AppLayouts.stores 1.0
 import AppLayouts.Chat.stores 1.0 as ChatStores
 import AppLayouts.Profile.stores 1.0
+import StatusQ.Core.Theme 0.1
 
 import shared.stores 1.0 as SharedStores
 
@@ -27,7 +28,8 @@ QtObject {
         OpenFinaliseOwnershipPopup = 2,
         OpenSendModalPopup = 3,
         ViewTransactionDetails = 4,
-        OpenFirstCommunityTokenPopup = 5
+        OpenFirstCommunityTokenPopup = 5,
+        OpenNewsMessagePopup = 6
     }
 
     // Stores:
@@ -146,7 +148,6 @@ QtObject {
         target: Global
 
         function onDisplayToastMessage(title: string, subTitle: string, icon: string, loading: bool, ephNotifType: int, url: string) {
-            (title, subTitle, icon, loading, ephNotifType, url)
             root.rootStore.mainModuleInst.displayEphemeralNotification(
                 title,
                 subTitle,
@@ -179,7 +180,6 @@ QtObject {
         }
 
         function onDisplayImageToastWithActionMessage(title: string, subTitle: string, image: string, ephNotifType: int, actionType: int, actionData: string) {
-            (title, subTitle, image, ephNotifType, actionType, actionData)
             root.rootStore.mainModuleInst.displayEphemeralNotification(
                 title,
                 subTitle,
@@ -194,6 +194,22 @@ QtObject {
             )
         }
     }
+
+    readonly property Connections _mainConnections: Connections {
+        target: root.rootStore.mainModuleInst
+
+        function onNewsFeedEphemeralNotification(newsTitle: string, notificationId: string) {
+            Global.displayImageToastWithActionMessage(
+                newsTitle,
+                qsTr("Read more"),
+                Theme.png("status-logo"),
+                Constants.ephemeralNotificationType.normal,
+                ToastsManager.ActionType.OpenNewsMessagePopup,
+                notificationId
+            )
+        }
+    }
+
 
     // Profile settings related toasts:
     readonly property Connections _profileStoreConnections: Connections {
@@ -232,6 +248,9 @@ QtObject {
         switch(actionType) {
         case ToastsManager.ActionType.NavigateToCommunityAdmin:
             root.rootChatStore.setActiveCommunity(actionData)
+            return
+        case ToastsManager.ActionType.OpenNewsMessagePopup:
+            Global.openNewsMessagePopupRequested(null, actionData)
             return
         case ToastsManager.ActionType.OpenFinaliseOwnershipPopup:
             Global.openFinaliseOwnershipPopup(actionData)

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -146,17 +146,52 @@ QtObject {
         target: Global
 
         function onDisplayToastMessage(title: string, subTitle: string, icon: string, loading: bool, ephNotifType: int, url: string) {
-            root.rootStore.mainModuleInst.displayEphemeralNotification(title, subTitle, icon, loading, ephNotifType, url)
+            (title, subTitle, icon, loading, ephNotifType, url)
+            root.rootStore.mainModuleInst.displayEphemeralNotification(
+                title,
+                subTitle,
+                "", // image
+                icon,
+                "", // iconColor
+                loading,
+                ephNotifType,
+                0, // actionType
+                "", // actionData
+                url
+            )
         }
 
         // TO UNIFY with the one above.
         // Further refactor will be done in a next step
         function onDisplayToastWithActionMessage(title: string, subTitle: string, icon: string, iconColor: string, loading: bool, ephNotifType: int, actionType: int, actionData: string) {
-            root.rootStore.mainModuleInst.displayEphemeralWithActionNotification(title, subTitle, icon, iconColor, loading, ephNotifType, actionType, actionData)
+            root.rootStore.mainModuleInst.displayEphemeralNotification(
+                title,
+                subTitle,
+                "", // image
+                icon,
+                iconColor,
+                loading,
+                ephNotifType,
+                actionType,
+                actionData,
+                "" // url
+            )
         }
 
         function onDisplayImageToastWithActionMessage(title: string, subTitle: string, image: string, ephNotifType: int, actionType: int, actionData: string) {
-            root.rootStore.mainModuleInst.displayEphemeralImageWithActionNotification(title, subTitle, image, ephNotifType, actionType, actionData)
+            (title, subTitle, image, ephNotifType, actionType, actionData)
+            root.rootStore.mainModuleInst.displayEphemeralNotification(
+                title,
+                subTitle,
+                image,
+                "", // icon
+                "", // iconColor
+                false, // loading
+                ephNotifType,
+                actionType,
+                actionData,
+                "" // url
+            )
         }
     }
 

--- a/ui/app/mainui/activitycenter/helpers/ActivityNotification.qml
+++ b/ui/app/mainui/activitycenter/helpers/ActivityNotification.qml
@@ -1,0 +1,28 @@
+import QtQml 2.15
+
+QtObject {
+    required property string notificationId
+    property string chatId
+    property string communityId
+    property int membershipStatus
+    property string sectionId
+    property string name
+    property string newsTitle
+    property string newsDescription
+    property string newsContent
+    property string newsImageUrl
+    property string newsLink
+    property string newsLinkLabel
+    property string author
+    property int notificationType
+    property var message
+    property double timestamp
+    property double previousTimestamp
+    property bool read
+    property bool dismissed
+    property bool accepted
+    property var repliedMessage
+    property int chatType
+    property var tokenData
+    property string installationId
+}

--- a/ui/app/mainui/activitycenter/helpers/NotificationModelEntry.qml
+++ b/ui/app/mainui/activitycenter/helpers/NotificationModelEntry.qml
@@ -1,0 +1,50 @@
+import StatusQ 0.1
+import StatusQ.Core.Utils 0.1
+
+import utils 1.0
+
+/**
+  * Wrapper over generic ModelEntry to expose entries from model of notifications.
+  */
+QObject {
+    id: root
+
+    required property string notificationId
+    required property var activityCenterNotifications
+
+    readonly property ActivityNotification notification: ActivityNotification {
+        readonly property var entry: itemData.item
+
+        notificationId: root.notificationId
+        chatId: entry.chatId ?? ""
+        communityId: entry.communityId ?? ""
+        membershipStatus: entry.membershipStatus ?? 0
+        sectionId: entry.sectionId ?? ""
+        name: ensName
+        newsTitle: entry.newsTitle ?? ""
+        newsDescription: entry.newsDescription ?? ""
+        newsContent: entry.newsContent ?? ""
+        newsImageUrl: entry.newsImageUrl ?? ""
+        newsLink: entry.newsLink ?? ""
+        newsLinkLabel: entry.newsLinkLabel ?? ""
+        author: entry.author ?? ""
+        notificationType: entry.notificationType ?? 0
+        message: entry.message ?? null
+        timestamp: entry.timestamp ?? 0
+        previousTimestamp: entry.previousTimestamp ?? 0
+        read: entry.read ?? false
+        dismissed: entry.dismissed ?? false
+        accepted: entry.accepted ?? false
+        repliedMessage: entry.repliedMessage ?? null
+        chatType: entry.chatType ?? 0
+        tokenData: entry.tokenData ?? null
+        installationId: entry.installationId ?? ""
+    }
+
+    ModelEntry {
+        id: itemData
+        sourceModel: root.activityCenterNotifications
+        key: "id"
+        value: root.notificationId
+    }
+}

--- a/ui/app/mainui/activitycenter/helpers/qmldir
+++ b/ui/app/mainui/activitycenter/helpers/qmldir
@@ -1,0 +1,2 @@
+ActivityNotification 1.0 ActivityNotification.qml
+NotificationModelEntry 1.0 NotificationModelEntry.qml

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -372,9 +372,8 @@ Popup {
             activityCenterStore: root.activityCenterStore
             onReadMoreClicked: {
                 root.close()
-                Global.openPopup(newsMessagePopup, {
-                    notification: parent.notification
-                })
+                Global.openNewsMessagePopupRequested(parent.notification, parent.notification.id)
+                // TODO figure out if we want the link
                 Global.addCentralizedMetricIfEnabled("news-info-opened", {"news-link": parent.notification.link})
 
             }
@@ -523,14 +522,6 @@ Popup {
                 }
             }
             footer: null
-        }
-    }
-
-    Component {
-        id: newsMessagePopup
-
-        NewsMessagePopup {
-            onLinkClicked: Global.openLinkWithConfirmation(link, StatusQUtils.StringUtils.extractDomainFromLink(link));
         }
     }
 }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationNewsMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationNewsMessage.qml
@@ -31,13 +31,13 @@ ActivityNotificationBase {
 
             StatusMessageHeader {
                 Layout.fillWidth: true
-                displayNameLabel.text: root.notification ? root.notification.title : ""
+                displayNameLabel.text: root.notification ? root.notification.newsTitle : ""
                 timestamp: root.notification ? root.notification.timestamp : 0
             }
 
             StatusBaseText {
                 Layout.fillWidth: true
-                text: root.notification ? root.notification.description : ""
+                text: root.notification ? root.notification.newsDescription : ""
                 font.italic: true
                 wrapMode: Text.WordWrap
                 color: Theme.palette.baseColor1

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -9,14 +9,25 @@ import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 
+import mainui.activitycenter.helpers 1.0
+
 import shared 1.0
 import utils 1.0
 
 StatusDialog {
     id: root
 
-    required property var notification
+    property var notification
+    property string notificationId
+    property var activityCenterNotifications
     signal linkClicked(string link)
+
+    Component.onCompleted: {
+        if (!root.notification && root.notificationId) {
+            notificationModelEntryLoader.active = true
+            root.notification = notificationModelEntryLoader.item.notification
+        }
+    }
 
     width: 480
     padding: Theme.bigPadding
@@ -29,7 +40,7 @@ StatusDialog {
             visible: false
         }
 
-        headline.title: notification.title
+        headline.title: notification.newsTitle
         headline.subtitle: dateGroupLabel.text
         actions.closeButton.onClicked: root.close()
         leftComponent: StatusSmartIdenticon {
@@ -42,15 +53,24 @@ StatusDialog {
         width: parent.width
 
         Loader {
-            active: !!notification.imageUrl
+            id: notificationModelEntryLoader
+            active: false // Only enabled if we do not have a notification and need to get it from the model
+
+            sourceComponent: NotificationModelEntry {
+                notificationId: root.notificationId
+                activityCenterNotifications: root.activityCenterNotifications
+            }
+        }
+
+        Loader {
+            active: !!notification.newsImageUrl
 
             Layout.bottomMargin: active ? Theme.bigPadding : 0
             Layout.fillWidth: true
             Layout.preferredHeight: active ? 300 : 0
 
             sourceComponent: StatusRoundedImage {
-
-                image.source: notification.imageUrl
+                image.source: notification.newsImageUrl
                 color: "transparent"
                 border.color: root.backgroundColor
                 border.width: 1
@@ -59,7 +79,7 @@ StatusDialog {
         }
 
         StatusBaseText {
-            text: notification.content || notification.description
+            text: notification.newsContent || notification.newsDescription
             Layout.fillWidth: true
             Layout.fillHeight: true
             wrapMode: Text.WordWrap
@@ -68,9 +88,9 @@ StatusDialog {
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
-                text: !!notification.linkLabel ? notification.linkLabel : qsTr("Visit the website")
+                text: !!notification.newsLinkLabel ? notification.newsLinkLabel : qsTr("Visit the website")
                 icon.name: "external"
-                onClicked: root.linkClicked(root.notification.link)
+                onClicked: root.linkClicked(root.notification.newsLink)
             }
         }
     }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -90,6 +90,8 @@ QtObject {
 
     signal openPaymentRequestModalRequested(var callback)
 
+    signal openNewsMessagePopupRequested(var notification, string notificationId)
+
     // Swap
     signal openSwapModalRequested(var formDataParams, var callback)
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/17690
Status-go PR: https://github.com/status-im/status-go/pull/6487

When receiving a new News, shows an Ephemeral or OS notification depending on the active state of the app

Contains 3 commits:
1. Basic implementation of the ephemeral notification without action
2. Clean up of old duplicated code
3. Adding the action of opening the News popup when clicking the toast and also move the opening logic to QML to have `qsTr`.

### Affected areas

Notification manager, AC code, main module code

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

[toast-message.webm](https://github.com/user-attachments/assets/401dd75b-68d9-4b06-868d-2b4dd1587671)

There are a lot of toasts popping up just because I use Hackers News for the RSS and there are a lot of News there

### Impact on end user

None for now since it's behind a feature flag in status-go.

Once enabled, receives News for an RSS feed and shows then in the AC and in toast messages

### How to test

- Enable the feature flag in status-go
- See the taosts

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

Low because of feature flag
