### PR TITLE
fix(AppRun): drop setting LD_LIBRARY_PATH in AppRun

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -1,5 +1,6 @@
 #!/bin/bash
 APPDIR="$(dirname "$(readlink -f "${0}")")"
+export PATH="${APPDIR}/usr/bin:${PATH}"
 export GST_PLUGIN_SCANNER="${APPDIR}/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
 export GST_PLUGIN_PATH="${APPDIR}/usr/lib/gstreamer-1.0"
 export GST_PLUGIN_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"

--- a/scripts/init_app_dir.sh
+++ b/scripts/init_app_dir.sh
@@ -29,41 +29,48 @@ cp "${FCITX5_QT}" "${APP_DIR}/usr/plugins/platforminputcontexts/"
 
 # Copy dependencies, which linuxdeployqt can't manage from nix store or system (FHS)
 if [[ -z "${IN_NIX_SHELL}" ]]; then
-	cp -r /usr/lib/x86_64-linux-gnu/nss "${APP_DIR}/usr/lib/"
-	cp -P /usr/lib/x86_64-linux-gnu/libgst* "${APP_DIR}/usr/lib/"
-	cp -r /usr/lib/x86_64-linux-gnu/gstreamer-1.0 "${APP_DIR}/usr/lib/"
-	cp -r /usr/lib/x86_64-linux-gnu/gstreamer1.0 "${APP_DIR}/usr/lib/"
+    echo "Bundling gstreamer 1.0..."
+    cp -r /usr/lib/x86_64-linux-gnu/nss "${APP_DIR}/usr/lib/"
+    cp -P /usr/lib/x86_64-linux-gnu/libgst* "${APP_DIR}/usr/lib/"
+    cp -r /usr/lib/x86_64-linux-gnu/gstreamer-1.0 "${APP_DIR}/usr/lib/"
+    cp -r /usr/lib/x86_64-linux-gnu/gstreamer1.0 "${APP_DIR}/usr/lib/"
 
-	# fix for missing QtWebEngineProcess since QT6
-  cp /opt/qt/6.9.0/gcc_64/libexec/QtWebEngineProcess "${APP_DIR}/usr/libexec/"
-  chmod +x "${APP_DIR}/usr/libexec/QtWebEngineProcess"
+    # fix for missing QtWebEngineProcess since QT6
+    cp /opt/qt/6.9.0/gcc_64/libexec/QtWebEngineProcess "${APP_DIR}/usr/libexec/"
+    chmod +x "${APP_DIR}/usr/libexec/QtWebEngineProcess"
 
-	echo "Bundling pcsc-lite 2.2.3..."
-	cp -L /usr/local/lib/x86_64-linux-gnu/libpcsclite.so* "${APP_DIR}/usr/lib/"
-	cp -L /usr/local/lib/x86_64-linux-gnu/libpcsclite_real.so* "${APP_DIR}/usr/lib/"
-	cp -L /usr/local/lib/x86_64-linux-gnu/pkgconfig/libpcsclite.pc "${APP_DIR}/usr/lib/"
+    echo "Bundling pcsc-lite 2.2.3..."
+    cp -L /usr/local/lib/x86_64-linux-gnu/libpcsclite.so* "${APP_DIR}/usr/lib/"
+    cp -L /usr/local/lib/x86_64-linux-gnu/libpcsclite_real.so* "${APP_DIR}/usr/lib/"
+    cp -L /usr/local/lib/x86_64-linux-gnu/pkgconfig/libpcsclite.pc "${APP_DIR}/usr/lib/"
 
-	chmod 755 "${APP_DIR}/usr/lib/libpcsclite.so"*
-	chmod 755 "${APP_DIR}/usr/lib/libpcsclite_real.so"*
-	chmod 755 "${APP_DIR}/usr/lib/libpcsclite.pc"
+    chmod 755 "${APP_DIR}/usr/lib/libpcsclite.so"*
+    chmod 755 "${APP_DIR}/usr/lib/libpcsclite_real.so"*
+    chmod 755 "${APP_DIR}/usr/lib/libpcsclite.pc"
 
-	echo "Bundling pcscd..."
-	cp -L "/usr/local/sbin/pcscd"* "${APP_DIR}/usr/bin/"
-	chmod 755 "${APP_DIR}/usr/bin/pcscd"*
+    echo "Bundling pcscd..."
+    cp -L "/usr/local/sbin/pcscd"* "${APP_DIR}/usr/bin/"
+    chmod 755 "${APP_DIR}/usr/bin/pcscd"*
 
+    echo "Bundling Dash shell..."
+    cp /usr/bin/dash "${APP_DIR}/usr/bin/"
+    ln -rs "${APP_DIR}/usr/bin/dash" "${APP_DIR}/usr/bin/sh"
+
+    echo "Bundling xdg-open wrapper..."
+    cp scripts/xdg-open-wrapper.sh "${APP_DIR}/usr/bin/xdg-open"
 else
-	mkdir -p "${APP_DIR}"/usr/lib/{gstreamer1.0,gstreamer-1.0,nss}
-	mkdir -p "${APP_DIR}"/usr/libexec
+    mkdir -p "${APP_DIR}"/usr/lib/{gstreamer1.0,gstreamer-1.0,nss}
+    mkdir -p "${APP_DIR}"/usr/libexec
 
-	echo "${GST_PLUGIN_SYSTEM_PATH_1_0}" | tr ':' '\n' | sort -u | xargs -I {} find {} -name "*.so" | xargs -I {} cp {} "${APP_DIR}/usr/lib/gstreamer-1.0/"
-	cp -r "${GSTREAMER_PATH}/libexec/gstreamer-1.0" "${APP_DIR}/usr/lib/gstreamer1.0/"
-	cp "${LIBKRB5_PATH}/lib/libcom_err.so.3" "${APP_DIR}/usr/lib/libcom_err.so.3"
-	cp "${NSS_PATH}"/lib/{libfreebl3,libfreeblpriv3,libnssckbi,libnssdbm3,libsoftokn3}.{chk,so} "${APP_DIR}/usr/lib/nss/" || true
-	cp "${QTWEBENGINE_PATH}/libexec/QtWebEngineProcess" "${APP_DIR}/usr/libexec/QtWebEngineProcess"
-	cp "${QTWEBENGINE_PATH}"/resources/* "${APP_DIR}/usr/libexec/"
-	cp -r "${QTWEBENGINE_PATH}/translations/qtwebengine_locales" "${APP_DIR}/usr/libexec/"
+    echo "${GST_PLUGIN_SYSTEM_PATH_1_0}" | tr ':' '\n' | sort -u | xargs -I {} find {} -name "*.so" | xargs -I {} cp {} "${APP_DIR}/usr/lib/gstreamer-1.0/"
+    cp -r "${GSTREAMER_PATH}/libexec/gstreamer-1.0" "${APP_DIR}/usr/lib/gstreamer1.0/"
+    cp "${LIBKRB5_PATH}/lib/libcom_err.so.3" "${APP_DIR}/usr/lib/libcom_err.so.3"
+    cp "${NSS_PATH}"/lib/{libfreebl3,libfreeblpriv3,libnssckbi,libnssdbm3,libsoftokn3}.{chk,so} "${APP_DIR}/usr/lib/nss/" || true
+    cp "${QTWEBENGINE_PATH}/libexec/QtWebEngineProcess" "${APP_DIR}/usr/libexec/QtWebEngineProcess"
+    cp "${QTWEBENGINE_PATH}"/resources/* "${APP_DIR}/usr/libexec/"
+    cp -r "${QTWEBENGINE_PATH}/translations/qtwebengine_locales" "${APP_DIR}/usr/libexec/"
 
-	#TODO: bundle pcsc-lite and pcscd in nix-shell
+    #TODO: bundle pcsc-lite and pcscd in nix-shell
 
-	chmod -R u+w "${APP_DIR}/usr"
+    chmod -R u+w "${APP_DIR}/usr"
 fi

--- a/scripts/xdg-open-wrapper.sh
+++ b/scripts/xdg-open-wrapper.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# Avoid 'undefined symbol: rl_trim_arg_from_keyseq' from newer Bash.
+unset LD_LIBRARY_PATH
+# Remove AppImage path to avoid recursive loop of xdg-open executions.
+PATH=$(echo "${PATH}" | tr ':' '\n' | grep -v "${APPDIR}" | tr '\n' ':')
+exec xdg-open "$@"


### PR DESCRIPTION
This fixes an error on NixOS when trying to Connect a dApp via Status Connector which should open the Status Wallet Connector chrome plugin page but fails with:
```
/nix/store/1q9lw4r2mbap8rsr8cja46nap6wvrw2p-bash-interactive-5.2p37/bin/bash: symbol lookup error:
/nix/store/1q9lw4r2mbap8rsr8cja46nap6wvrw2p-bash-interactive-5.2p37/bin/bash: undefined symbol: rl_trim_arg_from_keyseq
```
Resolves:
- https://github.com/status-im/status-desktop/issues/18451