### PR TITLE
fix(@desktop/wallet): Wallet address is not being resolved into a link in chat

### DIFF
--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -211,6 +211,7 @@ SplitView {
                     outgoingStatus: model.outgoingStatus
                     resendError: model.outgoingStatus === StatusMessage.OutgoingStatus.Expired ? model.resendError : ""
                     linkAddressAndEnsName: true
+                    disabledTooltipText: disableLinkCheckbox.checked ? "Send not available": ""
 
                     messageDetails {
                         readonly property bool isEnsVerified: model.senderDisplayName.endsWith(".eth")
@@ -261,6 +262,11 @@ SplitView {
             SplitView.preferredHeight: 200
 
             logsView.logText: logs.logText
+
+            CheckBox {
+                id: disableLinkCheckbox
+                text: "Disable Address/Ens link"
+            }
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -78,6 +78,7 @@ Control {
     property string highlightedLink: ""
     property string hoveredLink: ""
     property bool linkAddressAndEnsName
+    property string disabledTooltipText
 
     property StatusMessageDetails messageDetails: StatusMessageDetails {}
     property StatusMessageDetails replyDetails: StatusMessageDetails {}
@@ -291,6 +292,7 @@ Control {
                             textField.anchors.rightMargin: root.isInPinnedPopup ? Theme.xlPadding : 0 // margin for the "Unpin" floating button
                             highlightedLink: root.highlightedLink
                             linkAddressAndEnsName: root.linkAddressAndEnsName
+                            disabledTooltipText: root.disabledTooltipText
                             onLinkActivated: {
                                 root.linkActivated(link);
                             }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -4,6 +4,7 @@ import QtGraphicalEffects 1.15
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ 0.1
+import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
 
@@ -14,6 +15,7 @@ Item {
 
     property string highlightedLink: ""
     property bool linkAddressAndEnsName
+    property string disabledTooltipText
 
     property StatusMessageDetails messageDetails: StatusMessageDetails {}
     property bool isEdited: false
@@ -68,7 +70,11 @@ Item {
                 // short return not to add styling when no html
                 return formattedMessage
 
-            return Utils.getMessageWithStyle(formattedMessage)
+            return Utils.getMessageWithStyle(formattedMessage, chatText.hoveredLink, !!root.disabledTooltipText)
+        }
+
+        function showDisabledTooltipForAddressEnsName(link) {
+            return link.startsWith('//send-via-personal-chat//') && !!root.disabledTooltipText
         }
     }
 
@@ -104,7 +110,23 @@ Item {
         readOnly: true
         selectByMouse: true
         onLinkActivated: {
-            root.linkActivated(link);
+            if(d.showDisabledTooltipForAddressEnsName(link)) {
+                return
+            }
+            root.linkActivated(link)
+        }
+        onLinkHovered: {
+            disabledLinkTooltip.visible = d.showDisabledTooltipForAddressEnsName(link)
+        }
+        HoverHandler {
+            id: hoverHandler
+        }
+        StatusToolTip {
+            id: disabledLinkTooltip
+            text: root.disabledTooltipText
+            delay: 100
+            x: hoverHandler.point.position.x - 60
+            y: -disabledLinkTooltip.height + hoverHandler.point.position.y - 10
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -169,12 +169,12 @@ QtObject {
         if (linkAddressAndEnsName) {
             // Wallet address
             var replacePatternWalletAddress = /(^|[^\/])(0x[a-fA-F0-9]{40})/gim;
-            replacedText = replacedText.replace(replacePatternWalletAddress, "$1<a href='//send-via-personal-chat//$2'>$2</a>");
+            replacedText = replacedText.replace(replacePatternWalletAddress, "$1<a class='eth-link' href='//send-via-personal-chat//$2'>$2</a>");
 
             // Ens Name
             var replacePatternENS = /\b[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.eth\b(?!\.\w)/g;
             replacedText = replacedText.replace(replacePatternENS, function(match) {
-                return "<a href='//send-via-personal-chat//" + match + "'>" + match + "</a>";
+                return "<a class='eth-link' href='//send-via-personal-chat//" + match + "'>" + match + "</a>";
             });
         }
 
@@ -185,7 +185,10 @@ QtObject {
         return XSS.filterXSS(inputText)
     }
 
-    function getMessageWithStyle(msg, hoveredLink = "") {
+    function getMessageWithStyle(msg, hoveredLink = "", ethLinkDisabled = false) {
+        const ethLinkColor = ethLinkDisabled ? Theme.palette.directColor1 : Theme.palette.primaryColor1
+        const ethLinkHoverColor = ethLinkDisabled ? Theme.palette.baseColor1 : Theme.palette.primaryColor1
+        const ethLinkHoverBackgroundColor = ethLinkDisabled ? Theme.palette.directColor8 : Theme.palette.primaryColor3
         return `<style type="text/css">` +
                     `img, a, del, code, blockquote { margin: 0; padding: 0; }` +
                     `code {` +
@@ -204,6 +207,15 @@ QtObject {
                     `a {` +
                         `color: ${Theme.palette.primaryColor1};` +
                     `}` +
+                    `a.eth-link {` +
+                        `color: ${ethLinkColor};` +
+                    `}` +
+                    // Simulated hover effect for eth-link via hoveredLink
+                    (hoveredLink !== "" ?
+                        `a[href="${hoveredLink}"].eth-link {` +
+                            `color: ${ethLinkHoverColor};` +
+                            `background-color: ${ethLinkHoverBackgroundColor};` +
+                        `}` : ``) +
                     `a.mention {` +
                         `color: ${Theme.palette.mentionColor1};` +
                         `background-color: ${Theme.palette.mentionColor4};` +

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -57,6 +57,7 @@ StackLayout {
     property bool communitySettingsDisabled
 
     property bool sendViaPersonalChatEnabled
+    property string disabledTooltipText
 
     property var emojiPopup
     property var stickersPopup
@@ -180,6 +181,7 @@ StackLayout {
                              root.sectionItemModel.memberRole === Constants.memberRole.tokenMaster
             hasViewOnlyPermissions: root.permissionsStore.viewOnlyPermissionsModel.count > 0
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
 
             hasUnrestrictedViewOnlyPermission: {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -57,6 +57,7 @@ Item {
     property var viewAndPostHoldingsModel
     property bool amISectionAdmin: false
     property bool sendViaPersonalChatEnabled
+    property string disabledTooltipText
     property bool paymentRequestFeatureEnabled
 
     signal openStickerPackPopup(string stickerPackId)
@@ -256,6 +257,7 @@ Item {
                         stickersLoaded: root.stickersLoaded
                         isBlocked: model.blocked
                         sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+                        disabledTooltipText: root.disabledTooltipText
                         areTestNetworksEnabled: root.areTestNetworksEnabled
                         onOpenStickerPackPopup: {
                             root.openStickerPackPopup(stickerPackId)

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -62,6 +62,7 @@ ColumnLayout {
     }
 
     property bool sendViaPersonalChatEnabled
+    property string disabledTooltipText
 
     signal showReplyArea(messageId: string)
     signal forceInputFocus()
@@ -108,6 +109,7 @@ ColumnLayout {
             isContactBlocked: root.isBlocked
             channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
             onShowReplyArea: (messageId, senderId) => {
                 root.showReplyArea(messageId)

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -53,6 +53,7 @@ Item {
     property bool isOneToOne: false
 
     property bool sendViaPersonalChatEnabled
+    property string disabledTooltipText
 
     signal openStickerPackPopup(string stickerPackId)
     signal tokenPaymentRequested(string recipientAddress, string symbol, string rawAmount, int chainId)
@@ -300,6 +301,7 @@ Item {
             isChatBlocked: root.isChatBlocked
 
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
 
             chatId: root.chatId

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -80,6 +80,7 @@ StatusSectionLayout {
     property var collectiblesModel
 
     property bool sendViaPersonalChatEnabled
+    property string disabledTooltipText
     property bool paymentRequestFeatureEnabled
 
     readonly property bool contentLocked: {
@@ -290,6 +291,7 @@ StatusSectionLayout {
             canPost: !root.rootStore.chatCommunitySectionModule.isCommunity() || root.canPost
             amISectionAdmin: root.amISectionAdmin
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
+            disabledTooltipText: root.disabledTooltipText
             paymentRequestFeatureEnabled: root.paymentRequestFeatureEnabled
             onOpenStickerPackPopup: {
                 Global.openPopup(statusStickerPackClickPopup, {packId: stickerPackId, store: root.stickersPopup.store} )

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1984,7 +1984,9 @@ Item {
                                 networksStore: appMain.networksStore
                                 emojiPopup: statusEmojiPopup.item
                                 stickersPopup: statusStickersPopupLoader.item
-                                sendViaPersonalChatEnabled: featureFlagsStore.sendViaPersonalChatEnabled && appMain.networkConnectionStore.sendBuyBridgeEnabled
+                                sendViaPersonalChatEnabled: featureFlagsStore.sendViaPersonalChatEnabled
+                                disabledTooltipText: !appMain.networkConnectionStore.sendBuyBridgeEnabled ?
+                                                         appMain.networkConnectionStore.sendBuyBridgeToolTipText : ""
                                 paymentRequestFeatureEnabled: featureFlagsStore.paymentRequestEnabled
 
                                 mutualContactsModel: contactsModelAdaptor.mutualContacts

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -139,6 +139,7 @@ Loader {
     property bool hasMention: false
 
     property bool sendViaPersonalChatEnabled
+    property string disabledTooltipText
 
     property bool areTestNetworksEnabled
 
@@ -747,6 +748,7 @@ Loader {
                 disableEmojis: !d.addReactionAllowed
                 hideMessage: d.hideMessage
                 linkAddressAndEnsName: root.sendViaPersonalChatEnabled
+                disabledTooltipText: root.disabledTooltipText
 
                 overrideBackground: root.placeholderMessage
                 profileClickable: !root.isDiscordMessage


### PR DESCRIPTION
fixes #17757

### What does the PR do

Adds disabled tooltip over address/end name link in chat so that the user can know that the send in chat is unavailable because send functionality is not working currently. 

### Affected areas

Send 1-1 chat

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/0756b4fd-0b48-48f7-8d24-5bb54d4b05c3

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
