### PR TITLE
chore(@e2e): bring back change password test

### DIFF
--- a/test/e2e/gui/components/change_password_popup.py
+++ b/test/e2e/gui/components/change_password_popup.py
@@ -2,14 +2,15 @@ import driver
 from constants.settings import PasswordView
 from gui.components.base_popup import BasePopup
 from gui.elements.button import Button
+from gui.elements.object import QObject
 from gui.elements.text_label import TextLabel
 from gui.objects_map import names
 
 
-class ChangePasswordPopup(BasePopup):
+class ChangePasswordPopup(QObject):
 
     def __init__(self):
-        super(ChangePasswordPopup, self).__init__()
+        super().__init__(names.changePasswordPopup)
         self.re_encrypt_data_restart_button = Button(names.reEncryptRestartButton)
         self.re_encryption_complete_element = TextLabel(names.reEncryptionComplete)
 

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -165,7 +165,6 @@ class MainWindow(Window):
         profile = settings_screen.left_panel.open_profile_settings()
         profile.set_name(user_account.name)
         profile.save_changes_button.click()
-        self.left_panel.open_wallet()
         return self
 
     @allure.step('Log in returning user')

--- a/test/e2e/gui/objects_map/home_names.py
+++ b/test/e2e/gui/objects_map/home_names.py
@@ -19,6 +19,7 @@ home_grid_item_unpin_menu_action = {"container": home_grid_item_context_menu, "t
 
 # HomePage Dock
 home_dock = {"container": statusDesktop_mainWindow, "type": "ListView", "visible": True}
+home_profile = {"checkable": True, "container": statusDesktop_mainWindow, "objectName": "homeProfileButton", "type": "ProfileButton", "visible": True}
 
 # Regular Dock Buttons
 home_regular_dock_button_wallet = {"container": statusDesktop_mainWindow, "objectName": "regularDockButtonWallet", "type": "HomePageDockButton", "visible": True}

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -862,6 +862,7 @@ change_password_menu_new_password_confirm = {"container": settingsContentBase_Sc
 change_password_menu_change_password_button = {"container": settingsContentBase_ScrollView,
                                                "objectName": "changePasswordModalSubmitButton", "type": "StatusButton",
                                                "visible": True}
+changePasswordPopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmChangePasswordModal", "type": "PopupItem", "visible": True}
 reEncryptRestartButton = {"container": statusDesktop_mainWindow_overlay,
                           "objectName": "changePasswordModalSubmitButton", "type": "StatusButton", "visible": True}
 reEncryptionComplete = {"container": statusDesktop_mainWindow_overlay, "objectName": "statusListItemSubTitle",

--- a/test/e2e/gui/screens/home.py
+++ b/test/e2e/gui/screens/home.py
@@ -3,6 +3,7 @@ import time
 import allure
 
 import driver
+from gui.components.online_identifier import OnlineIdentifier
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.text_edit import TextEdit
@@ -21,6 +22,7 @@ class HomeScreen(QObject):
         self.search_field = TextEdit(home_names.home_search_field)
         self.grid = QObject(home_names.home_grid)
         self.dock = QObject(home_names.home_dock)
+        self.profile_button = QObject(home_names.home_profile)
 
         # Dock button mapping
         self.dock_buttons = {
@@ -95,6 +97,11 @@ class HomeScreen(QObject):
         """Navigate to Communities Portal from home grid"""
         self.click_grid_item_by_title("Communities")
         return CommunitiesPortal().wait_until_appears()
+
+    @allure.step('Open online identifier from home screen')
+    def open_online_identifier(self) -> OnlineIdentifier:
+        self.profile_button.click()
+        return OnlineIdentifier().wait_until_appears()
 
     # =============================================================================
     # DOCK FUNCTIONS

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -11,24 +11,21 @@ from driver.aut import AUT
 from gui.main_window import MainWindow
 
 
-@pytest.mark.timeout(timeout=180)
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/703005',
                  'Change the password and login with new password')
 @pytest.mark.case(703005)
 # @pytest.mark.critical
-@pytest.mark.skip(reason='https://github.com/status-im/status-desktop/issues/15178')
 # TODO: follow up on https://github.com/status-im/status-desktop/issues/13013
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account):
     with step('Open change password view'):
-        settings_scr = main_screen.home.open_from_dock(DockButtons.SETTINGS.value)
-        password_view = settings_scr.left_panel.open_password_settings()
+        password_view = main_screen.left_panel.open_settings().left_panel.open_password_settings()
 
     with step('Fill in the change password form and submit'):
         new_password = random_password_string()
-        password_view.change_password(user_account.password, new_password)
+        change_password_popup = password_view.change_password(user_account.password, new_password)
 
     with step('Click re-encrypt data button and then restart'):
-        ChangePasswordPopup().click_re_encrypt_data_restart_button()
+        change_password_popup.click_re_encrypt_data_restart_button()
 
     with step('Restart application'):
         aut.restart()
@@ -39,6 +36,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
                                                password=new_password))
 
     with step('Verify that the user logged in correctly'):
-        online_identifier = main_screen.left_panel.open_online_identifier()
+        online_identifier = main_screen.home.open_online_identifier()
         profile_popup = online_identifier.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18352

- fixed change password test and enabled it for nightly (for now)
- open profile from home screen too to cover it more
- deleted not needed step to open wallet from profile creation logic

<img width="1840" height="1106" alt="Screenshot 2025-07-14 at 16 51 49" src="https://github.com/user-attachments/assets/12cea063-4ad2-4102-82b2-6f884aba1a59" />

