### PR TITLE
chore(Communities): Allow commas in the community description

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/DescriptionInput.qml
+++ b/ui/app/AppLayouts/Communities/controls/DescriptionInput.qml
@@ -28,8 +28,8 @@ StatusInput {
                                                 qsTr("community description"))
         },
         StatusRegularExpressionValidator {
-            regularExpression: Constants.regularExpressions.alphanumericalExpanded
-            errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
+            regularExpression: Constants.regularExpressions.alphanumericalExpanded3
+            errorMessage: Constants.errorMessages.alphanumericalExpanded3RegExp
         }
     ]
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -659,6 +659,7 @@ QtObject {
         readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_\.\u0020]+$/
         readonly property var alphanumericalExpanded1: /^[a-zA-Z0-9\-_]+(?: [a-zA-Z0-9\-_]+)*$/
         readonly property var alphanumericalExpanded2: /^$|^[a-zA-Z0-9\-_\.\u0020\&]+$/
+        readonly property var alphanumericalExpanded3: /^$|^[a-zA-Z0-9\-_\.\,\u0020]+$/
         readonly property var alphanumericalWithSpace: /^$|^[a-zA-Z0-9\s]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/
@@ -674,6 +675,7 @@ QtObject {
         readonly property string alphanumericalRegExp: qsTr("Only letters and numbers allowed")
         readonly property string alphanumericalExpandedRegExp: qsTr("Only letters, numbers, underscores, periods, whitespaces and hyphens allowed")
         readonly property string alphanumericalExpanded1RegExp: qsTr("Invalid characters (A-Z and 0-9, single whitespace, hyphens and underscores only)")
+        readonly property string alphanumericalExpanded3RegExp: qsTr("Only letters, numbers, underscores, periods, commas, whitespaces and hyphens allowed")
         readonly property string alphanumericalWithSpaceRegExp: qsTr("Special characters are not allowed")
         readonly property string asciiRegExp: qsTr("Only letters, numbers and ASCII characters allowed")
         readonly property string emojRegExp: qsTr("Name is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)")


### PR DESCRIPTION
### What does the PR do

Adds comma to the set of allowed character for community description.

Closes: #17896

Note: created task for improving constants handling: https://github.com/status-im/status-desktop/issues/17898

### Affected areas
`DescriptionInput`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

![Screenshot from 2025-05-09 10-08-17](https://github.com/user-attachments/assets/e6d692e5-3334-4b70-83f8-be0baba89f27)

![Screenshot from 2025-05-09 10-08-29](https://github.com/user-attachments/assets/06396016-43cf-44ce-bf6a-8f9392b8cfc2)


