### PR TITLE
feat(Shell): Add support for community channels

### DIFF
--- a/src/app/modules/main/chat_search_item.nim
+++ b/src/app/modules/main/chat_search_item.nim
@@ -9,8 +9,9 @@ type
     sectionName: string
     colorHash: string
     emoji: string
+    chatType: int
 
-proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, sectionId, sectionName, emoji: string): Item =
+proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, sectionId, sectionName, emoji: string, chatType: int): Item =
   result = Item()
   result.chatId = chatId
   result.name = name
@@ -21,6 +22,7 @@ proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, secti
   result.sectionId = sectionId
   result.sectionName = sectionName
   result.emoji = emoji
+  result.chatType = chatType
 
 proc chatId*(self: Item): string =
   self.chatId
@@ -48,3 +50,6 @@ proc sectionName*(self: Item): string =
 
 proc emoji*(self: Item): string =
   self.emoji
+
+proc chatType*(self: Item): int =
+  self.chatType

--- a/src/app/modules/main/chat_search_model.nim
+++ b/src/app/modules/main/chat_search_model.nim
@@ -12,6 +12,7 @@ type
     SectionId
     SectionName
     Emoji
+    ChatType
 
 QtObject:
   type Model* = ref object of QAbstractListModel
@@ -46,6 +47,7 @@ QtObject:
       ModelRole.SectionId.int:"sectionId",
       ModelRole.SectionName.int:"sectionName",
       ModelRole.Emoji.int:"emoji",
+      ModelRole.ChatType.int:"chatType",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -75,3 +77,5 @@ QtObject:
         result = newQVariant(item.sectionName)
       of ModelRole.Emoji:
         result = newQVariant(item.emoji)
+      of ModelRole.ChatType:
+        result = newQVariant(item.chatType)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1274,6 +1274,7 @@ method rebuildChatSearchModel*[T](self: Module[T]) =
       sectionId,
       sectionName,
       chat.emoji,
+      chat.chatType.int
     ))
 
   self.view.chatSearchModel().setItems(items)

--- a/storybook/pages/ShellContainerPage.qml
+++ b/storybook/pages/ShellContainerPage.qml
@@ -31,12 +31,14 @@ SplitView {
 
             sectionsBaseModel: SectionsModel {}
             chatsBaseModel: ChatsModel {}
+            chatsSearchBaseModel: ChatsSearchModel {}
             walletsBaseModel: WalletAccountsModel {}
             dappsBaseModel: DappsModel {}
 
             showCommunities: ctrlShowCommunities.checked || ctrlShowAllEntries.checked
             showSettings: ctrlShowSettings.checked || ctrlShowAllEntries.checked
             showChats: ctrlShowChats.checked || ctrlShowAllEntries.checked
+            showAllChats: ctrlShowAllChats.checked || ctrlShowAllEntries.checked
             showWallets: ctrlShowWallets.checked || ctrlShowAllEntries.checked
             showDapps: ctrlShowDapps.checked || ctrlShowAllEntries.checked
 
@@ -64,6 +66,7 @@ SplitView {
             readonly property string icon: ModelsData.icons.rarible
             readonly property int colorId: 7
             readonly property var colorHash: [{colorId: 7, segmentLength: 1}, {colorId: 6, segmentLength: 2}]
+            readonly property bool usesDefaultName: false
             property int currentUserStatus: Constants.currentUserStatus.automatic
         }
 
@@ -148,6 +151,12 @@ SplitView {
                     text: "Show Chats"
                     checked: true
                     enabled: !ctrlShowAllEntries.checked
+                }
+                Switch {
+                    id: ctrlShowAllChats
+                    text: "Show All Chats"
+                    checked: true
+                    enabled: ctrlShowChats.checked && !ctrlShowAllEntries.checked
                 }
                 Switch {
                     id: ctrlShowWallets

--- a/storybook/src/Models/ChatsSearchModel.qml
+++ b/storybook/src/Models/ChatsSearchModel.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.15
+import StatusQ.Components 0.1
+
+ListModel {
+    ListElement {
+        chatId: "id1"
+        chatType: StatusChatListItem.Type.OneToOneChat
+        name: "John Doe"
+        color: ""
+        colorId: 3
+        icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAAoCAYAAABjPNNTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAALiSURBVHgB1ZhPTxNBGId/24IWYiIeNEUikkg1EtL2APRSYoKUNl5EvEhjgn4Ba3rxqEc92MgXUE/WE9GDxCKSEIkJcqnBQAyYkCqIxQChBLG1xX2n2dp/6u7sbFOepNnuzM7uk3fm3ZlZ6f7NF9ekPekRqhQJ0uMaCGZ96xsWv8zmzrvaeqEX4ZKfZMGnr0K586qTDMtyG1txiEao5MzcOIxAiGR4LISZeWMECV2SSpKsJ8R3cT66JIuTxChM4ISSRE0Xs+t0jlXuSKp9sHJdp45XkWZJJUkWnt8pqbNd/FN290Y/Lp93sv8jE1EEhy9g0BPkklXd3ZQk7+So2E7WYaAn+3CTuRY1dYfZkaDyrvaWkrZNxxpY3Y9UjN3DMEklSeynzbgX6M82PlgPy5HjMMtHgsqV6OXjksWpzmRa5Eo07jFpaWhEJp3C7sYKMsmdEiFXmYjywi1ZU9+AXzubSCa+F5QrXSsSbsntlXlUCtWSzc0n4Pf70Wp3wmJtAQ/nepNy2zZoRbWk292N7kvXoYehM30Yko8Pb7/V1E615NTUGzZ7UDTdbjcre//VjJcLtQXXORvT8NpSqI1EYI5GC+pSPh/SDge0oloyFvssSz7JCRKr2yZEiiQJkiRBEs0n7XRySap6T9Js8TM9wWYZT1Mca5MPUEl0rYKshzLwtaYKyhxydxMUNUhSQV3GagUPuiRJSJEqJuX1sp8IVEtOf1jCreFnGJCnPZpNEh/HoJWR11F2n46jVzW1Uy25HN9kqxlaQLjagd3VOWhlcnyU3aMjYIBkKDDK1oVhFYsDkqCIK5Rb0mlF+L67qubuv+Fiw6EFIuHe4+RT3MWiESI5PbvERI1CSHfTIpd++XschapLHNEJoyBUUtn7iEZ4dpdDGbN76VZc8fRAK0IS538sr2VnK8uBZq7vlUIiSa+ff2U3fRCgWYsXod3debZ8lE412aEHoZKDfUEYQUXGpF72heRvWCUEXU7sGx8AAAAASUVORK5CYII="
+        colorHash: ""
+        sectionId: "section1"
+        sectionName: "Messages"
+        emoji: ""
+    }
+    ListElement {
+        chatId: "id2"
+        chatType: StatusChatListItem.Type.CommunityChat
+        name: "welcome"
+        color: "lightsalmon"
+        colorId: 0
+        icon: ""
+        colorHash: ""
+        sectionId: "section2"
+        sectionName: "ACME Community"
+        emoji: "💩"
+    }
+    ListElement {
+        chatId: "id3"
+        chatType: StatusChatListItem.Type.GroupChat
+        name: "Cool Gang"
+        color: "mintcream"
+        colorId: 0
+        icon: ""
+        colorHash: ""
+        sectionId: "section3"
+        sectionName: "Messages"
+        emoji: ""
+    }
+}

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -4,6 +4,7 @@ AssetsModel 1.0 AssetsModel.qml
 BannerModel 1.0 BannerModel.qml
 ChannelsModel 1.0 ChannelsModel.qml
 ChatsModel 1.0 ChatsModel.qml
+ChatsSearchModel 1.0 ChatsSearchModel.qml
 CollectiblesModel 1.0 CollectiblesModel.qml
 DappsModel 1.0 DappsModel.qml
 FeesModel 1.0 FeesModel.qml

--- a/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
@@ -187,7 +187,7 @@ QtObject {
     readonly property int defaultBigPadding: defaultPadding * 1.5
     readonly property int defaultPadding: 16
     readonly property int defaultHalfPadding: defaultPadding / 2
-    readonly property int defaultSmallPadding: defaultPadding * 0.75
+    readonly property int defaultSmallPadding: defaultPadding * 0.625
     readonly property int defaultRadius: defaultHalfPadding
 
     readonly property real disabledOpacity: 0.3
@@ -228,7 +228,7 @@ QtObject {
         bigPadding = basePadding * 1.5
         padding = basePadding
         halfPadding = basePadding / 2
-        smallPadding = basePadding * 0.75
+        smallPadding = basePadding * 0.625
         radius = basePadding
     }
 

--- a/ui/app/AppLayouts/Shell/ShellDock.qml
+++ b/ui/app/AppLayouts/Shell/ShellDock.qml
@@ -159,7 +159,7 @@ Control {
             icon.color: model.color ?? Theme.palette.directColor1
             icon.width: 24
             icon.height: 24
-            tooltipText: "%1 (%2)".arg(text).arg(Utils.translatedSectionName(sectionType))
+            tooltipText: "%1 (%2)".arg(text).arg(Utils.translatedSectionName(sectionType) || model.sectionName)
 
             chatType: model.chatType ?? Constants.chatType.unknown
             onlineStatus: model.onlineStatus ?? Constants.onlineStatus.unknown

--- a/ui/app/AppLayouts/Shell/ShellDockButton.qml
+++ b/ui/app/AppLayouts/Shell/ShellDockButton.qml
@@ -87,7 +87,7 @@ ToolButton {
 
         // for chat items
         badge {
-            visible: root.chatType === Constants.chatType.oneToOne
+            visible: root.chatType === Constants.chatType.oneToOne && root.onlineStatus !== Constants.onlineStatus.unknown
             color: root.onlineStatus === Constants.onlineStatus.online ? Theme.palette.successColor1
                                                                        : Theme.palette.baseColor1
             border.width: 1

--- a/ui/app/AppLayouts/Shell/ShellGrid.qml
+++ b/ui/app/AppLayouts/Shell/ShellGrid.qml
@@ -113,6 +113,7 @@ StatusScrollView {
                         case Constants.appSection.wallet:
                             return walletDelegate
                         case Constants.appSection.chat:
+                        case -1: // search
                             return chatDelegate
                         case Constants.appSection.dApp:
                             return dappDelegate
@@ -124,7 +125,7 @@ StatusScrollView {
                     Connections {
                         target: item ?? null
                         function onClicked() {
-                            root.itemActivated(model.key, item.sectionType, item.itemId)
+                            root.itemActivated(model.key, model.sectionType, item.itemId)
                         }
                         function onPinRequested() {
                             root.itemPinRequested(model.key, !model.pinned)
@@ -148,11 +149,11 @@ StatusScrollView {
                     notificationsCount: model.notificationsCount
                     pinned: model.pinned
 
-                    membersCount: model.members
-                    activeMembersCount: model.activeMembers
+                    membersCount: model.members ?? 0
+                    activeMembersCount: model.activeMembers ?? 0
 
-                    pending: model.pending
-                    banned: model.banned
+                    pending: model.pending ?? false
+                    banned: model.banned ?? false
                 }
             }
 
@@ -169,7 +170,7 @@ StatusScrollView {
                     notificationsCount: model.notificationsCount
                     pinned: model.pinned
 
-                    isExperimental: model.isExperimental
+                    isExperimental: model.isExperimental ?? false
                 }
             }
 
@@ -187,8 +188,8 @@ StatusScrollView {
                     notificationsCount: model.notificationsCount
                     pinned: model.pinned
 
-                    currencyBalance: model.currencyBalance
-                    walletType: model.walletType
+                    currencyBalance: model.currencyBalance ?? ""
+                    walletType: model.walletType ?? ""
                 }
             }
 
@@ -199,16 +200,22 @@ StatusScrollView {
                     width: root.delegateWidth
                     height: root.delegateHeight
                     itemId: model.id
-                    title: model.name
+                    title: chatType === Constants.chatType.communityChat ? "#" + model.name : model.name
                     icon.name: model.icon
                     icon.color: model.color
-                    hasNotification: model.hasNotification
-                    notificationsCount: model.notificationsCount
+                    hasNotification: model.hasNotification ?? false
+                    notificationsCount: model.notificationsCount ?? 0
                     pinned: model.pinned
-                    lastMessageText: model.lastMessageText
+                    lastMessageText: {
+                        if (!!model.lastMessageText)
+                            return model.lastMessageText
+                        if (model.sectionType === -1 && model.chatType === Constants.chatType.communityChat)
+                            return model.sectionName
+                        return ""
+                    }
 
-                    chatType: model.chatType
-                    onlineStatus: model.onlineStatus
+                    chatType: model.chatType ?? Constants.chatType.unknown
+                    onlineStatus: model.onlineStatus ?? Constants.onlineStatus.unknown
                 }
             }
 

--- a/ui/app/AppLayouts/Shell/delegates/ShellGridChatItem.qml
+++ b/ui/app/AppLayouts/Shell/delegates/ShellGridChatItem.qml
@@ -32,7 +32,7 @@ ShellGridItem {
         name: root.title
 
         badge {
-            visible: root.chatType === Constants.chatType.oneToOne
+            visible: root.chatType === Constants.chatType.oneToOne && root.onlineStatus !== Constants.onlineStatus.unknown
             color: root.onlineStatus === Constants.onlineStatus.online ? Theme.palette.successColor1
                                                                        : Theme.palette.baseColor1
             border.width: 1
@@ -45,15 +45,12 @@ ShellGridItem {
     }
 
     bottomRowComponentFillsWidth: true
-    bottomRowComponent: Loader {
-        active: root.lastMessageText && root.lastMessageText.length > 0
-
-        sourceComponent: StatusBaseText {
-            text: root.lastMessageText
-            font.pixelSize: Theme.additionalTextSize
-            maximumLineCount: 1
-            textFormat: Text.PlainText
-            elide: Text.ElideRight
-        }
+    bottomRowComponent: StatusBaseText {
+        visible: !!root.lastMessageText
+        text: root.lastMessageText
+        font.pixelSize: Theme.additionalTextSize
+        maximumLineCount: 1
+        textFormat: Text.PlainText
+        elide: Text.ElideRight
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1816,6 +1816,10 @@ Item {
                         focus: active
                         active: appMain.featureFlagsStore.shellEnabled && appView.currentIndex === Constants.appViewStackIndex.shell
 
+                        onLoaded: {
+                            rootStore.rebuildChatSearchModel()
+                        }
+
                         sourceComponent: ShellContainer {
                             id: shell
 
@@ -1827,7 +1831,8 @@ Item {
 
                                 sectionsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.sectionsModel : null
                                 chatsBaseModel: sectionsLoaded ? appMain.rootStore.mainModuleInst.getChatSectionModule().model
-                                                            : null
+                                                               : null
+                                chatsSearchBaseModel: sectionsLoaded && !!rootStore.chatSearchModel ? rootStore.chatSearchModel : null
                                 walletsBaseModel: sectionsLoaded ? WalletStores.RootStore.accounts : null
                                 dappsBaseModel: dAppsServiceLoader.active && dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
 
@@ -1835,7 +1840,7 @@ Item {
                                 marketEnabled: appMain.featureFlagsStore.marketEnabled
 
                                 syncingBadgeCount: appMain.rootStore.profileSectionStore.devicesStore.devicesModel.count -
-                                                appMain.rootStore.profileSectionStore.devicesStore.devicesModel.pairedCount
+                                                   appMain.rootStore.profileSectionStore.devicesStore.devicesModel.pairedCount
                                 messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
                                 showBackUpSeed: !appMain.rootStore.profileSectionStore.profileStore.userDeclinedBackupBanner &&
                                                 !appMain.rootStore.profileSectionStore.profileStore.privacyStore.mnemonicBackedUp
@@ -1861,7 +1866,10 @@ Item {
                             onItemActivated: function(key, sectionType, itemId) {
                                 shellAdaptor.setTimestamp(key, new Date().valueOf())
 
-                                if (sectionType === Constants.appSection.profile) {
+                                if (sectionType === -1) { // search
+                                    const [sectionId, chatId] = key.split(";")
+                                    return rootStore.setActiveSectionChat(sectionId, chatId)
+                                } else if (sectionType === Constants.appSection.profile) {
                                     if (itemId == Constants.settingsSubsection.backUpSeed) {
                                         return Global.openBackUpSeedPopup()
                                     } else if (itemId == Constants.settingsSubsection.signout) {


### PR DESCRIPTION
### What does the PR do

- the community channels are displayed by default only when searching (in order not to pollute the grid with too many items)
- extend the chat_search_model with `chatType` field to be able to filter out the otherwise duplicate chat items (which we already have in the grid with much more detailed info)
- reuse the same grid chat delegate and use the `lastMessageText` to identify the community name
- extend/adjust the Storybook page with the respective option

Fixes #18137

### Affected areas

Shell

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/user-attachments/assets/4733329b-ec63-4bf8-abc4-283756120bb6
