### PR TITLE
Monitoring tool: aligned to run on Qt 6

### DIFF
--- a/monitoring/Main.qml
+++ b/monitoring/Main.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
+import StatusQ.Core.Utils 0.1 as SQUtils
+
 ApplicationWindow {
     id: monitorRoot
 
@@ -16,13 +18,10 @@ ApplicationWindow {
         repeat: true
 
         onTriggered: {
-            const xhr = new XMLHttpRequest()
-            xhr.open("GET", "MonitorEntryPoint.qml", false)
-            xhr.send()
+            const content = SQUtils.StringUtils.readTextFile(
+                              Qt.resolvedUrl("MonitorEntryPoint.qml"))
 
-            const content = xhr.responseText
-
-            if (loader.source != content)
+            if (loader.source !== content)
                 loader.source = content
         }
     }

--- a/monitoring/ModelInspectionPane.qml
+++ b/monitoring/ModelInspectionPane.qml
@@ -112,6 +112,8 @@ Item {
                 implicitWidth: flow.implicitWidth
                 implicitHeight: flow.implicitHeight
 
+                color: "transparent"
+
                 readonly property var topModel: model
 
                 Row {
@@ -218,7 +220,7 @@ Item {
                 z: 2
 
                 Rectangle {
-                    color: "whitesmoke"
+                    color: "transparent"
                     anchors.fill: parent
                     border.color: "gray"
                 }


### PR DESCRIPTION
### What does the PR do

Makes the Monitoring tool usable on Qt 6:
- loading UI components fixed
- colors fixed to be readable in dark mode

### Affected areas
`Monitoring tool`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

![Screenshot from 2025-06-26 11-20-47](https://github.com/user-attachments/assets/b391ca6e-e77e-46ab-adb9-6726e6b90b71)
