### PR TITLE
feat(wallet): fees/custom settings for non eip1559 chains

### DIFF
--- a/src/app/modules/main/wallet_section/send_new/controller.nim
+++ b/src/app/modules/main/wallet_section/send_new/controller.nim
@@ -111,13 +111,13 @@ proc setFeeMode*(self: Controller, feeMode: int, routerInputParamsUuid: string, 
   isApprovalTx: bool, communityId: string): string =
     return self.transactionService.setFeeMode(feeMode, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId)
 
-proc setCustomTxDetails*(self: Controller, nonce: int, gasAmount: int, maxFeesPerGas: string, priorityFee: string,
+proc setCustomTxDetails*(self: Controller, nonce: int, gasAmount: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string,
   routerInputParamsUuid: string, pathName: string, chainId: int, isApprovalTx: bool, communityId: string): string =
-    return self.transactionService.setCustomTxDetails(nonce, gasAmount, maxFeesPerGas, priorityFee, routerInputParamsUuid,
+    return self.transactionService.setCustomTxDetails(nonce, gasAmount, gasPrice, maxFeesPerGas, priorityFee, routerInputParamsUuid,
     pathName, chainId, isApprovalTx, communityId)
 
-proc getEstimatedTime*(self: Controller, chainId: int, maxFeesPerGas: string, priorityFee: string): int =
-    self.transactionService.getEstimatedTimeV2(chainId, maxFeesPerGas, priorityFee)
+proc getEstimatedTime*(self: Controller, chainId: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string): int =
+    self.transactionService.getEstimatedTimeV2(chainId, gasPrice, maxFeesPerGas, priorityFee)
 
 proc getCurrentNetworks*(self: Controller): seq[NetworkItem] =
   return self.networkService.getCurrentNetworks()

--- a/src/app/modules/main/wallet_section/send_new/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send_new/io_interface.nim
@@ -49,11 +49,11 @@ method setFeeMode*(self: AccessInterface, feeMode: int, routerInputParamsUuid: s
   isApprovalTx: bool, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setCustomTxDetails*(self: AccessInterface, nonce: int, gasAmount: int, maxFeesPerGas: string, priorityFee: string,
+method setCustomTxDetails*(self: AccessInterface, nonce: int, gasAmount: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string,
   routerInputParamsUuid: string, pathName: string, chainId: int, isApprovalTx: bool, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getEstimatedTime*(self: AccessInterface, chainId: int, maxFeesPerGas: string, priorityFee: string): int {.base.} =
+method getEstimatedTime*(self: AccessInterface, chainId: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method transactionWasSent*(self: AccessInterface, uuid: string, chainId: int = 0, approvalTx: bool = false, txHash: string = "", error: string = "") {.base.} =

--- a/src/app/modules/main/wallet_section/send_new/module.nim
+++ b/src/app/modules/main/wallet_section/send_new/module.nim
@@ -109,6 +109,8 @@ proc convertTransactionPathDtoV2ToPathItem(self: Module, txPath: TransactionPath
     processorName = txPath.processorName,
     fromChain = fromChainId,
     fromChainEIP1559Compliant = txPath.fromChain.eip1559Enabled,
+    fromChainNoBaseFee = txPath.fromChain.noBaseFee,
+    fromChainNoPriorityFee = txPath.fromChain.noPriorityFee,
     toChain = toChainId,
     fromToken = fromTokenSymbol,
     toToken = toTokenSymbol,

--- a/src/app/modules/main/wallet_section/send_new/module.nim
+++ b/src/app/modules/main/wallet_section/send_new/module.nim
@@ -108,12 +108,15 @@ proc convertTransactionPathDtoV2ToPathItem(self: Module, txPath: TransactionPath
   result = newPathItem(
     processorName = txPath.processorName,
     fromChain = fromChainId,
+    fromChainEIP1559Compliant = txPath.fromChain.eip1559Enabled,
     toChain = toChainId,
     fromToken = fromTokenSymbol,
     toToken = toTokenSymbol,
     amountIn = $txPath.amountIn,
     amountInLocked = txPath.amountInLocked,
     amountOut = $txPath.amountOut,
+    suggestedNonEIP1559GasPrice = $txPath.suggestedNonEIP1559Fees.gasPrice,
+    suggestedNonEIP1559EstimatedTime = txPath.suggestedNonEIP1559Fees.estimatedTime,
     suggestedMaxFeesPerGasLowLevel = $txPath.suggestedLevelsForMaxFeesPerGas.low,
     suggestedPriorityFeePerGasLowLevel = $txPath.suggestedLevelsForMaxFeesPerGas.lowPriority,
     suggestedEstimatedTimeLowLevel = txPath.suggestedLevelsForMaxFeesPerGas.lowEstimatedTime,
@@ -131,6 +134,7 @@ proc convertTransactionPathDtoV2ToPathItem(self: Module, txPath: TransactionPath
     suggestedApprovalTxNonce = $txPath.suggestedApprovalTxNonce,
     suggestedApprovalGasAmount = $txPath.suggestedApprovalGasAmount,
     txNonce = $txPath.txNonce,
+    txGasPrice = $txPath.txGasPrice,
     txGasFeeMode = txPath.txGasFeeMode,
     txMaxFeesPerGas = $txPath.txMaxFeesPerGas,
     txBaseFee = $txPath.txBaseFee,
@@ -145,6 +149,7 @@ proc convertTransactionPathDtoV2ToPathItem(self: Module, txPath: TransactionPath
     approvalAmountRequired = $txPath.approvalAmountRequired,
     approvalContractAddress = txPath.approvalContractAddress,
     approvalTxNonce = $txPath.approvalTxNonce,
+    approvalGasPrice = $txPath.approvalGasPrice,
     approvalGasFeeMode = txPath.approvalGasFeeMode,
     approvalMaxFeesPerGas = $txPath.approvalMaxFeesPerGas,
     approvalBaseFee = $txPath.approvalBaseFee,
@@ -336,14 +341,14 @@ method setFeeMode*(self: Module, feeMode: int, routerInputParamsUuid: string, pa
     var data = NotificationArgs(title: "Setting fee mode", message: err)
     self.events.emit(SIGNAL_DISPLAY_APP_NOTIFICATION, data)
 
-method setCustomTxDetails*(self: Module, nonce: int, gasAmount: int, maxFeesPerGas: string, priorityFee: string,
+method setCustomTxDetails*(self: Module, nonce: int, gasAmount: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string,
   routerInputParamsUuid: string, pathName: string, chainId: int, isApprovalTx: bool, communityId: string) =
-  let err = self.controller.setCustomTxDetails(nonce, gasAmount, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName,
+  let err = self.controller.setCustomTxDetails(nonce, gasAmount, gasPrice, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName,
     chainId, isApprovalTx, communityId)
   if err.len > 0:
     # TODO: translate this, or find a better way to display error at this step (maybe within the popup)
     var data = NotificationArgs(title: "Setting custom fee", message: err)
     self.events.emit(SIGNAL_DISPLAY_APP_NOTIFICATION, data)
 
-method getEstimatedTime*(self: Module, chainId: int, maxFeesPerGas: string, priorityFee: string): int =
-  return self.controller.getEstimatedTime(chainId, maxFeesPerGas, priorityFee)
+method getEstimatedTime*(self: Module, chainId: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string): int =
+  return self.controller.getEstimatedTime(chainId, gasPrice, maxFeesPerGas, priorityFee)

--- a/src/app/modules/main/wallet_section/send_new/path_item.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_item.nim
@@ -6,12 +6,15 @@ QtObject:
   type PathItem* = ref object of QObject
     processorName: string
     fromChain: int
+    fromChainEIP1559Compliant: bool
     toChain: int
     fromToken: string
     toToken: string
     amountIn: string
     amountInLocked: bool
     amountOut: string
+    suggestedNonEIP1559GasPrice: string
+    suggestedNonEIP1559EstimatedTime: int
     suggestedMaxFeesPerGasLowLevel: string
     suggestedPriorityFeePerGasLowLevel: string
     suggestedEstimatedTimeLowLevel: int
@@ -29,6 +32,7 @@ QtObject:
     suggestedApprovalTxNonce: string
     suggestedApprovalGasAmount: string
     txNonce: string
+    txGasPrice: string
     txGasFeeMode: int
     txMaxFeesPerGas: string
     txBaseFee: string
@@ -44,6 +48,7 @@ QtObject:
     approvalAmountRequired : string
     approvalContractAddress: string
     approvalTxNonce: string
+    approvalGasPrice: string
     approvalGasFeeMode: int
     approvalMaxFeesPerGas: string
     approvalBaseFee: string
@@ -56,12 +61,15 @@ QtObject:
   proc setup*(self: PathItem,
     processorName: string,
     fromChain: int,
+    fromChainEIP1559Compliant: bool,
     toChain: int,
     fromToken: string,
     toToken: string,
     amountIn: string,
     amountInLocked: bool,
     amountOut: string,
+    suggestedNonEIP1559GasPrice: string,
+    suggestedNonEIP1559EstimatedTime: int,
     suggestedMaxFeesPerGasLowLevel: string,
     suggestedPriorityFeePerGasLowLevel: string,
     suggestedEstimatedTimeLowLevel: int,
@@ -79,6 +87,7 @@ QtObject:
     suggestedApprovalTxNonce: string,
     suggestedApprovalGasAmount: string,
     txNonce: string,
+    txGasPrice: string,
     txGasFeeMode: int,
     txMaxFeesPerGas: string,
     txBaseFee: string,
@@ -94,6 +103,7 @@ QtObject:
     approvalAmountRequired: string,
     approvalContractAddress: string,
     approvalTxNonce: string,
+    approvalGasPrice: string,
     approvalGasFeeMode: int,
     approvalMaxFeesPerGas: string,
     approvalBaseFee: string,
@@ -106,12 +116,15 @@ QtObject:
     self.QObject.setup
     self.processorName = processorName
     self.fromChain = fromChain
+    self.fromChainEIP1559Compliant = fromChainEIP1559Compliant
     self.toChain = toChain
     self.fromToken = fromToken
     self.toToken = toToken
     self.amountIn = amountIn
     self.amountInLocked = amountInLocked
     self.amountOut = amountOut
+    self.suggestedNonEIP1559GasPrice = suggestedNonEIP1559GasPrice
+    self.suggestedNonEIP1559EstimatedTime = suggestedNonEIP1559EstimatedTime
     self.suggestedMaxFeesPerGasLowLevel = suggestedMaxFeesPerGasLowLevel
     self.suggestedPriorityFeePerGasLowLevel = suggestedPriorityFeePerGasLowLevel
     self.suggestedEstimatedTimeLowLevel = suggestedEstimatedTimeLowLevel
@@ -129,6 +142,7 @@ QtObject:
     self.suggestedApprovalTxNonce = suggestedApprovalTxNonce
     self.suggestedApprovalGasAmount = suggestedApprovalGasAmount
     self.txNonce = txNonce
+    self.txGasPrice = txGasPrice
     self.txGasFeeMode = txGasFeeMode
     self.txMaxFeesPerGas = txMaxFeesPerGas
     self.txBaseFee = txBaseFee
@@ -144,6 +158,7 @@ QtObject:
     self.approvalAmountRequired = approvalAmountRequired
     self.approvalContractAddress = approvalContractAddress
     self.approvalTxNonce = approvalTxNonce
+    self.approvalGasPrice = approvalGasPrice
     self.approvalGasFeeMode = approvalGasFeeMode
     self.approvalMaxFeesPerGas = approvalMaxFeesPerGas
     self.approvalBaseFee = approvalBaseFee
@@ -159,12 +174,15 @@ QtObject:
   proc newPathItem*(
     processorName: string,
     fromChain: int,
+    fromChainEIP1559Compliant: bool,
     toChain: int,
     fromToken: string,
     toToken: string,
     amountIn: string,
     amountInLocked: bool,
     amountOut: string,
+    suggestedNonEIP1559GasPrice: string,
+    suggestedNonEIP1559EstimatedTime: int,
     suggestedMaxFeesPerGasLowLevel: string,
     suggestedPriorityFeePerGasLowLevel: string,
     suggestedEstimatedTimeLowLevel: int,
@@ -182,6 +200,7 @@ QtObject:
     suggestedApprovalTxNonce: string,
     suggestedApprovalGasAmount: string,
     txNonce: string,
+    txGasPrice: string,
     txGasFeeMode: int,
     txMaxFeesPerGas: string,
     txBaseFee: string,
@@ -197,6 +216,7 @@ QtObject:
     approvalAmountRequired: string,
     approvalContractAddress: string,
     approvalTxNonce: string,
+    approvalGasPrice: string,
     approvalGasFeeMode: int,
     approvalMaxFeesPerGas: string,
     approvalBaseFee: string,
@@ -210,12 +230,15 @@ QtObject:
     result.setup(
       processorName,
       fromChain,
+      fromChainEIP1559Compliant,
       toChain,
       fromToken,
       toToken,
       amountIn,
       amountInLocked,
       amountOut,
+      suggestedNonEIP1559GasPrice,
+      suggestedNonEIP1559EstimatedTime,
       suggestedMaxFeesPerGasLowLevel,
       suggestedPriorityFeePerGasLowLevel,
       suggestedEstimatedTimeLowLevel,
@@ -233,6 +256,7 @@ QtObject:
       suggestedApprovalTxNonce,
       suggestedApprovalGasAmount,
       txNonce,
+      txGasPrice,
       txGasFeeMode,
       txMaxFeesPerGas,
       txBaseFee,
@@ -248,6 +272,7 @@ QtObject:
       approvalAmountRequired,
       approvalContractAddress,
       approvalTxNonce,
+      approvalGasPrice,
       approvalGasFeeMode,
       approvalMaxFeesPerGas,
       approvalBaseFee,
@@ -261,12 +286,15 @@ QtObject:
     result = "PathItem("
     result &= "\nprocessorName: " & $self.processorName
     result &= "\nfromChain: " & $self.fromChain
+    result &= "\nfromChainEIP1559Compliant: " & $self.fromChainEIP1559Compliant
     result &= "\ntoChain: " & $self.toChain
     result &= "\nfromToken: " & $self.fromToken
     result &= "\ntoToken: " & $self.toToken
     result &= "\namountIn: " & $self.amountIn
     result &= "\namountInLocked: " & $self.amountInLocked
     result &= "\namountOut: " & $self.amountOut
+    result &= "\nsuggestedNonEIP1559GasPrice: " & $self.suggestedNonEIP1559GasPrice
+    result &= "\nsuggestedNonEIP1559EstimatedTime: " & $self.suggestedNonEIP1559EstimatedTime
     result &= "\nsuggestedMaxFeesPerGasLowLevel: " & $self.suggestedMaxFeesPerGasLowLevel
     result &= "\nsuggestedPriorityFeePerGasLowLevel: " & $self.suggestedPriorityFeePerGasLowLevel
     result &= "\nsuggestedEstimatedTimeLowLevel: " & $self.suggestedEstimatedTimeLowLevel
@@ -284,6 +312,7 @@ QtObject:
     result &= "\nsuggestedApprovalTxNonce: " & $self.suggestedApprovalTxNonce
     result &= "\nsuggestedApprovalGasAmount: " & $self.suggestedApprovalGasAmount
     result &= "\ntxNonce: " & $self.txNonce
+    result &= "\ntxGasPrice: " & $self.txGasPrice
     result &= "\ntxGasFeeMode: " & $self.txGasFeeMode
     result &= "\ntxMaxFeesPerGas: " & $self.txMaxFeesPerGas
     result &= "\ntxBaseFee: " & $self.txBaseFee
@@ -299,6 +328,7 @@ QtObject:
     result &= "\napprovalAmountRequired: " & $self.approvalAmountRequired
     result &= "\napprovalContractAddress: " & $self.approvalContractAddress
     result &= "\napprovalTxNonce: " & $self.approvalTxNonce
+    result &= "\napprovalGasPrice: " & $self.approvalGasPrice
     result &= "\napprovalGasFeeMode: " & $self.approvalGasFeeMode
     result &= "\napprovalMaxFeesPerGas: " & $self.approvalMaxFeesPerGas
     result &= "\napprovalBaseFee: " & $self.approvalBaseFee
@@ -314,6 +344,9 @@ QtObject:
 
   proc fromChain*(self: PathItem): int =
     return self.fromChain
+
+  proc fromChainEIP1559Compliant*(self: PathItem): bool =
+    return self.fromChainEIP1559Compliant
 
   proc toChain*(self: PathItem): int =
     return self.toChain
@@ -332,6 +365,12 @@ QtObject:
 
   proc amountOut*(self: PathItem): string =
     return self.amountOut
+
+  proc suggestedNonEIP1559GasPrice*(self: PathItem): string =
+    return self.suggestedNonEIP1559GasPrice
+
+  proc suggestedNonEIP1559EstimatedTime*(self: PathItem): int =
+    return self.suggestedNonEIP1559EstimatedTime
 
   proc suggestedMaxFeesPerGasLowLevel*(self: PathItem): string =
     return self.suggestedMaxFeesPerGasLowLevel
@@ -384,6 +423,9 @@ QtObject:
   proc txNonce*(self: PathItem): string =
     return self.txNonce
 
+  proc txGasPrice*(self: PathItem): string =
+    return self.txGasPrice
+
   proc txGasFeeMode*(self: PathItem): int =
     return self.txGasFeeMode
 
@@ -428,6 +470,9 @@ QtObject:
 
   proc approvalTxNonce*(self: PathItem): string =
     return self.approvalTxNonce
+
+  proc approvalGasPrice*(self: PathItem): string =
+    return self.approvalGasPrice
 
   proc approvalGasFeeMode*(self: PathItem): int =
     return self.approvalGasFeeMode

--- a/src/app/modules/main/wallet_section/send_new/path_item.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_item.nim
@@ -7,6 +7,8 @@ QtObject:
     processorName: string
     fromChain: int
     fromChainEIP1559Compliant: bool
+    fromChainNoBaseFee: bool
+    fromChainNoPriorityFee: bool
     toChain: int
     fromToken: string
     toToken: string
@@ -62,6 +64,8 @@ QtObject:
     processorName: string,
     fromChain: int,
     fromChainEIP1559Compliant: bool,
+    fromChainNoBaseFee: bool,
+    fromChainNoPriorityFee: bool,
     toChain: int,
     fromToken: string,
     toToken: string,
@@ -117,6 +121,8 @@ QtObject:
     self.processorName = processorName
     self.fromChain = fromChain
     self.fromChainEIP1559Compliant = fromChainEIP1559Compliant
+    self.fromChainNoBaseFee = fromChainNoBaseFee
+    self.fromChainNoPriorityFee = fromChainNoPriorityFee
     self.toChain = toChain
     self.fromToken = fromToken
     self.toToken = toToken
@@ -175,6 +181,8 @@ QtObject:
     processorName: string,
     fromChain: int,
     fromChainEIP1559Compliant: bool,
+    fromChainNoBaseFee: bool,
+    fromChainNoPriorityFee: bool,
     toChain: int,
     fromToken: string,
     toToken: string,
@@ -231,6 +239,8 @@ QtObject:
       processorName,
       fromChain,
       fromChainEIP1559Compliant,
+      fromChainNoBaseFee,
+      fromChainNoPriorityFee,
       toChain,
       fromToken,
       toToken,
@@ -287,6 +297,8 @@ QtObject:
     result &= "\nprocessorName: " & $self.processorName
     result &= "\nfromChain: " & $self.fromChain
     result &= "\nfromChainEIP1559Compliant: " & $self.fromChainEIP1559Compliant
+    result &= "\nfromChainNoBaseFee: " & $self.fromChainNoBaseFee
+    result &= "\nfromChainNoPriorityFee: " & $self.fromChainNoPriorityFee
     result &= "\ntoChain: " & $self.toChain
     result &= "\nfromToken: " & $self.fromToken
     result &= "\ntoToken: " & $self.toToken
@@ -347,6 +359,12 @@ QtObject:
 
   proc fromChainEIP1559Compliant*(self: PathItem): bool =
     return self.fromChainEIP1559Compliant
+
+  proc fromChainNoBaseFee*(self: PathItem): bool =
+    return self.fromChainNoBaseFee
+
+  proc fromChainNoPriorityFee*(self: PathItem): bool =
+    return self.fromChainNoPriorityFee
 
   proc toChain*(self: PathItem): int =
     return self.toChain

--- a/src/app/modules/main/wallet_section/send_new/path_model.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_model.nim
@@ -10,6 +10,8 @@ type
     ProcessorName,
     FromChain,
     FromChainEIP1559Compliant,
+    FromChainNoBaseFee,
+    FromChainNoPriorityFee,
     ToChain,
     FromToken,
     ToToken,
@@ -90,6 +92,8 @@ QtObject:
       ModelRole.ProcessorName.int: "processorName",
       ModelRole.FromChain.int: "fromChain",
       ModelRole.FromChainEIP1559Compliant.int: "fromChainEIP1559Compliant",
+      ModelRole.FromChainNoBaseFee.int: "fromChainNoBaseFee",
+      ModelRole.FromChainNoPriorityFee.int: "fromChainNoPriorityFee",
       ModelRole.ToChain.int: "toChain",
       ModelRole.FromToken.int: "fromToken",
       ModelRole.ToToken.int: "toToken",
@@ -167,6 +171,10 @@ QtObject:
       result = newQVariant(item.fromChain)
     of ModelRole.FromChainEIP1559Compliant:
       result = newQVariant(item.fromChainEIP1559Compliant)
+    of ModelRole.FromChainNoBaseFee:
+      result = newQVariant(item.fromChainNoBaseFee)
+    of ModelRole.FromChainNoPriorityFee:
+      result = newQVariant(item.fromChainNoPriorityFee)
     of ModelRole.ToChain:
       result = newQVariant(item.toChain)
     of ModelRole.FromToken:

--- a/src/app/modules/main/wallet_section/send_new/path_model.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_model.nim
@@ -9,12 +9,15 @@ type
     Index = UserRole + 1,
     ProcessorName,
     FromChain,
+    FromChainEIP1559Compliant,
     ToChain,
     FromToken,
     ToToken,
     AmountIn,
     AmountInLocked,
     AmountOut,
+    SuggestedNonEIP1559GasPrice,
+    SuggestedNonEIP1559EstimatedTime,
     SuggestedMaxFeesPerGasLowLevel,
     SuggestedPriorityFeePerGasLowLevel,
     SuggestedEstimatedTimeLowLevel,
@@ -32,6 +35,7 @@ type
     SuggestedApprovalTxNonce,
     SuggestedApprovalGasAmount,
     TxNonce,
+    TxGasPrice,
     TxGasFeeMode,
     TxMaxFeesPerGas,
     TxBaseFee,
@@ -47,6 +51,7 @@ type
     ApprovalAmountRequired,
     ApprovalContractAddress,
     ApprovalTxNonce,
+    ApprovalGasPrice,
     ApprovalGasFeeMode,
     ApprovalMaxFeesPerGas,
     ApprovalBaseFee,
@@ -84,12 +89,15 @@ QtObject:
       ModelRole.Index.int: "index",
       ModelRole.ProcessorName.int: "processorName",
       ModelRole.FromChain.int: "fromChain",
+      ModelRole.FromChainEIP1559Compliant.int: "fromChainEIP1559Compliant",
       ModelRole.ToChain.int: "toChain",
       ModelRole.FromToken.int: "fromToken",
       ModelRole.ToToken.int: "toToken",
       ModelRole.AmountIn.int: "amountIn",
       ModelRole.AmountInLocked.int: "amountInLocked",
       ModelRole.AmountOut.int: "amountOut",
+      ModelRole.SuggestedNonEIP1559GasPrice.int: "suggestedNonEIP1559GasPrice",
+      ModelRole.SuggestedNonEIP1559EstimatedTime.int: "suggestedNonEIP1559EstimatedTime",
       ModelRole.SuggestedMaxFeesPerGasLowLevel.int: "suggestedMaxFeesPerGasLowLevel",
       ModelRole.SuggestedPriorityFeePerGasLowLevel.int: "suggestedPriorityFeePerGasLowLevel",
       ModelRole.SuggestedEstimatedTimeLowLevel.int: "suggestedEstimatedTimeLowLevel",
@@ -107,6 +115,7 @@ QtObject:
       ModelRole.SuggestedApprovalTxNonce.int: "suggestedApprovalTxNonce",
       ModelRole.SuggestedApprovalGasAmount.int: "suggestedApprovalGasAmount",
       ModelRole.TxNonce.int: "txNonce",
+      ModelRole.TxGasPrice.int: "txGasPrice",
       ModelRole.TxGasFeeMode.int: "txGasFeeMode",
       ModelRole.TxMaxFeesPerGas.int: "txMaxFeesPerGas",
       ModelRole.TxBaseFee.int: "txBaseFee",
@@ -122,6 +131,7 @@ QtObject:
       ModelRole.ApprovalAmountRequired.int: "approvalAmountRequired",
       ModelRole.ApprovalContractAddress.int: "approvalContractAddress",
       ModelRole.ApprovalTxNonce.int: "approvalTxNonce",
+      ModelRole.ApprovalGasPrice.int: "approvalGasPrice",
       ModelRole.ApprovalGasFeeMode.int: "approvalGasFeeMode",
       ModelRole.ApprovalMaxFeesPerGas.int: "approvalMaxFeesPerGas",
       ModelRole.ApprovalBaseFee.int: "approvalBaseFee",
@@ -155,6 +165,8 @@ QtObject:
       result = newQVariant(item.processorName)
     of ModelRole.FromChain:
       result = newQVariant(item.fromChain)
+    of ModelRole.FromChainEIP1559Compliant:
+      result = newQVariant(item.fromChainEIP1559Compliant)
     of ModelRole.ToChain:
       result = newQVariant(item.toChain)
     of ModelRole.FromToken:
@@ -167,6 +179,10 @@ QtObject:
       result = newQVariant(item.amountInLocked)
     of ModelRole.AmountOut:
       result = newQVariant(item.amountOut)
+    of ModelRole.SuggestedNonEIP1559GasPrice:
+      result = newQVariant(item.suggestedNonEIP1559GasPrice)
+    of ModelRole.SuggestedNonEIP1559EstimatedTime:
+      result = newQVariant(item.suggestedNonEIP1559EstimatedTime)
     of ModelRole.SuggestedMaxFeesPerGasLowLevel:
       result = newQVariant(item.suggestedMaxFeesPerGasLowLevel)
     of ModelRole.SuggestedPriorityFeePerGasLowLevel:
@@ -201,6 +217,8 @@ QtObject:
       result = newQVariant(item.suggestedApprovalGasAmount)
     of ModelRole.TxNonce:
       result = newQVariant(item.txNonce)
+    of ModelRole.TxGasPrice:
+      result = newQVariant(item.txGasPrice)
     of ModelRole.TxGasFeeMode:
       result = newQVariant(item.txGasFeeMode)
     of ModelRole.TxMaxFeesPerGas:
@@ -231,6 +249,8 @@ QtObject:
       result = newQVariant(item.approvalContractAddress)
     of ModelRole.ApprovalTxNonce:
       result = newQVariant(item.approvalTxNonce)
+    of ModelRole.ApprovalGasPrice:
+      result = newQVariant(item.approvalGasPrice)
     of ModelRole.ApprovalGasFeeMode:
       result = newQVariant(item.approvalGasFeeMode)
     of ModelRole.ApprovalMaxFeesPerGas:

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -101,10 +101,10 @@ QtObject:
     isApprovalTx: bool, communityId: string) {.slot.} =
       self.delegate.setFeeMode(feeMode, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId)
 
-  proc setCustomTxDetails*(self: View, nonce: int, gasAmount: int, maxFeesPerGas: string, priorityFee: string,
+  proc setCustomTxDetails*(self: View, nonce: int, gasAmount: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string,
     routerInputParamsUuid: string, pathName: string, chainId: int, isApprovalTx: bool, communityId: string) {.slot.} =
-      self.delegate.setCustomTxDetails(nonce, gasAmount, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName,
+      self.delegate.setCustomTxDetails(nonce, gasAmount, gasPrice, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName,
         chainId, isApprovalTx, communityId)
 
-  proc getEstimatedTime*(self: View, chainId: int, maxFeesPerGas: string, priorityFee: string): int {.slot.} =
-    return self.delegate.getEstimatedTime(chainId, maxFeesPerGas, priorityFee)
+  proc getEstimatedTime*(self: View, chainId: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string): int {.slot.} =
+    return self.delegate.getEstimatedTime(chainId, gasPrice, maxFeesPerGas, priorityFee)

--- a/src/app_service/service/network/network_item.nim
+++ b/src/app_service/service/network/network_item.nim
@@ -24,6 +24,7 @@ QtObject:
     relatedChainId*: int
     isActive*: bool
     isDeactivatable*: bool
+    eip1559Enabled*: bool
 
   proc setup*(self: NetworkItem,
     chainId: int,
@@ -41,7 +42,8 @@ QtObject:
     isEnabled: bool,
     relatedChainId: int,
     isActive: bool,
-    isDeactivatable: bool
+    isDeactivatable: bool,
+    eip1559Enabled: bool
     ) =
       self.QObject.setup
       self.chainId = chainId
@@ -60,7 +62,7 @@ QtObject:
       self.relatedChainId = relatedChainId
       self.isActive = isActive
       self.isDeactivatable = isDeactivatable
-
+      self.eip1559Enabled = eip1559Enabled
   proc delete*(self: NetworkItem) =
       self.QObject.delete
 
@@ -70,7 +72,7 @@ QtObject:
     result.setup(network.chainId, network.layer, network.chainName, network.iconUrl, network.shortName,
       network.chainColor, rpcProviders,
       network.blockExplorerURL, network.nativeCurrencyName, network.nativeCurrencySymbol, network.nativeCurrencyDecimals,
-      network.isTest, network.isEnabled, network.relatedChainId, network.isActive, network.isDeactivatable)
+      network.isTest, network.isEnabled, network.relatedChainId, network.isActive, network.isDeactivatable, network.eip1559Enabled)
 
   proc networkItemToDto*(network: NetworkItem): NetworkDto =
     result = NetworkDto(
@@ -89,7 +91,8 @@ QtObject:
       shortName: network.shortName,
       relatedChainId: network.relatedChainId,
       isActive: network.isActive,
-      isDeactivatable: network.isDeactivatable
+      isDeactivatable: network.isDeactivatable,
+      eip1559Enabled: network.eip1559Enabled
     )
 
   proc `$`*(self: NetworkItem): string =
@@ -109,7 +112,8 @@ QtObject:
       isEnabled: {self.isEnabled},
       relatedChainId: {self.relatedChainId},
       isActive: {self.isActive},
-      isDeactivatable: {self.isDeactivatable}
+      isDeactivatable: {self.isDeactivatable},
+      eip1559Enabled: {self.eip1559Enabled}
       ]"""
 
   proc chainId*(self: NetworkItem): int {.slot.} =

--- a/src/app_service/service/network/network_item.nim
+++ b/src/app_service/service/network/network_item.nim
@@ -25,6 +25,8 @@ QtObject:
     isActive*: bool
     isDeactivatable*: bool
     eip1559Enabled*: bool
+    noBaseFee*: bool
+    noPriorityFee*: bool
 
   proc setup*(self: NetworkItem,
     chainId: int,
@@ -43,7 +45,9 @@ QtObject:
     relatedChainId: int,
     isActive: bool,
     isDeactivatable: bool,
-    eip1559Enabled: bool
+    eip1559Enabled: bool,
+    noBaseFee: bool,
+    noPriorityFee: bool
     ) =
       self.QObject.setup
       self.chainId = chainId
@@ -63,6 +67,9 @@ QtObject:
       self.isActive = isActive
       self.isDeactivatable = isDeactivatable
       self.eip1559Enabled = eip1559Enabled
+      self.noBaseFee = noBaseFee
+      self.noPriorityFee = noPriorityFee
+
   proc delete*(self: NetworkItem) =
       self.QObject.delete
 
@@ -72,7 +79,8 @@ QtObject:
     result.setup(network.chainId, network.layer, network.chainName, network.iconUrl, network.shortName,
       network.chainColor, rpcProviders,
       network.blockExplorerURL, network.nativeCurrencyName, network.nativeCurrencySymbol, network.nativeCurrencyDecimals,
-      network.isTest, network.isEnabled, network.relatedChainId, network.isActive, network.isDeactivatable, network.eip1559Enabled)
+      network.isTest, network.isEnabled, network.relatedChainId, network.isActive, network.isDeactivatable,
+      network.eip1559Enabled, network.noBaseFee, network.noPriorityFee)
 
   proc networkItemToDto*(network: NetworkItem): NetworkDto =
     result = NetworkDto(
@@ -92,7 +100,9 @@ QtObject:
       relatedChainId: network.relatedChainId,
       isActive: network.isActive,
       isDeactivatable: network.isDeactivatable,
-      eip1559Enabled: network.eip1559Enabled
+      eip1559Enabled: network.eip1559Enabled,
+      noBaseFee: network.noBaseFee,
+      noPriorityFee: network.noPriorityFee
     )
 
   proc `$`*(self: NetworkItem): string =
@@ -113,7 +123,9 @@ QtObject:
       relatedChainId: {self.relatedChainId},
       isActive: {self.isActive},
       isDeactivatable: {self.isDeactivatable},
-      eip1559Enabled: {self.eip1559Enabled}
+      eip1559Enabled: {self.eip1559Enabled},
+      noBaseFee: {self.noBaseFee},
+      noPriorityFee: {self.noPriorityFee}
       ]"""
 
   proc chainId*(self: NetworkItem): int {.slot.} =
@@ -183,7 +195,7 @@ QtObject:
     return self.relatedChainId
   QtProperty[int] relatedChainId:
     read = relatedChainId
-  
+
   proc isActive*(self: NetworkItem): bool {.slot.} =
     return self.isActive
   QtProperty[bool] isActive:

--- a/src/app_service/service/transaction/dtoV2.nim
+++ b/src/app_service/service/transaction/dtoV2.nim
@@ -14,6 +14,11 @@ include  ../../common/json_utils
 import backend/network_types, ../token/dto
 
 type
+  SuggestedNonEIP1559Fees* = ref object
+    gasPrice*: UInt256
+    estimatedTime*: int
+
+type
   SuggestedLevelsForMaxFeesPerGasDto* = ref object
     low*: UInt256
     lowPriority*: UInt256
@@ -37,6 +42,7 @@ type
     amountInLocked*: bool
     amountOut*: UInt256
 
+    suggestedNonEIP1559Fees*: SuggestedNonEIP1559Fees
     suggestedLevelsForMaxFeesPerGas*: SuggestedLevelsForMaxFeesPerGasDto
     maxFeesPerGas*: UInt256
     suggestedMinPriorityFee*: UInt256
@@ -49,6 +55,7 @@ type
     usedContractAddress*: string
 
     txNonce*: UInt256
+    txGasPrice*: UInt256
     txGasFeeMode*: int
     txMaxFeesPerGas*: UInt256
     txBaseFee*: UInt256
@@ -65,6 +72,7 @@ type
     approvalAmountRequired*: UInt256
     approvalContractAddress*: string
     approvalTxNonce*: UInt256
+    approvalGasPrice*: UInt256
     approvalGasFeeMode*: int
     approvalMaxFeesPerGas*: UInt256
     approvalBaseFee*: UInt256
@@ -76,6 +84,13 @@ type
     approvalL1Fee*: UInt256
 
     txTotalFee*: UInt256
+
+proc toSuggestedNonEIP1559Fees*(jsonObj: JsonNode): SuggestedNonEIP1559Fees =
+  result = SuggestedNonEIP1559Fees()
+  var value: string
+  if jsonObj.getProp("gasPrice", value):
+    result.gasPrice = stint.fromHex(UInt256, $value)
+  discard jsonObj.getProp("estimatedTime", result.estimatedTime)
 
 proc toSuggestedLevelsForMaxFeesPerGasDto*(jsonObj: JsonNode): SuggestedLevelsForMaxFeesPerGasDto =
   result = SuggestedLevelsForMaxFeesPerGasDto()
@@ -107,6 +122,7 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   result.amountIn = stint.fromHex(UInt256, jsonObj{"AmountIn"}.getStr)
   discard jsonObj.getProp("AmountInLocked", result.amountInLocked)
   result.amountOut = stint.fromHex(UInt256, jsonObj{"AmountOut"}.getStr)
+  result.suggestedNonEIP1559Fees = jsonObj["SuggestedNonEIP1559Fees"].toSuggestedNonEIP1559Fees()
   result.suggestedLevelsForMaxFeesPerGas = jsonObj["SuggestedLevelsForMaxFeesPerGas"].toSuggestedLevelsForMaxFeesPerGasDto()
   result.maxFeesPerGas = stint.fromHex(UInt256, jsonObj{"MaxFeesPerGas"}.getStr)
   result.suggestedMinPriorityFee = stint.fromHex(UInt256, jsonObj{"SuggestedMinPriorityFee"}.getStr)
@@ -118,6 +134,7 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   discard jsonObj.getProp("SuggestedApprovalGasAmount", result.suggestedApprovalGasAmount)
   discard jsonObj.getProp("UsedContractAddress", result.usedContractAddress)
   result.txNonce = stint.fromHex(UInt256, jsonObj{"TxNonce"}.getStr)
+  result.txGasPrice = stint.fromHex(UInt256, jsonObj{"TxGasPrice"}.getStr)
   discard jsonObj.getProp("TxGasFeeMode", result.txGasFeeMode)
   result.txMaxFeesPerGas = stint.fromHex(UInt256, jsonObj{"TxMaxFeesPerGas"}.getStr)
   result.txBaseFee = stint.fromHex(UInt256, jsonObj{"TxBaseFee"}.getStr)
@@ -132,6 +149,7 @@ proc toTransactionPathDtoV2*(jsonObj: JsonNode): TransactionPathDtoV2 =
   result.approvalAmountRequired = stint.fromHex(UInt256, jsonObj{"ApprovalAmountRequired"}.getStr)
   discard jsonObj.getProp("ApprovalContractAddress", result.approvalContractAddress)
   result.approvalTxNonce = stint.fromHex(UInt256, jsonObj{"ApprovalTxNonce"}.getStr)
+  result.approvalGasPrice = stint.fromHex(UInt256, jsonObj{"ApprovalGasPrice"}.getStr)
   discard jsonObj.getProp("ApprovalGasFeeMode", result.approvalGasFeeMode)
   result.approvalMaxFeesPerGas = stint.fromHex(UInt256, jsonObj{"ApprovalMaxFeesPerGas"}.getStr)
   result.approvalBaseFee = stint.fromHex(UInt256, jsonObj{"ApprovalBaseFee"}.getStr)

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -110,6 +110,7 @@ rpc(getTransactionEstimatedTime, "wallet"):
 
 rpc(getTransactionEstimatedTimeV2, "wallet"):
   chainId: int
+  gasPrice: string
   maxFeePerGas: string
   maxPriorityFeePerGas: string
 

--- a/src/backend/network_types.nim
+++ b/src/backend/network_types.nim
@@ -59,6 +59,7 @@ type NetworkDto* = ref object of RootObj
   relatedChainID* {.serializedFieldName("relatedChainID").}: int
   isActive* {.serializedFieldName("isActive").}: bool
   isDeactivatable* {.serializedFieldName("isDeactivatable").}: bool
+  eip1559Enabled* {.serializedFieldName("eip1559Enabled").}: bool
 
 proc `$`*(self: NetworkDto): string =
   return fmt"""NetworkDto(
@@ -78,7 +79,8 @@ proc `$`*(self: NetworkDto): string =
     shortName:{self.shortName},
     relatedChainId:{self.relatedChainId},
     isActive:{self.isActive},
-    isDeactivatable:{self.isDeactivatable}
+    isDeactivatable:{self.isDeactivatable},
+    eip1559Enabled:{self.eip1559Enabled}
   )"""
 
 proc `%`*(t: NetworkDto): JsonNode {.inline.} =

--- a/src/backend/network_types.nim
+++ b/src/backend/network_types.nim
@@ -60,6 +60,8 @@ type NetworkDto* = ref object of RootObj
   isActive* {.serializedFieldName("isActive").}: bool
   isDeactivatable* {.serializedFieldName("isDeactivatable").}: bool
   eip1559Enabled* {.serializedFieldName("eip1559Enabled").}: bool
+  noBaseFee* {.serializedFieldName("noBaseFee").}: bool
+  noPriorityFee* {.serializedFieldName("noPriorityFee").}: bool
 
 proc `$`*(self: NetworkDto): string =
   return fmt"""NetworkDto(
@@ -80,7 +82,9 @@ proc `$`*(self: NetworkDto): string =
     relatedChainId:{self.relatedChainId},
     isActive:{self.isActive},
     isDeactivatable:{self.isDeactivatable},
-    eip1559Enabled:{self.eip1559Enabled}
+    eip1559Enabled:{self.eip1559Enabled},
+    noBaseFee:{self.noBaseFee},
+    noPriorityFee:{self.noPriorityFee}
   )"""
 
 proc `%`*(t: NetworkDto): JsonNode {.inline.} =

--- a/src/backend/wallet.nim
+++ b/src/backend/wallet.nim
@@ -242,7 +242,7 @@ proc setFeeMode*(feeMode: int, routerInputParamsUuid: string, pathName: string, 
 ## `isApprovalTx` is a flag that indicates if the tx is an approval tx - optional
 ## `communityId` is the id of the community - optional
 ## returns the error message if any, or an empty string
-proc setCustomTxDetails*(nonce: int, gasAmount: int, maxFeesPerGas: string, priorityFee: string,
+proc setCustomTxDetails*(nonce: int, gasAmount: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string,
   routerInputParamsUuid: string, pathName: string, chainId: int, isApprovalTx: bool = false,
   communityId: string = ""): string {.raises: [RpcException].} =
 
@@ -250,6 +250,7 @@ proc setCustomTxDetails*(nonce: int, gasAmount: int, maxFeesPerGas: string, prio
     "gasFeeMode": GasFeeCustom,
     "nonce": nonce,
     "gasAmount": gasAmount,
+    "gasPrice": gasPrice,
     "maxFeesPerGas": maxFeesPerGas,
     "priorityFee": priorityFee,
   }

--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -149,6 +149,9 @@ SplitView {
                     networkBlockExplorerUrl: priv.selectedNetwork.blockExplorerURL
                     networkChainId: priv.selectedNetwork.chainId
 
+                    fromChainEIP1559Compliant: true
+
+                    currentGasPrice: "0"
                     currentBaseFee: "8.2"
                     currentSuggestedMinPriorityFee: "0.06"
                     currentSuggestedMaxPriorityFee: "5.1"
@@ -156,6 +159,7 @@ SplitView {
                     currentNonce: 21
 
                     normalPrice: "1.45 EUR"
+                    normalGasPrice: "0"
                     normalBaseFee: "10000"
                     normalPriorityFee: "1000"
                     normalTime: 60
@@ -168,6 +172,7 @@ SplitView {
                     urgentPriorityFee: "100000"
                     urgentTime: 15
 
+                    customGasPrice: "0"
                     customBaseFee: "10000"
                     customPriorityFee: "1000"
                     customGasAmount: "35000"
@@ -179,7 +184,11 @@ SplitView {
                         return "0.25 USD"
                     }
 
-                    fnGetEstimatedTime: function(baseFeeInWei, priorityFeeInWei) {
+                    fnGetPriceInNativeTokenForFee: function(feeInWei) {
+                        return "0.000123 ETH"
+                    }
+
+                    fnGetEstimatedTime: function(gasPrice, baseFeeInWei, priorityFeeInWei) {
                         return 0
                     }
 

--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -150,6 +150,8 @@ SplitView {
                     networkChainId: priv.selectedNetwork.chainId
 
                     fromChainEIP1559Compliant: true
+                    fromChainNoBaseFee: false
+                    fromChainNoPriorityFee: false
 
                     currentGasPrice: "0"
                     currentBaseFee: "8.2"

--- a/storybook/pages/TransactionSettingsPanelPage.qml
+++ b/storybook/pages/TransactionSettingsPanelPage.qml
@@ -28,6 +28,10 @@ SplitView {
                 id: txSettings
                 anchors.centerIn: parent
 
+                fromChainEIP1559Compliant: true
+                nativeTokenSymbol: "ETH"
+
+                currentGasPrice: "0.0"
                 currentBaseFee: "8.2"
                 currentSuggestedMinPriorityFee: "0.06"
                 currentSuggestedMaxPriorityFee: "5.1"
@@ -41,7 +45,7 @@ SplitView {
                 urgentPrice: "1.85 EUR"
                 urgentTime: "~15s"
 
-                customBaseFee: "6.6"
+                customBaseFeeOrGasPrice: "6.6"
                 customPriorityFee: "7.7"
                 customGasAmount: "35000"
                 customNonce: "22"
@@ -52,7 +56,11 @@ SplitView {
                     return "0.25 USD"
                 }
 
-                fnGetEstimatedTime: function(baseFeeInWei, priorityFeeInWei) {
+                fnGetPriceInNativeTokenForFee: function(feeInWei) {
+                    return "0.000123 ETH"
+                }
+
+                fnGetEstimatedTime: function(gasPrice, baseFeeInWei, priorityFeeInWei) {
                     return 0
                 }
 
@@ -68,7 +76,7 @@ SplitView {
                     logs.logEvent("confirm clicked...")
                     logs.logEvent(`selected fee mode: ${txSettings.selectedFeeMode}`)
                     if (selectedFeeMode === Constants.FeePriorityModeType.Custom) {
-                        logs.logEvent(`selected customBaseFee...${txSettings.customBaseFee}`)
+                        logs.logEvent(`selected customBaseFeeOrGasPrice...${txSettings.customBaseFeeOrGasPrice}`)
                         logs.logEvent(`selected customPriorityFee...${txSettings.customPriorityFee}`)
                         logs.logEvent(`selected customGasAmount...${txSettings.customGasAmount}`)
                         logs.logEvent(`selected customNonce...${txSettings.customNonce}`)

--- a/storybook/pages/TransactionSettingsPanelPage.qml
+++ b/storybook/pages/TransactionSettingsPanelPage.qml
@@ -29,6 +29,8 @@ SplitView {
                 anchors.centerIn: parent
 
                 fromChainEIP1559Compliant: true
+                fromChainNoBaseFee: false
+                fromChainNoPriorityFee: false
                 nativeTokenSymbol: "ETH"
 
                 currentGasPrice: "0.0"

--- a/storybook/qmlTests/tests/tst_SendSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SendSignModal.qml
@@ -47,6 +47,9 @@ Item {
             networkBlockExplorerUrl: "https://etherscan.io/"
             networkChainId: 1
 
+            fromChainEIP1559Compliant: true
+
+            currentGasPrice: "0"
             currentBaseFee: "8.2"
             currentSuggestedMinPriorityFee: "0.06"
             currentSuggestedMaxPriorityFee: "5.1"
@@ -54,6 +57,7 @@ Item {
             currentNonce: 21
 
             normalPrice: "1.45 EUR"
+            normalGasPrice: "0"
             normalBaseFee: "10000"
             normalPriorityFee: "1000"
             normalTime: 60
@@ -66,6 +70,7 @@ Item {
             urgentPriorityFee: "100000"
             urgentTime: 15
 
+            customGasPrice: "0"
             customBaseFee: "10000"
             customPriorityFee: "1000"
             customGasAmount: "35000"
@@ -77,7 +82,11 @@ Item {
                 return "0.25 USD"
             }
 
-            fnGetEstimatedTime: function(baseFeeInWei, priorityFeeInWei) {
+            fnGetPriceInNativeTokenForFee: function(feeInWei) {
+                return "0.000123 ETH"
+            }
+
+            fnGetEstimatedTime: function(gasPrice, baseFeeInWei, priorityFeeInWei) {
                 return 0
             }
 

--- a/storybook/qmlTests/tests/tst_SendSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SendSignModal.qml
@@ -48,6 +48,8 @@ Item {
             networkChainId: 1
 
             fromChainEIP1559Compliant: true
+            fromChainNoBaseFee: false
+            fromChainNoPriorityFee: false
 
             currentGasPrice: "0"
             currentBaseFee: "8.2"

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
@@ -90,6 +90,8 @@ SignTransactionModalBase {
     required property int selectedFeeMode
 
     required property bool fromChainEIP1559Compliant
+    required property bool fromChainNoBaseFee
+    required property bool fromChainNoPriorityFee
 
     required property string currentGasPrice
     required property string currentBaseFee
@@ -275,6 +277,8 @@ SignTransactionModalBase {
         selectedFeeMode: root.selectedFeeMode
 
         fromChainEIP1559Compliant: root.fromChainEIP1559Compliant
+        fromChainNoBaseFee: root.fromChainNoBaseFee
+        fromChainNoPriorityFee: root.fromChainNoPriorityFee
         nativeTokenSymbol: Utils.getNativeTokenSymbol(root.networkChainId)
 
         currentGasPrice: root.currentGasPrice

--- a/ui/app/AppLayouts/Wallet/stores/TransactionStoreNew.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TransactionStoreNew.qml
@@ -31,12 +31,12 @@ QtObject {
         _walletSectionSendInst.setFeeMode(feeMode, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId)
     }
 
-    function setCustomTxDetails(nonce, gasAmount, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId) {
-        _walletSectionSendInst.setCustomTxDetails(nonce, gasAmount, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId)
+    function setCustomTxDetails(nonce, gasAmount, gasPrice, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId) {
+        _walletSectionSendInst.setCustomTxDetails(nonce, gasAmount, gasPrice, maxFeesPerGas, priorityFee, routerInputParamsUuid, pathName, chainId, isApprovalTx, communityId)
     }
 
-    function getEstimatedTime(chainId, baseFeeInWei, priorityFeeInWei) {
-        return _walletSectionSendInst.getEstimatedTime(chainId, baseFeeInWei, priorityFeeInWei)
+    function getEstimatedTime(chainId, gasPrice, baseFeeInWei, priorityFeeInWei) {
+        return _walletSectionSendInst.getEstimatedTime(chainId, gasPrice, baseFeeInWei, priorityFeeInWei)
     }
 
     Component.onCompleted: {

--- a/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionSettings.qml
@@ -21,6 +21,8 @@ Rectangle {
     id: root
 
     required property bool fromChainEIP1559Compliant
+    required property bool fromChainNoBaseFee
+    required property bool fromChainNoPriorityFee
     required property string nativeTokenSymbol
 
     required property string currentGasPrice
@@ -96,6 +98,9 @@ Rectangle {
         }
 
         function recalculatecustomBaseFeeOrGasPricePrice() {
+            if (root.fromChainEIP1559Compliant && root.fromChainNoBaseFee) {
+                return
+            }
             if (!customBaseFeeOrGasPriceInput.text) {
                 customBaseFeeOrGasPriceInput.bottomLabelMessageRightCmp.text = ""
                 return
@@ -106,7 +111,7 @@ Rectangle {
         }
 
         function recalculateCustomPriorityFeePrice() {
-            if (!root.fromChainEIP1559Compliant) {
+            if (!root.fromChainEIP1559Compliant || root.fromChainNoPriorityFee) {
                 return
             }
             if (!customPriorityFeeInput.text) {
@@ -313,6 +318,9 @@ Rectangle {
                         id: customBaseFeeOrGasPriceInput
 
                         readonly property bool displayLowBaseFeeOrGasPriceWarning: {
+                            if (root.fromChainEIP1559Compliant && root.fromChainNoBaseFee) {
+                                return false
+                            }
                             if (!customBaseFeeOrGasPriceInput.text) {
                                 return false
                             }
@@ -325,6 +333,9 @@ Rectangle {
                         }
 
                         readonly property bool displayHighBaseFeeOrGasPriceWarning: {
+                            if (root.fromChainEIP1559Compliant && root.fromChainNoBaseFee) {
+                                return false
+                            }
                             if (!customBaseFeeOrGasPriceInput.text) {
                                 return false
                             }
@@ -338,6 +349,7 @@ Rectangle {
 
                         Layout.preferredWidth: parent.width
                         Layout.topMargin: 20
+                        enabled: !(root.fromChainEIP1559Compliant && root.fromChainNoBaseFee)
                         label: !root.fromChainEIP1559Compliant? qsTr("Gas price") : qsTr("Max base fee")
                         labelIcon: "info"
                         labelIconColor: Theme.palette.baseColor1
@@ -395,6 +407,9 @@ Rectangle {
                         id: customPriorityFeeInput
 
                         readonly property bool displayHigherPriorityFeeWarning: {
+                            if (root.fromChainEIP1559Compliant && root.fromChainNoPriorityFee) {
+                                return false
+                            }
                             if (!customPriorityFeeInput.text) {
                                 return false
                             }
@@ -404,6 +419,9 @@ Rectangle {
                         }
 
                         readonly property bool displayHigherThanBaseFeeWarning: {
+                            if (root.fromChainEIP1559Compliant && root.fromChainNoBaseFee) {
+                                return false
+                            }
                             if (!customPriorityFeeInput.text || !customBaseFeeOrGasPriceInput.text) {
                                 return false
                             }
@@ -414,6 +432,7 @@ Rectangle {
 
                         Layout.preferredWidth: parent.width
                         visible: root.fromChainEIP1559Compliant
+                        enabled: !(root.fromChainEIP1559Compliant && root.fromChainNoPriorityFee)
                         label: qsTr("Priority fee")
                         labelIcon: "info"
                         labelIconColor: Theme.palette.baseColor1

--- a/ui/app/mainui/SendModalHandler.qml
+++ b/ui/app/mainui/SendModalHandler.qml
@@ -854,6 +854,8 @@ QtObject {
                     }
 
                     fromChainEIP1559Compliant: !!txPathUnderReviewEntry.item && txPathUnderReviewEntry.item.fromChainEIP1559Compliant
+                    fromChainNoBaseFee: !!txPathUnderReviewEntry.item && txPathUnderReviewEntry.item.fromChainNoBaseFee
+                    fromChainNoPriorityFee: !!txPathUnderReviewEntry.item && txPathUnderReviewEntry.item.fromChainNoPriorityFee
 
                     currentGasPrice: !!txPathUnderReviewEntry.item? txPathUnderReviewEntry.item.suggestedNonEIP1559GasPrice : ""
                     currentBaseFee: !!txPathUnderReviewEntry.item? txPathUnderReviewEntry.item.currentBaseFee : ""


### PR DESCRIPTION
Corresponding `stautsgo` PR:
- https://github.com/status-im/status-go/pull/6582

Apart from adding custom fee settings for BSC chain-based transactions, this PR solves some bugs that are in the master branch:
- missing bottom left message for the `Max base fee` input field from the custom transaction settings form
- incorrectly calculated fees on the bottom right side for the `Max base fee` and `Priority fee` inputs 
- issue with empty input fields if the user opens the custom transaction settings view, then goes to any other then comes back to the custom view again
- missing explanation message when hovering over fee options