### PR TITLE
fix: do not remove vendor folder from submodules when cleaning

### DIFF
--- a/scripts/clean-git.sh
+++ b/scripts/clean-git.sh
@@ -3,6 +3,5 @@
 git clean -qfdx
 git submodule foreach --recursive git reset -q --hard
 git submodule foreach --recursive git clean -qfdx
-git submodule foreach --recursive rm -fr vendor
 # to get rid of lingering DOtherSide
 git clean -xdf vendor


### PR DESCRIPTION
This is causing package version to include `-dirty` flag.