### PR TITLE
fix(Qt6): Broken styling on some platforms 

### DIFF
--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     QGuiApplication::setApplicationName(QStringLiteral("Status Desktop Storybook"));
     QGuiApplication::setApplicationDisplayName(QStringLiteral("%1 [Qt %2]").arg(QGuiApplication::applicationName(), qVersion()));
 
-    QQuickStyle::setStyle(QStringLiteral("Universal")); // StatusQ uses this as the default
+    QQuickStyle::setStyle(QStringLiteral("Universal")); // only used as a basic style for SB itself
 
     QCommandLineParser cmdParser;
     cmdParser.addHelpOption();

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -22,7 +22,8 @@ ApplicationWindow {
 
     font.pixelSize: 13
 
-    Universal.theme: darkModeCheckBox.checked ? Universal.Dark : Universal.Light
+    // cf. Universal theme kept here as the basic light/dark theme for the app itself
+    Universal.theme: darkModeCheckBox.checked ? Theme.Style.Dark : Theme.Style.Light
 
     onCurrentPageChanged: {
         testsReRunTimer.restart()
@@ -158,7 +159,7 @@ ApplicationWindow {
                         Layout.fillWidth: true
 
                         text: "Dark mode"
-                        onCheckedChanged: Theme.changeTheme(checked ? Universal.Dark : Universal.Light, !checked)
+                        onCheckedChanged: Theme.changeTheme(checked ? Theme.Style.Dark : Theme.Style.Light, !checked)
                     }
 
                     HotReloaderControls {

--- a/storybook/pages/ProfileContextMenuPage.qml
+++ b/storybook/pages/ProfileContextMenuPage.qml
@@ -13,57 +13,60 @@ import Models 1.0
 SplitView {
     Logs { id: logs }
 
-    SplitView {
-        orientation: Qt.Vertical
+    Component.onCompleted: contextMenu.open()
+
+    Pane {
         SplitView.fillWidth: true
+        SplitView.fillHeight: true
 
-        Item {
-            SplitView.fillWidth: true
-            SplitView.fillHeight: true
+        Button {
+            anchors.centerIn: parent
+            text: "Open menu"
+            onClicked: contextMenu.open()
+        }
 
-            ProfileContextMenu {
-                anchors.centerIn: parent
-                visible: true
-                closePolicy: Popup.NoAutoClose
-                userIcon: useIconCheckBox.checked ? ModelsData.icons.cryptPunks : ""
+        ProfileContextMenu {
+            id: contextMenu
+            anchors.centerIn: parent
+            closePolicy: Popup.NoAutoClose
+            userIcon: useIconCheckBox.checked ? ModelsData.icons.cryptPunks : ""
 
-                compressedPubKey: "zQ3shQBu4PRDX17veeYYhSczbTjgi44iTXxcMNvQLeyQsBDF4"
-                displayName: displayNameTextField.text
-                hideDisabledItems: hideDisabledCheckBox.checked
-                profileType: profileTypeSelector.currentValue
-                trustStatus: trustStatusSelector.currentValue
-                contactType: contactTypeSelector.currentValue
-                ensVerified: ensVerifiedCheckBox.checked
-                onlineStatus: onlineStatusSelector.currentValue
-                hasLocalNickname: hasLocalNicknameCheckBox.checked
-                chatType: chatTypeSelector.currentValue
-                isAdmin: isAdminCheckBox.checked
+            compressedPubKey: "zQ3shQBu4PRDX17veeYYhSczbTjgi44iTXxcMNvQLeyQsBDF4"
+            displayName: displayNameTextField.text
+            hideDisabledItems: hideDisabledCheckBox.checked
+            profileType: profileTypeSelector.currentValue
+            trustStatus: trustStatusSelector.currentValue
+            contactType: contactTypeSelector.currentValue
+            ensVerified: ensVerifiedCheckBox.checked
+            onlineStatus: onlineStatusSelector.currentValue
+            hasLocalNickname: hasLocalNicknameCheckBox.checked
+            chatType: chatTypeSelector.currentValue
+            isAdmin: isAdminCheckBox.checked
 
-                colorHash: [
-                    { segmentLength: 3, colorId: 11 },
-                    { segmentLength: 5, colorId: 9  },
-                    { segmentLength: 1, colorId: 26 },
-                    { segmentLength: 2, colorId: 19 },
-                    { segmentLength: 5, colorId: 17 }
-                ]
+            colorHash: [
+                { segmentLength: 3, colorId: 11 },
+                { segmentLength: 5, colorId: 9  },
+                { segmentLength: 1, colorId: 26 },
+                { segmentLength: 2, colorId: 19 },
+                { segmentLength: 5, colorId: 17 }
+            ]
 
-                colorId: colorIdSpinBox.value
+            colorId: colorIdSpinBox.value
 
-                onOpenProfileClicked: logs.logEvent("Open profile clicked")
-                onCreateOneToOneChat: logs.logEvent("Create one-to-one chat clicked")
-                onReviewContactRequest: logs.logEvent("Review contact request")
-                onSendContactRequest: logs.logEvent("Send contact request")
-                onEditNickname: logs.logEvent("Edit nickname")
-                onRemoveNickname: logs.logEvent("Remove nickname")
-                onUnblockContact: logs.logEvent("Unblock contact")
-                onMarkAsUntrusted: logs.logEvent("Mark as untrusted")
-                onRemoveTrustStatus: logs.logEvent("Remove trust status")
-                onRemoveContact: logs.logEvent("Remove contact")
-                onBlockContact: logs.logEvent("Block contact")
-                onRemoveFromGroup: logs.logEvent("Remove from group")
+            onOpenProfileClicked: logs.logEvent("Open profile clicked")
+            onCreateOneToOneChat: logs.logEvent("Create one-to-one chat clicked")
+            onReviewContactRequest: logs.logEvent("Review contact request")
+            onSendContactRequest: logs.logEvent("Send contact request")
+            onEditNickname: logs.logEvent("Edit nickname")
+            onRemoveNickname: logs.logEvent("Remove nickname")
+            onUnblockContact: logs.logEvent("Unblock contact")
+            onMarkAsUntrusted: logs.logEvent("Mark as untrusted")
+            onRemoveTrustStatus: logs.logEvent("Remove trust status")
+            onRemoveContact: logs.logEvent("Remove contact")
+            onBlockContact: logs.logEvent("Block contact")
+            onRemoveFromGroup: logs.logEvent("Remove from group")
 
-                onClosed: open()
-            }
+            onClosed: open()
         }
     }
 

--- a/storybook/pages/StatusNavBarTabButtonPage.qml
+++ b/storybook/pages/StatusNavBarTabButtonPage.qml
@@ -29,6 +29,11 @@ Item {
             tooltip.text: "With icon"
         }
         StatusNavBarTabButton {
+            icon.name: "help"
+            tooltip.text: "Disabled with icon"
+            enabled: false
+        }
+        StatusNavBarTabButton {
             icon.source: ModelsData.icons.socks
             tooltip.text: "With image"
         }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -7,8 +7,12 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Utils 0.1
 
-Button {
+AbstractButton {
     id: root
+
+    // compat with `Button`, cf https://bugreports.qt.io/browse/QTBUG-136704
+    property bool flat
+    property bool highlighted
 
     enum Size {
         XSmall,

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -34,6 +34,8 @@ Button {
         color: d.textColor
     }
 
+    hoverEnabled: enabled
+
     property alias tooltip: tooltip
 
     property bool loading

--- a/ui/StatusQ/src/StatusQ/Controls/StatusIconTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusIconTabButton.qml
@@ -20,6 +20,8 @@ TabButton {
     icon.width: 24
     icon.color: Theme.palette.baseColor1
 
+    hoverEnabled: enabled
+
     contentItem: Item {
         anchors.fill: parent
         StatusSmartIdenticon {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTabButton.qml
@@ -35,6 +35,8 @@ TabButton {
     font.weight: Font.Medium
     font.pixelSize: Theme.primaryTextFontSize
 
+    hoverEnabled: enabled
+
     opacity: enabled ? 1 : Theme.disabledOpacity
 
     spacing: Theme.smallPadding

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -67,7 +67,7 @@ TextArea {
 
     font {
         family: Theme.baseFont.name
-        pixelSize: 15
+        pixelSize: Theme.primaryTextFontSize
     }
 
     selectByMouse: true

--- a/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
@@ -1,7 +1,6 @@
 pragma Singleton
 
 import QtQuick 2.15
-import QtQuick.Controls.Universal 2.15
 
 QtObject {
     enum FontSize {
@@ -13,6 +12,12 @@ QtObject {
         FontSizeXXL
     }
 
+    enum Style {
+        Light,
+        Dark,
+        System
+    }
+
     property ThemePalette palette: StatusLightTheme {}
 
     readonly property ThemePalette statusQLightTheme: StatusLightTheme {}
@@ -22,13 +27,13 @@ QtObject {
 
     function changeTheme(theme:int, isCurrentSystemThemeDark:bool) {
         switch (theme) {
-        case Universal.Light:
+        case Theme.Style.Light:
             Theme.palette = statusQLightTheme
             break
-        case Universal.Dark:
+        case Theme.Style.Dark:
             Theme.palette = statusQDarkTheme
             break
-        case Universal.System:
+        case Theme.Style.System:
             Theme.palette = isCurrentSystemThemeDark ? statusQDarkTheme : statusQLightTheme
             break
         default:

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -70,8 +70,8 @@ Menu {
 
     dim: false
     closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
-    topPadding: Theme.halfPadding
-    bottomPadding: Theme.halfPadding
+    verticalPadding: Theme.halfPadding
+    horizontalPadding: 0
     margins: Theme.padding
 
     onOpened: {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -13,7 +13,9 @@ MenuItem {
     objectName: action ? action.objectName : "StatusMenuItemDelegate"
 
     spacing: 4
-    horizontalPadding: 8
+    horizontalPadding: Theme.halfPadding
+
+    hoverEnabled: enabled
 
     property bool visibleOnDisabled: d.isStatusAction ? action.visibleOnDisabled : false
 
@@ -94,7 +96,7 @@ MenuItem {
         }
 
         readonly property StatusFontSettings defaultFontSettings: StatusFontSettings {
-            pixelSize: 13
+            pixelSize: Theme.additionalTextSize
             bold: false
             italic: false
         }
@@ -178,10 +180,8 @@ MenuItem {
         }
     }
 
-    StatusMouseArea {
-        anchors.fill: parent
-        cursorShape: Qt.PointingHandCursor
-        acceptedButtons: Qt.NoButton
-        hoverEnabled: root.enabled
+    HoverHandler {
+        cursorShape: hovered ? Qt.PointingHandCursor : undefined
+        enabled: root.enabled
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -515,9 +515,9 @@ Rectangle {
                         id: channelPermsSubPanel
 
                         readonly property int permissionType: modelData
-                        readonly property alias tokenCriteriaMet: overallPermissionRow2.tokenCriteriaMet
+                        readonly property bool tokenCriteriaMet: overallPermissionRow2.tokenCriteriaMet
                         readonly property bool permissionLost: d.initialChannelPermissions[channelPermsPanel.channelKey][index] && !tokenCriteriaMet
-                        readonly property alias channelPermissionsModel: permissionsRepeater2.model
+                        readonly property var channelPermissionsModel: permissionsRepeater2.model
 
                         Layout.fillWidth: true
                         Layout.preferredHeight: grid2.implicitHeight + grid2.anchors.margins*2

--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -2,7 +2,6 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
-import QtQuick.Controls.Universal 2.15
 
 import utils 1.0
 import shared 1.0
@@ -140,10 +139,10 @@ SettingsContentBase {
                 Layout.preferredHeight: implicitHeight
                 image.source: Theme.png("appearance-light")
                 control.text: qsTr("Light")
-                control.checked: localAppSettings.theme === Universal.Light
+                control.checked: localAppSettings.theme === Theme.Style.Light
                 onRadioCheckedChanged: {
                     if (checked) {
-                        appearanceView.updateTheme(Universal.Light)
+                        appearanceView.updateTheme(Theme.Style.Light)
                     }
                 }
             }
@@ -152,10 +151,10 @@ SettingsContentBase {
                 Layout.preferredWidth: parent.width/3 - parent.spacing
                 image.source: Theme.png("appearance-dark")
                 control.text: qsTr("Dark")
-                control.checked: localAppSettings.theme === Universal.Dark
+                control.checked: localAppSettings.theme === Theme.Style.Dark
                 onRadioCheckedChanged: {
                     if (checked) {
-                        appearanceView.updateTheme(Universal.Dark)
+                        appearanceView.updateTheme(Theme.Style.Dark)
                     }
                 }
             }
@@ -164,10 +163,10 @@ SettingsContentBase {
                 Layout.preferredWidth: parent.width/3 - parent.spacing
                 image.source: Theme.png("appearance-system")
                 control.text: qsTr("System")
-                control.checked: localAppSettings.theme === Universal.System
+                control.checked: localAppSettings.theme === Theme.Style.System
                 onRadioCheckedChanged: {
                     if (checked) {
-                        appearanceView.updateTheme(Universal.System)
+                        appearanceView.updateTheme(Theme.Style.System)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -171,7 +171,7 @@ RightTabBaseView {
                             // TODO remove me when Activity is no longer experimental
                             // Keep Activity as the last tab for now as the Experimental tag don't flow 
                             anchors.top: parent.top
-                            anchors.topMargin: 6
+                            anchors.topMargin: parent.verticalPadding
                             anchors.left: parent.right
                             anchors.leftMargin: 5
                             cursorShape: Qt.PointingHandCursor

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1307,7 +1307,7 @@ Rectangle {
                         padding: 0
                         contentWidth: availableWidth
 
-                        TextArea {
+                        StatusQ.StatusTextArea {
                             id: messageInputField
 
                             objectName: "messageInputField"
@@ -1319,17 +1319,13 @@ Rectangle {
                             width: inputScrollView.availableWidth
 
                             textFormat: Text.RichText
-                            font.pixelSize: 15
-                            font.family: Theme.baseFont.name
-                            wrapMode: TextArea.Wrap
                             placeholderText: control.chatInputPlaceholder
-                            placeholderTextColor: Theme.palette.secondaryText
-                            selectByMouse: true
                             color: isEdit ? Theme.palette.directColor1 : Theme.palette.textColor
                             topPadding: 9
                             bottomPadding: 9
                             leftPadding: 0
-                            padding: 0
+                            rightPadding: 0
+                            background: null
                             // This is needed to make sure the text area is disabled when the input is disabled
                             Binding on enabled {
                                 value: control.enabled
@@ -1354,8 +1350,6 @@ Rectangle {
                             }
                             Keys.onReleased: onRelease(event) // gives much more up to date cursorPosition
                             Keys.onShortcutOverride: event.accepted = isUploadFilePressed(event)
-                            selectionColor: Theme.palette.primaryColor2
-                            persistentSelection: true
                             property var keyEvent
 
                             Component.onDestruction: {
@@ -1430,10 +1424,6 @@ Rectangle {
                                     clear()
                                     control.hideExtendedArea()
                                 }
-                            }
-
-                            cursorDelegate: StatusCursorDelegate {
-                                cursorVisible: messageInputField.cursorVisible
                             }
 
                             StatusSyntaxHighlighter {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -5,7 +5,6 @@ import Qt.labs.platform 1.1
 import Qt.labs.settings 1.1
 import QtQuick.Window 2.15
 import QtQml 2.15
-import QtQuick.Controls.Universal 2.15
 
 import utils 1.0
 import shared 1.0
@@ -46,8 +45,6 @@ StatusWindow {
 
     property MetricsStore metricsStore: MetricsStore {}
     property UtilsStore utilsStore: UtilsStore {}
-
-    Universal.theme: Universal.System
 
     objectName: "mainWindow"
     minimumWidth: 1200
@@ -261,14 +258,14 @@ StatusWindow {
     }
 
     function changeThemeFromOutside() {
-        Theme.changeTheme(startupOnboardingLoader.item.visible ? Universal.System : localAppSettings.theme,
+        Theme.changeTheme(startupOnboardingLoader.item.visible ? Theme.Style.System : localAppSettings.theme,
                           systemPalette.isCurrentSystemThemeDark())
     }
 
     Component.onCompleted: {
         console.info(">>> %1 %2 started, using Qt version %3".arg(Qt.application.name).arg(Qt.application.version).arg(SystemUtils.qtRuntimeVersion()))
 
-        Theme.changeTheme(Universal.System, systemPalette.isCurrentSystemThemeDark());
+        Theme.changeTheme(Theme.Style.System, systemPalette.isCurrentSystemThemeDark());
 
         restoreAppState();
 


### PR DESCRIPTION
### What does the PR do

- fix Qt6 styling for Status(Base)Button and StatusChatInput
- remove `Universal` style imports
- bring Qt6 hover effects/events in line with the old behavior of Qt 5, that is when the control is disabled, we get no hover events (changed bg, different cursor shape, etc)
- fix some spurious startup issue (more visible on mac), related to nested `Rectangle` aliased properties

(see the commits for a more detailed description) 

Fixes #17763
Fixes https://github.com/status-im/status-desktop/issues/17693
Fixes https://github.com/status-im/status-desktop/issues/17905

### Affected areas

StatusButton, StatusChatInput

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/user-attachments/assets/d9d6d9b8-46a6-472b-9c2e-cfef04b10373)

![image](https://github.com/user-attachments/assets/a7f18b1f-99ae-46bd-883c-9aa5c84f7916)
