### PR TITLE
fix(news): fix toast notifs sometimes showing when they should not

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -12,7 +12,6 @@ logScope:
   topics = "notifications-manager"
 
 # Signals which may be emitted by this class:
-const SIGNAL_ADD_NOTIFICATION_TO_ACTIVITY_CENTER* = "addNotificationToActivityCenter"
 const SIGNAL_DISPLAY_APP_NOTIFICATION* = "displayAppNotification"
 const SIGNAL_DISPLAY_WINDOWS_OS_NOTIFICATION* = "displayWindowsOsNotification"
 const SIGNAL_OS_NOTIFICATION_CLICKED* = "osNotificationClicked"
@@ -81,7 +80,6 @@ QtObject:
     signalConnect(singletonInstance.globalEvents, "showCommunityTokenPermissionCreationFailedNotification(QString, QString, QString)", self, "onShowCommunityTokenPermissionCreationFailedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityTokenPermissionUpdateFailedNotification(QString, QString, QString)", self, "onShowCommunityTokenPermissionUpdateFailedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityTokenPermissionDeletionFailedNotification(QString, QString, QString)", self, "onShowCommunityTokenPermissionDeletionFailedNotification(QString, QString, QString)", 2)
-
     signalConnect(singletonInstance.globalEvents, "showCommunityMemberKickedNotification(QString, QString, QString)", self, "onShowCommunityMemberKickedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityMemberBannedNotification(QString, QString, QString)", self, "onShowCommunityMemberBannedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityMemberUnbannedNotification(QString, QString, QString)", self, "onShowCommunityMemberUnbannedNotification(QString, QString, QString)", 2)
@@ -226,10 +224,6 @@ QtObject:
   proc notificationCheck(self: NotificationsManager, title: string, message: string, details: NotificationDetails,
       notificationWay: string) =
     var data = NotificationArgs(title: title, message: message, details: details)
-    # All but the NewMessage notifications go to Activity Center
-    if details.notificationType != NotificationType.NewMessage:
-      debug "Add AC notification", notificationType=details.notificationType
-      self.events.emit(SIGNAL_ADD_NOTIFICATION_TO_ACTIVITY_CENTER, data)
 
     # An exemption from the diagrams, at least for now, is that we don't need to implement the "Badge Check" block here,
     # cause that's already handled in appropriate modules.

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -59,7 +59,12 @@ proc init*(self: Controller) =
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED) do(e: Args):
     let args = ActivityCenterNotificationsArgs(e)
-    self.delegate.addActivityCenterNotifications(args.activityCenterNotifications)
+    self.delegate.addActivityCenterNotifications(args.activityCenterNotifications, initialLoad = true)
+    self.updateActivityGroupCounters()
+
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED) do(e: Args):
+    let args = ActivityCenterNotificationsArgs(e)
+    self.delegate.addActivityCenterNotifications(args.activityCenterNotifications, initialLoad = false)
     self.updateActivityGroupCounters()
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_MARK_NOTIFICATIONS_AS_READ) do(e: Args):

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -81,7 +81,7 @@ method acceptActivityCenterNotificationDone*(self: AccessInterface, notification
 method dismissActivityCenterNotificationDone*(self: AccessInterface, notificationId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method addActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =
+method addActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto], initialLoad: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method resetActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -210,14 +210,15 @@ method markActivityCenterNotificationReadDone*(self: Module, notificationIds: se
 method markAsSeenActivityCenterNotifications*(self: Module) =
   self.controller.markAsSeenActivityCenterNotifications()
 
-method addActivityCenterNotifications*(self: Module, activityCenterNotifications: seq[ActivityCenterNotificationDto]) =
-  for notif in activityCenterNotifications:
-    if notif.notificationType == ActivityCenterNotificationTypeNews:
-      # Show an AC or OS notification for News Feed notifications
-      singletonInstance.globalEvents.showNewsMessageNotification(
-        notif.id,
-        notif.newsTitle,
-      )
+method addActivityCenterNotifications*(self: Module, activityCenterNotifications: seq[ActivityCenterNotificationDto], initialLoad: bool) =
+  if not initialLoad:
+    for notif in activityCenterNotifications:
+      if notif.notificationType == ActivityCenterNotificationTypeNews:
+        # Show an AC or OS notification for News Feed notifications
+        singletonInstance.globalEvents.showNewsMessageNotification(
+          notif.id,
+          notif.newsTitle,
+        )
   self.view.addActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
   self.view.hasUnseenActivityCenterNotificationsChanged()
 

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -37,6 +37,7 @@ type
 
 # Signals which may be emitted by this service:
 const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED* = "activityCenterNotificationsLoaded"
+const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED* = "activityCenterNotificationsReceived"
 const SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED* = "activityCenterNotificationsCountMayChanged"
 const SIGNAL_ACTIVITY_CENTER_UNSEEN_UPDATED* = "activityCenterNotificationsHasUnseenUpdated"
 const SIGNAL_ACTIVITY_CENTER_MARK_NOTIFICATIONS_AS_READ* = "activityCenterMarkNotificationsAsRead"
@@ -99,7 +100,7 @@ QtObject:
 
     if (filteredNotifications.len > 0):
       self.events.emit(
-        SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED,
+        SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED,
         ActivityCenterNotificationsArgs(activityCenterNotifications: filteredNotifications)
       )
 

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -6,7 +6,7 @@ import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../constants as app_constants
 
-from app_service/service/activity_center/service import SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED, ActivityCenterNotificationsArgs
+from app_service/service/activity_center/service import SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED, ActivityCenterNotificationsArgs
 from app_service/service/activity_center/dto/notification import parseActivityCenterNotifications
 
 import ../accounts/dto/accounts
@@ -46,7 +46,7 @@ QtObject:
     if response.result.contains("activityCenterNotifications"):
       let notifications = JsonNode(%{"notifications": response.result["activityCenterNotifications"]})
       let activityCenterNotificationsTuple = parseActivityCenterNotifications(notifications)
-      self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED,
+      self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED,
         ActivityCenterNotificationsArgs(activityCenterNotifications: activityCenterNotificationsTuple[1]))
 
   proc logout*(self: Service) =
@@ -115,7 +115,7 @@ QtObject:
       if rpcResponseObj["response"]["result"].contains("activityCenterNotifications"):
         let notifications = JsonNode(%{"notifications": rpcResponseObj["response"]["result"]["activityCenterNotifications"]})
         let activityCenterNotificationsTuple = parseActivityCenterNotifications(notifications)
-        self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED,
+        self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED,
           ActivityCenterNotificationsArgs(activityCenterNotifications: activityCenterNotificationsTuple[1]))
     except Exception as e:
       error "error:", procName="asyncFetchWakuBackupMessages", errName = e.name, errDesription = e.msg


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/17895

The issue was that I was too permissive when I wrote the code to show the toasts and it triggered any time a notification was added or loaded, so on app start, it could trigger too.
However, I got lucky because most of the time the load happened before the NotificationManager was ready, so this race condition hid the issue.

I fixed it by using different event names for when an AC notif is received vs loaded

I also added a second commit that cleans some dead code. This event was never listened to, so it can be safely removed.

### Affected areas

AC service and module

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

Fixes the random issue of toasts showing wrongly on app start

### How to test

- See that the AC notifications are still loaded and that new ones show up

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

