### PR TITLE
fix(Onboarding): don't crash with wrong password on Qt6

### DIFF
--- a/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding2/OnboardingFlow.qml
@@ -62,7 +62,7 @@ OnboardingStackView {
     signal finished(int flow)
 
     function restart() {
-        replace(null, initialComponent)
+        replace(null, loginAccountsModel.ModelCount.empty ? welcomePage : loginScreenComponent)
     }
 
     function setBiometricResponse(secret: string, error = "") {
@@ -77,6 +77,12 @@ OnboardingStackView {
 
         property int flow
         property LoginScreen loginScreen: null
+
+        readonly property int loginAccountsModelCount: loginAccountsModel.ModelCount.count
+        onLoginAccountsModelCountChanged: {
+            // NB: have to delay showing the LoginScreen as the model is populated in an async way; therefore can't use `StackView::initialItem`
+            root.restart()
+        }
 
         function pushOrSkipBiometricsPage() {
             if (root.biometricsAvailable) {
@@ -126,17 +132,6 @@ OnboardingStackView {
 
         function onAddKeyPairStateChanged() {
             d.handleKeycardProgressFailedState(addKeyPairState)
-        }
-    }
-
-    initialItem: initialComponent
-
-    Component {
-        id: initialComponent
-
-        Loader {
-            sourceComponent: loginAccountsModel.ModelCount.empty ? welcomePage
-                                                                 : loginScreenComponent
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- avoid binding component nested in Loader and StackView which causes a crash under Qt6 (https://bugreports.qt.io/browse/QTBUG-135295)

Fixes #17827

### Affected areas

Onboarding/Login

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/d8580743-6d4e-423b-bc2b-8d4baf60f49c