### PR TITLE
chore(@e2e): remove useless waitFor that was leading tests to stuck forever

### DIFF
--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -23,7 +23,7 @@ class QObject:
         try:
             return driver.waitForObject(self.real_name, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         except LookupError as e:
-            raise LookupError(f"Object {self.real_name} was not found within {configs.timeouts.UI_LOAD_TIMEOUT_MSEC} ms") from e
+            raise Exception(f"Object {self.real_name} was not found within {configs.timeouts.UI_LOAD_TIMEOUT_MSEC} ms") from e
 
     def set_text_property(self, text):
         self.object.forceActiveFocus()

--- a/test/e2e/gui/screens/community.py
+++ b/test/e2e/gui/screens/community.py
@@ -152,16 +152,13 @@ class ToolBar(QObject):
 
     @allure.step('Open more options dropdown')
     def open_more_options_dropdown(self):
-        self._more_options_button.click()
-        return ContextMenu()
-
-    @allure.step('Get visibility state of edit item')
-    def is_edit_item_visible(self) -> bool:
-        return self._edit_channel_context_item.exists
-
-    @allure.step('Get visibility state of delete item')
-    def is_delete_item_visible(self) -> bool:
-        return self._delete_channel_context_item.exists
+        for _ in range(2):
+            self._more_options_button.click()
+            try:
+                return ContextMenu().wait_until_appears()
+            except Exception:
+                pass  # Retry one more time
+        raise LookupError(f'Could not open context menu for a channel')
 
 
 class CategoryItem:
@@ -337,7 +334,7 @@ class LeftPanel(QObject):
 
     @allure.step('Open join community popup')
     def open_welcome_community_popup(self):
-        self._join_community_button.wait_until_appears(configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
+        self._join_community_button.wait_until_appears(timeout_msec=10000)
         self._join_community_button.click()
         return WelcomeCommunityPopup().wait_until_appears()
 

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -92,19 +92,6 @@ class ToolBar(QObject):
         self.contact_tag = QObject(messaging_names.statusToolBar_StatusTagItem)
         self.notifications_button = Button(messaging_names.statusToolBar_notificationButton_StatusActivityCenterButton)
 
-    @property
-    @allure.step('Get visibility of pin message tooltip')
-    def is_pin_message_tooltip_visible(self) -> bool:
-        return self.pinned_message_tooltip.is_visible
-
-    @allure.step('Click on pin message tooltip')
-    def click_pin_message_tooltip(self):
-        return self.pinned_message_tooltip.click()
-
-    @allure.step('Confirm action in toolbar')
-    def confirm_action_in_toolbar(self):
-        self.confirm_button.click()
-
     @allure.step('Remove member by clicking close icon on member tag')
     def click_contact_close_icon(self, member):
         for item in driver.findAllObjects(self.contact_tag.real_name):
@@ -481,7 +468,7 @@ class ChatMessagesView(QObject):
         tool_bar = ToolBar().wait_until_appears()
         tool_bar.click_contact_close_icon(member)
         time.sleep(1)
-        tool_bar.confirm_action_in_toolbar()
+        tool_bar.confirm_button.click()
         time.sleep(1)
 
     @allure.step('Clear chat history option')

--- a/test/e2e/tests/communities/test_communities_kick_ban.py
+++ b/test/e2e/tests/communities/test_communities_kick_ban.py
@@ -171,15 +171,12 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             assert driver.waitFor(lambda: user_one.name not in community_screen.right_panel.members, timeout)
             main_screen.hide()
 
-        with step(f'User {user_one.name} rejoins community after being kicked'):
+        with step(f'User {user_one.name} can rejoin community after being kicked'):
             aut_one.attach()
             main_screen.prepare()
-            assert driver.waitFor(lambda: community.name not in main_screen.left_panel.communities, timeout)
-
             messages_view = main_screen.left_panel.open_messages_screen()
             chat = messages_view.left_panel.click_chat_by_name(user_two.name)
             community_screen = chat.click_community_invite(community.name, 0)
-
             welcome_popup = community_screen.left_panel.open_welcome_community_popup()
             welcome_popup.join().authenticate(user_one.password)
             assert driver.waitFor(lambda: not community_screen.left_panel.is_join_community_visible,

--- a/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
+++ b/test/e2e/tests/communities/test_communities_pin_and_unpin_messages.py
@@ -131,7 +131,7 @@ def test_join_community_and_pin_unpin_message(multiple_instances):
         with step(f'User {user_two.name} unpin message from pinned messages popup'):
             aut_two.attach()
             main_screen.prepare()
-            messages_screen.tool_bar.click_pin_message_tooltip()
+            messages_screen.tool_bar.pinned_message_tooltip.click()
             PinnedMessagesPopup().wait_until_appears().unpin_message().close()
 
         with step(f'User {user_one.name} see the {second_message_text} as unpinned'):
@@ -139,6 +139,6 @@ def test_join_community_and_pin_unpin_message(multiple_instances):
             main_screen.prepare()
             time.sleep(2)
             message = messages_screen.chat.find_message_by_text(second_message_text, 1)
-            assert driver.waitFor(lambda: message.message_is_pinned) is False
+            assert not message.message_is_pinned
             assert message.user_name_in_pinned_message == ''
-            assert driver.waitFor(lambda: messages_screen.tool_bar.is_pin_message_tooltip_visible) is False
+            assert not messages_screen.tool_bar.pinned_message_tooltip.is_visible


### PR DESCRIPTION
### What does the PR do

- replace the waitFor with explicit condition, no need to wait there
- replace the Lookup class with general exception in order not to re-define built-in Squish Lookup error
- removed a bit of unused code
