### PR TITLE
fix(@desktop/wallet): Send modal - Network selector does not show Mainnet as default chain

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -169,7 +169,6 @@ StatusComboBox {
         multiSelection: root.multiSelection
         showSelectionIndicator: root.showSelectionIndicator
         showManageNetworksButton: root.showManageNetworksButton
-        selection: root.selection
         showNewChainIcon: root.showNewChainIcon
 
         onToggleNetwork: root.toggleNetwork(chainId, index)

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -65,7 +65,6 @@ Popup {
             interactive: root.selectionAllowed
             multiSelection: root.multiSelection
             showIndicator: root.showSelectionIndicator
-            selection: root.selection
             showNewChainIcon: root.showNewChainIcon
 
             onToggleNetwork: {


### PR DESCRIPTION
fixes #17775

### What does the PR do

Removed Binding errors and now it works as excpected

### Affected areas

NetworkFilter -> Swap, Send and Buy modal

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/02739fea-0e9a-4d7f-b5ec-5f9870dbfe18

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
