### PR TITLE
ci: remove nix job

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -67,11 +67,6 @@ pipeline {
             }
           }
         }
-        stage('Linux/x86_64/Nix') { steps { script {
-          linux_x86_64_nix = getArtifacts(
-            'Linux-Nix', jenkins.Build('status-desktop/systems/linux/x86_64/package-nix')
-          )
-        } } }
         stage('Windows/x86_64') { steps { script {
           windows_x86_64 = getArtifacts(
             'Windows', jenkins.Build('status-desktop/systems/windows/x86_64/package')


### PR DESCRIPTION
### Summary

In the light of upcoming QT6 upgrade we've decided to stop building nix package in CI.
We will re think the nix builds after QT6 upgrade.