### PR TITLE
fix(news): fix News popup CTA not opening the website

### DIFF
--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1345,7 +1345,7 @@ QtObject {
 
             NewsMessagePopup {
                 activityCenterNotifications: root.activityCenterStore.activityCenterNotifications
-                onLinkClicked: Global.openLinkWithConfirmation(link, StatusQUtils.StringUtils.extractDomainFromLink(link));
+                onLinkClicked: Global.openLinkWithConfirmation(link, SQUtils.StringUtils.extractDomainFromLink(link));
             }
         }
     ]


### PR DESCRIPTION
Fixes #17883

[cta-fix.webm](https://github.com/user-attachments/assets/b464baa8-d13e-4259-8e4f-80482108d893)
