### PR TITLE
fix(swap): build paraswap tx error

### DIFF
--- a/src/app/core/signals/remote_signals/wallet.nim
+++ b/src/app/core/signals/remote_signals/wallet.nim
@@ -106,6 +106,6 @@ proc fromEvent*(T: type WalletSignal, signalType: SignalType, jsonSignal: JsonNo
       if event.contains("UpdatedPrices"):
         for tokenSymbol, price in event["UpdatedPrices"].pairs():
           result.updatedPrices[tokenSymbol] = price.getFloat
-    except:
-      error "Error parsing best route"
+    except Exception as e:
+      error "Error parsing best route: ", err=e.msg
     return

--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -137,15 +137,16 @@ proc suggestedRoutes*(self: Controller,
     amountOut: string = "",
     disabledFromChainIDs: seq[int] = @[],
     disabledToChainIDs: seq[int] = @[],
+    slippagePercentage: float = 0.0,
     extraParamsTable: Table[string, string] = initTable[string, string]()) =
   self.transactionService.suggestedRoutes(uuid, sendType, accountFrom, accountTo, token, tokenIsOwnerToken, amountIn, toToken, amountOut,
-    disabledFromChainIDs, disabledToChainIDs, extraParamsTable)
+    disabledFromChainIDs, disabledToChainIDs, slippagePercentage, extraParamsTable)
 
 proc stopSuggestedRoutesAsyncCalculation*(self: Controller) =
   self.transactionService.stopSuggestedRoutesAsyncCalculation()
 
-proc buildTransactionsFromRoute*(self: Controller, uuid: string, slippagePercentage: float): string =
-  return self.transactionService.buildTransactionsFromRoute(uuid, slippagePercentage)
+proc buildTransactionsFromRoute*(self: Controller, uuid: string): string =
+  return self.transactionService.buildTransactionsFromRoute(uuid)
 
 proc signMessage*(self: Controller, address: string, hashedPassword: string, hashedMessage: string): tuple[res: string, err: string] =
   return self.transactionService.signMessage(address, hashedPassword, hashedMessage)

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -34,6 +34,7 @@ method suggestedRoutes*(self: AccessInterface,
   amountOut: string = "",
   disabledFromChainIDs: seq[int] = @[],
   disabledToChainIDs: seq[int] = @[],
+  slippagePercentage: float = 0.0,
   extraParamsTable: Table[string, string] = initTable[string, string]()) {.base.} =
     raise newException(ValueError, "No implementation available")
 
@@ -43,7 +44,7 @@ method stopUpdatesForSuggestedRoute*(self: AccessInterface) {.base.} =
 method suggestedRoutesReady*(self: AccessInterface, uuid: string, suggestedRoutes: SuggestedRoutesDto, errCode: string, errDescription: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateAndTransfer*(self: AccessInterface, fromAddr: string, uuid: string, slippagePercentage: float) {.base.} =
+method authenticateAndTransfer*(self: AccessInterface, fromAddr: string, uuid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onUserAuthenticated*(self: AccessInterface, password: string, pin: string) {.base.} =

--- a/src/app/modules/main/wallet_section/send/suggested_route_item.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_item.nim
@@ -22,7 +22,7 @@ QtObject:
     approvalGasFees: float
     approvalAmountRequired: string
     approvalContractAddress: string
-
+    slippagePercentage: float
   proc setup*(self: SuggestedRouteItem,
     bridgeName: string,
     fromNetwork: int,
@@ -42,6 +42,7 @@ QtObject:
     approvalGasFees: float,
     approvalAmountRequired: string,
     approvalContractAddress: string,
+    slippagePercentage: float
   ) =
     self.QObject.setup
     self.bridgeName = bridgeName
@@ -62,6 +63,7 @@ QtObject:
     self.approvalGasFees = approvalGasFees
     self.approvalAmountRequired = approvalAmountRequired
     self.approvalContractAddress = approvalContractAddress
+    self.slippagePercentage = slippagePercentage
 
   proc delete*(self: SuggestedRouteItem) =
       self.QObject.delete
@@ -84,12 +86,13 @@ QtObject:
     approvalRequired: bool = false,
     approvalGasFees: float = 0,
     approvalAmountRequired: string = "",
-    approvalContractAddress: string = ""
+    approvalContractAddress: string = "",
+    slippagePercentage: float = 0.0
     ): SuggestedRouteItem =
       new(result, delete)
       result.setup(bridgeName, fromNetwork, toNetwork, maxAmountIn, amountIn, amountOut, gasAmount, gasFees, tokenFees,
         cost, estimatedTime, amountInLocked, isFirstSimpleTx, isFirstBridgeTx, approvalRequired, approvalGasFees,
-        approvalAmountRequired, approvalContractAddress)
+        approvalAmountRequired, approvalContractAddress, slippagePercentage)
 
   proc `$`*(self: SuggestedRouteItem): string =
     result = "SuggestedRouteItem("
@@ -111,6 +114,7 @@ QtObject:
     result = result & "\napprovalGasFees: " & $self.approvalGasFees
     result = result & "\napprovalAmountRequired: " & $self.approvalAmountRequired
     result = result & "\napprovalContractAddress: " & $self.approvalContractAddress
+    result = result & "\nslippagePercentage: " & $self.slippagePercentage
     result = result & ")"
 
   proc bridgeNameChanged*(self: SuggestedRouteItem) {.signal.}
@@ -238,3 +242,10 @@ QtObject:
   QtProperty[string] approvalContractAddress:
     read = getApprovalContractAddress
     notify = approvalContractAddressChanged
+
+  proc slippagePercentageChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getSlippagePercentage*(self: SuggestedRouteItem): float {.slot.} =
+    return self.slippagePercentage
+  QtProperty[float] slippagePercentage:
+    read = getSlippagePercentage
+    notify = slippagePercentageChanged

--- a/src/app/modules/main/wallet_section/send_new/controller.nim
+++ b/src/app/modules/main/wallet_section/send_new/controller.nim
@@ -99,9 +99,10 @@ proc suggestedRoutes*(self: Controller,
     amountOut: string = "",
     disabledFromChainIDs: seq[int] = @[],
     disabledToChainIDs: seq[int] = @[],
+    slippagePercentage: float = 0.0,
     extraParamsTable: Table[string, string] = initTable[string, string]()) =
   self.transactionService.suggestedRoutes(uuid, sendType, accountFrom, accountTo, token, tokenIsOwnerToken, amountIn, toToken, amountOut,
-    disabledFromChainIDs, disabledToChainIDs, extraParamsTable)
+    disabledFromChainIDs, disabledToChainIDs, slippagePercentage, extraParamsTable)
 
 proc stopSuggestedRoutesAsyncCalculation*(self: Controller) =
   self.transactionService.stopSuggestedRoutesAsyncCalculation()
@@ -121,8 +122,8 @@ proc getEstimatedTime*(self: Controller, chainId: int, maxFeesPerGas: string, pr
 proc getCurrentNetworks*(self: Controller): seq[NetworkItem] =
   return self.networkService.getCurrentNetworks()
 
-proc buildTransactionsFromRoute*(self: Controller, uuid: string, slippagePercentage: float): string =
-  return self.transactionService.buildTransactionsFromRoute(uuid, slippagePercentage)
+proc buildTransactionsFromRoute*(self: Controller, uuid: string): string =
+  return self.transactionService.buildTransactionsFromRoute(uuid)
 
 proc signMessage*(self: Controller, address: string, hashedPassword: string, hashedMessage: string): tuple[res: string, err: string] =
   return self.transactionService.signMessage(address, hashedPassword, hashedMessage)

--- a/src/app/modules/main/wallet_section/send_new/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send_new/io_interface.nim
@@ -29,13 +29,14 @@ method suggestedRoutes*(self: AccessInterface,
   amountIn: string,
   toToken: string = "",
   amountOut: string = "",
+  slippagePercentage: float = 0.0,
   extraParamsTable: Table[string, string] = initTable[string, string]()) {.base.} =
     raise newException(ValueError, "No implementation available")
 
 method stopUpdatesForSuggestedRoute*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateAndTransfer*(self: AccessInterface, fromAddr: string, uuid: string, slippagePercentage: float) {.base.} =
+method authenticateAndTransfer*(self: AccessInterface, fromAddr: string, uuid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onUserAuthenticated*(self: AccessInterface, password: string, pin: string) {.base.} =

--- a/src/app/modules/main/wallet_section/send_new/module.nim
+++ b/src/app/modules/main/wallet_section/send_new/module.nim
@@ -34,7 +34,6 @@ type TmpSendTransactionDetails = object
   password: string
   txHashBeingProcessed: string
   resolvedSignatures: TransactionsSignatures
-  slippagePercentage: float
 
 type
   Module* = ref object of io_interface.AccessInterface
@@ -159,14 +158,13 @@ proc convertTransactionPathDtoV2ToPathItem(self: Module, txPath: TransactionPath
     )
 
 proc buildTransactionsFromRoute(self: Module) =
-  let err = self.controller.buildTransactionsFromRoute(self.tmpSendTransactionDetails.uuid, self.tmpSendTransactionDetails.slippagePercentage)
+  let err = self.controller.buildTransactionsFromRoute(self.tmpSendTransactionDetails.uuid)
   if err.len > 0:
     self.transactionWasSent(uuid = self.tmpSendTransactionDetails.uuid, chainId = 0, approvalTx = false, txHash = "", error = err)
     self.clearTmpData()
 
-method authenticateAndTransfer*(self: Module, uuid: string, fromAddr: string, slippagePercentage: float) =
+method authenticateAndTransfer*(self: Module, uuid: string, fromAddr: string) =
   self.tmpSendTransactionDetails.uuid = uuid
-  self.tmpSendTransactionDetails.slippagePercentage = slippagePercentage
   self.tmpSendTransactionDetails.resolvedSignatures.clear()
 
   if self.tmpKeepPinPass:
@@ -302,6 +300,7 @@ method suggestedRoutes*(self: Module,
   amountIn: string,
   toToken: string = "",
   amountOut: string = "",
+  slippagePercentage: float = 0.0,
   extraParamsTable: Table[string, string] = initTable[string, string]()) =
   # maybe not needed
   # self.tmpSendTransactionDetails.sendType = sendType
@@ -319,6 +318,7 @@ method suggestedRoutes*(self: Module,
     amountOut,
     disabledNetworks,
     disabledNetworks,
+    slippagePercentage,
     extraParamsTable
   )
 

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -39,6 +39,7 @@ QtObject:
     token: string,
     amountOut: string,
     toToken: string,
+    slippagePercentageString: string,
     extraParamsJson: string) {.slot.} =
     var extraParamsTable: Table[string, string]
     self.pathModel.setItems(@[])
@@ -54,6 +55,12 @@ QtObject:
     except Exception as e:
       error "Error parsing extraParamsJson: ", msg=e.msg
 
+    var slippagePercentage: float
+    try:
+      slippagePercentage = slippagePercentageString.parseFloat()
+    except:
+      error "parsing slippage failed", slippage=slippagePercentageString
+
     self.delegate.suggestedRoutes(
         uuid,
         SendType(sendType),
@@ -65,19 +72,14 @@ QtObject:
         amountIn,
         toToken,
         amountOut,
+        slippagePercentage,
         extraParamsTable)
 
   proc stopUpdatesForSuggestedRoute*(self: View) {.slot.} =
     self.delegate.stopUpdatesForSuggestedRoute()
 
-  proc authenticateAndTransfer*(self: View, uuid: string, fromAddr: string, slippagePercentageString: string) {.slot.} =
-    var slippagePercentage: float
-    try:
-      if slippagePercentageString.len > 0:
-        slippagePercentage = slippagePercentageString.parseFloat()
-    except:
-      error "parsing slippage failed", slippage=slippagePercentageString
-    self.delegate.authenticateAndTransfer(uuid, fromAddr, slippagePercentage)
+  proc authenticateAndTransfer*(self: View, uuid: string, fromAddr: string) {.slot.} =
+    self.delegate.authenticateAndTransfer(uuid, fromAddr)
 
   proc suggestedRoutesReady(self: View, uuid: string, pathModel: QVariant, errCode: string, errDescription: string) {.signal.}
   proc sendSuggestedRoutesReadySignal*(self: View, uuid: string, errCode: string, errDescription: string) =

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -1266,7 +1266,7 @@ QtObject:
     self.transactionService.stopSuggestedRoutesAsyncCalculation()
 
   proc buildTransactionsFromRoute*(self: Service, uuid: string): string =
-    return self.transactionService.buildTransactionsFromRoute(uuid, slippagePercentage = 0.0)
+    return self.transactionService.buildTransactionsFromRoute(uuid)
 
   proc sendRouterTransactionsWithSignatures*(self: Service, uuid: string, signatures: TransactionsSignatures): string =
     return self.transactionService.sendRouterTransactionsWithSignatures(uuid, signatures)

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -268,6 +268,7 @@ type
     approvalGasFees*: float
     approvalAmountRequired*: UInt256
     approvalContractAddress*: string
+    slippagePercentage*: float
 
 proc `$`*(self: TransactionPathDto): string =
   return fmt"""TransactionPath(
@@ -291,6 +292,7 @@ proc `$`*(self: TransactionPathDto): string =
     approvalGasFees:{self.approvalGasFees},
     approvalAmountRequired:{self.approvalAmountRequired},
     approvalContractAddress:{self.approvalContractAddress},
+    slippagePercentage:{self.slippagePercentage},
     gasFees:{$self.gasFees}
   )"""
 
@@ -315,6 +317,7 @@ proc convertToTransactionPathDto*(jsonObj: JsonNode): TransactionPathDto =
   result.approvalAmountRequired = stint.u256(jsonObj{"approvalAmountRequired"}.getStr)
   discard jsonObj.getProp("approvalGasFees", result.approvalGasFees)
   discard jsonObj.getProp("approvalContractAddress", result.approvalContractAddress)
+  discard jsonObj.getProp("slippagePercentage", result.slippagePercentage)
 
 type
   FeesDto* = ref object

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -374,6 +374,7 @@ QtObject:
     amountOut: string = "",
     disabledFromChainIDs: seq[int] = @[],
     disabledToChainIDs: seq[int] = @[],
+    slippagePercentage: float = 0.0,
     extraParamsTable: Table[string, string] = initTable[string, string]()) =
 
     self.lastRequestForSuggestedRoutes = (uuid, sendType)
@@ -386,7 +387,7 @@ QtObject:
 
     try:
       let err = wallet.suggestedRoutesAsync(uuid, ord(sendType), accountFrom, accountTo, amountInHex, amountOutHex, token,
-        tokenIsOwnerToken, toToken, disabledFromChainIDs, disabledToChainIDs, extraParamsTable)
+        tokenIsOwnerToken, toToken, disabledFromChainIDs, disabledToChainIDs, slippagePercentage, extraParamsTable)
       if err.len > 0:
         raise newException(CatchableError, "err fetching the best route: " & err)
     except CatchableError as e:
@@ -505,9 +506,9 @@ proc signMessage*(self: Service, address: string, hashedPassword: string, hashed
   result.res = signMsgRes.getStr
   return
 
-proc buildTransactionsFromRoute*(self: Service, uuid: string, slippagePercentage: float): string =
+proc buildTransactionsFromRoute*(self: Service, uuid: string): string =
   var response: JsonNode
-  let err = transactions.buildTransactionsFromRoute(response, uuid, slippagePercentage)
+  let err = transactions.buildTransactionsFromRoute(response, uuid)
   if err.len > 0:
     error "status-go - transfer failed", err=err
     return err

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -67,12 +67,9 @@ proc `%`*(self: MultiTransactionCommandDto): JsonNode {.inline.} =
   result["toAmount"] = %(self.toAmount)
   result["type"] = %int(self.multiTxType)
 
-proc buildTransactionsFromRoute*(resultOut: var JsonNode, uuid: string, slippagePercentage: float): string =
+proc buildTransactionsFromRoute*(resultOut: var JsonNode, uuid: string): string =
   try:
-    let payload = %* [{
-      "uuid": uuid,
-      "slippagePercentage": slippagePercentage
-    }]
+    let payload = %* [uuid]
     let response = core.callPrivateRPC("wallet_buildTransactionsFromRoute", payload)
     return prepareResponse(resultOut, response)
   except Exception as e:

--- a/src/backend/wallet.nim
+++ b/src/backend/wallet.nim
@@ -132,6 +132,7 @@ proc prepareDataForSuggestedRoutes(
   toToken: string,
   disabledFromChainIDs,
   disabledToChainIDs: seq[int],
+  slippagePercentage: float,
   extraParamsTable: Table[string, string],
   communityRouteInputParameters: JsonNode = JsonNode(),
   ): JsonNode =
@@ -149,6 +150,7 @@ proc prepareDataForSuggestedRoutes(
     "disabledFromChainIDs": disabledFromChainIDs,
     "disabledToChainIDs": disabledToChainIDs,
     "gasFeeMode": GasFeeLow,
+    "slippagePercentage": slippagePercentage,
     "communityRouteInputParams": communityRouteInputParameters,
   }
 
@@ -164,10 +166,10 @@ proc prepareDataForSuggestedRoutes(
   return %* [data]
 
 proc suggestedRoutesAsync*(uuid: string, sendType: int, accountFrom: string, accountTo: string, amountIn: string, amountOut: string, token: string,
-  tokenIsOwnerToken: bool, toToken: string, disabledFromChainIDs, disabledToChainIDs: seq[int], extraParamsTable: Table[string, string]):
+  tokenIsOwnerToken: bool, toToken: string, disabledFromChainIDs, disabledToChainIDs: seq[int], slippagePercentage: float, extraParamsTable: Table[string, string]):
   string {.raises: [RpcException].} =
   let payload = prepareDataForSuggestedRoutes(uuid, sendType, accountFrom, accountTo, amountIn, amountOut, token, tokenIsOwnerToken,  toToken,
-    disabledFromChainIDs, disabledToChainIDs, extraParamsTable)
+    disabledFromChainIDs, disabledToChainIDs, slippagePercentage, extraParamsTable)
   if payload.isNil:
     raise newException(RpcException, "Invalid key in extraParamsTable")
   let rpcResponse = core.callPrivateRPC("wallet_getSuggestedRoutesAsync", payload)
@@ -193,7 +195,7 @@ proc suggestedRoutesAsyncForCommunities*(uuid: string, sendType: int, accountFro
   }
 
   let payload = prepareDataForSuggestedRoutes(uuid, sendType, accountFrom, accountTo=ZERO_ADDRESS, amountIn="0x0", amountOut="0x0", token="ETH",
-    tokenIsOwnerToken=false, toToken="", disabledFromChainIDs, disabledToChainIDs, extraParamsTable=initTable[string, string](),
+    tokenIsOwnerToken=false, toToken="", disabledFromChainIDs, disabledToChainIDs, slippagePercentage=0.0, extraParamsTable=initTable[string, string](),
     communityRouteInputParameters=data)
   let rpcResponse = core.callPrivateRPC("wallet_getSuggestedRoutesAsync", payload)
   if isErrorResponse(rpcResponse):

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapInputParamsForm.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapInputParamsForm.qml
@@ -32,6 +32,7 @@ QtObject {
     onFromTokenAmountChanged: root.formValuesChanged()
     onToTokenKeyChanged: root.formValuesChanged()
     onToTokenAmountChanged: root.formValuesChanged()
+    onSelectedSlippageChanged: root.formValuesChanged()
 
     function resetFormData() {
         selectedAccountAddress = ""

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -222,7 +222,7 @@ QObject {
 
             root.swapStore.fetchSuggestedRoutes(d.uuid, accountAddress, accountAddress,
                                                 cryptoValueInRaw, "0", root.swapFormData.fromTokensKey, root.swapFormData.toTokenKey,
-                                                disabledChainIds, disabledChainIds, Constants.SendType.Swap)
+                                                disabledChainIds, disabledChainIds, Constants.SendType.Swap, root.swapFormData.selectedSlippage)
         } else {
             root.swapProposalLoading = false
             root.swapOutputData.reset()
@@ -235,10 +235,10 @@ QObject {
 
     function sendApproveTx() {
         root.approvalPending = true
-        root.swapStore.authenticateAndTransfer(d.uuid, "")
+        root.swapStore.authenticateAndTransfer(d.uuid)
     }
 
     function sendSwapTx() {
-        root.swapStore.authenticateAndTransfer(d.uuid, root.swapFormData.selectedSlippage)
+        root.swapStore.authenticateAndTransfer(d.uuid)
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
@@ -32,19 +32,19 @@ QtObject {
     }
 
     function fetchSuggestedRoutes(uuid, accountFrom, accountTo, amountIn, amountOut, tokenFrom, tokenTo,
-        disabledFromChainIDs, disabledToChainIDs, sendType) {
+        disabledFromChainIDs, disabledToChainIDs, sendType, slippagePercentage) {
         const valueIn = AmountsArithmetic.fromNumber(amountIn)
         const valueOut = AmountsArithmetic.fromNumber(amountOut)
         root.walletSectionSendInst.fetchSuggestedRoutesWithParameters(uuid, accountFrom, accountTo, valueIn.toFixed(), valueOut.toFixed(),
-            tokenFrom, tokenTo, disabledFromChainIDs, disabledToChainIDs, sendType)
+            tokenFrom, tokenTo, disabledFromChainIDs, disabledToChainIDs, sendType, slippagePercentage)
     }
 
     function stopUpdatesForSuggestedRoute() {
         root.walletSectionSendInst.stopUpdatesForSuggestedRoute()
     }
 
-    function authenticateAndTransfer(uuid, slippagePercentage) {
-        root.walletSectionSendInst.authenticateAndTransfer(uuid, slippagePercentage)
+    function authenticateAndTransfer(uuid) {
+        root.walletSectionSendInst.authenticateAndTransfer(uuid)
     }
 
     function getWei2Eth(wei, decimals) {

--- a/ui/app/AppLayouts/Wallet/stores/TransactionStoreNew.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TransactionStoreNew.qml
@@ -9,17 +9,18 @@ QtObject {
     signal transactionSent(string uuid, int chainId, bool approvalTx, string txHash, string error)
     signal successfullyAuthenticated(string uuid)
 
-    function authenticateAndTransfer(uuid, fromAddr, slippagePercentage = "") {
-        _walletSectionSendInst.authenticateAndTransfer(uuid, fromAddr, slippagePercentage)
+    function authenticateAndTransfer(uuid, fromAddr) {
+        _walletSectionSendInst.authenticateAndTransfer(uuid, fromAddr)
     }
 
     function fetchSuggestedRoutes(uuid, sendType, chainId, accountFrom,
                                   accountTo, amountIn, token,
                                   amountOut = "0", toToken = "",
+                                  slippagePercentage = "",
                                   extraParamsJson = "") {
         _walletSectionSendInst.fetchSuggestedRoutes(uuid, sendType, chainId, accountFrom,
                                                     accountTo, amountIn, token,
-                                                    amountOut, toToken, extraParamsJson)
+                                                    amountOut, toToken, slippagePercentage, extraParamsJson)
     }
 
     function stopUpdatesForSuggestedRoute() {

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -520,6 +520,7 @@ QtObject {
                                                                   tokenKey,
                                                                   /*amountOut = */ "0",
                                                                   /*toToken =*/ "",
+                                                                  /*slippagePercentage*/ "",
                                                                   handler.extraParamsJson)
                 }
             }

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -171,7 +171,11 @@ StatusDialog {
 
         property var debounceRecalculateRoutesAndFees: Backpressure.debounce(popup, 1000, function() {
             if(d.areInputParametersValid()) {
-                popup.store.suggestedRoutes(d.uuid, d.isCollectiblesTransfer ? "1" : amountToSend.amount, "0", d.extraParamsJson)
+                popup.store.suggestedRoutes(d.uuid,
+                                            d.isCollectiblesTransfer ? "1" : amountToSend.amount,
+                                            /* amountOut */ "0",
+                                            /* slippagePercentage */ "",
+                                            d.extraParamsJson)
             }
         })
 

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -58,14 +58,14 @@ QtObject {
         return networksModule.getBlockExplorerTxURL(chainID)
     }
 
-    function authenticateAndTransfer(uuid, slippagePercentage = "") {
-        walletSectionSendInst.authenticateAndTransfer(uuid, slippagePercentage)
+    function authenticateAndTransfer(uuid) {
+        walletSectionSendInst.authenticateAndTransfer(uuid)
     }
 
-    function suggestedRoutes(uuid, amountIn, amountOut = "0", extraParamsJson = "") {
+    function suggestedRoutes(uuid, amountIn, amountOut = "0", slippagePercentage = "", extraParamsJson = "") {
         const valueIn = AmountsArithmetic.fromNumber(amountIn)
         const valueOut = AmountsArithmetic.fromNumber(amountOut)
-        walletSectionSendInst.suggestedRoutes(uuid, valueIn.toFixed(), valueOut.toFixed(), extraParamsJson)
+        walletSectionSendInst.suggestedRoutes(uuid, valueIn.toFixed(), valueOut.toFixed(), slippagePercentage, extraParamsJson)
     }
 
     function stopUpdatesForSuggestedRoute() {


### PR DESCRIPTION
After improvements on the fees calculation the build transaction 1001 error started to occur. It was because of missed slippage param when doing the build tx call. Fixed on the statusgo side.

These changes also bring some improvements on setting custom slippage.

Corresponding `status-go` changes:
- https://github.com/status-im/status-go/pull/6548