### PR TITLE
fix(StatusChatInfoButton): Wrong hover/cursor on Qt6

### DIFF
--- a/storybook/pages/StatusChatInfoButtonPage.qml
+++ b/storybook/pages/StatusChatInfoButtonPage.qml
@@ -1,0 +1,136 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
+import Models 1.0
+import Storybook 1.0
+
+SplitView {
+    id: root
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        StatusChatInfoButton {
+            anchors.centerIn: parent
+
+            title: ctrlTitle.text
+            subTitle: ctrlSubTitle.text
+            type: ctrlType.currentValue
+
+            asset {
+                color: Theme.palette.primaryColor1
+                name: ctrlIcon.checked ? ModelsData.icons.cryptPunks : ""
+                emoji: ctrlEmoji.checked ? "💩" : ""
+            }
+
+            muted: ctrlMuted.checked
+            onUnmute: {
+                logs.logEvent("onUnmute")
+                ctrlMuted.checked = false
+            }
+
+            pinnedMessagesCount: ctrlPinnedMessagesCount.value
+            onPinnedMessagesCountClicked: logs.logEvent("onPinnedMessagesCountClicked")
+
+            requiresPermissions: ctrlRequiresPermissions.checked
+            locked: ctrlLocked.checked
+
+            onLinkActivated: logs.logEvent("onLinkActivated", ["link"], arguments)
+            onClicked: logs.logEvent("onClicked")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 300
+        SplitView.preferredHeight: 300
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            TextField {
+                Layout.preferredWidth: 200
+                id: ctrlTitle
+                placeholderText: "Title"
+                text: "Channel title"
+            }
+
+            TextField {
+                Layout.preferredWidth: 200
+                id: ctrlSubTitle
+                placeholderText: "Subtitle"
+                text: "This is a subtitle with a clickable <a href='https://status.app'>link</a>"
+            }
+
+            RowLayout {
+                Label { text: "Type:" }
+                ComboBox {
+                    Layout.preferredWidth: 200
+                    id: ctrlType
+                    textRole: "text"
+                    valueRole: "value"
+                    displayText: currentText || ""
+                    currentIndex: 0
+                    model: [
+                        { value: StatusChatInfoButton.Type.OneToOneChat, text: "OneToOneChat" },
+                        { value: StatusChatInfoButton.Type.PublicChat, text: "PublicChat" },
+                        { value: StatusChatInfoButton.Type.GroupChat, text: "GroupChat" },
+                        { value: StatusChatInfoButton.Type.CommunityChat, text: "CommunityChat" },
+                    ]
+                }
+                Switch {
+                    id: ctrlRequiresPermissions
+                    text: "Requires permissions"
+                    enabled: ctrlType.currentValue === StatusChatInfoButton.Type.CommunityChat
+                }
+                Switch {
+                    id: ctrlLocked
+                    text: "Locked"
+                    enabled: ctrlType.currentValue === StatusChatInfoButton.Type.CommunityChat
+                }
+            }
+
+            RowLayout {
+                Label { text: "Image" }
+                RadioButton {
+                    id: ctrlIcon
+                    text: "Icon"
+                    checked: true
+                }
+                RadioButton {
+                    id: ctrlEmoji
+                    text: "Emoji"
+                }
+                RadioButton {
+                    id: ctrlNoImage
+                    text: "None"
+                }
+            }
+
+            RowLayout {
+                Label { text: "Pinned messages:" }
+                SpinBox {
+                    id: ctrlPinnedMessagesCount
+                    from: 0
+                    to: 100
+                }
+            }
+            Switch {
+                id: ctrlMuted
+                text: "Muted"
+            }
+        }
+    }
+}
+
+// category: Controls
+// status: good

--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -47,14 +47,14 @@ Button {
     verticalPadding: 2
     spacing: 4
 
-    background: Rectangle {
-        radius: 8
-        color: root.enabled && root.hovered ? Theme.palette.baseColor2 : "transparent"
+    HoverHandler {
+        enabled: root.hoverEnabled
+        cursorShape: hovered ? Qt.PointingHandCursor : undefined
+    }
 
-        HoverHandler {
-            enabled: root.hoverEnabled
-            cursorShape: enabled ? Qt.PointingHandCursor : undefined
-        }
+    background: Rectangle {
+        radius: Theme.radius
+        color: root.enabled && root.hovered ? Theme.palette.baseColor2 : "transparent"
     }
 
     component TruncatedTextWithTooltip: StatusBaseText {
@@ -113,7 +113,7 @@ Button {
                             var iconName = "tiny/channel"
                             if (root.requiresPermissions)
                                 iconName = root.locked ? "tiny/channel-locked" : "tiny/channel-unlocked"
-                            return Theme.palette.name === "light" ? iconName : iconName+"-white"
+                            return iconName
                         }
                         default:
                             return ""
@@ -124,7 +124,6 @@ Button {
                 TruncatedTextWithTooltip {
                     Layout.fillWidth: true
                     Layout.maximumWidth: Math.ceil(implicitWidth)
-                    Layout.alignment: Qt.AlignVCenter
                     objectName: "statusChatInfoButtonNameText"
                     text: root.title
                     color: root.muted ? Theme.palette.directColor5 : Theme.palette.directColor1
@@ -170,8 +169,8 @@ Button {
                     text: root.subTitle
                     visible: text
                     color: Theme.palette.baseColor1
-                    font.pixelSize: 12
-                    onLinkActivated: root.linkActivated(link)
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    onLinkActivated: (link) => root.linkActivated(link)
                 }
 
                 Rectangle {
@@ -197,7 +196,7 @@ Button {
                     Layout.fillWidth: true
                     Layout.maximumWidth: Math.ceil(implicitWidth)
                     text: qsTr("%Ln pinned message(s)", "", root.pinnedMessagesCount)
-                    font.pixelSize: 12
+                    font.pixelSize: Theme.tertiaryTextFontSize
                     font.underline: hovered
                     visible: root.pinnedMessagesCount
                     color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1


### PR DESCRIPTION
### What does the PR do
- the HoverHandler doesn't work as expected when it's placed inside `background` since it's now really behind the actual `contentItem`
- added a dedicated Storybook page
- some minor cleanups

Fixes #18136

### Affected areas

StatusChatInfoButton

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/cf13424b-c358-4a24-89e3-e807cca425ff


