### PR TITLE
fix(tokens): fix token holder list not showing the right member

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1422,7 +1422,7 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string, getVerifi
     # contact dto props
     "displayName": contactDetails.dto.displayName,
     "publicKey": contactDetails.dto.id,
-    "compressedPublicKey": accounts_utils.compressPk(contactDetails.dto.id),
+    "compressedPubKey": accounts_utils.compressPk(contactDetails.dto.id),
     "name": contactDetails.dto.name,
     "ensVerified": contactDetails.dto.ensVerified,
     "alias": contactDetails.dto.alias,

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1536,7 +1536,7 @@ method errorLoadingTokenHolders*[T](self: Module[T], communityId: string, chainI
 method onCommunityTokenOwnersFetched*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner]) =
   let item = self.view.model().getItemById(communityId)
   if item.id != "":
-    item.setCommunityTokenOwners(chainId, contractAddress, owners)
+    item.setCommunityTokenOwners(chainId, contractAddress, owners, item.memberRole == MemberRole.Owner)
 
 method onCommunityTokenDeployStateChanged*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string, deployState: DeployState) =
   let item = self.view.model().getItemById(communityId)

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -394,8 +394,8 @@ proc updateBurnState*(self: SectionItem, chainId: int, contractAddress: string, 
 proc updateRemoteDestructedAddresses*(self: SectionItem, chainId: int, contractAddress: string, addresess: seq[string]) {.inline.} =
   self.communityTokensModel.updateRemoteDestructedAddresses(chainId, contractAddress, addresess)
 
-proc setCommunityTokenOwners*(self: SectionItem, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner]) {.inline.} =
-  self.communityTokensModel.setCommunityTokenOwners(chainId, contractAddress, owners)
+proc setCommunityTokenOwners*(self: SectionItem, chainId: int, contractAddress: string, owners: seq[CommunityCollectibleOwner], isOwner: bool) {.inline.} =
+  self.communityTokensModel.setCommunityTokenOwners(chainId, contractAddress, owners, isOwner)
 
 proc setCommunityTokenHoldersLoading*(self: SectionItem, chainId: int, contractAddress: string, value: bool) {.inline.} =
   self.communityTokensModel.setCommunityTokenHoldersLoading(chainId, contractAddress, value)

--- a/storybook/pages/SortableTokenHoldersListPage.qml
+++ b/storybook/pages/SortableTokenHoldersListPage.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.15
 
 import AppLayouts.Communities.panels 1.0
 
+import StatusQ 0.1
 import Storybook 1.0
 import Models 1.0
 
@@ -16,13 +17,15 @@ SplitView {
 
     orientation: Qt.Vertical
 
-    TokenHoldersModel {
-        id: tokenHoldersModel
+    TokenHoldersJoinModel {
+        id: joinModel
     }
 
     Item {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
+
+
 
         SortableTokenHoldersList {
             id: holdersList
@@ -31,7 +34,7 @@ SplitView {
             anchors.margins: 50
 
             model: TokenHoldersProxyModel {
-                sourceModel: tokenHoldersModel
+                sourceModel: joinModel
 
                 sortBy: holdersList.sortBy
                 sortOrder: holdersList.sortOrder ? Qt.DescendingOrder : Qt.AscendingOrder
@@ -48,32 +51,6 @@ SplitView {
         SplitView.preferredHeight: 200
 
         logsView.logText: logs.logText
-
-        RowLayout {
-            Button {
-                text: "Set all remotely burn to completed"
-
-                onClicked: {
-                    for (let i = 0; i < tokenHoldersModel.count; i++) {
-                        tokenHoldersModel.setProperty(
-                                    i, "remotelyDestructState",
-                                    Constants.ContractTransactionStatus.Completed)
-                    }
-                }
-            }
-
-            Button {
-                text: "Set all remotely burn to in progress"
-
-                onClicked: {
-                    for (let i = 0; i < tokenHoldersModel.count; i++) {
-                        tokenHoldersModel.setProperty(
-                                    i, "remotelyDestructState",
-                                    Constants.ContractTransactionStatus.InProgress)
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/storybook/pages/SortableTokenHoldersPanelPage.qml
+++ b/storybook/pages/SortableTokenHoldersPanelPage.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.15
 
 import AppLayouts.Communities.panels 1.0
 
+import StatusQ 0.1
 import Storybook 1.0
 import Models 1.0
 
@@ -33,15 +34,15 @@ SplitView {
             width: 568
             tokenName: "Aniversary"
 
-            TokenHoldersModel {
-                id: tokenHoldersModel
+            TokenHoldersJoinModel {
+                id: joinModel
             }
 
             ListModel {
                 id: emptyModel
             }
 
-            model: emptyCheckBox.checked ? emptyModel : tokenHoldersModel
+            model: emptyCheckBox.checked ? emptyModel : joinModel
             showRemotelyDestructMenuItem: remotelyDestructCheckBox.checked
             isAirdropEnabled: airdropCheckBox.checked
 

--- a/storybook/src/Models/TokenHoldersJoinModel.qml
+++ b/storybook/src/Models/TokenHoldersJoinModel.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.15
+
+import StatusQ 0.1
+
+LeftJoinModel {
+    id: root
+
+    leftModel: RolesRenamingModel {
+        sourceModel: TokenHoldersModel {}
+        mapping: [
+            RoleRename {
+                from: "contactId"
+                to: "pubKey"
+            }
+        ]
+    }
+    rightModel: UsersModel {}
+    joinRole: "pubKey"
+}

--- a/storybook/src/Models/TokenHoldersModel.qml
+++ b/storybook/src/Models/TokenHoldersModel.qml
@@ -61,7 +61,6 @@ ListModel {
             numberOfMessages: 0,
             remotelyDestructState: Constants.ContractTransactionStatus.None
         }
-
     ]
 
     Component.onCompleted: append(data)

--- a/storybook/src/Models/UsersModel.qml
+++ b/storybook/src/Models/UsersModel.qml
@@ -5,7 +5,7 @@ import utils 1.0
 ListModel {
     readonly property var data: [
         {
-            pubKey: "0x043a7ed0e8d1012cf04",
+            pubKey: "0x043a7ed0e8752236a4688563652fd0296453cef00a5dcddbe252dc74f72cc1caa97a2b65e4a1a52d9c30a84c9966beaaaf6b333d659cbdd2e486b443ed1012cf04",
             compressedPubKey: "zQ3shQBu4PRDX17vewYyvSczbTj344viTXxcMNvQLeyQsBDF4",
             onlineStatus: Constants.onlineStatus.online,
             isContact: true,
@@ -32,7 +32,7 @@ ListModel {
             trustStatus: Constants.trustStatus.unknown
         },
         {
-            pubKey: "0x04df12f12f12f12f1234",
+            pubKey: "0x043a8ed0e8752236a4688563652fd0296453cef00a5dcddbe252dc74f72cc1caa97a2b65e4a1a52d9c30a84c9966beaaaf6b333d659cbdd2e486b443ed1012cf04",
             compressedPubKey: "zQ3shQBAAPRDX17vewYyvSczbTj344viTXxcMNvQLeyQsBDF4",
             onlineStatus: Constants.onlineStatus.inactive,
             isContact: false,
@@ -58,7 +58,7 @@ ListModel {
             trustStatus: Constants.trustStatus.unknown
         },
         {
-            pubKey: "0x04d1b7cc0ef3f470f1238",
+            pubKey: "0x043a7ed0e9752236a4688563652fd0296453cef00a5dcddbe252dc74f72cc1caa97a2b65e4a1a52d9c30a84c9966beaaaf6b333d659cbdd2e486b443ed1012cf04",
             compressedPubKey: "zQ3shQ7u3PRDX17vewYyvSczbTj344viTXxcMNvQLeyQsCDF4",
             onlineStatus: Constants.onlineStatus.inactive,
             isContact: false,

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -14,6 +14,7 @@ ManageCollectiblesModel 1.0 ManageCollectiblesModel.qml
 RecipientModel 1.0 RecipientModel.qml
 SourceOfTokensModel 1.0 SourceOfTokensModel.qml
 TokenHoldersModel 1.0 TokenHoldersModel.qml
+TokenHoldersJoinModel 1.0 TokenHoldersJoinModel.qml
 UsersModel 1.0 UsersModel.qml
 WalletSendAccountsModel 1.0 WalletSendAccountsModel.qml
 WalletAccountsModel 1.0 WalletAccountsModel.qml

--- a/ui/StatusQ/src/StatusQ/Components/StatusMemberListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMemberListItem.qml
@@ -89,10 +89,10 @@ ItemDelegate {
     // FIXME: move Constants.onlineStatus from status-desktop
     property int status: 0
     /*!
-       \qmlproperty bool StatusMemberListItem::isAdmin
-       This property holds the admin status of the member represented.
+       \qmlproperty bool StatusMemberListItem::isOwner
+       This property holds the owner status of the member represented.
     */
-    property bool isAdmin: false
+    property bool isOwner: false
 
     /*!
        \qmlproperty bool StatusMemberListItem::isAwaitingAddress
@@ -272,7 +272,7 @@ ItemDelegate {
 
         Loader {
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-            active: root.isAdmin
+            active: root.isOwner
             sourceComponent: StatusIcon {
                 anchors.verticalCenter: parent.verticalCenter
                 icon: "crown"

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -131,7 +131,7 @@ Item {
                 isVerified: model.isVerified
                 isUntrustworthy: model.isUntrustworthy
                 isBlocked: model.isBlocked
-                isAdmin: model.memberRole === Constants.memberRole.owner
+                isOwner: model.memberRole === Constants.memberRole.owner
                 icon.name: model.icon
                 icon.color: Utils.colorForColorId(model.colorId)
                 status: model.onlineStatus

--- a/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
@@ -59,7 +59,7 @@ ItemDelegate {
     */
     property string userName: ""
     /*!
-       \qmlproperty string TokenHolderListItem::compressedPublicKey
+       \qmlproperty string TokenHolderListItem::compressedPubKey
        This property holds the compressed public key of the member represented.
     */
     property string compressedPubKey: ""
@@ -174,11 +174,11 @@ ItemDelegate {
             hoverEnabled: false
             nickName: root.nickName
             userName: root.userName
-            pubKey: root.isEnsVerified ? "" : root.compressedPublicKey
+            pubKey: root.isEnsVerified ? "" : root.compressedPubKey
             isContact: root.isContact
             isVerified: root.trustStatus === Constants.trustStatus.trusted
             isUntrustworthy: root.trustStatus === Constants.trustStatus.untrustworthy
-            isAdmin: root.memberRole === Constants.memberRole.owner
+            isOwner: root.memberRole === Constants.memberRole.owner
             status: root.onlineStatus
             icon.name: root.iconName
             icon.color: Utils.colorForPubkey(root.pubKey)

--- a/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
@@ -27,26 +27,94 @@ ItemDelegate {
     property bool showSeparator: false
     property bool isFirstRowAddress: false
 
-    property string name
-    property string contactId
+    /*!
+       \qmlproperty string TokenHolderListItem::pubKey
+       This property holds the chat public key of the member represented.
+    */
+    property string pubKey
+    /*!
+       \qmlproperty string TokenHolderListItem::walletAddress
+       This property holds the wallet address of the member represented.
+    */
     property string walletAddress
-    property string imageSource
+    /*!
+       \qmlproperty int TokenHolderListItem::numberOfMessages
+        This property holds the number of messages sent by the member represented.
+    */
     property int numberOfMessages: 0
+    /*!
+       \qmlproperty string TokenHolderListItem::amount
+       This property holds the amount of tokens held by the member represented.
+    */
     property string amount: "0"
 
-    property var contactDetails: null
+    /*!
+       \qmlproperty string TokenHolderListItem::nickName
+       This property holds the nick name of the member represented.
+    */
+    property string nickName: ""
+    /*!
+       \qmlproperty string TokenHolderListItem::userName
+       This property holds the user name of the member represented.
+    */
+    property string userName: ""
+    /*!
+       \qmlproperty string TokenHolderListItem::compressedPublicKey
+       This property holds the compressed public key of the member represented.
+    */
+    property string compressedPubKey: ""
+    /*!
+       \qmlproperty bool TokenHolderListItem::isContact
+       This property holds if the member represented is contact.
+    */
+    property bool isContact: false
+    /*!
+       \qmlproperty bool TokenHolderListItem::isVerified
+       This property holds if the member represented is verified contact.
+    */
+    property bool isVerified: false
+    /*!
+       \qmlproperty bool TokenHolderListItem::isEnsVerified
+       This property holds if the member's ENS name was verified.
+    */
+    property bool isEnsVerified: false
+    /*!
+       \qmlproperty int TokenHolderListItem::trustStatus
+     This property holds the trust status of the member represented.
+    */
+    property int trustStatus: 0
+    /*!
+       \qmlproperty int TokenHolderListItem::memberRole
+        This property holds the member role (admin, owner, etc.) of the member represented.
+    */
+    property int memberRole: 0
+    /*!
+       \qmlproperty string TokenHolderListItem::iconName
+        This property holds the icon name of the member represented.
+    */
+    property string iconName
+    /*!
+       \qmlproperty bool TokenHolderListItem::isUntrustworthy
+       This property holds if the member represented is untrustworthy.
+    */
+    property bool isUntrustworthy: false
+
+    /*!
+       \qmlproperty int TokenHolderListItem::status
+       This property holds the connectivity status of the member represented.
+
+    int unknown: -1
+    int inactive: 0
+    int online: 1
+
+    */
+    // FIXME: move Constants.onlineStatus from status-desktop
+    property int onlineStatus: 0
 
     readonly property string addressElided:
         StatusQUtils.Utils.elideAndFormatWalletAddress(root.walletAddress)
 
     signal clicked(var mouse)
-
-    function updateContactDetails() {
-        contactDetails = contactId !== "" ? Utils.getContactDetailsAsJson(contactId, false) : null
-    }
-
-    Component.onCompleted: root.updateContactDetails()
-    onContactIdChanged: root.updateContactDetails()
 
     onRemotelyDestructInProgressChanged: {
         if (!remotelyDestructInProgress)
@@ -104,17 +172,17 @@ ItemDelegate {
             leftPadding: 0
             rightPadding: 0
             hoverEnabled: false
-            nickName: root.contactDetails.localNickname
-            userName: ProfileUtils.displayName("", root.contactDetails.ensName, root.contactDetails.displayName, root.contactDetails.alias)
-            pubKey: root.contactDetails.isEnsVerified ? "" : root.contactDetails.compressedPublicKey
-            isContact: root.contactDetails.isContact
-            isVerified: root.contactDetails.trustStatus === Constants.trustStatus.trusted
-            isUntrustworthy: root.contactDetails.trustStatus === Constants.trustStatus.untrustworthy
-            isAdmin: root.contactDetails.memberRole === Constants.memberRole.owner
-            status: root.contactDetails.onlineStatus
-            icon.name: root.contactDetails.thumbnailImage
-            icon.color: Utils.colorForPubkey(root.contactId)
-            ringSettings.ringSpecModel: Utils.getColorHashAsJson(root.contactId)
+            nickName: root.nickName
+            userName: root.userName
+            pubKey: root.isEnsVerified ? "" : root.compressedPublicKey
+            isContact: root.isContact
+            isVerified: root.trustStatus === Constants.trustStatus.trusted
+            isUntrustworthy: root.trustStatus === Constants.trustStatus.untrustworthy
+            isAdmin: root.memberRole === Constants.memberRole.owner
+            status: root.onlineStatus
+            icon.name: root.iconName
+            icon.color: Utils.colorForPubkey(root.pubKey)
+            ringSettings.ringSpecModel: Utils.getColorHashAsJson(root.pubKey)
         }
     }
 
@@ -131,9 +199,6 @@ ItemDelegate {
             statusListItemSubTitle.font.pixelSize: Theme.asideTextFontSize
             statusListItemSubTitle.lineHeightMode: Text.FixedHeight
             statusListItemSubTitle.lineHeight: 14
-            asset.name: root.imageSource
-            asset.isImage: true
-            asset.isLetterIdenticon: true
             asset.color: Theme.palette.userCustomizationColors[d.red2Color]
         }
     }
@@ -149,13 +214,13 @@ ItemDelegate {
 
             Loader {
                 Layout.preferredWidth: root.usernameHeaderWidth
-                sourceComponent: contactDetails ? communityMemberContentItem : bareAddressContentItem
+                sourceComponent: !!root.pubKey  ? communityMemberContentItem : bareAddressContentItem
             }
 
             TokenHolderNumberCell {
                 Layout.preferredWidth: root.noOfMessagesHeaderWidth
 
-                text: root.name
+                text: root.pubKey
                         ? LocaleUtils.numberToLocaleString(root.numberOfMessages)
                         : "-"
             }

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -602,7 +602,6 @@ StackView {
             token: tokenViewPage.token
             membersModel: tokenViewPage.membersModel
             tokenOwnersModel: tokenViewPage.tokenOwnersModel
-            isOwnerTokenItem: tokenViewPage.isOwnerTokenItem
 
             onStartTokenHoldersManagement: root.startTokenHoldersManagement(chainId, address)
             onStopTokenHoldersManagement: root.stopTokenHoldersManagement()

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersList.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersList.qml
@@ -154,12 +154,18 @@ StatusListView {
 
         remotelyDestructInProgress: model.remotelyDestructState === Constants.ContractTransactionStatus.InProgress
 
-        contactId: model.contactId
-        name: model.name
+        pubKey: model.pubKey
         walletAddress: model.walletAddress
-        imageSource: model.imageSource
         numberOfMessages: model.numberOfMessages
         amount: LocaleUtils.numberToLocaleString(StatusQUtils.AmountsArithmetic.toNumber(model.amount, root.multiplierIndex))
+        nickName: model.localNickname
+        userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
+        compressedPubKey: model.compressedPubKey
+        isContact: model.isContact
+        trustStatus: model.trustStatus
+        memberRole: model.memberRole
+        onlineStatus: model.onlineStatus
+        iconName: model.icon
 
         showSeparator: isFirstRowAddress && root.sortBy === TokenHoldersProxyModel.SortBy.Username
         isFirstRowAddress: {

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -15,7 +15,10 @@ import shared.controls 1.0
 Control {
     id: root
 
-    // Expected roles: name, walletAddress, imageSource, NumberOfMessages, amount
+    // Join of MembersModel and TokenHoldersModel
+    // Expected roles: name, walletAddress, imageSource, NumberOfMessages, amount, pubkey,
+    // isContact, isVerified, isEnsVerified, trustStatus, nickName, userName, compressedPubKey,
+    // memberRole, iconName, isUntrustworthy, onlineStatus
     property var model
 
     property string tokenName
@@ -26,7 +29,7 @@ Control {
     readonly property alias sortBy: holdersList.sortBy
     readonly property alias sorting: holdersList.sortOrder
 
-    readonly property bool empty: countCheckHelper.count === 0
+    readonly property bool empty: !root.model || !root.model.ModelCount || root.model.ModelCount.empty
 
     signal viewProfileRequested(string contactId)
     signal viewMessagesRequested(string contactId)
@@ -36,13 +39,6 @@ Control {
     signal banRequested(string name, string contactId, string address)
 
     signal generalAirdropRequested
-
-    Instantiator {
-        id: countCheckHelper
-
-        model: root.model
-        delegate: QtObject {}
-    }
 
     TokenHoldersProxyModel {
         id: proxyModel
@@ -136,7 +132,7 @@ Control {
 
                 const entry = SQUtils.ModelUtils.get(proxyModel, index)
 
-                menu.contactId = entry.contactId
+                menu.contactId = entry.pubKey
                 menu.name = entry.name
                 menu.currentAddress = entry.walletAddress
                 menu.popup(parent, mouse.x, mouse.y)

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -29,7 +29,7 @@ Control {
     readonly property alias sortBy: holdersList.sortBy
     readonly property alias sorting: holdersList.sortOrder
 
-    readonly property bool empty: !root.model || !root.model.ModelCount || root.model.ModelCount.empty
+    readonly property bool empty: countCheckHelper.count === 0
 
     signal viewProfileRequested(string contactId)
     signal viewMessagesRequested(string contactId)
@@ -39,6 +39,13 @@ Control {
     signal banRequested(string name, string contactId, string address)
 
     signal generalAirdropRequested
+
+    Instantiator {
+        id: countCheckHelper
+
+        model: root.model
+        delegate: QtObject {}
+    }
 
     TokenHoldersProxyModel {
         id: proxyModel

--- a/ui/app/AppLayouts/Communities/panels/TokenHoldersProxyModel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TokenHoldersProxyModel.qml
@@ -1,5 +1,7 @@
 import SortFilterProxyModel 0.2
 
+import StatusQ.Core.Utils 0.1
+
 SortFilterProxyModel {
     id: root
 
@@ -13,15 +15,26 @@ SortFilterProxyModel {
         None, Username, NumberOfMessages, Holding
     }
 
-    filters: ExpressionFilter {
-        expression: {
-            root.searchTextLowerCase
-
-            const nameLowerCase = model.name.toLowerCase()
-            const addressLowerCase = model.walletAddress.toLowerCase()
-
-            return nameLowerCase.includes(searchTextLowerCase) ||
-                    addressLowerCase.includes(searchTextLowerCase)
+    filters: AnyOf {
+        SearchFilter {
+            roleName: "name"
+            searchPhrase: searchText
+        }
+        SearchFilter {
+            roleName: "displayName"
+            searchPhrase: searchText
+        }
+        SearchFilter {
+            roleName: "ensName"
+            searchPhrase: searchText
+        }
+        SearchFilter {
+            roleName: "localNickname"
+            searchPhrase: searchText
+        }
+        SearchFilter {
+            roleName: "walletAddress"
+            searchPhrase: searchText
         }
     }
 
@@ -35,21 +48,49 @@ SortFilterProxyModel {
                 inverted: true
             }
 
-            priority: 3
+            priority: 5
+        },
+
+        RoleSorter {
+            enabled: root.sortBy === TokenHoldersProxyModel.SortBy.Username
+            roleName: "localNickname"
+            sortOrder: root.sortOrder
+            priority: 1
         },
 
         RoleSorter {
             enabled: root.sortBy === TokenHoldersProxyModel.SortBy.Username
             roleName: "name"
             sortOrder: root.sortOrder
+            priority: 1
+        },
+
+        RoleSorter {
+            enabled: root.sortBy === TokenHoldersProxyModel.SortBy.Username
+            roleName: "ensName"
+            sortOrder: root.sortOrder
             priority: 2
+        },
+
+        RoleSorter {
+            enabled: root.sortBy === TokenHoldersProxyModel.SortBy.Username
+            roleName: "displayName"
+            sortOrder: root.sortOrder
+            priority: 3
+        },
+
+        RoleSorter {
+            enabled: root.sortBy === TokenHoldersProxyModel.SortBy.Username
+            roleName: "alias"
+            sortOrder: root.sortOrder
+            priority: 4
         },
 
         RoleSorter {
             enabled: root.sortBy === TokenHoldersProxyModel.SortBy.Username
             roleName: "walletAddress"
             sortOrder: root.sortOrder
-            priority: 1
+            priority: 5
         },
 
         RoleSorter {

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -14,8 +14,6 @@ import shared.panels 1.0
 import AppLayouts.Communities.helpers 1.0
 import AppLayouts.Communities.panels 1.0
 
-import SortFilterProxyModel 0.2
-
 StatusScrollView {
     id: root
 
@@ -108,8 +106,8 @@ StatusScrollView {
         }
 
         readonly property LeftJoinModel joinModel: LeftJoinModel {
-            leftModel: root.membersModel
-            rightModel: d.renamedTokenOwnersModel
+            leftModel: d.renamedTokenOwnersModel
+            rightModel: root.membersModel
 
             joinRole: "pubKey"
         }
@@ -228,7 +226,7 @@ StatusScrollView {
             id: tokenHolderLoader
 
             visible: !root.preview && root.deploymentCompleted
-            sourceComponent: isOwnerTokenItem ? tokenHolderContact : (token.tokenHoldersLoading ? tokenHoldersLoadingComponent : sortableTokenHolderPanel)
+            sourceComponent: token.tokenHoldersLoading ? tokenHoldersLoadingComponent : sortableTokenHolderPanel
         }
 
         Component {
@@ -243,7 +241,7 @@ StatusScrollView {
             id: sortableTokenHolderPanel
 
             SortableTokenHoldersPanel {
-                model: root.tokenOwnersModel
+                model: d.joinModel
                 tokenName: root.name
                 showRemotelyDestructMenuItem: !root.isAssetView && root.remotelyDestruct
                 isAirdropEnabled: root.deploymentCompleted &&
@@ -261,71 +259,6 @@ StatusScrollView {
 
                 onKickRequested: root.kickRequested(name, contactId, address)
                 onBanRequested: root.banRequested(name, contactId, address)
-            }
-        }
-
-        Component {
-            id: tokenHolderContact
-
-            ColumnLayout {
-                Layout.topMargin: Theme.padding
-                Layout.fillWidth: true
-
-                StatusBaseText {
-                    Layout.fillWidth: true
-
-                    wrapMode: Text.Wrap
-                    font.pixelSize: Theme.primaryTextFontSize
-                    color: Theme.palette.baseColor1
-
-                    text: qsTr("%1 token hodler").arg(root.name)
-                }
-
-                StatusInfoBoxPanel {
-                    id: infoBoxPanel
-
-                    Layout.fillWidth: true
-                    Layout.topMargin: Theme.padding
-
-                    enabled: root.deploymentCompleted && (token.infiniteSupply || token.remainingTokens > 0)
-                    visible: d.joinModel.rowCount() === 0
-                    title: qsTr("No hodlers just yet")
-                    text: qsTr("You can Airdrop tokens to deserving Community members or to give individuals token-based permissions.")
-                    buttonText: qsTr("Airdrop")
-
-                    onClicked: root.generalAirdropRequested()
-                }
-
-                StatusListView {
-                    id: tokenOwnerList
-                    objectName: "tokenOwnerList"
-
-                    clip: false
-
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    anchors.bottomMargin: Theme.bigPadding
-                    displayMarginEnd: anchors.bottomMargin
-
-                    model: d.joinModel
-                    delegate: StatusMemberListItem {
-                        color: "transparent"
-                        leftPadding: 0
-                        rightPadding: 0
-                        hoverEnabled: false
-
-                        nickName: model.localNickname
-                        userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
-                        pubKey: model.isEnsVerified ? "" : model.compressedPubKey
-                        isContact: model.isContact
-                        isVerified: model.trustStatus === Constants.trustStatus.trusted
-                        isUntrustworthy: model.trustStatus === Constants.trustStatus.untrustworthy
-                        status: model.onlineStatus
-                        icon.name: model.icon
-                        icon.color: Utils.colorForPubkey(model.pubKey)
-                        ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey)
-                    }
-                }
             }
         }
     }

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -19,7 +19,6 @@ StatusScrollView {
 
     property int viewWidth: 560 // by design
     property bool preview: false
-    property bool isOwnerTokenItem: false
 
     // https://bugreports.qt.io/browse/QTBUG-84269
     /* required */ property TokenObject token

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -26,7 +26,7 @@ ActivityNotificationBase {
         messageText: notification && notification.message ? notification.message.messageText : ""
         amISender: false
         sender.id: contactId
-        sender.compressedPubKey: contactDetails ? contactDetails.compressedPublicKey : ""
+        sender.compressedPubKey: contactDetails ? contactDetails.compressedPubKey : ""
         sender.displayName: contactName
         sender.secondaryName: contactDetails && contactDetails.localNickname ?
                                   ProfileUtils.displayName("", contactDetails.name, contactDetails.displayName, contactDetails.alias) : ""

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -185,7 +185,7 @@ Loader {
 
         const params = {
             pubKey, profileType, contactType, chatType, isAdmin,
-            compressedPubKey: contactDetails.compressedPublicKey,
+            compressedPubKey: contactDetails.compressedPubKey,
             displayName: isReply ? quotedMessageAuthorDetailsDisplayName : root.senderDisplayName,
             userIcon: isReply ? quotedMessageAuthorDetailsThumbnailImage : root.senderIcon,
             colorHash: isReply ? quotedMessageAuthorDetailsColorHash : root.senderColorHash,

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -936,7 +936,7 @@ QtObject {
             colorHash: [],
             displayName: "",
             publicKey: publicKey,
-            compressedPublicKey: "",
+            compressedPubKey: "",
             name: "",
             ensVerified: false,
             alias: "",


### PR DESCRIPTION
### What does the PR do

Fixes #17146

The issue was that we didn't use the LeftJoinModel correctly. The TokenHolderModel should have been on the left.

Then, we often do not have access to the shared address of the members as a TokenMaster, so it would show an empty member. I fixed that by doing a clean up so that we use the normal token list component, which has a mode where it shows the address only if we don't have access to the member's info.

This differs from the design a little but makes the code way cleaner, as we don't need two different components and also I removed the use of `getContactbyIDJson`

Finally, if the Owner is yourself, we also never got the full info, because we do not save our own revealed addresses as an owner.

I implemented a workaround fix to the problem.
The fix here is to simply identify if we got the Owner token holders and if we are the owner, we set the Pubkey to ourselves. This is sufficient to get the full details from the member list during the JoinModel

### Affected areas

Token Holder lists

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

[owner-token.webm](https://github.com/user-attachments/assets/cf127d86-ef67-4de5-9186-4e06efca6a2c)

### Impact on end user

Fixes the Token lists

### How to test

- Open the token lists of different tokens, especially the owner token

### Risk 

Those lists were super broken before, so worst case it's still broken, but as far as I tested, it works way better now. At least now it will show the address of the owner.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
