### PR TITLE
fix(StatusDialog): fix evaluating the window width/height

### DIFF
--- a/storybook/pages/ProfileShowcaseInfoPopupPage.qml
+++ b/storybook/pages/ProfileShowcaseInfoPopupPage.qml
@@ -8,8 +8,6 @@ import AppLayouts.Profile.popups
 
 import shared.popups
 
-
-
 SplitView {
     Logs { id: logs }
 
@@ -54,3 +52,4 @@ SplitView {
 }
 
 // category: Popups
+// status: good

--- a/storybook/pages/StatusDialogPage.qml
+++ b/storybook/pages/StatusDialogPage.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQml.Models
-import Qt5Compat.GraphicalEffects
 
 import Storybook
 
@@ -37,11 +36,8 @@ SplitView {
         StatusDialog {
             id: dialog
 
-            closePolicy: Popup.NoAutoClose
-
             title: ctrlTitle.text
             subtitle: ctrlSubTitle.text
-            //backgroundColor: Theme.palette.baseColor3
             backgroundColor: !!ctrlBgColor.text ? ctrlBgColor.text : Theme.palette.statusModal.backgroundColor
 
             padding: ctrlPadding.text
@@ -71,7 +67,6 @@ SplitView {
 
             // custom header; not needed unless you want to override the icon or the (close) button(s)
             header: StatusDialogHeader {
-                //color: Theme.palette.baseColor3
                 color: !!ctrlHeaderBgColor.text ? ctrlHeaderBgColor.text : Theme.palette.statusModal.backgroundColor
                 dropShadowEnabled: ctrlHeaderDropShadow.checked
 
@@ -93,7 +88,6 @@ SplitView {
             }
 
             footer: StatusDialogFooter {
-                //color: Theme.palette.baseColor3
                 color: !!ctrlFooterBgColor.text ? ctrlFooterBgColor.text : Theme.palette.statusModal.backgroundColor
                 dropShadowEnabled: ctrlDropShadow.checked
 
@@ -261,3 +255,4 @@ SplitView {
 }
 
 // category: Popups
+// status: good

--- a/storybook/qmlTests/tests/tst_StatusDialog.qml
+++ b/storybook/qmlTests/tests/tst_StatusDialog.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Popups.Dialog
+
+import utils
+
+Item {
+    id: root
+    width: d.desktopWindowWidth
+    height: d.desktopWindowHeight
+
+    Component {
+        id: componentUnderTest
+        StatusDialog {
+            width: 400
+            title: "Test dialog"
+            standardButtons: Dialog.Ok
+            contentItem: StatusBaseText {
+                text: "Nothing to see here"
+            }
+        }
+    }
+
+    QtObject {
+        id: d
+        readonly property int desktopWindowWidth: Theme.portraitBreakpoint.width + 100
+        readonly property int desktopWindowHeight: Theme.portraitBreakpoint.height + 100
+        readonly property int mobileWindowWidth: mobileWindowHeight / 2
+        readonly property int mobileWindowHeight: Theme.portraitBreakpoint.height - 100
+    }
+
+    property StatusDialog controlUnderTest: null
+
+    TestCase {
+        name: "StatusDialog"
+        when: windowShown
+
+        function init() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+        }
+
+        function cleanup() {
+            root.width = d.desktopWindowWidth
+            root.height = d.desktopWindowHeight
+        }
+
+        function test_centered_on_desktop() {
+            verify(!!controlUnderTest)
+            controlUnderTest.open()
+            tryCompare(controlUnderTest, "opened", true)
+
+            tryCompare(controlUnderTest, "width", 400) // popup width should stay the same
+            verify(controlUnderTest.height > 0)
+
+            tryVerify(() => controlUnderTest.x > 0) // popup not stuck in topleft corner
+            tryVerify(() => controlUnderTest.y > 0)
+
+            compare(controlUnderTest.bottomSheet, false) // not bottom sheet on desktop
+        }
+
+        function test_bottomSheet_on_mobile() {
+            root.width = d.mobileWindowWidth
+            root.height = d.mobileWindowHeight
+
+            verify(!!controlUnderTest)
+            controlUnderTest.open()
+            tryCompare(controlUnderTest, "opened", true)
+
+            tryCompare(controlUnderTest, "width", root.width) // popup width should match the window width
+            verify(controlUnderTest.height > 0)
+
+            compare(controlUnderTest.bottomSheet, true) // bottom sheet on mobile
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/Theme.qml
@@ -190,10 +190,7 @@ QtObject {
     readonly property int defaultSmallPadding: defaultPadding * 0.625
     readonly property int defaultRadius: defaultHalfPadding
 
-    property var portraitBreakpoint: QtObject {
-        readonly property int width: 1200
-        readonly property int height: 680
-    }
+    readonly property var portraitBreakpoint: Qt.size(1200, 680)
 
     readonly property real disabledOpacity: 0.3
     readonly property real pressedOpacity: 0.7

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -39,18 +39,23 @@ Dialog {
     */
     property string okButtonText: qsTr("OK")
 
-    readonly property bool bottomSheet: d.windowHeight
-                                        > d.windowWidth
-                                        && d.windowWidth
-                                        <= Theme.portraitBreakpoint.width // The max width of a phone in portrait mode
+    readonly property bool bottomSheet: d.windowHeight > d.windowWidth
+                                        && d.windowWidth <= Theme.portraitBreakpoint.width // The max width of a phone in portrait mode
 
-    readonly property real desiredY: root.bottomSheet ? root.contentItem.Window.height - root.height : ((root.Overlay.overlay.height - root.height) / 2)
+    readonly property real desiredY: root.bottomSheet ? d.windowHeight - root.height
+                                                      : (root.Overlay.overlay.height - root.height) / 2
 
     QtObject {
         id: d
 
-        readonly property int windowWidth: root.contentItem.Window ? root.contentItem.Window.width: Screen.width
-        readonly property int windowHeight: root.contentItem.Window? root.contentItem.Window.height : Screen.height
+        // NB: needs to be delayed for the `contentItem` to be not null
+        property int windowWidth
+        property int windowHeight
+    }
+
+    onAboutToShow: {
+        d.windowWidth = Qt.binding(() => root.contentItem.Window ? root.contentItem.Window.width: Screen.width)
+        d.windowHeight = Qt.binding(() => root.contentItem.Window? root.contentItem.Window.height : Screen.height)
     }
 
     enter: Transition {
@@ -60,13 +65,13 @@ Dialog {
                 property: "opacity"
                 from: 0.0
                 to: 1.0
-                duration: 150
+                duration: Theme.AnimationDuration.Fast
             }
             NumberAnimation {
                 property: "y"
                 from: root.parent.height
                 to: root.desiredY
-                duration: 150
+                duration: Theme.AnimationDuration.Fast
                 easing.type: Easing.OutCubic
             }
         }
@@ -76,35 +81,29 @@ Dialog {
 
     Binding on width {
         when: root.bottomSheet
-        restoreMode: Binding.RestoreBindingOrValue
         value: d.windowWidth
     }
     Binding on height {
         when: root.bottomSheet && !enterTransition.running
-        restoreMode: Binding.RestoreBindingOrValue
         value: Math.min(root.implicitHeight, d.windowHeight * 0.9)
     }
     Binding on y {
         when: root.bottomSheet && !enterTransition.running
-        restoreMode: Binding.RestoreBindingOrValue
         value: root.desiredY
     }
 
     Binding on y {
         when: !root.bottomSheet && !enterTransition.running
-        restoreMode: Binding.RestoreBindingOrValue
         value: (d.windowHeight - root.height) / 2
     }
 
     Binding on x {
         when: !root.bottomSheet
-        restoreMode: Binding.RestoreBindingOrValue
         value: (d.windowWidth - root.width) / 2
     }
 
     Binding on x {
         when: root.bottomSheet
-        restoreMode: Binding.RestoreBindingOrValue
         value: 0
     }
 


### PR DESCRIPTION
### What does the PR do
- need to delay constructing the windowWidth/Height bindings for after the `contentItem` becomes non-null
- add a QML testcase for the centered on desktop and bottomSheet on mobile behavior
- fixes some popups having wrong position and size

Fixes #18356

### Affected areas

Popups

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/08d2e34c-7263-4adc-895a-dfbf2f0eae7e

https://github.com/user-attachments/assets/083ac759-71c7-4989-8d6e-2719ba54fb3d

SB with correct behavior and passing tests:
<img width="1417" height="907" alt="image" src="https://github.com/user-attachments/assets/68e9f5ab-d678-4cca-92f8-4f28487c1c75" />


### Impact on end user

low

### How to test

Open some popups, should be either centered, or appear as a bottom edge sheet in size constrained scenarios

### Risk 

Low
