### PR TITLE
fix(@desktop/wallet): No possibility to add decimal point when adding a number on Send, Swap, Bridge modals

### DIFF
--- a/ui/imports/shared/popups/send/views/AmountToSend.qml
+++ b/ui/imports/shared/popups/send/views/AmountToSend.qml
@@ -221,7 +221,7 @@ Control {
                 leftPadding: 0
                 background: null
 
-                inputMethodHints: Qt.ImhDigitsOnly | Qt.ImhFormattedNumbersOnly
+                inputMethodHints: Qt.ImhFormattedNumbersOnly | Qt.ImhNoPredictiveText
 
                 readOnly: !root.interactive
 


### PR DESCRIPTION
### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

              `  inputMethodHints: Qt.ImhDigitsOnly | Qt.ImhFormattedNumbersOnly`
                
                this in the AmountToSend in incorrect changing this to 
                
               ` inputMethodHints: Qt.ImhFormattedNumbersOnly | Qt.ImhNoPredictiveText`

### Affected areas

Send, Bridge, Swap Modals
### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

iOS:
<img width="1290" height="2796" alt="IMG_0656" src="https://github.com/user-attachments/assets/524ed746-0b27-4570-a66f-58cad3644500" />

android:

https://github.com/user-attachments/assets/5f414984-364b-4622-bc76-8b60fb1fe60c




### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
