### PR TITLE
ci: upgrade go to 1.23

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,11 +45,11 @@ Run with **Administrator** privileges:
 choco install make cmake mingw wget
 ```
 
-#### Install Go 1.22
+#### Install Go 1.23
 
-Download and install Go 1.22 from the [official website](https://go.dev/dl/).
+Download and install Go 1.23 from the [official website](https://go.dev/dl/).
 
-> ⚠️ Note: 1.22 version is a strict requirement for now. Version 1.23 won't work
+> ⚠️ Note: 1.23 version is a strict requirement for now. Version 1.24 won't work
 
 > ⚠️ Note: There is a script `scripts/windows_build_setup.ps1`, but it may be outdated.
 
@@ -71,7 +71,7 @@ wget https://launchpad.net/~ubuntu-security-proposed/+archive/ubuntu/ppa/+build/
 sudo dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
 ```
 
-Install **Go 1.22**:
+Install **Go 1.23**:
 
 Download and install from the [official website](https://go.dev/dl/).
 
@@ -127,7 +127,7 @@ Install [Homebrew](https://brew.sh/) if not already installed.
 #### Install Required Packages
 
 ```bash
-brew install cmake pkg-config go@1.22 qt@5 jq nvm yarn protobuf
+brew install cmake pkg-config go@1.23 qt@5 jq nvm yarn protobuf
 ```
 
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -125,9 +125,9 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1
 ENV PATH="/opt/cmake/bin:${PATH}"
 
 # Installing Golang
-RUN GOLANG_SHA256="736ce492a19d756a92719a6121226087ccd91b652ed5caec40ad6dbfb2252092" \
- && GOLANG_TARBALL="go1.22.10.linux-amd64.tar.gz" \
- && wget -q -L "https://dl.google.com/go/${GOLANG_TARBALL}" \
+RUN GOLANG_SHA256="535f9f81802499f2a7dbfa70abb8fda3793725fcc29460f719815f6e10b5fd60" \
+ && GOLANG_TARBALL="go1.23.10.linux-amd64.tar.gz" \
+ && wget -q "https://dl.google.com/go/${GOLANG_TARBALL}" \
  && echo "${GOLANG_SHA256} ${GOLANG_TARBALL}" | sha256sum -c \
  && sudo tar -C /usr/local -xzf "${GOLANG_TARBALL}" \
  && rm "${GOLANG_TARBALL}" \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT 6.9.0 */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.1-qt6.9.0'
+      image 'statusteam/nim-status-client-build:2.0.2-qt6.9.0'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -7,7 +7,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-6.9.0 && go-1.22 && xcode-16.2"
+    label "${getAgentLabels().join(' && ')} && qt-6.9.0 && go-1.23 && xcode-16.2"
   }
 
   parameters {

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -8,7 +8,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.1-qt6.9.0'
+      image 'statusteam/nim-status-client-build:2.0.2-qt6.9.0'
     }
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -5,7 +5,7 @@ library 'status-jenkins-lib@v1.9.24'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'windows && x86_64 && qt-6.9.0 && go-1.22' }
+  agent { label 'windows && x86_64 && qt-6.9.0 && go-1.23' }
 
   parameters {
     booleanParam(

--- a/scripts/macos_build_setup.sh
+++ b/scripts/macos_build_setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-GO_VERSION="1.22.10"
+GO_VERSION="1.23.10"
 GO_INSTALL_DIR="/usr/local/go"
 QT_VERSION="6.9.0"
 CMAKE_VERSION="3.31.6"
@@ -54,14 +54,14 @@ function install_golang {
   fi
   declare -A GO_SHA256_MAP
   GO_SHA256_MAP=(
-    ["amd64"]="dd2c4ac3702658c2c20e3a8b394da1917d86156b2cb4312c9d2f657f80067874"
-    ["arm64"]="21cf49415ffe0755b45f2b63e75d136528a32f7bb7bdd0166f51d22a03eb0a3f"
+    ["amd64"]="1cbd7af6f07bc6fa1f8672f9b913c961986864100e467e0acdc942e0ae46fe68"
+    ["arm64"]="25c64bfa8a8fd8e7f62fb54afa4354af8409a4bb2358c2699a1003b733e6fce5"
   )
   echo "Install GoLang ${GO_VERSION}"
   GO_ARCH=$(get_go_arch)
   GO_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
   GO_TARBALL="go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
-  # example: https://dl.google.com/go/go1.22.10.darwin-amd64.tar.gz
+  # example: https://dl.google.com/go/go1.23.10.darwin-amd64.tar.gz
   wget -q "https://dl.google.com/go/${GO_TARBALL}" -O "${GO_TARBALL}"
   echo "${GO_SHA256_MAP[${GO_ARCH}]} ${GO_TARBALL}" | sha256sum -c
   tar -C "${GO_INSTALL_DIR%/go}" -xzf "${GO_TARBALL}"

--- a/scripts/ubuntu_build_setup.sh
+++ b/scripts/ubuntu_build_setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-GO_VERSION="1.22.10"
+GO_VERSION="1.23.10"
 GO_INSTALL_DIR="/usr/local/go"
 QT_VERSION="6.9.0"
 QT_INSTALL_DIR="/opt/qt"
@@ -69,15 +69,15 @@ function install_golang {
   fi
   declare -A GO_SHA256_MAP
   GO_SHA256_MAP=(
-    ["amd64"]="736ce492a19d756a92719a6121226087ccd91b652ed5caec40ad6dbfb2252092"
-    ["arm64"]="5213c5e32fde3bd7da65516467b7ffbfe40d2bb5a5f58105e387eef450583eec"
-    ["armv6l"]="a7bbbc80fe736269820bbdf3555e91ada5d18a5cde2276aac3b559bc1d52fc70"
+    ["amd64"]="535f9f81802499f2a7dbfa70abb8fda3793725fcc29460f719815f6e10b5fd60"
+    ["arm64"]="bfb1f1df7173f44648ee070a39ab0481068632f595305a699d89cd56a33b8081"
+    ["armv6l"]="b6e00c9a72406d394b9f167e74670e28b72ed559cca8115b21be1cb9d5316cb4"
   )
   echo "Install GoLang ${GO_VERSION}"
   GO_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
   GO_ARCH=$(get_go_arch)
   GO_TARBALL="go${GO_VERSION}.${GO_OS}-${GO_ARCH}.tar.gz"
-  # example: https://dl.google.com/go/go1.22.10.linux-amd64.tar.gz
+  # example: https://dl.google.com/go/go1.23.10.linux-amd64.tar.gz
   wget -q "https://dl.google.com/go/${GO_TARBALL}" -O "${GO_TARBALL}"
   echo "${GO_SHA256_MAP[${GO_ARCH}]} ${GO_TARBALL}" | sha256sum -c
   tar -C "${GO_INSTALL_DIR}" -xzf "${GO_TARBALL}"

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -33,7 +33,7 @@ function Install-Dependencies {
     if (!(scoop bucket list | Where { $_.Name -eq "extras" })) {
         scoop bucket add extras
     }
-    scoop install --global go@1.22.10
+    scoop install --global go@1.23.10
     scoop install --global protobuf@3.20.0
     scoop install --global vcredist2022
     scoop install --global cmake@3.31.6


### PR DESCRIPTION
## Summary

- update status-go to point to changes in https://github.com/status-im/status-go/pull/6678
- update build scripts for windows,linux and desktop for go 1.23
- use docker image with go 1.23
