### PR TITLE
chore: simplify macos building && update building docs to Qt 6

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -64,13 +64,6 @@ sudo apt update
 sudo apt install libpcsclite-dev libpcre3-dev build-essential mesa-common-dev libglu1-mesa-dev libssl-dev cmake jq libxcb-xinerama0 protobuf-compiler
 ```
 
-Install **libssl 1.1** (if not available in your distribution):
-
-```bash
-wget https://launchpad.net/~ubuntu-security-proposed/+archive/ubuntu/ppa/+build/23606713/+files/libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
-sudo dpkg -i libssl1.1_1.1.1l-1ubuntu1.3_amd64.deb
-```
-
 Install **Go 1.23**:
 
 Download and install from the [official website](https://go.dev/dl/).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -127,7 +127,7 @@ Install [Homebrew](https://brew.sh/) if not already installed.
 #### Install Required Packages
 
 ```bash
-brew install cmake pkg-config go@1.23 qt@5 protobuf 
+brew install cmake pkg-config go@1.23 qt protobuf 
 ```
 
 Install additional packages if you are planning to build DMG
@@ -199,22 +199,22 @@ python3 -m pip install setuptools --break-system-packages
 
 ### Windows & Linux
 
-Install **Qt 5.15.2** using the [Qt Online Installer](https://www.qt.io/download).
+Install **Qt 6.9.0** using the [Qt Online Installer](https://download.qt.io/official_releases/online_installers/).
 
 ### Linux (Alternative)
 
-You can use any newer 5.15.x version available in your system's package manager.
+You can use any newer 6.9.x version available in your system's package manager.
 
 #### Ubuntu
 
 ```bash
-sudo apt install qtbase5-dev qt5-qmake qtquickcontrols2-5-dev
+sudo apt install qt6-base-dev qt6-declarative-dev qt6-tools-dev qt6-multimedia-dev qt6-svg-dev qt6-webengine-dev
 ```
 
 #### Fedora
 
 ```bash
-sudo dnf install qt5-qtbase qt5-qtbase-devel qt5-qtquickcontrols
+sudo dnf install qt6-qtbase-devel qt6-qtbase-private-devel qt6-qt5compat-devel qt6-qtsvg-devel qt6-qtdeclarative-devel qt6-qtwebchannel-devel qt6-qtwebengine-devel qt6-qtwebsockets-devel
 ```
 
 
@@ -225,9 +225,9 @@ sudo dnf install qt5-qtbase qt5-qtbase-devel qt5-qtquickcontrols
 Set environment variables:
 
 ```powershell
-$env:QTPATH = "C:\Qt\5.15.2\5.15.2"
-$env:QTBASE = "C:\Qt\5.15.2"
-$env:QTDIR = "C:\Qt\5.15.2\msvc2017_64"
+$env:QTPATH = "C:\Qt\6.9.0\6.9.0"
+$env:QTBASE = "C:\Qt\6.9.0"
+$env:QTDIR = "C:\Qt\6.9.0\msvc2017_64"
 $env:GOPATH = "C:\Users\{your_username}\go\bin"
 $env:VCINSTALLDIR = "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC"
 $env:VS160COMNTOOLS = "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build"
@@ -242,7 +242,7 @@ C:\Users\{your_username}\scoop\apps\cmake\3.31.6\bin
 C:\Users\{your_username}\scoop\apps\mingw\15.1.0-rt_v12-rev0\bin
 С:\Users\{your_username}\go\bin
 C:\Program Files\Go\bin
-C:\Qt\5.15.2\msvc2019_64\bin
+C:\Qt\6.9.0\msvc2019_64\bin
 C:\protoc-30.2-win64\bin
 C:\Qt\Tools\Ninja
 C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin
@@ -256,7 +256,7 @@ If you installed Qt via your system's package manager, additional environment co
 
 Otherwise, set those envirionment variables:
 ```shell
-export QTDIR="/path/to/Qt/5.15.2/gcc_64"
+export QTDIR="/path/to/Qt/6.9.0/gcc_64"
 export PATH="${QTDIR}/bin:${PATH}"
 ```
 
@@ -307,7 +307,7 @@ make run
 Make sure your `QTDIR` and `PATH` are correctly set. You can also try:
 
 ```bash
-export QTDIR=/path/to/Qt/5.15.2/gcc_64
+export QTDIR=/path/to/Qt/6.9.0/gcc_64
 export PATH=$QTDIR/bin:$PATH
 ```
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,17 +104,6 @@ Install required packages:
 sudo dnf install pcsc-lite-devel pcre-devel openssl-devel protobuf-devel protobuf-compiler
 ```
 
-If **OpenSSL 1.1** is not available:
-
-```bash
-sudo dnf install perl-FindBin perl-File-Compare perl-File-Copy perl-Pod-Html
-wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz
-tar xvf openssl-1.1.1w.tar.gz
-cd openssl-1.1.1w
-./config --prefix=$HOME/.local/lib/openssl1.1
-make && make install
-```
-
 Install **nvm** and Node.js as per the [Ubuntu instructions above](#ubuntu).
 
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -127,7 +127,7 @@ Install [Homebrew](https://brew.sh/) if not already installed.
 #### Install Required Packages
 
 ```bash
-brew install cmake pkg-config go@1.23 qt@5 jq nvm yarn protobuf
+brew install cmake pkg-config go@1.23 qt@5 jq nvm yarn protobuf fileicon
 ```
 
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -262,6 +262,17 @@ git clone https://github.com/status-im/status-desktop.git
 cd status-desktop
 ```
 
+Install some `status-go` dependencies:
+
+```bash
+make status-go-deps
+```
+
+Make sure you have `~/go/bin` in your `PATH`:
+```bash
+echo "export PATH=\"$HOME/go/bin:\$PATH\"" >> ~/.zshrc
+```
+
 Update all submodules and build the dependencies:
 
 ```bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -127,9 +127,14 @@ Install [Homebrew](https://brew.sh/) if not already installed.
 #### Install Required Packages
 
 ```bash
-brew install cmake pkg-config go@1.23 qt@5 jq nvm yarn protobuf fileicon
+brew install cmake pkg-config go@1.23 qt@5 protobuf 
 ```
 
+Install additional packages if you are planning to build DMG
+
+```bash
+brew install nvm yarn fileicon
+```
 
 #### Export GITHUB_USER and GITHUB_TOKEN environment variables
 
@@ -145,6 +150,9 @@ export GITHUB_USER=yourgithubname
 
 
 #### Install Node.js
+
+> [!TIP]
+> You can skip this step if not planning to build a DMG
 
 Create NVM's working directory:
 
@@ -176,6 +184,9 @@ brew install coreutils
 ```
 
 #### Install Python Dependencies
+
+> [!TIP]
+> You can skip this step if not planning to build a DMG
 
 If using Python ≥ 3.12:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -225,9 +225,9 @@ sudo dnf install qt6-qtbase-devel qt6-qtbase-private-devel qt6-qt5compat-devel q
 Set environment variables:
 
 ```powershell
-$env:QTPATH = "C:\Qt\6.9.0\6.9.0"
-$env:QTBASE = "C:\Qt\6.9.0"
-$env:QTDIR = "C:\Qt\6.9.0\msvc2017_64"
+$env:QTPATH = "C:\Qt\5.15.2\5.15.2"
+$env:QTBASE = "C:\Qt\5.15.2"
+$env:QTDIR = "C:\Qt\5.15.2\msvc2017_64"
 $env:GOPATH = "C:\Users\{your_username}\go\bin"
 $env:VCINSTALLDIR = "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC"
 $env:VS160COMNTOOLS = "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build"
@@ -242,7 +242,7 @@ C:\Users\{your_username}\scoop\apps\cmake\3.31.6\bin
 C:\Users\{your_username}\scoop\apps\mingw\15.1.0-rt_v12-rev0\bin
 С:\Users\{your_username}\go\bin
 C:\Program Files\Go\bin
-C:\Qt\6.9.0\msvc2019_64\bin
+C:\Qt\5.15.2\msvc2019_64\bin
 C:\protoc-30.2-win64\bin
 C:\Qt\Tools\Ninja
 C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -254,7 +254,7 @@ C:\Users\{your_username}\AppData\Local\Programs\Microsoft VS Code\bin
 
 If you installed Qt via your system's package manager, additional environment configuration may not be necessary.
 
-Otherwise, set those envirionment variables:
+Otherwise, set those environment variables:
 ```shell
 export QTDIR="/path/to/Qt/6.9.0/gcc_64"
 export PATH="${QTDIR}/bin:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -884,8 +884,6 @@ force-rebuild-status-go:
 
 run: $(RUN_TARGET)
 
-ICON_TOOL := node_modules/.bin/fileicon
-
 # Will only work at password login. Keycard login doesn't forward the configuration
 # STATUS_PORT ?= 30306
 # WAKUV2_PORT ?= 30307
@@ -906,7 +904,7 @@ run-macos: nim_status_client
 	cp status-dev.icns bin/StatusDev.app/Contents/Resources/
 	cd bin/StatusDev.app/Contents/MacOS && \
 		ln -fs ../../../nim_status_client ./
-	./node_modules/.bin/fileicon set bin/nim_status_client status-dev.icns
+	fileicon set bin/nim_status_client status-dev.icns
 	echo -e "\033[92mRunning:\033[39m bin/StatusDev.app/Contents/MacOS/nim_status_client"
 	./bin/StatusDev.app/Contents/MacOS/nim_status_client $(ARGS)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "nodemon": "3.0.1"
       },
       "devDependencies": {
-        "create-dmg": "status-im/create-dmg#678fbd4",
-        "fileicon": "0.3.0"
+        "create-dmg": "status-im/create-dmg#678fbd4"
       },
       "engines": {
         "node": ">=10",
@@ -483,18 +482,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/fileicon": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fileicon/-/fileicon-0.3.0.tgz",
-      "integrity": "sha512-sIDuHQjKkM9UA5szqdCqcMbIfImg7jRVb83+0mWESRl6x3DTRxuAwYCUxXNhAJ2NdvALSxh9xlgARWBNRt8NMw==",
-      "dev": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "fileicon": "bin/fileicon"
       }
     },
     "node_modules/fill-range": {
@@ -2239,12 +2226,6 @@
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
       }
-    },
-    "fileicon": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fileicon/-/fileicon-0.3.0.tgz",
-      "integrity": "sha512-sIDuHQjKkM9UA5szqdCqcMbIfImg7jRVb83+0mWESRl6x3DTRxuAwYCUxXNhAJ2NdvALSxh9xlgARWBNRt8NMw==",
-      "dev": true
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "files": [],
   "devDependencies": {
-    "create-dmg": "status-im/create-dmg#678fbd4",
-    "fileicon": "0.3.3"
+    "create-dmg": "status-im/create-dmg#678fbd4"
   },
   "engines": {
     "node": ">=10",


### PR DESCRIPTION
### What does the PR do

1. Update building instructions for Qt 6
2. Use `fileicon` from `homebrew` instead of `npm`. 
Ideally we should also use [shell version create-dmg](https://github.com/create-dmg/create-dmg) instead of [nodejs version create-dmg](https://github.com/status-im/create-dmg), then we can remove NPM and Yarn dependencies. 
3. Added instruction to run `make status-go-deps`
4. Added tips to skip some steps only required for DMG building