### PR TITLE
fix: various small UI fixes for popup menus under Qt6

### DIFF
--- a/storybook/pages/ProfileShowcasePanelPage.qml
+++ b/storybook/pages/ProfileShowcasePanelPage.qml
@@ -30,7 +30,7 @@ SplitView {
             hasImage: true
             image: "https://picsum.photos/200/300?random=1"
             iconName: "https://picsum.photos/40/40?random=1"
-            showcaseVisibility: 1
+            showcaseVisibility: 2
             name: "Test community"
             joined: true
             isControlNode: true
@@ -194,7 +194,7 @@ SplitView {
                                                                        hasImage: true,
                                                                        image: "https://picsum.photos/200/300?random=" + i,
                                                                        iconName: "https://picsum.photos/40/40?random=" + i,
-                                                                       showcaseVisibility: Math.ceil(Math.random() * 3),
+                                                                       showcaseVisibility: Math.random() > 0.5 ? Constants.ShowcaseVisibility.Everyone : Constants.ShowcaseVisibility.Contacts,
                                                                        name: "Test community",
                                                                        joined: true,
                                                                        isControlNode: true,
@@ -202,7 +202,7 @@ SplitView {
                                                                        hasTag: Math.random() > 0.5,
                                                                        tagText: "New " + 1,
                                                                        tagAsset: "https://picsum.photos/40/40?random=" + i,
-                                                                       tagLoading: Math.random() > 0.5
+                                                                       tagLoading: Math.random() > 0.9
                                                                    })} : (i) => {
             inShowcaseModelItem.remove(inShowcaseModelItem.count - 1);
         }
@@ -222,7 +222,7 @@ SplitView {
                                                                    hasImage: true,
                                                                    image: "https://picsum.photos/200/300?random=" + i,
                                                                    iconName: "https://picsum.photos/40/40?random=" + i,
-                                                                   showcaseVisibility: 0,
+                                                                   showcaseVisibility: Constants.ShowcaseVisibility.NoOne,
                                                                    name: "Test community",
                                                                    joined: true,
                                                                    memberRole: Constants.memberRole.owner,
@@ -243,3 +243,4 @@ SplitView {
 }
 
 // category: Panels
+// status: good

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -37,7 +37,7 @@ Item {
 
     readonly property Component defaultBackgroundComponent: Rectangle {
         color: root.type === StatusComboBox.Type.Secondary ? "transparent" : Theme.palette.baseColor2
-        radius: 8
+        radius: Theme.radius
         border.width: (!!root.validationError || root.forceError
                         || comboBox.hovered || comboBox.down
                         || comboBox.visualFocus

--- a/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
@@ -229,7 +229,7 @@ QtObject {
         padding = basePadding
         halfPadding = basePadding / 2
         smallPadding = basePadding * 0.625
-        radius = basePadding
+        radius = halfPadding
     }
 
     enum AnimationDuration {

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuHeadline.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuHeadline.qml
@@ -6,19 +6,16 @@ import StatusQ.Core.Theme 0.1
 
 MenuSeparator {
     id: root
+
     property string text
-    height: visible && enabled ? implicitHeight : 0
-    contentItem: Item {
-        implicitWidth: 176
-        implicitHeight: 16
-        StatusBaseText {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.left
-            anchors.leftMargin: 12
-            color: Theme.palette.baseColor1
-            font.pixelSize: Theme.tertiaryTextFontSize
-            text: root.text
-        }
+
+    background: Rectangle {
+        color: Theme.palette.statusMenu.backgroundColor
+    }
+
+    contentItem: StatusBaseText {
+        color: Theme.palette.baseColor1
+        font.pixelSize: Theme.tertiaryTextFontSize
+        text: root.text
     }
 }
-

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -5,7 +5,6 @@ import QtQuick.Layouts 1.15
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
-import StatusQ.Popups 0.1
 
 MenuItem {
     id: root
@@ -23,10 +22,10 @@ MenuItem {
         id: d
 
         readonly property bool isSubMenu: !!root.subMenu
-        readonly property bool isStatusSubMenu: isSubMenu && (root.subMenu instanceof StatusMenu)
+        readonly property bool isStatusSubMenu: isSubMenu && root.subMenu.toString().startsWith("StatusMenu_")
         readonly property bool subMenuOpened: isSubMenu && root.subMenu.opened
         readonly property bool hasAction: !!root.action
-        readonly property bool isStatusAction: d.hasAction && (root.action instanceof StatusAction)
+        readonly property bool isStatusAction: d.hasAction && root.action.toString().startsWith("StatusAction_")
         readonly property bool isStatusDangerAction: (d.isStatusAction && root.action.type === StatusAction.Type.Danger) ||
                                                      (d.isStatusSubMenu && root.subMenu.type === StatusAction.Type.Danger)
         readonly property bool isStatusSuccessAction: (d.isStatusAction && root.action.type === StatusAction.Type.Success) ||

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -151,7 +151,7 @@ MenuItem {
         StatusIcon {
             Layout.preferredHeight: 16
             Layout.alignment: Qt.AlignRight
-            visible: root.checkable && root.checked
+            visible: root.checked
             icon: "tiny/checkmark"
             color: Theme.palette.primaryColor1
         }

--- a/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
@@ -36,7 +36,7 @@ ComboBox {
     }
 
     enabled: d.searchTextLowerCase || d.combinedProxyModel.count || d.uncategorizedModel.count
-    opacity: enabled ? 1 : 0.3
+    opacity: enabled ? 1 : Theme.disabledOpacity
 
     displayText: qsTr("Collection")
 
@@ -257,22 +257,12 @@ ComboBox {
                     height: d.defaultDelegateHeight
                     spacing: 0
 
-                    Rectangle {
+                    StatusMenuHeadline {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        color: Theme.palette.statusListItem.backgroundColor
 
-                        StatusBaseText {
-                            anchors.fill: parent
-                            anchors.leftMargin: Theme.padding
-                            anchors.rightMargin: Theme.padding
-                            verticalAlignment: Text.AlignVCenter
-                            text: section === "community" ? qsTr("Community minted") : root.hasCommunityGroups ? qsTr("Other")
-                                                                                                               : qsTr("Collections")
-                            color: Theme.palette.baseColor1
-                            font.pixelSize: Theme.tertiaryTextFontSize
-                            elide: Text.ElideRight
-                        }
+                        text: section === "community" ? qsTr("Community minted") : root.hasCommunityGroups ? qsTr("Other")
+                                                                                                           : qsTr("Collections")
                     }
 
                     // floating divider

--- a/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ManageTokensCommunityTag.qml
@@ -66,6 +66,8 @@ Control {
             }
 
             function updateCommunityImage() {
+                if (!root.communityId) // in a grouped (non-community) delegate don't overwrite the group icon
+                    return
                 // Ensure we keep the flag in sync with the type of asset otherwise we generate warnings
                 identicon.asset.name = ""
                 identicon.asset.isImage = !!root.communityImage
@@ -100,7 +102,7 @@ Control {
                     return root.communityName
                 }
                 elide: Text.ElideRight
-                color: enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1                
+                color: enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
             }
 
             CopyToClipBoardButton {
@@ -113,7 +115,7 @@ Control {
                 icon.color: Theme.palette.directColor1
                 color: Theme.palette.transparent
                 textToCopy: root.communityName
-                onCopyClicked: ClipboardUtils.setText(textToCopy)
+                onCopyClicked: (textToCopy) => ClipboardUtils.setText(textToCopy)
             }           
         }
     }

--- a/ui/app/AppLayouts/Wallet/controls/MaxSendButton.qml
+++ b/ui/app/AppLayouts/Wallet/controls/MaxSendButton.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 StatusButton {

--- a/ui/app/AppLayouts/Wallet/controls/SortOrderComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SortOrderComboBox.qml
@@ -107,14 +107,10 @@ ComboBox {
 
         contentItem: ColumnLayout {
             spacing: 0
-            StatusBaseText {
+            StatusMenuHeadline {
                 Layout.fillWidth: true
                 Layout.preferredHeight: d.defaultDelegateHeight
                 text: qsTr("Sort by")
-                font.pixelSize: Theme.tertiaryTextFontSize
-                leftPadding: Theme.padding
-                verticalAlignment: Qt.AlignVCenter
-                color: Theme.palette.baseColor1
             }
             StatusListView {
                 Layout.fillWidth: true

--- a/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
@@ -109,42 +109,4 @@ CalloutCard {
             onClicked: root.dismiss()
         }
     }
-
-    component ContextMenu: StatusMenu {
-        id: contextMenu
-
-        signal enableLinkPreviewForThisMessage()
-        signal enableLinkPreview()
-        signal disableLinkPreview()
-
-        hideDisabledItems: false
-        StatusAction {
-            text: qsTr("Link previews")
-            enabled: false
-        }
-
-        StatusAction {
-            text: qsTr("Show for this message")
-            objectName: "showForThisMessagePreviewMenuItem"
-            icon.name: "show"
-            onTriggered: contextMenu.enableLinkPreviewForThisMessage()
-        }
-
-        StatusAction {
-            text: qsTr("Always show previews")
-            objectName: "alwaysShowPreviewMenuItem"
-            icon.name: "show"
-            onTriggered: contextMenu.enableLinkPreview()
-        }
-
-        StatusMenuSeparator { }
-
-        StatusAction {
-            text: qsTr("Never show previews")
-            objectName: "neverShowPreviewsMenuItem"
-            icon.name: "hide"
-            type: StatusAction.Type.Danger
-            onTriggered: contextMenu.disableLinkPreview()
-        }
-    }
 }

--- a/ui/imports/shared/controls/chat/LinkPreviewSettingsCardMenu.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewSettingsCardMenu.qml
@@ -9,9 +9,8 @@ StatusMenu {
 
     hideDisabledItems: false
 
-    StatusAction {
+    StatusMenuHeadline {
         text: qsTr("Link previews")
-        enabled: false
     }
 
     StatusAction {


### PR DESCRIPTION
### What does the PR do

Bunch of small fixes for various UI issues in popup menus when running under Qt6; see the individual commits for details

Fixes #18216

### Affected areas

StatusMenuItem

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Menuitem checkmark:
![image](https://github.com/user-attachments/assets/d4614a9d-2e97-44dc-afc4-2c3999922c96)

Destructive/danger menuitem:
![image](https://github.com/user-attachments/assets/0e40323c-07c3-46da-83a3-50a493521f62)


Group icon:
![image](https://github.com/user-attachments/assets/a441d1ba-ec5a-4884-abc7-334d7b1781a8)

Max send button:
![image](https://github.com/user-attachments/assets/2fb87cf7-8034-4608-a8da-927c4d84f771)

