### PR TITLE
feat(news): hook settings to the backend

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -241,7 +241,8 @@ QtObject:
         details.notificationType == NotificationType.NewMessageWithGlobalMention or
         details.notificationType == NotificationType.NewContactRequest or
         details.notificationType == NotificationType.ContactRemoved or
-        details.notificationType == NotificationType.IdentityVerificationRequest:
+        details.notificationType == NotificationType.IdentityVerificationRequest or
+        details.notificationType == NotificationType.NewsFeedMessage:
 
       if notificationWay == VALUE_NOTIF_DELIVER_QUIETLY:
         return
@@ -291,6 +292,13 @@ QtObject:
     if(details.notificationType == NotificationType.NewContactRequest):
       if(self.settingsService.getNotifSettingContactRequests() != VALUE_NOTIF_TURN_OFF):
         self.notificationCheck(title, message, details, self.settingsService.getNotifSettingContactRequests())
+        return
+
+    # In case of News message
+    elif details.notificationType == NotificationType.NewsFeedMessage:
+      let newsSetting = self.settingsService.getNotifSettingStatusNews()
+      if newsSetting != VALUE_NOTIF_TURN_OFF:
+        self.notificationCheck(title, message, details, newsSetting)
         return
 
     # In case of new message (regardless it's message with mention or not)

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -55,6 +55,9 @@ const PROFILE_MIGRATION_NEEDED* = "profile-migration-needed"
 const KEY_URL_UNFURLING_MODE* = "url-unfurling-mode"
 const KEY_AUTO_REFRESH_TOKENS* = "auto-refresh-tokens-enabled"
 const KEY_LAST_TOKENS_UPDATE* = "last-tokens-update"
+const KEY_NEWS_FEED_ENABLED* = "news-feed-enabled?"
+const KEY_NEWS_NOTIFICATIONS_ENABLED* = "news-notifications-enabled?"
+const KEY_NEWS_RSS_ENABLED* = "news-rss-enabled?"
 
 # Notifications Settings Values
 const VALUE_NOTIF_SEND_ALERTS* = "SendAlerts"
@@ -145,6 +148,9 @@ type
     gifRecents*: JsonNode
     gifFavorites*: JsonNode
     testNetworksEnabled*: bool
+    newsFeedEnabled*: bool
+    newsNotificationsEnabled*: bool
+    newsRSSEnabled*: bool
     notificationsAllowNotifications*: bool
     notificationsOneToOneChats*: string
     notificationsGroupChats*: string
@@ -248,6 +254,10 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
 
   discard jsonObj.getProp(KEY_NODE_CONFIG, result.nodeConfig)
   discard jsonObj.getProp(KEY_WAKU_BLOOM_FILTER_MODE, result.wakuBloomFilterMode)
+
+  discard jsonObj.getProp(KEY_NEWS_FEED_ENABLED, result.newsFeedEnabled)
+  discard jsonObj.getProp(KEY_NEWS_NOTIFICATIONS_ENABLED, result.newsNotificationsEnabled)
+  discard jsonObj.getProp(KEY_NEWS_RSS_ENABLED, result.newsRSSEnabled)
 
   var usernamesArr: JsonNode
   if (jsonObj.getProp(KEY_ENS_USERNAMES, usernamesArr)):

--- a/src/backend/settings.nim
+++ b/src/backend/settings.nim
@@ -1,5 +1,5 @@
 import json
-import ./core, ./response_type
+import ./core, ./response_type, ../app_service/common/utils
 
 export response_type
 
@@ -95,3 +95,18 @@ proc mnemonicWasShown*(): RpcResponse[JsonNode] =
 
 proc lastTokensUpdate*(): RpcResponse[JsonNode] =
   return core.callPrivateRPC("settings_lastTokensUpdate")
+
+proc newsFeedEnabled*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("settings_newsFeedEnabled")
+
+proc newsNotificationsEnabled*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("settings_newsNotificationsEnabled")
+
+proc newsRSSEnabled*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("settings_newsRSSEnabled")
+
+proc toggleNewsFeedEnabled*(value: bool): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("toggleNewsFeedEnabled".prefix, %*[value])
+
+proc toggleNewsRSSEnabled*(value: bool): RpcResponse[JsonNode] =
+  result = core.callPrivateRPC("toggleNewsRSSEnabled".prefix, %*[ value ])

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -527,7 +527,9 @@ StatusSectionLayout {
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.privacyAndSecurity)
                 contentWidth: d.contentWidth
 
-                onIsStatusNewsViaRSSEnabledChanged: root.store.privacyStore.isStatusNewsViaRSSEnabled = isStatusNewsViaRSSEnabled
+                onSetNewsRSSEnabledRequested: function (isStatusNewsViaRSSEnabled) {
+                    root.store.privacyStore.setNewsRSSEnabled(isStatusNewsViaRSSEnabled)
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
@@ -5,7 +5,7 @@ QtObject {
     id: root
 
     property var notificationsModule
-    property var notificationsSettings: appSettings /*TODO: Add appSettings.notifSettingStatusNews notifiable property in the backend*/
+    property var notificationsSettings: appSettings
 
     property var exemptionsModel: notificationsModule.exemptionsModel
 

--- a/ui/app/AppLayouts/Profile/stores/PrivacyStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/PrivacyStore.qml
@@ -11,9 +11,11 @@ QtObject {
     readonly property string keyUid: userProfile.keyUid
 
     // The following properties wrap Privacy and Security View related properties:
-    property bool isStatusNewsViaRSSEnabled: true /*TODO: Connect it to the backend corresponding property*/
+    readonly property bool isStatusNewsViaRSSEnabled: appSettings.newsRSSEnabled
 
-    onIsStatusNewsViaRSSEnabledChanged: console.warn("TODO: Connect it to the backend corresponding setting: " + isStatusNewsViaRSSEnabled)
+    function setNewsRSSEnabled(isStatusNewsViaRSSEnabled) {
+        appSettings.newsRSSEnabled = isStatusNewsViaRSSEnabled
+    }
 
     function changePassword(password, newPassword) {
         root.privacyModule.changePassword(password, newPassword)

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -311,7 +311,7 @@ SettingsContentBase {
                     visible: !root.privacyStore.isStatusNewsViaRSSEnabled
                     text: qsTr("Enable RSS")
 
-                    onClicked: root.privacyStore.isStatusNewsViaRSSEnabled = true
+                    onClicked: root.privacyStore.setNewsRSSEnabled(true)
                 },
                 NotificationSelect {
                     visible: root.privacyStore.isStatusNewsViaRSSEnabled

--- a/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyAndSecurityView.qml
@@ -10,8 +10,10 @@ import StatusQ.Controls 0.1
 SettingsContentBase {
     id: root
 
-    property alias isStatusNewsViaRSSEnabled: statusNewsSwitch.checked
+    property bool isStatusNewsViaRSSEnabled
     required property bool isCentralizedMetricsEnabled
+
+    signal setNewsRSSEnabledRequested(bool isStatusNewsViaRSSEnabled)
 
     function refreshSwitch() {
         enableMetricsSwitch.checked = Qt.binding(function() { return root.isCentralizedMetricsEnabled })
@@ -30,9 +32,11 @@ SettingsContentBase {
             components: [
                 StatusSwitch {
                     id: statusNewsSwitch
+                    checked: root.isStatusNewsViaRSSEnabled
+                    onToggled: root.setNewsRSSEnabledRequested(statusNewsSwitch.checked)
                 }
             ]
-            onClicked: statusNewsSwitch.checked = !statusNewsSwitch.checked
+            onClicked: root.setNewsRSSEnabledRequested(!statusNewsSwitch.checked)
         }
         StatusListItem {
             Layout.preferredWidth: root.contentWidth

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -597,8 +597,8 @@ Popup {
                 font.pixelSize: Theme.additionalTextSize
 
                 onClicked: {
-                    if(isEnableRSSNotificationPanelType) {
-                        root.privacyStore.isStatusNewsViaRSSEnabled = true
+                    if (isEnableRSSNotificationPanelType) {
+                        root.privacyStore.setNewsRSSEnabled(true)
                     } else {
                         d.notificationsSettings.notifSettingStatusNews = Constants.settingsSection.notifications.sendAlertsValue
                     }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -51,6 +51,7 @@ StatusDialog {
 
     ColumnLayout {
         width: parent.width
+        spacing: 0
 
         Loader {
             id: notificationModelEntryLoader
@@ -74,12 +75,12 @@ StatusDialog {
                 color: "transparent"
                 border.color: root.backgroundColor
                 border.width: 1
-                radius: 10
+                radius: 16
             }
         }
 
         StatusBaseText {
-            text: notification.newsContent || notification.newsDescription
+            text: notification.newsDescription || notification.newsContent
             Layout.fillWidth: true
             Layout.fillHeight: true
             wrapMode: Text.WordWrap


### PR DESCRIPTION
Fixes #17811

Based on top of https://github.com/status-im/status-desktop/pull/17809
Status-go PR: https://github.com/status-im/status-go/pull/6540

Hooks the NewsFeedNotification setting and the RSS setting to the backend.

The Notification setting has a bit of complexity on the service side, because while the UI setting is a select of 3 options, the status-go settings are actually 2 bool settings. So the service does some logic to set the right setting from those two.

The settings are used to disable the polling if one of the settings is disabled. If the setting is on DeliverQuietly, the AC notif is shown, but no OS or toast notification

### What does the PR do

Hooks the UI settings to the backend settings. Makes the UX for the News Feed complete, once the feature flag on the status-go side is enabled and once we'll have a good RSS feed for Status

### Affected areas

- Nim Settings (adds the QtProperties to access the RSS and notification settings, ie the backend getters and setters)
- Notification manager (skip OS and Toast notif if notif is OFF or DeliverQuietly)
- Modifies/Fixes the QML code a little to be able to set the properties properly

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

[settings-hooked.webm](https://github.com/user-attachments/assets/3c1a1085-5a4b-412c-be0c-830cc759e8a3)

### Impact on end user

None without the feature flag on
Once it's turned on, it let's users choose the right settings for notifications or if they want to disable the feature altogether.

### How to test

- Play with the settings in the Notifications settings, the Privacy settings and in the AC screen

### Risk 

Nonce since the feature flag is disabled

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

