### PR TITLE
fix(StatusBaseInput): clicking in bottom text of the input not working

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -368,7 +368,6 @@ Item {
                         property string previousText: text
                         property var keyEvent
                         width: flick.width
-                        height: flick.height
                         verticalAlignment: TextEdit.AlignVCenter
                         selectByMouse: true
                         selectionColor: Theme.palette.primaryColor2

--- a/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml
@@ -58,7 +58,7 @@ Item {
                 StatusValidator {
                     name: "maxLengthValidator"
                     validate: function (t) { return t.length <= bioInput.charLimit}
-                    errorMessage: qsTr("Bio can’t be longer than %n character(s)", "", bioInput.charLimit)
+                    errorMessage: qsTr("Bio can't be longer than %n character(s)", "", bioInput.charLimit)
                 },
                 StatusRegularExpressionValidator {
                     regularExpression: Constants.regularExpressions.asciiWithEmoji

--- a/ui/imports/shared/views/profile/ShareProfileDialog.qml
+++ b/ui/imports/shared/views/profile/ShareProfileDialog.qml
@@ -99,8 +99,6 @@ StatusDialog {
                 Layout.preferredHeight: 44
                 leftPadding: Theme.padding
                 rightPadding: Theme.halfPadding
-                topPadding: 0
-                bottomPadding: 0
                 placeholder.rightPadding: Theme.halfPadding
                 placeholder.elide: Text.ElideMiddle
                 placeholderText: root.linkToProfile
@@ -129,8 +127,6 @@ StatusDialog {
                 Layout.preferredHeight: 44
                 leftPadding: Theme.padding
                 rightPadding: Theme.halfPadding
-                topPadding: 0
-                bottomPadding: 0
                 edit.readOnly: true
                 background.color: "transparent"
                 background.border.color: Theme.palette.baseColor2


### PR DESCRIPTION
### What does the PR do

Fixes #14467

The issue was that the TextEdit was bound to the size of the flickable, so when it got scrolled, mouse clicked we only on the ScrollView and no longer on the TextEdit, ie the mouse click was only good to scroll (drag) but not to select text.

Removing the height property and letting the TextEdit follow its content fixes it.

### Affected areas

All `StatusBaseInput`s, ie all `StatusInput`s :see_no_evil: 

As far as I could see, only the ShareProfileDialog was affected, where the placeholder text for the share link was stuck to the top of the input. I fixed it in this PR too.

Other Inputs seem fine.

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

In this video, I show the long bio issue being fixed and also that other inputs also work fine

[fix-long-bio.webm](https://github.com/user-attachments/assets/e9aeea56-37bb-45c6-bc80-2e6ad4b6f29e)

### Impact on end user

Fixes the annoying issue

### How to test

- Test the bio input
- Test other inputs real quick to see if there is not formatting issue

### Risk 

Low risk, because even if it affects all Inputs, it would only affect them visually and it's easy to fix

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

