### PR TITLE
fix(@desktop/wallet): [Qt6] BridgeModal layout broken

### DIFF
--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -105,7 +105,7 @@ SplitView {
     }
 
     NetworksStore {
-        id: networksStore
+        id: networkStore
     }
 
     QtObject {
@@ -207,7 +207,7 @@ SplitView {
                 closePolicy: Popup.NoAutoClose
                 onlyAssets: loader.onlyAssets
                 store: txStore
-                networksStore: networksStore
+                networksStore: networkStore
                 preSelectedAccountAddress: loader.preSelectedAccount.address
                 preDefinedAmountToSend: loader.preDefinedAmountToSend
                 preSelectedRecipient: loader.preSelectedRecipient

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -434,7 +434,7 @@ StatusDialog {
                         property bool onlyAssets: false
 
                         assetsModel: assetsAdaptor.outputAssetsModel
-                        collectiblesModel: collectiblesAdaptorLoader.active
+                        collectiblesModel: collectiblesAdaptorLoader.active && !!collectiblesAdaptorLoader.item
                                            ? collectiblesAdaptorLoader.item.model : null
                         Layout.fillWidth: true
                         Layout.maximumWidth: implicitWidth

--- a/ui/imports/shared/popups/send/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/popups/send/views/NetworkCardsComponent.qml
@@ -63,7 +63,7 @@ Item {
         d.draw()
     }
 
-    height: visible ? networkCardsLayout.height : 0
+    implicitHeight: visible ? networkCardsLayout.height : 0
 
     RowLayout {
         id: networkCardsLayout

--- a/ui/imports/shared/popups/send/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/popups/send/views/NetworksAdvancedCustomRoutingView.qml
@@ -87,7 +87,6 @@ ColumnLayout {
             Loader {
                 id: networksLoader
                 Layout.fillWidth: true
-                Layout.preferredHeight: item.height
                 Layout.topMargin: Theme.padding
                 visible: active
                 sourceComponent: NetworkCardsComponent {

--- a/ui/imports/shared/popups/send/views/TransactionModalFooter.qml
+++ b/ui/imports/shared/popups/send/views/TransactionModalFooter.qml
@@ -46,7 +46,7 @@ StatusDialogFooter {
                 text: root.totalTimeEstimate
 
                 onTextChanged: {
-                    if (text === "" || text === d.emptyValue) {
+                    if (estimatedTime.text === "" || estimatedTime.text === d.emptyValue) {
                         return
                     }
                     estimatedTimeAnimation.restart()
@@ -74,7 +74,7 @@ StatusDialogFooter {
                     wrapMode: Text.WordWrap
 
                     onTextChanged: {
-                        if (text === "" || text === d.emptyValue) {
+                        if (fees.text === "" || fees.text === d.emptyValue) {
                             return
                         }
                         feesAnimation.restart()


### PR DESCRIPTION
fixes #17949

### What does the PR do

Fixes broken layout in Bridge modal advanced mode

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/30a71472-de20-44d1-abf5-b1624569e5a1



<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<!-- Uncomment this section for status-go upgrade/dogfooding pull requests

### Impact on end user

What is the impact of these changes on the end user (before/after behaviour)

### How to test

- How should one proceed with testing this PR.
- What kind of user flows should be checked?

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
