### PR TITLE
chore: import cleanups, remove libp2p

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,9 +45,6 @@
 [submodule "vendor/nim-eth"]
 	path = vendor/nim-eth
 	url = https://github.com/status-im/nim-eth
-[submodule "vendor/nim-libp2p"]
-	path = vendor/nim-libp2p
-	url = https://github.com/status-im/nim-libp2p
 [submodule "vendor/nim-chronos"]
 	path = vendor/nim-chronos
 	url = https://github.com/status-im/nim-chronos.git

--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, chronicles
+import nimqml, sequtils, chronicles
 
 import app_service/service/general/service as general_service
 import app_service/service/keychain/service as keychain_service

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, chronicles
+import nimqml, strutils, chronicles
 import ../eventemitter
 
 import ../../global/app_signals

--- a/src/app/core/main.nim
+++ b/src/app/core/main.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import
   eventemitter,
   ./fleets/fleet_configuration,

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles
+import nimqml, json, chronicles
 
 import ../../global/app_signals
 import ../../global/global_singleton

--- a/src/app/core/signals/remote_signals/wallet.nim
+++ b/src/app/core/signals/remote_signals/wallet.nim
@@ -1,4 +1,4 @@
-import json, options, chronicles, Tables
+import json, options, chronicles, tables
 
 import base
 import signal_type

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, chronicles
+import nimqml, json, strutils, chronicles
 import ../eventemitter
 
 include types

--- a/src/app/core/tasks/qt.nim
+++ b/src/app/core/tasks/qt.nim
@@ -1,5 +1,5 @@
 import # vendor libs
-  NimQml, json_serialization
+  nimqml, json_serialization
 
 import # status-desktop libs
   ./common

--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import os, macros, strutils
 
 proc boolToEnv*(defaultValue: bool): string =

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 QtObject:
   type GlobalEvents* = ref object of QObject

--- a/src/app/global/global_singleton.nim
+++ b/src/app/global/global_singleton.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import local_account_settings
 import local_account_sensitive_settings

--- a/src/app/global/loader_deactivator.nim
+++ b/src/app/global/loader_deactivator.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import std/deques
 
 const MAX_CHATS_IN_MEMORY = 5

--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -1,4 +1,4 @@
-import NimQml, os, json, chronicles
+import nimqml, os, json, chronicles
 
 import ../../constants
 

--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -1,4 +1,4 @@
-import NimQml, os
+import nimqml, os
 
 import ../../constants
 

--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, os
+import nimqml, strutils, os
 
 import constants
 

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../../constants as main_constants
 import local_account_settings

--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, uri, stew/shims/strformat, re, stint, httpclient, os
+import nimqml, strutils, uri, stew/shims/strformat, re, stint, httpclient, os
 import stew/byteutils
 import ./utils/qrcodegen
 

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 import ./item
 import ../../../../app_service/service/activity_center/service as activity_center_service
 

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strutils
+import nimqml, tables, json, sequtils, strutils
 import ./item
 
 type

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils
+import nimqml, tables, json, sequtils
 
 import ./io_interface, ./view, ./controller, ./token_data_item
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/activity_center/token_data_item.nim
+++ b/src/app/modules/main/activity_center/token_data_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, stew/shims/strformat
+import nimqml, strutils, stew/shims/strformat
 
 QtObject:
   type TokenDataItem* = ref object of QObject

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, sequtils, std/tables
+import nimqml, json, strutils, sequtils, std/tables
 import ../../../../app_service/service/activity_center/service as activity_center_service
 
 import ./model

--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -1,4 +1,4 @@
-import Tables, chronicles
+import tables, chronicles
 import io_interface
 
 import ../../../global/app_signals

--- a/src/app/modules/main/app_search/io_interface.nim
+++ b/src/app/modules/main/app_search/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../../../../app_service/service/message/dto/message
 

--- a/src/app/modules/main/app_search/location_menu_model.nim
+++ b/src/app/modules/main/app_search/location_menu_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import nimqml, tables, strutils
 
 import location_menu_item, location_menu_sub_item
 

--- a/src/app/modules/main/app_search/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/location_menu_sub_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import location_menu_sub_item
 

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import json, strutils, chronicles, sequtils, tables, std/algorithm
 import io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/app_search/result_model.nim
+++ b/src/app/modules/main/app_search/result_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import result_item
 

--- a/src/app/modules/main/app_search/view.nim
+++ b/src/app/modules/main/app_search/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import result_model, location_menu_model
 import io_interface
 

--- a/src/app/modules/main/chat_search_model.nim
+++ b/src/app/modules/main/chat_search_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import chat_search_item
 
 type

--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import item
 import ../../../../app_service/common/types
 

--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ../../../../../app_service/common/types
 
 

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json
+import nimqml, tables, json
 import io_interface
 
 import ../../../../../app_service/service/settings/service as settings_service

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import nimqml, tables
 
 import ../../../../../../app_service/service/gif/dto
 import ../../../../../../app_service/service/message/dto/link_preview

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import nimqml, tables
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/chat_section/chat_content/input_area/preserved_properties.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/preserved_properties.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 QtObject:
   type

--- a/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, sequtils
+import nimqml, tables, sequtils
 
 type
   ModelRole {.pure.} = enum

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sets
+import nimqml, sets
 import ./io_interface
 import ./preserved_properties
 import ./urls_model

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../item as chat_item
 import app_service/service/message/dto/pinned_message

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, uuids
+import nimqml, uuids
 
 import ../../../../../../app_service/service/message/dto/[message, reaction, pinned_message]
 import ../../../../../../app_service/service/community/dto/community

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, uuids, sets, times, tables, system
+import nimqml, chronicles, sequtils, uuids, sets, times, tables, system
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json
+import nimqml, json
 import ../../../../shared_models/message_model
 import ../../../../shared_models/message_item
 import ../../../../../../app_service/service/chat/dto/chat

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils
+import nimqml, chronicles, sequtils
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/dto/[message]

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar
+import nimqml, sequtils, sugar
 import io_interface
 import view, controller
 import ../../../../shared_models/[member_model, member_item]

--- a/src/app/modules/main/chat_section/chat_content/users/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sets, strutils
+import nimqml, sequtils, sets, strutils
 import ../../../../shared_models/[member_model]
 import io_interface
 

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ../../../shared_models/message_model as pinned_msg_model
 import ../item as chat_item
 import ../../../../../app_service/common/types

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 
 import io_interface
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/node_configuration/service as node_configuration_service

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, json, sequtils, system
+import nimqml, tables, stew/shims/strformat, json, sequtils, system
 import ../../../../app_service/common/types
 import ../../../../app_service/service/chat/dto/chat
 import item

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, sequtils, stew/shims/strformat, sugar, marshal
+import nimqml, tables, chronicles, json, sequtils, stew/shims/strformat, sugar, marshal
 
 import io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, strutils
+import nimqml, json, sequtils, strutils
 import model as chats_model
 import item, active_item
 import ../../shared_models/user_model as user_model

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import curated_community_item
 import ../../../shared_models/token_permission_item
 

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import discord_category_item
 
 type

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import nimqml, tables, strutils
 import discord_channel_item
 
 type

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import discord_file_item
 
 type

--- a/src/app/modules/main/communities/models/discord_import_errors_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_errors_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import discord_import_error_item
 
 type

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import discord_import_error_item, discord_import_errors_model
 import discord_import_task_item as taskItem 
 import ../../../../../app_service/service/community/dto/community

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, sequtils, sugar, tables, stint, chronicles, json
+import nimqml, strutils, sequtils, sugar, tables, stint, chronicles, json
 
 import ./io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, sequtils, stint
+import nimqml, tables, stew/shims/strformat, sequtils, stint
 import token_item
 import token_owners_item
 import token_owners_model

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, stint
+import nimqml, tables, stew/shims/strformat, stint
 import token_owners_item
 
 type

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import tables, json, sequtils, sugar, stint, strutils, chronicles
 
 import app_service/service/wallet_account/service as wallet_account_service

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, sequtils
+import nimqml, json, strutils, sequtils
 
 import ./io_interface as community_tokens_module_interface
 import app/modules/shared_models/currency_amount

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, sequtils
+import nimqml, json, strutils, sequtils
 
 import ./io_interface
 import ../../shared_models/[section_model, section_item, token_list_model, token_list_item,

--- a/src/app/modules/main/ephemeral_notification_model.nim
+++ b/src/app/modules/main/ephemeral_notification_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import ephemeral_notification_item
 
 type

--- a/src/app/modules/main/gifs/gif_column_model.nim
+++ b/src/app/modules/main/gifs/gif_column_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils
+import nimqml, tables, sequtils
 
 import ../../../../app_service/service/gif/dto
 

--- a/src/app/modules/main/gifs/module.nim
+++ b/src/app/modules/main/gifs/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/gifs/view.nim
+++ b/src/app/modules/main/gifs/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ./io_interface
 import ./gif_column_model
 import ../../../../app_service/service/gif/dto

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, stint, json
+import nimqml, stint, json
 
 import app_service/service/settings/service as settings_service
 import app_service/service/node_configuration/service as node_configuration_service

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, options
+import nimqml, tables, options
 
 import app_service/service/market/service as market_service
 

--- a/src/app/modules/main/market_section/module.nim
+++ b/src/app/modules/main/market_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 
 import controller, view
 import ./io_interface as io_interface

--- a/src/app/modules/main/market_section/view.nim
+++ b/src/app/modules/main/market_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import io_interface, market_leaderboard_model
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, strutils
+import nimqml, tables, json, sequtils, stew/shims/strformat, marshal, times, chronicles, stint, strutils
 
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model

--- a/src/app/modules/main/network_connection/module.nim
+++ b/src/app/modules/main/network_connection/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import io_interface, view, controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/network_connection/network_connection_item.nim
+++ b/src/app/modules/main/network_connection/network_connection_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 
 QtObject:
   type NetworkConnectionItem* = ref object of QObject

--- a/src/app/modules/main/network_connection/view.nim
+++ b/src/app/modules/main/network_connection/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface
 import ./network_connection_item

--- a/src/app/modules/main/node_section/module.nim
+++ b/src/app/modules/main/node_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/node_section/view.nim
+++ b/src/app/modules/main/node_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils
+import nimqml, json, strutils
 import io_interface
 import ../../../core/signals/types
 

--- a/src/app/modules/main/profile_section/about/module.nim
+++ b/src/app/modules/main/profile_section/about/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/about/view.nim
+++ b/src/app/modules/main/profile_section/about/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json
+import nimqml, json
 
 # import ./controller_interface
 import ./io_interface

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface
 
 QtObject:

--- a/src/app/modules/main/profile_section/communities/io_interface.nim
+++ b/src/app/modules/main/profile_section/communities/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/communities/module.nim
+++ b/src/app/modules/main/profile_section/communities/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/communities/view.nim
+++ b/src/app/modules/main/profile_section/communities/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface
 

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ../../../../../app_service/service/contacts/dto/contacts as contacts
 import ../../../../../app_service/service/contacts/dto/status_update
 import app_service/common/types

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_accounts_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_accounts_model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, sequtils, json
+import nimqml, tables, strutils, sequtils, json
 
 type
   ShowcaseContactAccountItem* = object of RootObj

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_generic_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_generic_model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, sequtils, json
+import nimqml, tables, strutils, sequtils, json
 
 type
   ShowcaseContactGenericItem* = object of RootObj

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_social_links_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_social_links_model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, sequtils, json
+import nimqml, tables, strutils, sequtils, json
 
 type
   ShowcaseContactSocialLinkItem* = object of RootObj

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 
 import io_interface, view, controller, json
 import ../../../shared_models/user_item

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../../../shared_models/[user_model]
 import ./io_interface

--- a/src/app/modules/main/profile_section/devices/io_interface.nim
+++ b/src/app/modules/main/profile_section/devices/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import nimqml, tables
 import app_service/service/devices/service
 from app_service/service/keycard/service import KeyDetails
 

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils
+import nimqml, tables, sequtils
 import item
 import ../../../../../app_service/service/devices/dto/[installation]
 

--- a/src/app/modules/main/profile_section/devices/module.nim
+++ b/src/app/modules/main/profile_section/devices/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, chronicles
+import nimqml, tables, strutils, chronicles
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item

--- a/src/app/modules/main/profile_section/devices/view.nim
+++ b/src/app/modules/main/profile_section/devices/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface, model
 import ../../../../../app_service/service/devices/service
 

--- a/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 
 type Item* = object
   ensUsername*: string

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -1,4 +1,4 @@
-import NimQml, json, stint, strutils, stew/shims/strformat, chronicles
+import nimqml, json, stint, strutils, stew/shims/strformat, chronicles
 
 import io_interface
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface
 import model
 from app_service/service/ens/utils import ENS_REGISTRY

--- a/src/app/modules/main/profile_section/io_interface.nim
+++ b/src/app/modules/main/profile_section/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/keycard/io_interface.nim
+++ b/src/app/modules/main/profile_section/keycard/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import app_service/service/wallet_account/dto/keypair_dto
 import app/modules/shared_modules/keycard_popup/io_interface as keycard_shared_module
 

--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, sequtils, sugar, strutils
+import nimqml, chronicles, sequtils, sugar, strutils
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/keycard/view.nim
+++ b/src/app/modules/main/profile_section/keycard/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ../../../shared_modules/keycard_popup/models/keycard_model
 

--- a/src/app/modules/main/profile_section/language/io_interface.nim
+++ b/src/app/modules/main/profile_section/language/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/language/model.nim
+++ b/src/app/modules/main/profile_section/language/model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import nimqml, tables
 
 import item
 

--- a/src/app/modules/main/profile_section/language/module.nim
+++ b/src/app/modules/main/profile_section/language/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, chronicles
+import nimqml, tables, chronicles
 
 import io_interface, view, controller, item, model, locale_table
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/language/view.nim
+++ b/src/app/modules/main/profile_section/language/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import io_interface, model
 

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface, view, controller
 import ../io_interface as delegate_interface
 import ../../../global/global_singleton

--- a/src/app/modules/main/profile_section/notifications/io_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 from ../../../../../app_service/service/community/dto/community import CommunityDto
 from ../../../../../app_service/service/chat/dto/chat import ChatDto
 

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import item
 
 import ../../../../../app_service/service/settings/dto/settings

--- a/src/app/modules/main/profile_section/notifications/module.nim
+++ b/src/app/modules/main/profile_section/notifications/module.nim
@@ -1,4 +1,4 @@
-import NimQml, algorithm, chronicles
+import nimqml, algorithm, chronicles
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item

--- a/src/app/modules/main/profile_section/notifications/view.nim
+++ b/src/app/modules/main/profile_section/notifications/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface, model
 
 QtObject:

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 
 import ../../../../../app/global/global_singleton
 

--- a/src/app/modules/main/profile_section/privacy/view.nim
+++ b/src/app/modules/main/profile_section/privacy/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface
 

--- a/src/app/modules/main/profile_section/profile/io_interface.nim
+++ b/src/app/modules/main/profile_section/profile/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import app_service/service/profile/dto/profile_showcase_preferences
 

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_generic_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_generic_model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, sequtils, json
+import nimqml, tables, strutils, sequtils, json
 
 import app_service/service/profile/dto/profile_showcase_preferences
 

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, sequtils, json
+import nimqml, tables, strutils, sequtils, json
 
 type
   ShowcasePreferencesSocialLinkItem* = object of RootObj

--- a/src/app/modules/main/profile_section/profile/module.nim
+++ b/src/app/modules/main/profile_section/profile/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, strutils
+import nimqml, chronicles, strutils
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils
+import nimqml, json, sequtils
 
 import io_interface
 

--- a/src/app/modules/main/profile_section/sync/io_interface.nim
+++ b/src/app/modules/main/profile_section/sync/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/sync/model.nim
+++ b/src/app/modules/main/profile_section/sync/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import item
 
 type

--- a/src/app/modules/main/profile_section/sync/module.nim
+++ b/src/app/modules/main/profile_section/sync/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item

--- a/src/app/modules/main/profile_section/sync/view.nim
+++ b/src/app/modules/main/profile_section/sync/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface, model
 
 type

--- a/src/app/modules/main/profile_section/view.nim
+++ b/src/app/modules/main/profile_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface
 

--- a/src/app/modules/main/profile_section/waku/io_interface.nim
+++ b/src/app/modules/main/profile_section/waku/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/waku/model.nim
+++ b/src/app/modules/main/profile_section/waku/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import item
 
 type

--- a/src/app/modules/main/profile_section/waku/module.nim
+++ b/src/app/modules/main/profile_section/waku/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item

--- a/src/app/modules/main/profile_section/waku/view.nim
+++ b/src/app/modules/main/profile_section/waku/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface, model
 
 QtObject:

--- a/src/app/modules/main/profile_section/wallet/accounts/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, stew/shims/strformat
+import nimqml, tables, strutils, sequtils, stew/shims/strformat
 
 import ../../../../shared_models/wallet_account_item
 

--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar
+import nimqml, sequtils, sugar
 
 import ./io_interface, ./view
 import ./controller as accountsc

--- a/src/app/modules/main/profile_section/wallet/accounts/view.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, strutils
+import nimqml, sequtils, strutils
 
 import ./io_interface
 import ./model

--- a/src/app/modules/main/profile_section/wallet/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import app/modules/shared_modules/keypair_import/module as keypair_import_module
 import app_service/service/devices/service as devices_service
 

--- a/src/app/modules/main/profile_section/wallet/module.nim
+++ b/src/app/modules/main/profile_section/wallet/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 
 import ./io_interface as io_interface
 import ./controller, ./view

--- a/src/app/modules/main/profile_section/wallet/view.nim
+++ b/src/app/modules/main/profile_section/wallet/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface
 from app/modules/shared_modules/keypair_import/module import ImportKeypairModuleMode

--- a/src/app/modules/main/shared_urls/module.nim
+++ b/src/app/modules/main/shared_urls/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import io_interface, view, controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/shared_urls/view.nim
+++ b/src/app/modules/main/shared_urls/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, sequtils
+import nimqml, json, strutils, sequtils
 
 import ./io_interface
 

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -1,4 +1,4 @@
-import Tables, uuids, stint
+import tables, uuids, stint
 
 import ./io_interface
 

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 import ./item
 
 import app_service/service/stickers/service as stickers_service

--- a/src/app/modules/main/stickers/models/sticker_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_list.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils
+import nimqml, tables, sequtils
 import ../io_interface, ../item
 
 type

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils, sugar
+import nimqml, tables, sequtils, sugar
 import ./sticker_list
 import ../io_interface, ../item
 # TODO remove those uses of services stuff

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sugar, sequtils
+import nimqml, tables, sugar, sequtils
 import ./io_interface, ./view, ./controller, ./item, ./models/sticker_pack_list
 import ../io_interface as delegate_interface
 import app/global/global_singleton

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils
+import nimqml, json, strutils
 
 import ./models/[sticker_list, sticker_pack_list]
 import ./io_interface, ./item

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils
+import nimqml, strutils
 import app/global/global_singleton
 import app/modules/shared_models/section_model
 import app/modules/shared_models/section_item

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ../../../shared_models/wallet_account_item
 import ../../../shared_models/currency_amount
 

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat, std/sequtils, chronicles
+import nimqml, tables, strutils, stew/shims/strformat, std/sequtils, chronicles
 
 import ./item
 import ../../../shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, sugar, tables
+import nimqml, json, sequtils, sugar, tables
 
 import ./io_interface, ./view, ./controller
 import ./item as wallet_accounts_item

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, strutils, tables
+import nimqml, json, sequtils, strutils, tables
 
 import app_service/service/wallet_account/service as wallet_account_service
 import app/modules/shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/activity/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat, sequtils, stint, options
+import nimqml, tables, strutils, stew/shims/strformat, sequtils, stint, options
 import chronicles
 
 import ./collectibles_item

--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, std/json, sequtils, sugar, options, strutils
+import nimqml, chronicles, std/json, sequtils, sugar, options, strutils
 import tables, stint, sets
 
 import model

--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -1,4 +1,4 @@
-import NimQml, json, stew/shims/strformat, sequtils, strutils, chronicles, stint, options
+import nimqml, json, stew/shims/strformat, sequtils, strutils, chronicles, stint, options
 
 import backend/activity as backend
 import app/modules/shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/activity/events_handler.nim
+++ b/src/app/modules/main/wallet_section/activity/events_handler.nim
@@ -1,4 +1,4 @@
-import NimQml, std/json, sequtils, strutils, options
+import nimqml, std/json, sequtils, strutils, options
 import tables, stint
 
 import entry

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat, sequtils, chronicles, options
+import nimqml, tables, strutils, stew/shims/strformat, sequtils, chronicles, options
 
 import ./entry
 

--- a/src/app/modules/main/wallet_section/activity/recipients_model.nim
+++ b/src/app/modules/main/wallet_section/activity/recipients_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, chronicles
+import nimqml, tables, strutils, sequtils, chronicles
 
 type
   ModelRole {.pure.} = enum

--- a/src/app/modules/main/wallet_section/activity/status.nim
+++ b/src/app/modules/main/wallet_section/activity/status.nim
@@ -1,4 +1,4 @@
-import NimQml, std/json, sequtils, strutils, times
+import nimqml, std/json, sequtils, strutils, times
 import atomics
 
 import app/core/signals/types

--- a/src/app/modules/main/wallet_section/activity/transaction_identities_model.nim
+++ b/src/app/modules/main/wallet_section/activity/transaction_identities_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat, sequtils
+import nimqml, tables, strutils, stew/shims/strformat, sequtils
 
 import backend/backend
 

--- a/src/app/modules/main/wallet_section/all_collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./io_interface, ./view
 import  ./controller as all_collectibles_controller

--- a/src/app/modules/main/wallet_section/all_collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, strutils, chronicles
+import nimqml, sequtils, strutils, chronicles
 
 import ./io_interface
 

--- a/src/app/modules/main/wallet_section/all_tokens/address_per_chain_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/address_per_chain_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import nimqml, tables, strutils
 
 import ./io_interface
 

--- a/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import nimqml, tables, strutils
 
 import ./io_interface, ./market_details_item
 

--- a/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/market_details_item.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils
+import nimqml, strutils
 
 import ./io_interface
 import app/modules/shared/wallet_utils

--- a/src/app/modules/main/wallet_section/all_tokens/module.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/wallet_section/all_tokens/sources_of_tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/sources_of_tokens_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 
 
 import ./io_interface

--- a/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import nimqml, tables, strutils
 
 import ./io_interface, ./address_per_chain_model, ./market_details_item
 

--- a/src/app/modules/main/wallet_section/all_tokens/view.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, strutils, chronicles
+import nimqml, sequtils, strutils, chronicles
 
 import ./io_interface, ./sources_of_tokens_model, ./flat_tokens_model, ./token_by_symbol_model
 

--- a/src/app/modules/main/wallet_section/assets/balances_model.nim
+++ b/src/app/modules/main/wallet_section/assets/balances_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, stint
+import nimqml, tables, strutils, sequtils, stint
 
 import ./io_interface
 

--- a/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
+++ b/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils
+import nimqml, tables, sequtils
 
 import ./io_interface, ./balances_model
 

--- a/src/app/modules/main/wallet_section/assets/module.nim
+++ b/src/app/modules/main/wallet_section/assets/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import app/global/global_singleton
 import app/core/eventemitter

--- a/src/app/modules/main/wallet_section/assets/view.nim
+++ b/src/app/modules/main/wallet_section/assets/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils
+import nimqml, json, strutils
 
 import ./io_interface
 import ./grouped_account_assets_model as grouped_account_assets_model

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/model.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 
 import item
 

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/module.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/module.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar
+import nimqml, sequtils, sugar
 
 import ./io_interface, ./view, ./controller, ./utils
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/view.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import options
 
 import ./model

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ../../shared_models/currency_amount
 export CurrencyAmount
 

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles, sequtils, strutils, sugar
+import nimqml, json, chronicles, sequtils, strutils, sugar
 
 import ./controller, ./view, ./filter
 import ./io_interface as io_interface

--- a/src/app/modules/main/wallet_section/networks/model.nim
+++ b/src/app/modules/main/wallet_section/networks/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, sugar
+import nimqml, tables, strutils, sequtils, sugar
 
 import ./io_interface
 

--- a/src/app/modules/main/wallet_section/networks/module.nim
+++ b/src/app/modules/main/wallet_section/networks/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import ../io_interface as delegate_interface
 import io_interface, view, controller
 import app/global/global_singleton

--- a/src/app/modules/main/wallet_section/networks/rpc_providers_model.nim
+++ b/src/app/modules/main/wallet_section/networks/rpc_providers_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils
+import nimqml, tables, strutils, sequtils
 
 import ./io_interface
 

--- a/src/app/modules/main/wallet_section/networks/view.nim
+++ b/src/app/modules/main/wallet_section/networks/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, strutils
+import nimqml, sequtils, strutils
 
 import ./io_interface, ./model, ./rpc_providers_model
 

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import app/global/global_singleton
 import app/core/eventemitter

--- a/src/app/modules/main/wallet_section/overview/view.nim
+++ b/src/app/modules/main/wallet_section/overview/view.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, json
+import nimqml, sequtils, json
 
 import ./io_interface
 import ../../../shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/saved_addresses/model.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import item
 import app_service/common/account_constants

--- a/src/app/modules/main/wallet_section/saved_addresses/module.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/module.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sugar, sequtils
+import nimqml, json, sugar, sequtils
 import ../io_interface as delegate_interface
 
 import app/global/global_singleton

--- a/src/app/modules/main/wallet_section/saved_addresses/view.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import model
 import io_interface

--- a/src/app/modules/main/wallet_section/send/controller.nim
+++ b/src/app/modules/main/wallet_section/send/controller.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 import uuids, chronicles
 import io_interface
 import app_service/service/wallet_account/service as wallet_account_service

--- a/src/app/modules/main/wallet_section/send/gas_estimate_item.nim
+++ b/src/app/modules/main/wallet_section/send/gas_estimate_item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 QtObject:
   type GasEstimateItem* = ref object of QObject

--- a/src/app/modules/main/wallet_section/send/gas_fees_item.nim
+++ b/src/app/modules/main/wallet_section/send/gas_fees_item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 QtObject:
   type GasFeesItem* = ref object of QObject

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 import app/modules/shared_models/currency_amount
 import app_service/service/transaction/dto
 import app_service/service/transaction/router_transactions_dto

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -1,4 +1,4 @@
-import tables, NimQml, sequtils, sugar, stint, strutils, chronicles
+import tables, nimqml, sequtils, sugar, stint, strutils, chronicles
 
 import ./io_interface, ./view, ./controller, ./network_route_item, ./transaction_routes, ./suggested_route_item, ./suggested_route_model, ./gas_estimate_item, ./gas_fees_item, ./network_route_model
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/wallet_section/send/network_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_route_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat, sequtils, sugar, json, stint
+import nimqml, tables, strutils, stew/shims/strformat, sequtils, sugar, json, stint
 
 import app_service/service/network/types
 import app/modules/shared_models/currency_amount

--- a/src/app/modules/main/wallet_section/send/suggested_route_item.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import ./gas_fees_item
 

--- a/src/app/modules/main/wallet_section/send/suggested_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import ./suggested_route_item
 

--- a/src/app/modules/main/wallet_section/send/transaction_routes.nim
+++ b/src/app/modules/main/wallet_section/send/transaction_routes.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat, stint
+import nimqml, stew/shims/strformat, stint
 
 import ./gas_estimate_item, ./suggested_route_model, ./network_route_model, ./io_interface
 

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strutils, stint, chronicles
+import nimqml, tables, json, sequtils, strutils, stint, chronicles
 
 import ./io_interface, ./network_route_model, ./network_route_item, ./suggested_route_item, ./transaction_routes
 import app_service/service/network/service as network_service

--- a/src/app/modules/main/wallet_section/send_new/controller.nim
+++ b/src/app/modules/main/wallet_section/send_new/controller.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 import uuids, chronicles
 
 import io_interface

--- a/src/app/modules/main/wallet_section/send_new/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send_new/io_interface.nim
@@ -1,4 +1,4 @@
-import Tables
+import tables
 
 import app_service/service/transaction/dto
 import app_service/service/transaction/router_transactions_dto

--- a/src/app/modules/main/wallet_section/send_new/module.nim
+++ b/src/app/modules/main/wallet_section/send_new/module.nim
@@ -1,4 +1,4 @@
-import tables, NimQml, sequtils, sugar, strutils, chronicles, stint
+import tables, nimqml, sequtils, sugar, strutils, chronicles, stint
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface

--- a/src/app/modules/main/wallet_section/send_new/path_item.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import app_service/common/wallet_constants
 

--- a/src/app/modules/main/wallet_section/send_new/path_model.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import ./path_item
 

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strutils, stint, chronicles
+import nimqml, tables, json, sequtils, strutils, stint, chronicles
 
 import ./io_interface, ./path_model, ./path_item
 import app_service/common/utils as common_utils

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml, json
+import nimqml, json
 
 import ./activity/controller as activityc
 import app/modules/shared_modules/collectible_details/controller as collectible_detailsc

--- a/src/app/modules/onboarding/models/login_account_item.nim
+++ b/src/app/modules/onboarding/models/login_account_item.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import sequtils, sugar
 import ../../shared_models/[color_hash_item, color_hash_model]

--- a/src/app/modules/onboarding/models/login_account_model.nim
+++ b/src/app/modules/onboarding/models/login_account_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import nimqml, tables, strutils
 
 import login_account_item
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, json, strutils, sequtils
+import nimqml, chronicles, json, strutils, sequtils
 import chronicles
 
 import io_interface, states

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface, states
 from app_service/service/keycardV2/dto import KeycardEventDto
 from app_service/service/devices/dto/local_pairing_status import LocalPairingState

--- a/src/app/modules/shared_models/collectible_ownership_model.nim
+++ b/src/app/modules/shared_models/collectible_ownership_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 import stint
 
 import backend/collectibles_types as backend

--- a/src/app/modules/shared_models/collectible_trait_model.nim
+++ b/src/app/modules/shared_models/collectible_trait_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import backend/collectibles as backend
 

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -1,4 +1,4 @@
-import NimQml, json, stew/shims/strformat, sequtils, strutils, stint, strutils
+import nimqml, json, stew/shims/strformat, sequtils, strutils, stint, strutils
 import options
 
 import backend/collectibles as backend

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat, sequtils, stint, json
+import nimqml, tables, strutils, stew/shims/strformat, sequtils, stint, json
 import chronicles
 
 import ./collectibles_entry

--- a/src/app/modules/shared_models/color_hash_model.nim
+++ b/src/app/modules/shared_models/color_hash_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json
+import nimqml, tables, json
 
 import color_hash_item
 

--- a/src/app/modules/shared_models/contract_model.nim
+++ b/src/app/modules/shared_models/contract_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import ./contract_item
 

--- a/src/app/modules/shared_models/currency_amount.nim
+++ b/src/app/modules/shared_models/currency_amount.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat, json
+import nimqml, stew/shims/strformat, json
 
 include app_service/common/json_utils
 

--- a/src/app/modules/shared_models/derived_address_item.nim
+++ b/src/app/modules/shared_models/derived_address_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 
 QtObject:
   type DerivedAddressItem* = ref object of QObject

--- a/src/app/modules/shared_models/derived_address_model.nim
+++ b/src/app/modules/shared_models/derived_address_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, sugar, stew/shims/strformat
+import nimqml, tables, strutils, sequtils, sugar, stew/shims/strformat
 
 import ./derived_address_item
 

--- a/src/app/modules/shared_models/emoji_reactions_model.nim
+++ b/src/app/modules/shared_models/emoji_reactions_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import emoji_reactions_item
 
 type

--- a/src/app/modules/shared_models/keypair_account_item.nim
+++ b/src/app/modules/shared_models/keypair_account_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 import app_service/service/wallet_account/dto/account_dto as wa_dto
 import ./currency_amount
 

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, strutils
+import nimqml, tables, stew/shims/strformat, strutils
 import keypair_account_item
 import ./currency_amount
 

--- a/src/app/modules/shared_models/keypair_item.nim
+++ b/src/app/modules/shared_models/keypair_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat, sequtils, sugar
+import nimqml, stew/shims/strformat, sequtils, sugar
 import keypair_account_model
 import ./currency_amount
 

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, sequtils, sugar
+import nimqml, tables, stew/shims/strformat, sequtils, sugar
 import keypair_item
 import keypair_account_item
 import ./currency_amount

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat, tables, sequtils, sets
+import nimqml, stew/shims/strformat, tables, sequtils, sets
 import ./link_preview_item
 import ../../../app_service/service/message/dto/link_preview
 import ../../../app_service/service/message/utils/link_preview_utils

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, sequtils, sugar
+import nimqml, tables, stew/shims/strformat, sequtils, sugar
 # TODO: use generics to remove duplication between user_model and member_model
 
 import app/global/global_singleton

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -1,4 +1,4 @@
-import NimQml, std/wrapnils, strutils
+import nimqml, std/wrapnils, strutils
 import ./message_item
 
 QtObject:

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sets, algorithm, sequtils, strutils, stew/shims/strformat, sugar
+import nimqml, tables, json, sets, algorithm, sequtils, strutils, stew/shims/strformat, sugar
 
 import message_item, message_reaction_item, message_transaction_parameters_item, contacts_utils
 

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, strutils, stew/shims/strformat
+import nimqml, tables, json, strutils, stew/shims/strformat
 
 import message_reaction_item
 
@@ -67,7 +67,7 @@ QtObject:
     of ModelRole.NumberOfReactions:
       result = newQVariant(item.numberOfReactions)
     of ModelRole.JsonArrayOfUsersReactedWithThisEmoji:
-      # Would be good if we could return QVariant of array (seq) here, but it's not supported in our NimQml,
+      # Would be good if we could return QVariant of array (seq) here, but it's not supported in our nimqml,
       # because of that we're returning json array as a string.
       result = newQVariant($item.jsonArrayOfUsersReactedWithThisEmoji)
 

--- a/src/app/modules/shared_models/payment_request_model.nim
+++ b/src/app/modules/shared_models/payment_request_model.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat, tables, sequtils
+import nimqml, stew/shims/strformat, tables, sequtils
 import ../../../app_service/service/message/dto/payment_request
 
 type

--- a/src/app/modules/shared_models/section_details.nim
+++ b/src/app/modules/shared_models/section_details.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import section_item
 
 QtObject:

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, stew/shims/strformat
+import nimqml, tables, strutils, stew/shims/strformat
 
 import json
 

--- a/src/app/modules/shared_models/token_criteria_model.nim
+++ b/src/app/modules/shared_models/token_criteria_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 
 import app_service/common/types
 

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import token_list_item
 
 type

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import token_permission_chat_list_item
 
 type

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import nimqml, tables
 import token_permission_item
 import token_permission_chat_list_item
 import token_permission_chat_list_model

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, sequtils, sugar
+import nimqml, tables, stew/shims/strformat, sequtils, sugar
 import user_item
 
 import ../../../app_service/common/types

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 import app_service/service/wallet_account/dto/account_dto as wa_dto
 
 export wa_dto

--- a/src/app/modules/shared_modules/add_account/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/add_account/internal/state_wrapper.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import state
 
 QtObject:

--- a/src/app/modules/shared_modules/add_account/io_interface.nim
+++ b/src/app/modules/shared_modules/add_account/io_interface.nim
@@ -1,4 +1,4 @@
-import Tables, NimQml
+import tables, nimqml
 
 import ../../../../app_service/service/accounts/dto/generated_accounts
 import ../../../../app_service/service/wallet_account/dto/derived_address_dto

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, sequtils, chronicles
+import nimqml, tables, strutils, sequtils, chronicles
 
 import io_interface
 import view, controller

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface
 import internal/[state, state_wrapper]
 import ../../shared_models/[keypair_model, keypair_item, derived_address_model]

--- a/src/app/modules/shared_modules/collectible_details/controller.nim
+++ b/src/app/modules/shared_modules/collectible_details/controller.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, std/json, sequtils, strutils
+import nimqml, chronicles, std/json, sequtils, strutils
 import stint
 
 import app/modules/shared_models/collectibles_entry

--- a/src/app/modules/shared_modules/collectible_details/events_handler.nim
+++ b/src/app/modules/shared_modules/collectible_details/events_handler.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, std/json, sequtils, strutils, options
+import nimqml, chronicles, std/json, sequtils, strutils, options
 import tables
 
 import app/core/eventemitter

--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -1,5 +1,5 @@
-import NimQml, std/json, sequtils, sugar, strutils
-import stint, chronicles, Tables
+import nimqml, std/json, sequtils, sugar, strutils
+import stint, chronicles, tables
 
 import app/modules/shared_models/collectibles_entry
 import app/modules/shared_models/collectibles_model

--- a/src/app/modules/shared_modules/collectibles/events_handler.nim
+++ b/src/app/modules/shared_modules/collectibles/events_handler.nim
@@ -1,4 +1,4 @@
-import NimQml, std/json, sequtils, strutils, options
+import nimqml, std/json, sequtils, strutils, options
 import tables, sets
 
 import app/core/eventemitter

--- a/src/app/modules/shared_modules/connector/controller.nim
+++ b/src/app/modules/shared_modules/connector/controller.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import json, strutils
 import chronicles
 import app/core/eventemitter

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_wrapper.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import state
 
 QtObject:

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, tables
+import nimqml, tables
 import app/core/eventemitter
 from app_service/service/keycard/service import KeycardEvent, CardMetadata, KeyDetails
 

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 import ../../../shared_models/keypair_item
 
 export keypair_item

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, stew/shims/strformat, sequtils
+import nimqml, tables, stew/shims/strformat, sequtils
 import keycard_item
 
 export keycard_item

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, strutils, sequtils, sugar, chronicles
+import nimqml, tables, strutils, sequtils, sugar, chronicles
 
 import io_interface
 import view, controller

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface
 import internal/[state, state_wrapper]
 import ../../shared_models/[keypair_model, keypair_item]

--- a/src/app/modules/shared_modules/keypair_import/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/keypair_import/internal/state_wrapper.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import state
 
 QtObject:

--- a/src/app/modules/shared_modules/keypair_import/io_interface.nim
+++ b/src/app/modules/shared_modules/keypair_import/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 
 import app/modules/shared_models/[keypair_item]
 import app_service/service/wallet_account/dto/derived_address_dto

--- a/src/app/modules/shared_modules/keypair_import/module.nim
+++ b/src/app/modules/shared_modules/keypair_import/module.nim
@@ -1,4 +1,4 @@
-import NimQml, strutils, chronicles
+import nimqml, strutils, chronicles
 
 import io_interface
 import view, controller

--- a/src/app/modules/shared_modules/keypair_import/view.nim
+++ b/src/app/modules/shared_modules/keypair_import/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import io_interface
 import internal/[state, state_wrapper]
 import app/modules/shared_models/[keypair_model, derived_address_model]

--- a/src/app/modules/shared_modules/wallet_connect/controller.nim
+++ b/src/app/modules/shared_modules/wallet_connect/controller.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import chronicles, times, json
 
 import app/core/eventemitter

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -1,4 +1,5 @@
-import json, times, stint, strutils, sugar, os, re, chronicles
+import std/[json, sugar, strutils]
+import stint, os, re, chronicles
 
 import nimcrypto
 import account_constants
@@ -83,12 +84,10 @@ proc intersectSeqs*[T](seq1, seq2: seq[T]): seq[T] =
       result.add(item)
 
 proc stringToUint256*(value: string): Uint256 =
-  var parsedValue = stint.u256(0)
   try:
-    parsedValue = value.parse(Uint256)
-  except Exception as e:
-    discard
-  return parsedValue
+    value.parse(Uint256)
+  except:
+    stint.u256(0)
 
 proc createHash*(signature: string): string =
   let signatureHex = if signature.startsWith("0x"): signature[2..^1] else: signature

--- a/src/app_service/service/about/service.nim
+++ b/src/app_service/service/about/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles
+import nimqml, json, chronicles
 
 import ../settings/service as settings_service
 import ../network/types

--- a/src/app_service/service/accounts/dto/generated_accounts.nim
+++ b/src/app_service/service/accounts/dto/generated_accounts.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import Tables, json
+import tables, json
 
 import ../../../common/account_constants
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, os, json, stew/shims/strformat, sequtils, strutils, times, std/options
+import nimqml, tables, os, json, stew/shims/strformat, sequtils, strutils, times, std/options
 import app_service/common/safe_json_serialization, chronicles
 
 import ../../../app/global/global_singleton

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, chronicles, strutils, strutils, stint, sugar, tables, app_service/common/safe_json_serialization
+import nimqml, json, sequtils, chronicles, strutils, strutils, stint, sugar, tables, app_service/common/safe_json_serialization
 
 import ../../../app/core/eventemitter
 import ../../../app/core/[main]

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, chronicles, os, strutils, uuids, base64
+import nimqml, tables, json, sequtils, chronicles, os, strutils, uuids, base64
 import std/[times, os]
 
 import app/core/tasks/[qt, threadpool]

--- a/src/app_service/service/collectible/service.nim
+++ b/src/app_service/service/collectible/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, chronicles, strutils
+import nimqml, json, sequtils, chronicles, strutils
 
 import backend/collectibles as backend
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, std/sets, std/algorithm, stew/shims/strformat, strutils, chronicles, sugar, times
+import nimqml, tables, json, sequtils, std/sets, std/algorithm, stew/shims/strformat, strutils, chronicles, sugar, times
 import json_serialization/std/tables as ser_tables # Needed to serialize tables inside objects
 
 import app_service/common/safe_json_serialization

--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -1,4 +1,4 @@
-import stint, Tables
+import stint, tables
 
 import backend/collectibles
 import app/core/tasks/qt

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, stint, strutils, sugar, sequtils, stew/shims/strformat, times
+import nimqml, tables, chronicles, json, stint, strutils, sugar, sequtils, stew/shims/strformat, times
 
 import app/global/global_singleton
 import app/core/eventemitter

--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, json
+import nimqml, chronicles, json
 
 import backend/connector as status_go
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, stew/shims/strformat, chronicles, strutils, times, std/times
+import nimqml, tables, json, sequtils, stew/shims/strformat, chronicles, strutils, times, std/times
 
 import app/global/global_singleton
 import app/core/signals/types

--- a/src/app_service/service/currency/service.nim
+++ b/src/app_service/service/currency/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, strutils, tables, json, stint
+import nimqml, chronicles, strutils, tables, json, stint
 
 import ../../../backend/backend as backend
 

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, system, chronicles, uuids
+import nimqml, json, sequtils, system, chronicles, uuids
 
 import std/os
 

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strutils, stint, sugar, chronicles
+import nimqml, tables, json, sequtils, strutils, stint, sugar, chronicles
 import web3/eth_api_types, stew/byteutils, nimcrypto, app_service/common/safe_json_serialization
 
 import app/core/eventemitter

--- a/src/app_service/service/ens/utils.nim
+++ b/src/app_service/service/ens/utils.nim
@@ -1,6 +1,6 @@
-import Tables, json, chronicles, strutils
-import stew/shims/strformat, sets, options
-import chronicles, libp2p/[multihash, multicodec, cid]
+import std/[json, options, strutils]
+import stew/shims/strformat
+import chronicles
 import nimcrypto, stint
 import ../../common/conversion as common_conversion
 import ../eth/dto/transaction as eth_transaction_dto

--- a/src/app_service/service/eth/dto/coder.nim
+++ b/src/app_service/service/eth/dto/coder.nim
@@ -1,9 +1,4 @@
-import tables, strutils, stint, macros
-import
-  web3/[encoding, eth_api_types], stew/byteutils, nimcrypto, json_serialization, chronicles
-import json, tables, app_service/common/safe_json_serialization
-
-include  ../../../common/json_utils
+import stint, web3/[encoding, eth_api_types]
 
 type
   Transfer* = object

--- a/src/app_service/service/eth/utils.nim
+++ b/src/app_service/service/eth/utils.nim
@@ -1,12 +1,11 @@
 import
-  json, tables, sequtils, net
-import json, strutils, stew/shims/strformat, tables, chronicles, unicode, times
-import
+  std/[json, net, sequtils, strutils, times, unicode],
+  stew/shims/strformat,
   stew/byteutils,
-  json_serialization, chronicles, libp2p/[multihash, multicodec, cid], stint, nimcrypto
+  json_serialization,
+  stint
+
 from sugar import `=>`, `->`
-import stint
-from times import getTime, toUnix, nanosecond
 
 import ../../common/conversion as common_conversion
 

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -1,4 +1,4 @@
-import NimQml, os, json, chronicles
+import nimqml, os, json, chronicles
 
 import backend/mailservers as status_mailservers
 import backend/general as status_general

--- a/src/app_service/service/gif/service.nim
+++ b/src/app_service/service/gif/service.nim
@@ -4,7 +4,7 @@ import os
 import uri
 import chronicles
 import sequtils
-import NimQml
+import nimqml
 
 import ../settings/service as settings_service
 import ../../../app/core/eventemitter

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, os
+import nimqml, chronicles, os
 import app/global/feature_flags
 import constants
 import app/core/tasks/[qt, threadpool]

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, os, chronicles, strutils, random, app_service/common/safe_json_serialization
+import nimqml, tables, json, os, chronicles, strutils, random, app_service/common/safe_json_serialization
 import app/global/feature_flags
 import app/global/global_singleton
 import app/core/eventemitter

--- a/src/app_service/service/keychain/service.nim
+++ b/src/app_service/service/keychain/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles
+import nimqml, chronicles
 
 import ../../../app/core/eventemitter
 

--- a/src/app_service/service/language/service.nim
+++ b/src/app_service/service/language/service.nim
@@ -1,4 +1,4 @@
-import NimQml
+import nimqml
 import chronicles, os, stew/shims/strformat, re
 
 import ../../../constants as main_constants

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, strutils, system, uuids, chronicles, os
+import nimqml, tables, json, sequtils, strutils, system, uuids, chronicles, os
 
 import ./dto/mailserver as mailserver_dto
 import ../../../app/core/signals/types

--- a/src/app_service/service/market/service.nim
+++ b/src/app_service/service/market/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles
+import nimqml, tables, chronicles
 
 import app/core/eventemitter
 import app/core/signals/types

--- a/src/app_service/service/message/dto/link_preview_thumbnail.nim
+++ b/src/app_service/service/message/dto/link_preview_thumbnail.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, NimQml, chronicles
+import json, stew/shims/strformat, nimqml, chronicles
 include ../../../common/json_utils
 
 QtObject:

--- a/src/app_service/service/message/dto/standard_link_preview.nim
+++ b/src/app_service/service/message/dto/standard_link_preview.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, NimQml
+import json, stew/shims/strformat, nimqml
 import ./link_preview_thumbnail
 include ../../../common/json_utils
 

--- a/src/app_service/service/message/dto/status_community_channel_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_channel_link_preview.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, NimQml, chronicles
+import json, stew/shims/strformat, nimqml, chronicles
 import link_preview_thumbnail
 import status_community_link_preview
 

--- a/src/app_service/service/message/dto/status_community_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_link_preview.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, NimQml, chronicles
+import json, stew/shims/strformat, nimqml, chronicles
 import link_preview_thumbnail
 
 include ../../../common/json_utils

--- a/src/app_service/service/message/dto/status_contact_link_preview.nim
+++ b/src/app_service/service/message/dto/status_contact_link_preview.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, NimQml, chronicles
+import json, stew/shims/strformat, nimqml, chronicles
 import app/global/global_singleton
 import link_preview_thumbnail
 import ../../contacts/dto/contact_details

--- a/src/app_service/service/message/dto/urls_unfurling_plan.nim
+++ b/src/app_service/service/message/dto/urls_unfurling_plan.nim
@@ -1,4 +1,4 @@
-import json, stew/shims/strformat, chronicles, Tables
+import json, stew/shims/strformat, chronicles, tables
 include ../../../common/json_utils
 
 type 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1,4 +1,4 @@
-import NimQml, tables, json, re, sequtils, stew/shims/strformat, strutils, chronicles, times, oids, uuids
+import nimqml, tables, json, re, sequtils, stew/shims/strformat, strutils, chronicles, times, oids, uuids
 
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/core/signals/types

--- a/src/app_service/service/metrics/service.nim
+++ b/src/app_service/service/metrics/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles, times
+import nimqml, json, chronicles, times
 include ../../common/json_utils
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/global/global_singleton

--- a/src/app_service/service/network/network_item.nim
+++ b/src/app_service/service/network/network_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 import sequtils, sugar
 
 import backend/network_types

--- a/src/app_service/service/network/rpc_provider_item.nim
+++ b/src/app_service/service/network/rpc_provider_item.nim
@@ -1,4 +1,4 @@
-import NimQml, stew/shims/strformat
+import nimqml, stew/shims/strformat
 
 import backend/network_types
 

--- a/src/app_service/service/network_connection/service.nim
+++ b/src/app_service/service/network_connection/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, Tables, strutils, sequtils, json
+import nimqml, chronicles, tables, strutils, sequtils, json
 
 import ../../../app/global/global_singleton
 import ../../../app/core/eventemitter

--- a/src/app_service/service/node/service.nim
+++ b/src/app_service/service/node/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, strutils, json
+import nimqml, chronicles, strutils, json
 
 import ../settings/service as settings_service
 import ../node_configuration/service as node_configuration_service

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, strutils, chronicles
+import nimqml, json, strutils, chronicles
 
 
 import ../settings/service as settings_service

--- a/src/app_service/service/profile/service.nim
+++ b/src/app_service/service/profile/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles, tables, sequtils
+import nimqml, json, chronicles, tables, sequtils
 
 import ../settings/service as settings_service
 import app/global/global_singleton

--- a/src/app_service/service/ramp/service.nim
+++ b/src/app_service/service/ramp/service.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar, chronicles, json
+import nimqml, sequtils, sugar, chronicles, json
 
 import app/core/[main]
 import app/core/signals/types

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, strutils, sequtils, json
+import nimqml, chronicles, strutils, sequtils, json
 
 import dto
 

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -1,4 +1,4 @@
-import Tables, json, options, tables, strutils, times, chronicles
+import tables, json, options, tables, strutils, times, chronicles
 import ../../stickers/dto/stickers
 
 include ../../../common/json_utils

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, json, strutils, sequtils, tables, times
+import nimqml, chronicles, json, strutils, sequtils, tables, times
 
 import app/core/eventemitter
 import app/core/fleets/fleet_configuration

--- a/src/app_service/service/shared_urls/service.nim
+++ b/src/app_service/service/shared_urls/service.nim
@@ -1,4 +1,4 @@
-import NimQml, json, chronicles, strutils
+import nimqml, json, chronicles, strutils
 
 import ../../../backend/general as status_general
 import ../../../app/core/eventemitter

--- a/src/app_service/service/stickers/dto/stickers.nim
+++ b/src/app_service/service/stickers/dto/stickers.nim
@@ -59,7 +59,7 @@ proc `%`*(stuint256: Stuint[256]): JsonNode =
   newJString($stuint256)
 
 proc readValue*(reader: var JsonReader, value: var Stuint[256])
-               {.raises: [IOError, SerializationError, Defect].} =
+               {.raises: [IOError, SerializationError].} =
   try:
     let strVal = reader.readValue(string)
     value = strVal.parse(Stuint[256])

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, chronicles, strutils, sets, stint
+import nimqml, tables, json, sequtils, chronicles, strutils, sets, stint
 
 import app/core/[main]
 import app/core/tasks/[qt, threadpool]

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, chronicles, strutils, algorithm, sugar
+import nimqml, tables, json, sequtils, chronicles, strutils, algorithm, sugar
 
 import web3/eth_api_types
 import backend/backend as backend

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -1,5 +1,5 @@
 import json, strutils, stint, app_service/common/safe_json_serialization, stew/shims/strformat
-import Tables, sequtils
+import tables, sequtils
 
 import
   web3/eth_api_types

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -1,4 +1,4 @@
-import Tables, NimQml, chronicles, sequtils, sugar, stint, strutils, json, stew/shims/strformat
+import tables, nimqml, chronicles, sequtils, sugar, stint, strutils, json, stew/shims/strformat
 
 import backend/collectibles as collectibles
 import backend/transactions as transactions

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, sugar, chronicles, stew/shims/strformat, stint
+import nimqml, tables, json, sequtils, sugar, chronicles, stew/shims/strformat, stint
 import net, strutils, os, times, algorithm, options
 import web3/eth_api_types
 

--- a/src/app_service/service/wallet_connect/service.nim
+++ b/src/app_service/service/wallet_connect/service.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, times, json, uuids
+import nimqml, chronicles, times, json, uuids
 import strutils
 
 import backend/wallet_connect as status_go

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -1,5 +1,5 @@
 import json, stew/shims/strformat
-import stint, Tables, strutils
+import stint, tables, strutils
 import core
 import response_type, collectibles_types
 

--- a/src/backend/collectibles_types.nim
+++ b/src/backend/collectibles_types.nim
@@ -1,5 +1,5 @@
 import json, stew/shims/strformat, app_service/common/safe_json_serialization
-import stint, Tables, options, strutils
+import stint, tables, options, strutils
 import community_tokens_types
 
 include app_service/common/json_utils

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -1,4 +1,4 @@
-import Tables, json, app_service/common/safe_json_serialization, stew/shims/strformat, chronicles
+import tables, json, app_service/common/safe_json_serialization, stew/shims/strformat, chronicles
 
 import ./core as core
 

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, os, stew/shims/strformat, strutils, times, checksums/md5, json, re
+import nimqml, chronicles, os, stew/shims/strformat, strutils, times, checksums/md5, json, re
 
 import status_go
 import app/core/main
@@ -52,7 +52,7 @@ proc prepareLogging() =
   # Outputs logs in the node tab
   when compiles(defaultChroniclesStream.output.writer):
     defaultChroniclesStream.output.writer =
-      proc (logLevel: LogLevel, msg: LogOutputStr) {.gcsafe, raises: [Defect].} =
+      proc (logLevel: LogLevel, msg: LogOutputStr) {.gcsafe, raises: [].} =
         try:
           if signalsManagerQObjPointer != nil:
             signal_handler(signalsManagerQObjPointer, ($(%* {"type": "chronicles-log", "event": msg})).cstring, "receiveChroniclesLogEvent")


### PR DESCRIPTION
Modules are lowercase by convention in Nim, and relying on case insensitivity can sometimes lead to surprising symbol resolution issues. Using lowercase across the board is easier and safer overall.

Also cleans up a few imports - in particular, there are no more `libp2p` imports and we can remove the submodule for now which reduces both clone and build times (though one fine day it might get readded as part of nwaku - that's a bridge to cross then).

### What does the PR do

Refactor / remove stuff

### Impact on end user

Better developer experience

### Risk 

Low