### PR TITLE
refactor(UsersStore): Decouple users store from UI components and centralize instantiation in `Chat.RootStore`

### DIFF
--- a/storybook/pages/MembersSelectorPage.qml
+++ b/storybook/pages/MembersSelectorPage.qml
@@ -210,9 +210,27 @@ SplitView {
 
                     sourceComponent: MembersEditSelectorView {
                         rootStore: rootStoreMock
-                        usersStore: usersStoreMock
-
+                        usersModel: usersStoreMock.usersModel
+                        temporaryUsersModel: usersStoreMock.temporaryModel
+                        amIChatAdmin: rootStoreMock.amIChatAdmin()
                         contactsModel: contacts
+
+                        onUpdateGroupMembers: {
+                            logs.logEvent("MembersEditSelectorView::updateGroupMembers")
+                            usersStoreMock.updateGroupMembers()
+                        }
+                        onResetTemporaryUsersModel: {
+                            logs.logEvent("MembersEditSelectorView::resetTemporaryUsersModel")
+                            usersStoreMock.resetTemporaryModel()
+                        }
+                        onAppendTemporaryUsersModel: {
+                            logs.logEvent("MembersEditSelectorView::appendTemporaryUsersModel")
+                            usersStoreMock.appendTemporaryModel(pubKey, displayName)
+                        }
+                        onRemoveFromTemporaryUsersModel: {
+                            logs.logEvent("MembersEditSelectorView::removeFromTemporaryUsersModel")
+                            usersStoreMock.removeFromTemporaryModel(pubKey)
+                        }
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -65,6 +65,19 @@ StackLayout {
     property bool gifUnfurlingEnabled
     property bool neverAskAboutUnfurlingAgain
 
+    // Users related data:
+    readonly property bool amIChatAdmin: root.rootStore.amIChatAdmin()
+    property var usersModel
+
+    // Users related but just for group chats:
+    property var temporaryUsersModel
+
+    // Users related signals
+    signal updateGroupMembers()
+    signal resetTemporaryUsersModel()
+    signal appendTemporaryUsersModel(string pubKey, string displayName)
+    signal removeFromTemporaryUsersModel(string pubKey)
+
     signal profileButtonClicked()
     signal openAppSearch()
     signal buyStickerPackRequested(string packId, int price)
@@ -181,6 +194,7 @@ StackLayout {
             sectionItemModel: root.sectionItemModel
             joinedMembersCount: membersModelAdaptor.joinedMembers.ModelCount.count
             areTestNetworksEnabled: root.networksStore.areTestNetworksEnabled
+            amIChatAdmin: root.rootStore.amIChatAdmin()
             amIMember: sectionItem.amIMember
             amISectionAdmin: root.sectionItemModel.memberRole === Constants.memberRole.owner ||
                              root.sectionItemModel.memberRole === Constants.memberRole.admin ||
@@ -239,6 +253,15 @@ StackLayout {
             // Unfurling related data:
             gifUnfurlingEnabled: root.gifUnfurlingEnabled
             neverAskAboutUnfurlingAgain: root.neverAskAboutUnfurlingAgain
+
+            // Users related data:
+            usersModel: root.usersModel
+            temporaryUsersModel: root.temporaryUsersModel
+
+            onUpdateGroupMembers: root.updateGroupMembers()
+            onResetTemporaryUsersModel: root.resetTemporaryUsersModel()
+            onAppendTemporaryUsersModel: root.appendTemporaryUsersModel(pubKey, displayName)
+            onRemoveFromTemporaryUsersModel: root.removeFromTemporaryUsersModel(pubKey)
 
             onFinaliseOwnershipClicked: Global.openFinaliseOwnershipPopup(communityId)
             onCommunityInfoButtonClicked: root.currentIndex = 1

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -69,14 +69,8 @@ StackLayout {
     readonly property bool amIChatAdmin: root.rootStore.amIChatAdmin()
     property var usersModel
 
-    // Users related but just for group chats:
-    property var temporaryUsersModel
-
     // Users related signals
-    signal updateGroupMembers()
-    signal resetTemporaryUsersModel()
-    signal appendTemporaryUsersModel(string pubKey, string displayName)
-    signal removeFromTemporaryUsersModel(string pubKey)
+    signal groupMembersUpdateRequested(string membersPubKeysList)
 
     signal profileButtonClicked()
     signal openAppSearch()
@@ -256,12 +250,8 @@ StackLayout {
 
             // Users related data:
             usersModel: root.usersModel
-            temporaryUsersModel: root.temporaryUsersModel
 
-            onUpdateGroupMembers: root.updateGroupMembers()
-            onResetTemporaryUsersModel: root.resetTemporaryUsersModel()
-            onAppendTemporaryUsersModel: root.appendTemporaryUsersModel(pubKey, displayName)
-            onRemoveFromTemporaryUsersModel: root.removeFromTemporaryUsersModel(pubKey)
+            onGroupMembersUpdateRequested: root.groupMembersUpdateRequested(membersPubKeysList)
 
             onFinaliseOwnershipClicked: Global.openFinaliseOwnershipPopup(communityId)
             onCommunityInfoButtonClicked: root.currentIndex = 1

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -22,6 +22,7 @@ Item {
     property alias suggestionsDelegate: suggestionsListView.delegate
     property alias suggestionsDialog: suggestionsDialog
     property size suggestionsDelegateSize: Qt.size(344, 64)
+    property alias dirty: confirmBtn.enabled
 
     readonly property alias label: label
     readonly property alias warningLabel: warningLabel
@@ -208,6 +209,8 @@ Item {
         }
 
         StatusButton {
+            id: confirmBtn
+
             objectName: "inlineSelectorConfirmButton"
             enabled: (listView.count > 0)
             text: qsTr("Confirm")

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -16,6 +16,14 @@ import utils 1.0
 QtObject {
     id: root
 
+    // Backend Entry Point:
+    // Important:
+    // Each `ChatLayout` has its own chatCommunitySectionModule
+    // (on the backend chat and community sections share the same module since they are actually the same)
+    property var chatCommunitySectionModule
+
+    readonly property var activeChatContentModule: root.currentChatContentModule()
+
     property ContactsStore contactsStore
     property CommunityTokensStore communityTokensStore
     property WalletStore.RootStore walletStore
@@ -28,12 +36,17 @@ QtObject {
         chatCommunitySectionModuleInst: chatCommunitySectionModule
     }
 
+    // Unique instance for all the chat / channel related low-level UI components
+    readonly property UsersStore usersStore: UsersStore {
+        property var chatDetails: !!root.activeChatContentModule ? root.activeChatContentModule.chatDetails : null
+
+        isFullCommunityMembers: chatDetails.belongsToCommunity && !chatDetails.requiresPermissions
+        usersModule: !!root.activeChatContentModule ? root.activeChatContentModule.usersModule : null
+        chatCommunitySectionModule: root.chatCommunitySectionModule
+    }
+
     property bool openCreateChat: false
 
-    // Important:
-    // Each `ChatLayout` has its own chatCommunitySectionModule
-    // (on the backend chat and community sections share the same module since they are actually the same)
-    property var chatCommunitySectionModule
     readonly property var sectionDetails: d.sectionDetailsInstantiator.count ? d.sectionDetailsInstantiator.objectAt(0) : null
 
     property var communityItemsModel: chatCommunitySectionModule.model

--- a/ui/app/AppLayouts/Chat/stores/UsersStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/UsersStore.qml
@@ -18,18 +18,7 @@ QtObject {
     }
 
     // Used for editing:
-    readonly property var temporaryModel: root.usersModule ? root.usersModule.temporaryModel : null
-
-    function appendTemporaryModel(pubKey, displayName) {
-        root.usersModule.appendTemporaryModel(pubKey, displayName)
-    }
-    function removeFromTemporaryModel(pubKey) {
-        root.usersModule.removeFromTemporaryModel(pubKey)
-    }
-    function resetTemporaryModel() {
-        root.usersModule.resetTemporaryModel()
-    }
-    function updateGroupMembers() {
-        root.usersModule.updateGroupMembers()
+    function groupMembersUpdateRequested(membersPubKeysList) {
+        root.usersModule.groupMembersUpdateRequested(membersPubKeysList)
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/UsersStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/UsersStore.qml
@@ -3,33 +3,33 @@ import QtQuick 2.15
 QtObject {
     id: root
 
-    property var chatCommunitySectionModule
-    property var chatDetails
-    property var usersModule
+    // External properties:
+    required property var chatCommunitySectionModule
+    required property var usersModule
+    required property bool isFullCommunityMembers
 
+    // Public API:
     readonly property var usersModel: {
-        if (!chatDetails && !chatCommunitySectionModule) {
-            return null
-        }
-        let isFullCommunityList = !chatDetails.requiresPermissions
-        if (chatDetails.belongsToCommunity && isFullCommunityList && !!chatCommunitySectionModule) {
+        if (root.isFullCommunityMembers) {
             // Community channel with no permisisons. We can use the section's membersModel
-            return chatCommunitySectionModule.membersModel
+            return root.chatCommunitySectionModule ? root.chatCommunitySectionModule.membersModel : null
         }
-        return usersModule ? usersModule.model : null
+        return root.usersModule ? root.usersModule.model : null
     }
-    readonly property var temporaryModel: usersModule ? usersModule.temporaryModel : null
+
+    // Used for editing:
+    readonly property var temporaryModel: root.usersModule ? root.usersModule.temporaryModel : null
 
     function appendTemporaryModel(pubKey, displayName) {
-        usersModule.appendTemporaryModel(pubKey, displayName)
+        root.usersModule.appendTemporaryModel(pubKey, displayName)
     }
     function removeFromTemporaryModel(pubKey) {
-        usersModule.removeFromTemporaryModel(pubKey)
+        root.usersModule.removeFromTemporaryModel(pubKey)
     }
     function resetTemporaryModel() {
-        usersModule.resetTemporaryModel()
+        root.usersModule.resetTemporaryModel()
     }
     function updateGroupMembers() {
-        usersModule.updateGroupMembers()
+        root.usersModule.updateGroupMembers()
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -62,6 +62,9 @@ Item {
     property bool gifUnfurlingEnabled
     property bool neverAskAboutUnfurlingAgain
 
+    // Users related data:
+    property var usersModel
+
     signal openStickerPackPopup(string stickerPackId)
     signal tokenPaymentRequested(string recipientAddress, string symbol, string rawAmount, int chainId)
 
@@ -108,12 +111,6 @@ Item {
 
         readonly property ModelChangeTracker urlsModelChangeTracker: ModelChangeTracker {
             model: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.urlsModel : null
-        }
-
-        readonly property ChatStores.UsersStore activeUsersStore: ChatStores.UsersStore {
-            usersModule: !!d.activeChatContentModule ? d.activeChatContentModule.usersModule : null
-            chatDetails: !!d.activeChatContentModule ? d.activeChatContentModule.chatDetails : null
-            chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
         }
 
         readonly property ChatStores.MessageStore activeMessagesStore: ChatStores.MessageStore {
@@ -209,7 +206,7 @@ Item {
             preservedText = d.activeChatContentModule.inputAreaModule.preservedProperties.text
 
             d.activeChatContentModule.inputAreaModule.clearLinkPreviewCache()
-            // Call later to make sure activeUsersStore and activeMessagesStore bindings are updated
+            // Call later to make sure usersStore and activeMessagesStore bindings are updated
             Qt.callLater(d.restoreInputState, preservedText)
         }
 
@@ -232,6 +229,7 @@ Item {
     // The best would be if we made qml to follow the struct we have on the backend side.
 
     ColumnLayout {
+
         anchors.fill: parent
         spacing: 0
 
@@ -268,6 +266,8 @@ Item {
                         // Unfurling related data:
                         gifUnfurlingEnabled: root.gifUnfurlingEnabled
                         neverAskAboutUnfurlingAgain: root.neverAskAboutUnfurlingAgain
+
+                        usersModel: root.usersModel
 
                         onOpenStickerPackPopup: {
                             root.openStickerPackPopup(stickerPackId)
@@ -322,7 +322,7 @@ Item {
                                  && !d.sendingInProgress
                     }
 
-                    usersModel: d.activeUsersStore.usersModel
+                    usersModel: root.usersModel
                     linkPreviewModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.linkPreviewModel : null
                     paymentRequestModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.paymentRequestModel : null
                     formatBalance: d.formatBalance

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -43,9 +43,9 @@ ColumnLayout {
 
     property var emojiPopup
     property var stickersPopup
-    property UsersStore usersStore: UsersStore {
-        chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
-    }
+
+    // Users related data:
+    property var usersModel
 
     signal openStickerPackPopup(string stickerPackId)
     signal tokenPaymentRequested(string recipientAddress, string symbol, string rawAmount, int chainId)
@@ -76,11 +76,6 @@ ColumnLayout {
     objectName: "chatContentViewColumn"
     spacing: 0
 
-    onChatContentModuleChanged: if (!!chatContentModule) {
-        root.usersStore.chatDetails = root.chatContentModule.chatDetails
-        root.usersStore.usersModule = root.chatContentModule.usersModule
-    }
-
     Loader {
         Layout.fillWidth: true
         active: root.isBlocked
@@ -105,7 +100,6 @@ ColumnLayout {
             formatBalance: root.formatBalance
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
-            usersStore: root.usersStore
             stickersLoaded: root.stickersLoaded
             chatId: root.chatId
             isOneToOne: root.chatType === Constants.chatType.oneToOne
@@ -115,6 +109,7 @@ ColumnLayout {
             sendViaPersonalChatEnabled: root.sendViaPersonalChatEnabled
             disabledTooltipText: root.disabledTooltipText
             areTestNetworksEnabled: root.areTestNetworksEnabled
+            usersModel: root.usersModel
 
             // Unfurling related data:
             gifUnfurlingEnabled: root.gifUnfurlingEnabled

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -29,6 +29,15 @@ Item {
     property var emojiPopup
     property int padding: Theme.halfPadding
 
+    property var usersModel
+    property var temporaryUsersModel
+    property var amIChatAdmin
+
+    signal updateGroupMembers()
+    signal resetTemporaryUsersModel()
+    signal appendTemporaryUsersModel(string pubKey, string displayName)
+    signal removeFromTemporaryUsersModel(string pubKey)
+
     signal searchButtonClicked()
     signal displayEditChannelPopup(string chatId,
                                    string chatName,
@@ -345,16 +354,19 @@ Item {
         id: membersSelector
 
         MembersEditSelectorView {
-            rootStore: root.rootStore
-            usersStore: UsersStore {
-                chatDetails: chatContentModule.chatDetails
-                chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
-                usersModule: root.chatContentModule.usersModule
-            }
             contactsModel: root.mutualContactsModel
+            usersModel: root.usersModel
+            temporaryUsersModel: root.temporaryUsersModel
+
+            amIChatAdmin: root.amIChatAdmin
 
             onConfirmed: root.state = d.stateInfoButtonContent
             onRejected: root.state = d.stateInfoButtonContent
+
+            onUpdateGroupMembers: root.updateGroupMembers()
+            onResetTemporaryUsersModel: root.resetTemporaryUsersModel()
+            onAppendTemporaryUsersModel: root.appendTemporaryUsersModel(pubKey, displayName)
+            onRemoveFromTemporaryUsersModel: root.removeFromTemporaryUsersModel(pubKey)
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -30,13 +30,9 @@ Item {
     property int padding: Theme.halfPadding
 
     property var usersModel
-    property var temporaryUsersModel
     property var amIChatAdmin
 
-    signal updateGroupMembers()
-    signal resetTemporaryUsersModel()
-    signal appendTemporaryUsersModel(string pubKey, string displayName)
-    signal removeFromTemporaryUsersModel(string pubKey)
+    signal groupMembersUpdateRequested(string membersPubKeysList)
 
     signal searchButtonClicked()
     signal displayEditChannelPopup(string chatId,
@@ -356,17 +352,13 @@ Item {
         MembersEditSelectorView {
             contactsModel: root.mutualContactsModel
             usersModel: root.usersModel
-            temporaryUsersModel: root.temporaryUsersModel
 
             amIChatAdmin: root.amIChatAdmin
 
             onConfirmed: root.state = d.stateInfoButtonContent
             onRejected: root.state = d.stateInfoButtonContent
 
-            onUpdateGroupMembers: root.updateGroupMembers()
-            onResetTemporaryUsersModel: root.resetTemporaryUsersModel()
-            onAppendTemporaryUsersModel: root.appendTemporaryUsersModel(pubKey, displayName)
-            onRemoveFromTemporaryUsersModel: root.removeFromTemporaryUsersModel(pubKey)
+            onGroupMembersUpdateRequested: root.groupMembersUpdateRequested(membersPubKeysList)
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -33,10 +33,12 @@ Item {
 
     property RootStore rootStore
     property MessageStore messageStore
-    property UsersStore usersStore
     property ContactsStore contactsStore
     property string channelEmoji
     property var formatBalance
+
+    // Users related data:
+    property var usersModel
 
     property var emojiPopup
     property var stickersPopup
@@ -293,7 +295,6 @@ Item {
 
             rootStore: root.rootStore
             messageStore: root.messageStore
-            usersStore: root.usersStore
             contactsStore: root.contactsStore
             channelEmoji: root.channelEmoji
             emojiPopup: root.emojiPopup
@@ -301,6 +302,7 @@ Item {
             chatLogView: ListView.view
             chatContentModule: root.chatContentModule
             formatBalance: root.formatBalance
+            usersModel: root.usersModel
 
             isChatBlocked: root.isChatBlocked
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -110,6 +110,17 @@ StatusSectionLayout {
     property bool gifUnfurlingEnabled
     property bool neverAskAboutUnfurlingAgain
 
+    // Users related data:
+    property var usersModel
+    property var temporaryUsersModel
+    property bool amIChatAdmin
+
+    // Users related signals
+    signal updateGroupMembers()
+    signal resetTemporaryUsersModel()
+    signal appendTemporaryUsersModel(string pubKey, string displayName)
+    signal removeFromTemporaryUsersModel(string pubKey)
+
     // Community transfer ownership related props:
     required property bool isPendingOwnershipRequest
     signal finaliseOwnershipClicked
@@ -191,12 +202,6 @@ StatusSectionLayout {
     rightPanel: Component {
         id: userListComponent
         UserListPanel {
-            readonly property var usersStore: ChatStores.UsersStore {
-                usersModule: !!root.chatContentModule ? root.chatContentModule.usersModule : null
-                chatDetails: !!root.chatContentModule ? root.chatContentModule.chatDetails : null
-                chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
-            }
-
             anchors.fill: parent
 
             chatType: root.chatContentModule.chatDetails.type
@@ -205,7 +210,7 @@ StatusSectionLayout {
             label: qsTr("Members")
             communityMemberReevaluationStatus: root.rootStore.communityMemberReevaluationStatus
 
-            usersModel: usersStore.usersModel
+            usersModel: root.usersModel
 
             onOpenProfileRequested: Global.openProfilePopup(pubKey, null)
             onReviewContactRequestRequested: Global.openReviewContactRequestPopup(pubKey, null)
@@ -243,6 +248,10 @@ StatusSectionLayout {
             mutualContactsModel: root.mutualContactsModel
             emojiPopup: root.emojiPopup
 
+            usersModel: root.usersModel
+            temporaryUsersModel: root.temporaryUsersModel
+            amIChatAdmin: root.amIChatAdmin
+
             onSearchButtonClicked: root.openAppSearch()
             onDisplayEditChannelPopup: {
                 Global.openPopup(contactColumnLoader.item.createChannelPopup, {
@@ -258,6 +267,11 @@ StatusSectionLayout {
                     hideIfPermissionsNotMet: hideIfPermissionsNotMet
                 });
             }
+
+            onUpdateGroupMembers: root.updateGroupMembers()
+            onResetTemporaryUsersModel: root.resetTemporaryUsersModel()
+            onAppendTemporaryUsersModel: root.appendTemporaryUsersModel(pubKey, displayName)
+            onRemoveFromTemporaryUsersModel: root.removeFromTemporaryUsersModel(pubKey)
         }
     }
 
@@ -294,6 +308,9 @@ StatusSectionLayout {
             // Unfurling related data:
             gifUnfurlingEnabled: root.gifUnfurlingEnabled
             neverAskAboutUnfurlingAgain: root.neverAskAboutUnfurlingAgain
+
+            // Users related data:
+            usersModel: root.usersModel
 
             onOpenStickerPackPopup: {
                 Global.openPopup(statusStickerPackClickPopup, {packId: stickerPackId, store: root.stickersPopup.store} )

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -112,14 +112,10 @@ StatusSectionLayout {
 
     // Users related data:
     property var usersModel
-    property var temporaryUsersModel
     property bool amIChatAdmin
 
     // Users related signals
-    signal updateGroupMembers()
-    signal resetTemporaryUsersModel()
-    signal appendTemporaryUsersModel(string pubKey, string displayName)
-    signal removeFromTemporaryUsersModel(string pubKey)
+    signal groupMembersUpdateRequested(string membersPubKeysList)
 
     // Community transfer ownership related props:
     required property bool isPendingOwnershipRequest
@@ -249,7 +245,6 @@ StatusSectionLayout {
             emojiPopup: root.emojiPopup
 
             usersModel: root.usersModel
-            temporaryUsersModel: root.temporaryUsersModel
             amIChatAdmin: root.amIChatAdmin
 
             onSearchButtonClicked: root.openAppSearch()
@@ -268,10 +263,7 @@ StatusSectionLayout {
                 });
             }
 
-            onUpdateGroupMembers: root.updateGroupMembers()
-            onResetTemporaryUsersModel: root.resetTemporaryUsersModel()
-            onAppendTemporaryUsersModel: root.appendTemporaryUsersModel(pubKey, displayName)
-            onRemoveFromTemporaryUsersModel: root.removeFromTemporaryUsersModel(pubKey)
+            onGroupMembersUpdateRequested: root.groupMembersUpdateRequested(membersPubKeysList)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -64,7 +64,6 @@ Page {
                 Layout.leftMargin: Theme.halfPadding
                 Layout.rightMargin: Theme.halfPadding
 
-                rootStore: root.rootStore
                 utilsStore: root.utilsStore
                 contactsModel: root.mutualContactsModel
 

--- a/ui/app/AppLayouts/Chat/views/MembersEditSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersEditSelectorView.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import StatusQ 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
@@ -11,7 +12,6 @@ import StatusQ.Components 0.1
 import AppLayouts.Chat.stores 1.0
 
 import utils 1.0
-
 import SortFilterProxyModel 0.2
 
 import "private"
@@ -19,39 +19,48 @@ import "private"
 MembersSelectorBase {
     id: root
 
-    property var usersModel
-    property var temporaryUsersModel
+    property var usersModel // Source model
     property bool amIChatAdmin
 
-    signal updateGroupMembers()
-    signal resetTemporaryUsersModel()
-    signal appendTemporaryUsersModel(string pubKey, string displayName)
-    signal removeFromTemporaryUsersModel(string pubKey)
+    signal groupMembersUpdateRequested(string membersPubKeysList)
 
-    onConfirmed: {
-        root.updateGroupMembers()
-        root.resetTemporaryUsersModel()
-    }
+    QtObject {
+        id: d
 
-    onRejected: {
-        root.resetTemporaryUsersModel()
-    }
+        property ListModel tempUsersList: ListModel {}
 
-    onEntryAccepted: if (suggestionsDelegate) {
-        if (!root.limitReached) {
-            root.appendTemporaryUsersModel(suggestionsDelegate._pubKey, suggestionsDelegate.userName)
-            root.edit.clear()
+        property string originalPubKeysList: ""
+        property string currentPubKeysList: ""
+
+        readonly property bool dirty: originalPubKeysList !== currentPubKeysList
+
+        function calculatePublicKeysList(model) {
+            const keys = ModelUtils.modelToFlatArray(model, "pubKey")
+            keys.sort()
+            return keys.join(",")
+        }
+
+        function resetTempUsersList() {
+            tempUsersList.clear()
+            const items = []
+            for (let i = 0; i < root.usersModel.ModelCount.count; ++i) {
+                const item = ModelUtils.get(root.usersModel, i)
+                items.push({
+                               pubKey: item.pubKey,
+                               preferredDisplayName: item.preferredDisplayName,
+                               memberRole: item.memberRole ?? Constants.memberRole.none
+                           })
+            }
+            tempUsersList.append(items)
+            originalPubKeysList = calculatePublicKeysList(tempUsersList)
+            currentPubKeysList = originalPubKeysList
         }
     }
 
-    onEntryRemoved: if (delegate) {
-        if (!delegate.isReadonly) {
-            root.removeFromTemporaryUsersModel(delegate._pubKey)
-        }
-    }
+    dirty: d.dirty
 
     model: SortFilterProxyModel {
-        sourceModel: root.temporaryUsersModel
+        sourceModel: d.tempUsersList
         sorters: RoleSorter {
             roleName: "memberRole"
             sortOrder: Qt.DescendingOrder
@@ -67,14 +76,52 @@ MembersSelectorBase {
         isReadonly: {
             if (model.memberRole === Constants.memberRole.owner) return true
             if (root.amIChatAdmin) return false
-            return index < root.usersModel.count
+            return index < root.usersModel.ModelCount.count
         }
         icon: model.memberRole === Constants.memberRole.owner ? "crown" : ""
 
         onClosed: root.entryRemoved(this)
     }
 
+    onRejected: {
+        d.resetTempUsersList()
+    }
+
+    onConfirmed: {
+        if (d.dirty) {
+            groupMembersUpdateRequested(d.currentPubKeysList)
+        }
+        d.resetTempUsersList()
+    }
+
+    onEntryAccepted: {
+        if (suggestionsDelegate && !root.limitReached) {
+            const pubKey = suggestionsDelegate._pubKey
+            const exists = ModelUtils.contains(d.tempUsersList, "pubKey", pubKey)
+            if (!exists) {
+                d.tempUsersList.append({
+                                           pubKey: pubKey,
+                                           preferredDisplayName: suggestionsDelegate.userName,
+                                           memberRole: suggestionsDelegate.memberRole ?? Constants.memberRole.none
+                                       })
+                d.currentPubKeysList = d.calculatePublicKeysList(d.tempUsersList)
+            }
+            root.edit.clear()
+        }
+    }
+
+    onEntryRemoved: {
+        if (delegate && !delegate.isReadonly) {
+            const pubKey = delegate._pubKey
+            const index = ModelUtils.indexOf(d.tempUsersList, "pubKey", pubKey)
+            if (index >= 0) {
+                d.tempUsersList.remove(index)
+                d.currentPubKeysList = d.calculatePublicKeysList(d.tempUsersList)
+            }
+        }
+    }
+
     Component.onCompleted: {
-        root.resetTemporaryUsersModel()
+        d.resetTempUsersList()
     }
 }

--- a/ui/app/AppLayouts/Chat/views/MembersEditSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersEditSelectorView.qml
@@ -19,32 +19,39 @@ import "private"
 MembersSelectorBase {
     id: root
 
-    property UsersStore usersStore
+    property var usersModel
+    property var temporaryUsersModel
+    property bool amIChatAdmin
+
+    signal updateGroupMembers()
+    signal resetTemporaryUsersModel()
+    signal appendTemporaryUsersModel(string pubKey, string displayName)
+    signal removeFromTemporaryUsersModel(string pubKey)
 
     onConfirmed: {
-        usersStore.updateGroupMembers()
-        usersStore.resetTemporaryModel()
+        root.updateGroupMembers()
+        root.resetTemporaryUsersModel()
     }
 
     onRejected: {
-        usersStore.resetTemporaryModel()
+        root.resetTemporaryUsersModel()
     }
 
     onEntryAccepted: if (suggestionsDelegate) {
         if (!root.limitReached) {
-            usersStore.appendTemporaryModel(suggestionsDelegate._pubKey, suggestionsDelegate.userName)
+            root.appendTemporaryUsersModel(suggestionsDelegate._pubKey, suggestionsDelegate.userName)
             root.edit.clear()
         }
     }
 
     onEntryRemoved: if (delegate) {
         if (!delegate.isReadonly) {
-            usersStore.removeFromTemporaryModel(delegate._pubKey)
+            root.removeFromTemporaryUsersModel(delegate._pubKey)
         }
     }
 
     model: SortFilterProxyModel {
-        sourceModel: root.usersStore.temporaryModel
+        sourceModel: root.temporaryUsersModel
         sorters: RoleSorter {
             roleName: "memberRole"
             sortOrder: Qt.DescendingOrder
@@ -59,8 +66,8 @@ MembersSelectorBase {
 
         isReadonly: {
             if (model.memberRole === Constants.memberRole.owner) return true
-            if (root.rootStore.amIChatAdmin()) return false
-            return index < root.usersStore.usersModel.count
+            if (root.amIChatAdmin) return false
+            return index < root.usersModel.count
         }
         icon: model.memberRole === Constants.memberRole.owner ? "crown" : ""
 
@@ -68,6 +75,6 @@ MembersSelectorBase {
     }
 
     Component.onCompleted: {
-        usersStore.resetTemporaryModel()
+        root.resetTemporaryUsersModel()
     }
 }

--- a/ui/app/AppLayouts/Chat/views/private/MembersSelectorBase.qml
+++ b/ui/app/AppLayouts/Chat/views/private/MembersSelectorBase.qml
@@ -17,8 +17,6 @@ import SortFilterProxyModel 0.2
 InlineSelectorPanel {
     id: root
 
-    property ChatStores.RootStore rootStore
-
     property alias contactsModel: suggestionsModel.sourceModel
 
     readonly property int membersLimit: 20 // see: https://github.com/status-im/status-mobile/issues/13066

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1883,8 +1883,9 @@ Item {
                                     communityTokensStore: appMain.communityTokensStore
                                     emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                                     openCreateChat: createChatView.opened
-                                    chatCommunitySectionModule: appMain.rootStore.mainModuleInst.getChatSectionModule()
                                     networkConnectionStore: appMain.networkConnectionStore
+
+                                    chatCommunitySectionModule: appMain.rootStore.mainModuleInst.getChatSectionModule()
                                 }
                                 createChatPropertiesStore: appMain.createChatPropertiesStore
                                 tokensStore: appMain.tokensStore
@@ -1906,6 +1907,11 @@ Item {
                                 gifUnfurlingEnabled: appMain.sharedRootStore.gifUnfurlingEnabled
                                 neverAskAboutUnfurlingAgain: appMain.sharedRootStore.neverAskAboutUnfurlingAgain
 
+                                // Users related data
+                                property var usersStore: rootStore.usersStore
+                                usersModel: usersStore.usersModel
+                                temporaryUsersModel: usersStore.temporaryModel
+
                                 onProfileButtonClicked: {
                                     Global.changeAppSectionBySectionType(Constants.appSection.profile);
                                 }
@@ -1921,6 +1927,12 @@ Item {
                                 onSetNeverAskAboutUnfurlingAgain: appMain.sharedRootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
 
                                 onOpenGifPopupRequest: popupRequestsHandler.statusGifPopupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
+
+                                // Edit group chat members signals:
+                                onUpdateGroupMembers: usersStore.updateGroupMembers()
+                                onResetTemporaryUsersModel: usersStore.resetTemporaryModel()
+                                onAppendTemporaryUsersModel: usersStore.appendTemporaryModel(pubKey, displayName)
+                                onRemoveFromTemporaryUsersModel: usersStore.removeFromTemporaryModel(pubKey)
                             }
                         }
                     }
@@ -2133,6 +2145,7 @@ Item {
                                     communityTokensStore: appMain.communityTokensStore
                                     emojiReactionsModel: appMain.rootStore.emojiReactionsModel
                                     openCreateChat: createChatView.opened
+
                                     chatCommunitySectionModule: {
                                         appMain.rootStore.mainModuleInst.prepareCommunitySectionModuleForCommunityId(model.id)
                                         return appMain.rootStore.mainModuleInst.getCommunitySectionModule()
@@ -2151,6 +2164,8 @@ Item {
                                 // Unfurling related data:
                                 gifUnfurlingEnabled: appMain.sharedRootStore.gifUnfurlingEnabled
                                 neverAskAboutUnfurlingAgain: appMain.sharedRootStore.neverAskAboutUnfurlingAgain
+
+                                usersModel: rootStore.usersStore.usersModel
 
                                 onProfileButtonClicked: {
                                     Global.changeAppSectionBySectionType(Constants.appSection.profile);

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1908,9 +1908,7 @@ Item {
                                 neverAskAboutUnfurlingAgain: appMain.sharedRootStore.neverAskAboutUnfurlingAgain
 
                                 // Users related data
-                                property var usersStore: rootStore.usersStore
-                                usersModel: usersStore.usersModel
-                                temporaryUsersModel: usersStore.temporaryModel
+                                usersModel: rootStore.usersStore.usersModel
 
                                 onProfileButtonClicked: {
                                     Global.changeAppSectionBySectionType(Constants.appSection.profile);
@@ -1929,10 +1927,7 @@ Item {
                                 onOpenGifPopupRequest: popupRequestsHandler.statusGifPopupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
 
                                 // Edit group chat members signals:
-                                onUpdateGroupMembers: usersStore.updateGroupMembers()
-                                onResetTemporaryUsersModel: usersStore.resetTemporaryModel()
-                                onAppendTemporaryUsersModel: usersStore.appendTemporaryModel(pubKey, displayName)
-                                onRemoveFromTemporaryUsersModel: usersStore.removeFromTemporaryModel(pubKey)
+                                onGroupMembersUpdateRequested: rootStore.usersStore.groupMembersUpdateRequested(membersPubKeysList)
                             }
                         }
                     }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -27,7 +27,6 @@ Loader {
 
     property ChatStores.RootStore rootStore
     property ChatStores.MessageStore messageStore
-    property ChatStores.UsersStore usersStore
     property ProfileStores.ContactsStore contactsStore
     property var chatContentModule
     property var chatCommunitySectionModule
@@ -160,6 +159,9 @@ Loader {
     property bool isText: messageContentType === Constants.messageContentType.messageType || messageContentType === Constants.messageContentType.contactRequestType || isDiscordMessage || isBridgeMessage
     property bool isMessage: isEmoji || isImage || isSticker || isText
                              || messageContentType === Constants.messageContentType.communityInviteType || messageContentType === Constants.messageContentType.transactionType
+
+    // Users related data:
+    property var usersModel
 
     function openProfileContextMenu(sender, isReply = false) {
         if (isViewMemberMessagesePopup)
@@ -956,7 +958,7 @@ Loader {
                             suggestionsOpened = false
                         }
 
-                        usersModel: root.usersStore.usersModel
+                        usersModel: root.usersModel
                         emojiPopup: root.emojiPopup
                         stickersPopup: root.stickersPopup
 


### PR DESCRIPTION
Closes #18000

### What does the PR do

This refactor separates the `UsersStore` usage from low-level UI components by lifting its instantiation up to the `Chat.RootStore`. All components now use this single centralized instance, eliminating unnecessary store instantiations and improving state consistency and maintainability across the app.

No functional changes to user flows.

Updated all affected components and flows:
- User mentions list in the status chat input (for both standard and edit chat input modes)
- Right-side members/users column
- Group chat members management

### Affected areas

Chat / Channels User Flows:
- Mentions list (chat input + edit chat input)
- Members list (right column)
- Group chat flow (list, create, add, remove..) 

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Impact on end user

No impact

### How to test

Do some testing on the following flows of `Chat / Channels User Flows` like:
- Mentions list (chat input + edit chat input)
- Members list (right column)
- Group chat flow (list, create, add, remove..) 

### Risk 

Introducing some regression on loading user related data / incorrect model

Tick **one**:
- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [X] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
