### PR TITLE
fix: Clicking profile image in the chat list won't trigger any action

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -242,7 +242,7 @@ Control {
                     imageHeight: root.messageDetails.sender.profileImage.assetSettings.height
                     ensVerified: root.messageDetails.sender.isEnsVerified
                     isBridgedAccount: root.messageDetails.contentType === StatusMessage.ContentType.BridgeMessage
-                    onClicked: root.profilePictureClicked(this, mouse)
+                    onClicked: (mouse) => root.profilePictureClicked(this, mouse)
                 }
 
                 ColumnLayout {

--- a/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusUserImage.qml
@@ -25,7 +25,7 @@ Loader {
     property color userColor
     property var colorHash: []
 
-    signal clicked()
+    signal clicked(var mouse)
 
     sourceComponent: StatusSmartIdenticon {
         name: root.name
@@ -78,9 +78,9 @@ Loader {
             sourceComponent: StatusMouseArea {
                 cursorShape: hoverEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                 hoverEnabled: !root.disabled
-                onClicked: {
+                onClicked: (mouse) => {
                     if (!root.disabled) {
-                        root.clicked()
+                        root.clicked(mouse)
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

Fixing profile image click in messenger following the Qt6 migration.

### Screencapture of the functionality


https://github.com/user-attachments/assets/cbf8cc7a-4b8b-447d-8fc0-69af23cc7d4b

