### PR TITLE
fix: StatusMenu padding with qt6

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtQml 2.15
-import QtQuick.Controls 2.15
+import QtQuick.Controls.Universal 2.15
 import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.15
 


### PR DESCRIPTION
### What does the PR do

Adding the Universal style to StatusMenu


Before:

<img width="325" alt="Screenshot 2025-05-22 at 16 33 18" src="https://github.com/user-attachments/assets/454a431d-d493-4cdc-b51a-af9f75082c7b" />


After:

<img width="269" alt="Screenshot 2025-05-22 at 16 34 02" src="https://github.com/user-attachments/assets/0bec88ff-cdd0-4c90-84a8-76a9387c1bc5" />
