### PR TITLE
chore: Allow IOS simulator selection

### DIFF
--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -54,9 +54,9 @@ if [[ "${OS}" == "android" ]]; then
 else
     qmake "$CWD/../wrapperApp/Status-tablet.pro" RESOURCES+="$COMPAT_RESOURCES" -spec macx-ios-clang CONFIG+=release CONFIG+="$SDK" CONFIG+=device -after
     # Compile resources
-    xcodebuild -configuration Release -target "Qt Preprocess" -sdk "$SDK" -arch "$ARCH"
+    xcodebuild -configuration Release -target "Qt Preprocess" -sdk "$SDK" -arch "$ARCH" CODE_SIGN_STYLE=Automatic
     # Compile the app
-    xcodebuild -configuration Release -target Status-tablet install -sdk "$SDK" -arch "$ARCH" DSTROOT="$BIN_DIR" INSTALL_PATH="/" TARGET_BUILD_DIR="$BIN_DIR" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+    xcodebuild -configuration Release -target Status-tablet install -sdk "$SDK" -arch "$ARCH" DSTROOT="$BIN_DIR" INSTALL_PATH="/" TARGET_BUILD_DIR="$BIN_DIR" CODE_SIGN_STYLE=Automatic
 
     if [[ -e "$BIN_DIR/Status-tablet.app/Info.plist" ]]; then
         echo "Build succeeded"

--- a/mobile/scripts/ios/run.sh
+++ b/mobile/scripts/ios/run.sh
@@ -1,35 +1,133 @@
 #!/usr/bin/env bash
-set -ef pipefail
-set -o xtrace
+# iOS run helper – mirrors the behaviour of mobile/scripts/android/run.sh
+# 1. Lists available iOS simulators and lets the user choose one.
+# 2. If no simulator exists, a default iPad simulator is created automatically.
+# 3. Boots the chosen simulator (if needed), installs the built app and launches it.
+
+set -euo pipefail
 
 CWD=$(realpath "$(dirname "$0")")
-APPID=${APPID:-com.statusim.Status}
-APP=${APP:-"$CWD/../../bin/Applications/Status-tablet.app"}
-echo "APP: $APP"
-SIMULATOR_INFO=$(xcrun simctl list devices "iPad Pro" | grep -m 1 "iPad Pro" || true)
+APPID=${APPID:-im.status.Status-tablet}            # Bundle identifier of the app
+APP=${APP:-"$CWD/../../bin/Applications/Status-tablet.app"}  # Path to the .app bundle
+SIMULATOR_UDID=${SIMULATOR_UDID:-""}               # Specify to skip interactive selection
+IPHONE_SDK=${IPHONE_SDK:-iphonesimulator}  # Default to simulator if not set
+DEVICE_ID=${DEVICE_ID:-""}                # For physical device selection
 
-echo "Simulator info: $SIMULATOR_INFO"
-if [[ -z "$SIMULATOR_INFO" ]]; then
-    echo "No matching simulator found. Creating a new one..."
-    xcrun simctl create "iPad Pro" com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M4-16GB
-    SIMULATOR_INFO=$(xcrun simctl list devices | grep -m 1 "iPad Pro")
-    if [[ -z "$SIMULATOR_INFO" ]]; then
-        echo "Failed to create or find the simulator. Exiting."
-        exit 1
-    fi
+# Create a default iPad simulator if none are found
+create_default_simulator() {
+  DEFAULT_NAME="status-default-sim"
+  DEVICE_TYPE="com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M4-16GB"
+
+  echo "Creating default simulator: $DEFAULT_NAME ($DEVICE_TYPE)"
+  xcrun simctl create "$DEFAULT_NAME" "$DEVICE_TYPE" || {
+    echo "Failed to create the default simulator"; exit 1;
+  }
+}
+
+# Present the list of available devices and let the user pick one
+select_device() {
+  local device_lines
+  device_lines=$(xcrun devicectl list devices --hide-headers)
+
+  if [[ -z "$device_lines" ]]; then
+    echo "No available devices found. Exiting."; exit 1;
+  fi
+
+  echo "Available devices:"
+  echo "$device_lines" | nl -w2 -s': '
+
+  read -rp "Select a device to use (enter number): " selection
+
+  local selected_line
+  selected_line=$(echo "$device_lines" | sed -n "${selection}p")
+  if [[ -z "$selected_line" ]]; then
+    echo "Invalid selection. Exiting."; exit 1;
+  fi
+
+  DEVICE_ID=$(echo "$selected_line" | awk '{print $3}')
+  DEVICE_NAME=$(echo "$selected_line" | awk '{print substr($0, 1, index($0, $3)-2)}' | xargs)
+}
+
+# Present the list of available simulators and let the user pick one
+select_simulator() {
+  local device_lines
+  device_lines=$(xcrun simctl list devices available | grep -E "^\s{4}.*\(" || true)
+
+  if [[ -z "$device_lines" ]]; then
+    echo "No simulators found. Creating a default one..."
+    create_default_simulator
+    device_lines=$(xcrun simctl list devices available | grep -E "^\s{4}.*\(")
+  fi
+
+  echo "Available simulators:"
+  echo "$device_lines" | nl -w2 -s': '
+
+  read -rp "Select a simulator to use (enter number): " selection
+
+  local selected_line
+  selected_line=$(echo "$device_lines" | sed -n "${selection}p")
+  if [[ -z "$selected_line" ]]; then
+    echo "Invalid selection. Exiting."; exit 1;
+  fi
+
+  SIMULATOR_UDID=$(echo "$selected_line" | grep -E -o "([0-9A-Fa-f-]{36})")
+  SIMULATOR_NAME=$(echo "$selected_line" | sed -E 's/^\s+([^()]*)\s+\(.*/\1/' | xargs)
+}
+
+run_device() {
+  if [[ -z "$DEVICE_ID" ]]; then
+    select_device
+  fi
+
+  echo "Using device: ${DEVICE_NAME:-$DEVICE_ID}"
+
+  # Install the app on the device
+  echo "Installing app $APP onto device $DEVICE_ID"
+  xcrun devicectl device install app --device "$DEVICE_ID" "$APP"
+
+  # Launch the app on the device
+  echo "Launching $APPID on device $DEVICE_ID"
+  xcrun devicectl device process launch --activate --console --device "$DEVICE_ID" "$APPID"
+}
+
+run_simulator() {
+  # If no UDID provided via env var, ask the user
+  if [[ -z "$SIMULATOR_UDID" ]]; then
+    select_simulator
+  fi
+
+  # Get info/state for the chosen simulator
+  SIMULATOR_INFO=$(xcrun simctl list devices | grep "$SIMULATOR_UDID" | head -n 1 || true)
+  if [[ -z "$SIMULATOR_INFO" ]]; then
+    echo "Simulator $SIMULATOR_UDID not found. Exiting."; exit 1;
+  fi
+  SIMULATOR_STATE=$(echo "$SIMULATOR_INFO" | grep -E -o "\((Booted|Shutdown|Shutting Down|Creating|Deleting)\)" | tr -d '()')
+
+  echo "Using simulator: ${SIMULATOR_NAME:-$SIMULATOR_UDID} – state: $SIMULATOR_STATE"
+
+  # Boot if necessary
+  if [[ "$SIMULATOR_STATE" != "Booted" ]]; then
+    echo "Booting simulator $SIMULATOR_UDID..."
+    xcrun simctl boot "$SIMULATOR_UDID"
+  fi
+
+  # Bring Simulator app to foreground with the chosen device
+  open -a Simulator --args -CurrentDeviceUDID "$SIMULATOR_UDID"
+
+  # Re-install the app
+  echo "Installing app $APP onto simulator $SIMULATOR_UDID"
+  xcrun simctl install "$SIMULATOR_UDID" "$APP"
+
+  # Launch the app (using --console-pty to avoid freeze issues)
+  echo "Launching $APPID"
+  xcrun simctl launch --console-pty "$SIMULATOR_UDID" "$APPID"
+}
+
+if [[ "$IPHONE_SDK" == "iphoneos" ]]; then
+  run_device
+elif [[ "$IPHONE_SDK" == "iphonesimulator" ]]; then
+  run_simulator
+else
+  echo "Invalid SDK specified: $IPHONE_SDK. Use 'iphonesimulator' or 'iphoneos'."
+  exit 1
 fi
-
-SIMULATOR_DEVICE_ID=$(echo "$SIMULATOR_INFO" | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")
-SIMULATOR_DEVICE_STATE=$(echo "$SIMULATOR_INFO" | grep -E -o -i "\((Booted|Shutdown|Shutting Down|Creating|Deleting)\)" | tr -d '()')
-
-echo "Booting simulator with device id: $SIMULATOR_DEVICE_ID and state: $SIMULATOR_DEVICE_STATE"
-
-if [[ "$SIMULATOR_DEVICE_STATE" != "Booted" ]]; then
-    xcrun simctl boot "$SIMULATOR_DEVICE_ID"
-fi
-
-echo "Installing app $APP on simulator $SIMULATOR_DEVICE_ID"
-open -a Simulator --args -CurrentDeviceUDID "$SIMULATOR_DEVICE_ID"
-xcrun simctl install "$SIMULATOR_DEVICE_ID" "$APP"
-# For some reason --console will freeze the app, so we need to use --console-pty
-xcrun simctl launch --console-pty "$SIMULATOR_DEVICE_ID" im.status.Status-tablet


### PR DESCRIPTION
### What does the PR do

Mirror the android run flow where we're asking on what device to run the app. It allows us to easily test different devices and configurations



https://github.com/user-attachments/assets/c757063f-fa8c-46c1-a88c-b3b1cae4d9cc

