### PR TITLE
Chore/remove legacy telemetry

### DIFF
--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -68,26 +68,10 @@ proc setWakuV2LightClientEnabled*(self: Controller, enabled: bool) =
   self.delegate.onWakuV2LightClientSet()
 
 proc enableDeveloperFeatures*(self: Controller) =
-  discard self.settingsService.saveTelemetryServerUrl(DEFAULT_TELEMETRY_SERVER_URL)
   discard self.settingsService.saveAutoMessageEnabled(true)
   discard self.nodeConfigurationService.setLogLevel(LogLevel.DEBUG)
 
   quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
-
-proc isTelemetryEnabled*(self: Controller): bool =
-  return self.settingsService.getTelemetryServerUrl().len > 0
-
-proc toggleTelemetry*(self: Controller) =
-  var value = ""
-  if(not self.isTelemetryEnabled()):
-    value = DEFAULT_TELEMETRY_SERVER_URL
-
-  if(not self.settingsService.saveTelemetryServerUrl(value)):
-    # in the future we may do a call from here to show a popup about this error
-    error "an error occurred, we couldn't toggle telemetry message"
-    return
-
-  self.delegate.onTelemetryToggled()
 
 proc toggleAutoMessage*(self: Controller) =
   let enabled = self.settingsService.autoMessageEnabled()
@@ -103,7 +87,7 @@ proc isAutoMessageEnabled*(self: Controller): bool =
 
 proc isDebugEnabled*(self: Controller): bool =
   return self.nodeConfigurationService.isDebugEnabled()
-  
+
 proc toggleDebug*(self: Controller) =
   var logLevel = LogLevel.DEBUG
   if(self.isDebugEnabled()):

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -21,9 +21,6 @@ method onFleetSet*(self: AccessInterface) {.base.} =
 method onWakuV2LightClientSet*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onTelemetryToggled*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onAutoMessageToggled*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -49,12 +46,6 @@ method getWakuV2LightClientEnabled*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setWakuV2LightClientEnabled*(self: AccessInterface, enabled: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method isTelemetryEnabled*(self: AccessInterface): bool {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method toggleTelemetry*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method isAutoMessageEnabled*(self: AccessInterface): bool {.base.} =

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -75,17 +75,8 @@ method onWakuV2LightClientSet*(self: Module) =
   info "quit the app because of successful WakuV2 light client change"
   quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
 
-method isTelemetryEnabled*(self: Module): bool =
-  self.controller.isTelemetryEnabled()
-
 method enableDeveloperFeatures*(self: Module) =
   self.controller.enableDeveloperFeatures()
-
-method toggleTelemetry*(self: Module) =
-  self.controller.toggleTelemetry()
-
-method onTelemetryToggled*(self: Module) =
-  self.view.emitTelemetryEnabledSignal()
 
 method isAutoMessageEnabled*(self: Module): bool =
   self.controller.isAutoMessageEnabled()

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -48,19 +48,6 @@ QtObject:
   # proc emitWakuV2LightClientEnabledSignal*(self: View) =
   #   self.wakuV2LightClientEnabledChanged()
 
-  proc isTelemetryEnabledChanged*(self: View) {.signal.}
-  proc getIsTelemetryEnabled*(self: View): bool {.slot.} =
-    return self.delegate.isTelemetryEnabled()
-  QtProperty[bool] isTelemetryEnabled:
-    read = getIsTelemetryEnabled
-    notify = isTelemetryEnabledChanged
-
-  proc emitTelemetryEnabledSignal*(self: View) =
-    self.isTelemetryEnabledChanged()
-
-  proc toggleTelemetry*(self: View) {.slot.} =
-    self.delegate.toggleTelemetry()
-
   proc isAutoMessageEnabledChanged*(self: View) {.signal.}
   proc getIsAutoMessageEnabled*(self: View): bool {.slot.} =
     return self.delegate.isAutoMessageEnabled()

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -30,7 +30,6 @@ const KEY_APPEARANCE* = "appearance"
 const KEY_USE_MAILSERVERS* = "use-mailservers?"
 const KEY_WALLET_ROOT_ADDRESS* = "wallet-root-address"
 const KEY_SEND_STATUS_UPDATES* = "send-status-updates?"
-const KEY_TELEMETRY_SERVER_URL* = "telemetry-server-url"
 const KEY_PINNED_MAILSERVERS* = "pinned-mailservers"
 const KEY_CURRENT_USER_STATUS* = "current-user-status"
 const KEY_RECENT_STICKERS* = "stickers/recent-stickers"
@@ -139,7 +138,6 @@ type
     useMailservers*: bool
     walletRootAddress*: string
     sendStatusUpdates*: bool
-    telemetryServerUrl*: string
     fleet*: string
     currentUserStatus*: CurrentUserStatus
     nodeConfig*: JsonNode
@@ -217,7 +215,6 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_USE_MAILSERVERS, result.useMailservers)
   discard jsonObj.getProp(KEY_WALLET_ROOT_ADDRESS, result.walletRootAddress)
   discard jsonObj.getProp(KEY_SEND_STATUS_UPDATES, result.sendStatusUpdates)
-  discard jsonObj.getProp(KEY_TELEMETRY_SERVER_URL, result.telemetryServerUrl)
   discard jsonObj.getProp(KEY_FLEET, result.fleet)
   discard jsonObj.getProp(KEY_AUTO_MESSAGE_ENABLED, result.autoMessageEnabled)
   discard jsonObj.getProp(KEY_GIF_RECENTS, result.gifRecents)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -16,7 +16,6 @@ export stickers_dto
 
 # Default values:
 const DEFAULT_CURRENCY* = "USD"
-const DEFAULT_TELEMETRY_SERVER_URL* = "https://telemetry.status.im"
 const DEFAULT_FLEET* = Fleet.StatusProd
 
 # Signals:
@@ -350,15 +349,6 @@ QtObject:
 
   proc getSendStatusUpdates*(self: Service): bool =
     self.settings.sendStatusUpdates
-
-  proc saveTelemetryServerUrl*(self: Service, value: string): bool =
-    if(self.saveSetting(KEY_TELEMETRY_SERVER_URL, value)):
-      self.settings.telemetryServerUrl = value
-      return true
-    return false
-
-  proc getTelemetryServerUrl*(self: Service): string =
-    return self.settings.telemetryServerUrl
 
   proc saveSendStatusUpdates*(self: Service, newStatus: StatusType): bool =
     try:
@@ -1006,7 +996,7 @@ QtObject:
     result = VALUE_NOTIF_SEND_ALERTS # Default value
 
     var newsFeedEnabled = false
-    var newsOSNotificationsEnabled = false 
+    var newsOSNotificationsEnabled = false
 
     if self.initialized:
       newsFeedEnabled = self.settings.newsFeedEnabled
@@ -1033,7 +1023,7 @@ QtObject:
     # Send alerts means the News Feed is enabled + OS notifications are enabled
     # Deliver quietly means the News Feed is enabled + OS notifications are disabled (so only AC notifications)
     # Turn OFF means the News Feed is disabled (so no notifications at all and no polling)
-    if not newsFeedEnabled: 
+    if not newsFeedEnabled:
       return VALUE_NOTIF_TURN_OFF
     if not newsOSNotificationsEnabled:
       return VALUE_NOTIF_DELIVER_QUIETLY
@@ -1070,7 +1060,7 @@ QtObject:
     read = getNotifSettingStatusNews
     write = setNotifSettingStatusNews
     notify = notifSettingStatusNewsChanged
-  
+
   proc newsRSSEnabledChanged*(self: Service) {.signal.}
   proc getNewsRSSEnabled*(self: Service): bool {.slot.} =
     if self.initialized:

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -11,7 +11,6 @@ QtObject {
     // Advanced Module Properties
     property string fleet: advancedModule? advancedModule.fleet : ""
     property bool wakuV2LightClientEnabled: advancedModule? advancedModule.wakuV2LightClientEnabled : false
-    property bool isTelemetryEnabled: advancedModule? advancedModule.isTelemetryEnabled : false
     property bool isAutoMessageEnabled: advancedModule? advancedModule.isAutoMessageEnabled : false
     property bool isNimbusProxyEnabled: advancedModule? advancedModule.isNimbusProxyEnabled : false
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
@@ -68,13 +67,6 @@ QtObject {
             return
 
         root.advancedModule.setWakuV2LightClientEnabled(mode)
-    }
-
-    function toggleTelemetry() {
-        if(!root.advancedModule)
-            return
-
-        root.advancedModule.toggleTelemetry()
     }
 
     function toggleAutoMessage() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -320,7 +320,6 @@ SettingsContentBase {
                 text: qsTr("Full developer mode")
                 isEnabled: {
                     return !localAccountSensitiveSettings.downloadChannelMessagesEnabled ||
-                        !root.advancedStore.isTelemetryEnabled ||
                         !root.advancedStore.isDebugEnabled ||
                         !root.advancedStore.isAutoMessageEnabled
                 }
@@ -366,18 +365,6 @@ SettingsContentBase {
                 switchChecked: localAccountSensitiveSettings.downloadChannelMessagesEnabled
                 onClicked: {
                     localAccountSensitiveSettings.downloadChannelMessagesEnabled = !localAccountSensitiveSettings.downloadChannelMessagesEnabled
-                }
-            }
-
-            // TODO: replace with StatusQ component
-            StatusSettingsLineButton {
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
-                text: qsTr("Telemetry")
-                isSwitch: true
-                switchChecked: root.advancedStore.isTelemetryEnabled
-                onClicked: {
-                    Global.openPopup(enableTelemetryConfirmationDialogComponent)
                 }
             }
 
@@ -499,25 +486,6 @@ SettingsContentBase {
                 onConfirmButtonClicked: {
                     localAccountSensitiveSettings.downloadChannelMessagesEnabled = true
                     Qt.callLater(root.advancedStore.enableDeveloperFeatures)
-                    close()
-                }
-                onCancelButtonClicked: {
-                    close()
-                }
-            }
-        }
-
-        Component {
-            id: enableTelemetryConfirmationDialogComponent
-            ConfirmationDialog {
-                property bool mode: false
-
-                id: confirmDialog
-                destroyOnClose: true
-                showCancelButton: true
-                confirmationText: qsTr("Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.")
-                onConfirmButtonClicked: {
-                    root.advancedStore.toggleTelemetry()
                     close()
                 }
                 onCancelButtonClicked: {


### PR DESCRIPTION
### What does the PR do

Remove telemetry toggle as it was superseded by local metrics. For
justification see:

https://forum.vac.dev/t/the-future-of-status-telemetry/405
https://github.com/status-im/status-go/pull/6256
https://github.com/waku-org/status-metrics

Fixes #18379

### Affected areas
- Settings

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

No telemetry toggle.

### How to test

Both old and new account should run the app just fine.

### Risk 

None.