### PR TITLE
chore(@e2e): scroll to the very last element on the advanced screen

### DIFF
--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -190,6 +190,7 @@ mainWindow_EnsRegisteredView = {"container": statusDesktop_mainWindow, "type": "
 mainWindow_AdvancedView = {"container": statusDesktop_mainWindow, "type": "AdvancedView", "unnamed": 1, "visible": True}
 mainWindow_settingsContentBaseScrollView_StatusScrollView = {"container": statusDesktop_mainWindow, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
 manageCommunitiesOnTestnetButton_StatusSettingsLineButton = {"container": mainWindow_settingsContentBaseScrollView_StatusScrollView, "objectName": "manageCommunitiesOnTestnetButton", "type": "StatusSettingsLineButton", "visible": True}
+rpcStatisticsButton = {"container": settingsContentBase_ScrollView, "id": "rpcStatsButton", "type": "StatusSettingsLineButton", "unnamed": 1, "visible": True}
 enableCreateCommunityButton_StatusSettingsLineButton = {"container": settingsContentBase_ScrollView, "objectName": "enableCreateCommunityButton", "type": "StatusSettingsLineButton", "visible": True}
 settingsContentBaseScrollViewLightWakuModeBloomSelectorButton = {"container": mainWindow_settingsContentBaseScrollView_StatusScrollView, "objectName": "lightWakuModeButton", "type": "BloomSelectorButton", "visible": True}
 settingsContentBaseScrollViewRelayWakuModeBloomSelectorButton = {"container": mainWindow_settingsContentBaseScrollView_StatusScrollView, "objectName": "relayWakuModeButton", "type": "BloomSelectorButton", "visible": True}

--- a/test/e2e/gui/screens/settings_advanced.py
+++ b/test/e2e/gui/screens/settings_advanced.py
@@ -14,13 +14,15 @@ class AdvancedSettingsView(QObject):
         self.scroll = Scroll(settings_names.settingsContentBase_ScrollView)
         self.manage_community_on_testnet_button = Button(
             settings_names.manageCommunitiesOnTestnetButton_StatusSettingsLineButton)
+        self.rpc_statistics_button = Button(settings_names.rpcStatisticsButton)
         self.light_mode_button = Button(settings_names.settingsContentBaseScrollViewLightWakuModeBloomSelectorButton)
         self.relay_mode_button = Button(settings_names.settingsContentBaseScrollViewRelayWakuModeBloomSelectorButton)
 
     @allure.step('Switch manage community on testnet option')
     def enable_manage_communities_on_testnet_toggle(self):
         for _ in range(2):
-            self.scroll.vertical_scroll_down(self.manage_community_on_testnet_button)
+            if not self.rpc_statistics_button.is_visible:
+                self.scroll.vertical_scroll_down(self.rpc_statistics_button)
             if not self.manage_community_on_testnet_button.object.switchChecked:
                 try:
                     self.manage_community_on_testnet_button.click()


### PR DESCRIPTION
### What does the PR do

allow test to scroll to the very bottom of the advanced screen so test can access the "manage communities on testnet" toggle easily

