### PR TITLE
chore: update status-go

### DIFF
--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -23,7 +23,8 @@ class QObject:
         try:
             return driver.waitForObject(self.real_name, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
         except LookupError as e:
-            raise Exception(f"Object {self.real_name} was not found within {configs.timeouts.UI_LOAD_TIMEOUT_MSEC} ms") from e
+            raise Exception(
+                f"Object {self.real_name} was not found within {configs.timeouts.UI_LOAD_TIMEOUT_MSEC} ms") from e
 
     def set_text_property(self, text):
         self.object.forceActiveFocus()
@@ -96,7 +97,6 @@ class QObject:
         except (LookupError, RuntimeError, AttributeError):
             return False
 
-
     @property
     @allure.step('Get image {0}')
     def image(self):
@@ -125,13 +125,13 @@ class QObject:
 
         # if timeout is not None:
         #     pass
-            # TODO: enable after fixing https://github.com/status-im/status-desktop/issues/15345
-            # if not isFrozen(timeout):
-            #    pass
+        # TODO: enable after fixing https://github.com/status-im/status-desktop/issues/15345
+        # if not isFrozen(timeout):
+        #    pass
 
-            # else:
-            #    LOG.info("Application context did not respond after click")
-            #    raise Exception(f'Application UI is not responding within {timeout} second(s)')
+        # else:
+        #    LOG.info("Application context did not respond after click")
+        #    raise Exception(f'Application UI is not responding within {timeout} second(s)')
 
     @allure.step('Native click {0}')
     def native_mouse_click(

--- a/test/e2e/gui/screens/home.py
+++ b/test/e2e/gui/screens/home.py
@@ -99,9 +99,14 @@ class HomeScreen(QObject):
         return CommunitiesPortal().wait_until_appears()
 
     @allure.step('Open online identifier from home screen')
-    def open_online_identifier(self) -> OnlineIdentifier:
-        self.profile_button.click()
-        return OnlineIdentifier().wait_until_appears()
+    def open_online_identifier_from_home_screen(self, attempts: int = 3) -> OnlineIdentifier:
+        for _ in range(attempts):
+            try:
+                self.profile_button.click()
+                return OnlineIdentifier().wait_until_appears()
+            except Exception:
+                pass
+        raise LookupError(f'Online identifier popup was not opened after {attempts} retries')
 
     # =============================================================================
     # DOCK FUNCTIONS

--- a/test/e2e/gui/screens/wallet.py
+++ b/test/e2e/gui/screens/wallet.py
@@ -128,20 +128,24 @@ class WalletLeftPanel(QObject):
         return AccountPopup().wait_until_appears().verify_edit_account_popup_present()
 
     @allure.step('Open account popup')
-    def open_add_account_popup(self, attempt: int = 2):
-        self.add_account_button.click()
-        try:
-            return AccountPopup().wait_until_appears()
-        except AssertionError as err:
-            if attempt:
-                self.open_add_account_popup(attempt - 1)
-            else:
-                raise err
+    def open_add_account_popup(self, attempts: int = 3) -> 'AccountPopup':
+        for _ in range(attempts):
+            try:
+                self.add_account_button.click()
+                return AccountPopup().wait_until_appears()
+            except Exception:
+                pass
+        raise LookupError(f'Account popup is not opened with {attempts} retries')
 
     @allure.step('Select add watched address from context menu')
-    def select_add_watched_address_from_context_menu(self) -> AccountPopup:
-        self._open_context_menu().add_watched_address.click()
-        return AccountPopup().wait_until_appears()
+    def select_add_watched_address_from_context_menu(self, attempts: int = 3) -> 'AccountPopup':
+        for _ in range(attempts):
+            try:
+                self._open_context_menu().add_watched_address.click()
+                return AccountPopup().wait_until_appears()
+            except Exception:
+                pass
+        raise LookupError(f'Account popup is not opened with {attempts} retries')
 
     @allure.step('Delete account from the list from context menu')
     def delete_account_from_context_menu(self, account_name: str, attempts: int = 2) -> RemoveAccountWithConfirmation:

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -36,6 +36,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
                                                password=new_password))
 
     with step('Verify that the user logged in correctly'):
-        online_identifier = main_screen.home.open_online_identifier()
+        online_identifier = main_screen.home.open_online_identifier_from_home_screen()
         profile_popup = online_identifier.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name


### PR DESCRIPTION
### What does the PR do

- get latest status-go
- a couple of tweaks to reopen popups if closed because of UI jumping
