### PR TITLE
docs(pr): update PR template to fix links and adapt to new flows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,32 +8,22 @@
 
 ### Architecture compliance
 
-- [ ] I am familiar with the application architecture and agreed good practices.
-My PR is consistent with this document: [Status Desktop Architecture Guide](https://github.com/status-im/status-desktop/blob/master/CONTRIBUTING.md)
+- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
+My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
 
-### Screenshot of functionality (including design for comparison)
+### Screencapture of the functionality
 
-- [ ] I've checked the design and this PR matches it
-
-<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
-
-<!-- Uncomment this section for status-go upgrade/dogfooding pull requests
+<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->
 
 ### Impact on end user
 
-What is the impact of these changes on the end user (before/after behaviour)
+<!-- What is the impact of these changes on the end user (before/after behaviour) -->
 
 ### How to test
 
-- How should one proceed with testing this PR.
-- What kind of user flows should be checked?
+- <!-- How should one proceed with testing this PR. -->
+- <!-- What kind of user flows should be checked? -->
 
 ### Risk 
 
-Described potential risks and worst case scenarios.
-
-Tick **one**:
-- [ ] Low risk: 2 devs MUST perform testing as specified above and attach their results as comments to this PR **before** merging.
-- [ ] High risk: QA team MUST perform additional testing in the specified affected areas **before** merging.
-
--->
+<!-- Described potential risks and worst case scenarios. -->


### PR DESCRIPTION
The links to the architecture guideline still pointed to CONTRIBUTING. Also I added a link to the architecture.

I removed the part about matching designs because no one does it. I replaced by  a stronger emphasis on having a video, because that's the best.

Finally, I removed the checkboxes about QA testing as every dev should test their work thoroughly themselves.