### PR TITLE
Fix banner member screen and invite friends popup filtering

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -204,6 +204,7 @@ method getCommunityItem(self: Module, community: CommunityDto): SectionItem =
       community.canManageUsers,
       community.canRequestAccess,
       community.isMember,
+      isBanned = false,
       community.permissions.access,
       community.permissions.ensOnly,
       community.muted,

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -591,12 +591,6 @@ QtObject:
   proc emitCommunityInfoRequestCompleted*(self: View, communityId: string, errorMsg: string) =
     self.communityInfoRequestCompleted(communityId, errorMsg)
 
-  proc isMemberOfCommunity*(self: View, communityId: string, pubKey: string): bool {.slot.} =
-    let sectionItem = self.model.getItemById(communityId)
-    if (section_item.id == ""):
-       return false
-    return sectionItem.hasMember(pubKey)
-
   proc removeFileListItem*(self: View, filePath: string) {.slot.} =
     var path = filePath
     if path.startsWith("file://"):

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -557,12 +557,6 @@ QtObject:
       if not found:
         result.add(pubkey)
 
-  proc isUserBanned*(self: Model, pubkey: string): bool = 
-    let ind = self.findIndexForMember(pubkey)
-    if ind == -1:
-      return false
-    return self.getMemberItemByIndex(ind).membershipRequestState == MembershipRequestState.Banned
-
   proc createMemberItemFromDtos*(
       contactDetails: ContactDetails,
       status: OnlineStatus,

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -208,6 +208,10 @@ QtObject:
     if ind != -1:
       return self.items[ind]
 
+  proc hasMember*(self: Model, pubKey: string): bool {.slot.} =
+    let ind = self.findIndexForMember(pubKey)
+    return ind != -1
+
   proc removeItemWithIndex(self: Model, index: int) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete

--- a/src/app/modules/shared_models/model_utils.nim
+++ b/src/app/modules/shared_models/model_utils.nim
@@ -3,7 +3,7 @@ import std/macros
 # Macro that simplifies checking and updating values in a model
 # IMPORTANT:
   # The model's items need to be in a `seq` called `items`
-  # A `seq[string]` named `roles` needs to exist
+  # A `seq[int]` named `roles` needs to exist
   # The index of the item being checked must be named `ind`
 macro updateRole*(propertyName: untyped, roleName: untyped): untyped =
   quote do:

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -3,8 +3,6 @@ import ./member_model, ./member_item
 import ../main/communities/tokens/models/token_model as community_tokens_model
 import ../main/communities/tokens/models/token_item
 
-import ../../global/global_singleton
-
 import ../../../app_service/common/types
 import ../../../app_service/service/community_tokens/community_collectible_owner
 
@@ -41,6 +39,7 @@ type
     active: bool
     enabled: bool
     isMember: bool
+    isBanned: bool
     joined: bool
     canJoin: bool
     spectated: bool
@@ -87,6 +86,7 @@ proc initSectionItem*(
     canManageUsers = false,
     canRequestAccess = false,
     isMember = false,
+    isBanned = false,
     access: int = 0,
     ensOnly = false,
     muted = false,
@@ -125,6 +125,7 @@ proc initSectionItem*(
   result.canManageUsers = canManageUsers
   result.canRequestAccess = canRequestAccess
   result.isMember = isMember
+  result.isBanned = isBanned
   result.access = access
   result.ensOnly = ensOnly
   result.muted = muted
@@ -172,6 +173,7 @@ proc `$`*(self: SectionItem): string =
     canManageUsers:{self.canManageUsers},
     canRequestAccess:{self.canRequestAccess},
     isMember:{self.isMember},
+    isBanned:{self.isBanned},
     access:{self.access},
     ensOnly:{self.ensOnly},
     muted:{self.muted},
@@ -324,6 +326,12 @@ proc isMember*(self: SectionItem): bool {.inline.} =
 proc `isMember=`*(self: var SectionItem, value: bool) {.inline.} =
   self.isMember = value
 
+proc isBanned*(self: SectionItem): bool {.inline.} =
+  self.isBanned
+
+proc `isBanned=`*(self: var SectionItem, value: bool) {.inline.} =
+  self.isBanned = value
+
 proc access*(self: SectionItem): int {.inline.} =
   self.access
 
@@ -356,9 +364,6 @@ proc hasMember*(self: SectionItem, pubkey: string): bool =
 
 proc setOnlineStatusForMember*(self: SectionItem, pubKey: string, onlineStatus: OnlineStatus) =
   self.membersModel.setOnlineStatus(pubkey, onlineStatus)
-
-proc amIBanned*(self: SectionItem): bool {.inline.} =
-  return self.membersModel.isUserBanned(singletonInstance.userProfile.getPubKey())
 
 proc isPendingOwnershipRequest*(self: SectionItem): bool {.inline.} =
   self.isPendingOwnershipRequest

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -359,12 +359,6 @@ proc joinedMembersCount*(self: SectionItem): int {.inline.} =
 proc `joinedMembersCount=`*(self: var SectionItem, value: int) {.inline.} =
   self.joinedMembersCount = value
 
-proc hasMember*(self: SectionItem, pubkey: string): bool =
-  self.membersModel.isContactWithIdAdded(pubkey)
-
-proc setOnlineStatusForMember*(self: SectionItem, pubKey: string, onlineStatus: OnlineStatus) =
-  self.membersModel.setOnlineStatus(pubkey, onlineStatus)
-
 proc isPendingOwnershipRequest*(self: SectionItem): bool {.inline.} =
   self.isPendingOwnershipRequest
 

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -203,7 +203,7 @@ QtObject:
     of ModelRole.CommunityTokensModel:
       result = newQVariant(item.communityTokens)
     of ModelRole.AmIBanned:
-      result = newQVariant(item.amIBanned)
+      result = newQVariant(item.isBanned)
     of ModelRole.PubsubTopic:
       result = newQVariant(item.pubsubTopic)
     of ModelRole.PubsubTopicKey:
@@ -540,7 +540,7 @@ QtObject:
           "canManageUsers": item.canManageUsers,
           "canRequestAccess": item.canRequestAccess,
           "isMember": item.isMember,
-          "amIBanned": item.amIBanned,
+          "amIBanned": item.isBanned,
           "access": item.access,
           "ensOnly": item.ensOnly,
           "nbMembers": item.members.getCount(),
@@ -602,3 +602,19 @@ QtObject:
       return
 
     self.items[i].members.removeItemById(memberId)
+
+  proc setIsBanned*(self: SectionModel, communityId: string, isBanned: bool) =
+    let ind = self.getItemIndex(communityId)
+    if ind == -1:
+      return
+
+    var roles: seq[int] = @[]
+
+    updateRole(isBanned, AmIBanned)
+
+    if roles.len == 0:
+      return
+
+    let dataIndex = self.createIndex(ind, 0, nil)
+    defer: dataIndex.delete
+    self.dataChanged(dataIndex, dataIndex, roles)

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -62,12 +62,6 @@ SplitView {
                     name: "community-name"
                 })
 
-                rootStore: AppLayoutStores.RootStore {
-                    function communityHasMember(communityId, pubKey) {
-                        return false
-                    }
-                }
-
                 communitySectionModule: QtObject {
                     function shareCommunityToUsers(keys, message) {
                         logs.logEvent("communitySectionModule::shareCommunityToUsers",

--- a/storybook/pages/ProfilePopupInviteFriendsPanelPage.qml
+++ b/storybook/pages/ProfilePopupInviteFriendsPanelPage.qml
@@ -11,12 +11,6 @@ Item {
         ProfilePopupInviteFriendsPanel {
             communityId: "communityId"
 
-            rootStore: AppLayoutStores.RootStore {
-                function communityHasMember(communityId, pubKey) {
-                    return false
-                }
-            }
-
             contactsModel: ListModel {
                 Component.onCompleted: {
                     const keys = []

--- a/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
@@ -22,9 +22,8 @@ ColumnLayout {
 
     property string headerTitle: ""
 
-    property AppLayoutStores.RootStore rootStore
-
     property var contactsModel
+    property var membersModel
     property string communityId
 
     property var pubKeys: ([])
@@ -54,11 +53,8 @@ ColumnLayout {
     }
 
     ExistingContacts {
-        id: existingContacts
-
-        rootStore: root.rootStore
-
         contactsModel: root.contactsModel
+        membersModel: root.membersModel
         communityId: root.communityId
 
         hideCommunityMembers: true

--- a/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
@@ -16,8 +16,6 @@ import AppLayouts.Profile.stores as ProfileStores
 StatusStackModal {
     id: root
 
-    property AppLayoutStores.RootStore rootStore
-
     property var contactsModel
     property var community
     property var communitySectionModule
@@ -95,9 +93,9 @@ StatusStackModal {
 
     stackItems: [
         ProfilePopupInviteFriendsPanel {
-            rootStore: root.rootStore
 
             contactsModel: root.contactsModel
+            membersModel: root.communitySectionModule.membersModel
             communityId: root.community.id
 
             onPubKeysChanged: root.pubKeys = pubKeys

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -254,11 +254,6 @@ QtObject {
                                               bannerJsonStr, encrypted);
     }
 
-    function communityHasMember(communityId, pubKey)
-    {
-        return communitiesModuleInst.isMemberOfCommunity(communityId, pubKey)
-    }
-
     function isMyCommunityRequestPending(id: string) {
         return communitiesModuleInst.isMyCommunityRequestPending(id)
     }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -499,8 +499,6 @@ QtObject {
             id: inviteFriendsToCommunityPopup
 
             InviteFriendsToCommunityPopup {
-                rootStore: root.rootStore
-
                 contactsModel: root.mutualContactsModel
 
                 onClosed: destroy()

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ
 import StatusQ.Core
 import StatusQ.Controls
 import StatusQ.Components
@@ -19,9 +20,8 @@ import SortFilterProxyModel
 Item {
     id: root
 
-    property AppLayoutStores.RootStore rootStore
-
     property var contactsModel
+    property var membersModel
     property string communityId
 
     property string filterText: ""
@@ -53,7 +53,7 @@ Item {
         model: SortFilterProxyModel {
             sourceModel: root.contactsModel
             filters: [
-                ExpressionFilter {
+                FastExpressionFilter {
                     expression: {
                         root.filterText
                         root.hideCommunityMembers
@@ -74,8 +74,9 @@ Item {
                             return false
 
                         return !root.hideCommunityMembers ||
-                               !root.rootStore.communityHasMember(root.communityId, model.pubKey)
+                               !root.membersModel.hasMember(model.pubKey)
                     }
+                    expectedRoles: [ "isContact", "isBlocked", "alias", "displayName", "ensName", "localNickname", "pubKey" ]
                 }
             ]
         }


### PR DESCRIPTION
### What does the PR do

Two fixes in one.

Fixes https://github.com/status-im/status-desktop/issues/18412

The problem was introduced when I implemented the lazy loading for the members in the section model. Turns out even if that member list is never shown to members, we do use it for some checks, like the banned one.

I fixed by passing the banned value to the sectionItem directly. Relying on the members model was a crutch.

Then also fixes a bug with the Invite friend to community popup that no longer hid contacts that are already member of the community.

We relied on the main section's members model to see if a contact was member of the community, but instead we can use the chat section members model

### Affected areas

Mostly Main section's Model and Items

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Ban fix:

[ban-unban.webm](https://github.com/user-attachments/assets/809ac458-cbbd-4125-bafd-0d7d5d36da17)

Invite friends fix:

[invite-fix.webm](https://github.com/user-attachments/assets/6232d515-fc05-4334-8470-040d434fd644)

### Impact on end user

Fixes the bugs

### How to test

- Get banned
- Have more than 1 contact and have one of them join a community you are in

### Risk 

Low risk. Worst case, some of the issues still persists
