### PR TITLE
chore(@e2e): mark permission creation test xfail

### DIFF
--- a/test/e2e/tests/communities/test_communities_limit_to_5_permissions.py
+++ b/test/e2e/tests/communities/test_communities_limit_to_5_permissions.py
@@ -13,6 +13,7 @@ from gui.main_window import MainWindow
                  'Can create up to 5 member role permissions')
 @pytest.mark.case(739309)
 @pytest.mark.communities
+@pytest.mark.xfail(reason='https://github.com/status-im/status-desktop/issues/17786')
 def test_add_5_member_role_permissions(main_screen: MainWindow):
 
     with step('Create community and select it'):


### PR DESCRIPTION
### What does the PR do

Test for permission creation is marked as expected to fail because of https://github.com/status-im/status-desktop/issues/17786

