### PR TITLE
fix(@desktop/wallet):iOS:: Cannot edit seed phrase words after typing

### DIFF
--- a/ui/imports/shared/panels/EnterSeedPhrase.qml
+++ b/ui/imports/shared/panels/EnterSeedPhrase.qml
@@ -81,6 +81,10 @@ ColumnLayout {
             return sortTable.map(x => x.seed).join(" ")
         }
 
+        function isWordAtPosition(word, pos) {
+            return mnemonicInput.some(entry => entry.pos === pos && entry.seed === word);
+        }
+
         function checkWordExistence(word, pos) {
             if (word !== "" && !ModelUtils.contains(d.seedPhrases_en, "seedWord", word)) {
                 const incorrectWordAtIndex = d.incorrectWordAtIndex
@@ -195,6 +199,11 @@ ColumnLayout {
         model: switchTabBar.currentItem.wordCount
 
         function addWord(pos, word, ignoreGoingNext = false) {
+
+            // if the word is already added at given pos, we return
+            if(d.isWordAtPosition(word, pos)) {
+                return
+            }
 
             const words = d.mnemonicInput
 


### PR DESCRIPTION
fixes #18140

### What does the PR do

Check if word already entered and ignoring adding new word and moving focus to next text input

### Affected areas

EnterSeedPhrase screen

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/f5615ce1-5823-4fbc-a3a6-e7459d641bf9


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
