### PR TITLE
WIP test(tablet-build): add support for Squish testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -939,6 +939,10 @@ mobile-build: | deps-common
 	echo -e "\033[92mBuilding:\033[39m mobile app"
 	$(MAKE) -C mobile
 
+mobile-build-squish: | deps-common
+	echo -e "\033[92mBuilding:\033[39m mobile app (Squish enabled)"
+	$(MAKE) -C mobile QMAKE_EXTRA_ARGS="ENABLE_SQUISH=1"
+
 mobile-clean:
 	echo -e "\033[92mCleaning:\033[39m mobile app"
 	$(MAKE) -C mobile clean

--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -10,6 +10,7 @@ BIN_DIR=${BIN_DIR:-"$CWD/../bin/ios"}
 BUILD_DIR=${BUILD_DIR:-"$CWD/../build"}
 ANDROID_ABI=${ANDROID_ABI:-"arm64-v8a"}
 QT_MAJOR=${QT_MAJOR:-"5"}
+QMAKE_EXTRA_ARGS=${QMAKE_EXTRA_ARGS:-""}
 
 echo "Building wrapperApp for ${OS}, ${ANDROID_ABI}"
 
@@ -39,7 +40,7 @@ if [[ "${OS}" == "android" ]]; then
         exit 1
     fi
 
-    qmake "$CWD/../wrapperApp/Status-tablet.pro" CONFIG+=device CONFIG+=release RESOURCES+="$COMPAT_RESOURCES" -spec android-clang ANDROID_ABIS="$ANDROID_ABI" -after
+    qmake "$CWD/../wrapperApp/Status-tablet.pro" CONFIG+=device CONFIG+=release RESOURCES+="$COMPAT_RESOURCES" -spec android-clang ANDROID_ABIS="$ANDROID_ABI" -after $QMAKE_EXTRA_ARGS
 
     # Build the app
     make -j"$(nproc)" apk_install_target

--- a/mobile/wrapperApp/Status-tablet.pro
+++ b/mobile/wrapperApp/Status-tablet.pro
@@ -35,6 +35,33 @@ android {
                         $$PWD/../lib/android/$$LIB_PREFIX/libpcre.so \
                         $$PWD/../lib/android/$$LIB_PREFIX/libstatus.so \
                         $$PWD/../lib/android/$$LIB_PREFIX/libStatusQ$$(LIB_SUFFIX)$$(LIB_EXT)
+
+    # Squish integration for testing
+    equals(ENABLE_SQUISH, "1") {
+        message("Squish integration enabled for test builds")
+        
+        # Set SQUISH_ATTACH_PORT (use environment variable with fallback)
+        TEMP_PORT = $$(SQUISH_ATTACH_PORT)
+        isEmpty(TEMP_PORT) {
+            TEMP_PORT = 4711
+        }
+        SQUISH_ATTACH_PORT = $$TEMP_PORT
+        
+        # Set SQUISH_WRAPPER_EXTENSIONS for Android/static Qt builds
+        SQUISH_WRAPPER_EXTENSIONS = squishqtquick squishqtquicktypes
+        
+        SQUISH_DIR = $$(SQUISH_DIR)
+        isEmpty(SQUISH_DIR) {
+            SQUISH_DIR = /Applications/Squish for Qt 9.0.1 - qt6.9
+        }
+
+        SQUISH_DIR_ANDROID = $$(SQUISH_DIR_ANDROID)
+        isEmpty(SQUISH_DIR_ANDROID) {
+            SQUISH_DIR = $$(SQUISH_DIR)/squish-9.0.1-qt69x-android-x64
+        }
+        
+        include($$SQUISH_DIR_ANDROID/qtbuiltinhook.pri)
+    }
 }
 
 ios {


### PR DESCRIPTION
closes #18266 

WIP POC - do not merge.

- Introduced a new target `mobile-build-squish` to enable Squish testing during mobile app builds.
- Updated the `Makefile` to differentiate between production builds and test builds with Squish enabled.
- Enhanced the `Status-tablet.pro` file to configure Squish settings, including attach port and wrapper extensions for Android.
