### PR TITLE
fix(channel): enable the use of commas and ampersands in channel desc

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -777,7 +777,7 @@ StatusStackModal {
                             errorMessage: Utils.getErrorMessage(descriptionTextArea.errors, qsTr("channel description"))
                         },
                         StatusRegularExpressionValidator {
-                            regularExpression: Constants.regularExpressions.alphanumericalExpanded
+                            regularExpression: Constants.regularExpressions.alphanumericalExpanded3
                             errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
                         }
                     ]

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -659,10 +659,14 @@ QtObject {
 
     readonly property QtObject regularExpressions: QtObject {
         readonly property var alphanumerical: /^$|^[a-zA-Z0-9]+$/
+        // Adds space, dash, underscore and dot
         readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_\.\u0020]+$/
+        // Adds dash and underscore
         readonly property var alphanumericalExpanded1: /^[a-zA-Z0-9\-_]+(?: [a-zA-Z0-9\-_]+)*$/
+        // Adds dash, underscore, dot space and ampersand
         readonly property var alphanumericalExpanded2: /^$|^[a-zA-Z0-9\-_\.\u0020\&]+$/
-        readonly property var alphanumericalExpanded3: /^$|^[a-zA-Z0-9\-_\.\,\u0020]+$/
+        // Adds dash, underscore, dot, space, comma and ampersand
+        readonly property var alphanumericalExpanded3: /^$|^[a-zA-Z0-9\-_\.\,\u0020\&]+$/
         readonly property var alphanumericalWithSpace: /^$|^[a-zA-Z0-9\s]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/


### PR DESCRIPTION
While testing other bugs, I found that channel descriptions didn't support commas, like the community description.

So I changed it to use the same regex.

I also added `&` in the list of accepted characters. I don't think it can cause issues, as it's just a description.

Finally, I added comments to the regexes, because reading regexes is a pain.