### PR TITLE
fix(StatusMemberListItem): fixup hover over extra buttons

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMemberListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMemberListItem.qml
@@ -173,10 +173,15 @@ ItemDelegate {
         radius: Theme.radius
     }
 
+    // handles the hover & cursor for the item except the extra buttons
+    HoverHandler {
+       cursorShape: root.enabled && root.hoverEnabled && root.hovered ? Qt.PointingHandCursor : undefined
+    }
+
+    // handles the right click & cursor for the extra buttons
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.RightButton
-        hoverEnabled: root.enabled
         cursorShape: containsMouse ? Qt.PointingHandCursor : undefined
         onClicked: root.rightClicked()
     }


### PR DESCRIPTION
### What does the PR do

- got caught by e2e tests; we still need the HoverHandler to handle the hover & cursorShape for the whole item in a way that doesn't obscur the extra buttons placed on top
- the MouseArea handles the right mouse click, and nothing else

Fixes #17944

### Affected areas

StatusMemberListItem

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/4b950b79-340e-44d0-bd2c-1adb367a1766


