### PR TITLE
perf(chat_section): lazy load chat modules and improve performance

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -161,14 +161,20 @@ proc init*(self: Controller) =
     var args = ChatUpdateArgs(e)
     for chat in args.chats:
       let belongsToCommunity = chat.communityId.len > 0
-      discard self.delegate.addOrUpdateChat(chat, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
+      var community = CommunityDto()
+      if belongsToCommunity:
+        community = self.getMyCommunity()
+      discard self.delegate.addOrUpdateChat(chat, community, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
         self.contactService, self.chatService, self.communityService, self.messageService,
         self.mailserversService, self.sharedUrlsService, setChatAsActive = false)
 
   self.events.on(SIGNAL_CHAT_CREATED) do(e: Args):
     var args = CreatedChatArgs(e)
     let belongsToCommunity = args.chat.communityId.len > 0
-    discard self.delegate.addOrUpdateChat(args.chat, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
+    var community = CommunityDto()
+    if belongsToCommunity:
+      community = self.getMyCommunity()
+    discard self.delegate.addOrUpdateChat(args.chat, community, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
@@ -176,7 +182,10 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
       let belongsToCommunity = args.chat.communityId.len > 0
-      discard self.delegate.addOrUpdateChat(args.chat, belongsToCommunity, self.events, self.settingsService,
+      var community = CommunityDto()
+      if belongsToCommunity:
+        community = self.getMyCommunity()
+      discard self.delegate.addOrUpdateChat(args.chat, community, belongsToCommunity, self.events, self.settingsService,
         self.nodeConfigurationService, self.contactService, self.chatService, self.communityService,
         self.messageService, self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
@@ -504,8 +513,8 @@ proc getOneToOneChatNameAndImage*(self: Controller, chatId: string):
 
 proc createOneToOneChat*(self: Controller, communityID: string, chatId: string, ensName: string) =
   let response = self.chatService.createOneToOneChat(communityID, chatId, ensName)
-  if(response.success):
-    discard self.delegate.addOrUpdateChat(response.chatDto, false, self.events, self.settingsService, self.nodeConfigurationService,
+  if response.success:
+    discard self.delegate.addOrUpdateChat(response.chatDto, CommunityDto(), false, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService)
 
@@ -577,15 +586,15 @@ proc makeAdmin*(self: Controller, communityID: string, chatId: string, pubKey: s
 
 proc createGroupChat*(self: Controller, communityID: string, groupName: string, pubKeys: seq[string]) =
   let response = self.chatService.createGroupChat(communityID, groupName, pubKeys)
-  if(response.success):
-    discard self.delegate.addOrUpdateChat(response.chatDto, false, self.events, self.settingsService, self.nodeConfigurationService,
+  if response.success:
+    discard self.delegate.addOrUpdateChat(response.chatDto, CommunityDto(), false, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService)
 
 proc joinGroupChatFromInvitation*(self: Controller, groupName: string, chatId: string, adminPK: string) =
   let response = self.chatService.createGroupChatFromInvitation(groupName, chatId, adminPK)
-  if(response.success):
-    discard self.delegate.addOrUpdateChat(response.chatDto, false, self.events, self.settingsService, self.nodeConfigurationService,
+  if response.success:
+    discard self.delegate.addOrUpdateChat(response.chatDto, CommunityDto(), false, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService)
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -75,6 +75,7 @@ method doesTopLevelChatExist*(self: AccessInterface, chatId: string): bool {.bas
 
 method addOrUpdateChat*(self: AccessInterface,
     chat: ChatDto,
+    community: CommunityDto,
     belongsToCommunity: bool,
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1184,7 +1184,7 @@ method activeSectionSet*[T](self: Module[T], sectionId: string, skipSavingInSett
     return
   let item = self.view.model().getItemById(sectionId)
 
-  if(item.isEmpty()):
+  if item.isEmpty():
     # should never be here
     warn "main-module, incorrect section id", sectionId
     return

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -454,7 +454,7 @@ QtObject:
         return idx
     return -1
 
-  proc findIndexById(id: string, categories: seq[Category]): int =
+  proc findIndexById*(id: string, categories: seq[Category]): int =
     var idx = -1
     for category in categories:
       inc idx
@@ -933,7 +933,7 @@ QtObject:
       return 0
 
   proc getCategoryById*(self: Service, communityId: string, categoryId: string): Category =
-    if(not self.communities.contains(communityId)):
+    if not self.communities.contains(communityId):
       error "trying to get community categories for an unexisting community id"
       return
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -992,7 +992,9 @@ Item {
         }
 
         function onAppSectionBySectionTypeChanged(sectionType, subsection, subSubsection = -1, data = {}) {
-            appMain.rootStore.setActiveSectionBySectionType(sectionType)
+            if (sectionType !== Constants.appSection.community) {
+                appMain.rootStore.setActiveSectionBySectionType(sectionType)
+            }
 
             if (sectionType === Constants.appSection.profile) {
                 profileLoader.settingsSubsection = subsection || Constants.settingsSubsection.profile


### PR DESCRIPTION
### What does the PR do

Fixes #18361 and #14431

Lazy loads the chat section's children modules so that only when a chat is activated are the modules loaded (content, users, messages and chat input). This improves performance and memory a little bit.

Also fixes other performance issues in the chat_section for communities, like useless calls to the service, useless calls to update the model (for categories) and also useless calls to update the badge. All of those slowed down the load. Most of those were fixed by simply accessing the `community` object already available.

I added those additional fixes because just lazy loading didn't give much of an improvement.

### Affected areas

chat_section module (mostly communities)

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

OLD (very slow loading): 

[old-loading.webm](https://github.com/user-attachments/assets/1608a509-27f8-484a-8a45-dd0e9d43fff6)

NEW (faster loading):

[new-comm-loading.webm](https://github.com/user-attachments/assets/c6d79b59-ba0c-4f5d-9871-2637a4192005)

### Impact on end user

Speeds up the loading of communities when it's the first time going on them

### How to test

- Have a big community and load it
- Make sure categories and unread messages still work

### Risk 

The only risk is that I might have affected the categories collapsing (saved state after a reload) and maybe also the badges, since I removed some seemingly useless code, since we already set the badges on the Item itself and I added it for the categories.
