### PR TITLE
chore(news): remove stripHtml workaround for the news content

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -246,14 +246,6 @@ QtObject {
         return text.replace(/<[^>]*>?/gm, '')
     }
 
-    function stripHtmlPreserveBreaks(text) {
-        return text
-            .split(/<\/p>/i)
-            .map(part => part.replace(/<[^>]+>/g, '').trim())
-            .filter((part, index, arr) => part || index < arr.length - 1)
-            .join('<br><br>');
-    }
-
     function elideText(text, leftCharsCount, rightCharsCount = leftCharsCount) {
         return text.substr(0, leftCharsCount) + "…" + text.substr(text.length - rightCharsCount)
     }

--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -56,6 +56,7 @@ StatusDialog {
 
     ColumnLayout {
         width: parent.width
+        height: parent.height
         spacing: 0
 
         Loader {
@@ -88,12 +89,11 @@ StatusDialog {
         }
 
         StatusBaseText {
-            // Temporary fix to the HTML being present in the content
-            // TODO remove when it's handled on the Web side
-            text: CoreUtils.Utils.stripHtmlPreserveBreaks(notification.newsContent)
+            text: notification.newsContent
             Layout.fillWidth: true
             Layout.fillHeight: true
             wrapMode: Text.WordWrap
+            elide: Text.ElideRight
         }
     }
     footer: StatusDialogFooter {


### PR DESCRIPTION
Removes the Utils stripHtmlPreserveBreaks function that was used as a workaround since the RSS contained HTML tags still.

Also fixes a little layout issue where if the Content was too long, it didn't elide.

![image](https://github.com/user-attachments/assets/071845ea-4eb7-4717-81a8-ae34856628d9)
