### PR TITLE
chore(@e2e): fix toast messages method and seed phrase import

### DIFF
--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -217,6 +217,7 @@ class OnboardingImportSeedPhraseView(QObject):
                 driver.type(self.seed_phrase_input_text_edit.object, "<Return>")
             else:
                 self.seed_phrase_input_text_edit.text = word
+                time.sleep(0.2)
 
     def continue_import(self):
         self.continue_button.click()

--- a/test/e2e/gui/screens/settings_wallet.py
+++ b/test/e2e/gui/screens/settings_wallet.py
@@ -144,9 +144,9 @@ class WalletSettingsView(QObject):
         return RenameKeypairPopup().wait_until_appears()
 
 
-class AccountDetailsView(WalletSettingsView):
+class AccountDetailsView(QObject):
     def __init__(self):
-        super().__init__()
+        super().__init__(settings_names.settingsWallet_View)
         self._back_button = Button(settings_names.main_toolBar_back_button)
         self._edit_account_button = Button(settings_names.walletAccountViewEditAccountButton)
         self._remove_account_button = Button(settings_names.walletAccountViewRemoveAccountButton)

--- a/test/e2e/tests/communities/test_communities_kick_ban.py
+++ b/test/e2e/tests/communities/test_communities_kick_ban.py
@@ -91,7 +91,7 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             members.ban_member(user_one.name).confirm_banning()
 
         with step('Check toast message about banned member'):
-            toast_messages = main_screen.wait_for_notification()
+            toast_messages = main_screen.wait_for_toast_notifications()
             assert user_one.name + ToastMessages.BANNED_USER_TOAST.value + community.name in toast_messages, \
                 f"{user_one.name + ToastMessages.BANNED_USER_TOAST.value + community.name} is not found in {toast_messages}"
 
@@ -119,7 +119,7 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             aut_two.attach()
             main_screen.prepare()
             members.unban_member(user_one.name)
-            toast_messages = main_screen.wait_for_notification()
+            toast_messages = main_screen.wait_for_toast_notifications()
             assert user_one.name + ToastMessages.UNBANNED_USER_TOAST.value + community.name in toast_messages, \
                 f"{user_one.name + ToastMessages.UNBANNED_USER_TOAST.value + community.name} is not found in {toast_messages}"
             main_screen.hide()
@@ -129,7 +129,7 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             main_screen.prepare()
             chat1 = messages_view.left_panel.click_chat_by_name(user_two.name)
             community_screen = chat1.open_banned_community(community.name, 0)
-            toast_messages = main_screen.wait_for_notification()
+            toast_messages = main_screen.wait_for_toast_notifications()
             assert ToastMessages.UNBANNED_USER_CONFIRM.value + community.name in toast_messages, \
                 f"{ToastMessages.UNBANNED_USER_CONFIRM.value} is not present in {toast_messages}"
             main_screen.left_panel.open_community_context_menu(community.name).leave_community_option.click()
@@ -152,7 +152,7 @@ def test_community_admin_ban_kick_member_and_delete_message(multiple_instances):
             kick_popup.confirm_kicking()
 
         with step('Check toast message about kicked member'):
-            toast_messages = main_screen.wait_for_notification()
+            toast_messages = main_screen.wait_for_toast_notifications()
             assert user_one.name + ToastMessages.KICKED_USER_TOAST.value + community.name in toast_messages, \
                 f"{user_one.name + ToastMessages.KICKED_USER_TOAST.value} is not found in  {toast_messages}"
 

--- a/test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
@@ -77,7 +77,7 @@ def test_delete_generated_account_from_wallet_settings(
         delete_confirmation_popup.remove_account_with_confirmation()
 
     with step('Verify toast message notification when removing account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{account_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/test/e2e/tests/crtitical_tests_prs/test_add_edit_restart_add_delete_generated_account.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_edit_restart_add_delete_generated_account.py
@@ -43,7 +43,7 @@ def test_add_edit_restart_add_delete_generated_account(aut: AUT, main_screen: Ma
             account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{name1}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -74,7 +74,7 @@ def test_add_edit_restart_add_delete_generated_account(aut: AUT, main_screen: Ma
             account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{name2}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -85,7 +85,7 @@ def test_add_edit_restart_add_delete_generated_account(aut: AUT, main_screen: Ma
         wallet.left_panel.delete_account_from_context_menu(new_name).remove_account_with_confirmation()
 
     with step('Verify toast message notification when removing account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/test/e2e/tests/crtitical_tests_prs/test_community_permissions_add_edit_delete_duplicate.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_community_permissions_add_edit_delete_duplicate.py
@@ -40,7 +40,7 @@ def test_add_edit_remove_duplicate_permissions(main_screen: MainWindow):
         permissions_settings.create_permission()
 
     with step('Check toast message for permission creation'):
-        toast_messages = main_screen.wait_for_notification()
+        toast_messages = main_screen.wait_for_toast_notifications()
         message = toast_messages[0]
         assert ToastMessages.CREATE_PERMISSION_TOAST.value in toast_messages, \
             f"Toast message is incorrect, current message is {message}"
@@ -99,7 +99,7 @@ def test_add_edit_remove_duplicate_permissions(main_screen: MainWindow):
                                   configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     with step('Check toast message for edited permission'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert ToastMessages.UPDATE_PERMISSION_TOAST.value in messages, \
             f"Toast message is incorrect, current message is {message}"
 
@@ -111,7 +111,7 @@ def test_add_edit_remove_duplicate_permissions(main_screen: MainWindow):
         assert driver.waitFor(lambda: PermissionsIntroView().is_visible)
 
     with step('Check toast message for deleted permission'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert ToastMessages.DELETE_PERMISSION_TOAST.value in messages, \
             f"Toast message is incorrect, current message is {message}"
 

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
@@ -32,7 +32,6 @@ def test_import_and_reimport_random_seed(
             import_seed_and_log_in(create_your_profile_view, seed_phrase, user_account)
 
     with step('Verify that restored account reveals correct status wallet address'):
-        left_panel = MainLeftPanel()
         profile = main_window.home.open_from_dock(DockButtons.SETTINGS.value).left_panel.open_profile_settings()
         profile.set_name(user_account.name)
         profile.save_changes_button.click()

--- a/test/e2e/tests/crtitical_tests_prs/test_wallet_settings_saved_addresses_add.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_wallet_settings_saved_addresses_add.py
@@ -39,7 +39,7 @@ def test_wallet_settings_add_saved_address(main_screen: MainWindow, address: str
             configs.timeouts.LOADING_LIST_TIMEOUT_MSEC), f'Address: {name} not found'
 
     with step('Verify toast message when adding saved address'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'{name} successfully added to your saved addresses' in messages, \
             f"Toast message about adding saved address is not correct or not present. \
                 Current list of messages: {messages}"

--- a/test/e2e/tests/settings/settings_messaging/test_block_unblock_user.py
+++ b/test/e2e/tests/settings/settings_messaging/test_block_unblock_user.py
@@ -75,7 +75,7 @@ def test_block_and_unblock_user_from_settings_and_profile(multiple_instances):
             block_popup.block_user_button.click()
 
         with step('Check toast message about blocked member'):
-            toast_messages = main_screen.wait_for_notification()
+            toast_messages = main_screen.wait_for_toast_notifications()
             message_1 = ToastMessages.REMOVED_CONTACT_TOAST.value
             message_2 = user_two.name + ToastMessages.BLOCKED_USER_TOAST.value
             assert driver.waitFor(lambda: message_1 in toast_messages,
@@ -109,7 +109,7 @@ def test_block_and_unblock_user_from_settings_and_profile(multiple_instances):
             unblock_popup.unblock_user_button.click()
 
         with step('Check toast message about unblocked member'):
-            toast_messages = main_screen.wait_for_notification()
+            toast_messages = main_screen.wait_for_toast_notifications()
             message_2 = user_two.name + ToastMessages.UNBLOCKED_USER_TOAST.value
             assert driver.waitFor(lambda: message_2 in toast_messages,
                                   timeout), f"Toast message {message_2} is incorrect, current message is {toast_messages}"

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_rename_keypair.py
@@ -65,6 +65,6 @@ def test_rename_keypair_test(main_screen: MainWindow, user_account, emoji: str, 
         assert pk_new_name in settings.get_keypairs_names()
 
     with step('Verify toast message with successful renaming appears'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert WalletRenameKeypair.WALLET_SUCCESSFUL_RENAMING.value + 'from "' + pk_name + '" to "' + pk_new_name + '"' in messages, \
             f"Toast message have not appeared"

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_acct_interactions_edit_status_account.py
@@ -7,7 +7,8 @@ import pytest
 from allure_commons._allure import step
 
 from constants.wallet import WalletNetworkSettings, WalletAccountSettings, DerivationPathValue
-from gui.main_window import MainWindow
+from gui.main_window import MainWindow, MainLeftPanel
+from gui.screens.settings_wallet import AccountDetailsView
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704433',
@@ -33,7 +34,7 @@ def test_settings_edit_status_account(main_screen: MainWindow, new_name):
 
     with step('Open Status account view in wallet settings'):
         status_account_index = 0
-        status_acc_view = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_account_in_settings('Account 1', status_account_index)
+        status_acc_view = main_screen.left_panel.open_settings().left_panel.open_wallet_settings().open_account_in_settings(WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value, status_account_index)
 
     with step('Check the default values on the account details view for main account'):
         assert status_acc_view.get_account_name_value() == WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value, \
@@ -53,13 +54,13 @@ def test_settings_edit_status_account(main_screen: MainWindow, new_name):
         edit_acc_pop_up.edit_account(new_name)
 
     with step('Make sure Delete button is not present for Status account'):
-        time.sleep(2)  # to allow the UI to refresh
         assert not status_acc_view._remove_account_button.is_visible, \
             f"Delete button should not be present for Status account"
 
     with step('Check the new values appear on account details view for  main account'):
-        account_emoji_id_after = status_acc_view.get_account_emoji_id()
-        assert status_acc_view.get_account_name_value() == new_name, f"Account name has not been changed"
+        new_screen = AccountDetailsView().wait_until_appears()
+        account_emoji_id_after = new_screen.get_account_emoji_id()
+        assert new_screen.get_account_name_value() == new_name, f"Account name has not been changed"
         assert account_emoji_id_before != account_emoji_id_after, f"Account emoji has not been changed"
         current_color = status_acc_view.get_account_color_value()
         assert WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_COLOR.value != current_color, \

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_add_account.py
@@ -44,7 +44,7 @@ def test_add_new_account_from_wallet_settings(
             add_account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_networks_edit_network.py
@@ -66,15 +66,15 @@ def test_settings_networks_edit_restore_defaults(main_screen: MainWindow, networ
 
     with step('Verify toast message appears for reverting to defaults'):
         if network_tab == WalletNetworkSettings.EDIT_NETWORK_LIVE_TAB.value:
-            assert len(main_screen.wait_for_notification()) == 1, \
+            assert len(main_screen.wait_for_toast_notifications()) == 1, \
                 f"Multiple toast messages appeared"
-            message = main_screen.wait_for_notification()[0]
+            message = main_screen.wait_for_toast_notifications()[0]
             assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_LIVE_MAINNET_TOAST_MESSAGE.value, \
                 f"Toast message is incorrect, current message is {message}"
         elif network_tab == WalletNetworkSettings.EDIT_NETWORK_TEST_TAB.value:
-            assert len(main_screen.wait_for_notification()) == 1, \
+            assert len(main_screen.wait_for_toast_notifications()) == 1, \
                 f"Multiple toast messages appeared"
-            message = main_screen.wait_for_notification()[0]
+            message = main_screen.wait_for_toast_notifications()[0]
             assert message == WalletNetworkSettings.REVERT_TO_DEFAULT_TEST_MAINNET_TOAST_MESSAGE.value, \
                 f"Toast message is incorrect, current message is {message}"
 

--- a/test/e2e/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
+++ b/test/e2e/tests/settings/settings_wallet/test_wallet_settings_networks_testnet_mode.py
@@ -30,9 +30,9 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().turn_on_button.click()
 
     with step('Verify that Testnet mode turned on'):
-        assert len(main_screen.wait_for_notification()) == 1, \
+        assert len(main_screen.wait_for_toast_notifications()) == 1, \
             f"Multiple toast messages appeared"
-        message = main_screen.wait_for_notification()[0]
+        message = main_screen.wait_for_toast_notifications()[0]
         assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
@@ -52,8 +52,8 @@ def test_switch_testnet_mode(main_screen: MainWindow):
         networks.switch_testnet_mode_toggle().turn_off_button.click()
 
     with step('Verify that Testnet mode turned off'):
-        assert len(main_screen.wait_for_notification()) == 2
-        message = main_screen.wait_for_notification()[1]
+        assert len(main_screen.wait_for_toast_notifications()) == 2
+        message = main_screen.wait_for_toast_notifications()[1]
         assert message == WalletNetworkSettings.TESTNET_DISABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:
@@ -107,9 +107,9 @@ def test_switch_testnet_off_by_toggle_and_cancel_in_confirmation(main_screen: Ma
         testnet_modal.turn_on_button.click()
 
     with step('Verify testnet mode is enabled'):
-        assert len(main_screen.wait_for_notification()) == 1, \
+        assert len(main_screen.wait_for_toast_notifications()) == 1, \
             f"Multiple toast messages appeared"
-        message = main_screen.wait_for_notification()[0]
+        message = main_screen.wait_for_toast_notifications()[0]
         assert message == WalletNetworkSettings.TESTNET_ENABLED_TOAST_MESSAGE.value, \
             f"Toast message is incorrect, current message is {message}"
         if not configs.system.TEST_MODE and not configs._local.DEV_BUILD:

--- a/test/e2e/tests/transactions_tests/test_buy_ens_name_in_settings.py
+++ b/test/e2e/tests/transactions_tests/test_buy_ens_name_in_settings.py
@@ -61,7 +61,7 @@ def test_ens_name_purchase(main_window, user_account, ens_name):
 
     with step('Verify toast message with Transaction pending appears'):
         assert WalletTransactions.ENS_TRANSACTION_REGISTERING_TOAST_MESSAGE.value in ' '.join(
-            main_window.wait_for_notification())
+            main_window.wait_for_toast_notifications())
 
     with step('Verify username registered view appears'):
         ENSRegisteredView().wait_until_appears()

--- a/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
+++ b/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
@@ -70,7 +70,7 @@ def test_mint_owner_and_tokenmaster_tokens(main_window, user_account):
         minted_tokens_view = MintedTokensView()
 
     with step('Verify toast messages about started minting process appears'):
-        toast_messages = main_window.wait_for_notification()
+        toast_messages = main_window.wait_for_toast_notifications()
         assert f'Minting Owner-{community.name} and TMaster-{community.name} tokens for {community.name} using Account 1' in toast_messages
 
     with step('Verify that status of both tokens'):

--- a/test/e2e/tests/transactions_tests/test_wallet_send_eth.py
+++ b/test/e2e/tests/transactions_tests/test_wallet_send_eth.py
@@ -50,4 +50,4 @@ def test_wallet_send_0_eth(main_window, user_account, receiver_account_address, 
         authenticate_with_password(user_account)
 
     assert f'Sending {amount} ETH from {WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value} to {receiver_account_address[:6]}' in ' '.join(
-        main_window.wait_for_notification()).replace('×', 'x')
+        main_window.wait_for_toast_notifications()).replace('×', 'x')

--- a/test/e2e/tests/transactions_tests/test_wallet_send_nft.py
+++ b/test/e2e/tests/transactions_tests/test_wallet_send_nft.py
@@ -44,4 +44,4 @@ def test_wallet_send_nft(main_window, user_account, receiver_account_address, am
         authenticate_with_password(user_account)
 
     assert WalletTransactions.TRANSACTION_SENDING_TOAST_MESSAGE.value in ' '.join(
-        main_window.wait_for_notification())
+        main_window.wait_for_toast_notifications())

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_add_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_add_watched_address.py
@@ -33,7 +33,7 @@ def test_plus_button_add_watched_address(main_screen: MainWindow, address: str):
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added'in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_added_for_new_generated_seed.py
@@ -28,7 +28,7 @@ def test_plus_button_manage_account_added_for_new_seed(main_screen: MainWindow, 
             account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_private_key.py
@@ -28,7 +28,7 @@ def test_plus_button_manage_account_from_private_key(main_screen: MainWindow, us
             account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):
@@ -60,7 +60,7 @@ def test_plus_button_manage_account_from_private_key(main_screen: MainWindow, us
         wallet.left_panel.delete_account_from_context_menu(new_name).remove_account_with_confirmation()
 
     with step('Verify toast message notification when removing account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_account_from_seed_phrase.py
@@ -32,7 +32,7 @@ def test_plus_button_manage_account_from_seed_phrase(main_screen: MainWindow, us
             account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - plus button/test_plus_button_manage_generated_account_custom_derivation_path.py
@@ -25,7 +25,7 @@ def test_plus_button_manage_generated_account_custom_derivation_path(main_screen
             user_account.password).save_changes()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added' in messages
 
     with step('Verify that the account is correctly displayed in accounts list'):

--- a/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - right click out of account area/test_right_click_manage_watched_address.py
@@ -27,7 +27,7 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
         account_popup.wait_until_hidden()
 
     with step('Verify toast message notification when adding account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{wallet_account.name}" successfully added' in messages, \
             f"Toast message about adding account is not correct or not present. Current list of messages: {messages}"
 
@@ -46,7 +46,7 @@ def test_right_click_manage_watch_only_account_context_menu(main_screen: MainWin
         wallet.left_panel.delete_account_from_context_menu(new_name).remove_button.click()
 
     with step('Verify toast message notification when removing account'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'"{new_name}" successfully removed' in messages, \
             f"Toast message about account removal is not correct or not present. Current list of messages: {messages}"
 

--- a/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
+++ b/test/e2e/tests/wallet_main_screen/wallet - saved addresses/test_saved_addresses.py
@@ -29,7 +29,7 @@ def test_manage_saved_address(main_screen: MainWindow, address: str):
             configs.timeouts.LOADING_LIST_TIMEOUT_MSEC), f'Address: {name} not found'
 
     with step('Verify toast message when adding saved address'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'{name} successfully added to your saved addresses' in messages, \
             f"Toast message about adding saved address is not correct or not present. Current list of messages: {messages}"
 
@@ -42,7 +42,7 @@ def test_manage_saved_address(main_screen: MainWindow, address: str):
             10000), f'Address: {new_name} is not present when it should be'
 
     with step('Verify toast message when editing saved address'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'{new_name} saved address successfully edited' in messages, \
             f"Toast message about editing saved address is not correct or not present. Current list of messages: {messages}"
 
@@ -50,7 +50,7 @@ def test_manage_saved_address(main_screen: MainWindow, address: str):
         cofirmation = wallet.left_panel.open_saved_addresses().delete_saved_address(new_name)
 
     with step('Verify toast message when deleting saved address'):
-        messages = main_screen.wait_for_notification()
+        messages = main_screen.wait_for_toast_notifications()
         assert f'{new_name} was successfully removed from your saved addresses' in messages, \
             f"Toast message about deleting saved address is not correct or not present. Current list of messages: {messages}"
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18406
Fixes https://github.com/status-im/status-desktop/issues/18255

Noticed, that method for toast messages exits as soon as it gets the very first toast message, got it fixed. Also, i have no idea why import seed button could be disabled from time to time, but i added short time sleep when entering words into the form, its good anyway