### PR TITLE
ci: add tests/e2e to GitHub jenkins jobs table

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -60,6 +60,8 @@ pipeline {
   }
 
   environment {
+    PLATFORM = 'tests/e2e'
+
     SQUISH_DIR = '/opt/squish-runner-9.0.1-qt-6.9'
     PYTHONPATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/lib/python:${PYTHONPATH}"
     LD_LIBRARY_PATH = "${SQUISH_DIR}/lib:${SQUISH_DIR}/python3/lib:${LD_LIBRARY_PATH}"
@@ -199,9 +201,15 @@ pipeline {
         properties: [],
         jdk: '',
       ])
+      /* Link for Jenkins Builds GitHub comment. */
+      env.PKG_URL = "${env.BUILD_URL}allure/"
       updateGitHubStatus()
     } } }
+    success { script {
+      github.notifyPR(true)
+    } }
     failure { script {
+      github.notifyPR(false)
       discord.send(
         header: '**Desktop E2E test failure!**',
         cred: 'discord-status-desktop-e2e-webhook',


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18378

It should be easier now to get to the allure report link, it is now visible in the `Jenkins Builds` table:

<img width="1345" height="127" alt="image" src="https://github.com/user-attachments/assets/5d4e8478-38b6-4cf6-9af3-998ea9c40426" />

The link in the last column takes you to the Allure report.