### PR TITLE
feat(backup): add SettingsLine in SyncingView to change backup path

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, uri, stew/shims/strformat, re, stint, httpclient
+import NimQml, strutils, uri, stew/shims/strformat, re, stint, httpclient, os
 import stew/byteutils
 import ./utils/qrcodegen
 
@@ -27,11 +27,20 @@ QtObject:
     new(result, delete)
     result.setup
 
-  proc formatImagePath*(self: Utils, imagePath: string): string =
-    result = uri.decodeUrl(replace(imagePath, "file://", ""), decodePlus=false)
+  proc fromPathUri*(self: Utils, path: string): string {.slot.} =
+    result = uri.decodeUrl(replace(path, "file://", ""), decodePlus=false)
     if defined(windows):
       # Windows doesn't work with paths starting with a slash
       result.removePrefix('/')
+
+  proc toFileUri*(self: Utils, path: string): string {.slot.} =
+    let absPath = absolutePath(path)   # Ensure it's absolute
+    let uriPath = if defined(windows):
+                    # Convert to URI-compliant format
+                    "file:///" & absPath.replace("\\", "/")
+                  else:
+                    "file://" & absPath
+    return uriPath
 
   proc isAlias*(self: Utils, value: string): bool {.slot.} =
     result = isAlias(value)

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -357,7 +357,7 @@ method computeDeployCollectiblesFee*(self: Module, uuid: string, communityId: st
   self.tempDeploymentParams.description = description
 
   let croppedImage = imageCropInfoJson.parseJson
-  let base65Image = singletonInstance.utils.formatImagePath(croppedImage["imagePath"].getStr)
+  let base65Image = singletonInstance.utils.fromPathUri(croppedImage["imagePath"].getStr)
   self.tempDeploymentParams.base64image = base65Image
 
   self.tempDeploymentParams.communityId = communityId
@@ -378,7 +378,7 @@ method computeDeployTokenOwnerFee*(self: Module, uuid: string, communityId: stri
   self.tempCommunityId = communityId
   self.tempChainId = chainId
   let croppedImage = imageCropInfoJson.parseJson
-  let base65Image = singletonInstance.utils.formatImagePath(croppedImage["imagePath"].getStr)
+  let base65Image = singletonInstance.utils.fromPathUri(croppedImage["imagePath"].getStr)
   (self.tempOwnerDeploymentParams, self.tempMasterDeploymentParams) = self.createOwnerAndMasterDeploymentParams(communityId)
   self.tempOwnerDeploymentParams.description = ownerDescription
   self.tempOwnerDeploymentParams.tokenType = TokenType.ERC721
@@ -413,7 +413,7 @@ method computeDeployAssetsFee*(self: Module, uuid: string, communityId: string, 
   self.tempDeploymentParams.description = description
 
   let croppedImage = imageCropInfoJson.parseJson
-  let base65Image = singletonInstance.utils.formatImagePath(croppedImage["imagePath"].getStr)
+  let base65Image = singletonInstance.utils.fromPathUri(croppedImage["imagePath"].getStr)
   self.tempDeploymentParams.base64image = base65Image
 
   self.tempDeploymentParams.communityId = communityId

--- a/src/app/modules/main/profile_section/profile/module.nim
+++ b/src/app/modules/main/profile_section/profile/module.nim
@@ -86,7 +86,7 @@ method setIsFirstShowcaseInteraction(self: Module) =
 
 proc storeIdentityImage*(self: Module, identityImage: IdentityImage): bool =
   let keyUid = singletonInstance.userProfile.getKeyUid()
-  let image = singletonInstance.utils.formatImagePath(identityImage.source)
+  let image = singletonInstance.utils.fromPathUri(identityImage.source)
   # FIXME the function to get the file size is messed up
   # let size = image_getFileSize(image)
   # TODO find a way to i18n this (maybe send just a code and then QML sets the right string)

--- a/src/app/modules/main/profile_section/sync/module.nim
+++ b/src/app/modules/main/profile_section/sync/module.nim
@@ -104,7 +104,7 @@ method setUseMailservers*(self: Module, value: bool) =
     self.view.useMailserversChanged()
 
 method importLocalBackupFile*(self: Module, filePath: string) =
-  let formattedFilePath = singletonInstance.utils.formatImagePath(filePath)
+  let formattedFilePath = singletonInstance.utils.fromPathUri(filePath)
   self.controller.importLocalBackupFile(formattedFilePath)
 
 method onLocalBackupImportCompleted*(self: Module, error: string) =

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -3,7 +3,7 @@ import json, times, stint, strutils, sugar, os, re, chronicles
 import nimcrypto
 import account_constants
 
-import ../../constants as main_constants
+import constants as main_constants
 
 const STATUS_DOMAIN* = ".stateofus.eth"
 const ETH_DOMAIN* = ".eth"

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -685,7 +685,7 @@ QtObject:
   proc updateGroupChatDetails*(self: Service, communityID: string, chatID: string, name: string, color: string, imageJson: string) =
     try:
       var parsedImage = imageJson.parseJson
-      parsedImage["imagePath"] = %singletonInstance.utils.formatImagePath(parsedImage["imagePath"].getStr)
+      parsedImage["imagePath"] = %singletonInstance.utils.fromPathUri(parsedImage["imagePath"].getStr)
       let response = status_chat.editChat(communityID, chatID, name, color, $parsedImage)
 
       discard self.processMessengerResponse(response)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1113,7 +1113,7 @@ QtObject:
       filesToImport: seq[string],
       fromTimestamp: int) =
     try:
-      var image = singletonInstance.utils.formatImagePath(imageUrl)
+      var image = singletonInstance.utils.fromPathUri(imageUrl)
       var tagsString = tags
       if len(tagsString) == 0:
         tagsString = "[]"
@@ -1184,7 +1184,7 @@ QtObject:
       bannerJsonStr: string) =
     try:
       var bannerJson = bannerJsonStr.parseJson
-      bannerJson{"imagePath"} = newJString(singletonInstance.utils.formatImagePath(bannerJson["imagePath"].getStr))
+      bannerJson{"imagePath"} = newJString(singletonInstance.utils.fromPathUri(bannerJson["imagePath"].getStr))
       var tagsString = tags
       if len(tagsString) == 0:
         tagsString = "[]"
@@ -1197,7 +1197,7 @@ QtObject:
         access,
         color,
         tagsString,
-        singletonInstance.utils.formatImagePath(imageUrl),
+        singletonInstance.utils.fromPathUri(imageUrl),
         aX, aY, bX, bY,
         historyArchiveSupportEnabled,
         pinMessageAllMembersEnabled,
@@ -1242,7 +1242,7 @@ QtObject:
       let cropRectJson = logoJson["cropRect"]
       var tagsString = tags
       var bannerJson = bannerJsonStr.parseJson
-      bannerJson{"imagePath"} = newJString(singletonInstance.utils.formatImagePath(bannerJson["imagePath"].getStr))
+      bannerJson{"imagePath"} = newJString(singletonInstance.utils.fromPathUri(bannerJson["imagePath"].getStr))
       if len(tagsString) == 0:
         tagsString = "[]"
       let response = status_go.editCommunity(
@@ -1254,7 +1254,7 @@ QtObject:
         access,
         color,
         tagsString,
-        singletonInstance.utils.formatImagePath(logoJson["imagePath"].getStr()),
+        singletonInstance.utils.fromPathUri(logoJson["imagePath"].getStr()),
         int(cropRectJson["x"].getFloat()),
         int(cropRectJson["y"].getFloat()),
         int(cropRectJson["x"].getFloat() + cropRectJson["width"].getFloat()),

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -57,6 +57,7 @@ const KEY_LAST_TOKENS_UPDATE* = "last-tokens-update"
 const KEY_NEWS_FEED_ENABLED* = "news-feed-enabled?"
 const KEY_NEWS_NOTIFICATIONS_ENABLED* = "news-notifications-enabled?"
 const KEY_NEWS_RSS_ENABLED* = "news-rss-enabled?"
+const KEY_BACKUP_PATH* = "backup-path"
 
 # Notifications Settings Values
 const VALUE_NOTIF_SEND_ALERTS* = "SendAlerts"
@@ -114,6 +115,7 @@ type
 type
   SettingsDto* = object # There is no point to keep all these info as settings, but we must follow status-go response
     address*: string
+    backupPath*: string
     currency*: string
     dappsAddress*: string
     eip1581Address*: string
@@ -228,6 +230,7 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_COLLECTIBLE_GROUP_BY_COLLECTION, result.collectibleGroupByCollection)
   discard jsonObj.getProp(PROFILE_MIGRATION_NEEDED, result.profileMigrationNeeded)
   discard jsonObj.getProp(KEY_AUTO_REFRESH_TOKENS, result.autoRefreshTokens)
+  discard jsonObj.getProp(KEY_BACKUP_PATH, result.backupPath)
 
   var lastTokensUpdate: string
   discard jsonObj.getProp(KEY_LAST_TOKENS_UPDATE, lastTokensUpdate)

--- a/src/backend/settings.nim
+++ b/src/backend/settings.nim
@@ -110,3 +110,6 @@ proc toggleNewsFeedEnabled*(value: bool): RpcResponse[JsonNode] =
 
 proc toggleNewsRSSEnabled*(value: bool): RpcResponse[JsonNode] =
   result = core.callPrivateRPC("toggleNewsRSSEnabled".prefix, %*[ value ])
+
+proc backupPath*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("settings_backupPath")

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -28,7 +28,8 @@ let
   OPENURI* = desktopConfig.uri
   DATADIR* = baseDir & sep
   STATUSGODIR* = joinPath(baseDir, "data") & sep
-  ROOTKEYSTOREDIR* = joinPath(baseDir, "data", "keystore")
+  ROOTKEYSTOREDIR* = joinPath(STATUSGODIR, "keystore")
+  DEFAULT_BACKUP_DIR* = joinPath(STATUSGODIR, "backups") & sep
   TMPDIR* = joinPath(baseDir, "tmp") & sep
   LOGDIR* = joinPath(baseDir, "logs") & sep
   KEYCARD_DATA_DIR* = joinPath(baseDir, "data", "keycard")

--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -35,7 +35,11 @@ SplitView {
 
         isProduction: ctrlIsProduction.checked
         localBackupEnabled: localBackupEnabledSwitch.checked
-
+        backupPath: "file:///home/dev/status-desktop/backups"
+        toFileUri: function(path) {return path}
+        onBackupPathSet: function(path) {
+            logs.logEvent("SyncingView::onBackupPathSet", path)
+        }
         advancedStore: ProfileStores.AdvancedStore {
             readonly property bool isDebugEnabled: ctrlDebugEnabled.checked
         }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -416,8 +416,13 @@ StatusSectionLayout {
                 privacyStore: root.privacyStore
                 advancedStore: root.advancedStore
                 localBackupEnabled: root.devicesStore.localBackupEnabled
+                backupPath: root.devicesStore.backupPath
+                toFileUri: root.devicesStore.toFileUri
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.syncingSettings)
                 contentWidth: d.contentWidth
+                onBackupPathSet: function(path) {
+                    root.devicesStore.setBackupPath(path)
+                }
             }
         }
 

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import utils
 
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
 QtObject {
     id: root
 
@@ -22,6 +24,21 @@ QtObject {
     // Backup import properties
     readonly property int backupImportState: syncModule ? syncModule.backupImportState : 0
     readonly property string backupImportError: syncModule ? syncModule.backupImportError : ""
+    readonly property url backupPath: d.appSettingsInst.backupPath
+
+    readonly property QtObject _d: StatusQUtils.QObject {
+        id: d
+        readonly property var appSettingsInst: appSettings
+        readonly property var globalUtilsInst: globalUtils
+    }
+
+    function setBackupPath(path) {
+        d.appSettingsInst.setBackupPath(path)
+    }
+
+    function toFileUri(path) {
+        return d.globalUtilsInst.toFileUri(path)
+    }
 
     function loadDevices() {
         return root.devicesModule.loadDevices()

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -17,6 +17,7 @@ import shared.panels
 import shared.popups
 import shared.controls
 import shared.controls.chat
+import shared.status
 
 import SortFilterProxyModel
 
@@ -35,6 +36,10 @@ SettingsContentBase {
 
     required property bool isProduction
     required property bool localBackupEnabled
+    required property url backupPath
+    required property var toFileUri // Function to convert a file path to a file URI
+
+    signal backupPathSet(url path)
 
     ColumnLayout {
         id: layout
@@ -282,6 +287,14 @@ SettingsContentBase {
             onClicked: Global.openPopup(getSyncCodeInstructionsPopup)
         }
 
+        StatusSettingsLineButton {
+            anchors.leftMargin: 0
+            anchors.rightMargin: 0
+            text: qsTr("Directory of the local backup files")
+            currentValue: root.backupPath
+            onClicked: backupPathDialog.open()
+        }
+
         StatusButton {
             objectName: "setupSyncBackupDataButton"
 
@@ -402,6 +415,14 @@ SettingsContentBase {
             onAccepted: {
                 root.devicesStore.importLocalBackupFile(importBackupFileDialog.selectedFile)
             }
+        }
+
+        StatusFolderDialog {
+            id: backupPathDialog
+
+            title: qsTr("Select your backup directory")
+            currentFolder: root.devicesStore.toFileUri(root.backupPath)
+            onAccepted: root.backupPathSet(backupPathDialog.selectedFolder)
         }
 
         Item {


### PR DESCRIPTION
### What does the PR do

Fixes #18128

Adds a SettingsLine above the "Backup Data" and "Import Backup" buttons that shows what is the current path for the backup and let's the user change that path.

Status-go PR: https://github.com/status-im/status-go/pull/6699

### Affected areas

- settings service
- SyncingView
- Renamed `formatImagePath` to `fromPathUri` because it's not just useful for images

### Architecture compliance

- [x] I am familiar with the application architecture and agreed good practices.
My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)

### Screenshot of functionality

[change-setting-path.webm](https://github.com/user-attachments/assets/d826c2dc-f4a9-4fb6-b892-cbf111c30c75)

### Impact on end user

Let's the user know what the path is and change it if needed

### How to test

- Have the feature flags enabled (in status-go remove the commented option in `service.ext` and in Desktop `export FLAG_LOCAL_BACKUP_ENABLED=1`)
- Go to SyncingView
- Play with the new setting line and click Backup Data

### Risk 

Tick **one**:
- [x] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.

-->
