### PR TITLE
feat(Communities): Add promotional card into community portal

### DIFF
--- a/storybook/pages/PromotionalCommunityCardPage.qml
+++ b/storybook/pages/PromotionalCommunityCardPage.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+import AppLayouts.Communities.controls 1.0
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PromotionalCommunityCard {
+            anchors.centerIn: parent
+
+            onLearnMore: logs.logEvent("PromotionalCommunityCard::onLearnMore")
+            onInitiateVote: logs.logEvent("PromotionalCommunityCard::onInitiateVote")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 160
+
+        logsView.logText: logs.logText
+    }
+}
+
+// category: Components
+// status: good
+// https://www.figma.com/design/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?node-id=55170-330778&m=dev

--- a/ui/app/AppLayouts/Communities/controls/PromotionalCommunityCard.qml
+++ b/ui/app/AppLayouts/Communities/controls/PromotionalCommunityCard.qml
@@ -1,0 +1,105 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import shared.controls 1.0
+import shared.panels 1.0
+
+Item {
+    id: root
+
+    /*!
+        \qmlsignal StatusCommunityCard::learnMore
+        This signal is emitted when the card learn more button is clicked.
+    */
+    signal learnMore
+
+    /*!
+        \qmlsignal StatusCommunityCard::initiateVote
+        This signal is emitted when the card initiate vote button is clicked
+    */
+    signal initiateVote
+
+    QtObject {
+        id: d
+        readonly property int cardWidth: 335
+        readonly property int cardHeight: 230
+        readonly property int defaultMargin: 12
+        readonly property int defaultSpacing: 8
+    }
+
+    implicitWidth: d.cardWidth
+    implicitHeight: d.cardHeight
+
+    ShapeRectangle {
+        anchors.fill: parent
+
+        ColumnLayout {
+            width: parent.width
+            anchors.centerIn: parent
+            spacing: d.defaultSpacing
+
+            StatusIcon {
+                Layout.topMargin: 28
+                Layout.alignment: Qt.AlignHCenter
+
+                icon: "communities"
+            }
+
+            StatusBaseText {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.maximumWidth: parent.width - 4 * d.defaultMargin
+
+                text: qsTr("Want to see your community here?")
+                font.weight: Font.Bold
+            }
+
+            StatusBaseText {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.maximumWidth: parent.width - 4 * d.defaultMargin
+
+                text: qsTr("Help more people discover your community - start or join the vote to get it on the board.")
+                font.pixelSize: Theme.additionalTextSize
+                lineHeight: 1.2
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+            }
+
+            Separator {
+                Layout.fillWidth: true
+                Layout.topMargin: 22
+                Layout.leftMargin: d.defaultMargin
+                Layout.rightMargin: d.defaultMargin
+                Layout.bottomMargin: 4
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                Layout.leftMargin: d.defaultMargin
+                Layout.rightMargin: d.defaultMargin
+                spacing: d.defaultSpacing
+
+                StatusButton {
+                    text: qsTr("Learn more")
+                    icon.name: "external-link"
+                    size: StatusBaseButton.Size.Small
+
+                    onClicked: root.learnMore()
+                }
+
+                StatusButton {
+                    text: qsTr("Initiate the vote")
+                    icon.name: "external-link"
+                    size: StatusBaseButton.Size.Small
+
+                    onClicked: root.initiateVote()
+                }
+            }
+
+        } // End of content card
+    }
+}

--- a/ui/app/AppLayouts/Communities/controls/qmldir
+++ b/ui/app/AppLayouts/Communities/controls/qmldir
@@ -27,6 +27,7 @@ OutroMessageInput 1.0 OutroMessageInput.qml
 PermissionItem 1.0 PermissionItem.qml
 PermissionListItem 1.0 PermissionListItem.qml
 PermissionsRow 1.0 PermissionsRow.qml
+PromotionalCommunityCard 1.0 PromotionalCommunityCard.qml
 SettingsPageHeader 1.0 SettingsPageHeader.qml
 TagsPicker 1.0 TagsPicker.qml
 TagsRow 1.0 TagsRow.qml


### PR DESCRIPTION
Closes #17754

### What does the PR do

- It creates`PromotionalCommunityCard` component and added corresponding `storybook` page.
- It adds a promotional card into the third position of the current `Communities Portal` layout as per design.

### Affected areas

Communities Portal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- `Storybook` page

https://github.com/user-attachments/assets/f14f229e-6036-429d-86e7-50787b12239f

- `App`

<img width="1243" alt="Screenshot 2025-04-15 at 18 22 10" src="https://github.com/user-attachments/assets/1fcdaa36-0f53-4f09-9ebc-b680fdf379d9" />

### Impact on end user

It promotes the Community Directory Curation to encourage community owners and members to have their community featured on the Communities Portal page.

### How to test

- Test the component at `storybook`
- Test the promotional card at `Communities Portal` page