### PR TITLE
Fix News Popup layout when it has an image

### DIFF
--- a/storybook/pages/NewsMessagePopupPage.qml
+++ b/storybook/pages/NewsMessagePopupPage.qml
@@ -31,7 +31,9 @@ SplitView {
             property string newsContent: "Status Desktop's next release brings the app up-to-speed with Status Mobile. That means: SWAPS! Now you can trade Ethereum, Arbitrum and Optimism tokens directly in-app. Status leverages Paraswap so you always benefit from the best prices and fastest settlements!"
             property string newsLink: "https://status.app/"
             property string newsLinkLabel: linkLabelInput.text
-            property string newsImageUrl: hasImage.checked ? "https://picsum.photos/438/300" : ""
+
+            // The max height of the image is 300, but we handle it
+            property string newsImageUrl: hasImage.checked ? "https://picsum.photos/438/400" : ""
             property double timestamp: Date.now()
             property double previousTimestamp: 0
             property bool read: false

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -246,6 +246,14 @@ QtObject {
         return text.replace(/<[^>]*>?/gm, '')
     }
 
+    function stripHtmlPreserveBreaks(text) {
+        return text
+            .split(/<\/p>/i)
+            .map(part => part.replace(/<[^>]+>/g, '').trim())
+            .filter((part, index, arr) => part || index < arr.length - 1)
+            .join('<br><br>');
+    }
+
     function elideText(text, leftCharsCount, rightCharsCount = leftCharsCount) {
         return text.substr(0, leftCharsCount) + "…" + text.substr(text.length - rightCharsCount)
     }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -80,7 +80,9 @@ StatusDialog {
         }
 
         StatusBaseText {
-            text: notification.newsDescription || notification.newsContent
+            // Temporary fix to the HTML being present in the content
+            // TODO remove when it's handled on the Web side
+            text: CoreUtils.Utils.stripHtmlPreserveBreaks(notification.newsContent)
             Layout.fillWidth: true
             Layout.fillHeight: true
             wrapMode: Text.WordWrap

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -8,6 +8,7 @@ import StatusQ.Popups.Dialog 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
+import StatusQ.Core.Utils 0.1 as CoreUtils
 
 import mainui.activitycenter.helpers 1.0
 
@@ -43,9 +44,13 @@ StatusDialog {
         headline.title: notification.newsTitle
         headline.subtitle: dateGroupLabel.text
         actions.closeButton.onClicked: root.close()
-        leftComponent: StatusSmartIdenticon {
-            asset.name: Theme.png("status-logo-icon")
-            asset.isImage: true
+        leftComponent: Item {
+            width: 40
+            height: 40
+            StatusImage {
+                source: Theme.png("status")
+                anchors.fill: parent
+            }
         }
     }
 
@@ -66,16 +71,19 @@ StatusDialog {
         Loader {
             active: !!notification.newsImageUrl
 
-            Layout.bottomMargin: active ? Theme.bigPadding : 0
+            Layout.bottomMargin: active ? Theme.padding : 0
             Layout.fillWidth: true
-            Layout.preferredHeight: active ? 300 : 0
+            Layout.maximumHeight: active ? 300 : 0
 
             sourceComponent: StatusRoundedImage {
+                implicitWidth: parent.width
+                implicitHeight: image.implicitHeight
                 image.source: notification.newsImageUrl
+                image.fillMode: Image.PreserveAspectCrop
                 color: "transparent"
                 border.color: root.backgroundColor
                 border.width: 1
-                radius: 16
+                radius: 8
             }
         }
 


### PR DESCRIPTION
### What does the PR do

Fixes the layout of the News popup when it has an image.

Before, it would always make the "image" 300px high and if the image was smaller than that, it would have a lot of empty space.

Now it adapts and has a **max** of 300.

### Affected areas

NewsMessagePopup

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

Implementation:
![image](https://github.com/user-attachments/assets/628ec53c-6cf6-424b-92a7-7e499a9bd425)

Design:
![image](https://github.com/user-attachments/assets/b4864bd2-2432-4f37-88cb-10234e842061)



### Impact on end user

None

### How to test

- Check the storybook
- Check a News with an image

### Risk 


None