### PR TITLE
Fix shell's chats not being loaded at start and missing image

### DIFF
--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -4,7 +4,7 @@ import ../../../../app_service/common/types
 
 QtObject:
   type ActiveItem* = ref object of QObject
-    item: Item
+    item: ChatItem
 
   proc setup(self: ActiveItem) =
     self.QObject.setup
@@ -22,12 +22,12 @@ QtObject:
 
   #################################################
 
-  proc setActiveItemData*(self: ActiveItem, item: Item) =
+  proc setActiveItemData*(self: ActiveItem, item: ChatItem) =
     self.item = item
 
   # Used when there is no longer an active item (last channel was deleted)
   proc resetActiveItemData*(self: ActiveItem) =
-    self.item = Item()
+    self.item = ChatItem()
     self.idChanged()
 
   proc getId(self: ActiveItem): string {.slot.} =

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -10,13 +10,13 @@ type
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method load*(self: AccessInterface, chatItem: chat_item.Item) {.base.} =
+method load*(self: AccessInterface, chatItem: ChatItem) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onChatUpdated*(self: AccessInterface, chatItem: chat_item.Item) {.base.} =
+method onChatUpdated*(self: AccessInterface, chatItem: ChatItem) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -73,7 +73,7 @@ method delete*(self: Module) =
   if self.usersModule != nil:
     self.usersModule.delete
 
-method load*(self: Module, chatItem: chat_item.Item) =
+method load*(self: Module, chatItem: ChatItem) =
   self.controller.init()
 
   var chatName = chatItem.name
@@ -342,7 +342,7 @@ method onContactDetailsUpdated*(self: Module, contactId: string) =
 method onNotificationsUpdated*(self: Module, hasUnreadMessages: bool, notificationCount: int) =
   self.view.updateChatDetailsNotifications(hasUnreadMessages, notificationCount)
 
-method onChatUpdated*(self: Module, chatItem: chat_item.Item) =
+method onChatUpdated*(self: Module, chatItem: ChatItem) =
   if chatItem.`type` != ChatType.OneToOne.int:
     self.view.chatDetails.setName(chatItem.name)
     self.view.chatDetails.setIcon(chatItem.icon)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -88,7 +88,7 @@ method addOrUpdateChat*(self: AccessInterface,
     setChatAsActive: bool = true,
     insertIntoModel: bool = true,
     isSectionBuild: bool = false,
-  ): Item {.base.} =
+  ): ChatItem {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string,

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -22,7 +22,7 @@ type
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method load*(self: AccessInterface) {.base.} =
+method load*(self: AccessInterface, buildChats: bool = false) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onChatsLoaded*(self: AccessInterface,

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -8,7 +8,7 @@ import ../../shared_models/[color_hash_item, color_hash_model]
 const CATEGORY_TYPE* = -1
 
 type
-  Item* = ref object
+  ChatItem* = ref object
     id: string
     name: string
     `type`: int
@@ -42,7 +42,7 @@ type
     hideIfPermissionsNotMet: bool
     missingEncryptionKey: bool
 
-proc initItem*(
+proc initChatItem*(
     id,
     name,
     icon,
@@ -73,10 +73,10 @@ proc initItem*(
     canView = true,
     canPostReactions = true,
     viewersCanPostReactions = true,
-    hideIfPermissionsNotMet: bool,
-    missingEncryptionKey: bool
-    ): Item =
-  result = Item()
+    hideIfPermissionsNotMet: bool = false,
+    missingEncryptionKey: bool = false,
+    ): ChatItem =
+  result = ChatItem()
   result.id = id
   result.name = name
   result.memberRole = memberRole
@@ -111,8 +111,8 @@ proc initItem*(
   result.hideIfPermissionsNotMet = hideIfPermissionsNotMet
   result.missingEncryptionKey = missingEncryptionKey
 
-proc `$`*(self: Item): string =
-  result = fmt"""chat_section/Item(
+proc `$`*(self: ChatItem): string =
+  result = fmt"""chat_section/ChatItem(
     id: {self.id},
     name: {$self.name},
     memberRole: {$self.memberRole},
@@ -145,7 +145,7 @@ proc `$`*(self: Item): string =
     hideIfPermissionsNotMet: {$self.hideIfPermissionsNotMet},
     ]"""
 
-proc toJsonNode*(self: Item): JsonNode =
+proc toJsonNode*(self: ChatItem): JsonNode =
   result = %* {
     "itemId": self.id,
     "name": self.name,
@@ -179,191 +179,191 @@ proc toJsonNode*(self: Item): JsonNode =
     "hideIfPermissionsNotMet": self.hideIfPermissionsNotMet,
   }
 
-proc delete*(self: Item) =
+proc delete*(self: ChatItem) =
   discard
 
-proc id*(self: Item): string =
+proc id*(self: ChatItem): string =
   self.id
 
-proc name*(self: Item): string =
+proc name*(self: ChatItem): string =
   self.name
 
-proc `name=`*(self: var Item, value: string) =
+proc `name=`*(self: var ChatItem, value: string) =
   self.name = value
 
-proc memberRole*(self: Item): MemberRole =
+proc memberRole*(self: ChatItem): MemberRole =
   self.memberRole
 
-proc icon*(self: Item): string =
+proc icon*(self: ChatItem): string =
   self.icon
 
-proc `icon=`*(self: var Item, value: string) =
+proc `icon=`*(self: var ChatItem, value: string) =
   self.icon = value
 
-proc color*(self: Item): string =
+proc color*(self: ChatItem): string =
   self.color
 
-proc `color=`*(self: var Item, value: string) =
+proc `color=`*(self: var ChatItem, value: string) =
   self.color = value
 
-proc colorId*(self: Item): int =
+proc colorId*(self: ChatItem): int =
   self.colorId
 
-proc emoji*(self: Item): string =
+proc emoji*(self: ChatItem): string =
   self.emoji
 
-proc `emoji=`*(self: var Item, value: string) =
+proc `emoji=`*(self: var ChatItem, value: string) =
   self.emoji = value
 
-proc colorHash*(self: Item): color_hash_model.Model =
+proc colorHash*(self: ChatItem): color_hash_model.Model =
   self.colorHash
 
-proc description*(self: Item): string =
+proc description*(self: ChatItem): string =
   self.description
 
-proc `description=`*(self: var Item, value: string) =
+proc `description=`*(self: var ChatItem, value: string) =
   self.description = value
 
-proc type*(self: Item): int =
+proc type*(self: ChatItem): int =
   self.`type`
 
-proc hasUnreadMessages*(self: Item): bool =
+proc hasUnreadMessages*(self: ChatItem): bool =
   self.hasUnreadMessages
 
-proc `hasUnreadMessages=`*(self: var Item, value: bool) =
+proc `hasUnreadMessages=`*(self: var ChatItem, value: bool) =
   self.hasUnreadMessages = value
 
-proc lastMessageTimestamp*(self: Item): int =
+proc lastMessageTimestamp*(self: ChatItem): int =
   self.lastMessageTimestamp
 
-proc `lastMessageTimestamp=`*(self: var Item, value: int) =
+proc `lastMessageTimestamp=`*(self: var ChatItem, value: int) =
   self.lastMessageTimestamp = value
 
-proc notificationsCount*(self: Item): int =
+proc notificationsCount*(self: ChatItem): int =
   self.notificationsCount
 
-proc `notificationsCount=`*(self: var Item, value: int) =
+proc `notificationsCount=`*(self: var ChatItem, value: int) =
   self.notificationsCount = value
 
-proc muted*(self: Item): bool =
+proc muted*(self: ChatItem): bool =
   self.muted
 
-proc `muted=`*(self: Item, value: bool) =
+proc `muted=`*(self: ChatItem, value: bool) =
   self.muted = value
 
-proc blocked*(self: Item): bool =
+proc blocked*(self: ChatItem): bool =
   self.blocked
 
-proc `blocked=`*(self: var Item, value: bool) =
+proc `blocked=`*(self: var ChatItem, value: bool) =
   self.blocked = value
 
-proc active*(self: Item): bool =
+proc active*(self: ChatItem): bool =
   self.active
 
-proc `active=`*(self: var Item, value: bool) =
+proc `active=`*(self: var ChatItem, value: bool) =
   self.active = value
 
-proc position*(self: Item): int =
+proc position*(self: ChatItem): int =
   self.position
 
-proc `position=`*(self: var Item, value: int) =
+proc `position=`*(self: var ChatItem, value: int) =
   self.position = value
 
-proc categoryId*(self: Item): string =
+proc categoryId*(self: ChatItem): string =
   self.categoryId
 
-proc `categoryId=`*(self: var Item, value: string) =
+proc `categoryId=`*(self: var ChatItem, value: string) =
   self.categoryId = value
 
-proc hideIfPermissionsNotMet*(self: Item): bool =
+proc hideIfPermissionsNotMet*(self: ChatItem): bool =
   self.hideIfPermissionsNotMet
 
-proc `hideIfPermissionsNotMet=`*(self: var Item, value: bool) =
+proc `hideIfPermissionsNotMet=`*(self: var ChatItem, value: bool) =
   self.hideIfPermissionsNotMet = value
 
-proc categoryPosition*(self: Item): int =
+proc categoryPosition*(self: ChatItem): int =
   self.categoryPosition
 
-proc `categoryPosition=`*(self: var Item, value: int) =
+proc `categoryPosition=`*(self: var ChatItem, value: int) =
   self.categoryPosition = value
 
-proc highlight*(self: Item): bool =
+proc highlight*(self: ChatItem): bool =
   self.highlight
 
-proc `highlight=`*(self: var Item, value: bool) =
+proc `highlight=`*(self: var ChatItem, value: bool) =
   self.highlight = value
 
-proc categoryOpened*(self: Item): bool =
+proc categoryOpened*(self: ChatItem): bool =
   self.categoryOpened
 
-proc `categoryOpened=`*(self: var Item, value: bool) =
+proc `categoryOpened=`*(self: var ChatItem, value: bool) =
   self.categoryOpened = value
 
-proc trustStatus*(self: Item): TrustStatus =
+proc trustStatus*(self: ChatItem): TrustStatus =
   self.trustStatus
 
-proc `trustStatus=`*(self: var Item, value: TrustStatus) =
+proc `trustStatus=`*(self: var ChatItem, value: TrustStatus) =
   self.trustStatus = value
 
-proc onlineStatus*(self: Item): OnlineStatus =
+proc onlineStatus*(self: ChatItem): OnlineStatus =
   self.onlineStatus
 
-proc `onlineStatus=`*(self: var Item, value: OnlineStatus) =
+proc `onlineStatus=`*(self: var ChatItem, value: OnlineStatus) =
   self.onlineStatus = value
 
-proc setHasUnreadMessages*(self: Item, value: bool) =
+proc setHasUnreadMessages*(self: ChatItem, value: bool) =
   self.hasUnreadMessages = value
 
-proc loaderActive*(self: Item): bool =
+proc loaderActive*(self: ChatItem): bool =
   self.loaderActive
 
-proc `loaderActive=`*(self: var Item, value: bool) =
+proc `loaderActive=`*(self: var ChatItem, value: bool) =
   self.loaderActive = value
 
-proc isCategory*(self: Item): bool =
+proc isCategory*(self: ChatItem): bool =
   self.`type` == CATEGORY_TYPE
 
-proc locked*(self: Item): bool =
+proc locked*(self: ChatItem): bool =
   self.locked
 
-proc `locked=`*(self: Item, value: bool) =
+proc `locked=`*(self: ChatItem, value: bool) =
   self.locked = value
 
-proc requiresPermissions*(self: Item): bool =
+proc requiresPermissions*(self: ChatItem): bool =
   self.requiresPermissions
 
-proc `requiresPermissions=`*(self: Item, value: bool) =
+proc `requiresPermissions=`*(self: ChatItem, value: bool) =
   self.requiresPermissions = value
 
-proc canPost*(self: Item): bool =
+proc canPost*(self: ChatItem): bool =
   self.canPost
 
-proc `canPost=`*(self: Item, value: bool) =
+proc `canPost=`*(self: ChatItem, value: bool) =
   self.canPost = value
 
-proc canView*(self: Item): bool =
+proc canView*(self: ChatItem): bool =
   self.canView
 
-proc `canView=`*(self: Item, value: bool) =
+proc `canView=`*(self: ChatItem, value: bool) =
   self.canView = value
 
-proc canPostReactions*(self: Item): bool =
+proc canPostReactions*(self: ChatItem): bool =
   self.canPostReactions
 
-proc `canPostReactions=`*(self: Item, value: bool) =
+proc `canPostReactions=`*(self: ChatItem, value: bool) =
   self.canPostReactions = value
 
-proc viewersCanPostReactions*(self: Item): bool =
+proc viewersCanPostReactions*(self: ChatItem): bool =
   self.viewersCanPostReactions
 
-proc `viewersCanPostReactions=`*(self: Item, value: bool) =
+proc `viewersCanPostReactions=`*(self: ChatItem, value: bool) =
   self.viewersCanPostReactions = value
 
-proc hideBecausePermissionsAreNotMet*(self: Item): bool =
+proc hideBecausePermissionsAreNotMet*(self: ChatItem): bool =
   self.hideIfPermissionsNotMet and not self.canPost and not self.canView
 
-proc missingEncryptionKey*(self: Item): bool =
+proc missingEncryptionKey*(self: ChatItem): bool =
   self.missingEncryptionKey
 
-proc `missingEncryptionKey=`*(self: var Item, value: bool) =
+proc `missingEncryptionKey=`*(self: var ChatItem, value: bool) =
   self.missingEncryptionKey = value

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -359,8 +359,11 @@ proc convertPubKeysToJson(self: Module, pubKeys: string): seq[string] =
 proc showPermissionUpdateNotification(self: Module, community: CommunityDto, tokenPermission: CommunityTokenPermissionDto): bool =
   return tokenPermission.state == TokenPermissionState.Approved and (community.isControlNode or not tokenPermission.isPrivate) and community.isMember
 
-method load*(self: Module) =
+method load*(self: Module, buildChats: bool = false) =
   self.controller.init()
+  if buildChats:
+    self.controller.getChatsAndBuildUI()
+
   self.view.load()
 
 method onChatsLoaded*(

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -90,7 +90,7 @@ method addOrUpdateChat(self: Module,
     setChatAsActive: bool = true,
     insertIntoModel: bool = true,
     isSectionBuild: bool = false,
-  ): chat_item.Item
+  ): ChatItem
 proc updateParentBadgeNotifications(self: Module)
 
 proc newModule*(
@@ -219,9 +219,9 @@ proc removeSubmodule(self: Module, chatId: string) =
   self.chatContentModules.del(chatId)
 
 
-proc addCategoryItem(self: Module, category: Category, memberRole: MemberRole, communityId: string, insertIntoModel: bool = true): chat_item.Item =
+proc addCategoryItem(self: Module, category: Category, memberRole: MemberRole, communityId: string, insertIntoModel: bool = true): ChatItem =
   let hasUnreadMessages = self.controller.categoryHasUnreadMessages(communityId, category.id)
-  result = chat_item.initItem(
+  result = chat_item.initChatItem(
         id = category.id,
         category.name,
         icon = "",
@@ -263,7 +263,7 @@ proc buildChatSectionUI(
   var selectedItemId = ""
   let sectionLastOpenChat = singletonInstance.localAccountSensitiveSettings.getSectionLastOpenChat(self.controller.getMySectionId())
 
-  var items: seq[chat_item.Item] = @[]
+  var items: seq[ChatItem] = @[]
   for categoryDto in community.categories:
     # Add items for the categories. We use a special type to identify categories
     items.add(self.addCategoryItem(categoryDto, community.memberRole, community.id))
@@ -603,7 +603,7 @@ proc getChatItemFromChatDto(
     chatDto: ChatDto,
     community: CommunityDto,
     setChatAsActive: bool = true,
-    ): chat_item.Item =
+    ): ChatItem =
 
   let hasNotification = chatDto.unviewedMessagesCount > 0
   let notificationsCount = chatDto.unviewedMentionsCount
@@ -681,7 +681,7 @@ proc getChatItemFromChatDto(
       viewersCanPostReactions = chatDto.viewersCanPostReactions
       missingEncryptionKey = chatDto.missingEncryptionKey
 
-  result = chat_item.initItem(
+  result = chat_item.initChatItem(
     chatDto.id,
     chatName,
     chatImage,
@@ -717,7 +717,7 @@ proc getChatItemFromChatDto(
 
 proc addNewChat(
     self: Module,
-    chatItem: chat_item.Item,
+    chatItem: ChatItem,
     chatDto: ChatDto,
     belongsToCommunity: bool,
     events: EventEmitter,
@@ -857,7 +857,7 @@ method onCommunityChannelEdited*(self: Module, chat: ChatDto) =
   if(not self.chatContentModules.contains(chat.id)):
     return
   self.changeCanPostValues(chat.id, chat.canPost, chat.canView, chat.canPostReactions, chat.viewersCanPostReactions)
-  self.view.chatsModel().updateItemDetailsById(chat.id, chat.name, chat.description, chat.emoji, chat.color, chat.hideIfPermissionsNotMet)
+  discard self.view.chatsModel().updateItemDetailsById(chat.id, chat.name, chat.description, chat.emoji, chat.color, chat.hideIfPermissionsNotMet)
   self.refreshHiddenBecauseNotPermittedState()
 
 method switchToOrCreateOneToOneChat*(self: Module, chatId: string) =
@@ -910,7 +910,7 @@ method changeMutedOnChat*(self: Module, chatId: string, muted: bool) =
   self.updateParentBadgeNotifications()
 
 proc changeCanPostValues*(self: Module, chatId: string, canPost, canView, canPostReactions, viewersCanPostReactions: bool) =
-  self.view.chatsModel().changeCanPostValues(chatId, canPost, canView, canPostReactions, viewersCanPostReactions)
+  discard self.view.chatsModel().changeCanPostValues(chatId, canPost, canView, canPostReactions, viewersCanPostReactions)
 
 proc updateChatsRequiredPermissions(self: Module, communityChats: seq[ChatDto]) =
   for communityChat in communityChats:
@@ -1330,7 +1330,7 @@ method prepareEditCategoryModel*(self: Module, categoryId: string) =
   let chats = self.controller.getChats(communityId, categoryId="")
   for chat in chats:
     let c = self.controller.getChatDetails(chat.id)
-    let chatItem = chat_item.initItem(
+    let chatItem = chat_item.initChatItem(
       c.id,
       c.name,
       icon="",
@@ -1354,7 +1354,7 @@ method prepareEditCategoryModel*(self: Module, categoryId: string) =
   let catChats = self.controller.getChats(communityId, categoryId)
   for chat in catChats:
     let c = self.controller.getChatDetails(chat.id)
-    let chatItem = chat_item.initItem(
+    let chatItem = chat_item.initChatItem(
       c.id,
       c.name,
       icon="",
@@ -1407,7 +1407,7 @@ method addOrUpdateChat(self: Module,
     setChatAsActive: bool = true,
     insertIntoModel: bool = true,
     isSectionBuild: bool = false,
-  ): chat_item.Item =
+  ): ChatItem =
   let sectionId = self.controller.getMySectionId()
   if belongsToCommunity and sectionId != chat.communityId or
     not belongsToCommunity and sectionId != singletonInstance.userProfile.getPubKey():

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -122,7 +122,7 @@ QtObject:
     read = getActiveItem
     notify = activeItemChanged
 
-  proc activeItemSet*(self: View, item: Item) =
+  proc activeItemSet*(self: View, item: ChatItem) =
     self.activeItem.setActiveItemData(item)
     self.activeItemChanged()
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -199,7 +199,7 @@ method getCommunityItem(self: Module, community: CommunityDto): SectionItem =
 
   memberItems = concat(memberItems, pendingMembers, declinedMemberItems, bannedMembers)
 
-  return initItem(
+  return initSectionItem(
       community.id,
       SectionType.Community,
       community.name,

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -407,7 +407,7 @@ proc createCommunitySectionItem[T](self: Module[T], communityDetails: CommunityD
     if not finalMembers.contains(memberItem.pubKey):
       finalMembers[memberItem.pubKey] = memberItem
 
-  result = initItem(
+  result = initSectionItem(
     communityDetails.id,
     sectionType = SectionType.Community,
     communityDetails.name,
@@ -705,7 +705,7 @@ method load*[T](
     activeSectionId = WALLET_SECTION_ID
 
   # Communities Portal Section
-  let communitiesPortalSectionItem = initItem(
+  let communitiesPortalSectionItem = initSectionItem(
     COMMUNITIESPORTAL_SECTION_ID,
     SectionType.CommunitiesPortal,
     COMMUNITIESPORTAL_SECTION_NAME,
@@ -724,7 +724,7 @@ method load*[T](
     activeSection = communitiesPortalSectionItem
 
   # Wallet Section
-  let walletSectionItem = initItem(
+  let walletSectionItem = initSectionItem(
     WALLET_SECTION_ID,
     SectionType.Wallet,
     WALLET_SECTION_NAME,
@@ -745,7 +745,7 @@ method load*[T](
     activeSection = walletSectionItem
 
   # Node Management Section
-  let nodeManagementSectionItem = initItem(
+  let nodeManagementSectionItem = initSectionItem(
     NODEMANAGEMENT_SECTION_ID,
     SectionType.NodeManagement,
     NODEMANAGEMENT_SECTION_NAME,
@@ -766,7 +766,7 @@ method load*[T](
     activeSection = nodeManagementSectionItem
 
   # Profile Section
-  let profileSettingsSectionItem = initItem(
+  let profileSettingsSectionItem = initSectionItem(
     SETTINGS_SECTION_ID,
     SectionType.ProfileSettings,
     SETTINGS_SECTION_NAME,
@@ -788,7 +788,7 @@ method load*[T](
 
   if singletonInstance.featureFlags().getMarketEnabled():
     # Market Section
-    let marketItem = initItem(
+    let marketItem = initSectionItem(
       MARKET_SECTION_ID,
       SectionType.Market,
       MARKET_SECTION_NAME,
@@ -809,7 +809,7 @@ method load*[T](
       activeSection = marketItem
   else:
     # Swap Section
-    let swapSectionItem = initItem(
+    let swapSectionItem = initSectionItem(
       SWAP_SECTION_ID,
       SectionType.Swap,
       SWAP_SECTION_NAME,
@@ -898,7 +898,7 @@ method onChatsLoaded*[T](
   )
   var items: seq[SectionItem] = @[]
 
-  let personalChatSectionItem = initItem(
+  let personalChatSectionItem = initSectionItem(
     myPubKey,
     sectionType = SectionType.Chat,
     name = CHAT_SECTION_NAME,

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -917,7 +917,8 @@ method onChatsLoaded*[T](
   if activeSectionId == personalChatSectionItem.id:
     activeSection = personalChatSectionItem
 
-  self.chatSectionModules[myPubKey].load()
+  # For the personal chat section we load the chats immediately
+  self.chatSectionModules[myPubKey].load(buildChats = true)
 
   let communities = self.controller.getJoinedAndSpectatedCommunities()
   # Create Community sections

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -59,7 +59,7 @@ type
     isPendingOwnershipRequest: bool
     activeMembersCount: int
 
-proc initItem*(
+proc initSectionItem*(
     id: string,
     sectionType: SectionType,
     name: string,

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -1,11 +1,9 @@
 {.used.}
 
 import json, stew/shims/strformat, strutils, tables
-import ../../community/dto/community
 import ../../shared_urls/dto/url_data
 
 include ../../../common/json_utils
-import ../../../../app_service/common/types
 
 type ChatType* {.pure.}= enum
   Unknown = 0,

--- a/test/nim/chat_section_model_test.nim
+++ b/test/nim/chat_section_model_test.nim
@@ -1,0 +1,114 @@
+import unittest
+
+import app/modules/main/chat_section/[model, Item]
+
+import app_service/common/types
+
+proc createTestChatItem(id: string, catId: string = "", isCategory: bool = false): ChatItem =
+  discard
+  return initChatItem(
+      id = id,
+      name = "",
+      icon = "",
+      color = "",
+      emoji = "",
+      description = "",
+      `type` = if isCategory: CATEGORY_TYPE else: 0,
+      memberRole = MemberRole.None,
+      lastMessageTimestamp = 0,
+      hasUnreadMessages = false,
+      notificationsCount = 0,
+      muted = false,
+      blocked = false,
+      active = false,
+      position = 0,
+      categoryId = catId,
+    )
+
+let chatA = createTestChatItem("0xa")
+let chatB = createTestChatItem("0xb")
+let chatC = createTestChatItem("0xc", catId = "0xcatA")
+let catA = createTestChatItem("0xcatA", catId = "0xcatA", isCategory = true)
+
+suite "empty member model":
+  let model = newModel()
+
+  test "initial size":
+    require(model.rowCount() == 0)
+
+suite "updating chat items":
+  setup:
+    let model = newModel()
+    model.setData(@[chatA, catA, chatB])
+    check(model.rowCount() == 3)
+
+  test "update can post values":
+    # Call with the same values, so nothing should change
+    var updatedRoles = model.changeCanPostValues(
+        id = "0xa",
+        canPost = true,
+        canView = true,
+        canPostReactions = true,
+        viewersCanPostReactions = true,
+      )
+    check(updatedRoles.len() == 0)
+
+    # Call with two updated value
+    updatedRoles = model.changeCanPostValues(
+        id = "0xa",
+        canPost = false,
+        canView = false,
+        canPostReactions = true,
+        viewersCanPostReactions = true,
+      )
+    # Four roles should be updated because there are collateral updates
+    check(updatedRoles.len() == 4)
+
+    let item = model.getItemById("0xa")
+    check(item.canPost == false)
+    check(item.canView == false)
+
+  test "update item details by id":
+    # Don't touch hideIfPermissionsNotMet
+    var updatedRoles = model.updateItemDetailsById(
+        id = "0xa",
+        name = "Chat A",
+        description = "Desc A",
+        emoji = "emojiA",
+        color = "#FF0000",
+        hideIfPermissionsNotMet = false,
+      )
+    check(updatedRoles.len() == 4)
+
+    # Only update hideIfPermissionsNotMet
+    updatedRoles = model.updateItemDetailsById(
+        id = "0xa",
+        name = "Chat A",
+        description = "Desc A",
+        emoji = "emojiA",
+        color = "#FF0000",
+        hideIfPermissionsNotMet = true,
+      )
+    # Two roles because hideIfPermissionsNotMet has a collateral role update
+    check(updatedRoles.len() == 2)
+
+  test "append a chat to category and change the opened state":
+    # Append a chat to a category
+    model.appendItem(chatC)
+    check(model.rowCount() == 4)
+
+    # Check if the chat is now under the category
+    let index = model.getItemIdxById("0xc")
+    # Index is 2 because the category is at index 1 and the chat is appended after it
+    check(index == 2)
+
+    # Check that the category is opened at the start
+    var cat = model.getItemById("0xcatA")
+    check(cat.categoryOpened == true)
+
+    # Change the category's opened state to false, it will affect the chat as well
+    model.changeCategoryOpened("0xcatA", false)
+    cat = model.getItemById("0xcatA")
+    check(cat.categoryOpened == false)
+    let chat = model.getItemById("0xc")
+    check(chat.categoryOpened == false)

--- a/ui/app/AppLayouts/Shell/ShellAdaptor.qml
+++ b/ui/app/AppLayouts/Shell/ShellAdaptor.qml
@@ -312,6 +312,7 @@ QObject {
 
         markerRoleName: "sectionType"
         expectedRoles: ["key", "id", "enabled", "name", "icon", "color", "hasNotification", "notificationsCount", // common props
+            "chatType", "onlineStatus", // chat
             "banner", "members", "activeMembers", "pending", "banned", // community
             "isExperimental", // settings
             "walletType", "currencyBalance", // wallet

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1156,11 +1156,6 @@ Item {
     StatusMainLayout {
         anchors.fill: parent
 
-        Component.onCompleted: {
-            if (appMain.featureFlagsStore.shellEnabled)
-                appMain.rootStore.mainModuleInst.setActiveSectionBySectionType(Constants.appSection.chat) // force the chat section to finish loading
-        }
-
         Component {
             id: shellButtonComp
             StatusNavBarTabButton {
@@ -2353,7 +2348,7 @@ Item {
                 readonly property bool sectionsLoaded: appMain.rootStore.mainModuleInst && appMain.rootStore.mainModuleInst.sectionsLoaded
 
                 sectionsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.sectionsModel : null
-                chatsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.getChatSectionModule().model // FIXME model null initially or with empty images
+                chatsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.getChatSectionModule().model
                                                : null
                 walletsBaseModel: sectionsLoaded ? WalletStores.RootStore.accounts : null
                 dappsBaseModel: dAppsServiceLoader.active && dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null


### PR DESCRIPTION
### What does the PR do

> Note: review per commit

Fixes https://github.com/status-im/status-desktop/issues/18030

I moved the initialization of the chats to the Nim side. The personal section's chats get loaded on app start now. It will impact the login a little, but not much, since it only loads the model of chats, not messages.

For the image issue, the problem was that the ShellAdaptor didn't have the `chatType` as an `expectedRole`. Same for `onlineStatus`. I guess there is a bug in the SFPM where without the expectedRole, it's undefined at first, but then when you reload the page it works, the bug being that it somehow works on reload.

---

I also did a clean up of the chat Item and Model because I was annoyed that we always use Item.

Changes Item to ChatItem. initItem to initChatItem.
Plus some clean ups to unused imports.
Adds use of `updateRole` to the model to clean up the code.
Adds a test file for the chat Model

### Affected areas

- Shell screen (model)
- Chat Item and Model

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

![Screenshot from 2025-06-02 16-53-10](https://github.com/user-attachments/assets/704da940-ca7a-416b-866b-44c2b3067427)

### Impact on end user

Fixes the issue

### How to test

- Use the feature flag `FLAG_SHELL_ENABLED=1`

### Risk 

Described potential risks and worst case scenarios.

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

