### PR TITLE
fix(CommunityAdmin): hide Community History and Node transfer on mobile

### DIFF
--- a/storybook/pages/OverviewSettingsChartPage.qml
+++ b/storybook/pages/OverviewSettingsChartPage.qml
@@ -62,11 +62,11 @@ SplitView {
             id: timestampMetrics
             text: "Metrics using timestamps"
             checked: false
-            onCheckedChanged: chart.reset()
+            onToggled: chart.reset()
         }
     }
 }
 
 // category: Panels
-
+// status: good
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?type=design&node-id=31281-635619&mode=design&t=RYpVRgwqCjp8fUEX-0

--- a/storybook/pages/OverviewSettingsFooterPage.qml
+++ b/storybook/pages/OverviewSettingsFooterPage.qml
@@ -63,6 +63,6 @@ SplitView {
 }
 
 // category: Panels
-
+// status: good
 // https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=36894-684461&mode=design&t=6k1ago8SSQ5Ip9J8-0
 // https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=36894-684611&mode=design&t=6k1ago8SSQ5Ip9J8-0

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -31,6 +31,7 @@ SplitView {
         logoImageData: communityEditor.image
         color: communityEditor.color
         bannerImageData: communityEditor.banner
+            isMobile: ctrlIsMobile.checked
 
         isOwner: communityEditor.amISectionAdmin
         isAdmin: ctrlIsAdmin.checked
@@ -56,6 +57,10 @@ SplitView {
             CommunityInfoEditor {
                 id: communityEditor
 
+                Switch {
+                    id: ctrlIsMobile
+                    text: "Is mobile?"
+                }
                 Switch {
                     id: pendingOwnershipSwitch
                     text: "Pending transfer ownership request?"

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -8,6 +8,8 @@ import AppLayouts.Communities.panels 1.0
 
 import shared.stores 1.0 as SharedStores
 
+import Models 1.0
+
 SplitView {
     id: root
     SplitView.fillWidth: true

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.14
+import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
@@ -22,28 +22,83 @@ SplitView {
         networksStore: SharedStores.NetworksStore {}
     }
 
-    OverviewSettingsPanel {
+    ColumnLayout {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        name: communityEditor.name
-        description: communityEditor.description
-        logoImageData: communityEditor.image
-        color: communityEditor.color
-        bannerImageData: communityEditor.banner
+        Button {
+            text: "<-- Back to %1".arg(panel.previousPageName)
+            visible: panel.currentIndex !== 0
+            onClicked: panel.navigateBack()
+        }
+
+        OverviewSettingsPanel {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            id: panel
+
+            communityId: "commId"
+            name: communityEditor.name
+            description: communityEditor.description
+            logoImageData: communityEditor.image
+            color: communityEditor.color
+            bannerImageData: communityEditor.banner
+            tags: ModelsData.communityTags
+
+            isOwner: communityEditor.amISectionAdmin
+            isAdmin: ctrlIsAdmin.checked
+            isTokenMaster: ctrlIsTM.checked
+
+            editable: communityEditor.isCommunityEditable
+            communitySettingsDisabled: !editable
+
+            shardingEnabled: communityEditor.shardingEnabled
+            shardIndex: communityEditor.shardIndex
+
+            isPendingOwnershipRequest: pendingOwnershipSwitch.checked
+
+            isControlNode: ctrlControlNode.checked
+            isTokenDeployed: ctrlTokenDeployed.checked
+
             isMobile: ctrlIsMobile.checked
 
-        isOwner: communityEditor.amISectionAdmin
-        isAdmin: ctrlIsAdmin.checked
-        isTokenMaster: ctrlIsTM.checked
+            onCollectCommunityMetricsMessagesCount: (intervals) => generateRandomModel(intervals)
+        }
+    }
 
-        editable: communityEditor.isCommunityEditable
-        communitySettingsDisabled: !editable
+    function generateRandomModel(intervalsStr) {
+        if(!intervalsStr) return
 
-        shardingEnabled: communityEditor.shardingEnabled
-        shardIndex: communityEditor.shardIndex
+        var response = {
+            communityId: panel.communityId,
+            metricsType: "MessagesCount",
+            intervals: []
+        }
 
-        isPendingOwnershipRequest: pendingOwnershipSwitch.checked
+        var intervals = JSON.parse(intervalsStr)
+
+        response.intervals = intervals.map( x => {
+            var timestamps = generateRandomDate(x.startTimestamp, x.endTimestamp, Math.random() * 10)
+
+            return {
+                startTimestamp: x.startTimestamp,
+                endTimestamp: x.endTimestamp,
+                timestamps: timestamps,
+                count: timestamps.length
+            }
+        })
+
+        panel.overviewChartData = JSON.stringify(response)
+    }
+
+    function generateRandomDate(from, to, count) {
+        var newModel = []
+        for(var i = 0; i < count; i++) {
+            var date = from + Math.random() * (to - from)
+            newModel.push(date)
+        }
+        return newModel
     }
 
     Pane {
@@ -58,9 +113,21 @@ SplitView {
                 id: communityEditor
 
                 Switch {
+                    id: ctrlControlNode
+                    text: "Is control node?"
+                    checked: true
+                }
+
+                Switch {
                     id: ctrlIsMobile
                     text: "Is mobile?"
                 }
+
+                Switch {
+                    id: ctrlTokenDeployed
+                    text: "Token deployed?"
+                }
+
                 Switch {
                     id: pendingOwnershipSwitch
                     text: "Pending transfer ownership request?"
@@ -81,5 +148,5 @@ SplitView {
 }
 
 // category: Panels
-
+// status: good
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?type=design&node-id=31229-627216&mode=design&t=KoQOW7vmoNc7f41m-0

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
@@ -13,7 +13,6 @@ import utils 1.0
 Control {
     id: root
 
-    property bool isPromoteSelfToControlNodeEnabled: false
     property bool isControlNode: true
     property string communityName: ""
     property string communityColor: ""
@@ -46,7 +45,6 @@ Control {
         id: mainGrid
         columnSpacing: 16
         rowSpacing: 16
-        visible: root.isPromoteSelfToControlNodeEnabled
 
         StatusRoundIcon {
             id: icon

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -1,12 +1,11 @@
-﻿import QtQuick 2.14
-import QtQuick.Layouts 1.14
-import QtQuick.Controls 2.14
+﻿import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
-import StatusQ.Core.Utils 0.1 as SQUtils
 
 import AppLayouts.Communities.layouts 1.0
 import AppLayouts.Communities.panels 1.0
@@ -14,7 +13,6 @@ import AppLayouts.Communities.popups 1.0
 import AppLayouts.Communities.helpers 1.0
 
 import shared.popups 1.0
-
 
 import utils 1.0
 
@@ -44,7 +42,6 @@ StackLayout {
     property bool archiveSupporVisible: true
     property bool editable: false
     property bool isControlNode: false
-    property int loginType: Constants.LoginType.Password
     property bool communitySettingsDisabled
     property var ownerToken: null
 
@@ -168,7 +165,7 @@ StackLayout {
 
             OverviewSettingsChart {
                 model: JSON.parse(root.overviewChartData)
-                onCollectCommunityMetricsMessagesCount: {
+                onCollectCommunityMetricsMessagesCount: (intervals) => {
                     root.collectCommunityMetricsMessagesCount(intervals)
                 }
                 Layout.topMargin: 16

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -55,7 +55,7 @@ StackLayout {
 
     property bool isTokenDeployed: !!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed
 
-    required property bool isMobile
+    property bool isMobile
 
     // Community transfer ownership related props:
     required property bool isPendingOwnershipRequest
@@ -204,7 +204,6 @@ StackLayout {
             communityColor: root.color
             isControlNode: root.isControlNode
             isPendingOwnershipRequest: root.isPendingOwnershipRequest
-            isPromoteSelfToControlNodeEnabled: root.isControlNode || root.isTokenDeployed
 
             onExportControlNodeClicked:{
                 if(root.isTokenDeployed) {
@@ -249,9 +248,11 @@ StackLayout {
             active: {
                 if (root.communitySettingsDisabled)
                     return false
+                if (root.isMobile)
+                    return false
                 if (root.isAdmin || root.isTokenMaster)
                     return root.isPendingOwnershipRequest // not allowed for admin or TM unless there's the pending request
-                return true
+                return root.isControlNode || root.isTokenDeployed
             }
         }
     }
@@ -313,7 +314,7 @@ StackLayout {
 
                 options {
                     archiveSupportEnabled: root.archiveSupportEnabled
-                    archiveSupporVisible: root.archiveSupporVisible
+                    archiveSupporVisible: root.archiveSupporVisible && !root.isMobile
                     requestToJoinEnabled: root.requestToJoinEnabled
                     pinMessagesEnabled: root.pinMessagesEnabled
                 }

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -55,6 +55,8 @@ StackLayout {
 
     property bool isTokenDeployed: !!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed
 
+    required property bool isMobile
+
     // Community transfer ownership related props:
     required property bool isPendingOwnershipRequest
     signal finaliseOwnershipClicked
@@ -121,7 +123,7 @@ StackLayout {
                     Layout.preferredHeight: 38
                     Layout.alignment: Qt.AlignTop
                     objectName: "communityOverviewSettingsTransferOwnershipButton"
-                    visible: root.isOwner
+                    visible: root.isOwner && !root.isMobile
                     text: qsTr("Transfer ownership")
                     size: StatusBaseButton.Size.Small
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -229,6 +229,8 @@ StatusSectionLayout {
 
                 isPendingOwnershipRequest: root.isPendingOwnershipRequest
 
+                isMobile: Constants.isMobile
+
                 onFinaliseOwnershipClicked: root.finaliseOwnershipClicked()
 
                 onCollectCommunityMetricsMessagesCount: {

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -216,7 +216,6 @@ StatusSectionLayout {
                 requestToJoinEnabled: root.community.access === Constants.communityChatOnRequestAccess
                 pinMessagesEnabled: root.community.pinMessageAllMembersEnabled
                 editable: true
-                loginType: root.rootStore.loginType
                 isControlNode: root.isControlNode
                 communitySettingsDisabled: root.communitySettingsDisabled
                 overviewChartData: rootStore.overviewChartData

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1056,8 +1056,6 @@ QtObject {
         "connected-different-key": qsTr("Continuing will require a transaction to connect the username with your current chat key."),
     }
 
-    readonly property bool isCppApp: typeof cppApp !== "undefined" ? cppApp : false
-
     readonly property QtObject startupErrorType: QtObject {
         readonly property int unknownType: 0
         readonly property int importAccError: 1


### PR DESCRIPTION
### What does the PR do

separate commits fixing:
- Hide Control node transfer (Admin screen) on mobile (Fixes #18175)
- Hide Community History Service switch on mobile (Fixes #18177)
- improve the respective SB pages

### Affected areas

Community Admin

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/user-attachments/assets/e7c7ba13-ecad-4e44-98ba-bddaa162d6f1


