### PR TITLE
fix(wallet): ensure the token list auto-refresh option is enabled by default

### DIFF
--- a/src/app_service/service/accounts/dto/create_account_request.nim
+++ b/src/app_service/service/accounts/dto/create_account_request.nim
@@ -31,6 +31,7 @@ type
     logEnabled*: bool
 
     previewPrivacy*: bool
+    autoRefreshTokensEnabled*: bool
 
     verifyTransactionURL*: Option[string]
     verifyENSURL*: Option[string]
@@ -64,6 +65,7 @@ proc toJson*(self: CreateAccountRequest): JsonNode =
     "logFilePath": self.logFilePath,
     "logEnabled": self.logEnabled,
     "previewPrivacy": self.previewPrivacy,
+    "autoRefreshTokensEnabled": self.autoRefreshTokensEnabled,
     "upstreamConfig": self.upstreamConfig,
     "keycardInstanceUID": self.keycardInstanceUID,
     "keycardPairingDataFile": self.keycardPairingDataFile,

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -213,6 +213,7 @@ QtObject:
         wakuV2EnableMissingMessageVerification: true,
         wakuV2EnableStoreConfirmationForMessagesSent: true,
         previewPrivacy: true,
+        autoRefreshTokensEnabled: true,
         torrentConfigEnabled: some(false),
         torrentConfigPort: some(TORRENT_CONFIG_PORT),
         keycardPairingDataFile: main_constants.KEYCARDPAIRINGDATAFILE,


### PR DESCRIPTION
Setting the auto-refresh option by default to true was already implemented on the statusgo side and that way old Status profiles were affected, but for newly created Status profile that setting has to be sent from the client. That's now fixed in this PR.

Closes #17868