### PR TITLE
fix(swap): Swap BNB chain tokens - Swap tx gets stuck in Pending

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
@@ -291,18 +291,18 @@ SignTransactionModalBase {
 
             if (!customBaseFeeDirty) {
                 if (selectedFeeMode === root.selectedFeeMode) {
-                    customBaseFee = !!root.customBaseFee? root.fnRawToGas(root.networkChainId, root.customBaseFee).toFixed() : "0"
+                    customBaseFee = !!root.customBaseFee? fnRawToGas(root.customBaseFee).toFixed() : "0"
                 } else {
-                    customBaseFee = root.fnRawToGas(root.networkChainId, root.normalBaseFee).toFixed()
+                    customBaseFee = fnRawToGas(root.normalBaseFee).toFixed()
                 }
                 customBaseFeeDirty = false
             }
 
             if (!customPriorityFeeDirty) {
                 if (selectedFeeMode === root.selectedFeeMode) {
-                    customPriorityFee = !!root.customPriorityFee? root.fnRawToGas(root.networkChainId, root.customPriorityFee).toFixed() : "0"
+                    customPriorityFee = !!root.customPriorityFee? fnRawToGas(root.customPriorityFee).toFixed() : "0"
                 } else {
-                    customPriorityFee = root.fnRawToGas(root.networkChainId, root.normalPriorityFee).toFixed()
+                    customPriorityFee = fnRawToGas(root.normalPriorityFee).toFixed()
                 }
                 customPriorityFeeDirty = false
             }


### PR DESCRIPTION
This PR solves the following two issues:
Closes #17932
Closes #17934

Corresponding statusgo PR:
- https://github.com/status-im/status-go/pull/6575

Swap made from the Stauts app:
- approval: https://optimistic.etherscan.io/tx/0x79f4c93ea35e9e8129cba00cf14fd54ba5536f9f77d470df94e1d60619bce9d9
- swap: https://optimistic.etherscan.io/tx/0x7570e654150862ac4e3517271d5c15db7f0ff8fa33141328fe8f692c05ae2841

**Note:**
If you have a gap in nonces for your account, make sure it's fixed before testing the swap. That's a good opportunity to test the custom settings part. If you need help on this, feel free to ping me.