### PR TITLE
fix: clean mobile vendor

### DIFF
--- a/scripts/clean-git.sh
+++ b/scripts/clean-git.sh
@@ -5,3 +5,4 @@ git submodule foreach --recursive git reset -q --hard
 git submodule foreach --recursive git clean -qfdx
 # to get rid of lingering DOtherSide
 git clean -xdf vendor
+git clean -xdf mobile/vendor


### PR DESCRIPTION
## Summary

To fix errors like this in CI 

```
[2025-06-13T15:41:23.856Z] + make update
[2025-06-13T15:41:26.301Z] error: cannot rebase: You have unstaged changes.
[2025-06-13T15:41:26.301Z] error: Please commit or stash them.
[2025-06-13T15:41:26.301Z] fatal: Unable to rebase 'ede3886cc5507c2ba000ab9b057f198da03e8766' in 
submodule path 'mobile/vendors/openssl/gost-engine'
[2025-06-13T15:41:26.301Z] fatal: Failed to recurse into submodule path 'mobile/vendors/openssl'
[2025-06-13T15:41:26.301Z] error: cannot rebase: You have unstaged changes.
[2025-06-13T15:41:26.301Z] error: Please commit or stash them.
[2025-06-13T15:41:26.301Z] fatal: Unable to rebase 'ede3886cc5507c2ba000ab9b057f198da03e8766' in 
submodule path 'mobile/vendors/openssl/gost-engine'
[2025-06-13T15:41:26.301Z] fatal: Failed to recurse into submodule path 'mobile/vendors/openssl'
[2025-06-13T15:41:26.301Z] make: *** [vendor/nimbus-build-system/makefiles/targets.mk:111: update-common] 
Error 128
```
