### PR TITLE
fix(StatusEmojiPopup): fix the `skinColor` emoji setting

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -840,7 +840,7 @@ Item {
         property var whitelistedUnfurledDomains: []
         property bool introduceYourselfPopupSeen
         property var recentEmojis
-        property color skinColor
+        property string skinColor // NB: must be a string for the twemoji lib to work; we don't want the `#` in the name
         property int theme: Theme.Style.System
         property int fontSize: Theme.FontSize.FontSizeM
 


### PR DESCRIPTION
### What does the PR do

- fixes the StatusEmojiPopup searching for emojis with a skin color variant
- has to be a string (as before), otherwise it gets prepended with the `#` character and twemoji won't find the SVG file

Fixes #18362

### Affected areas

StatusEmojiPopup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1419" height="1032" alt="Snímek obrazovky z 2025-07-16 11-54-37" src="https://github.com/user-attachments/assets/36c3e3d7-0e2c-47a9-8c89-98f3253b14b2" />


### Impact on end user

Low

### How to test

- search e.g. for "man_white_haired" in the emoji popup

### Risk 

Low
