### PR TITLE
chore(Popup): set default margins so that the Popup status within Window bounds

### DIFF
--- a/storybook/pages/AssetSelectorPage.qml
+++ b/storybook/pages/AssetSelectorPage.qml
@@ -96,3 +96,4 @@ Pane {
 }
 
 // category: Controls
+// status: good

--- a/storybook/pages/InlineNetworksComboBoxPage.qml
+++ b/storybook/pages/InlineNetworksComboBoxPage.qml
@@ -104,3 +104,4 @@ Item {
 }
 
 // category: Components
+// status: good

--- a/storybook/pages/NetworkFilterPage.qml
+++ b/storybook/pages/NetworkFilterPage.qml
@@ -165,5 +165,5 @@ SplitView {
 }
 
 // category: Components
-
+// status: good
 // https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?type=design&node-id=13179-346563&mode=design&t=RUkJVqqhgam32C1S-0

--- a/storybook/pages/PopupSizingPage.qml
+++ b/storybook/pages/PopupSizingPage.qml
@@ -255,3 +255,4 @@ Item {
 }
 
 // category: Research / Examples
+// status: good

--- a/storybook/pages/SwapInputPanelPage.qml
+++ b/storybook/pages/SwapInputPanelPage.qml
@@ -280,5 +280,5 @@ SplitView {
 }
 
 // category: Panels
-
+// status: good
 // https://www.figma.com/design/TS0eQX9dAZXqZtELiwKIoK/Swap---Milestone-1?node-id=3404-111405&t=G96tBLQr2j73HT9X-0

--- a/storybook/pages/TokenSelectorPanelPage.qml
+++ b/storybook/pages/TokenSelectorPanelPage.qml
@@ -199,17 +199,17 @@ Pane {
         collectiblesModel: collectiblesModelCheckBox.checked
                            ? collectiblesModel : null
 
-        onCollectibleSelected: {
+        onCollectibleSelected: function(key) {
             highlightedKey = key
             console.log("collectible selected:", key)
         }
 
-        onCollectionSelected: {
+        onCollectionSelected: function(key) {
             highlightedKey = key
             console.log("collection selected:", key)
         }
 
-        onAssetSelected: {
+        onAssetSelected: function(key) {
             highlightedKey = key
             console.log("asset selected:", key)
         }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -78,7 +78,7 @@ Item {
     implicitWidth: layout.implicitWidth
     implicitHeight: layout.implicitHeight
 
-    opacity: enabled ? 1 : 0.3
+    opacity: enabled ? 1 : Theme.disabledOpacity
 
     LayoutMirroring.childrenInherit: true
 
@@ -107,8 +107,8 @@ Item {
             font.family: Theme.baseFont.name
             font.pixelSize: root.size === StatusComboBox.Size.Large ? Theme.secondaryTextFontSize : 13
 
-            padding: 16
-            spacing: 16
+            padding: Theme.padding
+            spacing: Theme.padding
 
             background: Loader {
                 sourceComponent: root.defaultBackgroundComponent
@@ -147,14 +147,14 @@ Item {
                 implicitWidth: comboBox.width
                 height: Math.min(implicitContentHeight + topPadding + bottomPadding,
                                  comboBox.Window.height - topMargin - bottomMargin)
-                margins: 8
+                margins: Theme.halfPadding
 
                 padding: 1
-                verticalPadding: 8
+                verticalPadding: Theme.halfPadding
 
                 background: Rectangle {
                     color: Theme.palette.statusSelect.menuItemBackgroundColor
-                    radius: 8
+                    radius: Theme.radius
                     border.color: Theme.palette.baseColor2
                     layer.enabled: true
                     layer.effect: DropShadow {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 import QtGraphicalEffects 1.15
-import QtQuick.Controls 2.15 as QC
+import QtQuick.Controls 2.15
 import QtQml 2.15
 
 import StatusQ.Core.Theme 0.1
@@ -12,7 +12,7 @@ import StatusQ.Core.Theme 0.1
    \since StatusQ.Controls 0.1
    \brief The StatusDropdown provides a template for creating dropdowns.
 
-   NOTE: Each consumer needs to set the x and y postion of the dropdown.
+   NOTE: Each consumer needs to set the x and y position of the dropdown.
 
    Example of how to use it:
 
@@ -28,18 +28,18 @@ import StatusQ.Core.Theme 0.1
 
    For a list of components available see StatusQ.
 */
-QC.Popup {
+Popup {
     id: root
 
     dim: false
 
+    margins: 0 // NB: !== -1 to stay within Window bounds
+
     background: Rectangle {
        color: Theme.palette.statusMenu.backgroundColor
        radius: Theme.radius
-       border.color: "transparent"
        layer.enabled: true
        layer.effect: DropShadow {
-           source: root.background
            horizontalOffset: 0
            verticalOffset: 4
            radius: 12

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -13,8 +13,8 @@ ItemDelegate {
     property int cursorShape: Qt.PointingHandCursor
     property color highlightColor: Theme.palette.statusMenu.hoverBackgroundColor
 
-    padding: 8
-    spacing: 8
+    padding: Theme.halfPadding
+    spacing: Theme.halfPadding
 
     icon.width: 16
     icon.height: 16
@@ -55,10 +55,7 @@ ItemDelegate {
         radius: root.radius
     }
 
-    MouseArea {
-        // NOTE The hover handler would break control's hover in some corner cases, hence mouse area is used
-        hoverEnabled: true
+    HoverHandler {
         cursorShape: root.cursorShape
-        propagateComposedEvents: true
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -234,6 +234,7 @@ Item {
         y: parent.height + Theme.halfPadding
         visible: edit.text !== "" && !forceHide
         padding: Theme.halfPadding
+        margins: 0 // NB: !== -1 to stay within Window bounds
         background: StatusDialogBackground {
             id: bg
             layer.enabled: true

--- a/ui/app/AppLayouts/Communities/controls/InlineNetworksComboBox.qml
+++ b/ui/app/AppLayouts/Communities/controls/InlineNetworksComboBox.qml
@@ -45,8 +45,8 @@ StatusComboBox {
 
         readonly property bool oneItem: control.count === 1
 
-        readonly property int padding: 8
-        readonly property int radius: 8
+        readonly property int padding: Theme.halfPadding
+        readonly property int radius: Theme.radius
         readonly property int fontSize: Theme.additionalTextSize
         readonly property int iconSize: 32
 

--- a/ui/app/AppLayouts/Communities/popups/InDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/InDropdown.qml
@@ -19,10 +19,7 @@ StatusDropdown {
     id: root
 
     width: 289
-    padding: 8
-
-    // force keeping within the bounds of the enclosing window
-    margins: 0
+    padding: Theme.halfPadding
 
     property bool allowChoosingEntireCommunity: false
     property bool showAddChannelButton: false

--- a/ui/app/AppLayouts/Communities/popups/PermissionsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/PermissionsDropdown.qml
@@ -29,9 +29,6 @@ StatusDropdown {
     width: d.width
     padding: d.padding
 
-    // force keeping within the bounds of the enclosing window
-    margins: 0
-
     onAboutToShow: {
         group.checkState = Qt.Unchecked
         d.initialPermissionTypeChanged()

--- a/ui/app/AppLayouts/Communities/popups/RecipientTypeSelectionDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/RecipientTypeSelectionDropdown.qml
@@ -2,7 +2,7 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 
 import StatusQ.Controls 0.1
-
+import StatusQ.Core.Theme 0.1
 
 StatusDropdown {
     id: root
@@ -11,8 +11,8 @@ StatusDropdown {
     signal communityMembersSelected
 
     width: 289
-    padding: 8
-    leftPadding: 16
+    padding: Theme.halfPadding
+    leftPadding: Theme.padding
 
     contentItem: ColumnLayout {
         spacing: 8

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -172,7 +172,7 @@ StatusComboBox {
         showManageNetworksButton: root.showManageNetworksButton
         showNewChainIcon: root.showNewChainIcon
 
-        onToggleNetwork: root.toggleNetwork(chainId, index)
+        onToggleNetwork: (chainId, index) => root.toggleNetwork(chainId, index)
 
         onManageNetworksClicked: {
             control.popup.close()

--- a/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SearchableAssetsPanel.qml
@@ -68,6 +68,7 @@ Control {
 
         StatusBaseText {
             Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: 4
             Layout.bottomMargin: 4
             text: qsTr("Your assets will appear here")
             color: Theme.palette.baseColor1
@@ -97,11 +98,9 @@ Control {
 
             objectName: "assetsListView"
 
-            clip: true
-
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.preferredHeight: contentHeight
+            implicitHeight: contentHeight
             Layout.leftMargin: 4
             Layout.rightMargin: 4
 
@@ -113,7 +112,7 @@ Control {
             section.delegate: TokenSelectorSectionDelegate {
                 width: ListView.view.width
                 text: section
-                height: root.showSectionName ? implicitHeight : 0
+                height: root.showSectionName ? implicitHeight + 4 : 0
             }
 
             delegate: TokenSelectorAssetDelegate {

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -31,8 +31,9 @@ Popup {
     signal toggleNetwork(int chainId, int index)
     signal manageNetworksClicked()
 
-
     modal: false
+
+    margins: 0 // NB: !== -1 to stay within Window bounds
 
     padding: 4
     implicitWidth: 300
@@ -67,7 +68,7 @@ Popup {
             showIndicator: root.showSelectionIndicator
             showNewChainIcon: root.showNewChainIcon
 
-            onToggleNetwork: {
+            onToggleNetwork: function (chainId, index) {
                 if (!root.multiSelection && root.closePolicy !== Popup.NoAutoClose)
                     root.close()
                 root.toggleNetwork(chainId, index)

--- a/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/views/TokenSelectorAssetDelegate.qml
@@ -28,7 +28,9 @@ ItemDelegate {
     horizontalPadding: Theme.padding
     verticalPadding: 4
 
-    opacity: enabled ? 1 : 0.3
+    hoverEnabled: enabled
+
+    opacity: enabled ? 1 : Theme.disabledOpacity
     implicitHeight: 60
 
     icon.width: 32

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -42,6 +42,7 @@ Popup {
 
     implicitWidth: 560
     padding: 0
+    margins: 0 // NB: !== -1 to stay within Window bounds
     modal: true
     parent: Overlay.overlay
 

--- a/ui/imports/shared/popups/ModalPopup.qml
+++ b/ui/imports/shared/popups/ModalPopup.qml
@@ -42,6 +42,7 @@ Popup {
             popup.destroy();
     }
     padding: 0
+    margins: 0 // NB: !== -1 to stay within Window bounds
     contentItem: Item {
 
         Item {

--- a/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
@@ -23,6 +23,8 @@ Popup {
     horizontalPadding: 6
     verticalPadding: 32
 
+    margins: 0 // NB: !== -1 to stay within Window bounds
+
     modal: false
     closePolicy: Popup.NoAutoClose
 

--- a/ui/imports/shared/status/StatusInputListPopup.qml
+++ b/ui/imports/shared/status/StatusInputListPopup.qml
@@ -25,6 +25,8 @@ Popup {
     property bool showSearchBox: false
     property var messageInput
 
+    margins: 0 // NB: !== -1 to stay within Window bounds
+
     function openPopup(listParam) {
         modelList = listParam
         popup.open()

--- a/ui/imports/shared/status/StatusSearchListPopup.qml
+++ b/ui/imports/shared/status/StatusSearchListPopup.qml
@@ -20,6 +20,8 @@ Popup {
     width: 400
     height: 300
 
+    margins: 0 // NB: !== -1 to stay within Window bounds
+
     required property var model
 
     property string searchBoxPlaceholder: qsTr("Search...")

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -24,6 +24,8 @@ Popup {
     signal stickerSelected(string hashId, string packId, string url)
     signal buyClicked(string packId, string price)
 
+    margins: 0 // NB: !== -1 to stay within Window bounds
+
     QtObject {
         id: d
 


### PR DESCRIPTION
### What does the PR do

- and as a result, becomes properly scrollable
- fix some hardcoded margins/padding/spacings
- silence some Qt6 warnings

### Affected areas

Popups

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

TBD

### Impact on end user

Popups not scrollable -> Popups can be scrolled

### How to test

Open various popups, if the popup overflows the available height, should become scrollable

### Risk 

- low
