### PR TITLE
fix(wallet): reevaluating fees for swap after approval tx gets confirmed

### DIFF
--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -187,3 +187,6 @@ proc runSignFlow*(self: Controller, pin, bip44Path, txHash: string) =
 
 proc getChainsWithNoGasFromError*(self: Controller, errCode: string, errDescription: string): Table[int, string] =
   return self.walletAccountService.getChainsWithNoGasFromError(errCode, errDescription)
+
+proc reevaluateRouterPath*(self: Controller, uuid: string, pathName: string, chainId: int, isApprovalTx: bool): string =
+  return self.transactionService.reevaluateRouterPath(uuid, pathName, chainId, isApprovalTx)

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -88,3 +88,6 @@ method getNetworkItem*(self: AccessInterface, chainId: int): NetworkItem {.base.
 
 method getNetworkChainId*(self: AccessInterface, shortName: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method reevaluateSwap*(self: AccessInterface, uuid: string, chainId: int, isApprovalTx: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/send/suggested_route_item.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_item.nim
@@ -3,7 +3,7 @@ import NimQml
 import ./gas_fees_item
 
 QtObject:
-  type SuggestedRouteItem* = ref object of QObject
+  type  SuggestedRouteItem* = ref object of QObject
     bridgeName: string
     fromNetwork: int
     toNetwork: int
@@ -23,6 +23,12 @@ QtObject:
     approvalAmountRequired: string
     approvalContractAddress: string
     slippagePercentage: float
+
+    txFeeInWei: string
+    txL1FeeInWei: string
+    approvalFeeInWei: string
+    approvalL1FeeInWei: string
+
   proc setup*(self: SuggestedRouteItem,
     bridgeName: string,
     fromNetwork: int,
@@ -42,7 +48,11 @@ QtObject:
     approvalGasFees: float,
     approvalAmountRequired: string,
     approvalContractAddress: string,
-    slippagePercentage: float
+    slippagePercentage: float,
+    txFeeInWei: string,
+    txL1FeeInWei: string,
+    approvalFeeInWei: string,
+    approvalL1FeeInWei: string
   ) =
     self.QObject.setup
     self.bridgeName = bridgeName
@@ -64,6 +74,10 @@ QtObject:
     self.approvalAmountRequired = approvalAmountRequired
     self.approvalContractAddress = approvalContractAddress
     self.slippagePercentage = slippagePercentage
+    self.txFeeInWei = txFeeInWei
+    self.txL1FeeInWei = txL1FeeInWei
+    self.approvalFeeInWei = approvalFeeInWei
+    self.approvalL1FeeInWei = approvalL1FeeInWei
 
   proc delete*(self: SuggestedRouteItem) =
       self.QObject.delete
@@ -87,12 +101,17 @@ QtObject:
     approvalGasFees: float = 0,
     approvalAmountRequired: string = "",
     approvalContractAddress: string = "",
-    slippagePercentage: float = 0.0
+    slippagePercentage: float = 0.0,
+    txFeeInWei: string = "",
+    txL1FeeInWei: string = "",
+    approvalFeeInWei: string = "",
+    approvalL1FeeInWei: string = ""
     ): SuggestedRouteItem =
       new(result, delete)
       result.setup(bridgeName, fromNetwork, toNetwork, maxAmountIn, amountIn, amountOut, gasAmount, gasFees, tokenFees,
         cost, estimatedTime, amountInLocked, isFirstSimpleTx, isFirstBridgeTx, approvalRequired, approvalGasFees,
-        approvalAmountRequired, approvalContractAddress, slippagePercentage)
+        approvalAmountRequired, approvalContractAddress, slippagePercentage, txFeeInWei, txL1FeeInWei, approvalFeeInWei,
+        approvalL1FeeInWei)
 
   proc `$`*(self: SuggestedRouteItem): string =
     result = "SuggestedRouteItem("
@@ -115,6 +134,10 @@ QtObject:
     result = result & "\napprovalAmountRequired: " & $self.approvalAmountRequired
     result = result & "\napprovalContractAddress: " & $self.approvalContractAddress
     result = result & "\nslippagePercentage: " & $self.slippagePercentage
+    result = result & "\ntxFeeInWei: " & $self.txFeeInWei
+    result = result & "\ntxL1FeeInWei: " & $self.txL1FeeInWei
+    result = result & "\napprovalFeeInWei: " & $self.approvalFeeInWei
+    result = result & "\napprovalL1FeeInWei: " & $self.approvalL1FeeInWei
     result = result & ")"
 
   proc bridgeNameChanged*(self: SuggestedRouteItem) {.signal.}
@@ -249,3 +272,31 @@ QtObject:
   QtProperty[float] slippagePercentage:
     read = getSlippagePercentage
     notify = slippagePercentageChanged
+
+  proc txFeeInWeiChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getTxFeeInWei*(self: SuggestedRouteItem): string {.slot.} =
+    return self.txFeeInWei
+  QtProperty[string] txFeeInWei:
+    read = getTxFeeInWei
+    notify = txFeeInWeiChanged
+
+  proc txL1FeeInWeiChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getTxL1FeeInWei*(self: SuggestedRouteItem): string {.slot.} =
+    return self.txL1FeeInWei
+  QtProperty[string] txL1FeeInWei:
+    read = getTxL1FeeInWei
+    notify = txL1FeeInWeiChanged
+
+  proc approvalFeeInWeiChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getApprovalFeeInWei*(self: SuggestedRouteItem): string {.slot.} =
+    return self.approvalFeeInWei
+  QtProperty[string] approvalFeeInWei:
+    read = getApprovalFeeInWei
+    notify = approvalFeeInWeiChanged
+
+  proc approvalL1FeeInWeiChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getApprovalL1FeeInWei*(self: SuggestedRouteItem): string {.slot.} =
+    return self.approvalL1FeeInWei
+  QtProperty[string] approvalL1FeeInWei:
+    read = getApprovalL1FeeInWei
+    notify = approvalL1FeeInWeiChanged

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -174,6 +174,9 @@ QtObject:
   proc authenticateAndTransfer*(self: View, uuid: string) {.slot.} =
     self.delegate.authenticateAndTransfer(self.selectedSenderAccountAddress, uuid)
 
+  proc reevaluateSwap*(self: View, uuid: string, chainId: int, isApprovalTx: bool) {.slot.} =
+    self.delegate.reevaluateSwap(uuid, chainId, isApprovalTx)
+
   proc suggestedRoutesReady*(self: View, suggestedRoutes: QVariant, errCode: string, errDescription: string) {.signal.}
   proc setTransactionRoute*(self: View, routes: TransactionRoutes, errCode: string, errDescription: string) =
     self.transactionRoutes = routes

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -4,6 +4,7 @@ import Tables, sequtils
 import
   web3/ethtypes
 
+import dtoV2
 import backend/network_types
 import backend/transactions
 import app_service/common/conversion as service_conversion
@@ -363,6 +364,7 @@ proc convertSendToNetwork*(jsonObj: JsonNode): SendToNetwork =
 type
   SuggestedRoutesDto* = ref object
     best*: seq[TransactionPathDto]
+    bestRoute*: seq[TransactionPathDtoV2]
     rawBest*: string # serialized seq[TransactionPathDtoV2]
     gasTimeEstimate*: FeesDto
     amountToReceive*: UInt256

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -341,6 +341,7 @@ QtObject:
 
     let suggestedDto = SuggestedRoutesDto(
       best: addFirstSimpleBridgeTxFlag(oldRoute),
+      bestRoute: route,
       rawBest: routeRaw,
       gasTimeEstimate: getFeesTotal(oldRoute),
       amountToReceive: getTotalAmountToReceive(oldRoute),
@@ -531,3 +532,12 @@ proc sendRouterTransactionsWithSignatures*(self: Service, uuid: string, signatur
     error "unexpected sending transactions response"
     return "unexpected sending transactions response"
   return ""
+
+proc reevaluateRouterPath*(self: Service, uuid: string, pathName: string, chainId: int, isApprovalTx: bool): string =
+  try:
+    let err = wallet.reevaluateRouterPath(uuid, pathName, chainId, isApprovalTx)
+    if err.len > 0:
+      raise newException(CatchableError, err)
+  except CatchableError as e:
+    error "reevaluateRouterPath", exception=e.msg
+    return e.msg

--- a/src/backend/wallet.nim
+++ b/src/backend/wallet.nim
@@ -268,3 +268,24 @@ proc setCustomTxDetails*(nonce: int, gasAmount: int, maxFeesPerGas: string, prio
   let rpcResponse = core.callPrivateRPC("wallet_setCustomTxDetails", payload)
   if isErrorResponse(rpcResponse):
     return rpcResponse.error.message
+
+
+## Reevaluates reevaluates the tx-fields from the router path that matches the provided pathTxIdentity and sends signal.SuggestedRoutes.
+## `uuid` is the uuid of the router input params
+## `routerInputParamsUuid` is the uuid of the router input params
+## `pathName` is the name of the path
+## `chainId` is the chain id of the network
+## `isApprovalTx` is a flag that indicates if the tx is an approval tx - optional
+proc reevaluateRouterPath*(routerInputParamsUuid: string, pathName: string, chainId: int, isApprovalTx: bool = false): string {.raises: [RpcException].} =
+  var pathTxIdentity = %* {
+      "routerInputParamsUuid": routerInputParamsUuid,
+      "pathName": pathName,
+      "chainID": chainId,
+    }
+  if isApprovalTx:
+    pathTxIdentity["isApprovalTx"] = %* true
+
+  let payload = %* [pathTxIdentity]
+  let rpcResponse = core.callPrivateRPC("wallet_reevaluateRouterPath", payload)
+  if isErrorResponse(rpcResponse):
+    return rpcResponse.error.message

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -486,9 +486,11 @@ StatusDialog {
                             }
 
                             if(root.swapAdaptor.validSwapProposalReceived) {
-                                return root.swapAdaptor.currencyStore.formatCurrencyAmount(
-                                            root.swapAdaptor.swapOutputData.totalFees,
-                                            root.swapAdaptor.currencyStore.currentCurrency)
+                                let fees = root.swapAdaptor.swapOutputData.txFeesInFiat
+                                if(root.swapAdaptor.swapOutputData.approvalNeeded && !root.swapAdaptor.approvalSuccessful) {
+                                    fees = root.swapAdaptor.swapOutputData.approvalTxFeesFiat
+                                }
+                                return root.swapAdaptor.currencyStore.formatCurrencyAmount(fees, root.swapAdaptor.currencyStore.currentCurrency)
                             }
 
                             return "--"
@@ -594,11 +596,13 @@ StatusDialog {
             networkBlockExplorerUrl: networkFilter.singleSelectionItemData.blockExplorerURL
             networkChainId: networkFilter.singleSelectionItemData.chainId
 
-            fiatFees: {
-                const feesInFloat = root.swapAdaptor.currencyStore.getFiatValue(root.swapAdaptor.swapOutputData.approvalGasFees, d.nativeTokenSymbol)
-                return root.swapAdaptor.currencyStore.formatCurrencyAmount(feesInFloat, root.swapAdaptor.currencyStore.currentCurrency)
+            fiatFees: root.swapAdaptor.currencyStore.formatCurrencyAmount(root.swapAdaptor.swapOutputData.approvalTxFeesFiat, root.swapAdaptor.currencyStore.currentCurrency)
+
+            cryptoFees: {
+                const cryptoValue = Utils.nativeTokenRawToDecimal(root.swapInputParamsForm.selectedNetworkChainId, root.swapAdaptor.swapOutputData.approvalTxFeesWei).toString()
+                return root.swapAdaptor.currencyStore.formatCurrencyAmount(cryptoValue, d.nativeTokenSymbol)
             }
-            cryptoFees: root.swapAdaptor.currencyStore.formatCurrencyAmount(parseFloat(root.swapAdaptor.swapOutputData.approvalGasFees), d.nativeTokenSymbol)
+
             estimatedTime: root.swapAdaptor.swapOutputData.estimatedTime
 
             serviceProviderName: root.swapAdaptor.swapOutputData.txProviderName
@@ -652,12 +656,22 @@ StatusDialog {
             networkBlockExplorerUrl: networkFilter.singleSelectionItemData.blockExplorerURL
             networkChainId: root.swapInputParamsForm.selectedNetworkChainId
 
-            fiatFees: root.swapAdaptor.currencyStore.formatCurrencyAmount(root.swapAdaptor.swapOutputData.totalFees,
-                                                                          root.swapAdaptor.currencyStore.currentCurrency)
+            fiatFees: {
+                let fees = root.swapAdaptor.swapOutputData.txFeesInFiat
+                if(root.swapAdaptor.swapOutputData.approvalNeeded && !root.swapAdaptor.approvalSuccessful) {
+                    fees = root.swapAdaptor.swapOutputData.approvalTxFeesFiat
+                }
+                return root.swapAdaptor.currencyStore.formatCurrencyAmount(fees, root.swapAdaptor.currencyStore.currentCurrency)
+            }
+
             cryptoFees: {
-                const cryptoValue = root.swapAdaptor.currencyStore.getCryptoValue(root.swapAdaptor.swapOutputData.totalFees, d.nativeTokenSymbol)
+                let cryptoValue = Utils.nativeTokenRawToDecimal(root.swapInputParamsForm.selectedNetworkChainId, root.swapAdaptor.swapOutputData.txFeesWei)
+                if(root.swapAdaptor.swapOutputData.approvalNeeded && !root.swapAdaptor.approvalSuccessful) {
+                    cryptoValue = Utils.nativeTokenRawToDecimal(root.swapInputParamsForm.selectedNetworkChainId, root.swapAdaptor.swapOutputData.approvalTxFeesWei).toString()
+                }
                 return root.swapAdaptor.currencyStore.formatCurrencyAmount(cryptoValue, d.nativeTokenSymbol)
             }
+
             slippage: root.swapInputParamsForm.selectedSlippage
 
             serviceProviderName: root.swapAdaptor.swapOutputData.txProviderName

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -141,6 +141,14 @@ QObject {
                 root.swapOutputData.totalFees = root.currencyStore.getFiatValue(gasTimeEstimate.totalFeesInNativeCrypto, d.nativeTokenSymbol) + totalTokenFeesInFiat
                 let bestPath = ModelUtils.get(txRoutes.suggestedRoutes, 0, "route")
 
+                root.swapOutputData.txFeesWei = AmountsArithmetic.sum(AmountsArithmetic.fromString(bestPath.txFeeInWei), AmountsArithmetic.fromString(bestPath.txL1FeeInWei)).toString()
+                const txFeesNative = Utils.nativeTokenRawToDecimal(root.swapFormData.selectedNetworkChainId, root.swapOutputData.txFeesWei)
+                root.swapOutputData.txFeesInFiat = root.currencyStore.getFiatValue(txFeesNative, d.nativeTokenSymbol)
+
+                root.swapOutputData.approvalTxFeesWei = AmountsArithmetic.sum(AmountsArithmetic.fromString(bestPath.approvalFeeInWei), AmountsArithmetic.fromString(bestPath.approvalL1FeeInWei)).toString()
+                const txApprovalFeesNative = Utils.nativeTokenRawToDecimal(root.swapFormData.selectedNetworkChainId, root.swapOutputData.approvalTxFeesWei)
+                root.swapOutputData.approvalTxFeesFiat = root.currencyStore.getFiatValue(txApprovalFeesNative, d.nativeTokenSymbol)
+
                 const totalMaxFeesInGasUnit = Math.ceil(bestPath.gasFees.maxFeePerGasM) * bestPath.gasAmount
                 root.swapOutputData.maxFeesToReserveRaw = Utils.nativeTokenGasToRaw(root.swapFormData.selectedNetworkChainId, totalMaxFeesInGasUnit).toString()
 
@@ -174,6 +182,8 @@ QObject {
                 root.approvalPending = false
                 root.approvalSuccessful = status == "Success" // TODO: make a all tx statuses Constants (success, pending, failed)
                 d.txHash = ""
+
+                root.swapStore.reevaluateSwap(d.uuid, root.swapFormData.selectedNetworkChainId, true)
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapOutputData.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapOutputData.qml
@@ -11,6 +11,12 @@ QtObject {
     property string toTokenAmount: ""
     // TODO: this should be string but backend gas_estimate_item.nim passes this as float
     property real totalFees: 0
+
+    property string txFeesWei: "0"
+    property real txFeesInFiat: 0
+    property string approvalTxFeesWei: "0"
+    property real approvalTxFeesFiat: 0
+
     property string maxFeesToReserveRaw: ""
     property bool hasError
     property string errCode
@@ -42,6 +48,10 @@ QtObject {
         root.approvalGasFees = ""
         root.approvalAmountRequired = ""
         root.approvalContractAddress = ""
+        root.txFeesWei = "0"
+        root.txFeesInFiat = 0
+        root.approvalTxFeesWei = "0"
+        root.approvalTxFeesFiat = 0
         resetPathInfoAndError()
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/SwapStore.qml
@@ -50,4 +50,8 @@ QtObject {
     function getWei2Eth(wei, decimals) {
         return globalUtils.wei2Eth(wei, decimals)
     }
+
+    function reevaluateSwap(routerInputParamsUuid, chainId, isApprovalTx) {
+        root.walletSectionSendInst.reevaluateSwap(routerInputParamsUuid, chainId, isApprovalTx)
+    }
 }


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/6568

In the video below you can spot the different fees for an already approved amount of 0.5 USDC and a higher value which was not approved yet. In the second part higher value of 0.59 USDC was approved and sent.

Related tx:
- approval tx: https://etherscan.io/tx/0x1cb64c2007f7b44fced952fbf327fce9f60f9a3b6186b900bb5918f64b69bc09
- swap tx: https://etherscan.io/tx/0xc5f6bcb913b4f0a636de1528ed5658a05d8737767d660fb5020d6d20c04310fa


https://github.com/user-attachments/assets/01410ce8-a1a2-4615-9e52-98ecf913da42

