### PR TITLE
chore(ci): remove unnecessary label for e2e tests

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -4,7 +4,7 @@ library 'status-jenkins-lib@v1.9.16'
 pipeline {
 
   agent {
-    label "linux && x86_64 && qt-6.9.0 && desktop-e2e-qt-6.9.0"
+    label 'linux && x86_64 && qt-6.9.0'
   }
 
   parameters {


### PR DESCRIPTION
Was added and not removed during work on parallel Qt5 and Qt6 support.