### PR TITLE
fix(ProfileLayout): fix side-by-side profile preview on Qt6

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutLandscape.qml
@@ -65,7 +65,7 @@ SplitView {
         \qmlproperty Item StatusSectionLayout::rightPanel
         This property holds the right panel of the component.
     */
-    property Item rightPanel
+    property alias rightPanel: rightPanelProxy.target
     /*!
         \qmlproperty Item StatusSectionLayout::navBar
         This property holds the navigation bar of the component. Usually displayed next to the leftPanel.
@@ -77,7 +77,7 @@ SplitView {
     */
     property Item footer
     /*!
-        \qmlproperty Component StatusAppLayout::headerBackground
+        \qmlproperty Item StatusAppLayout::headerBackground
         This property holds the headerBackground of the component.
     */
     property Item headerBackground
@@ -233,7 +233,7 @@ SplitView {
             color: Theme.palette.baseColor4
         }
         contentItem: LayoutItemProxy {
-            target: root.rightPanel
+            id: rightPanelProxy
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/+qt6/StatusSectionLayoutPortrait.qml
@@ -62,7 +62,7 @@ SwipeView {
     */
     property alias centerPanel: centerPanelProxy.target
     /*!
-        \qmlproperty Component StatusSectionLayout::rightPanel
+        \qmlproperty Item StatusSectionLayout::rightPanel
         This property holds the right panel of the component.
     */
     property alias rightPanel: rightPanelProxy.target
@@ -72,7 +72,7 @@ SwipeView {
     */
     property alias footer: footerProxy.target
     /*!
-        \qmlproperty Component StatusAppLayout::headerBackground
+        \qmlproperty Item StatusAppLayout::headerBackground
         This property holds the headerBackground of the component.
     */
     property Item headerBackground

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -538,7 +538,10 @@ StatusSectionLayout {
 
     showRightPanel: d.isProfilePanelActive && d.sideBySidePreviewAvailable
     rightPanelWidth: d.rightPanelWidth
-    rightPanel: d.isProfilePanelActive ? profileContainer.currentItem.sideBySidePreviewComponent : null
+    rightPanel: Loader {
+        active: root.showRightPanel
+        sourceComponent: profileContainer.currentItem.sideBySidePreviewComponent
+    }
 
     Connections {
         target: root.store.keycardStore.keycardModule


### PR DESCRIPTION
### What does the PR do

- the section layout under Qt6 has a slightly different API (Item vs. Component), so use a Loader for the `rightPanel`
- fix the docu

Fixes #18250

### Affected areas

Settings/Profile

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

![image](https://github.com/user-attachments/assets/faf967e7-3041-41c4-86e6-684067af8e7c)
