### PR TITLE
Fix(StatusSectionLayout) Bring back the section toolbar in qt6

### DIFF
--- a/storybook/pages/StatusSectionLayoutPage.qml
+++ b/storybook/pages/StatusSectionLayoutPage.qml
@@ -100,18 +100,28 @@ Page {
     }
 
     Page {
-         id: footerItem
-         implicitWidth: 400
-         implicitHeight: 50
-         Rectangle {
-             color: "gray"
-             anchors.fill: parent
-             Label {
-                 text: "Footer Content"
-                 anchors.centerIn: parent
-             }
-         }
-     }
+        id: footerItem
+        implicitWidth: 400
+        implicitHeight: 50
+        Rectangle {
+            color: "gray"
+            anchors.fill: parent
+            Label {
+                text: "Footer Content"
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    ToolBar {
+        id: headerContent
+        RowLayout {
+            anchors.fill: parent
+            spacing: 5
+            Button { text: "Action 1" }
+            Button { text: "Action 2" }
+        }
+    }
 
     Frame {
         id: wrapper
@@ -129,6 +139,20 @@ Page {
             showRightPanel: rightPanelCheckBox.checked
             navBar: navBarItem
             footer: footerItem
+            headerContent: headerContent
+            headerBackground: Control {
+                implicitHeight: 115
+
+                contentItem: Loader {
+                    sourceComponent: Rectangle {
+                                id: headerBackground
+                                color: "yellow"
+                                width: 300
+                                height: 50
+                                onHeightChanged: console.trace()
+                        }
+                    }
+                }
+            }
         }
     }
-}

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
@@ -127,7 +127,7 @@ SplitView {
         This property holds a reference to the custom header content of
         the header component.
     */
-    property alias headerContent: statusToolBar.headerContent
+    property Item headerContent
     /*!
         \qmlproperty alias StatusSectionLayout::notificationButton
         This property holds a reference to the notification button of the header
@@ -182,20 +182,23 @@ SplitView {
             color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
         }
         contentItem: Item {
-            Item {
+            LayoutItemProxy {
                 id: headerBackgroundSlot
                 anchors.top: parent.top
                 // Needed cause I see a gap otherwise
                 anchors.topMargin: -3
-                width: visible ? parent.width : 0
-                height: visible ? childrenRect.height : 0
-                visible: (!!headerBackground)
+                width: parent.width
+                target: root.headerBackground
             }
             StatusToolBar {
                 id: statusToolBar
                 anchors.top: parent.top
                 width: visible ? parent.width : 0
                 visible: root.showHeader
+                headerContent: LayoutItemProxy {
+                    id: headerContentProxy
+                    target: root.headerContent
+                }
                 onBackButtonClicked: {
                     root.backButtonClicked();
                 }

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
@@ -75,7 +75,7 @@ SwipeView {
         \qmlproperty Component StatusAppLayout::headerBackground
         This property holds the headerBackground of the component.
     */
-    property alias headerBackground: headerBackgroundProxy.target
+    property Item headerBackground
     /*!
         \qmlproperty bool StatusSectionLayout::showRightPanel
         This property sets the right panel component's visibility to true/false.
@@ -122,7 +122,7 @@ SwipeView {
         This property holds a reference to the custom header content of
         the header component.
     */
-    property alias headerContent: statusToolBar.headerContent
+    property Item headerContent
     /*!
         \qmlproperty alias StatusSectionLayout::notificationButton
         This property holds a reference to the notification button of the header
@@ -203,25 +203,22 @@ SwipeView {
             objectName: "centerPanelLayout"
             anchors.fill: parent
             spacing: 0
-            LayoutItemProxy {
-                id: headerBackgroundProxy
+            Item {
                 Layout.fillWidth: true
-                StatusToolBar {
+                implicitHeight: headerBackgroundProxy.implicitHeight
+                LayoutItemProxy {
+                    id: headerBackgroundProxy
+                    anchors.fill: parent
+                    target: root.headerBackground
+                }
+                BaseToolBar {
                     id: statusToolBar
                     anchors.top: parent.top
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    visible: root.showHeader
-                    backButtonVisible: root.currentIndex !== 0
-                    onBackButtonClicked: {
-                        if (!root.backButtonName) {
-                            root.currentIndex = root.currentIndex - 1
-                            return
-                        }
-                        root.backButtonClicked();
-                    }
-                    onNotificationButtonClicked: {
-                        root.notificationButtonClicked();
+                    headerContent: LayoutItemProxy {
+                        id: headerContentProxy
+                        target: root.headerContent
                     }
                 }
             }
@@ -243,9 +240,36 @@ SwipeView {
     }
 
     BaseProxyPanel {
-        id: rightPanelProxy
         backgroundColor: Theme.palette.baseColor4
         implicitIndex: 2
         inView: !!root.rightPanel && root.showRightPanel
+        target: ColumnLayout {
+            objectName: "rightPanelLayout"
+            anchors.fill: parent
+            spacing: 0
+            BaseToolBar {
+                Layout.fillWidth: true
+            }
+            LayoutItemProxy {
+                id: rightPanelProxy
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+            }
+        }
+    }
+
+    component BaseToolBar: StatusToolBar {
+        visible: root.showHeader
+        backButtonVisible: root.currentIndex !== 0
+        onBackButtonClicked: {
+            if (!root.backButtonName) {
+                root.currentIndex = root.currentIndex - 1
+                return
+            }
+            root.backButtonClicked();
+        }
+        onNotificationButtonClicked: {
+            root.notificationButtonClicked();
+        }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -112,6 +112,17 @@ Page {
                 onDownKeyPressed: {
                     contactsList.incrementCurrentIndex();
                 }
+
+                onResolveENS: (address) => root.rootStore.contactsStore.resolveENS(address);
+
+                Connections {
+                    enabled: membersSelector.visible
+                    target: root.rootStore.contactsStore
+                    function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
+                        membersSelector.ensResolved(resolvedPubKey, resolvedAddress, uuid);
+                    }
+                }
+
             }
 
             StatusActivityCenterButton {

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -15,11 +15,21 @@ MembersSelectorBase {
 
     property UtilsStore utilsStore
 
+    signal resolveENS(string address)
+
     limitReached: model.count >= membersLimit - 1 // -1 because creator is not on the list of members when creating chat
 
     function cleanup() {
         root.edit.clear()
         d.selectedMembers.clear()
+    }
+
+    function ensResolved(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
+        if (resolvedPubKey === "") {
+            root.suggestionsDialog.forceHide = false
+            return
+        }
+        d.processContact(resolvedPubKey)
     }
 
     onEntryAccepted: if (suggestionsDelegate) {
@@ -78,7 +88,7 @@ MembersSelectorBase {
             }
 
             if (Utils.isValidEns(value)) {
-                root.rootStore.contactsStore.resolveENS(value)
+                root.resolveENS(value)
                 return
             }
 
@@ -149,19 +159,6 @@ MembersSelectorBase {
         interval: 500
         onTriggered: {
             d.lookupContact(edit.text)
-        }
-    }
-
-    Connections {
-        enabled: root.visible
-        target: root.rootStore.contactsStore
-
-        function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
-            if (resolvedPubKey === "") {
-                root.suggestionsDialog.forceHide = false
-                return
-            }
-            d.processContact(resolvedPubKey)
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/controls/AccountHeaderGradient.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AccountHeaderGradient.qml
@@ -1,74 +1,77 @@
-import QtQuick 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.15
 
 import StatusQ.Core.Theme 0.1
 
 import utils 1.0
 
-Loader {
+Control {
     id: root
 
     property var overview
 
-    sourceComponent: root.overview && root.overview.isAllAccounts ? multipleAccountsGradient : singleAccountGradient
+    implicitHeight: 115
 
-    Component {
-        id: singleAccountGradient
-        Rectangle {
-            implicitHeight: 115
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: overview && overview.colorId ? Theme.palette.alphaColor(Utils.getColorForId(overview.colorId), 0.1) : "" }
-                GradientStop { position: 1.0; color: "transparent" }
-            }
-        }
-    }
-    Component {
-        id: multipleAccountsGradient
-        Item {
-            implicitHeight: 115
+    contentItem: Loader {
+        sourceComponent: root.overview && root.overview.isAllAccounts ? multipleAccountsGradient : singleAccountGradient
+
+        Component {
+            id: singleAccountGradient
             Rectangle {
-                id: base
-                anchors.fill: parent
-                Component.onCompleted: {
-                    let splitWords = root.overview.colorIds.split(';')
-
-                    var stops = []
-                    let numOfColors = splitWords.length
-                    let gap =  1/splitWords.length
-                    let startPosition = gap
-                    for (const word of splitWords) {
-                        stops.push(stopComponent.createObject(base, {"position":startPosition, "color": Theme.palette.alphaColor(Utils.getColorForId(word), 0.1)}))
-                        startPosition += gap
-                    }
-                    gradient.stops = stops
-                }
-
                 gradient: Gradient {
-                    id: gradient
-                    orientation: Gradient.Horizontal
-                }
-                visible: false
-            }
-
-            Rectangle {
-                id: mask
-                anchors.fill: parent
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color:  Theme.palette.statusAppLayout.rightPanelBackgroundColor}
+                    GradientStop { position: 0.0; color: overview && overview.colorId ? Theme.palette.alphaColor(Utils.getColorForId(overview.colorId), 0.1) : "" }
                     GradientStop { position: 1.0; color: "transparent" }
                 }
-                visible: false
-            }
-
-            OpacityMask {
-                anchors.fill: base
-                source: base
-                maskSource: mask
             }
         }
-    }
-    Component {
-        id:stopComponent
-        GradientStop {}
+        Component {
+            id: multipleAccountsGradient
+            Item {
+                Rectangle {
+                    id: base
+                    anchors.fill: parent
+                    Component.onCompleted: {
+                        let splitWords = root.overview.colorIds.split(';')
+
+                        var stops = []
+                        let numOfColors = splitWords.length
+                        let gap =  1/splitWords.length
+                        let startPosition = gap
+                        for (const word of splitWords) {
+                            stops.push(stopComponent.createObject(base, {"position":startPosition, "color": Theme.palette.alphaColor(Utils.getColorForId(word), 0.1)}))
+                            startPosition += gap
+                        }
+                        gradient.stops = stops
+                    }
+
+                    gradient: Gradient {
+                        id: gradient
+                        orientation: Gradient.Horizontal
+                    }
+                    visible: false
+                }
+
+                Rectangle {
+                    id: mask
+                    anchors.fill: parent
+                    gradient: Gradient {
+                        GradientStop { position: 0.0; color:  Theme.palette.statusAppLayout.rightPanelBackgroundColor}
+                        GradientStop { position: 1.0; color: "transparent" }
+                    }
+                    visible: false
+                }
+
+                OpacityMask {
+                    anchors.fill: base
+                    source: base
+                    maskSource: mask
+                }
+            }
+        }
+        Component {
+            id:stopComponent
+            GradientStop {}
+        }
     }
 }


### PR DESCRIPTION
### What does the PR do

closes #18171

Bring back the section toolbar in qt6. It needs to be proxied as well because we have only one instance of the toolbar actions defined by the section user.

+ fix the header background in wallet. It seems the LayoutItemProxy cannot work well with a Loader. Not sure if it's a bug in Qt or not.
+ enable the back button navigation for the right side panel
+ fix a bug where the ens name wasn't resolved in the create chat view

### Affected areas

chat toolbar
community toolbar

### Architecture compliance

- [ ] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

https://github.com/user-attachments/assets/7d90bc21-e691-437c-bcd0-037b4fee82a7

<img width="1212" alt="Screenshot 2025-06-19 at 22 45 21" src="https://github.com/user-attachments/assets/88833268-b6fe-4dcf-924d-993c4391c309" />

