### PR TITLE
fix: SortOrderComboBox doesn't render any text under Qt6

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/StatusComboboxBackground.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/StatusComboboxBackground.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 
-import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 Rectangle {
@@ -10,7 +9,7 @@ Rectangle {
 
     border.width: 1
     border.color: Theme.palette.directColor7
-    radius: 8
+    radius: Theme.radius
     color: root.active ? Theme.palette.directColor8 : "transparent"
     HoverHandler {
         cursorShape: root.enabled ? Qt.PointingHandCursor : undefined

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -182,10 +182,7 @@ Item {
                 width: comboBox.width
                 highlighted: comboBox.highlightedIndex === index
                 font: comboBox.font
-                text: control.textRole ? (Array.isArray(control.model)
-                                          ? modelData[control.textRole]
-                                          : model[control.textRole])
-                                       : modelData
+                text: control.textRole ? modelData[control.textRole] : modelData
             }
         }
 

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuSeparator.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuSeparator.qml
@@ -5,6 +5,7 @@ import StatusQ.Core.Theme 0.1
 
 MenuSeparator {
     height: visible && enabled ? implicitHeight : 0
+    background: null
     contentItem: Rectangle {
         implicitWidth: 176
         implicitHeight: 1

--- a/ui/app/AppLayouts/Wallet/controls/SortOrderComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SortOrderComboBox.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
-import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
@@ -30,7 +29,7 @@ ComboBox {
     displayText: root.currentValue === SortOrderComboBox.TokenOrderCustom ? currentText
                                                                           : "%1 %2".arg(currentText).arg(currentSortOrder === Qt.DescendingOrder ? "↓" : "↑")
 
-    onActivated: {
+    onActivated: function(index) {
         if (index === indexOfValue(SortOrderComboBox.TokenOrderCreateCustom)) { // restore the previous sort role and signal we want create/edit
             currentIndex = d.currentIndex
             root.createOrEditRequested()
@@ -97,8 +96,7 @@ ComboBox {
         y: root.topPadding + (root.availableHeight - height) / 2
     }
 
-    popup: Popup {
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+    popup: StatusDropdown {
         y: root.height + 4
 
         implicitWidth: 290
@@ -106,20 +104,6 @@ ComboBox {
 
         padding: 1
         verticalPadding: Theme.halfPadding
-
-        background: Rectangle {
-            color: Theme.palette.statusSelect.menuItemBackgroundColor
-            radius: Theme.radius
-            layer.enabled: true
-            layer.effect: DropShadow {
-                horizontalOffset: 0
-                verticalOffset: 4
-                radius: 12
-                samples: 25
-                spread: 0.2
-                color: Theme.palette.dropShadow
-            }
-        }
 
         contentItem: ColumnLayout {
             spacing: 0
@@ -209,7 +193,10 @@ ComboBox {
 
     Component {
         id: separatorMenuComponent
-        StatusMenuSeparator {}
+        StatusMenuSeparator {
+            topPadding: 0
+            bottomPadding: 0
+        }
     }
 
     delegate: ItemDelegate {
@@ -241,8 +228,7 @@ ComboBox {
         verticalPadding: isSeparator ? 2 : 5
         spacing: root.spacing
         font: root.font
-        text: root.textRole ? (Array.isArray(root.model) ? modelData[root.textRole] : model[root.textRole])
-                            : modelData
+        text: root.textRole ? modelData[root.textRole] : modelData
         icon.name: !!modelData["icon"] ? modelData["icon"] : ""
         icon.color: Theme.palette.primaryColor1
         background: Rectangle {


### PR DESCRIPTION
### What does the PR do

- also fix the separator height/bg color
- use the common StatusDropdown for the popup impl
- fix a similar generic prob in StatusComboBox

Fixes #17815

### Affected areas

SortOrderComboBox (in Assets/CollectiblesView)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Qt5 / light mode:
![Snímek obrazovky z 2025-04-22 13-10-49](https://github.com/user-attachments/assets/440d5acb-9022-415e-9c2c-5b3c83d5082c)

Qt6 / dark mode:
![Snímek obrazovky z 2025-04-22 13-11-22](https://github.com/user-attachments/assets/b2b35422-844b-48a3-b7eb-18c19536845f)

