### PR TITLE
docs: update README to point to the new BUILDING.md file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ nim_status_client.log
 *.csv
 .flatpak-builder
 /ui/StatusQ/sandbox/android/.gradle/
+.qmake_previous
 
 # Squish test ================================================================
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 ## 🛠️ Developing
 
-- [Building from Source](https://zealous-polka-dc7.notion.site/Building-ca1db4fb3baf4f15bab8da717832b743?pvs=74)
+- [Building from Source](BUILDING.md)
 - Check our [Architecture Docs](docs/architecture.md).
 - Read our [QML Architecture Guidelines](guidelines/QML_ARCHITECTURE_GUIDE.md).
 - Check out [good first issues](https://github.com/status-im/status-desktop/contribute) to get involved.

--- a/README.md
+++ b/README.md
@@ -64,17 +64,13 @@ Get the latest release for your platform:
 
 ## 🛠️ Build from Source
 
-<!-- TODO Move building docs to Github -->
-
-To build Status Desktop from source, follow the instructions specific to your operating system. Detailed build instructions are available in the [official documentation](https://zealous-polka-dc7.notion.site/Building-ca1db4fb3baf4f15bab8da717832b743?pvs=74).
-
+To build Status Desktop from source, follow the instructions specific to your operating system. Detailed build instructions are available in the [official documentation](BUILDING.md).
 
 ## 🤝 Contributing
 
 We welcome contributions from the community! To get started:
 
-<!-- TODO Improve the conributing guide to be more about how to contribute -->
-<!-- rename the current one to a style guide -->
+<!-- TODO Improve the contributing guide to be more about how to contribute -->
 <!-- TODO add guide on how to translate -->
 <!-- TODO Create a guide per persona in the contributing guide -->
 
@@ -87,11 +83,10 @@ We welcome contributions from the community! To get started:
 
 ## 📚 Documentation
 
-<!-- TODO Add architecture documentation -->
-
 - [User Help documentation](https://status.app/help)
 - [Installation Guide](https://status.app/help/getting-started#for-new-users)
-- [Building from Source](https://zealous-polka-dc7.notion.site/Building-ca1db4fb3baf4f15bab8da717832b743?pvs=74)
+- [Building from Source](BUILDING.md)
+- [Architecture Docs](docs/architecture.md).
 - [Contributing Guide](CONTRIBUTING.md)
 - [You have an idea for a cool feature or improvement?](https://discuss.status.app/c/features/51)
 
@@ -101,5 +96,3 @@ We welcome contributions from the community! To get started:
 ---
 
 For more information, visit our [official website](https://status.app/) or explore our [GitHub organization](https://github.com/status-im).
-
-


### PR DESCRIPTION
Updates the README since the BUILD.md file is now merged

Also ignores that `qmake_previous` file that kept annoying me in local changes. I'm not sure what it does, but I assume we should just ignore it.