### PR TITLE
fix(@desktop/wallet): [Mobile] CTA for “Ways to Buy / Receive Assets” Is Clipped on Mobile

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/BuyReceiveBanner.qml
+++ b/ui/app/AppLayouts/Wallet/panels/BuyReceiveBanner.qml
@@ -29,8 +29,8 @@ Control {
             objectName: "buyCard"
             Layout.fillWidth: true
             Layout.preferredWidth: root.buyEnabled ? layout.width / layout.children.length : 0
-            title: qsTr("Ways to buy assets")
-            subTitle: qsTr("Via card or bank transfer")
+            title: qsTr("Ways to buy")
+            subTitle: qsTr("Via card or bank")
             image: Theme.png("wallet/wallet-green")
             closeEnabled: root.closeEnabled
             visible: Layout.preferredWidth > 0
@@ -51,8 +51,8 @@ Control {
             objectName: "receiveCard"
             Layout.fillWidth: true
             Layout.preferredWidth: root.receiveEnabled ? layout.width / layout.children.length : 0
-            title: qsTr("Receive assets")
-            subTitle: qsTr("Deposit to your Wallet address")
+            title: qsTr("Receive")
+            subTitle: qsTr("Deposit to your Wallet")
             image: Theme.png("wallet/flying-coin")
             closeEnabled: root.closeEnabled
             visible: Layout.preferredWidth > 0


### PR DESCRIPTION
fixes #18197

### What does the PR do

Thus simple PR simply uses the same text as defined in the Mobile designs which makes it look good even on mobile devices.

### Affected areas

Wallet CTA

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Desktop:
<img width="2056" height="1237" alt="Screenshot 2025-07-22 at 15 05 52" src="https://github.com/user-attachments/assets/6202ebfa-4923-4437-a0b8-120f1bcb537f" />

iOS:
<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/e3dbd448-c406-4c32-8fc3-464f271f162e" />


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
