### PR TITLE
chore_: --no-ui-displacement flag to hide ConnectionWarnings

### DIFF
--- a/src/constants.nim
+++ b/src/constants.nim
@@ -42,6 +42,7 @@ let
   TORRENT_CONFIG_PORT* = desktopConfig.defaultTorentConfigPort
   LOG_LEVEL* = desktopConfig.logLevel
   FLEET_SELECTION_ENABLED* = desktopConfig.enableFleetSelection
+  NO_UI_DISPLACEMENT_ENABLED* = desktopConfig.noUiDisplacement
 
   # build variables
   POKT_TOKEN_RESOLVED* = desktopConfig.poktToken

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -335,6 +335,11 @@ type StatusDesktopConfig = object
     desc: "Sets address for prometheus metrics"
     name: "METRICS_ADDRESS"
     abbr: "metrics-address" .}: string
+  noUiDisplacement* {.
+    defaultValue: false
+    desc: "Disables UI displacement warnings like connection warnings"
+    name: "NO_UI_DISPLACEMENT"
+    abbr: "no-ui-displacement" .}: bool
 
 # On macOS the first time when a user gets the "App downloaded from the
 # internet" warning, and clicks the Open button, the OS passes a unique process

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -209,6 +209,7 @@ proc mainProc() =
   singletonInstance.engine.setRootContextProperty("singleInstance", newQVariant(singleInstance))
   singletonInstance.engine.setRootContextProperty("isExperimental", isExperimentalQVariant)
   singletonInstance.engine.setRootContextProperty("fleetSelectionEnabled", newQVariant(FLEET_SELECTION_ENABLED))
+  singletonInstance.engine.setRootContextProperty("noUiDisplacementEnabled", newQVariant(NO_UI_DISPLACEMENT_ENABLED))
   singletonInstance.engine.setRootContextProperty("signals", signalsManagerQVariant)
   singletonInstance.engine.setRootContextProperty("production", isProductionQVariant)
 

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -24,6 +24,8 @@ Loader {
     property string toastText
 
     function updateBanner() {
+        if (typeof noUiDisplacementEnabled !== "undefined" && noUiDisplacementEnabled)
+            return
         root.active = true
         if (connectionState === Constants.ConnectionStatus.Failure)
             item.show()


### PR DESCRIPTION
Add `--no-ui-displacement` command line flag to disable banners that might break auto-tests

Exposes `noUiDisplacementEnabled` QML context property.
ConnectionWarnings.qml now checks this flag and skips banner activation when enabled. Reduces fails during testing/automation.

Thinking out loud:
A better solution would be to redesign it so that the screens are unmovable and the banners simply overlap them without moving the main content

fixes #18335
