### PR TITLE
fix(ci): fix for signing using DigiCert timeserver

### DIFF
--- a/scripts/sign-windows-bin.sh
+++ b/scripts/sign-windows-bin.sh
@@ -40,7 +40,7 @@ for FILE in ${FOUND_FILES}; do
 done
 
 # Sign all the non-signed binaries. Add -debug if need be.
-"${SIGNTOOL}" sign -v -debug -fd SHA256 \
+"${SIGNTOOL}" sign -v -debug -td SHA256 -fd SHA256 \
     -p "${WINDOWS_CODESIGN_PASSWORD}" \
     -f "${WINDOWS_CODESIGN_PFX_PATH}" \
     -tr "${WINDOWS_CODESIGN_TIMESTAMP_URL}" \


### PR DESCRIPTION
### What does the PR do

Possibly a fix for signing errors while using default DigiCert timeserver.

- Windows signatures failing with error:

  ```groovy
  Error information: "Error: SignerSign() failed." (-2146869243/0x80096005)
  SignTool Error: An unexpected internal error has occurred.
  ```
 
Ref.: 
- https://github.com/status-im/status-desktop/issues/16199
- https://github.com/status-im/status-desktop/pull/17063
