### PR TITLE
chore(@e2e): retry decorator logic

### DIFF
--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -52,16 +52,16 @@ class MainLeftPanel(QObject):
         raise Exception(f"Failed to open {screen_class.__name__} after {attempts} attempts")
 
     @allure.step('Click Home button and open Home screen')
-    def open_home_screen(self, attempts: int = 2) -> 'HomeScreen':
-        return self._open_screen_from_left_nav(self.home_button, HomeScreen, attempts)
+    def open_home_screen(self) -> 'HomeScreen':
+        return self._open_screen_from_left_nav(self.home_button, HomeScreen)
 
     @allure.step('Click Chat button and open Messages screen')
     def open_messages_screen(self, attempts: int = 2) -> 'MessagesScreen':
         return self._open_screen_from_left_nav(self.messages_button, MessagesScreen, attempts)
 
     @allure.step('Click Gear button and open Settings screen')
-    def open_settings(self, attempts: int = 2) -> 'SettingsScreen':
-        return self._open_screen_from_left_nav(self.settings_button, SettingsScreen, attempts)
+    def open_settings(self) -> 'SettingsScreen':
+        return self._open_screen_from_left_nav(self.settings_button, SettingsScreen)
 
     @allure.step('Click Wallet button and open Wallet main screen')
     def open_wallet(self, attempts: int = 2) -> 'WalletScreen':

--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -26,7 +26,7 @@ settingsWalletOption = {"container": mainWindow_settingsList_SettingsList, "obje
 settingsSignOutQuitOption = {"container": LeftTabProfileMenu, "objectName": "17-ExtraMenuItem", "type": "StatusNavigationListItem", "visible": True}
 
 # Communities View
-mainWindow_CommunitiesView = {"container": statusDesktop_mainWindow, "type": "CommunitiesView", "unnamed": 1, "visible": True}
+mainWindow_CommunitiesView = {"container": statusDesktop_mainWindow, "id": "communitiesView", "type": "Loader", "unnamed": 1}
 mainWindow_settingsContentBaseScrollView_StatusScrollView = {"container": mainWindow_CommunitiesView, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
 settingsContentBaseScrollView_listItem_StatusListItem = {"container": mainWindow_settingsContentBaseScrollView_StatusScrollView, "id": "listItem", "type": "StatusListItem", "unnamed": 1, "visible": True}
 

--- a/test/e2e/gui/screens/settings.py
+++ b/test/e2e/gui/screens/settings.py
@@ -35,57 +35,57 @@ class SettingsLeftPanel(QObject):
 
     @allure.step('Choose back up seed phrase in settings')
     @retry_settings(BackUpYourSeedPhrasePopUp, '18-MenuItem')
-    def open_back_up_seed_phrase(self, click_attempts: int = 2) -> 'BackUpYourSeedPhrasePopUp':
+    def open_back_up_seed_phrase(self) -> 'BackUpYourSeedPhrasePopUp':
         return BackUpYourSeedPhrasePopUp().wait_until_appears()
 
     @allure.step('Open wallet settings')
     @retry_settings(WalletSettingsView, '5-MenuItem')
-    def open_wallet_settings(self, click_attempts: int = 2) -> 'WalletSettingsView':
+    def open_wallet_settings(self) -> 'WalletSettingsView':
         return WalletSettingsView().wait_until_appears()
 
     @allure.step('Open messaging settings')
     @retry_settings(MessagingSettingsView, '4-MenuItem')
-    def open_messaging_settings(self, click_attempts: int = 2) -> 'MessagingSettingsView':
+    def open_messaging_settings(self) -> 'MessagingSettingsView':
         return MessagingSettingsView().wait_until_appears()
 
     @allure.step('Open communities settings')
     @retry_settings(CommunitiesSettingsView, '12-MenuItem')
-    def open_communities_settings(self, attempts: int = 2) -> 'CommunitiesSettingsView':
+    def open_communities_settings(self) -> 'CommunitiesSettingsView':
         return CommunitiesSettingsView().wait_until_appears()
 
     @allure.step('Open profile settings')
     @retry_settings(ProfileSettingsView, '0-MenuItem')
-    def open_profile_settings(self, click_attempts: int = 2) -> 'ProfileSettingsView':
+    def open_profile_settings(self) -> 'ProfileSettingsView':
         return ProfileSettingsView().wait_until_appears()
 
     @allure.step('Open password settings')
     @retry_settings(ChangePasswordView, '1-MenuItem')
-    def open_password_settings(self, click_attempts: int = 2) -> 'ChangePasswordView':
+    def open_password_settings(self) -> 'ChangePasswordView':
         return ChangePasswordView().wait_until_appears()
 
     @allure.step('Open syncing settings')
     @retry_settings(SyncingSettingsView, '9-MenuItem')
-    def open_syncing_settings(self, click_attempts: int = 2) -> 'SyncingSettingsView':
+    def open_syncing_settings(self) -> 'SyncingSettingsView':
         return SyncingSettingsView().wait_until_appears()
 
     @allure.step('Choose sign out and quit in settings')
     @retry_settings(SignOutPopup, '17-MenuItem')
-    def open_sign_out_and_quit(self, click_attempts: int = 2) -> 'SignOutPopup':
+    def open_sign_out_and_quit(self) -> 'SignOutPopup':
         return SignOutPopup().wait_until_appears()
 
     @allure.step('Open keycard settings')
     @retry_settings(KeycardSettingsView, '13-MenuItem')
-    def open_keycard_settings(self, click_attempts: int = 2) -> 'KeycardSettingsView':
+    def open_keycard_settings(self) -> 'KeycardSettingsView':
         return KeycardSettingsView().wait_until_appears()
 
     @allure.step('Open ENS usernames settings')
     @retry_settings(ENSSettingsView, '3-MenuItem')
-    def open_ens_usernames_settings(self, click_attempts: int = 2) -> 'ENSSettingsView':
+    def open_ens_usernames_settings(self) -> 'ENSSettingsView':
         return ENSSettingsView().wait_until_appears()
 
     @allure.step('Open advanced settings')
     @retry_settings(AdvancedSettingsView, '10-MenuItem')
-    def open_advanced_settings(self, click_attempts: int = 2) -> 'AdvancedSettingsView':
+    def open_advanced_settings(self) -> 'AdvancedSettingsView':
         return AdvancedSettingsView().wait_until_appears()
 
 

--- a/test/e2e/scripts/utils/generators.py
+++ b/test/e2e/scripts/utils/generators.py
@@ -28,6 +28,10 @@ def random_ens_string():
         random.choices(string.digits + string.ascii_lowercase, k=8))
 
 
+def random_network():
+    return random.choice(['Arbitrum Sepolia', 'Optimism Sepolia', 'Base Sepolia', 'Status Network Sepolia'])
+
+
 def random_community_name():
     return ''.join(random.choices(string.ascii_letters +
                                   string.digits, k=30))

--- a/test/e2e/tests/crtitical_tests_prs/test_create_edit_join_community_pin_unpin_message.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_create_edit_join_community_pin_unpin_message.py
@@ -119,18 +119,20 @@ def test_create_edit_join_community_pin_unpin_message(multiple_instances):
                 community_setting.left_panel.back_to_community()
                 assert community_screen.left_panel.name == new_name
 
-            with step('Verify community parameters in community settings screen'):
-                settings_screen = main_screen.left_panel.open_settings()
-                community_settings = settings_screen.left_panel.open_communities_settings()
-                community_info = community_settings.communities[0]
-                assert community_info.name == new_name
-                assert community_info.description == new_description
-                assert '1' in community_info.members
+            # TODO: https://github.com/status-im/status-desktop/issues/18417
+
+            # with step('Verify community parameters in community settings screen'):
+            #     settings_screen = main_screen.left_panel.open_settings()
+            #     community_settings = settings_screen.left_panel.open_communities_settings()
+            #     community_info = community_settings.communities[0]
+            #     assert community_info.name == new_name
+            #     assert community_info.description == new_description
+            #     assert '1' in community_info.members
 
             assert new_name in main_screen.left_panel.communities(), \
                 f'Community {new_name} should be present in the list of communities but it is not'
             context_menu = main_screen.left_panel.open_community_context_menu(new_name)
-            # assert not context_menu.leave_community_option.is_visible, f'Leave option should not be present'
+            assert not context_menu.leave_community_option.is_visible, f'Leave option should not be present'
             main_screen.left_panel.click()
 
             with step(f'Invite {user_one.name}'):

--- a/test/e2e/tests/crtitical_tests_prs/test_create_edit_join_community_pin_unpin_message.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_create_edit_join_community_pin_unpin_message.py
@@ -121,13 +121,13 @@ def test_create_edit_join_community_pin_unpin_message(multiple_instances):
 
             # TODO: https://github.com/status-im/status-desktop/issues/18417
 
-            # with step('Verify community parameters in community settings screen'):
-            #     settings_screen = main_screen.left_panel.open_settings()
-            #     community_settings = settings_screen.left_panel.open_communities_settings()
-            #     community_info = community_settings.communities[0]
-            #     assert community_info.name == new_name
-            #     assert community_info.description == new_description
-            #     assert '1' in community_info.members
+            with step('Verify community parameters in community settings screen'):
+                settings_screen = main_screen.left_panel.open_settings()
+                community_settings = settings_screen.left_panel.open_communities_settings()
+                community_info = community_settings.communities[0]
+                assert community_info.name == new_name
+                assert community_info.description == new_description
+                assert '1' in community_info.members
 
             assert new_name in main_screen.left_panel.communities(), \
                 f'Community {new_name} should be present in the list of communities but it is not'

--- a/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
+++ b/test/e2e/tests/transactions_tests/test_mint_owner_and_tokenmaster_tokens.py
@@ -13,12 +13,14 @@ from helpers.onboarding_helper import open_create_profile_view, import_seed_and_
 from helpers.settings_helper import enable_testnet_mode, enable_managing_communities_toggle
 from constants.community import MintOwnerTokensElements
 from gui.screens.community_settings_tokens import MintedTokensView
+from scripts.utils.generators import random_network
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/727245', 'Mint owner token')
 @pytest.mark.case(727245)
 @pytest.mark.transaction
-def test_mint_owner_and_tokenmaster_tokens(main_window, user_account):
+@pytest.mark.parametrize('network_name', [pytest.param(random_network())])
+def test_mint_owner_and_tokenmaster_tokens(main_window, user_account, network_name):
 
     user_account = ReturningUser(
         seed_phrase=WALLET_SEED,
@@ -50,7 +52,6 @@ def test_mint_owner_and_tokenmaster_tokens(main_window, user_account):
 
     with step('Select network'):
         # no Sepolia L1 because of high gas prices
-        network_name = random.choice(['Arbitrum Sepolia', 'Optimism Sepolia', 'Base Sepolia', 'Status Network Sepolia'])
         edit_owner_token_view.select_network(network_name)
 
     with step('Verify fees title and gas fees exist'):

--- a/test/e2e/tests/transactions_tests/test_wallet_send_eth.py
+++ b/test/e2e/tests/transactions_tests/test_wallet_send_eth.py
@@ -10,6 +10,7 @@ from constants.wallet import WalletAddress, WalletNetworkSettings
 from helpers.onboarding_helper import open_create_profile_view, import_seed_and_log_in
 from helpers.settings_helper import enable_testnet_mode
 from helpers.wallet_helper import authenticate_with_password, open_send_modal_for_account
+from scripts.utils.generators import random_network
 
 
 @allure.testcase('https://ethstatus.testrail.net/index.php?/cases/view/704527',
@@ -20,7 +21,8 @@ from helpers.wallet_helper import authenticate_with_password, open_send_modal_fo
 @pytest.mark.parametrize('receiver_account_address, amount, asset, collectible', [
     pytest.param(WalletAddress.RECEIVER_ADDRESS.value, '0', 'ETH', '')
 ])
-def test_wallet_send_0_eth(main_window, user_account, receiver_account_address, amount, asset, collectible):
+@pytest.mark.parametrize('network_name', [pytest.param(random_network())])
+def test_wallet_send_0_eth(main_window, user_account, receiver_account_address, amount, asset, collectible, network_name):
 
     user_account = ReturningUser(
         seed_phrase=WALLET_SEED,
@@ -40,7 +42,6 @@ def test_wallet_send_0_eth(main_window, user_account, receiver_account_address, 
             main_window, account_name=WalletNetworkSettings.STATUS_ACCOUNT_DEFAULT_NAME.value)
 
     with step('Select network'):
-        network_name = random.choice(['Arbitrum Sepolia', 'Optimism Sepolia', 'Base Sepolia', 'Status Network Sepolia'])
         send_popup.select_network(network_name)
 
     with step('Sign and send transaction to blockchain'):

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -454,6 +454,8 @@ StatusSectionLayout {
         }
 
         Loader {
+            id: communitiesView
+            
             active: false
             asynchronous: true
             Layout.fillWidth: true


### PR DESCRIPTION
### What does the PR do

- improve the logic of retry decorator. Fixes https://github.com/status-im/status-desktop/issues/18413
- move the network selection to params of the tests, so it is more clear which network is selected for certain test