### PR TITLE
fix(pairing): profile img not updating when the paired device changes it

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -11,6 +11,7 @@ import ../../../../app_service/service/devices/dto/[installation]
 import ../../../../app_service/service/settings/dto/[settings]
 import ../../../../app_service/service/saved_address/dto as saved_address_dto
 import ../../../../app_service/service/wallet_account/dto/[keypair_dto]
+import ../../../../app_service/service/accounts/dto/[accounts]
 
 type MessageSignal* = ref object of Signal
   messages*: seq[MessageDto]
@@ -29,6 +30,7 @@ type MessageSignal* = ref object of Signal
   removedChats*: seq[string]
   currentStatus*: seq[StatusUpdateDto]
   settings*: seq[SettingsFieldDto]
+  identityImages*: seq[Image]
   clearedHistories*: seq[ClearedHistoryDto]
   savedAddresses*: seq[SavedAddressDto]
   keypairs*: seq[KeypairDto]
@@ -133,6 +135,10 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   if e.contains("settings"):
     for jsonSettingsField in e["settings"]:
       signal.settings.add(jsonSettingsField.toSettingsFieldDto())
+
+  if e.contains("identityImages"):
+    for jsonSettingsField in e["identityImages"]:
+      signal.identityImages.add(jsonSettingsField.toImage())
 
   if e.contains("savedAddresses"):
     for jsonSavedAddress in e["savedAddresses"]:

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -102,11 +102,6 @@ QtObject:
   proc getKeyStoreDir*(self: Service): string =
     return self.keyStoreDir
 
-  proc connectToFetchingFromWakuEvents*(self: Service) =
-    self.events.on(SignalType.WakuBackedUpProfile.event) do(e: Args):
-      var receivedData = WakuBackedUpProfileSignal(e)
-      self.updateLoggedInAccount(receivedData.backedUpProfile.displayName, receivedData.backedUpProfile.images)
-
   proc init*(self: Service) =
     discard
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -612,20 +612,15 @@ QtObject {
                 title: qsTr("Profile Picture")
                 acceptButtonText: qsTr("Make this my Profile Pic")
                 onImageCropped: {
-                    if (callback) {
-                        callback(image,
-                                 cropRect.x.toFixed(),
-                                 cropRect.y.toFixed(),
-                                 (cropRect.x + cropRect.width).toFixed(),
-                                 (cropRect.y + cropRect.height).toFixed())
+                    if (!callback) {
+                        console.error("ImageCropWorkflow: no callback provided")
                         return
                     }
-
-                    rootStore.profileSectionStore.profileStore.uploadImage(image,
-                                                  cropRect.x.toFixed(),
-                                                  cropRect.y.toFixed(),
-                                                  (cropRect.x + cropRect.width).toFixed(),
-                                                  (cropRect.y + cropRect.height).toFixed());
+                    callback(image,
+                            cropRect.x.toFixed(),
+                            cropRect.y.toFixed(),
+                            (cropRect.x + cropRect.width).toFixed(),
+                            (cropRect.y + cropRect.height).toFixed())
                 }
                 onDone: destroy()
             }

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -151,10 +151,10 @@ Item {
                     if (!!root.icon)
                         Global.openMenu(editImageMenuComponent, this)
                     else
-                        Global.openChangeProfilePicPopup(tempIcon);
+                        Global.openChangeProfilePicPopup(setTempIcon);
                 }
 
-                function tempIcon(image, aX, aY, bX, bY) {
+                function setTempIcon(image, aX, aY, bX, bY) {
                     root.icon = image
                     root.cropRect = Qt.rect(aX, aY, bX - aX, bY - aY)
 
@@ -271,13 +271,13 @@ Item {
             StatusAction {
                 text: !!root.icon ? qsTr("Select different image") : qsTr("Select image")
                 assetSettings.name: "image"
-                onTriggered: Global.openChangeProfilePicPopup(editButton.tempIcon)
+                onTriggered: Global.openChangeProfilePicPopup(editButton.setTempIcon)
             }
 
             StatusAction {
                 text: qsTr("Use a collectible")
                 assetSettings.name: "nft-profile"
-                onTriggered: Global.openChangeProfilePicPopup(editButton.tempIcon)
+                onTriggered: Global.openChangeProfilePicPopup(editButton.setTempIcon)
                 enabled: false // TODO enable this with the profile showcase (#13418)
             }
 


### PR DESCRIPTION
### What does the PR do

Fixes #17731

We just didn't listen to the property change from the signal.

### Affected areas

Signal listening

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

[profile-change.webm](https://github.com/user-attachments/assets/7ace2798-b14b-4643-a6a5-8f47e59937aa)

### Impact on end user

Fixes the issue (no longer need to restart the app)

### How to test

1. Pair your desktop app with a mobile one (though another desktop would do the same)
2. Update the profile pic on the new one
3. it updates now

### Risk 

Worst case the bug isn't fixed

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
