### PR TITLE
fix(import): fix importing communities using the c#key format

### DIFF
--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -56,11 +56,18 @@ StatusDialog {
                 }
                 return linkData.communityId
             }
-            if (!root.utilsStore.isCommunityPublicKey(inputKey))
+            let updatedKey = inputKey
+            if (inputKey.indexOf("#") !== -1) {
+                // It's likely <encoded_data>#<community_chat_key> and we only want the community key
+                updatedKey = inputKey.split("#")[1]
+            }
+            if (!root.utilsStore.isCommunityPublicKey(updatedKey)) {
                 return ""
-            if (!root.utilsStore.isCompressedPubKey(inputKey))
-                return inputKey
-            return root.utilsStore.changeCommunityKeyCompression(inputKey)
+            }
+            if (!root.utilsStore.isCompressedPubKey(updatedKey)) {
+                return updatedKey
+            }
+            return root.utilsStore.changeCommunityKeyCompression(updatedKey)
         }
         readonly property bool isInputValid: publicKey !== ""
 
@@ -158,7 +165,7 @@ StatusDialog {
                 StatusTextArea {
                     id: keyInput
                     anchors.fill: parent
-                    placeholderText: "0x0..."
+                    placeholderText: "zQ3..."
                     wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
                     onTextChanged: d.importErrorMessage = ""
                 }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -895,11 +895,7 @@ QtObject {
         return getCommunityChannelShareLink(communityId, channelId)
     }
 
-    function getCommunityDataFromSharedLink(link) {
-        const index = link.lastIndexOf("/c/")
-        if (index === -1)
-            return null
-
+    function getCommunityDataFromSharedLink(link: string) {
         const communityDataString = sharedUrlsModuleInst.parseCommunitySharedUrl(link)
         try {
             return JSON.parse(communityDataString)


### PR DESCRIPTION
### What does the PR do

Fixes #17904

Enables the use of short community urls, channel links and data+ID in the import community popup

### Affected areas

Import Community Popup and Utils function (but it's only used in the popup)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[import-keys.webm](https://github.com/user-attachments/assets/515d4f23-50f1-4011-bf37-d97909ce7f48)

### Impact on end user

Enables the user to import their community from more types of links

### How to test

- Paste links in the Join Community popup (formerly known as Import Community)

### Risk 

No risk

