### PR TITLE
fix(Storybook): unbreak (hot) reloading the pages

### DIFF
--- a/storybook/cachecleaner.cpp
+++ b/storybook/cachecleaner.cpp
@@ -1,5 +1,6 @@
 #include "cachecleaner.h"
 
+#include <QCoreApplication>
 #include <QQmlEngine>
 
 CacheCleaner::CacheCleaner(QQmlEngine* engine)
@@ -8,5 +9,9 @@ CacheCleaner::CacheCleaner(QQmlEngine* engine)
 }
 
 void CacheCleaner::clearComponentCache() const {
+    engine->collectGarbage();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QCoreApplication::processEvents();
+
     engine->clearComponentCache();
 }

--- a/storybook/cachecleaner.cpp
+++ b/storybook/cachecleaner.cpp
@@ -1,6 +1,5 @@
 #include "cachecleaner.h"
 
-#include <QCoreApplication>
 #include <QQmlEngine>
 
 CacheCleaner::CacheCleaner(QQmlEngine* engine)
@@ -9,9 +8,5 @@ CacheCleaner::CacheCleaner(QQmlEngine* engine)
 }
 
 void CacheCleaner::clearComponentCache() const {
-    engine->collectGarbage();
-    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
-    QCoreApplication::processEvents();
-
     engine->clearComponentCache();
 }

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -204,8 +204,7 @@ ApplicationWindow {
                 clip: true
 
                 source: reloader.reloading ? "" : `pages/${root.currentPage}Page.qml`
-                active: !!source
-                asynchronous: reloader.reloading ? false : settingsLayout.loadAsynchronously
+                asynchronous: !reloader.reloading && settingsLayout.loadAsynchronously
                 visible: status === Loader.Ready
 
                 // force reload when `asynchronous` changes

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -85,7 +85,6 @@ ApplicationWindow {
     HotReloader {
         id: reloader
 
-        loader: viewLoader
         enabled: hotReloaderControls.enabled
 
         onReloaded: {
@@ -204,8 +203,9 @@ ApplicationWindow {
                 anchors.fill: parent
                 clip: true
 
-                source: `pages/${root.currentPage}Page.qml`
-                asynchronous: settingsLayout.loadAsynchronously
+                source: reloader.reloading ? "" : `pages/${root.currentPage}Page.qml`
+                active: !!source
+                asynchronous: reloader.reloading ? false : settingsLayout.loadAsynchronously
                 visible: status === Loader.Ready
 
                 // force reload when `asynchronous` changes

--- a/storybook/src/Storybook/HotReloader.qml
+++ b/storybook/src/Storybook/HotReloader.qml
@@ -20,11 +20,9 @@ QtObject {
 
     readonly property Connections _d: Connections {
         target: SourceWatcher
+        enabled: root.enabled
 
         function onChanged() {
-            if (!root.enabled)
-                return
-
             forceReload()
         }
     }

--- a/storybook/src/Storybook/HotReloader.qml
+++ b/storybook/src/Storybook/HotReloader.qml
@@ -1,64 +1,25 @@
-import QtQml 2.14
-import QtQuick 2.14
+import QtQml 2.15
+import QtQuick 2.15
 
 import Storybook 1.0
 
 QtObject {
     id: root
 
-    /*required*/ property Loader loader
-    property bool enabled: false
+    property bool enabled
+    property bool reloading
 
     signal reloaded
 
     function forceReload() {
-        // clearing component cache right after removing
-        // source from async loader causes undefined behavior
-        // and app crashes on Qt 5.14.2. For that reason
-        // asynchronous is set to false first and restored
-        // to original value after clearing.
-        d.asyncBlocker.when = true
-        d.sourceBlocker.when = true
-
-        // Starting from Qt 6.8.3 QQmlEngine::clearComponentCache works
-        // differently. Components which objects are just removed are not
-        // considered as eligible for removal from cache even though there is no
-        // alive reference to any instance of that component. For that reason
-        // QQmlEngine::clearComponentCache call must be delayed by Qt.callLater
-        // to take effect. Within the function executed by Qt.callLater, the
-        // QQmlEngine::clearComponentCache actually removes cached version,
-        // allowing to reload the page.
-        Qt.callLater(() => {
-            CacheCleaner.clearComponentCache()
-            d.asyncBlocker.when = false
-            d.sourceBlocker.when = false
-
-             reloaded()
-
-             // Log to indicate the moment when the page is reloaded
-             const fileName = loader.source.toString().split('/').pop();
-             console.log("\n\n== Reloaded", fileName, "==")
-        })
+        reloading = true
+        CacheCleaner.clearComponentCache()
+        reloading = false
+        reloaded()
     }
 
     readonly property Connections _d: Connections {
-        id: d
-
         target: SourceWatcher
-
-        readonly property Binding asyncBlocker: Binding {
-            target: root.loader
-            property: "asynchronous"
-            value: false
-            when: false
-        }
-
-        readonly property Binding sourceBlocker: Binding {
-            target: root.loader
-            property: "source"
-            value: ""
-            when: false
-        }
 
         function onChanged() {
             if (!root.enabled)


### PR DESCRIPTION
### What does the PR do

- it's been a bit flimsy under Qt 6.9, and completely stopped working in 6.9.1
- simplify the QML logic for reloading the page: guard the reloading process with a simple boolean flag, instead of working directly on the view loader 

- improve the C++ cache cleaner with first manually running the GC, send a delayed event to all objects to do a cleanup/delete, and then finally clear the component cache (suggested by Pepe in
https://bugreports.qt.io/browse/QTBUG-135448?focusedCommentId=882898&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-882898)

Quoting:
> clearComponentCache() indeed does another GC run. However, both GC
runs are required here. The first one drops the component's JavaScript wrapper, calling deleteLater() on the component. Then the event processing deletes the component and instance QObjects. The second GC run drops the compilation unit the component and the object were holding on to.

Fixes https://github.com/status-im/status-desktop/issues/18069

See the related Qt bug for the full discussion: https://bugreports.qt.io/browse/QTBUG-135448

### Affected areas

Storybook (hot) reload

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/053708ba-baec-4edb-918e-166472fa9ee2


