### PR TITLE
fix(Qt6): impossible to quit the app

### DIFF
--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -6,7 +6,6 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QProcess>
-#include <QQuickItem>
 #include <QSaveFile>
 
 SystemUtilsInternal::SystemUtilsInternal(QObject *parent)
@@ -39,7 +38,7 @@ void SystemUtilsInternal::downloadImageByUrl(
     if (targetDir.isEmpty())
         targetDir = QDir::homePath();
 
-    QObject::connect(reply, &QNetworkReply::finished, [reply, targetDir] {
+    QObject::connect(reply, &QNetworkReply::finished, this, [reply, targetDir] {
         if(reply->error() != QNetworkReply::NoError) {
             qWarning() << "SystemUtilsInternal::downloadImageByUrl: Downloading image"
                        << reply->request().url() << "failed!";

--- a/ui/app/AppLayouts/Profile/views/SettingsLeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsLeftTabView.qml
@@ -41,7 +41,7 @@ Item {
         rightMargin: Theme.padding
         bottomMargin: Theme.bigPadding
 
-        onClicked: {
+        onClicked: function(subsection) {
             if (subsection === Constants.settingsSubsection.backUpSeed) {
                 Global.openBackUpSeedPopup()
                 return
@@ -67,6 +67,6 @@ Item {
         headerSettings.title: qsTr("Sign out")
         confirmationText: qsTr("Make sure you have your account password and recovery phrase stored. Without them you can lock yourself out of your account and lose funds.")
         confirmButtonLabel: qsTr("Sign out & Quit")
-        onConfirmButtonClicked: Qt.quit()
+        onConfirmButtonClicked: Qt.exit(0)
     }
 }

--- a/ui/app/AppLayouts/Profile/views/wallet/EditNetworkForm.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/EditNetworkForm.qml
@@ -356,7 +356,7 @@ ColumnLayout {
                     onClicked: {
                         close()
                         d.save()
-                        Qt.quit()
+                        Qt.exit(0)
                     }
                 }
             ]

--- a/ui/app/mainui/StatusTrayIcon.qml
+++ b/ui/app/mainui/StatusTrayIcon.qml
@@ -7,13 +7,11 @@ import utils 1.0
 SystemTrayIcon {
     id: root
 
-    property bool isProduction: true
     property bool showRedDot: false
 
     signal activateApp()
 
     visible: true
-
 
     icon.source: {
         if (Qt.platform.os === Constants.windows) {
@@ -42,7 +40,7 @@ SystemTrayIcon {
 
         MenuItem {
             text: qsTr("Quit")
-            onTriggered: Qt.quit()
+            onTriggered: Qt.exit(0)
         }
     }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -165,7 +165,7 @@ StatusWindow {
     Action {
         shortcut: StandardKey.Quit
         onTriggered: {
-            Qt.quit()
+            Qt.exit(0)
         }
     }
 
@@ -299,7 +299,6 @@ StatusWindow {
     StatusTrayIcon {
         id: systemTray
         objectName: "systemTray"
-        isProduction: production
         showRedDot: typeof mainModule !== "undefined" ? mainModule.notificationAvailable : false
         onActivateApp: {
             applicationWindow.makeStatusAppActive()


### PR DESCRIPTION
### What does the PR do

- workaround the `closing` signal differences between Qt5 and Qt6, and call `Qt::exit()` directly when we want to explicitly quit the app
- removed some unused stuff

Fixes https://github.com/status-im/status-desktop/issues/17855

### Affected areas

App

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

TBD
