### PR TITLE
fix(deep-links): fix the order of calling appReady to fix deep links

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -297,7 +297,6 @@ proc syncAppAndKeycardState[T](self: Module[T]) =
   self.controller.addKeycardOrAccounts(kcDto, accountsComingFromKeycard = true)
 
 proc finishAppLoading2[T](self: Module[T]) =
-  self.delegate.appReady()
 
   let isOnboarding = self.loginFlow == LoginMethod.Unknown
   let eventType = if isOnboarding: "onboarding-completed" else: "user-logged-in"
@@ -309,6 +308,7 @@ proc finishAppLoading2[T](self: Module[T]) =
   self.controller.stopKeycardService()
 
   self.delegate.finishAppLoading()
+  self.delegate.appReady()
 
 method onAccountLoginError*[T](self: Module[T], error: string) =
   # SQLITE_NOTADB: "file is not a database"


### PR DESCRIPTION
### What does the PR do

Fixes #17907

The problem was that we were calling appReady when the app wasn't fully loaded, so the main module wasn't loaded to listen to the event being emited by the url_manager.

### Affected areas

Order of events during login

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[deep-link-fix.webm](https://github.com/user-attachments/assets/27850e3e-0866-4131-a45f-1db1b9f31b07)

### Impact on end user

Fixes the use case where a user clicks on a deep link and the app is not opened yet

### How to test

1. Close the app
2. Click a deep link
3. App opens
4. Login
5. See that the link resolves

### Risk 

No risk as `appReady` only does the call to the urls_manager
