### PR TITLE
fix(@desktop/wallet): Fix Modal heights on mobile portrait

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -39,12 +39,19 @@ Dialog {
     */
     property string okButtonText: qsTr("OK")
 
-    readonly property bool bottomSheet: root.contentItem.Window.height
-                                        > root.contentItem.Window.width
-                                        && root.contentItem.Window.width
-                                        <= 1200 // The max width of a phone in portrait mode
+    readonly property bool bottomSheet: d.windowHeight
+                                        > d.windowWidth
+                                        && d.windowWidth
+                                        <= Theme.portraitBreakpoint.width // The max width of a phone in portrait mode
 
     readonly property real desiredY: root.bottomSheet ? root.contentItem.Window.height - root.height : ((root.Overlay.overlay.height - root.height) / 2)
+
+    QtObject {
+        id: d
+
+        readonly property int windowWidth: root.contentItem.Window ? root.contentItem.Window.width: Screen.width
+        readonly property int windowHeight: root.contentItem.Window? root.contentItem.Window.height : Screen.height
+    }
 
     enter: Transition {
         id: enterTransition
@@ -70,7 +77,12 @@ Dialog {
     Binding on width {
         when: root.bottomSheet
         restoreMode: Binding.RestoreBindingOrValue
-        value: root.contentItem.Window.width
+        value: d.windowWidth
+    }
+    Binding on height {
+        when: root.bottomSheet && !enterTransition.running
+        restoreMode: Binding.RestoreBindingOrValue
+        value: Math.min(root.implicitHeight, d.windowHeight * 0.9)
     }
     Binding on y {
         when: root.bottomSheet && !enterTransition.running
@@ -81,13 +93,13 @@ Dialog {
     Binding on y {
         when: !root.bottomSheet && !enterTransition.running
         restoreMode: Binding.RestoreBindingOrValue
-        value: (root.contentItem.Window.height - root.height) / 2
+        value: (d.windowHeight - root.height) / 2
     }
 
     Binding on x {
         when: !root.bottomSheet
         restoreMode: Binding.RestoreBindingOrValue
-        value: (root.contentItem.Window.width - root.width) / 2
+        value: (d.windowWidth - root.width) / 2
     }
 
     Binding on x {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -309,6 +309,7 @@ Item {
                 d.displayAllAddresses()
             }
             selectSavedAddresses: function() {
+                walletSectionLayout.goToNextPanel()
                 d.displaySavedAddresses()
             }
         }

--- a/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoModal.qml
@@ -138,7 +138,7 @@ StatusStackModal {
     }
 
     width: 560
-    height: 515
+    implicitHeight: 515
     padding: Theme.xlPadding
     stackTitle: !!root.buyCryptoInputParamsForm.selectedTokenKey ? qsTr("Ways to buy %1 for %2").arg(d.selectedTokenEntry.item.name).arg(!!d.selectedAccountEntry.item ? d.selectedAccountEntry.item.name: ""): qsTr("Ways to buy assets for %1").arg(!!d.selectedAccountEntry.item ? d.selectedAccountEntry.item.name: "")
     rightButtons: [d.buyButton, finishButton]

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -467,7 +467,7 @@ StatusDialog {
     }
 
     width: 556
-    height: d.calculatedHeight
+    implicitHeight: d.calculatedHeight
     padding: 0
     horizontalPadding: Theme.xlPadding
     topMargin: margins + accountSelector.height + Theme.padding

--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -221,6 +221,8 @@ Control {
                 leftPadding: 0
                 background: null
 
+                inputMethodHints: Qt.ImhDigitsOnly | Qt.ImhFormattedNumbersOnly
+
                 readOnly: !root.interactive
 
                 color: text.length === 0 || (root.valid && !root.markAsInvalid)


### PR DESCRIPTION
fix(@desktop/wallet): Fix Modal heights on mobile portrait, doesn't effect anything on desktop or landscape.
Add number only keyboard where amounts are to be entered

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

AddAcountModal
SimpleSend
Add saved address
SwapModal

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

![image](https://github.com/user-attachments/assets/0a63048d-aa66-4be7-b09c-80f3f443de60)

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
