### PR TITLE
fix(wallet): enhance route fetching and fee estimation logic for gasless Status chain

### DIFF
--- a/ui/app/mainui/Handlers/SendModalHandler.qml
+++ b/ui/app/mainui/Handlers/SendModalHandler.qml
@@ -736,12 +736,17 @@ QtObject {
                 readonly property var totalFeesAggregator: FunctionAggregator {
                     model: !!handler.fetchedPathModel ?
                                handler.fetchedPathModel: null
-                    initialValue: "0"
+                    initialValue: "-1"
                     roleName: "txTotalFee"
 
-                    aggregateFunction: (aggr, value) => SQUtils.AmountsArithmetic.sum(
-                                           SQUtils.AmountsArithmetic.fromString(aggr),
-                                           SQUtils.AmountsArithmetic.fromString(value)).toString()
+                    aggregateFunction: (aggr, value) => {
+                                            if (aggr === "-1") {
+                                                return value
+                                            }
+                                            return SQUtils.AmountsArithmetic.sum(
+                                                SQUtils.AmountsArithmetic.fromString(aggr),
+                                                SQUtils.AmountsArithmetic.fromString(value)).toString()
+                                        }
 
                     onValueChanged: {
                         const nativeTokenSymbol = Utils.getNativeTokenSymbol(simpleSendModal.selectedChainId)


### PR DESCRIPTION
Corresponding `status-go` changes:
- https://github.com/status-im/status-go/pull/6705

This PR integrates a fully gasless Status chain.

0 ETH tx from 0 balance account:
- https://sepoliascan.status.network/tx/0x2c651a91301094acea596b581d1c901f40c63c45044d6b091f1198889b1c5278

Token minted and transferred tx:
- https://sepoliascan.status.network/tx/0xf9af84ad53d89bf9293140e8d82285ebb80fdafec119b0a32267a74fafcc3b1d