### PR TITLE
fix(@desktop/wallet): Adding Bindings to set min width & height only for desktop

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
@@ -190,6 +190,11 @@ QtObject {
     readonly property int defaultSmallPadding: defaultPadding * 0.625
     readonly property int defaultRadius: defaultHalfPadding
 
+    property var portraitBreakpoint: QtObject {
+        readonly property int width: 1200
+        readonly property int height: 680
+    }
+
     readonly property real disabledOpacity: 0.3
     readonly property real pressedOpacity: 0.7
 

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayout.qml
@@ -5,6 +5,8 @@ import QtQuick.Controls
 // TODO: Remove this once qt5 is dropped
 import "./+qt6" as SectionLayout
 
+import StatusQ.Core.Theme 0.1
+
 /*!
      \qmltype StatusSectionLayout
      \inherits LayoutChooser
@@ -47,8 +49,8 @@ import "./+qt6" as SectionLayout
 
 SectionLayout.LayoutChooser {
     id: root
-    implicitWidth: Window.window.minimumWidth
-    implicitHeight: Window.window.minimumHeight
+    implicitWidth: Theme.portraitBreakpoint.width
+    implicitHeight: Theme.portraitBreakpoint.height
 
     property Component handle: Item { }
 

--- a/ui/app/AppLayouts/Onboarding2/pages/+qt6/WelcomePage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/+qt6/WelcomePage.qml
@@ -23,7 +23,7 @@ OnboardingPage {
     signal privacyPolicyRequested()
     signal termsOfUseRequested()
 
-    readonly property bool isPortrait: root.width < root.height && root.width < root.implicitWidth
+    readonly property bool isPortrait: root.width < root.height && root.width <= root.implicitWidth
 
     QtObject {
         id: d
@@ -75,9 +75,6 @@ OnboardingPage {
                 ColumnLayout {
                     id: logoAndTextLayout
                     Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.topMargin: root.isPortrait ? Theme.padding : logoAndTextLayout.height / 2
                     spacing: root.isPortrait ? 6 : 28
                     StatusImage {
                         Layout.preferredWidth: 90
@@ -139,7 +136,6 @@ OnboardingPage {
                     StatusBaseText {
                         objectName: "approvalLinks"
                         Layout.fillWidth: true
-                        Layout.topMargin: Theme.halfPadding
                         text: qsTr("By proceeding you accept Status<br>%1 and %2")
                             .arg(Utils.getStyledLink(qsTr("Terms of Use"), "#terms", hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
                             .arg(Utils.getStyledLink(qsTr("Privacy Policy"), "#privacy", hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -48,8 +48,6 @@ StatusWindow {
     property UtilsStore utilsStore: UtilsStore {}
 
     objectName: "mainWindow"
-    minimumWidth: 1200
-    minimumHeight: 680
     color: Theme.palette.background
     title: {
         // Set application settings
@@ -63,8 +61,8 @@ StatusWindow {
     visible: true
 
     function updatePaddings() {
-        if (applicationWindow.width < applicationWindow.minimumWidth) {
-            const coefficient = applicationWindow.width / applicationWindow.minimumWidth;
+        if (applicationWindow.width < Theme.portraitBreakpoint.width) {
+            const coefficient = applicationWindow.width / Theme.portraitBreakpoint.width;
             Theme.updatePaddings(Theme.defaultPadding * coefficient);
         } else {
             Theme.updatePaddings(Theme.defaultPadding);
@@ -104,8 +102,8 @@ StatusWindow {
         if (visibility === Window.Windowed) {
             applicationWindow.x = geometry.x;
             applicationWindow.y = geometry.y;
-            applicationWindow.width = Math.max(geometry.width, applicationWindow.minimumWidth)
-            applicationWindow.height = Math.max(geometry.height, applicationWindow.minimumHeight)
+            applicationWindow.width = Math.max(geometry.width, Theme.portraitBreakpoint.width)
+            applicationWindow.height = Math.max(geometry.height, Theme.portraitBreakpoint.height)
         }
     }
 
@@ -153,6 +151,20 @@ StatusWindow {
                 }
             }
         }
+    }
+
+    // Only set minimum width/height for desktop apps
+    Binding {
+        target: applicationWindow
+        property: "minimumWidth"
+        when: !Constants.isMobile
+        value: Theme.portraitBreakpoint.width
+    }
+    Binding {
+        target: applicationWindow
+        property: "minimumHeight"
+        when: !Constants.isMobile
+        value: Theme.portraitBreakpoint.height
     }
 
     Action {


### PR DESCRIPTION
Also fixes some small issues on welcome page, have tested on macOS desktop, android tablet and mobile

fixes #18236

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Overall screen size
Welcome Page

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

**Desktop macOS:**
<img width="1941" alt="Screenshot 2025-06-25 at 14 32 14" src="https://github.com/user-attachments/assets/e2930297-2a0a-4e76-b853-573fe73c1a29" />
<img width="2056" alt="Screenshot 2025-06-25 at 14 32 26" src="https://github.com/user-attachments/assets/73e1559f-bb87-4b85-b901-00e23b11893a" />


**Android Tablet:**
![Screenshot_20250625-143234](https://github.com/user-attachments/assets/9228afb7-198d-4172-a147-e37e5eb25424)
![Screenshot_20250625-143243](https://github.com/user-attachments/assets/277eefbd-ad8a-440e-809c-3e7953da53b2)


**Android Mobile:**
![Screenshot_2025-06-25-14-30-35-76_e349fe4ff9441aaf74d9ac7580838a5f](https://github.com/user-attachments/assets/f741cd9e-ded8-43b7-8f6b-08b6b2416130)
![Screenshot_2025-06-25-14-30-42-47_e349fe4ff9441aaf74d9ac7580838a5f](https://github.com/user-attachments/assets/cad581dc-2f65-4d2d-8c96-4e58b7de0084)





<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
