### PR TITLE
fix(AddAccountPopup): can't select derivation path

### DIFF
--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -534,7 +534,7 @@ method updateDerivedAddresses*[T](self: Module[T], derivedAddresses: seq[Derived
       path = derivedAddresses[0].path,
       alreadyCreated = derivedAddresses[0].alreadyCreated,
       hasActivity = derivedAddresses[0].hasActivity,
-      alreadyCreatedChecked = not errorInCheckedIfAccountAlreadyExists and not errorInScanningActivity,
+      alreadyCreatedChecked = not errorInCheckedIfAccountAlreadyExists,
       detailsLoaded = detailsLoaded,
       errorInScanningActivity = errorInScanningActivity)
     if currStateObj.stateType() == StateType.EnterPrivateKey:

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextWithLoadingState.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextWithLoadingState.qml
@@ -57,7 +57,7 @@ StatusBaseText {
         active: root.loading && root.text
         sourceComponent: LoadingComponent {
             anchors.centerIn: parent
-            radius: textMetrics.font.pixelSize === 15 ? 4 : 8
+            radius: textMetrics.font.pixelSize <= 15 ? 4 : 8
             height: textMetrics.tightBoundingRect.height
             width: Math.min(root.width, root.maximumLoadingStateWidth)
         }

--- a/ui/imports/shared/popups/addaccount/panels/AccountAddressSelection.qml
+++ b/ui/imports/shared/popups/addaccount/panels/AccountAddressSelection.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Core.Utils 0.1 as StatusQUtils
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
@@ -108,8 +107,7 @@ StatusMenu {
                 objectName: "AddAccountPopup-GeneratedAddress-%1".arg(model.addressDetails.order)
                 width: ListView.view.width
                 height: Constants.addAccountPopup.itemHeight
-                enabled: model.addressDetails.alreadyCreatedChecked &&
-                         !model.addressDetails.alreadyCreated
+                enabled: !model.addressDetails.alreadyCreated
                 radius: Theme.halfPadding
                 color: {
                     if (sensor.containsMouse) {
@@ -121,71 +119,63 @@ StatusMenu {
                 StatusMouseArea {
                     id: sensor
                     anchors.fill: parent
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: parent.enabled
+                    cursorShape: containsMouse ? Qt.PointingHandCursor : undefined
                     onClicked: {
                         root.selected(model.addressDetails.address)
                     }
                 }
 
-                GridLayout {
+                RowLayout {
                     anchors.fill: parent
                     anchors.leftMargin: Theme.padding
                     anchors.rightMargin: Theme.padding
-                    columnSpacing: Theme.padding
-                    rowSpacing: 0
 
                     StatusBaseText {
                         Layout.fillWidth: true
                         elide: Text.ElideMiddle
-                        color: model.addressDetails.alreadyCreatedChecked &&
-                               model.addressDetails.alreadyCreated? Theme.palette.baseColor1 :
-                                                                    Theme.palette.directColor1
+                        color: model.addressDetails.alreadyCreated ? Theme.palette.baseColor1 :
+                                                                     Theme.palette.directColor1
                         font.pixelSize: Constants.addAccountPopup.labelFontSize1
                         text: model.addressDetails.address
                     }
 
-                    RowLayout {
-                        spacing: Theme.halfPadding * 0.5
+                    StatusIcon {
+                        visible: model.addressDetails.detailsLoaded && model.addressDetails.hasActivity
+                        Layout.preferredWidth: 20
+                        Layout.preferredHeight: 20
+                        icon: "flash"
+                        color: Theme.palette.successColor1
+                    }
 
-                        StatusIcon {
-                            visible: model.addressDetails.detailsLoaded && model.addressDetails.hasActivity
-                            Layout.preferredWidth: 20
-                            Layout.preferredHeight: 20
-                            icon: "flash"
-                            color: Theme.palette.successColor1
-                        }
-
-                        StatusTextWithLoadingState {
-                            Layout.fillWidth: true
-                            font.pixelSize: Constants.addAccountPopup.labelFontSize1
-                            text: {
-                                if (!root.store.addAccountModule.scanningForActivityIsOngoing) {
-                                    return ""
-                                }
-                                if(model.addressDetails.detailsLoaded &&
-                                        model.addressDetails.errorInScanningActivity) {
-                                    return qsTr("Activity unknown")
-                                }
-                                if (!model.addressDetails.detailsLoaded) {
-                                    return qsTr("loading...")
-                                }
-                                if (model.addressDetails.hasActivity) {
-                                    return qsTr("Has activity")
-                                }
-                                return qsTr("No activity")
+                    StatusTextWithLoadingState {
+                        font.pixelSize: Constants.addAccountPopup.labelFontSize1
+                        text: {
+                            if (!root.store.addAccountModule.scanningForActivityIsOngoing) {
+                                return ""
                             }
-                            color: {
-                                if (!root.store.addAccountModule.scanningForActivityIsOngoing || !model.addressDetails.detailsLoaded) {
-                                    return "transparent"
-                                }
-                                if (model.addressDetails.hasActivity) {
-                                    return Theme.palette.successColor1
-                                }
-                                return Theme.palette.warningColor1
+                            if(model.addressDetails.detailsLoaded &&
+                                    model.addressDetails.errorInScanningActivity) {
+                                return qsTr("Activity unknown")
                             }
-                            loading: root.store.addAccountModule.scanningForActivityIsOngoing && !model.addressDetails.detailsLoaded
+                            if (!model.addressDetails.detailsLoaded) {
+                                return qsTr("loading...")
+                            }
+                            if (model.addressDetails.hasActivity) {
+                                return qsTr("Has activity")
+                            }
+                            return qsTr("No activity")
                         }
+                        color: {
+                            if (!root.store.addAccountModule.scanningForActivityIsOngoing || !model.addressDetails.detailsLoaded) {
+                                return "transparent"
+                            }
+                            if (model.addressDetails.hasActivity) {
+                                return Theme.palette.successColor1
+                            }
+                            return Theme.palette.warningColor1
+                        }
+                        loading: root.store.addAccountModule.scanningForActivityIsOngoing && !model.addressDetails.detailsLoaded
                     }
 
                     StatusBaseText {

--- a/ui/imports/shared/popups/addaccount/panels/DerivationPath.qml
+++ b/ui/imports/shared/popups/addaccount/panels/DerivationPath.qml
@@ -103,7 +103,7 @@ GridLayout {
                 translation: root.store.translation
                 selectedRootPath: root.store.selectedRootPath
 
-                onSelected: {
+                onSelected: function(rootPath) {
                     root.store.changeRootDerivationPath(rootPath)
                     derivationPathInput.resetDerivationPath(root.store.selectedRootPath, root.store.addAccountModule.derivationPath)
                 }
@@ -170,7 +170,7 @@ GridLayout {
             width: root.width
             store: root.store
 
-            onSelected: {
+            onSelected: function(address) {
                 accountAddressSelection.close()
                 root.store.changeSelectedDerivedAddress(address)
             }

--- a/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
+++ b/ui/imports/shared/popups/addaccount/stores/AddAccountStore.qml
@@ -290,7 +290,7 @@ BasePopupStore {
         if (root.currentState.stateType === Constants.addAccountPopup.state.enterPrivateKey) {
             return root.enteredPrivateKeyIsValid &&
                     !!root.privateKeyAccAddress &&
-                    root.privateKeyAccAddress.alreadyCreatedChecked  &&
+                    root.privateKeyAccAddress.alreadyCreatedChecked &&
                     !root.privateKeyAccAddress.alreadyCreated &&
                     root.privateKeyAccAddress.address !== "" &&
                     root.addAccountModule.newKeyPairName.length >= Constants.addAccountPopup.keyPairAccountNameMinLength

--- a/ui/imports/shared/popups/common/AddressDetails.qml
+++ b/ui/imports/shared/popups/common/AddressDetails.qml
@@ -35,7 +35,6 @@ Row {
                 return root.defaultMessage
             }
             if (root.alreadyCreatedAccountIsAnError &&
-                    root.addressDetailsItem.alreadyCreatedChecked &&
                     root.addressDetailsItem.alreadyCreated) {
                 return qsTr("Already added")
             }
@@ -53,7 +52,6 @@ Row {
         }
         color: {
             if (root.alreadyCreatedAccountIsAnError &&
-                    root.addressDetailsItem.alreadyCreatedChecked &&
                     root.addressDetailsItem.alreadyCreated) {
                 return Theme.palette.dangerColor1
             }


### PR DESCRIPTION
### What does the PR do

- remove the references to `alreadyCreatedChecked` in the UI when enabling the delegate
- fix the delegate hover behavior
- simplify the delegate layout (GridLayout->RowLayout, it's a single row anyway)
- silence some Qt6 warnings

Fixes #18315

### Affected areas

Wallet/AddAccountPopup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/8917de2e-45f3-47ef-ab3e-b297eaa1de00

### Impact on end user

Fixes selecting a custom derivation path
