### PR TITLE
fix(Shell): use system Theme colors and default icons

### DIFF
--- a/storybook/pages/ShellContainerPage.qml
+++ b/storybook/pages/ShellContainerPage.qml
@@ -121,7 +121,6 @@ SplitView {
             Switch {
                 id: ctrlNewIcons
                 text: "Use new dock icons"
-                checked: true
             }
             Switch {
                 id: ctrlShowEnabledSectionsOnly

--- a/storybook/src/Models/ChatsModel.qml
+++ b/storybook/src/Models/ChatsModel.qml
@@ -95,6 +95,6 @@ ListModel {
         muted: false
         isCategory: false
         categoryOpened: true
-        lastMessageText: ""
+        lastMessageText: "💩"
     }
 }

--- a/ui/app/AppLayouts/Shell/ShellContainer.qml
+++ b/ui/app/AppLayouts/Shell/ShellContainer.qml
@@ -74,7 +74,7 @@ Control {
 
         Rectangle {
             anchors.fill: parent
-            color: "#0b121d"
+            color: Theme.palette.baseColor3
         }
     }
 
@@ -152,10 +152,6 @@ Control {
             Layout.preferredWidth: 40
             Layout.preferredHeight: 40
             icon.height: 24
-            icon.color: hovered ? Theme.palette.white : Theme.palette.baseColor1
-            Behavior on icon.color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
-            color: "transparent"
-            tooltip.color: "#222833"
             unreadNotificationsCount: root.aCNotificationCount
             hasUnseenNotifications: root.hasUnseenACNotifications
             onClicked: root.notificationButtonClicked()
@@ -174,8 +170,6 @@ Control {
 
             getEmojiHashFn: root.getEmojiHashFn
             getLinkToProfileFn: root.getLinkToProfileFn
-
-            badge.border.color: hovered ? "#222833" : "#161c27"
 
             onSetCurrentUserStatusRequested: (status) => root.setCurrentUserStatusRequested(status)
             onViewProfileRequested: (pubKey) => root.viewProfileRequested(pubKey)

--- a/ui/app/AppLayouts/Shell/ShellDock.qml
+++ b/ui/app/AppLayouts/Shell/ShellDock.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtGraphicalEffects 1.15
 
 import StatusQ 0.1
 import StatusQ.Core.Theme 0.1
@@ -63,8 +64,18 @@ Control {
     spacing: Theme.smallPadding
 
     background: Rectangle {
-        color: "#161d27"
+        color: Theme.palette.baseColor4
         radius: Theme.smallPadding * 2
+    }
+
+    layer.enabled: true
+    layer.effect: DropShadow {
+        horizontalOffset: 0
+        verticalOffset: 4
+        radius: 12
+        samples: 25
+        spread: 0
+        color: Theme.palette.dropShadow
     }
 
     implicitHeight: 84 // by design
@@ -127,7 +138,7 @@ Control {
             hasNotification: model.hasNotification ?? false
             notificationsCount: model.notificationsCount ?? 0
             connectorBadge: model.connectorBadge ?? ""
-            icon.color: Theme.palette.white
+            icon.color: hovered ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
             icon.name: (root.useNewDockIcons ? "shell/" : "") + model.icon
             enabled: model.enabled
             onClicked: root.itemActivated(model.key, sectionType, "") // not interested in item (section) id here
@@ -145,7 +156,7 @@ Control {
             notificationsCount: model.notificationsCount ?? 0
             connectorBadge: model.connectorBadge ?? ""
             icon.name: model.icon
-            icon.color: model.color ?? Theme.palette.white
+            icon.color: model.color ?? Theme.palette.directColor1
             icon.width: 24
             icon.height: 24
             tooltipText: "%1 (%2)".arg(text).arg(Utils.translatedSectionName(sectionType))

--- a/ui/app/AppLayouts/Shell/ShellDockButton.qml
+++ b/ui/app/AppLayouts/Shell/ShellDockButton.qml
@@ -36,7 +36,8 @@ ToolButton {
     icon.height: 36
 
     background: Rectangle {
-        color: Qt.rgba(1, 1, 1, hovered ? 0.1 : 0.05) // FIXME get rid of opacity tricks
+        id: background
+        color: hovered ? Theme.palette.directColor7 : Theme.palette.directColor8
         Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
         radius: Theme.smallPadding * 2
 
@@ -44,10 +45,9 @@ ToolButton {
         StatusBadge {
             width: root.notificationsCount ? implicitWidth : 12 + border.width // bigger dot
             height: root.notificationsCount ? implicitHeight : 12 + border.width
-            color: hovered ? Qt.lighter(root.badgeColor, 1.25) : root.badgeColor
-            Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
             border.width: 2
-            border.color: "#161d27"
+            border.color: parent.color
+            Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
             anchors.right: parent.right
             anchors.rightMargin: root.notificationsCount ? -2 : 0
             anchors.top: parent.top
@@ -67,8 +67,8 @@ ToolButton {
         asset.bgRadius: root.pinned && root.sectionType === Constants.appSection.wallet ? Theme.padding : asset.bgWidth/2
         name: root.text
 
-        Binding on asset.bgColor {
-            value: Qt.lighter(root.icon.color, 1.8)
+        Binding on asset.bgColor { // need some round background around the icon
+            value: Theme.palette.primaryColor3//Theme.palette.name === Constants.lightThemeName ? Qt.lighter(root.icon.color, 1.7) : Qt.darker(root.icon.color, 1.7)
             when: root.pinned && (root.sectionType === Constants.appSection.dApp || root.sectionType === Constants.appSection.profile)
         }
 
@@ -90,8 +90,8 @@ ToolButton {
             visible: root.chatType === Constants.chatType.oneToOne
             color: root.onlineStatus === Constants.onlineStatus.online ? Theme.palette.successColor1
                                                                        : Theme.palette.baseColor1
-            border.width: 2
-            border.color: hovered ? "#222833" : "#161c27"
+            border.width: 1
+            border.color: background.color
             implicitHeight: 10
             implicitWidth: 10
             anchors.rightMargin: 1
@@ -102,7 +102,6 @@ ToolButton {
     StatusToolTip {
         visible: !!text && root.hovered
         offset: -(x + width/2 - root.width/2)
-        color: "#222833"
         text: root.tooltipText
     }
 

--- a/ui/app/AppLayouts/Shell/ShellGrid.qml
+++ b/ui/app/AppLayouts/Shell/ShellGrid.qml
@@ -7,6 +7,7 @@ import StatusQ.Core.Utils 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Backpressure 0.1
 
 import AppLayouts.Shell.delegates 1.0
 
@@ -72,8 +73,15 @@ StatusScrollView {
     padding: 0
     rightPadding: Theme.padding
 
+    contentWidth: availableWidth
+
+    QtObject {
+        id: d
+        property bool positioningComplete // delay the animations
+    }
+
     ColumnLayout {
-        width: root.width - root.rightPadding
+        width: root.availableWidth
 
         Flow {
             // calculate a tight bounding box, and then horizontally center over the scrollview width
@@ -82,6 +90,13 @@ StatusScrollView {
             Layout.alignment: Qt.AlignHCenter
 
             spacing: Theme.padding
+
+            // for the drop shadow
+            topPadding: Theme.smallPadding
+            bottomPadding: Theme.padding
+
+            // delay the animations
+            onPositioningComplete: Backpressure.debounce(this, 500, () => {d.positioningComplete = true})()
 
             Repeater {
                 id: repeater
@@ -216,9 +231,11 @@ StatusScrollView {
             }
 
             move: Transition {
+                enabled: d.positioningComplete
                 NumberAnimation { properties: "x,y"; }
             }
             add: Transition {
+                enabled: d.positioningComplete
                 NumberAnimation { properties: "x,y"; from: 0; duration: Theme.AnimationDuration.Fast }
             }
         }

--- a/ui/app/AppLayouts/Shell/ShellSearchField.qml
+++ b/ui/app/AppLayouts/Shell/ShellSearchField.qml
@@ -12,10 +12,6 @@ StatusTextField {
     background: null
     font.pixelSize: 27
     font.weight: Font.DemiBold
-    color: Theme.palette.white
-    selectedTextColor: Theme.palette.white
-    selectionColor: Theme.palette.primaryColor1
-    placeholderTextColor: Qt.rgba(1, 1, 1, 0.3)
 
     StatusClearButton {
         anchors.right: parent.right
@@ -26,8 +22,6 @@ StatusTextField {
         visible: parent.text
         icon.width: 24
         icon.height: 24
-        icon.color: Theme.palette.white
-        tooltip.color: "#222833"
         onClicked: {
             parent.forceActiveFocus()
             parent.clear()

--- a/ui/app/AppLayouts/Shell/ShellToolButton.qml
+++ b/ui/app/AppLayouts/Shell/ShellToolButton.qml
@@ -7,25 +7,24 @@ import StatusQ.Core.Theme 0.1
 
 AbstractButton {
     id: root
-    
+
     property string tooltipText: text
-    
+
     padding: 6
     hoverEnabled: enabled
     implicitWidth: 24
     implicitHeight: 24
-    
+
     icon.width: 20
     icon.height: 20
-    icon.color: hovered ? Theme.palette.white : "#d5c7cd"
+    icon.color: hovered ? Theme.palette.primaryColor1 : Theme.palette.primaryColor2
     Behavior on icon.color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
-    
+
     opacity: pressed || down ? Theme.pressedOpacity : enabled ? 1 : Theme.disabledOpacity
     Behavior on opacity { NumberAnimation { duration: Theme.AnimationDuration.Fast } }
-    
+
     background: Rectangle {
-        color: hovered ? "#6e899a" : "#707480"
-        Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
+        color: Theme.palette.baseColor5
         radius: Theme.halfPadding
     }
     contentItem: Item {
@@ -40,7 +39,6 @@ AbstractButton {
     StatusToolTip {
         visible: !!text && root.hovered
         offset: -(x + width/2 - root.width/2)
-        color: "#222833"
         text: root.tooltipText
     }
     HoverHandler {

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridChatItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridChatItem.qml
@@ -35,8 +35,8 @@ ShellGridItem {
             visible: root.chatType === Constants.chatType.oneToOne
             color: root.onlineStatus === Constants.onlineStatus.online ? Theme.palette.successColor1
                                                                        : Theme.palette.baseColor1
-            border.width: 2
-            border.color: hovered ? "#222833" : "#161c27"
+            border.width: 1
+            border.color: hovered ? Qt.lighter(Theme.palette.baseColor4, 1.5) : Theme.palette.baseColor4
             implicitHeight: 10
             implicitWidth: 10
             anchors.rightMargin: 1
@@ -51,7 +51,6 @@ ShellGridItem {
         sourceComponent: StatusBaseText {
             text: root.lastMessageText
             font.pixelSize: Theme.additionalTextSize
-            color: Theme.palette.white
             maximumLineCount: 1
             textFormat: Text.PlainText
             elide: Text.ElideRight

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridCommunityItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridCommunityItem.qml
@@ -60,8 +60,7 @@ ShellGridItem {
         horizontalPadding: Theme.halfPadding
         verticalPadding: 4
         bgRadius: 20
-        bgBorderColor: Qt.rgba(1, 1, 1, 0.1)
-        tagPrimaryLabel.color: Theme.palette.white
+        bgBorderColor: Theme.palette.directColor6
         tagPrimaryLabel.font.weight: Font.Medium
         asset.color: Theme.palette.baseColor1
     }

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridDAppItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridDAppItem.qml
@@ -21,7 +21,7 @@ ShellGridItem {
     extraMenuActions: [disconnectAction]
 
     background: Rectangle {
-        color: hovered ? "#222833" : "#161c27"
+        color: hovered ? Qt.lighter(Theme.palette.baseColor4, 1.5) : Theme.palette.baseColor4
         Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
         radius: Theme.padding
 
@@ -64,7 +64,6 @@ ShellGridItem {
         StatusToolTip {
             visible: titleTextHHandler.hovered
             offset: -(x + width/2 - root.width/2)
-            color: "#161c27"
             text: root.itemId
         }
     }

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridItem.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
@@ -42,6 +43,14 @@ AbstractButton {
 
     signal pinRequested
 
+    layer.enabled: true
+    layer.effect: Glow {
+        samples: 33
+        spread: 0.1
+        color: root.hovered ? Theme.palette.backdropColor : Theme.palette.dropShadow
+        Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
+    }
+
     background: Item {
         StatusRoundedImage {
             id: mainBgImage
@@ -67,7 +76,7 @@ AbstractButton {
             anchors.bottom: parent.bottom
             width: parent.width
 
-            color: hovered ? "#222833" : "#161c27"
+            color: hovered ? Qt.lighter(Theme.palette.baseColor4, 1.5) : Theme.palette.baseColor4
             Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
 
             radius: mainBgImage.radius
@@ -99,8 +108,6 @@ AbstractButton {
                 Layout.preferredHeight: root.icon.height
 
                 color: mainBgRect.color
-                Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
-
                 radius: width/2
 
                 Loader {
@@ -115,7 +122,6 @@ AbstractButton {
                 Layout.fillWidth: true
                 text: root.title
                 font.weight: Font.DemiBold
-                color: Theme.palette.white
                 elide: Text.ElideRight
 
                 HoverHandler {
@@ -125,7 +131,6 @@ AbstractButton {
                 StatusToolTip {
                     visible: titleTextHHandler.hovered
                     offset: -(x + width/2 - root.width/2)
-                    color: "#161c27"
                     text: root.title
                 }
             }
@@ -152,7 +157,6 @@ AbstractButton {
                 StatusBadge {
                     visible: root.hasNotification
                     value: root.notificationsCount
-                    color: Theme.palette.primaryColor1
                 }
             }
         }

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridSettingsItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridSettingsItem.qml
@@ -13,17 +13,13 @@ ShellGridItem {
     property int activeMembersCount
     property bool isExperimental
 
-    icon.color: Theme.palette.primaryColor1
-
     sectionType: Constants.appSection.profile
-    color: Qt.lighter(icon.color, 1.7)
+    color: Theme.palette.primaryColor2
 
     iconLoaderComponent: StatusRoundIcon {
         asset.name: root.icon.name
-        asset.color: root.icon.color
         asset.bgWidth: width
         asset.bgHeight: height
-        asset.bgColor: Qt.lighter(asset.color, 1.8)
     }
 
     bottomRowComponent: StatusBetaTag {

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridWalletItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridWalletItem.qml
@@ -19,7 +19,7 @@ ShellGridItem {
     subtitle: SQUtils.Utils.elideAndFormatWalletAddress(root.itemId)
 
     background: Rectangle {
-        color: hovered ? "#222833" : "#161c27"
+        color: hovered ? Qt.lighter(Theme.palette.baseColor4, 1.5) : Theme.palette.baseColor4
         Behavior on color { ColorAnimation { duration: Theme.AnimationDuration.Fast } }
         radius: Theme.padding
 
@@ -38,7 +38,6 @@ ShellGridItem {
         StatusBaseText {
             Layout.fillWidth: true
             text: root.currencyBalance
-            color: Theme.palette.white
             font.pixelSize: Theme.tertiaryTextFontSize
             font.weight: Font.Medium
         }
@@ -52,7 +51,7 @@ ShellGridItem {
                     return "keycard"
                 return ""
             }
-            color: Theme.palette.white
+            color: Theme.palette.directColor1
             visible: !!icon
         }
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1854,7 +1854,7 @@ Item {
                             getEmojiHashFn: appMain.utilsStore.getEmojiHash
                             getLinkToProfileFn: appMain.rootStore.contactStore.getLinkToProfile
 
-                            useNewDockIcons: true
+                            useNewDockIcons: false
                             hasUnseenACNotifications: appMain.activityCenterStore.hasUnseenNotifications
                             aCNotificationCount: appMain.activityCenterStore.unreadNotificationsCount
 


### PR DESCRIPTION
### What does the PR do

- fix the colors/icons to use the system Theme
- add some dropshadows around the grid items and dock to distinguish it more from the background
- provides proper light/dark theme support

Fixes #18167

### Affected areas

Shell

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Light theme:
![Snímek obrazovky z 2025-06-18 17-20-23](https://github.com/user-attachments/assets/9c18e5a3-9a74-4c3c-a473-00ff1e3c8670)

Dark theme:
![Snímek obrazovky z 2025-06-18 17-20-05](https://github.com/user-attachments/assets/0015b6a3-1e51-46da-b466-df8744c628f2)

