### PR TITLE
Chore(android): reduce app size - nim_status_client lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,9 +256,9 @@ ifeq ($(INCLUDE_DEBUG_SYMBOLS),true)
 else
  # Additional optimization flags for release builds are not included at present;
  # adding them will involve refactoring config.nims in the root of this repo
- NIM_PARAMS += -d:release
  STATUSGO_MAKE_PARAMS += CGO_CFLAGS="-O3"
  STATUSKEYCARDGO_MAKE_PARAMS += CGO_CFLAGS="-O3"
+ NIM_PARAMS += -d:release -d:lto
 endif
 
 NIM_PARAMS += --outdir:./bin

--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -36,7 +36,8 @@ FEATURE_FLAGS="FLAG_DAPPS_ENABLED=0 FLAG_CONNECTOR_ENABLED=0 FLAG_KEYCARD_ENABLE
 # build status-client with feature flags
 env $FEATURE_FLAGS ./vendor/nimbus-build-system/scripts/env.sh nim c "${PLATFORM_SPECIFIC[@]}" --outdir:./bin -d:DESKTOP_VERSION="$DESKTOP_VERSION" -d:STATUSGO_VERSION="$STATUSGO_VERSION" -d:GIT_COMMIT="$(git log --pretty=format:'%h' -n 1)" -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=file -d:chronicles_log_level=trace \
     --mm:refc \
-    --opt:speed \
+    --opt:size \
+    -d:lto \
     --cc:clang \
     --cpu:"$CARCH" \
     --noMain:on \


### PR DESCRIPTION
### What does the PR do

Iterates: [#18454](https://github.com/status-im/status-desktop/issues/18454)

The goal is to reduce the app size to less than 100mb.

Starting with nim_status_client.so at 14.8MB

--opt:size -> 14.3
-d:danger -> 12.9
-flto -> 2.1MB

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Mobile builds
