### PR TITLE
feat(IOSFileAccess): Enable IOS file access for images

### DIFF
--- a/mobile/ios/Info.plist
+++ b/mobile/ios/Info.plist
@@ -53,5 +53,11 @@
     <string>Status uses camera to scan QR codes</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>Status uses local network to discover devices for pairing</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Photos access is required to give you the ability to save images.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Photos access is required to give you the ability to send images.</string>
+    <key>NSAppleMusicUsageDescription</key>
+    <string>Status uses Media Library to save and send Images. The Media Library module internally requires permissions to Apple Music</string>
 </dict>
 </plist>

--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -43,7 +43,7 @@ else
     # Compile resources
     xcodebuild -configuration Release -target "Qt Preprocess" -sdk "$SDK" -arch "$ARCH" CODE_SIGN_STYLE=Automatic | xcbeautify
     # Compile the app
-    xcodebuild -configuration Release -target Status-tablet install -sdk "$SDK" -arch "$ARCH" DSTROOT="$BIN_DIR" INSTALL_PATH="/" TARGET_BUILD_DIR="$BIN_DIR" CODE_SIGN_STYLE=Automatic | xcbeautify
+    xcodebuild -configuration Release -target Status-tablet install -sdk "$SDK" -arch "$ARCH" DSTROOT="$BIN_DIR" INSTALL_PATH="/" TARGET_BUILD_DIR="$BIN_DIR" CODE_SIGN_STYLE=Automatic QMAKE_BUNDLE_SUFFIX=$(id -un) -allowProvisioningUpdates | xcbeautify
 
     if [[ -e "$BIN_DIR/Status-tablet.app/Info.plist" ]]; then
         echo "Build succeeded"

--- a/mobile/scripts/buildStatusGo.sh
+++ b/mobile/scripts/buildStatusGo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #Script designed to run in the context of the status-go repository
+set -ef pipefail
 set -o xtrace
 
 STATUS_GO=${STATUS_GO:-"../vendors/status-desktop/vendor/status-go"}
@@ -28,7 +29,7 @@ cd "$STATUS_GO"
 make generate V=3 SHELL=/bin/sh
 
 mkdir -p build/bin/statusgo-lib
-go run cmd/library/*.go > build/bin/statusgo-lib/main.go
+go run cmd/library/main.go cmd/library/const.go > build/bin/statusgo-lib/main.go
 
 GOFLAGS="" CGO_ENABLED=1 GOOS="$OS" GOARCH="$GOARCH" \
 	go build \

--- a/mobile/scripts/ios/run.sh
+++ b/mobile/scripts/ios/run.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 
 CWD=$(realpath "$(dirname "$0")")
-APPID=${APPID:-im.status.Status-tablet}            # Bundle identifier of the app
 APP=${APP:-"$CWD/../../bin/Applications/Status-tablet.app"}  # Path to the .app bundle
+APPID=${APPID:-$(mdls -name kMDItemCFBundleIdentifier -raw "$APP")} # Bundle identifier of the app
 SIMULATOR_UDID=${SIMULATOR_UDID:-""}               # Specify to skip interactive selection
 IPHONE_SDK=${IPHONE_SDK:-iphonesimulator}  # Default to simulator if not set
 DEVICE_ID=${DEVICE_ID:-""}                # For physical device selection

--- a/mobile/wrapperApp/Status-tablet.pro
+++ b/mobile/wrapperApp/Status-tablet.pro
@@ -43,7 +43,7 @@ ios {
     QMAKE_INFO_PLIST = $$PWD/../ios/Info.plist
     QMAKE_IOS_DEPLOYMENT_TARGET=16.0
     QMAKE_TARGET_BUNDLE_PREFIX = im.status
-    QMAKE_APPLICATION_BUNDLE_NAME = tablet
+    QMAKE_BUNDLE = status$${QMAKE_BUNDLE_SUFFIX}
     QMAKE_ASSET_CATALOGS += $$PWD/../ios/Images.xcassets
 
     LIBS += -L$$PWD/../lib/ios/$$LIB_PREFIX -lnim_status_client -lDOtherSideStatic -lstatusq -lstatus -lssl_3 -lcrypto_3 -lqzxing -lresolv -lqrcodegen -lpcre

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -156,6 +156,7 @@ add_library(StatusQ ${LIB_TYPE}
         src/typesregistration.cpp
         src/undefinedfilter.cpp
         src/urlutils.cpp
+        src/ios_utils.h
 
         # wallet
         src/wallet/managetokenscontroller.cpp
@@ -180,6 +181,12 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     target_sources(StatusQ PRIVATE
         src/statuswindow_osx.mm
         src/keychain_osx.mm
+    )
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
+    target_sources(StatusQ PRIVATE
+        src/ios_utils.mm
+        src/statuswindow_other.cpp
+        src/keychain_other.cpp
     )
 else ()
     target_sources(StatusQ PRIVATE

--- a/ui/StatusQ/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -221,8 +221,8 @@ Item {
                 property var lastDragPoint: null
                 onReleased: lastDragPoint = null
 
-                onMouseXChanged: updateDrag(Qt.point(mouse.x, mouse.y))
-                onMouseYChanged: updateDrag(Qt.point(mouse.x, mouse.y))
+                onMouseXChanged: (mouse) => updateDrag(Qt.point(mouse.x, mouse.y))
+                onMouseYChanged: (mouse) => updateDrag(Qt.point(mouse.x, mouse.y))
 
                 onWheel: {
                     const delta = wheel.angleDelta.y / 120

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -13,7 +13,9 @@ QtObject {
     readonly property string android: "android"
     readonly property string ios: "ios"
 
-    readonly property bool isMobile: Qt.platform.os === android || Qt.platform.os === ios
+    readonly property bool isMobile: isIOS || isAndroid
+    readonly property bool isIOS: Qt.platform.os === ios
+    readonly property bool isAndroid: Qt.platform.os === android
 
     function getAbsolutePosition(node) {
         var returnPos = {};

--- a/ui/StatusQ/src/ios_utils.h
+++ b/ui/StatusQ/src/ios_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+
+#ifdef Q_OS_IOS
+
+void saveImageToPhotosAlbum(const QByteArray& imageData);
+QString resolveIOSPhotoAsset(const QUrl &assetUrl);
+
+#endif // Q_OS_IOS

--- a/ui/StatusQ/src/ios_utils.mm
+++ b/ui/StatusQ/src/ios_utils.mm
@@ -1,0 +1,89 @@
+#include "ios_utils.h"
+#include <QStringList>
+#import <Foundation/Foundation.h>
+#import <Photos/Photos.h>
+#import <UIKit/UIKit.h>
+#include <QString>
+#include <QUrl>
+
+void saveImageToPhotosAlbum(const QByteArray &data)
+{
+    NSData *imageData = [NSData dataWithBytes:data.constData() length:data.length()];
+    UIImage *image = [UIImage imageWithData:imageData];
+    if (image) {
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
+    } else {
+        NSLog(@"Failed to save image");
+    }
+}
+QString resolveIOSPhotoAsset(const QUrl &assetUrl) {
+    @autoreleasepool {
+        if (!assetUrl.isValid()) {
+            NSLog(@"resolveIOSPhotoAsset: Invalid URL provided");
+            return {};
+        }
+
+        QString urlStringQt = assetUrl.toString();
+        NSString *urlString = urlStringQt.toNSString();
+
+        __block NSString *tempPath = nil;
+        __block BOOL success = NO;
+
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+        void (^handleResult)(NSData *) = ^(NSData *imageData) {
+            if (imageData) {
+                NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"resolved.jpg"];
+                if ([imageData writeToFile:path atomically:YES]) {
+                    tempPath = path;
+                    success = YES;
+                } else {
+                    NSLog(@"resolveIOSPhotoAsset: Failed to write data to file");
+                }
+            } else {
+                NSLog(@"resolveIOSPhotoAsset: No image data received");
+            }
+            dispatch_semaphore_signal(sema);
+        };
+
+        PHAsset *asset = nil;
+
+        if ([urlString hasPrefix:@"ph://"]) {
+            NSString *localId = [urlString substringFromIndex:5];
+            PHFetchResult<PHAsset *> *result = [PHAsset fetchAssetsWithLocalIdentifiers:@[localId] options:nil];
+            if (result.count > 0) {
+                asset = result.firstObject;
+            } else {
+                NSLog(@"resolveIOSPhotoAsset: No asset found for ph:// URL");
+            }
+        } else if ([urlString hasPrefix:@"assets-library://"]) {
+            NSURL *assetURL = [NSURL URLWithString:urlString];
+            PHFetchResult<PHAsset *> *result = [PHAsset fetchAssetsWithALAssetURLs:@[assetURL] options:nil];
+            if (result.count > 0) {
+                asset = result.firstObject;
+            } else {
+                NSLog(@"resolveIOSPhotoAsset: No asset found for assets-library:// URL");
+            }
+        } else {
+            NSLog(@"resolveIOSPhotoAsset: URL does not match known formats (ph:// or assets-library://)");
+        }
+
+        if (asset) {
+            PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+            options.synchronous = YES;
+            options.networkAccessAllowed = YES;
+
+            [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset
+                                                                           options:options
+                                                                     resultHandler:^(NSData *imageData, NSString *dataUTI, CGImagePropertyOrientation orientation, NSDictionary *info) {
+                handleResult(imageData);
+            }];
+
+            dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        } else {
+            NSLog(@"resolveIOSPhotoAsset: No valid asset found");
+        }
+
+        return success ? QString::fromNSString(tempPath) : assetUrl.toString();
+    }
+}

--- a/ui/StatusQ/src/urlutils.cpp
+++ b/ui/StatusQ/src/urlutils.cpp
@@ -4,6 +4,8 @@
 #include <QImageReader>
 #include <QUrl>
 
+#include "ios_utils.h"
+
 namespace {
 constexpr auto webpMime = "image/webp";
 }
@@ -48,6 +50,9 @@ qint64 UrlUtils::getFileSize(const QUrl& url)
 QString UrlUtils::convertUrlToLocalPath(const QString &url) const {
     const auto localFileOrUrl = QUrl::fromUserInput(url); // accept both "file:/foo/bar" and "/foo/bar"
     if (localFileOrUrl.isLocalFile()) {
+        #ifdef Q_OS_IOS
+        return resolveIOSPhotoAsset(localFileOrUrl.toLocalFile());
+        #endif // Q_OS_IOS
         return localFileOrUrl.toLocalFile();
     }
     return {};

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -344,6 +344,13 @@ QtObject {
     }
 
     function openDownloadImageDialog(imageSource) {
+        // On IOS the app is sandboxed and the FileDialog has limited access to the system.
+        // We'll save the image to the default location - currenty the Photos album.
+        if (SQUtils.Utils.isIOS) {
+            SystemUtils.downloadImageByUrl(imageSource, "")
+            return
+        }
+
         // We don't use `openPopup`, because there's no `FileDialog::closed` signal.
         const popup = downloadImageDialogComponent.createObject(popupParent, { imageSource })
         popup.open()
@@ -615,7 +622,7 @@ QtObject {
             ImageCropWorkflow {
                 title: qsTr("Profile Picture")
                 acceptButtonText: qsTr("Make this my Profile Pic")
-                onImageCropped: {
+                onImageCropped: (image, cropRect) => {
                     if (!callback) {
                         console.error("ImageCropWorkflow: no callback provided")
                         return


### PR DESCRIPTION
### What does the PR do

closes: #18077 

Adding StatusQ platform specific flows for saving images to photo album and for resolving iOS images.
This flow is supported by `ios_utils.mm`

- Fixing the IOS build. Apparently we can't register a signature for im.status.status-tablet more than once. I've updated the bundleId to append the username in the bundleId for dev purposes.

- Fixing status-go build script. It wasn't stopping on failure. The `go run` had errors ignored by the build system

### Affected areas

Send image
Download image
Changing profile picture


