### PR TITLE
feat(syncing): enable pairing and unpairing already paired devices

### DIFF
--- a/src/app/modules/main/profile_section/devices/controller.nim
+++ b/src/app/modules/main/profile_section/devices/controller.nim
@@ -108,3 +108,9 @@ proc getConnectionStringForBootstrappingAnotherDevice*(self: Controller, passwor
 
 proc inputConnectionStringForBootstrapping*(self: Controller, connectionString: string) =
   self.devicesService.inputConnectionStringForBootstrapping(connectionString)
+
+proc pairDevice*(self: Controller, installationId: string): string =
+  return self.devicesService.pairDevice(installationId)
+
+proc unpairDevice*(self: Controller, installationId: string): string =
+  return self.devicesService.unpairDevice(installationId)

--- a/src/app/modules/main/profile_section/devices/io_interface.nim
+++ b/src/app/modules/main/profile_section/devices/io_interface.nim
@@ -64,3 +64,9 @@ method inputConnectionStringForBootstrapping*(self: AccessInterface, connectionS
 
 method onLocalPairingStatusUpdate*(self: AccessInterface, status: LocalPairingStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method pairDevice*(self: AccessInterface, installationId: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method unpairDevice*(self: AccessInterface, installationId: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -138,14 +138,27 @@ QtObject:
 
   proc updateItemName*(self: Model, installationId: string, name: string) =
     var i = self.findIndexByInstallationId(installationId)
-    if(i == -1):
+    if i == -1 or self.items[i].installation.metadata.name == name:
       return
+
+    self.items[i].installation.metadata.name = name
 
     let index = self.createIndex(i, 0, nil)
     defer: index.delete
 
-    self.items[i].installation.metadata.name = name
     self.dataChanged(index, index, @[ModelRole.Name.int])
+
+  proc updateItemEnabled*(self: Model, installationId: string, enabled: bool) =
+    var i = self.findIndexByInstallationId(installationId)
+    if i == -1 or self.items[i].installation.enabled == enabled:
+      return
+
+    self.items[i].installation.enabled = enabled
+
+    let index = self.createIndex(i, 0, nil)
+    defer: index.delete
+
+    self.dataChanged(index, index, @[ModelRole.Enabled.int])
 
   proc getIsDeviceSetup*(self: Model, installationId: string): bool =
     return anyIt(self.items, it.installation.id == installationId and it.name != "")

--- a/src/app/modules/main/profile_section/devices/module.nim
+++ b/src/app/modules/main/profile_section/devices/module.nim
@@ -125,3 +125,9 @@ method inputConnectionStringForBootstrapping*(self: Module, connectionString: st
 
 method onLocalPairingStatusUpdate*(self: Module, status: LocalPairingStatus) =
   self.view.onLocalPairingStatusUpdate(status)
+
+method pairDevice*(self: Module, installationId: string): string =
+  return self.controller.pairDevice(installationId)
+
+method unpairDevice*(self: Module, installationId: string): string =
+  return self.controller.unpairDevice(installationId)

--- a/src/app/modules/main/profile_section/devices/view.nim
+++ b/src/app/modules/main/profile_section/devices/view.nim
@@ -138,3 +138,15 @@ QtObject:
 
   proc inputConnectionStringForBootstrapping*(self: View, connectionString: string) {.slot.} =
     self.delegate.inputConnectionStringForBootstrapping(connectionString)
+
+  proc pairDevice*(self: View, installationId: string): string {.slot.} =
+    let error = self.delegate.pairDevice(installationId)
+    if error.len == 0:
+      self.model.updateItemEnabled(installationId, true)
+    return error
+
+  proc unpairDevice*(self: View, installationId: string): string {.slot.} =
+    let error = self.delegate.unpairDevice(installationId)
+    if error.len == 0:
+      self.model.updateItemEnabled(installationId, false)
+    return error

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -391,3 +391,23 @@ QtObject:
       self.events.emit(SIGNAL_PAIRING_FALLBACK_COMPLETED, Args())
     except Exception as e:
       error "error: ", desription = e.msg
+
+  proc unpairDevice*(self: Service, installationId: string): string =
+    try:
+      let response = status_installations.unpairDevice(installationId)
+      if response.error != nil:
+        let e = Json.safeDecode($response.error, RpcError)
+        raise newException(CatchableError, e.message)
+    except Exception as e:
+      error "error in unpairDevice: ", desription = e.msg
+      return e.msg
+
+  proc pairDevice*(self: Service, installationId: string): string =
+    try:
+      let response = status_installations.pairDevice(installationId)
+      if response.error != nil:
+        let e = Json.safeDecode($response.error, RpcError)
+        raise newException(CatchableError, e.message)
+    except Exception as e:
+      error "error in pairDevice: ", desription = e.msg
+      return e.msg

--- a/src/backend/installations.nim
+++ b/src/backend/installations.nim
@@ -47,3 +47,11 @@ proc enableInstallationAndSync*(installationId: string): RpcResponse[JsonNode] =
     "installationId": installationId,
   }]
   result = callPrivateRPC("enableInstallationAndSync".prefix, payload)
+
+proc unpairDevice*(installationId: string): RpcResponse[JsonNode] =
+  let payload = %* [installationId]
+  result = callPrivateRPC("disableInstallation".prefix, payload)
+
+proc pairDevice*(installationId: string): RpcResponse[JsonNode] =
+  let payload = %* [installationId]
+  result = callPrivateRPC("enableInstallation".prefix, payload)

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -21,7 +21,8 @@ StatusListItem {
     property bool showOnlineBadge: !isCurrentDevice
 
     signal itemClicked
-    signal setupSyncingButtonClicked
+    signal pairRequested
+    signal unpairRequested
 
     title: root.deviceName || qsTr("Unknown device")
 
@@ -58,10 +59,19 @@ StatusListItem {
         StatusButton {
             anchors.verticalCenter: parent.verticalCenter
             visible: root.enabled && !root.deviceEnabled && !root.isCurrentDevice
-            text: qsTr("Setup syncing")
+            text: qsTr("Pair")
             size: StatusBaseButton.Size.Small
             onClicked: {
-                root.setupSyncingButtonClicked()
+                root.pairRequested()
+            }
+        },
+        StatusButton {
+            anchors.verticalCenter: parent.verticalCenter
+            visible: root.enabled && root.deviceEnabled && !root.isCurrentDevice
+            text: qsTr("Unpair")
+            size: StatusBaseButton.Size.Small
+            onClicked: {
+                root.unpairRequested()
             }
         },
         StatusIcon {

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -48,4 +48,12 @@ QtObject {
     function inputConnectionStringForBootstrapping(connectionString) {
         root.devicesModule.inputConnectionStringForBootstrapping(connectionString)
     }
+
+    function pairDevice(installationId) {
+        return root.devicesModule.pairDevice(installationId)
+    }
+
+    function unpairDevice(installationId) {
+        return root.devicesModule.unpairDevice(installationId)
+    }
 }

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -55,6 +55,18 @@ SettingsContentBase {
                                  })
             }
 
+            function setupPair(installationId) {
+                Global.openPopup(pairDeviceDialogComponent, {
+                                     "installationId": installationId
+                                 })
+            }
+
+            function setupUnpair(installationId) {
+                Global.openPopup(unpairDeviceDialogComponent, {
+                                     "installationId": installationId
+                                 })
+            }
+
             function setupSyncing() {
                 root.devicesStore.generateConnectionStringAndRunSetupSyncingPopup()
             }
@@ -128,14 +140,16 @@ SettingsContentBase {
                 deviceEnabled: model.enabled
                 timestamp: model.timestamp
                 isCurrentDevice: model.isCurrentDevice
-                onSetupSyncingButtonClicked: {
-                    d.setupSyncing()
+                onPairRequested: {
+                    d.setupPair(model.installationId)
+                }
+                onUnpairRequested: {
+                    d.setupUnpair(model.installationId)
                 }
                 onClicked: {
-                    if (deviceEnabled)
+                    if (deviceEnabled) {
                         d.personalizeDevice(model)
-                    else
-                        d.setupSyncing()
+                    }
                 }
             }
         }
@@ -296,6 +310,49 @@ SettingsContentBase {
                 destroyOnClose: true
                 devicesStore: root.devicesStore
                 profileStore: root.profileStore
+            }
+        }
+
+        Component {
+            id: pairDeviceDialogComponent
+            ConfirmationDialog {
+                property string installationId
+
+                id: pairDeviceDialog
+                destroyOnClose: true
+                headerSettings.title: qsTr("Pair Device")
+                confirmationText: qsTr("Are you sure you want to pair this device?")
+                confirmButtonLabel: qsTr("Pair")
+                btnType: "normal"
+                onConfirmButtonClicked: {
+                    const error = devicesStore.devicesModule.pairDevice(installationId)
+                    if (error) {
+                        pairDeviceDialog.confirmationText = qsTr("Error pairing device: %1").arg(error)
+                    } else {
+                        Global.closePopup()
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: unpairDeviceDialogComponent
+            ConfirmationDialog {
+                property string installationId
+
+                id: unpairDeviceDialog
+                destroyOnClose: true
+                headerSettings.title: qsTr("Unpair Device")
+                confirmationText: qsTr("Are you sure you want to unpair this device?")
+                confirmButtonLabel: qsTr("Unpair")
+                onConfirmButtonClicked: {
+                    const error = devicesStore.devicesModule.unpairDevice(installationId)
+                    if (error) {
+                        unpairDeviceDialog.confirmationText = qsTr("Error unpairing device: %1").arg(error)
+                    } else {
+                        Global.closePopup()
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### What does the PR do

Fixes #18399

The backend functionality already existed, we just needed to hook it. When Unpair is clicked, we no longer send messages to that installation. when Pair is clicked, we send them again

### Affected areas

Syncing View and Devices module/service

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[pairing-and-unpairing.webm](https://github.com/user-attachments/assets/d1346ad3-fab4-4358-bc85-132da832a783)

### Impact on end user

Enables the user to pair and unpair a device form the Syncing menu (if the device was already paired before)

### How to test

- Pair two devices using the normal onboarding method
- Go to settings > Syncing
- Click Unpair and confirm
- See that 1-1 messages no longer show for yourself

### Risk 

None. It's a new feature that doesn't touch other modules
