### PR TITLE
fix(collectibles): fix sending of collectibles in the SimpleSendModal

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -327,7 +327,7 @@ StatusDialog {
                                                                     selectedCollectibleEntry.item.symbol: ""
 
         readonly property double maxSafeCryptoValue: {
-            d.selectedAssetEntry.item.balances.ModelCount.count
+            !!d.selectedAssetEntry.item.balances ? d.selectedAssetEntry.item.balances.ModelCount.count : null
             if (selectedCollectibleEntryValid) {
                 let collectibleBalance = SQUtils.ModelUtils.getByKey(selectedCollectibleEntry.item.ownership, "accountAddress", root.selectedAccountAddress, "balance")
                 return !!collectibleBalance ? collectibleBalance: 0


### PR DESCRIPTION
Fixes #18015

That property is only used to bind the  balances, however, for collectible sends, those balances don't exist. This condition fixes the issue and also keeps the binding for asset sends

[fix-send.webm](https://github.com/user-attachments/assets/4fa3e9ee-a0c3-4d5c-a798-a5a11aa44362)
