### PR TITLE
ci: disable deferred wipeout for cleanWs task

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -108,7 +108,7 @@ pipeline {
         cred: 'discord-status-desktop-webhook',
       )
     } }
-    cleanup { cleanWs() }
+    cleanup { cleanWs(disableDeferredWipeout: true) }
   }
 }
 

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -207,7 +207,7 @@ pipeline {
         cred: 'discord-status-desktop-e2e-webhook',
       )
     } }
-    cleanup { cleanWs() }
+    cleanup { cleanWs(disableDeferredWipeout: true) }
   }
 }
 

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -77,6 +77,6 @@ pipeline {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
     always  { script { env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText" } }
-    cleanup { cleanWs() }
+    cleanup { cleanWs(disableDeferredWipeout: true) }
   }
 }

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -132,6 +132,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { cleanWs(disableDeferredWipeout: true) }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -141,7 +141,7 @@ pipeline {
     // Windows workspace often becomes broken if stoped during checkout.
     // Post cleanup will fail too.
     // Use 'Wipe out repository and force clone' manual UI option to prevent it.
-    cleanup { cleanWs() }
+    cleanup { cleanWs(disableDeferredWipeout: true) }
   }
 }
 


### PR DESCRIPTION
Suspected cause of Memory usage spikes in Java Jenkins agent:
- https://github.com/status-im/infra-ci/issues/200