### PR TITLE
fix(community): enable archive protocol when CHS is enabled during edit

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -37,6 +37,7 @@ StackLayout {
     required property WalletStore.WalletAssetsStore walletAssetsStore
     required property SharedStores.CurrenciesStore currencyStore
     required property SharedStores.NetworksStore networksStore
+    required property ProfileStores.AdvancedStore advancedStore
     property bool paymentRequestFeatureEnabled
 
     property var mutualContactsModel
@@ -272,6 +273,7 @@ StackLayout {
             activeNetworks: root.networksStore.activeNetworks
             tokensStore: root.tokensStore
             transactionStore: root.transactionStore
+            advancedStore: root.advancedStore
 
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -26,6 +26,7 @@ import AppLayouts.Communities.popups 1.0
 import AppLayouts.Communities.helpers 1.0
 
 import AppLayouts.Chat.stores 1.0 as ChatStores
+import AppLayouts.Profile.stores 1.0 as ProfileStores
 import AppLayouts.Wallet.stores 1.0
 
 StatusSectionLayout {
@@ -39,6 +40,7 @@ StatusSectionLayout {
     property UtilsStore utilsStore
     property var chatCommunitySectionModule
     required property TokensStore tokensStore
+    required property ProfileStores.AdvancedStore advancedStore
     required property var community
     required property var joinedMembers
     required property var bannedMembers
@@ -236,6 +238,7 @@ StatusSectionLayout {
                 }
 
                 onEdited: {
+                    // Step 1: Proceed with community creation
                     const error = root.chatCommunitySectionModule.editCommunity(
                                     StatusQUtils.Utils.filterXSS(item.name),
                                     StatusQUtils.Utils.filterXSS(item.description),
@@ -254,6 +257,12 @@ StatusSectionLayout {
                         errorDialog.text = error.error
                         errorDialog.open()
                     }
+                    // Step 2: Automatically set the archive protocol global property if it's been checked as
+                    // an option during community creation process. It's a more user friendly process
+                    else if(item.options.archiveSupportEnabled) {
+                        root.advancedStore.enableArchiveProtocolProperty()
+                    }
+                    
                 }
 
                 onAirdropTokensClicked: root.goTo(Constants.CommunitySettingsSections.Airdrops)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2236,6 +2236,7 @@ Item {
                                 walletAssetsStore: appMain.walletAssetsStore
                                 currencyStore: appMain.currencyStore
                                 networksStore: appMain.networksStore
+                                advancedStore: appMain.profileSectionStore.advancedStore
                                 paymentRequestFeatureEnabled: featureFlagsStore.paymentRequestEnabled
 
                                 mutualContactsModel: contactsModelAdaptor.mutualContacts


### PR DESCRIPTION
### What does the PR do

Fixes #18004

Apply same procedure as https://github.com/status-im/status-desktop/pull/17767 but for edit.

I tried to see if I could use a common store function for that, but there is no easy way since it's two different function (create vs edit).

### Affected areas

Community Edit

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[edit-comm-chs.webm](https://github.com/user-attachments/assets/b9cd01b4-cf7f-4a52-ac8c-ac865d9e1d16)

### Impact on end user

Fixes the issue

### How to test

- Make sure the AP is disabled
- Turn ON the CHS on a community
- Check the Advanced setting

### Risk 

No risk basically

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

