### PR TITLE
fix(@desktop/wallet): Make sure the mobile builds are running in light mode

### DIFF
--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -198,13 +198,16 @@ QtObject:
       marketDataPriceRefreshInterval: toInt(MARKET_DATA_PRICE_REFRESH_INTERVAL, 0),
     )
 
+  proc isMobilePlatform(): bool =
+    return defined(ios) or defined(android)
+
   proc defaultCreateAccountRequest*(): CreateAccountRequest =
     return CreateAccountRequest(
         rootDataDir: main_constants.STATUSGODIR,
         kdfIterations: KDF_ITERATIONS,
         customizationColor: DEFAULT_CUSTOMIZATION_COLOR,
         logLevel: some(main_constants.getStatusGoLogLevel()),
-        wakuV2LightClient: false,
+        wakuV2LightClient: isMobilePlatform(),
         wakuV2EnableMissingMessageVerification: true,
         wakuV2EnableStoreConfirmationForMessagesSent: true,
         previewPrivacy: true,


### PR DESCRIPTION
fixes #18154

### What does the PR do

set wake node to light client by default


### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

![IMG_2701FF0DF275-1](https://github.com/user-attachments/assets/c8b1a259-724b-4d13-82cf-2ecda35b9aad)


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
