### PR TITLE
fix(shell): fix chat being active in the background of the shell

### DIFF
--- a/src/app/global/app_sections_config.nim
+++ b/src/app/global/app_sections_config.nim
@@ -5,6 +5,10 @@ const LOADING_SECTION_ID* = "loadingSection"
 const LOADING_SECTION_NAME* = "Chat section loading..."
 const LOADING_SECTION_ICON* = "loading"
 
+const SHELL_SECTION_ID* = "shell"
+const SHELL_SECTION_NAME* = "Jump To"
+const SHELL_SECTION_ICON* = "shell/shell"
+
 const COMMUNITIESPORTAL_SECTION_ID* = "communitiesPortal"
 const COMMUNITIESPORTAL_SECTION_NAME* = "Communities Portal"
 const COMMUNITIESPORTAL_SECTION_ICON* = "communities"

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -704,6 +704,25 @@ method load*[T](
   if activeSectionId == "" or activeSectionId == SETTINGS_SECTION_ID:
     activeSectionId = WALLET_SECTION_ID
 
+  # Shell Section
+  let shellSectionItem = initSectionItem(
+    SHELL_SECTION_ID,
+    SectionType.Shell,
+    SHELL_SECTION_NAME,
+    memberRole = MemberRole.Owner,
+    description = "",
+    image = "",
+    icon = SHELL_SECTION_ICON,
+    color = "",
+    hasNotification = false,
+    notificationsCount = 0,
+    active = true,
+    enabled = true,
+  )
+  self.view.model().addItem(shellSectionItem)
+  # Default section, always active
+  activeSection = shellSectionItem
+
   # Communities Portal Section
   let communitiesPortalSectionItem = initSectionItem(
     COMMUNITIESPORTAL_SECTION_ID,
@@ -720,8 +739,6 @@ method load*[T](
     enabled = true,
   )
   self.view.model().addItem(communitiesPortalSectionItem)
-  if activeSectionId == communitiesPortalSectionItem.id:
-    activeSection = communitiesPortalSectionItem
 
   # Wallet Section
   let walletSectionItem = initSectionItem(
@@ -741,8 +758,6 @@ method load*[T](
     enabled = WALLET_ENABLED,
   )
   self.view.model().addItem(walletSectionItem)
-  if activeSectionId == walletSectionItem.id:
-    activeSection = walletSectionItem
 
   # Node Management Section
   let nodeManagementSectionItem = initSectionItem(
@@ -762,8 +777,6 @@ method load*[T](
     enabled = singletonInstance.localAccountSensitiveSettings.getNodeManagementEnabled(),
   )
   self.view.model().addItem(nodeManagementSectionItem)
-  if activeSectionId == nodeManagementSectionItem.id:
-    activeSection = nodeManagementSectionItem
 
   # Profile Section
   let profileSettingsSectionItem = initSectionItem(
@@ -783,8 +796,6 @@ method load*[T](
     enabled = true,
   )
   self.view.model().addItem(profileSettingsSectionItem)
-  if activeSectionId == profileSettingsSectionItem.id:
-    activeSection = profileSettingsSectionItem
 
   if singletonInstance.featureFlags().getMarketEnabled():
     # Market Section
@@ -805,8 +816,6 @@ method load*[T](
       enabled = WALLET_ENABLED,
     )
     self.view.model().addItem(marketItem)
-    if activeSectionId == marketItem.id:
-      activeSection = marketItem
   else:
     # Swap Section
     let swapSectionItem = initSectionItem(
@@ -826,8 +835,6 @@ method load*[T](
       enabled = WALLET_ENABLED,
     )
     self.view.model().addItem(swapSectionItem)
-    if activeSectionId == swapSectionItem.id:
-      activeSection = swapSectionItem
 
   self.profileSectionModule.load()
   self.stickersModule.load()
@@ -870,7 +877,6 @@ method onChatsLoaded*[T](
   if not self.isEverythingLoaded:
     return
   let myPubKey = singletonInstance.userProfile.getPubKey()
-  var activeSection: SectionItem
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
 
   # Create personal chat section
@@ -914,8 +920,6 @@ method onChatsLoaded*[T](
     muted = false,
   )
   items.add(personalChatSectionItem)
-  if activeSectionId == personalChatSectionItem.id:
-    activeSection = personalChatSectionItem
 
   # For the personal chat section we load the chats immediately
   self.chatSectionModules[myPubKey].load(buildChats = true)
@@ -943,8 +947,6 @@ method onChatsLoaded*[T](
     )
     let communitySectionItem = self.createCommunitySectionItem(community)
     items.add(communitySectionItem)
-    if activeSectionId == communitySectionItem.id:
-      activeSection = communitySectionItem
 
     self.chatSectionModules[community.id].load()
 
@@ -953,10 +955,6 @@ method onChatsLoaded*[T](
   self.checkIfWeHaveNotifications()
 
   self.events.emit(SIGNAL_MAIN_LOADED, Args())
-
-  # Set active section if it is one of the channel sections
-  if not activeSection.isEmpty():
-    self.setActiveSection(activeSection)
 
   self.view.sectionsLoaded()
   if self.statusDeepLinkToActivate != "":

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -167,7 +167,6 @@ QtObject:
 
   proc activeSectionSet*(self: View, item: SectionItem) =
     self.activeSection.setActiveSectionData(item)
-    self.activeSectionChanged()
 
   proc setNthEnabledSectionActive*(self: View, nth: int) {.slot.} =
     let item = self.model.getNthEnabledItem(nth)

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -10,7 +10,8 @@ import ../../../app_service/service/community_tokens/community_collectible_owner
 
 type
   SectionType* {.pure.} = enum
-    Wallet = 0,
+    Shell = 0,
+    Wallet,
     Chat,
     Community,
     ProfileSettings,

--- a/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -11,8 +11,6 @@ Rectangle {
     id: root
     objectName: "statusAppNavBar"
 
-    property alias shellItem: shellItemLoader.sourceComponent
-
     property alias topSectionModel: topSectionListview.model
     property alias topSectionDelegate: topSectionListview.delegate
 
@@ -51,13 +49,6 @@ Rectangle {
         }
 
         spacing: d.spacing
-
-        Loader {
-            id: shellItemLoader
-            Layout.alignment: Qt.AlignHCenter
-            active: !!sourceComponent
-            visible: active
-        }
 
         ListView {
             id: topSectionListview

--- a/ui/StatusQ/src/StatusQ/Layout/StatusMainLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusMainLayout.qml
@@ -55,8 +55,7 @@ SplitView {
     }
 
     Control {
-        SplitView.minimumWidth: 78
-        SplitView.preferredWidth: 78
+        SplitView.preferredWidth: !!leftPanel && leftPanel.visible ? leftPanel.width : 0
         SplitView.fillHeight: true
         background: null
         contentItem: (!!leftPanel) ? leftPanel : null

--- a/ui/app/AppLayouts/Shell/ShellAdaptor.qml
+++ b/ui/app/AppLayouts/Shell/ShellAdaptor.qml
@@ -101,6 +101,11 @@ QObject {
         filters: [
             ValueFilter {
                 roleName: "sectionType"
+                value: Constants.appSection.shell
+                inverted: true
+            },
+            ValueFilter {
+                roleName: "sectionType"
                 value: Constants.appSection.loadingSection
                 inverted: true
             },

--- a/ui/app/AppLayouts/Shell/ShellContainer.qml
+++ b/ui/app/AppLayouts/Shell/ShellContainer.qml
@@ -51,7 +51,8 @@ Control {
     spacing: Theme.bigPadding
 
     function focusSearch() {
-        searchField.forceActiveFocus()
+        // Need to use Qt.callLater to ensure the focus is set after the component is fully loaded
+        Qt.callLater(() => searchField.forceActiveFocus())
     }
 
     Component.onCompleted: focusSearch()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -818,12 +818,8 @@ Item {
         }
 
         function openShell() {
-            shellLoader.active = true
+            appMain.rootStore.mainModuleInst.setActiveSectionById("shell")
             shellLoader.item.focusSearch()
-        }
-
-        function closeShell() {
-            shellLoader.active = false
         }
 
         function maybeDisplayIntroduceYourselfPopup() {
@@ -973,8 +969,6 @@ Item {
             } else if (sectionType === Constants.appSection.community && subsection !== "") {
                 appMain.communitiesStore.setActiveCommunity(subsection)
             }
-
-            d.closeShell()
         }
 
         function onSwitchToCommunity(communityId: string) {
@@ -1057,7 +1051,6 @@ Item {
     }
 
     function changeAppSectionBySectionId(sectionId) {
-        d.closeShell()
         appMain.rootStore.mainModuleInst.setActiveSectionById(sectionId)
     }
 
@@ -1156,28 +1149,18 @@ Item {
     StatusMainLayout {
         anchors.fill: parent
 
-        Component {
-            id: shellButtonComp
-            StatusNavBarTabButton {
-                objectName: "ShellNavBarButton"
-                anchors.horizontalCenter: parent.horizontalCenter
-                icon.name: "shell/shell"
-                tooltip.text: "%1 (%2)".arg(Utils.translatedSectionName(Constants.appSection.shell)).arg(shellShortcut.nativeText)
-
-                onClicked: {
-                    d.openShell()
-                    checked = false // section is never "active"
-                }
-            }
-        }
-
         leftPanel: StatusAppNavBar {
-            shellItem: appMain.featureFlagsStore.shellEnabled ? shellButtonComp : undefined
+            visible: !shellLoader.active
+            width: visible ? implicitWidth : 0
 
             topSectionModel: SortFilterProxyModel {
                 sourceModel: appMain.rootStore.mainModuleInst.sectionsModel
                 filters: [
                     AnyOf {
+                        ValueFilter {
+                            roleName: "sectionType"
+                            value: Constants.appSection.shell
+                        }
                         ValueFilter {
                             roleName: "sectionType"
                             value: Constants.appSection.wallet
@@ -1383,7 +1366,12 @@ Item {
                     name: model.icon.length > 0? "" : model.name
                     icon.name: model.icon
                     icon.source: model.image
-                    tooltip.text: Utils.translatedSectionName(model.sectionType, model.name)
+                    tooltip.text: Utils.translatedSectionName(model.sectionType, model.name, (sectionType) => {
+                        if (sectionType === Constants.appSection.shell) {
+                            return shellShortcut.nativeText
+                        }
+                        return ""
+                    })
                     checked: model.active
 
                     readonly property bool displayCreateCommunityBadge: model.sectionType === Constants.appSection.communitiesPortal && !appMain.communitiesStore.createCommunityPopupSeen
@@ -1778,35 +1766,36 @@ Item {
 
                     currentIndex: {
                         const activeSectionType = appMain.rootStore.mainModuleInst.activeSection.sectionType
-
-                        if (activeSectionType === Constants.appSection.chat)
+                        switch (activeSectionType) {
+                        case Constants.appSection.shell:
+                            return Constants.appViewStackIndex.shell
+                        case Constants.appSection.chat:
                             return Constants.appViewStackIndex.chat
-                        if (activeSectionType === Constants.appSection.community) {
-                            for (let i = this.children.length - 1; i >=0; i--) {
+                        case Constants.appSection.community:
+                            for (let i = this.children.length - 1; i >= 0; i--) {
                                 var obj = this.children[i]
                                 if (obj && obj.sectionId && obj.sectionId === appMain.rootStore.mainModuleInst.activeSection.id) {
                                     return i
                                 }
                             }
-
                             // Should never be here, correct index must be returned from the for loop above
                             console.error("Wrong section type:", appMain.rootStore.mainModuleInst.activeSection.sectionType,
                                           "or section id: ", appMain.rootStore.mainModuleInst.activeSection.id)
                             return Constants.appViewStackIndex.community
-                        }
-                        if (activeSectionType === Constants.appSection.communitiesPortal)
+                        case Constants.appSection.communitiesPortal:
                             return Constants.appViewStackIndex.communitiesPortal
-                        if (activeSectionType === Constants.appSection.wallet)
+                        case Constants.appSection.wallet:
                             return Constants.appViewStackIndex.wallet
-                        if (activeSectionType === Constants.appSection.profile)
+                        case Constants.appSection.profile:
                             return Constants.appViewStackIndex.profile
-                        if (activeSectionType === Constants.appSection.node)
+                        case Constants.appSection.node:
                             return Constants.appViewStackIndex.node
-                        if (activeSectionType === Constants.appSection.market)
+                        case Constants.appSection.market:
                             return Constants.appViewStackIndex.market
-
-                        // We should never end up here
-                        console.error("AppMain: Unknown section type")
+                        default:
+                            // We should never end up here
+                            console.error("AppMain: Unknown section type")
+                        }
                     }
                     onCurrentIndexChanged: {
                         const sectionType = appMain.rootStore.mainModuleInst.activeSection.sectionType
@@ -1818,6 +1807,93 @@ Item {
                     // NOTE:
                     // If we ever change stack layout component order we need to updade
                     // Constants.appViewStackIndex accordingly
+
+                    Loader {
+                        id: shellLoader
+                        anchors.fill: parent
+                        focus: active
+                        active: appMain.featureFlagsStore.shellEnabled && appView.currentIndex === Constants.appViewStackIndex.shell
+
+                        sourceComponent: ShellContainer {
+                            id: shell
+
+                            objectName: "shellContainer"
+
+                            ShellAdaptor {
+                                id: shellAdaptor
+                                readonly property bool sectionsLoaded: appMain.rootStore.mainModuleInst && appMain.rootStore.mainModuleInst.sectionsLoaded
+
+                                sectionsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.sectionsModel : null
+                                chatsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.getChatSectionModule().model
+                                                            : null
+                                walletsBaseModel: sectionsLoaded ? WalletStores.RootStore.accounts : null
+                                dappsBaseModel: dAppsServiceLoader.active && dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
+
+                                showEnabledSectionsOnly: true
+                                marketEnabled: appMain.featureFlagsStore.marketEnabled
+
+                                syncingBadgeCount: appMain.rootStore.profileSectionStore.devicesStore.devicesModel.count -
+                                                appMain.rootStore.profileSectionStore.devicesStore.devicesModel.pairedCount
+                                messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
+                                showBackUpSeed: !appMain.rootStore.profileSectionStore.profileStore.userDeclinedBackupBanner &&
+                                                !appMain.rootStore.profileSectionStore.profileStore.privacyStore.mnemonicBackedUp
+
+                                searchPhrase: shell.searchPhrase
+
+                                profileId: appMain.profileStore.pubkey
+                            }
+
+                            shellEntriesModel: shellAdaptor.shellEntriesModel
+                            sectionsModel: shellAdaptor.sectionsModel
+                            pinnedModel: shellAdaptor.pinnedModel
+
+                            profileStore: appMain.profileStore
+
+                            getEmojiHashFn: appMain.utilsStore.getEmojiHash
+                            getLinkToProfileFn: appMain.rootStore.contactStore.getLinkToProfile
+
+                            useNewDockIcons: true
+                            hasUnseenACNotifications: appMain.activityCenterStore.hasUnseenNotifications
+                            aCNotificationCount: appMain.activityCenterStore.unreadNotificationsCount
+
+                            onItemActivated: function(key, sectionType, itemId) {
+                                shellAdaptor.setTimestamp(key, new Date().valueOf())
+
+                                if (sectionType === Constants.appSection.profile) {
+                                    if (itemId == Constants.settingsSubsection.backUpSeed) {
+                                        return Global.openBackUpSeedPopup()
+                                    } else if (itemId == Constants.settingsSubsection.signout) {
+                                        return Global.quitAppRequested()
+                                    }
+                                }
+
+                                let subsection = itemId
+                                let subSubsection = -1
+                                let data = {}
+
+                                if (sectionType === Constants.appSection.wallet && !!itemId) {
+                                    subsection = WalletLayout.LeftPanelSelection.Address
+                                    subSubsection = WalletLayout.RightPanelSelection.Assets
+                                    data = { address: itemId }
+                                }
+
+                                globalConns.onAppSectionBySectionTypeChanged(sectionType, subsection, subSubsection, data)
+                            }
+                            onItemPinRequested: function(key, pin) {
+                                shellAdaptor.setPinned(key, pin)
+                                if (pin)
+                                    shellAdaptor.setTimestamp(key, new Date().valueOf()) // update the timestamp so that the pinned dock items are sorted by their recency
+                            }
+                            onDappDisconnectRequested: function(dappUrl) {
+                                dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppDisconnectInitiated)
+                                dAppsServiceLoader.dappDisconnectRequested(dappUrl)
+                            }
+
+                            onNotificationButtonClicked: d.openActivityCenterPopup()
+                            onSetCurrentUserStatusRequested: (status) => appMain.rootStore.setCurrentUserStatus(status)
+                            onViewProfileRequested: (pubKey) => Global.openProfilePopup(pubKey)
+                        }
+                    }
 
                     Loader {
                         asynchronous: true
@@ -2329,93 +2405,6 @@ Item {
                     close()
                 }
             }
-        }
-    }
-
-    Loader {
-        id: shellLoader
-        anchors.fill: parent
-        focus: active
-        active: appMain.featureFlagsStore.shellEnabled
-
-        sourceComponent: ShellContainer {
-            id: shell
-
-            objectName: "shellContainer"
-
-            ShellAdaptor {
-                id: shellAdaptor
-                readonly property bool sectionsLoaded: appMain.rootStore.mainModuleInst && appMain.rootStore.mainModuleInst.sectionsLoaded
-
-                sectionsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.sectionsModel : null
-                chatsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.getChatSectionModule().model
-                                               : null
-                walletsBaseModel: sectionsLoaded ? WalletStores.RootStore.accounts : null
-                dappsBaseModel: dAppsServiceLoader.active && dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
-
-                showEnabledSectionsOnly: true
-                marketEnabled: appMain.featureFlagsStore.marketEnabled
-
-                syncingBadgeCount: appMain.rootStore.profileSectionStore.devicesStore.devicesModel.count -
-                                   appMain.rootStore.profileSectionStore.devicesStore.devicesModel.pairedCount
-                messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
-                showBackUpSeed: !appMain.rootStore.profileSectionStore.profileStore.userDeclinedBackupBanner &&
-                                !appMain.rootStore.profileSectionStore.profileStore.privacyStore.mnemonicBackedUp
-
-                searchPhrase: shell.searchPhrase
-
-                profileId: appMain.profileStore.pubkey
-            }
-
-            shellEntriesModel: shellAdaptor.shellEntriesModel
-            sectionsModel: shellAdaptor.sectionsModel
-            pinnedModel: shellAdaptor.pinnedModel
-
-            profileStore: appMain.profileStore
-
-            getEmojiHashFn: appMain.utilsStore.getEmojiHash
-            getLinkToProfileFn: appMain.rootStore.contactStore.getLinkToProfile
-
-            useNewDockIcons: true
-            hasUnseenACNotifications: appMain.activityCenterStore.hasUnseenNotifications
-            aCNotificationCount: appMain.activityCenterStore.unreadNotificationsCount
-
-            onItemActivated: function(key, sectionType, itemId) {
-                shellAdaptor.setTimestamp(key, new Date().valueOf())
-
-                if (sectionType === Constants.appSection.profile) {
-                    if (itemId == Constants.settingsSubsection.backUpSeed) {
-                        return Global.openBackUpSeedPopup()
-                    } else if (itemId == Constants.settingsSubsection.signout) {
-                        return Global.quitAppRequested()
-                    }
-                }
-
-                let subsection = itemId
-                let subSubsection = -1
-                let data = {}
-
-                if (sectionType === Constants.appSection.wallet && !!itemId) {
-                    subsection = WalletLayout.LeftPanelSelection.Address
-                    subSubsection = WalletLayout.RightPanelSelection.Assets
-                    data = { address: itemId }
-                }
-
-                globalConns.onAppSectionBySectionTypeChanged(sectionType, subsection, subSubsection, data)
-            }
-            onItemPinRequested: function(key, pin) {
-                shellAdaptor.setPinned(key, pin)
-                if (pin)
-                    shellAdaptor.setTimestamp(key, new Date().valueOf()) // update the timestamp so that the pinned dock items are sorted by their recency
-            }
-            onDappDisconnectRequested: function(dappUrl) {
-                dappMetrics.logNavigationEvent(DAppsMetrics.DAppsNavigationAction.DAppDisconnectInitiated)
-                dAppsServiceLoader.dappDisconnectRequested(dappUrl)
-            }
-
-            onNotificationButtonClicked: d.openActivityCenterPopup()
-            onSetCurrentUserStatusRequested: (status) => appMain.rootStore.setCurrentUserStatus(status)
-            onViewProfileRequested: (pubKey) => Global.openProfilePopup(pubKey)
         }
     }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -328,28 +328,29 @@ QtObject {
     readonly property int chatSectionLeftColumnWidth: 304
 
     readonly property QtObject appSection: QtObject {
-        readonly property int chat: 1
-        readonly property int community: 2
-        readonly property int wallet: 0
-        readonly property int profile: 3
-        readonly property int node: 4
-        readonly property int communitiesPortal: 5
-        readonly property int loadingSection: 6
-        readonly property int swap: 7
-        readonly property int market: 8
+        readonly property int chat: 2
+        readonly property int community: 3
+        readonly property int wallet: 1
+        readonly property int profile: 4
+        readonly property int node: 5
+        readonly property int communitiesPortal: 6
+        readonly property int loadingSection: 7
+        readonly property int swap: 8
+        readonly property int market: 9
 
-        readonly property int shell: 666
+        readonly property int shell: 0
         readonly property int dApp: 999
     }
 
     readonly property QtObject appViewStackIndex: QtObject {
-        readonly property int chat: 0
-        readonly property int community: 7 // any stack layout children with the index 7 or higher is community
-        readonly property int communitiesPortal: 1
-        readonly property int wallet: 2
-        readonly property int profile: 3
-        readonly property int node: 4
-        readonly property int market: 5
+        readonly property int shell: 0
+        readonly property int chat: 1
+        readonly property int community: 8 // any stack layout children with the index 7 or higher is community
+        readonly property int communitiesPortal: 2
+        readonly property int wallet: 3
+        readonly property int profile: 4
+        readonly property int node: 5
+        readonly property int market: 6
     }
 
     readonly property QtObject settingsSubsection: QtObject {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -409,7 +409,11 @@ QtObject {
     }
 
     // handle translations for section names coming from app_sections_config.nim
-    function translatedSectionName(sectionType, fallback) {
+    function translatedSectionName(sectionType, fallback, additionalTextFunction) {
+        if (additionalTextFunction === undefined) {
+            additionalTextFunction = function() { return "" }
+        }
+
         switch(sectionType) {
         case Constants.appSection.chat:
             return qsTr("Messages")
@@ -432,7 +436,7 @@ QtObject {
         case Constants.appSection.dApp:
             return qsTr("dApp")
         case Constants.appSection.shell:
-            return qsTr("Shell")
+            return "%1 (%2)".arg(qsTr("Shell")).arg(additionalTextFunction(sectionType))
         default:
             return fallback
         }


### PR DESCRIPTION
### What does the PR do

Fixes #18059

Fixes the issue by putting the Shell as part of the sections themselves. that way we ensure that no other section is active in the background for no reason. It simplifies the code a little since we no longer need a custom shell button

### Affected areas

- main module (added the new section and removed the old code to set a section as active)
- AppMain (moved the Shell in the StackLayout)

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

[chat-in-background-shell.webm](https://github.com/user-attachments/assets/b135e86d-a5f7-478e-b3d3-07c6297b59ec)

### Impact on end user

Fixes the issue of chat messages being marked as read even if not shown to the user. Nothing in the background when in the shell, so no risk of side effects

### How to test

- Use the shell as usual

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
