### PR TITLE
chore(wallet): properly update the list of tokens lists after fetching them from remote

### DIFF
--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -287,6 +287,7 @@ QtObject:
       var tokenBySymbolList: Table[string, TokenBySymbolItem] = initTable[string, TokenBySymbolItem]()
       var tokenSymbols: seq[string] = @[]
 
+      self.sourcesOfTokensList = @[]
       for s in tokenList.data:
         let newSource = SupportedSourcesItem(
           name: s.name,
@@ -378,7 +379,7 @@ QtObject:
           self.rebuildMarketData()
     # update and populate internal list and then emit signal when new custom token detected?
     self.events.on(SignalType.WalletTokensListsUpdated.event) do(e:Args):
-      self.events.emit(SIGNAL_TOKENS_LIST_UPDATED, Args())
+      self.getSupportedTokensList()
 
   proc getCurrency*(self: Service): string =
     return self.settingsService.getCurrency()

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -33,19 +33,17 @@ QtObject {
             expression: sourceImage(model.name)
             expectedRoles: ["name"]
         }
-        filters: AnyOf {
-            ValueFilter {
-                roleName: "name"
-                value: Constants.supportedTokenSources.uniswap
+        filters: FastExpressionFilter {
+            function shouldDisplayList(listName, tokensCount) {
+                return listName !== Constants.supportedTokenSources.nativeList &&
+                        listName !== Constants.supportedTokenSources.custom &&
+                        tokensCount > 0
             }
-            ValueFilter {
-                roleName: "name"
-                value: Constants.supportedTokenSources.aave
+
+            expression: {
+                return shouldDisplayList(model.name, model.tokensCount)
             }
-            ValueFilter {
-                roleName: "name"
-                value: Constants.supportedTokenSources.status
-            }
+            expectedRoles: ["name", "tokensCount"]
         }
     }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -794,6 +794,7 @@ QtObject {
     }
 
     readonly property QtObject supportedTokenSources: QtObject {
+        readonly property string nativeList: "native"
         readonly property string uniswap: "Uniswap Labs Default"
         readonly property string aave: "Aave token list"
         readonly property string status: "Status Token List"


### PR DESCRIPTION
This commit contains changes that align with adding kleros and superchain remote lists on the statusgo side.

Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/6606

For the recording, I've set the refresh interval to 30 seconds.

https://github.com/user-attachments/assets/2e61990e-7b8c-41eb-8c1a-2ded5dea32c5

