### PR TITLE
chore(ci): renew DigiCert Certificate for signing release builds

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.18'
+library 'status-jenkins-lib@v1.9.23'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.18'
+library 'status-jenkins-lib@v1.9.23'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
## Implement DigiCert Keylocker for Release Signing
This PR implements DigiCert Keylocker, a cloud-based HSM solution, for signing release binaries. Development builds continue to use self-signed certificates for code signing.

### Set up DigiCert Keylocker configuration for Windows code signing
Configure environment variables for DigiCert credentials
Update signing script to conditionally use either DigiCert (for releases) or development certificates

### Testing
Tested on Windows with this PR:
- https://github.com/status-im/status-desktop/pull/17862

Verifying development builds sign correctly with self-signed certificate
Confirming release builds successfully sign with DigiCert Keylocker

Closes [#183](https://github.com/status-im/infra-ci/issues/183)