### PR TITLE
[CHERRY-PICK] ci: update jenkins lib to v1.9.24

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.23'
+library 'status-jenkins-lib@v1.9.24'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.18'
+library 'status-jenkins-lib@v1.9.24'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.18'
+library 'status-jenkins-lib@v1.9.24'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.18'
+library 'status-jenkins-lib@v1.9.24'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.23'
+library 'status-jenkins-lib@v1.9.24'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/17984

Updated jenkins lib contains credentials for Market Data Proxy which will be injected in the desktop builds.

