### PR TITLE
Hook backup file form onboarding to backup functions

### DIFF
--- a/src/app/modules/main/profile_section/sync/module.nim
+++ b/src/app/modules/main/profile_section/sync/module.nim
@@ -109,5 +109,4 @@ method importLocalBackupFile*(self: Module, filePath: string) =
   self.controller.importLocalBackupFile(filePath)
 
 method onLocalBackupImportCompleted*(self: Module, error: string) =
-  self.view.setBackupImportState(BackupImportState.Completed)
-  self.view.setBackupImportError(error)
+  self.view.onLocalBackupImportCompleted(error)

--- a/src/app/modules/main/profile_section/sync/module.nim
+++ b/src/app/modules/main/profile_section/sync/module.nim
@@ -3,7 +3,6 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item
 
-import app/global/global_singleton
 import app/core/eventemitter
 import app_service/service/general/service as general_service
 import app_service/service/settings/service as settings_service
@@ -107,8 +106,7 @@ method performLocalBackup*(self: Module): string =
   return self.controller.performLocalBackup()
 
 method importLocalBackupFile*(self: Module, filePath: string) =
-  let formattedFilePath = singletonInstance.utils.fromPathUri(filePath)
-  self.controller.importLocalBackupFile(formattedFilePath)
+  self.controller.importLocalBackupFile(filePath)
 
 method onLocalBackupImportCompleted*(self: Module, error: string) =
   self.view.setBackupImportState(BackupImportState.Completed)

--- a/src/app/modules/main/profile_section/sync/view.nim
+++ b/src/app/modules/main/profile_section/sync/view.nim
@@ -132,6 +132,13 @@ QtObject:
     read = getBackupImportError
     notify = backupImportErrorChanged
 
+  proc localBackupImportCompleted*(self: View, success: bool) {.signal.}
+
+  proc onLocalBackupImportCompleted*(self: View, error: string) = # not a slot
+    self.setBackupImportState(BackupImportState.Completed)
+    self.setBackupImportError(error)
+    self.localBackupImportCompleted(error.len == 0)
+
   proc performLocalBackup*(self: View): string {.slot.} =
     return self.delegate.performLocalBackup()
 

--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -266,3 +266,6 @@ proc storeMetadata*(self: Controller, name: string, paths: seq[string]) =
 
 proc storeMetadataAsync*(self: Controller, name: string, paths: seq[string]) =
   self.keycardServiceV2.asyncStoreMetadata(name, paths)
+
+proc asyncImportLocalBackupFile*(self: Controller, filePath: string) =
+  self.generalService.asyncImportLocalBackupFile(filePath)

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -106,6 +106,9 @@ method requestSaveBiometrics*(self: AccessInterface, account: string, credential
 method requestDeleteBiometrics*(self: AccessInterface, account: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method requestLocalBackup*(self: AccessInterface, backupImportFileUrl: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/onboarding/post_onboarding/local_backup_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/local_backup_task.nim
@@ -1,0 +1,20 @@
+import chronicles
+import task
+import ../io_interface
+
+export task
+
+type LocalBackupTask* = ref object of PostOnboardingTask
+  backupImportFileUrl*: string
+
+proc newLocalBackupTask*(backupImportFileUrl: string): LocalBackupTask =
+  result = LocalBackupTask(
+      kind: kPostOnboardingTaskLocalBackup,
+      backupImportFileUrl: backupImportFileUrl,
+    )
+
+proc run*(self: LocalBackupTask, onboardingModule: AccessInterface) =
+  debug "running post-onboarding LocalBackupTask"
+
+  onboardingModule.requestLocalBackup(self.backupImportFileUrl)
+

--- a/src/app/modules/onboarding/post_onboarding/task.nim
+++ b/src/app/modules/onboarding/post_onboarding/task.nim
@@ -16,6 +16,9 @@ type PostOnboardingTaskKind* = enum
   # This task is scheduled in LoginWithLostKeycardSeedphrase to convert the keycard account to a regular account.
   kConvertKeycardAccountToRegular = 4
 
+  # This task is scheduled if the user provided a local backup file URL during onboarding.
+  kPostOnboardingTaskLocalBackup = 5
+
 type PostOnboardingTask* = ref object of RootObj
   kind*: PostOnboardingTaskKind
 

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -7,6 +7,7 @@ import app/core/tasks/[qt, threadpool]
 import ../../../constants as app_constants
 import ../../common/types
 import status_go
+import app/global/global_singleton
 
 from app_service/service/activity_center/service import SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED, ActivityCenterNotificationsArgs
 from app_service/service/activity_center/dto/notification import parseActivityCenterNotifications
@@ -142,11 +143,12 @@ QtObject:
       return e.msg
 
   proc asyncImportLocalBackupFile*(self: Service, filePath: string) =
+    let formattedFilePath = singletonInstance.utils.fromPathUri(filePath)
     let arg = AsyncImportLocalBackupFileTaskArg(
       tptr: asyncImportLocalBackupFileTask,
       vptr: cast[uint](self.vptr),
       slot: "onImportLocalBackupFileDone",
-      filePath: filePath
+      filePath: formattedFilePath
     )
     self.threadpool.start(arg)
 

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -32,6 +32,16 @@ QtObject {
         readonly property var globalUtilsInst: globalUtils
     }
 
+    signal localBackupImportCompleted(bool success)
+
+    readonly property Connections syncModuleConnections: Connections {
+        target: root.syncModule
+
+        function onLocalBackupImportCompleted(success: bool) {
+            root.localBackupImportCompleted(success)
+        }
+    }
+
     function setBackupPath(path) {
         d.appSettingsInst.setBackupPath(path)
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -172,6 +172,7 @@ Item {
         rootChatStore: appMain.rootChatStore
         communityTokensStore: appMain.communityTokensStore
         profileStore: appMain.profileStore
+        devicesStore: appMain.devicesStore
 
         onSendRequested: popupRequestsHandler.sendModalHandler.openSend()
     }
@@ -890,7 +891,7 @@ Item {
         communityTokensStore: appMain.communityTokensStore
         communitiesStore: appMain.communitiesStore
         profileStore: appMain.profileStore
-        devicesStore: appMain.rootStore.devicesStore
+        devicesStore: appMain.devicesStore
         currencyStore: appMain.currencyStore
         walletAssetsStore: appMain.walletAssetsStore
         walletCollectiblesStore: appMain.walletCollectiblesStore

--- a/ui/app/mainui/ToastsManager.qml
+++ b/ui/app/mainui/ToastsManager.qml
@@ -38,6 +38,7 @@ QtObject {
     required property ChatStores.RootStore rootChatStore
     required property SharedStores.CommunityTokensStore communityTokensStore
     required property ProfileStore profileStore
+    required property DevicesStore devicesStore
 
     // Utils:
     readonly property string checkmarkCircleAssetName: "checkmark-circle"
@@ -240,6 +241,24 @@ QtObject {
         function onTrustStatusRemoved(pubKey: string) {
             const displayName = SQUtils.ModelUtils.getByKey(root.contactsStore.contactsModel, "pubKey", pubKey, "preferredDisplayName")
             Global.displaySuccessToastMessage(qsTr("Trust mark removed for %1").arg(displayName))
+        }
+    }
+
+    readonly property Connections _devicesStoreConnections: Connections {
+        target: root.devicesStore
+
+        function onLocalBackupImportCompleted(success: bool) {
+            if (success) {
+                Global.displaySuccessToastMessage(qsTr("Local backup import completed"))
+            } else {
+                Global.displayToastMessage(qsTr("Local backup import failed"),
+                                       "",
+                                       root.warningAssetName,
+                                       false,
+                                        Constants.ephemeralNotificationType.danger,
+                                       "")
+            }
+            
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Based on top of https://github.com/status-im/status-desktop/pull/18434

Fixes https://github.com/status-im/status-desktop/issues/18359

When the user provides a file path to the backup, we call the async function to perform the backup after the signup.

Also adds a toast message when it completes.

### Affected areas

Onboarding and backup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

In this video, I disabled the Waku backup to make sure the local one worked

[local-backup-onboarding.webm](https://github.com/user-attachments/assets/f2906d1f-b6a5-4b6f-982f-a737b909805d)

### Impact on end user

Makes the local backup from the onboarding work

### How to test

- Enable the feature flag `export FLAG_LOCAL_BACKUP_ENABLED=1`
- Have an other account and get the mnemonic and do a local backup on it (Syncing View)
- Use a new installation and use the mnemonic and the file

### Risk 

Low
