### PR TITLE
[CHERRY-PICK] fix(community): enable archive protocol when CHS is enabled during edit

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -36,6 +36,7 @@ StackLayout {
     required property WalletStore.WalletAssetsStore walletAssetsStore
     required property SharedStores.CurrenciesStore currencyStore
     required property SharedStores.NetworksStore networksStore
+    required property ProfileStores.AdvancedStore advancedStore
     property bool paymentRequestFeatureEnabled
 
     property var mutualContactsModel
@@ -288,6 +289,7 @@ StackLayout {
             activeNetworks: root.networksStore.activeNetworks
             tokensStore: root.tokensStore
             transactionStore: root.transactionStore
+            advancedStore: root.advancedStore
 
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -26,6 +26,7 @@ import AppLayouts.Communities.popups 1.0
 import AppLayouts.Communities.helpers 1.0
 
 import AppLayouts.Chat.stores 1.0 as ChatStores
+import AppLayouts.Profile.stores 1.0 as ProfileStores
 import AppLayouts.Wallet.stores 1.0
 
 StatusSectionLayout {
@@ -39,6 +40,7 @@ StatusSectionLayout {
     property UtilsStore utilsStore
     property var chatCommunitySectionModule
     required property TokensStore tokensStore
+    required property ProfileStores.AdvancedStore advancedStore
     required property var community
     required property var joinedMembers
     required property var bannedMembers
@@ -236,6 +238,7 @@ StatusSectionLayout {
                 }
 
                 onEdited: {
+                    // Step 1: Proceed with community creation
                     const error = root.chatCommunitySectionModule.editCommunity(
                                     StatusQUtils.Utils.filterXSS(item.name),
                                     StatusQUtils.Utils.filterXSS(item.description),
@@ -254,6 +257,12 @@ StatusSectionLayout {
                         errorDialog.text = error.error
                         errorDialog.open()
                     }
+                    // Step 2: Automatically set the archive protocol global property if it's been checked as
+                    // an option during community creation process. It's a more user friendly process
+                    else if(item.options.archiveSupportEnabled) {
+                        root.advancedStore.enableArchiveProtocolProperty()
+                    }
+                    
                 }
 
                 onAirdropTokensClicked: root.goTo(Constants.CommunitySettingsSections.Airdrops)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1905,6 +1905,7 @@ Item {
                                 walletAssetsStore: appMain.walletAssetsStore
                                 currencyStore: appMain.currencyStore
                                 networksStore: appMain.networksStore
+                                advancedStore: appMain.profileSectionStore.advancedStore
                                 emojiPopup: statusEmojiPopup.item
                                 stickersPopup: statusStickersPopupLoader.item
                                 sendViaPersonalChatEnabled: featureFlagsStore.sendViaPersonalChatEnabled
@@ -2164,6 +2165,7 @@ Item {
                                 walletAssetsStore: appMain.walletAssetsStore
                                 currencyStore: appMain.currencyStore
                                 networksStore: appMain.networksStore
+                                advancedStore: appMain.profileSectionStore.advancedStore
                                 paymentRequestFeatureEnabled: featureFlagsStore.paymentRequestEnabled
 
                                 mutualContactsModel: contactsModelAdaptor.mutualContacts


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/18009

Fixes #18004

Apply same procedure as https://github.com/status-im/status-desktop/pull/17767 but for edit.

I tried to see if I could use a common store function for that, but there is no easy way since it's two different function (create vs edit).
