### PR TITLE
fix(chat_section): parent badge not being updated on start or on read

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -547,7 +547,7 @@ proc updateBadgeNotifications(self: Module, chat: ChatDto, hasUnreadMessages: bo
   if self.chatsLoaded:
     self.view.chatsModel().updateNotificationsForItemById(chatId, hasUnreadMessages, unviewedMentionsCount)
 
-    if (self.chatContentModules.contains(chatId)):
+    if self.chatContentModules.contains(chatId):
       self.chatContentModules[chatId].onNotificationsUpdated(hasUnreadMessages, unviewedMentionsCount)
 
     if self.isCommunity:
@@ -1429,6 +1429,9 @@ method addOrUpdateChat(self: Module,
   if belongsToCommunity and sectionId != chat.communityId or
     not belongsToCommunity and sectionId != singletonInstance.userProfile.getPubKey():
     return
+
+  if not isSectionBuild:
+    self.updateBadgeNotifications(chat, chat.unviewedMessagesCount > 0, chat.unviewedMentionsCount)
 
   if not self.chatsLoaded:
     return


### PR DESCRIPTION
### What does the PR do

Fixes #18441

It was my bad. That call is necessary to update the parent badge and also the channel's badge when the community is opened. Not sure how I missed that.

### Affected areas

Chat_section module

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[badge-fix.webm](https://github.com/user-attachments/assets/e2cd99bb-89ec-47fa-9e5d-e04f29bb4719)

### Impact on end user

Fixes the issue

### How to test

- Send messages in a community before and after login

### Risk 

Low
