### PR TITLE
feat(About): add a link to Status Help site

### DIFF
--- a/storybook/pages/AboutViewPage.qml
+++ b/storybook/pages/AboutViewPage.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
-import StatusQ.Core 0.1
+import StatusQ.Core 0.1 as SQCore
 import AppLayouts.Profile.views 1.0
 
 import Storybook 1.0
@@ -44,7 +44,7 @@ SplitView {
                 }
 
                 function qtRuntimeVersion() {
-                    return SystemUtils.qtRuntimeVersion()
+                    return SQCore.SystemUtils.qtRuntimeVersion()
                 }
 
                 function getReleaseNotes() {

--- a/ui/app/AppLayouts/Profile/views/AboutView.qml
+++ b/ui/app/AppLayouts/Profile/views/AboutView.qml
@@ -59,6 +59,7 @@ SettingsContentBase {
                 height: 80
                 source: root.store.isProduction ? Theme.png("status-logo-circle") : Theme.png("status-logo-dev-circle")
                 anchors.horizontalCenter: parent.horizontalCenter
+                mipmap: true
             }
 
             Item { width: 1; height: 8}
@@ -131,6 +132,12 @@ SettingsContentBase {
                 title: qsTr("Status Manifesto")
                 Layout.fillWidth: true
                 onClicked: root.store.openLink("https://status.app/manifesto")
+            }
+
+            LinkItem {
+                title: qsTr("Status Help")
+                Layout.fillWidth: true
+                onClicked: root.store.openLink(Constants.statusHelpLinkPrefix)
             }
 
             StatusDialogDivider {


### PR DESCRIPTION
### What does the PR do

- the link opens https://status.app/help in browser
- also fix the SB page (SystemUtils import conflict)

Fixes https://github.com/status-im/status-desktop/issues/17136

### Affected areas

Settings/About

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2025-06-06 12-17-02](https://github.com/user-attachments/assets/0acbd1b6-dd9b-4b79-bfe7-21b52e48c269)
