### PR TITLE
Storybook: cmake config for mac fixed

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -139,5 +139,5 @@ set(QML_IMPORT_PATH "${QML_DIRS}" CACHE STRING "Qt Creator extra QML import path
 if (APPLE)
   find_library(AppKit AppKit)
   find_library(Foundation Foundation)
-  target_link_libraries(${PROJECT_LIB} PRIVATE ${AppKit} ${Foundation})
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${AppKit} ${Foundation})
 endif()


### PR DESCRIPTION
### What does the PR do

Fixing regression introduced in https://github.com/status-im/status-desktop/pull/18431, affecting Storybook on mac. 

### Affected areas
Storybook's cmake config

