### PR TITLE
fix(wallet): swap - approve spending cap doesn't ask for password

### DIFF
--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -38,7 +38,7 @@ method suggestedRoutes*(self: AccessInterface,
   extraParamsTable: Table[string, string] = initTable[string, string]()) {.base.} =
     raise newException(ValueError, "No implementation available")
 
-method stopUpdatesForSuggestedRoute*(self: AccessInterface) {.base.} =
+method resetData*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method suggestedRoutesReady*(self: AccessInterface, uuid: string, suggestedRoutes: SuggestedRoutesDto, errCode: string, errDescription: string) {.base.} =

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -217,9 +217,6 @@ QtObject:
       extraParamsTable
     )
 
-  proc stopUpdatesForSuggestedRoute*(self: View) {.slot.} =
-    self.delegate.stopUpdatesForSuggestedRoute()
-
   proc updateRoutePreferredChains*(self: View, chainIds: string) {.slot.} =
     self.toNetworksRouteModel.updateRoutePreferredChains(chainIds)
 
@@ -231,7 +228,8 @@ QtObject:
       self.fromNetworksRouteModel.updateFromNetworks(path, not chainsWithNoGas.hasKey(fromChainId))
       self.toNetworksRouteModel.updateToNetworks(path)
 
-  proc resetStoredProperties*(self: View) {.slot.} =
+  proc resetData*(self: View) {.slot.} =
+    self.delegate.resetData()
     self.sendType = transaction_dto.SendType.Transfer
     self.selectedRecipient = ""
     self.fromNetworksRouteModel.reset()

--- a/src/app/modules/main/wallet_section/send_new/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send_new/io_interface.nim
@@ -33,7 +33,7 @@ method suggestedRoutes*(self: AccessInterface,
   extraParamsTable: Table[string, string] = initTable[string, string]()) {.base.} =
     raise newException(ValueError, "No implementation available")
 
-method stopUpdatesForSuggestedRoute*(self: AccessInterface) {.base.} =
+method resetData*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method authenticateAndTransfer*(self: AccessInterface, fromAddr: string, uuid: string) {.base.} =

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -75,8 +75,8 @@ QtObject:
         slippagePercentage,
         extraParamsTable)
 
-  proc stopUpdatesForSuggestedRoute*(self: View) {.slot.} =
-    self.delegate.stopUpdatesForSuggestedRoute()
+  proc resetData*(self: View) {.slot.} =
+    self.delegate.resetData()
 
   proc authenticateAndTransfer*(self: View, uuid: string, fromAddr: string) {.slot.} =
     self.delegate.authenticateAndTransfer(uuid, fromAddr)

--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -96,7 +96,7 @@ SplitView {
         property bool areTestNetworksEnabled: true
 
         function setRouteDisabledChains(chainId, disabled) {}
-        function stopUpdatesForSuggestedRoute() {}
+        function resetData() {}
 
         walletAssetStore: root.walletAssetStore
         tokensStore.showCommunityAssetsInSend: showCommunityAssetsCheckBox.checked

--- a/storybook/qmlTests/tests/tst_SwapModal.qml
+++ b/storybook/qmlTests/tests/tst_SwapModal.qml
@@ -40,7 +40,7 @@ Item {
         }
         function authenticateAndTransfer(uuid, accountFrom, accountTo, tokenFrom,
                                          tokenTo, sendType, tokenName, tokenIsOwnerToken, paths) {}
-        function stopUpdatesForSuggestedRoute() {}
+        function resetData() {}
         // local signals for testing function calls
         signal fetchSuggestedRoutesCalled()
     }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -116,7 +116,7 @@ StatusDialog {
         root.addMetricsEvent("popup opened")
     }
     onClosed: {
-        root.swapAdaptor.stopUpdatesForSuggestedRoute()
+        root.swapAdaptor.resetData()
         root.addMetricsEvent("popup closed")
     }
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -228,10 +228,6 @@ QObject {
         }
     }
 
-    function stopUpdatesForSuggestedRoute() {
-        root.swapStore.stopUpdatesForSuggestedRoute()
-    }
-
     function sendApproveTx() {
         root.approvalPending = true
         root.swapStore.authenticateAndTransfer(d.uuid)
@@ -239,5 +235,9 @@ QObject {
 
     function sendSwapTx() {
         root.swapStore.authenticateAndTransfer(d.uuid)
+    }
+
+    function resetData() {
+        root.swapStore.resetData()
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
@@ -39,8 +39,8 @@ QtObject {
             tokenFrom, tokenTo, disabledFromChainIDs, disabledToChainIDs, sendType, slippagePercentage)
     }
 
-    function stopUpdatesForSuggestedRoute() {
-        root.walletSectionSendInst.stopUpdatesForSuggestedRoute()
+    function resetData() {
+        root.walletSectionSendInst.resetData()
     }
 
     function authenticateAndTransfer(uuid) {

--- a/ui/app/AppLayouts/Wallet/stores/TransactionStoreNew.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TransactionStoreNew.qml
@@ -23,8 +23,8 @@ QtObject {
                                                     amountOut, toToken, slippagePercentage, extraParamsJson)
     }
 
-    function stopUpdatesForSuggestedRoute() {
-        _walletSectionSendInst.stopUpdatesForSuggestedRoute()
+    function resetData() {
+        _walletSectionSendInst.resetData()
     }
 
     function setFeeMode(feeMode, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId) {

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -487,7 +487,7 @@ QtObject {
             onClosed: {
                 handler.sendMetricsEvent("popup closed", "")
                 destroy()
-                root.transactionStoreNew.stopUpdatesForSuggestedRoute()
+                root.transactionStoreNew.resetData()
             }
 
             onFormChanged: {
@@ -786,7 +786,7 @@ QtObject {
                 }
 
                 function resetRouterValues() {
-                    root.transactionStoreNew.stopUpdatesForSuggestedRoute()
+                    root.transactionStoreNew.resetData()
                     handler.uuid = ""
                     handler.fetchedPathModel = null
                     handler.indexOfTxPathUnderReview = -1

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -328,8 +328,7 @@ StatusDialog {
     }
 
     onClosed: {
-        popup.store.stopUpdatesForSuggestedRoute()
-        popup.store.resetStoredProperties()
+        popup.store.resetData()
         d.addMetricsEvent("popup closed")
     }
 

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -68,8 +68,8 @@ QtObject {
         walletSectionSendInst.suggestedRoutes(uuid, valueIn.toFixed(), valueOut.toFixed(), slippagePercentage, extraParamsJson)
     }
 
-    function stopUpdatesForSuggestedRoute() {
-        walletSectionSendInst.stopUpdatesForSuggestedRoute()
+    function resetData() {
+        walletSectionSendInst.resetData()
     }
 
     function resolveENS(value) {
@@ -144,10 +144,6 @@ QtObject {
 
     function lockCard(chainId, amount, lock) {
         walletSectionSendInst.fromNetworksRouteModel.lockCard(chainId, amount, lock)
-    }
-
-    function resetStoredProperties() {
-        walletSectionSendInst.resetStoredProperties()
     }
 
     function splitAndFormatAddressPrefix(text, updateInStore) {


### PR DESCRIPTION
The password was permanently stored between different swap flow runs if the flow was closed after approval but before swap tx. The flow didn't ask for password if higher amount was entered after successfully completed approval tx.

How it works now:
- if the user runs Swap and provides pass for the approval the app doesn't ask for pass when placing a swap tx
- if the user closes the Swap popup after providing correct password the app will ask for it next time the user runs Swap popup and try to place approval/swap tx
- if the user runs Swap popup and tries to increase amount after an already approved amount during the same Swap flow, the app will ask for pass

Closes #17875 