### PR TITLE
chore(@e2e): retry enabling toggles if first attempt failed

### DIFF
--- a/test/e2e/gui/screens/community_settings_tokens.py
+++ b/test/e2e/gui/screens/community_settings_tokens.py
@@ -136,12 +136,16 @@ class TokensOwnerTokenSettingsView(QObject):
             master_token_text_labels.append(item)
         return sorted(master_token_text_labels, key=lambda item: item.y)
 
-    @allure.step('Click next button')
+    @allure.step('Click next button and open Edit owner token view')
     def click_next(self):
-        if not self._next_button.is_visible:
-            self._scroll.vertical_scroll_down(self._next_button)
-        self._next_button.click()
-        return EditOwnerTokenView().wait_until_appears()
+        for _ in range(2):
+            try:
+                self._scroll.vertical_scroll_down(self._next_button)
+                self._next_button.click()
+                return EditOwnerTokenView().wait_until_appears()
+            except Exception:
+                    pass
+        raise RuntimeError("Can't open Edit owner token view")
 
 
 class EditOwnerTokenView(QObject):
@@ -273,11 +277,18 @@ class EditOwnerTokenView(QObject):
         return self
 
     @allure.step('Click mint button')
-    def click_mint(self):
-        if not self._mint_button.is_visible:
-            self._scroll.vertical_scroll_down(self._mint_button)
-        self._mint_button.click()
-        return SignTransactionPopup().wait_until_appears()
+    def mint(self):
+        for _ in range(2):
+            try:
+                self._scroll.vertical_scroll_down(self._mint_button)
+                self._mint_button.click()
+                return SignTransactionPopup().wait_until_appears()
+            except Exception:
+                pass  # Retry one more time
+        raise RuntimeError(f'Could not open Sign transaction popup')
+
+
+
 
 
 class MintedTokensView(QObject):

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -354,7 +354,7 @@ class ChatMessagesView(QObject):
     @property
     @allure.step('Get group welcome message')
     def group_welcome_message(self) -> str:
-        for delegate in walk_children(self._group_chat_message_item.object):
+        for delegate in walk_children(self._group_chat_message_item.wait_until_appears().object):
             if getattr(delegate, 'id', '') == 'msgDelegate':
                 for item in walk_children(delegate):
                     if getattr(item, 'id', '') == 'descText':

--- a/test/e2e/gui/screens/settings_advanced.py
+++ b/test/e2e/gui/screens/settings_advanced.py
@@ -14,22 +14,30 @@ class AdvancedSettingsView(QObject):
         self.scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self.manage_community_on_testnet_button = Button(
             settings_names.manageCommunitiesOnTestnetButton_StatusSettingsLineButton)
-        self._light_mode_button = Button(settings_names.settingsContentBaseScrollViewLightWakuModeBloomSelectorButton)
-        self._relay_mode_button = Button(settings_names.settingsContentBaseScrollViewRelayWakuModeBloomSelectorButton)
+        self.light_mode_button = Button(settings_names.settingsContentBaseScrollViewLightWakuModeBloomSelectorButton)
+        self.relay_mode_button = Button(settings_names.settingsContentBaseScrollViewRelayWakuModeBloomSelectorButton)
 
     @allure.step('Switch manage community on testnet option')
-    def switch_manage_on_community(self):
+    def enable_manage_communities_on_testnet_toggle(self):
         self.scroll.vertical_scroll_down(self.manage_community_on_testnet_button)
-        self.manage_community_on_testnet_button.click()
+        if not self.manage_community_on_testnet_button.object.switchChecked:
+            for _ in range(2):
+                try:
+                    self.manage_community_on_testnet_button.click()
+                    assert self.manage_community_on_testnet_button.object.switchChecked
+                    return
+                except AssertionError:
+                    pass  # Retry one more time
+            raise RuntimeError(f'Could not enable Manage communities on testnet toggle')
 
     @allure.step('Switch waku mode')
     def switch_waku_mode(self, mode):
         if not self.manage_community_on_testnet_button.is_visible:
             self.scroll.vertical_scroll_down(self.manage_community_on_testnet_button)
         if mode == 'light':
-            self._light_mode_button.click()
+            self.light_mode_button.click()
         elif mode == 'relay':
-            self._relay_mode_button.click()
+            self.relay_mode_button.click()
         return SwitchWakuModePopup().wait_until_appears()
 
     @allure.step('Verify waku mode enabled states')
@@ -37,6 +45,6 @@ class AdvancedSettingsView(QObject):
         if not self.manage_community_on_testnet_button.is_visible:
             self.scroll.vertical_scroll_down(self.manage_community_on_testnet_button)
         if mode == 'light':
-            return self._light_mode_button.is_checked
+            return self.light_mode_button.is_checked
         elif mode == 'relay':
-            return self._relay_mode_button.is_checked
+            return self.relay_mode_button.is_checked

--- a/test/e2e/gui/screens/settings_wallet.py
+++ b/test/e2e/gui/screens/settings_wallet.py
@@ -317,8 +317,13 @@ class NetworkWalletSettings(WalletSettingsView):
 
     @allure.step('Switch testnet mode toggle')
     def switch_testnet_mode_toggle(self) -> TestnetModePopup:
-        self.testnet_mode_toggle.click()
-        return TestnetModePopup().wait_until_appears()
+        for _ in range(2):
+            self.testnet_mode_toggle.click()
+            try:
+                return TestnetModePopup().wait_until_appears()
+            except Exception:
+                pass  # Retry one more time
+        raise LookupError(f'Could not open testnet mode popup')
 
     @allure.step('Get testnet mode toggle status')
     def is_testnet_mode_toggle_checked(self) -> bool:

--- a/test/e2e/helpers/settings_helper.py
+++ b/test/e2e/helpers/settings_helper.py
@@ -6,5 +6,5 @@ def enable_testnet_mode(main_window):
 
 def enable_managing_communities_toggle(main_window):
     settings = main_window.left_panel.open_settings()
-    settings.left_panel.open_advanced_settings().switch_manage_on_community()
+    settings.left_panel.open_advanced_settings().enable_manage_communities_on_testnet_toggle()
 

--- a/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
+++ b/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
@@ -62,7 +62,7 @@ def test_mint_owner_and_tokenmaster_tokens(main_window, user_account):
                               configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     with step('Start minting'):
-        start_minting = edit_owner_token_view.click_mint()
+        start_minting = edit_owner_token_view.mint()
 
     with step('Verify fee text and sign transaction'):
         assert start_minting.get_fee_title == 'Mint ' + community.name + MintOwnerTokensElements.SIGN_TRANSACTION_MINT_TITLE.value + network_name


### PR DESCRIPTION
This is done in order to handle the UI movements when banners appear. So if test misclicked to enable certain toggle, it will try one more time