### PR TITLE
fix(AppMain): Backup seed phrase card is missing on home page

### DIFF
--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -20,8 +20,8 @@ QtObject {
     readonly property bool isOnline: internal.mainModuleInst.isOnline
     readonly property var sectionsModel: internal.mainModuleInst.sectionsModel
     readonly property bool sectionsLoaded: internal.mainModuleInst && internal.mainModuleInst.sectionsLoaded
-    readonly property var activeSectionId: internal.mainModuleInst.activeSection.id
-    readonly property var activeSectionType: internal.mainModuleInst.activeSection.sectionType
+    readonly property string activeSectionId: internal.mainModuleInst.activeSection.id
+    readonly property int activeSectionType: internal.mainModuleInst.activeSection.sectionType
 
     // Here define the needed properties that access to `Context Properties`:
     readonly property QtObject _internal: QtObject{

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1443,7 +1443,7 @@ Item {
                 id: bannersLayout
 
                 enabled: !localAppSettings.testEnvironment
-                         && appMain.rootStore.activeSection.sectionType !== Constants.appSection.homePage
+                         && appMain.rootStore.activeSectionType !== Constants.appSection.homePage
                 visible: enabled
 
                 property var updateBanner: null
@@ -1817,7 +1817,7 @@ Item {
                                 }
                             }
                             // Should never be here, correct index must be returned from the for loop above
-                            console.error("Wrong section type:", appMain.rootStore.activeSectionType,
+                            console.error("Wrong section type:", activeSectionType,
                                           "or section id: ", appMain.rootStore.activeSectionId)
                             return Constants.appViewStackIndex.community
                         case Constants.appSection.communitiesPortal:
@@ -1874,11 +1874,9 @@ Item {
                                 showEnabledSectionsOnly: true
                                 marketEnabled: appMain.featureFlagsStore.marketEnabled
 
-                                syncingBadgeCount: appMain.rootStore.profileSectionStore.devicesStore.devicesModel.count -
-                                                   appMain.rootStore.profileSectionStore.devicesStore.devicesModel.pairedCount
+                                syncingBadgeCount: appMain.devicesStore.devicesModel.count - appMain.devicesStore.devicesModel.pairedCount
                                 messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
-                                showBackUpSeed: !appMain.rootStore.profileSectionStore.profileStore.userDeclinedBackupBanner &&
-                                                !appMain.rootStore.profileSectionStore.profileStore.privacyStore.mnemonicBackedUp
+                                showBackUpSeed: !appMain.profileStore.userDeclinedBackupBanner && !appMain.privacyStore.mnemonicBackedUp
 
                                 searchPhrase: homePage.searchPhrase
 


### PR DESCRIPTION
### What does the PR do

- reference the correct properties after the recent stores' refactor
- aslo fixes the banners being visible on the Home Page

Fixes #18374

### Affected areas

AppMain/HomePage

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

TBD

### Impact on end user

low

### How to test

- have a new account
- the banner(s) should not be visible while on HomePage
- the HomePage should display the "Backup recovery phrase tile" with a (1) notification badge

### Risk 

- N/A
