### PR TITLE
feat: Adding basic main portrait layout

### DIFF
--- a/storybook/pages/StatusSectionLayoutPage.qml
+++ b/storybook/pages/StatusSectionLayoutPage.qml
@@ -99,6 +99,20 @@ Page {
         }
     }
 
+    Page {
+         id: footerItem
+         implicitWidth: 400
+         implicitHeight: 50
+         Rectangle {
+             color: "gray"
+             anchors.fill: parent
+             Label {
+                 text: "Footer Content"
+                 anchors.centerIn: parent
+             }
+         }
+     }
+
     Frame {
         id: wrapper
         width: layoutChooser.currentValue === "portrait" ? 400 : 800
@@ -112,6 +126,7 @@ Page {
             rightPanel: rightPanel
             showRightPanel: rightPanelCheckBox.checked
             navBar: navBarItem
+            footer: footerItem
         }
     }
 }

--- a/storybook/pages/StatusSectionLayoutPage.qml
+++ b/storybook/pages/StatusSectionLayoutPage.qml
@@ -1,0 +1,117 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Layout 0.1
+
+Page {
+    id: root
+
+    header: ToolBar {
+        id: toolbar
+        width: parent.width
+        Flow {
+            anchors.fill: parent
+            spacing: 5
+            ComboBox {
+                id: layoutChooser
+                model: ["landscape", "portrait"]
+                currentIndex: 0
+            }
+            CheckBox {
+                id: leftPanelCheckBox
+                text: "Show Left Panel"
+                checked: true
+            }
+            CheckBox {
+                id: centerPanelCheckBox
+                text: "Show Center Panel"
+                checked: true
+            }
+            CheckBox {
+                id: rightPanelCheckBox
+                text: "Show Right Panel"
+                checked: true
+            }
+            Button {
+                text: "Next Panel"
+                onClicked: sectionLayout.goToNextPanel()
+            }
+        }
+    }
+
+    Page {
+        id: leftPanel
+        objectName: "leftPanel"
+        title: "Left Panel"
+        implicitWidth: 200
+        implicitHeight: 400
+        Rectangle {
+            color: "red"
+            anchors.fill: parent
+        }
+        Label {
+            text: "This is the left panel"
+            anchors.centerIn: parent
+        }
+    }
+
+    Page {
+        id: centerPanel
+        objectName: "centerPanel"
+        title: "Center Panel"
+        implicitWidth: 400
+        implicitHeight: 400
+        Rectangle {
+            color: "blue"
+            anchors.fill: parent
+        }
+        Label {
+            text: "This is the center panel"
+            anchors.centerIn: parent
+        }
+    }
+    Page {
+        id: rightPanel
+        title: "Right Panel"
+        implicitWidth: 200
+        implicitHeight: 400
+        Rectangle {
+            color: "green"
+            anchors.fill: parent
+        }
+        Label {
+            text: "This is the right panel"
+            anchors.centerIn: parent
+        }
+    }
+
+    Page {
+        id: navBarItem
+        implicitWidth: 78
+        Rectangle {
+            color: "yellow"
+            anchors.fill: parent
+            Label {
+                text: "NavBar"
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    Frame {
+        id: wrapper
+        width: layoutChooser.currentValue === "portrait" ? 400 : 800
+        height: layoutChooser.currentValue === "portrait" ? 800 : 400
+        anchors.centerIn: parent
+        contentItem: StatusSectionLayout {
+            id: sectionLayout
+            clip: true
+            leftPanel: leftPanelCheckBox.checked ? leftPanel : null
+            centerPanel: centerPanelCheckBox.checked ? centerPanel : null
+            rightPanel: rightPanel
+            showRightPanel: rightPanelCheckBox.checked
+            navBar: navBarItem
+        }
+    }
+}

--- a/storybook/pages/StatusSectionLayoutPage.qml
+++ b/storybook/pages/StatusSectionLayoutPage.qml
@@ -1,6 +1,6 @@
-import QtQuick
-import QtQuick.Controls
-import QtQuick.Layouts
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Layout 0.1
 
@@ -121,6 +121,8 @@ Page {
         contentItem: StatusSectionLayout {
             id: sectionLayout
             clip: true
+            implicitWidth: 800
+            implicitHeight: 400
             leftPanel: leftPanelCheckBox.checked ? leftPanel : null
             centerPanel: centerPanelCheckBox.checked ? centerPanel : null
             rightPanel: rightPanel

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -27,6 +27,7 @@ Item {
     property var isEnsVerified: function(pubKey) { return false }
 
     signal chatItemSelected(string categoryId, string id)
+    signal chatItemClicked(string id)
     signal chatItemUnmuted(string id)
     signal categoryReordered(string categoryId, int to)
     signal chatItemReordered(string categoryId, string chatId, int to)
@@ -249,6 +250,7 @@ Item {
                             if (!statusChatListItem.selected) {
                                 root.chatItemSelected(statusChatListItem.categoryId, statusChatListItem.chatId)
                             }
+                            root.chatItemClicked(statusChatListItem.chatId)
                         }
 
                         onUnmute: root.chatItemUnmuted(statusChatListItem.chatId)

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -25,6 +25,7 @@ Item {
     property alias popupMenu: popupMenuSlot.sourceComponent
 
     signal chatItemSelected(string categoryId, string id)
+    signal chatItemClicked(string id)
     signal chatItemUnmuted(string id)
     signal chatItemReordered(string categoryId, string chatId, int to)
     signal chatListCategoryReordered(string categoryId, int to)
@@ -48,6 +49,7 @@ Item {
             width: parent.width
             visible: statusChatList.model.count > 0
             onChatItemSelected: root.chatItemSelected(categoryId, id)
+            onChatItemClicked: root.chatItemClicked(id)
             onChatItemUnmuted: root.chatItemUnmuted(id)
             onChatItemReordered: root.chatItemReordered(categoryId, chatId, to)
             onCategoryReordered: root.chatListCategoryReordered(categoryId, to)

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/LayoutChooser.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/LayoutChooser.qml
@@ -1,0 +1,47 @@
+// Copyright (C) 2023 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR GPL-3.0-only
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Window
+import QtQuick.Controls
+
+Item {
+    property var chosenLayout: undefined
+    property list<bool> criteria: []
+    property list<var> layoutChoices: []
+
+    implicitWidth: chosenLayout.implicitWidth
+    implicitHeight: chosenLayout.implicitHeight
+
+    onCriteriaChanged: {
+        showAndHide()
+    }
+
+    onLayoutChoicesChanged: {
+        showAndHide()
+    }
+
+    function showAndHide() {
+        const oldLayout = chosenLayout
+
+        let i = 0
+        for (; i < criteria.length; i++) {
+            if (criteria[i])
+                break
+        }
+
+        if (i < layoutChoices.length)
+            chosenLayout = layoutChoices[i]
+        else if (layoutChoices.length > 0)
+            chosenLayout = layoutChoices[0]
+        else
+            return
+
+        for (i = 0; i < layoutChoices.length; i++) {
+            layoutChoices[i].visible = false
+        }
+        chosenLayout.visible = true
+        chosenLayout.ensurePolished()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayout.qml
@@ -47,8 +47,8 @@ import "./+qt6" as SectionLayout
 
 SectionLayout.LayoutChooser {
     id: root
-    implicitWidth: 822
-    implicitHeight: 600
+    implicitWidth: Window.window.minimumWidth
+    implicitHeight: Window.window.minimumHeight
 
     property Component handle: Item { }
 

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayout.qml
@@ -1,0 +1,206 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+
+// TODO: Remove this once qt5 is dropped
+import "./+qt6" as SectionLayout
+
+/*!
+     \qmltype StatusSectionLayout
+     \inherits LayoutChooser
+     \inqmlmodule StatusQ.Layout
+     \since StatusQ.Layout 0.1
+     \brief Displays a three column layout in landscape mode or a three views swipeview in portrait mode, with a header in the central panel.
+     Inherits \l{https://doc.qt.io/qt-6/qml-qtquick-controls2-splitview.html}{SplitView}.
+
+     The \c StatusSectionLayout displays a three column layout in landscape mode or a three views swipeview in portrait mode, with a header in the central panel to be used as the base layout of all application
+     sections.
+     For example:
+
+     \qml
+    StatusSectionLayout {
+        id: root
+
+        notificationCount: 1
+        onNotificationButtonClicked: { showActivityCenter(); }
+
+        headerContent: RowLayout {
+            ...
+        }
+
+        leftPanel: Item {
+            ...
+        }
+
+        centerPanel: Item {
+            ...
+        }
+
+        rightPanel: Item {
+            ...
+        }
+     }
+     \endqml
+
+     For a list of components available see StatusQ.
+*/
+
+SectionLayout.LayoutChooser {
+    id: root
+    implicitWidth: 822
+    implicitHeight: 600
+
+    property Component handle: Item { }
+
+    /*!
+        \qmlproperty Item StatusSectionLayout::leftPanel
+        This property holds the left panel of the component.
+    */
+    property Item leftPanel
+    /*!
+        \qmlproperty Item StatusSectionLayout::centerPanel
+        This property holds the center panel of the component.
+    */
+    property Item centerPanel
+    /*!
+        \qmlproperty Component StatusSectionLayout::rightPanel
+        This property holds the right panel of the component.
+    */
+    property Item rightPanel
+    /*!
+        \qmlproperty Item StatusSectionLayout::navBar
+        This property holds the navigation bar of the component. Usually displayed next to the leftPanel.
+    */
+    property Item navBar
+    /*!
+        \qmlproperty Item StatusSectionLayout::footer
+        This property holds the footer of the component.
+    */
+    property Item footer
+    /*!
+        \qmlproperty Component StatusAppLayout::headerBackground
+        This property holds the headerBackground of the component.
+    */
+    property Item headerBackground
+    /*!
+        \qmlproperty bool StatusSectionLayout::showRightPanel
+        This property sets the right panel component's visibility to true/false.
+        Default value is false.
+    */
+    property bool showRightPanel: false
+
+    /*!
+        \qmlproperty int StatusSectionLayout::rightPanelWidth
+        This property sets the right panel component's width.
+        Default value is 250.
+    */
+    property int rightPanelWidth: 250
+    /*!
+        \qmlproperty bool StatusSectionLayout::showHeader
+        This property sets the header component's visibility to true/false.
+        Default value is true.
+    */
+    property bool showHeader: true
+
+    /*!
+        \qmlproperty int StatusSectionLayout::notificationCount
+        This property holds a reference to the notificationCount property of the
+        header component.
+    */
+    property int notificationCount
+
+    /*!
+        \qmlproperty bool StatusSectionLayout::hasUnseenNotifications
+        This property holds a reference to the hasUnseenNotifications property of the
+        header component.
+    */
+    property bool hasUnseenNotifications
+
+    /*!
+        \qmlproperty string StatusSectionLayout::backButtonName
+        This property holds a reference to the backButtonName property of the
+        header component.
+    */
+    property string backButtonName
+
+    /*!
+        \qmlproperty Item StatusSectionLayout::headerContent
+        This property holds a reference to the custom header content of
+        the header component.
+    */
+    property Item headerContent
+    /*!
+        \qmlproperty Item StatusSectionLayout::notificationButton
+        This property holds a reference to the notification button of the header
+        component.
+    */
+    property Item notificationButton
+
+    /*!
+        \qmlsignal
+        This signal is emitted when the back button of the header component
+        is pressed.
+    */
+
+    signal backButtonClicked()
+
+    /*!
+        \qmlsignal
+        This signal is emitted when the notification button of the header component
+        is pressed.
+    */
+    signal notificationButtonClicked()
+    /*!
+        \qmlmethod StatusSectionLayout::goToNextPanel()
+        This method is used to focus the panel that needs to be active.
+    */
+    function goToNextPanel() {
+        if (portraitView.visible)
+            portraitView.currentIndex = portraitView.currentIndex + 1;
+    }
+
+    criteria: [
+        root.height > root.width && root.width < root.implicitWidth, // Portrait mode
+        true // Defaults to landscape mode
+    ]
+
+    layoutChoices: [
+        portraitView,
+        landscapeView
+    ]
+
+    SectionLayout.StatusSectionLayoutLandscape {
+        id: landscapeView
+        anchors.fill: parent
+        handle: root.handle
+        leftPanel: root.leftPanel
+        centerPanel: root.centerPanel
+        rightPanel: root.rightPanel
+        navBar: root.navBar
+        footer: root.footer
+        headerBackground: root.headerBackground
+        showRightPanel: root.showRightPanel
+        rightPanelWidth: root.rightPanelWidth
+        showHeader: root.showHeader
+
+        onNotificationButtonClicked: root.notificationButtonClicked()
+        onBackButtonClicked: root.backButtonClicked()
+    }
+
+    SectionLayout.StatusSectionLayoutPortrait {
+        id: portraitView
+        anchors.fill: parent
+        leftPanel: root.leftPanel
+        centerPanel: root.centerPanel
+        rightPanel: root.rightPanel
+        navBar: root.navBar
+        footer: root.footer
+        headerBackground: root.headerBackground
+        showRightPanel: root.showRightPanel
+        rightPanelWidth: root.rightPanelWidth
+        showHeader: root.showHeader
+
+        onNotificationButtonClicked: root.notificationButtonClicked()
+        onBackButtonClicked: root.backButtonClicked()
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
@@ -211,12 +211,12 @@ SplitView {
                 anchors.bottomMargin: footerSlot.visible ? 8 : 0
                 target: root.centerPanel
             }
-            Item {
+            LayoutItemProxy {
                 id: footerSlot
                 width: parent.width
-                height: visible ? childrenRect.height : 0
+                height: root.footer ? root.footer.height : 0
                 anchors.bottom: parent.bottom
-                visible: (!!footer)
+                target: root.footer
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
@@ -1,23 +1,23 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.14
-import QtQuick.Controls 2.13
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 /*!
-     \qmltype StatusSectionLayout
+     \qmltype StatusSectionLayoutLandscape
      \inherits SplitView
      \inqmlmodule StatusQ.Layout
      \since StatusQ.Layout 0.1
      \brief Displays a three column layout with a header in the central panel.
      Inherits \l{https://doc.qt.io/qt-6/qml-qtquick-controls2-splitview.html}{SplitView}.
 
-     The \c StatusSectionLayout displays a three column layout with a header in the central panel to be used as the base layout of all application
+     The \c StatusSectionLayoutLandscape displays a three column layout with a header in the central panel to be used as the base layout of all application
      sections.
      For example:
 
      \qml
-    StatusSectionLayout {
+    StatusSectionLayoutLandscape {
         id: root
 
         notificationCount: 1
@@ -62,10 +62,10 @@ SplitView {
     */
     property Item centerPanel
     /*!
-        \qmlproperty Component StatusSectionLayout::rightPanel
+        \qmlproperty Item StatusSectionLayout::rightPanel
         This property holds the right panel of the component.
     */
-    property Component rightPanel
+    property Item rightPanel
     /*!
         \qmlproperty Item StatusSectionLayout::navBar
         This property holds the navigation bar of the component. Usually displayed next to the leftPanel.
@@ -149,31 +149,6 @@ SplitView {
         is pressed.
     */
     signal notificationButtonClicked()
-    /*!
-        \qmlmethod StatusSectionLayout::goToNextPanel()
-        This method is used to focus the panel that needs to be active.
-    */
-    function goToNextPanel() {
-        // Placeholder to align with qt6 StatusSectionLayout
-    }
-
-    onCenterPanelChanged: {
-        if (!!centerPanel) {
-            centerPanel.parent = centerPanelSlot;
-        }
-    }
-
-    onFooterChanged: {
-        if (!!footer) {
-            footer.parent = footerSlot
-        }
-    }
-
-    onHeaderBackgroundChanged:  {
-        if (!!headerBackground) {
-            headerBackground.parent = headerBackgroundSlot
-        }
-    }
 
     Control {
         id: navBarControl
@@ -182,12 +157,8 @@ SplitView {
         background: Rectangle {
             color: Theme.palette.baseColor4
         }
-        contentItem: root.navBar
-        Binding {
-            when: (!!navBar) && root.visible
+        contentItem: LayoutItemProxy {
             target: root.navBar
-            property: "parent"
-            value: navBarControl
         }
     }
 
@@ -198,7 +169,9 @@ SplitView {
         background: Rectangle {
             color: Theme.palette.baseColor4
         }
-        contentItem: (!!leftPanel) ? leftPanel : null
+        contentItem: LayoutItemProxy {
+            target: root.leftPanel
+        }
     }
 
     Control {
@@ -230,12 +203,13 @@ SplitView {
                     root.notificationButtonClicked();
                 }
             }
-            Item {
-                id: centerPanelSlot
+            LayoutItemProxy {
+                id: centerPanelProxy
                 width: parent.width
                 anchors.top: statusToolBar.bottom
                 anchors.bottom: footerSlot.top
                 anchors.bottomMargin: footerSlot.visible ? 8 : 0
+                target: root.centerPanel
             }
             Item {
                 id: footerSlot
@@ -255,8 +229,8 @@ SplitView {
         background: Rectangle {
             color: Theme.palette.baseColor4
         }
-        contentItem: Loader {
-            sourceComponent: (!!rightPanel) ? rightPanel : null
+        contentItem: LayoutItemProxy {
+            target: root.rightPanel
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
@@ -163,6 +163,8 @@ SwipeView {
             color: backgroundColor || Theme.palette.statusAppLayout.rightPanelBackgroundColor
         }
         onInViewChanged: {
+            // If the panel is not in view, we need to remove it from the swipe view
+            // and add it to the cache wrapper items so that we can restore it later if needed.
             if (!inView && !!parent) {
                 d.items.push(root.takeItem(baseProxyPanel.implicitIndex));
             } else if (inView && !parent) {

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
@@ -226,6 +226,8 @@ SwipeView {
             LayoutItemProxy {
                 id: footerProxy
                 Layout.fillWidth: true
+                Layout.preferredHeight: footer ? footer.implicitHeight : 0
+                Layout.alignment: Qt.AlignBottom
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Layout/StatusMainLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusMainLayout.qml
@@ -58,6 +58,7 @@ SplitView {
         SplitView.preferredWidth: !!leftPanel && leftPanel.visible ? leftPanel.width : 0
         SplitView.fillHeight: true
         background: null
+        visible: (!!leftPanel)
         contentItem: (!!leftPanel) ? leftPanel : null
     }
 

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -231,6 +231,10 @@
         <file>StatusQ/Layout/StatusMainLayout.qml</file>
         <file>StatusQ/Layout/StatusSectionLayout.qml</file>
         <file>StatusQ/Layout/qmldir</file>
+        <file>StatusQ/Layout/+qt6/StatusSectionLayout.qml</file>
+        <file>StatusQ/Layout/+qt6/LayoutChooser.qml</file>
+        <file>StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml</file>
+        <file>StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml</file>
         <file>StatusQ/Platform/StatusMacNotification.qml</file>
         <file>StatusQ/Platform/StatusMacTrafficLights.qml</file>
         <file>StatusQ/Platform/StatusWindowsTitleBar.qml</file>

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -37,6 +37,7 @@ StackLayout {
     required property SharedStores.NetworksStore networksStore
     required property ProfileStores.AdvancedStore advancedStore
     property bool paymentRequestFeatureEnabled
+    property Item navBar
 
     property var mutualContactsModel
     property var sectionItemModel
@@ -126,6 +127,7 @@ StackLayout {
         JoinCommunityView {
             id: joinCommunityView
             readonly property string communityId: sectionItemModel.id
+            navBar: root.navBar
             name: sectionItemModel.name
             introMessage: sectionItemModel.introMessage
             communityDesc: sectionItemModel.description
@@ -173,6 +175,7 @@ StackLayout {
             readonly property string communityId: root.sectionItemModel.id
 
             objectName: "chatViewComponent"
+            navBar: root.navBar
 
             contactsStore: root.contactsStore
             rootStore: root.rootStore
@@ -291,6 +294,7 @@ StackLayout {
 
         sourceComponent: CommunitySettingsView {
             id: communitySettingsView
+            navBar: root.navBar
 
             rootStore: root.rootStore
             walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
@@ -322,6 +326,7 @@ StackLayout {
         id: controlNodeOfflineComponent
         ControlNodeOfflineCommunityView {
             id: controlNodeOfflineView
+            navBar: root.navBar
             name: root.sectionItemModel.name
             communityDesc: root.sectionItemModel.description
             color: root.sectionItemModel.color
@@ -340,6 +345,7 @@ StackLayout {
         BannedMemberCommunityView {
             id: communityBanView
             readonly property var communityData: sectionItemModel
+            navBar: root.navBar
             name: root.sectionItemModel.name
             communityDesc: root.sectionItemModel.description
             color: root.sectionItemModel.color

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -195,44 +195,41 @@ StatusSectionLayout {
         return root.chatContentModule.chatDetails.isUsersListAvailable
     }
 
-    rightPanel: Component {
-        id: userListComponent
-        UserListPanel {
-            anchors.fill: parent
+    rightPanel: UserListPanel {
+        anchors.fill: parent
 
-            chatType: root.chatContentModule.chatDetails.type
-            isAdmin: root.chatContentModule.amIChatAdmin()
+        chatType: root.chatContentModule.chatDetails.type
+        isAdmin: root.chatContentModule.amIChatAdmin()
 
-            label: qsTr("Members")
-            communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
+        label: qsTr("Members")
+        communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
 
-            usersModel: root.usersModel
+        usersModel: root.usersModel
 
-            onOpenProfileRequested: Global.openProfilePopup(pubKey, null)
-            onReviewContactRequestRequested: Global.openReviewContactRequestPopup(pubKey, null)
-            onSendContactRequestRequested: Global.openContactRequestPopup(pubKey, null)
-            onEditNicknameRequested: Global.openNicknamePopupRequested(pubKey, null)
-            onBlockContactRequested: Global.blockContactRequested(pubKey)
-            onUnblockContactRequested: Global.unblockContactRequested(pubKey)
-            onMarkAsUntrustedRequested: Global.markAsUntrustedRequested(pubKey)
-            onRemoveContactRequested: Global.removeContactRequested(pubKey)
+        onOpenProfileRequested: Global.openProfilePopup(pubKey, null)
+        onReviewContactRequestRequested: Global.openReviewContactRequestPopup(pubKey, null)
+        onSendContactRequestRequested: Global.openContactRequestPopup(pubKey, null)
+        onEditNicknameRequested: Global.openNicknamePopupRequested(pubKey, null)
+        onBlockContactRequested: Global.blockContactRequested(pubKey)
+        onUnblockContactRequested: Global.unblockContactRequested(pubKey)
+        onMarkAsUntrustedRequested: Global.markAsUntrustedRequested(pubKey)
+        onRemoveContactRequested: Global.removeContactRequested(pubKey)
 
-            onRemoveNicknameRequested: {
-                const oldName = ModelUtils.getByKey(usersModel, "pubKey", pubKey, "localNickname")
-                root.contactsStore.changeContactNickname(pubKey, "", oldName, true)
-            }
-
-            onCreateOneToOneChatRequested: {
-                Global.changeAppSectionBySectionType(Constants.appSection.chat)
-                root.rootStore.chatCommunitySectionModule.createOneToOneChat("", pubKey, "")
-            }
-
-            onRemoveTrustStatusRequested: root.contactsStore.removeTrustStatus(pubKey)
-            onRemoveContactFromGroupRequested: root.rootStore.removeMemberFromGroupChat(pubKey)
-
-            onMarkAsTrustedRequested: Global.openMarkAsIDVerifiedPopup(pubKey, null)
-            onRemoveTrustedMarkRequested: Global.openRemoveIDVerificationDialog(pubKey, null)
+        onRemoveNicknameRequested: {
+            const oldName = ModelUtils.getByKey(usersModel, "pubKey", pubKey, "localNickname")
+            root.contactsStore.changeContactNickname(pubKey, "", oldName, true)
         }
+
+        onCreateOneToOneChatRequested: {
+            Global.changeAppSectionBySectionType(Constants.appSection.chat)
+            root.rootStore.chatCommunitySectionModule.createOneToOneChat("", pubKey, "")
+        }
+
+        onRemoveTrustStatusRequested: root.contactsStore.removeTrustStatus(pubKey)
+        onRemoveContactFromGroupRequested: root.rootStore.removeMemberFromGroupChat(pubKey)
+
+        onMarkAsTrustedRequested: Global.openMarkAsIDVerifiedPopup(pubKey, null)
+        onRemoveTrustedMarkRequested: Global.openRemoveIDVerificationDialog(pubKey, null)
     }
 
     Component {
@@ -359,6 +356,7 @@ StatusSectionLayout {
                     headerContentLoader.item.addRemoveGroupMember()
                 }
             }
+            onChatItemClicked: (id) => root.goToNextPanel()
         }
     }
 
@@ -377,6 +375,7 @@ StatusSectionLayout {
             onInfoButtonClicked: root.communityInfoButtonClicked()
             onManageButtonClicked: root.communityManageButtonClicked()
             onFinaliseOwnershipClicked: root.finaliseOwnershipClicked()
+            onChatItemClicked: (id) => root.goToNextPanel()
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -40,6 +40,7 @@ Item {
     signal openProfileClicked()
     signal openAppSearch()
     signal addRemoveGroupMemberClicked()
+    signal chatItemClicked(string id)
 
     // main layout
     ColumnLayout {
@@ -136,6 +137,9 @@ Item {
                 onChatItemSelected: {
                     Global.closeCreateChatView()
                     root.chatSectionModule.setActiveItem(id, "")
+                }
+                onChatItemClicked: (id) => {
+                    root.chatItemClicked(id)
                 }
                 onChatItemUnmuted: root.chatSectionModule.unmuteChat(id)
 

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -59,6 +59,7 @@ Item {
 
     signal infoButtonClicked
     signal manageButtonClicked
+    signal chatItemClicked(string id)
 
     QtObject {
         id: d
@@ -188,6 +189,9 @@ Item {
             onChatItemSelected: {
                 Global.closeCreateChatView()
                 root.communitySectionModule.setActiveItem(id)
+            }
+            onChatItemClicked: (id) => {
+                root.chatItemClicked(id)
             }
 
             showCategoryActionButtons: root.isSectionAdmin

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -142,6 +142,7 @@ StatusSectionLayout {
                 event.accepted = true;
                 profileContainer.currentItem.notifyDirty();
             }
+            root.goToNextPanel();
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -28,6 +28,8 @@ import "popups/buy"
 Item {
     id: root
 
+    property Item navBar
+
     property SharedStores.RootStore sharedRootStore
     property AppLayoutsStores.RootStore store
     property ProfileStores.ContactsStore contactsStore
@@ -274,6 +276,8 @@ Item {
     }
 
     StatusSectionLayout {
+        id: walletSectionLayout
+        navBar: root.navBar
         anchors.top: seedPhraseWarning.bottom
         height: root.height - seedPhraseWarning.height
         width: root.width
@@ -294,9 +298,11 @@ Item {
             isKeycardEnabled: root.isKeycardEnabled
 
             changeSelectedAccount: function(address) {
+                walletSectionLayout.goToNextPanel()
                 d.displayAddress(address)
             }
             selectAllAccounts: function() {
+                walletSectionLayout.goToNextPanel()
                 d.displayAllAddresses()
             }
             selectSavedAddresses: function() {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -342,7 +342,7 @@ Item {
 
             visible: anyActionAvailable
             width: parent.width
-            height: visible ? 61: implicitHeight
+            height: visible ? implicitHeight: 0
             walletStore: RootStore
             transactionStore: root.transactionStore
             swapEnabled: root.swapEnabled

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -35,12 +35,15 @@ Rectangle {
     required property bool isCommunityOwnershipTransfer
     property string communityName: ""
 
+    property real widthBreakpoint: 600 // Width at which the buttons will be displayed in a single row, with no text
+
     signal launchShareAddressModal()
     signal launchSendModal(string fromAddress)
     signal launchBridgeModal()
     signal launchSwapModal()
     signal launchBuyCryptoModal()
 
+    implicitHeight: 61
     color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
 
     QtObject {
@@ -107,6 +110,7 @@ Rectangle {
 
     RowLayout {
         id: layout
+        readonly property bool showText: root.width >= root.widthBreakpoint
         anchors.centerIn: parent
         height: parent.height
         width: Math.min(root.width, implicitWidth)
@@ -126,6 +130,7 @@ Rectangle {
             }
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be sent to another wallet") : networkConnectionStore.sendBuyBridgeToolTipText
             visible: d.sendActionAvailable
+            display: layout.showText ? StatusFlatButton.TextBesideIcon : StatusFlatButton.IconOnly
         }
 
         StatusFlatButton {
@@ -137,6 +142,7 @@ Rectangle {
                 root.transactionStore.setReceiverAccount(root.walletStore.selectedAddress)
                 launchShareAddressModal()
             }
+            display: layout.showText ? StatusFlatButton.TextBesideIcon : StatusFlatButton.IconOnly
         }
 
         StatusFlatButton {
@@ -147,6 +153,7 @@ Rectangle {
             onClicked: root.launchBridgeModal()
             tooltip.text: d.isCollectibleSoulbound ? qsTr("Soulbound collectibles cannot be bridged to another wallet") :  networkConnectionStore.sendBuyBridgeToolTipText
             visible: d.bridgeActionAvailable
+            display: layout.showText ? StatusFlatButton.TextBesideIcon : StatusFlatButton.IconOnly
         }
 
         StatusFlatButton {
@@ -157,6 +164,7 @@ Rectangle {
             icon.name: "token"
             text: qsTr("Buy")
             onClicked: root.launchBuyCryptoModal()
+            display: layout.showText ? StatusFlatButton.TextBesideIcon : StatusFlatButton.IconOnly
         }
 
         StatusFlatButton {
@@ -169,6 +177,7 @@ Rectangle {
             icon.name: "swap"
             text: qsTr("Swap")
             onClicked: root.launchSwapModal()
+            display: layout.showText ? StatusFlatButton.TextBesideIcon : StatusFlatButton.IconOnly
         }
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1146,259 +1146,259 @@ Item {
             onBuyClicked: popupRequestsHandler.sendModalHandler.buyStickerPack(packId, price)
         }
     }
+    
+    property Item navBar: StatusAppNavBar {
+        visible: !shellLoader.active
+        width: visible ? implicitWidth : 0
 
-    StatusMainLayout {
-        anchors.fill: parent
-
-        leftPanel: StatusAppNavBar {
-            visible: !shellLoader.active
-            width: visible ? implicitWidth : 0
-
-            topSectionModel: SortFilterProxyModel {
-                sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
-                filters: [
-                    AnyOf {
-                        ValueFilter {
-                            roleName: "sectionType"
-                            value: Constants.appSection.shell
-                        }
-                        ValueFilter {
-                            roleName: "sectionType"
-                            value: Constants.appSection.wallet
-                        }
-                        ValueFilter {
-                            roleName: "sectionType"
-                            value: Constants.appSection.swap
-                            enabled: !appMain.featureFlagsStore.marketEnabled
-                        }
-                        ValueFilter {
-                            roleName: "sectionType"
-                            value: Constants.appSection.market
-                            enabled: appMain.featureFlagsStore.marketEnabled
-                        }
-                        ValueFilter {
-                            roleName: "sectionType"
-                            value: Constants.appSection.chat
-                        }
-                    },
-                    ValueFilter {
-                        roleName: "enabled"
-                        value: true
-                    }
-                ]
-            }
-            topSectionDelegate: navbarButton
-
-            communityItemsModel: SortFilterProxyModel {
-                sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
-                filters: [
+        topSectionModel: SortFilterProxyModel {
+            sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
+            filters: [
+                AnyOf {
                     ValueFilter {
                         roleName: "sectionType"
-                        value: Constants.appSection.community
-                    },
+                        value: Constants.appSection.shell
+                    }
                     ValueFilter {
-                        roleName: "enabled"
-                        value: true
-                    }
-                ]
-            }
-            communityItemDelegate: StatusNavBarTabButton {
-                objectName: "CommunityNavBarButton"
-                anchors.horizontalCenter: parent.horizontalCenter
-                name: model.icon.length > 0? "" : model.name
-                icon.name: model.icon
-                icon.source: model.image
-                identicon.asset.color: (hovered || identicon.highlighted || checked) ? model.color : icon.color
-                tooltip.text: model.name
-                checked: model.active
-                badge.value: model.notificationsCount
-                badge.visible: model.hasNotification
-
-                stateIcon.color: Theme.palette.dangerColor1
-                stateIcon.border.color: Theme.palette.baseColor2
-                stateIcon.border.width: 2
-                stateIcon.visible: model.amIBanned
-                stateIcon.asset.name: "cancel"
-                stateIcon.asset.color: Theme.palette.baseColor2
-                stateIcon.asset.width: 14
-
-                onClicked: {
-                    changeAppSectionBySectionId(model.id)
-                }
-
-                popupMenu: Component {
-                    StatusMenu {
-                        id: communityContextMenu
-                        property var chatCommunitySectionModule
-
-                        readonly property bool isSpectator: model.spectated && !model.joined
-
-                        openHandler: function () {
-                            // we cannot return QVariant if we pass another parameter in a function call
-                            // that's why we're using it this way
-                            appMain.rootStore.mainModuleInst.prepareCommunitySectionModuleForCommunityId(model.id)
-                            communityContextMenu.chatCommunitySectionModule = appMain.rootStore.mainModuleInst.getCommunitySectionModule()
-                        }
-
-                        StatusAction {
-                            text: qsTr("Invite People")
-                            icon.name: "share-ios"
-                            objectName: "invitePeople"
-                            onTriggered: {
-                                popups.openInviteFriendsToCommunityPopup(model,
-                                                                         communityContextMenu.chatCommunitySectionModule,
-                                                                         null)
-                            }
-                        }
-
-                        StatusAction {
-                            text: qsTr("Community Info")
-                            icon.name: "info"
-                            onTriggered: popups.openCommunityProfilePopup(appMain.rootStore, model, communityContextMenu.chatCommunitySectionModule)
-                        }
-
-                        StatusAction {
-                            text: qsTr("Community Rules")
-                            icon.name: "text"
-                            onTriggered: popups.openCommunityRulesPopup(model.name, model.introMessage, model.image, model.color)
-                        }
-
-                        StatusMenuSeparator {}
-
-                        MuteChatMenuItem {
-                            enabled: !model.muted
-                            title: qsTr("Mute Community")
-                            onMuteTriggered: {
-                                communityContextMenu.chatCommunitySectionModule.setCommunityMuted(interval)
-                                communityContextMenu.close()
-                            }
-                        }
-
-                        StatusAction {
-                            enabled: model.muted
-                            text: qsTr("Unmute Community")
-                            icon.name: "notification"
-                            onTriggered: communityContextMenu.chatCommunitySectionModule.setCommunityMuted(Constants.MutingVariations.Unmuted)
-                        }
-
-                        StatusAction {
-                            text: qsTr("Mark as read")
-                            icon.name: "check-circle"
-                            onTriggered: communityContextMenu.chatCommunitySectionModule.markAllReadInCommunity()
-                        }
-
-                        StatusAction {
-                            text: qsTr("Edit Shared Addresses")
-                            icon.name: "wallet"
-                            enabled: {
-                                if (model.memberRole === Constants.memberRole.owner || communityContextMenu.isSpectator)
-                                    return false
-                                return true
-                            }
-                            onTriggered: {
-                                communityContextMenu.close()
-                                Global.openEditSharedAddressesFlow(model.id)
-                            }
-                        }
-
-                        StatusMenuSeparator { visible: leaveCommunityMenuItem.enabled }
-
-                        StatusAction {
-                            id: leaveCommunityMenuItem
-                            objectName: "leaveCommunityMenuItem"
-                            // allow to leave community for the owner in non-production builds
-                            enabled: model.memberRole !== Constants.memberRole.owner || !production
-                            text: {
-                                if (communityContextMenu.isSpectator)
-                                    return qsTr("Close Community")
-                                return qsTr("Leave Community")
-                            }
-                            icon.name: communityContextMenu.isSpectator ? "close-circle" : "arrow-left"
-                            type: StatusAction.Type.Danger
-                            onTriggered: communityContextMenu.isSpectator ? communityContextMenu.chatCommunitySectionModule.leaveCommunity()
-                                                                          : popups.openLeaveCommunityPopup(model.name, model.id, model.outroMessage)
-                        }
-                    }
-                }
-            }
-
-            regularItemsModel: SortFilterProxyModel {
-                sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
-                filters: [
-                    RangeFilter {
                         roleName: "sectionType"
-                        minimumValue: Constants.appSection.profile
-                        maximumValue: Constants.appSection.loadingSection
-                    },
+                        value: Constants.appSection.wallet
+                    }
                     ValueFilter {
-                        roleName: "enabled"
-                        value: true
+                        roleName: "sectionType"
+                        value: Constants.appSection.swap
+                        enabled: !appMain.featureFlagsStore.marketEnabled
                     }
-                ]
+                    ValueFilter {
+                        roleName: "sectionType"
+                        value: Constants.appSection.market
+                        enabled: appMain.featureFlagsStore.marketEnabled
+                    }
+                    ValueFilter {
+                        roleName: "sectionType"
+                        value: Constants.appSection.chat
+                    }
+                },
+                ValueFilter {
+                    roleName: "enabled"
+                    value: true
+                }
+            ]
+        }
+        topSectionDelegate: navbarButton
+
+        communityItemsModel: SortFilterProxyModel {
+            sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
+            filters: [
+                ValueFilter {
+                    roleName: "sectionType"
+                    value: Constants.appSection.community
+                },
+                ValueFilter {
+                    roleName: "enabled"
+                    value: true
+                }
+            ]
+        }
+        communityItemDelegate: StatusNavBarTabButton {
+            objectName: "CommunityNavBarButton"
+            anchors.horizontalCenter: parent.horizontalCenter
+            name: model.icon.length > 0? "" : model.name
+            icon.name: model.icon
+            icon.source: model.image
+            identicon.asset.color: (hovered || identicon.highlighted || checked) ? model.color : icon.color
+            tooltip.text: model.name
+            checked: model.active
+            badge.value: model.notificationsCount
+            badge.visible: model.hasNotification
+
+            stateIcon.color: Theme.palette.dangerColor1
+            stateIcon.border.color: Theme.palette.baseColor2
+            stateIcon.border.width: 2
+            stateIcon.visible: model.amIBanned
+            stateIcon.asset.name: "cancel"
+            stateIcon.asset.color: Theme.palette.baseColor2
+            stateIcon.asset.width: 14
+
+            onClicked: {
+                changeAppSectionBySectionId(model.id)
             }
-            regularItemDelegate: navbarButton
 
-            delegateHeight: 40
+            popupMenu: Component {
+                StatusMenu {
+                    id: communityContextMenu
+                    property var chatCommunitySectionModule
 
-            profileComponent: ProfileButton {
-                objectName: "statusProfileNavBarTabButton"
+                    readonly property bool isSpectator: model.spectated && !model.joined
 
-                name: appMain.profileStore.name
-                usesDefaultName: appMain.profileStore.usesDefaultName
-                pubKey: appMain.profileStore.pubkey
-                compressedPubKey: appMain.profileStore.compressedPubKey
-                isEnsVerified: !!appMain.profileStore.preferredName
-                iconSource: appMain.profileStore.icon
-                colorId: appMain.profileStore.colorId
-                colorHash: appMain.profileStore.colorHash
-                currentUserStatus: appMain.profileStore.currentUserStatus
-
-                getEmojiHashFn: appMain.utilsStore.getEmojiHash
-                getLinkToProfileFn: appMain.rootStore.contactStore.getLinkToProfile
-                onSetCurrentUserStatusRequested: (status) => appMain.rootStore.setCurrentUserStatus(status)
-                onViewProfileRequested: (pubKey) => Global.openProfilePopup(pubKey)
-            }
-
-            Component {
-                id: navbarButton
-                StatusNavBarTabButton {
-                    id: navbar
-                    objectName: model.name + "-navbar"
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    name: model.icon.length > 0? "" : model.name
-                    icon.name: model.icon
-                    icon.source: model.image
-                    tooltip.text: Utils.translatedSectionName(model.sectionType, model.name, (sectionType) => {
-                        if (sectionType === Constants.appSection.shell) {
-                            return shellShortcut.nativeText
-                        }
-                        return ""
-                    })
-                    checked: model.active
-
-                    readonly property bool displayCreateCommunityBadge: model.sectionType === Constants.appSection.communitiesPortal && !appMain.communitiesStore.createCommunityPopupSeen
-                    badge.value: model.notificationsCount
-                    badge.visible: {
-                        if (model.sectionType === Constants.appSection.profile && contactsModelAdaptor.pendingReceivedRequestContacts.ModelCount.count > 0) // pending contact request
-                            return true
-                        if (displayCreateCommunityBadge) // create new community badge
-                            return true
-                        return model.hasNotification // Otherwise, use the value coming from the model
+                    openHandler: function () {
+                        // we cannot return QVariant if we pass another parameter in a function call
+                        // that's why we're using it this way
+                        appMain.rootStore.mainModuleInst.prepareCommunitySectionModuleForCommunityId(model.id)
+                        communityContextMenu.chatCommunitySectionModule = appMain.rootStore.mainModuleInst.getCommunitySectionModule()
                     }
 
-                    StatusNewItemGradient { id: newGradient }
-                    badge.gradient: displayCreateCommunityBadge ? newGradient : undefined // gradient has precedence over a simple color
-
-                    onClicked: {
-                        if(model.sectionType === Constants.appSection.swap) {
-                            popupRequestsHandler.swapModalHandler.launchSwap()
-                        } else {
-                            changeAppSectionBySectionId(model.id)
+                    StatusAction {
+                        text: qsTr("Invite People")
+                        icon.name: "share-ios"
+                        objectName: "invitePeople"
+                        onTriggered: {
+                            popups.openInviteFriendsToCommunityPopup(model,
+                                                                        communityContextMenu.chatCommunitySectionModule,
+                                                                        null)
                         }
+                    }
+
+                    StatusAction {
+                        text: qsTr("Community Info")
+                        icon.name: "info"
+                        onTriggered: popups.openCommunityProfilePopup(appMain.rootStore, model, communityContextMenu.chatCommunitySectionModule)
+                    }
+
+                    StatusAction {
+                        text: qsTr("Community Rules")
+                        icon.name: "text"
+                        onTriggered: popups.openCommunityRulesPopup(model.name, model.introMessage, model.image, model.color)
+                    }
+
+                    StatusMenuSeparator {}
+
+                    MuteChatMenuItem {
+                        enabled: !model.muted
+                        title: qsTr("Mute Community")
+                        onMuteTriggered: {
+                            communityContextMenu.chatCommunitySectionModule.setCommunityMuted(interval)
+                            communityContextMenu.close()
+                        }
+                    }
+
+                    StatusAction {
+                        enabled: model.muted
+                        text: qsTr("Unmute Community")
+                        icon.name: "notification"
+                        onTriggered: communityContextMenu.chatCommunitySectionModule.setCommunityMuted(Constants.MutingVariations.Unmuted)
+                    }
+
+                    StatusAction {
+                        text: qsTr("Mark as read")
+                        icon.name: "check-circle"
+                        onTriggered: communityContextMenu.chatCommunitySectionModule.markAllReadInCommunity()
+                    }
+
+                    StatusAction {
+                        text: qsTr("Edit Shared Addresses")
+                        icon.name: "wallet"
+                        enabled: {
+                            if (model.memberRole === Constants.memberRole.owner || communityContextMenu.isSpectator)
+                                return false
+                            return true
+                        }
+                        onTriggered: {
+                            communityContextMenu.close()
+                            Global.openEditSharedAddressesFlow(model.id)
+                        }
+                    }
+
+                    StatusMenuSeparator { visible: leaveCommunityMenuItem.enabled }
+
+                    StatusAction {
+                        id: leaveCommunityMenuItem
+                        objectName: "leaveCommunityMenuItem"
+                        // allow to leave community for the owner in non-production builds
+                        enabled: model.memberRole !== Constants.memberRole.owner || !production
+                        text: {
+                            if (communityContextMenu.isSpectator)
+                                return qsTr("Close Community")
+                            return qsTr("Leave Community")
+                        }
+                        icon.name: communityContextMenu.isSpectator ? "close-circle" : "arrow-left"
+                        type: StatusAction.Type.Danger
+                        onTriggered: communityContextMenu.isSpectator ? communityContextMenu.chatCommunitySectionModule.leaveCommunity()
+                                                                        : popups.openLeaveCommunityPopup(model.name, model.id, model.outroMessage)
                     }
                 }
             }
         }
+
+        regularItemsModel: SortFilterProxyModel {
+            sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
+            filters: [
+                RangeFilter {
+                    roleName: "sectionType"
+                    minimumValue: Constants.appSection.profile
+                    maximumValue: Constants.appSection.loadingSection
+                },
+                ValueFilter {
+                    roleName: "enabled"
+                    value: true
+                }
+            ]
+        }
+        regularItemDelegate: navbarButton
+
+        delegateHeight: 40
+
+        profileComponent: ProfileButton {
+            objectName: "statusProfileNavBarTabButton"
+
+            name: appMain.profileStore.name
+            usesDefaultName: appMain.profileStore.usesDefaultName
+            pubKey: appMain.profileStore.pubkey
+            compressedPubKey: appMain.profileStore.compressedPubKey
+            isEnsVerified: !!appMain.profileStore.preferredName
+            iconSource: appMain.profileStore.icon
+            colorId: appMain.profileStore.colorId
+            colorHash: appMain.profileStore.colorHash
+            currentUserStatus: appMain.profileStore.currentUserStatus
+
+            getEmojiHashFn: appMain.utilsStore.getEmojiHash
+            getLinkToProfileFn: appMain.rootStore.contactStore.getLinkToProfile
+            onSetCurrentUserStatusRequested: (status) => appMain.rootStore.setCurrentUserStatus(status)
+            onViewProfileRequested: (pubKey) => Global.openProfilePopup(pubKey)
+        }
+
+        Component {
+            id: navbarButton
+            StatusNavBarTabButton {
+                id: navbar
+                objectName: model.name + "-navbar"
+                anchors.horizontalCenter: parent.horizontalCenter
+                name: model.icon.length > 0? "" : model.name
+                icon.name: model.icon
+                icon.source: model.image
+                tooltip.text: Utils.translatedSectionName(model.sectionType, model.name, (sectionType) => {
+                    if (sectionType === Constants.appSection.shell) {
+                        return shellShortcut.nativeText
+                    }
+                    return ""
+                })
+                checked: model.active
+
+                readonly property bool displayCreateCommunityBadge: model.sectionType === Constants.appSection.communitiesPortal && !appMain.communitiesStore.createCommunityPopupSeen
+                badge.value: model.notificationsCount
+                badge.visible: {
+                    if (model.sectionType === Constants.appSection.profile && contactsModelAdaptor.pendingReceivedRequestContacts.ModelCount.count > 0) // pending contact request
+                        return true
+                    if (displayCreateCommunityBadge) // create new community badge
+                        return true
+                    return model.hasNotification // Otherwise, use the value coming from the model
+                }
+
+                StatusNewItemGradient { id: newGradient }
+                badge.gradient: displayCreateCommunityBadge ? newGradient : undefined // gradient has precedence over a simple color
+
+                onClicked: {
+                    if(model.sectionType === Constants.appSection.swap) {
+                        popupRequestsHandler.swapModalHandler.launchSwap()
+                    } else {
+                        changeAppSectionBySectionId(model.id)
+                    }
+                }
+            }
+        }
+    }
+
+    StatusMainLayout {
+        anchors.fill: parent
 
         rightPanel: ColumnLayout {
             spacing: 0
@@ -1953,6 +1953,7 @@ Item {
                             ChatLayout {
                                 id: chatLayoutContainer
 
+                                navBar: appMain.navBar
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
                                     currencyStore: appMain.currencyStore
@@ -2013,6 +2014,7 @@ Item {
                         asynchronous: true
                         CommunitiesPortalLayout {
                             anchors.fill: parent
+                            navBar: appMain.navBar
                             communitiesStore: appMain.communitiesStore
                             assetsModel: appMain.rootStore.globalAssetsModel
                             collectiblesModel: appMain.rootStore.globalCollectiblesModel
@@ -2027,6 +2029,7 @@ Item {
                         asynchronous: true
                         sourceComponent: WalletLayout {
                             objectName: "walletLayoutReal"
+                            navBar: appMain.navBar
                             sharedRootStore: appMain.sharedRootStore
                             store: appMain.rootStore
                             contactsStore: appMain.rootStore.profileSectionStore.contactsStore
@@ -2079,6 +2082,7 @@ Item {
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
                         asynchronous: true
                         sourceComponent: ProfileLayout {
+                            navBar: appMain.navBar
                             sharedRootStore: appMain.sharedRootStore
                             utilsStore: appMain.utilsStore
                             store: appMain.rootStore.profileSectionStore
@@ -2117,7 +2121,9 @@ Item {
                     Loader {
                         active: appView.currentIndex === Constants.appViewStackIndex.node
                         asynchronous: true
-                        sourceComponent: NodeLayout {}
+                        sourceComponent: NodeLayout {
+                            navBar: appMain.navBar
+                        }
                     }
 
                     Loader {
@@ -2125,6 +2131,7 @@ Item {
                         asynchronous: true
                         sourceComponent: MarketLayout {
                             objectName: "marketLayout"
+                            navBar: appMain.navBar
 
                             notificationCount: appMain.activityCenterStore.unreadNotificationsCount
                             hasUnseenNotifications:  appMain.activityCenterStore.hasUnseenNotifications
@@ -2202,7 +2209,8 @@ Item {
                                         chatLayoutComponent.currentIndex = 0
                                     }
                                 }
-
+                                
+                                navBar: appMain.navBar
                                 emojiPopup: statusEmojiPopup.item
                                 stickersPopup: statusStickersPopupLoader.item
                                 sectionItemModel: model


### PR DESCRIPTION
### What does the PR do

Introducing `LayoutChooser` component from qml tests: https://codereview.qt-project.org/c/qt/qtdeclarative/+/456325/54/tests/manual/quicklayouts/layoutItemProxy/LayoutChooser.qml

The LayoutChooser is used to change the "StatusSectionLayout" from a SplitView to a SwipeView in portrait mode whenever the width is less than the implicitWidth.

Other changes:
Maintain compoatibility with qt5
Basic navigastion on item selection (channels, contacts, settings, accounts)

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

App layout, navBar
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/59f963b2-d87c-47e6-9637-416f1651ad8f



