### PR TITLE
perf: stop using data images for accounts

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -459,18 +459,12 @@ proc buildAndRegisterUserProfile(self: AppController) =
   let currentUserStatus = self.settingsService.getCurrentUserStatus()
 
   let loggedInAccount = self.accountsService.getLoggedInAccount()
-  var thumbnail, large: string
-  for img in loggedInAccount.images:
-    if(img.imgType == "large"):
-      large = img.uri
-    elif(img.imgType == "thumbnail"):
-      thumbnail = img.uri
 
   singletonInstance.userProfile.setFixedData(alias, loggedInAccount.keyUid, pubKey, loggedInAccount.keycardPairing.len > 0)
   singletonInstance.userProfile.setDisplayName(displayName)
   singletonInstance.userProfile.setPreferredName(preferredName)
-  singletonInstance.userProfile.setThumbnailImage(thumbnail)
-  singletonInstance.userProfile.setLargeImage(large)
+  singletonInstance.userProfile.setThumbnailImage(loggedInAccount.images.thumbnail)
+  singletonInstance.userProfile.setLargeImage(loggedInAccount.images.large)
   singletonInstance.userProfile.setCurrentUserStatus(currentUserStatus.statusType.int)
 
   singletonInstance.engine.setRootContextProperty("userProfile", self.userProfileVariant)

--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -2,16 +2,18 @@ import json, chronicles, tables
 
 import base
 
-import ../../../../app_service/service/message/dto/[message, pinned_message_update, reaction, removed_message]
-import ../../../../app_service/service/chat/dto/[chat]
-import ../../../../app_service/service/community/dto/[community]
-import ../../../../app_service/service/activity_center/dto/[notification]
-import ../../../../app_service/service/contacts/dto/[contacts, status_update]
-import ../../../../app_service/service/devices/dto/[installation]
-import ../../../../app_service/service/settings/dto/[settings]
-import ../../../../app_service/service/saved_address/dto as saved_address_dto
-import ../../../../app_service/service/wallet_account/dto/[keypair_dto]
-import ../../../../app_service/service/accounts/dto/[accounts]
+import app_service/service/message/dto/[message, pinned_message_update, reaction, removed_message]
+import app_service/service/chat/dto/[chat]
+import app_service/service/community/dto/[community]
+import app_service/service/activity_center/dto/[notification]
+import app_service/service/contacts/dto/[contacts, status_update]
+import app_service/service/devices/dto/[installation]
+import app_service/service/settings/dto/[settings]
+import app_service/service/saved_address/dto as saved_address_dto
+import app_service/service/wallet_account/dto/[keypair_dto]
+import app_service/service/accounts/dto/[accounts]
+
+include app_service/common/json_utils
 
 type MessageSignal* = ref object of Signal
   messages*: seq[MessageDto]
@@ -30,7 +32,7 @@ type MessageSignal* = ref object of Signal
   removedChats*: seq[string]
   currentStatus*: seq[StatusUpdateDto]
   settings*: seq[SettingsFieldDto]
-  identityImages*: seq[Image]
+  identityImages*: contacts.Images
   clearedHistories*: seq[ClearedHistoryDto]
   savedAddresses*: seq[SavedAddressDto]
   keypairs*: seq[KeypairDto]
@@ -136,9 +138,9 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
     for jsonSettingsField in e["settings"]:
       signal.settings.add(jsonSettingsField.toSettingsFieldDto())
 
-  if e.contains("identityImages"):
-    for jsonSettingsField in e["identityImages"]:
-      signal.identityImages.add(jsonSettingsField.toImage())
+  var imagesObj: JsonNode
+  if e.getProp("identityImages", imagesObj):
+    signal.identityImages = contacts.toImages(imagesObj)
 
   if e.contains("savedAddresses"):
     for jsonSavedAddress in e["savedAddresses"]:

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -57,7 +57,8 @@ proc init*(self: Controller) =
     self.delegate.loadProfileShowcasePreferences(args.preferences)
 
 proc storeIdentityImage*(self: Controller, address: string, image: string, aX: int, aY: int, bX: int, bY: int): bool =
-  len(self.profileService.storeIdentityImage(address, image, aX, aY, bX, bY)) > 0
+  let images = self.profileService.storeIdentityImage(address, image, aX, aY, bX, bY)
+  return images.large.len > 0 or images.thumbnail.len > 0
 
 proc deleteIdentityImage*(self: Controller, address: string): bool =
   self.profileService.deleteIdentityImage(address)

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -98,11 +98,17 @@ method load*[T](self: Module[T]) =
     var items: seq[login_acc_item.Item]
     for i in 0..<openedAccounts.len:
       let acc = openedAccounts[i]
-      var thumbnailImage: string
-      var largeImage: string
-      acc.extractImages(thumbnailImage, largeImage)
-      items.add(login_acc_item.initItem(order = i, acc.name, icon = "", thumbnailImage, largeImage, acc.keyUid, acc.colorHash,
-        acc.colorId, acc.keycardPairing))
+      items.add(login_acc_item.initItem(
+        order = i,
+        acc.name,
+        icon = "",
+        acc.images.thumbnail,
+        acc.images.large,
+        acc.keyUid,
+        acc.colorHash,
+        acc.colorId,
+        acc.keycardPairing
+      ))
 
     self.view.setLoginAccountsModelItems(items)
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -1,7 +1,7 @@
 import nimqml, tables, os, json, stew/shims/strformat, sequtils, strutils, times, std/options
 import app_service/common/safe_json_serialization, chronicles
 
-import ../../../app/global/global_singleton
+import app/global/global_singleton
 import ./dto/accounts as dto_accounts
 import ./dto/generated_accounts as dto_generated_accounts
 import ./dto/login_request
@@ -9,16 +9,17 @@ import ./dto/restore_account_request
 
 from ../keycard/service import KeycardEvent, KeyDetails
 from ../keycardV2/dto import KeycardExportedKeysDto, KeyDetailsV2
-import ../../../backend/general as status_general
-import ../../../backend/core as status_core
-import ../../../backend/privacy as status_privacy
+import backend/general as status_general
+import backend/core as status_core
+import backend/privacy as status_privacy
 
-import ../../../app/core/eventemitter
-import ../../../app/core/signals/types
-import ../../../app/core/tasks/[qt, threadpool]
-import ../../../app/core/fleets/fleet_configuration
-import ../../common/[account_constants, utils]
-import ../../../constants as main_constants
+import app/core/eventemitter
+import app/core/signals/types
+import app/core/tasks/[qt, threadpool]
+import app/core/fleets/fleet_configuration
+import app_service/common/[account_constants, utils]
+from app_service/service/contacts/dto/contacts import Images
+import constants as main_constants
 
 export dto_accounts
 export dto_generated_accounts
@@ -88,7 +89,7 @@ QtObject:
     self.loggedInAccount = account
     self.setLocalAccountSettingsFile()
 
-  proc updateLoggedInAccount*(self: Service, displayName: string, images: seq[Image]) =
+  proc updateLoggedInAccount*(self: Service, displayName: string, images: Images) =
     self.loggedInAccount.name = displayName
     self.loggedInAccount.images = images
     singletonInstance.localAccountSettings.setFileName(displayName)

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -62,16 +62,28 @@ proc `$`*(self: ContactsDto): string =
     contactRequestState:{self.contactRequestState},
     )"""
 
-proc toImages(jsonObj: JsonNode): Images =
+proc toImages*(jsonObj: JsonNode): Images =
   result = Images()
 
   var largeObj: JsonNode
-  if(jsonObj.getProp("large", largeObj)):
+  if jsonObj.getProp("large", largeObj):
     discard largeObj.getProp("localUrl", result.large)
 
   var thumbnailObj: JsonNode
-  if(jsonObj.getProp("thumbnail", thumbnailObj)):
+  if jsonObj.getProp("thumbnail", thumbnailObj):
     discard thumbnailObj.getProp("localUrl", result.thumbnail)
+
+proc toImagesFromArray*(jsonObj: JsonNode): Images =
+  result = Images()
+
+  for image in jsonObj:
+    if image.kind == JObject:
+      var imgType: string
+      discard image.getProp("type", imgType)
+      if imgType == "large":
+        discard image.getProp("localUrl", result.large)
+      elif imgType == "thumbnail":
+        discard image.getProp("localUrl", result.thumbnail)
 
 proc toContactRequestState*(value: int): ContactRequestState =
   result = ContactRequestState.None
@@ -107,9 +119,9 @@ proc toContactsDto*(jsonObj: JsonNode): ContactsDto =
   discard jsonObj.getProp("trustStatus", trustStatusInt)
   result.trustStatus = trustStatusInt.toTrustStatus()
 
-  var imageObj: JsonNode
-  if(jsonObj.getProp("images", imageObj)):
-    result.image = toImages(imageObj)
+  var imagesObj: JsonNode
+  if jsonObj.getProp("images", imagesObj):
+    result.image = toImages(imagesObj)
 
   discard jsonObj.getProp("added", result.added)
   discard jsonObj.getProp("blocked", result.blocked)

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -67,18 +67,6 @@ QtObject:
     except Exception as e:
       error "error: ", methodName="getPasswordStrengthScore", errName = e.name, errDesription = e.msg
 
-  proc generateImages*(self: Service, image: string, aX: int, aY: int, bX: int, bY: int): seq[Image] =
-    try:
-      let response = status_general.generateImages(image, aX, aY, bX, bY)
-      if(response.result.kind != JArray):
-        error "error: ", procName="generateImages", errDesription = "response is not an array"
-        return
-
-      for img in response.result:
-        result.add(toImage(img))
-    except Exception as e:
-      error "error: ", procName="generateImages", errName = e.name, errDesription = e.msg
-
   proc runTimer(self: Service) =
     let arg = TimerTaskArg(
       tptr: timerTask,

--- a/src/backend/general.nim
+++ b/src/backend/general.nim
@@ -59,13 +59,6 @@ proc getPasswordStrengthScore*(password: string, userInputs: seq[string]): RpcRe
     error "error", methodName = "getPasswordStrengthScore", exception=e.msg
     raise newException(RpcException, e.msg)
 
-proc generateImages*(imagePath: string, aX, aY, bX, bY: int): RpcResponse[JsonNode] =
-  try:
-    let response = status_go.generateImages(imagePath, aX, aY, bX, bY)
-    result.result = Json.safeDecode(response, JsonNode)
-  except RpcException as e:
-    error "error", methodName = "generateImages", exception=e.msg
-    raise newException(RpcException, e.msg)
 
 proc backupData*(): RpcResponse[JsonNode] =
   let payload = %* []


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18428

status-go PR: https://github.com/status-im/status-go/pull/6776

Changes the use of the base 64 images for Accounts to the local URL one.

I also cleaned up the code a lot. We used two different types of `Image` dtos, but they were the same one on the status-go side, so I re-aligned them.

### Affected areas

Account images

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[account-image.webm](https://github.com/user-attachments/assets/aa7955ce-c22c-496c-9f1a-bd797cab24ed)

### Impact on end user

No UX impact
Better memory usage and performance

### How to test

- Have accounts with profile images

### Risk 

Mid risk. If something is not set correctly, it's possible that the user's own image doesn't show
