### PR TITLE
Server-based storybook

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
 ARG QT_VERSION="6.9.0"
-ARG QT_MODULES="qtwebchannel qtwebview qtwebsockets qt5compat qtmultimedia qtwebengine qtpositioning qtserialport qtshadertools qtimageformats qtscxml"
+ARG QT_MODULES="qtwebchannel qtwebview qtwebsockets qt5compat qtmultimedia qtwebengine qtpositioning qtserialport qtshadertools qtimageformats qtscxml qthttpserver"
 ARG LINUXDEPLOYQT_VERSION="20250615-0393b84"
 ARG PCSCLITE_VERSION="2.2.3"
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT 6.9.0 */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.2-qt6.9.0'
+      image 'statusteam/nim-status-client-build:2.0.4-qt6.9.0'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -8,7 +8,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.2-qt6.9.0'
+      image 'statusteam/nim-status-client-build:2.0.4-qt6.9.0'
     }
   }
 

--- a/scripts/ubuntu_build_setup.sh
+++ b/scripts/ubuntu_build_setup.sh
@@ -49,7 +49,7 @@ function install_qt {
   pip install aqtinstall
   aqt install-qt linux desktop ${QT_VERSION} linux_gcc_64 -m qtwebchannel \
   qtwebview qtwebsockets qt5compat \
-  qtmultimedia qtwebengine qtpositioning \
+  qtmultimedia qtwebengine qtpositioning qthttpserver \
   qtserialport qtshadertools qtimageformats qtscxml -O ${QT_INSTALL_DIR}
 }
 

--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -42,10 +42,6 @@ set(STATUSQ_BUILD_SANITY_CHECKER OFF)
 set(STATUSQ_BUILD_TESTS OFF)
 set(STATUSQ_STATIC_LIB ON)
 
-if(ANDROID)
-  set(STATUSQ_SHADOW_BUILD ON)
-endif()
-
 add_subdirectory(../ui/StatusQ StatusQ)
 
 include(FetchContent)
@@ -53,7 +49,7 @@ FetchContent_Declare(
   QmlStorybook
 
   GIT_REPOSITORY https://github.com/status-im/QmlStorybook.git
-  GIT_TAG 4c81083311a8fd6d5d33157e814e902873f00fc2
+  GIT_TAG 9f580944e929ca70247703d1f2a7237005437374
 )
 FetchContent_MakeAvailable(QmlStorybook)
 

--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -41,6 +41,11 @@ set(STATUSQ_BUILD_SANDBOX OFF)
 set(STATUSQ_BUILD_SANITY_CHECKER OFF)
 set(STATUSQ_BUILD_TESTS OFF)
 set(STATUSQ_STATIC_LIB ON)
+
+if(ANDROID)
+  set(STATUSQ_SHADOW_BUILD ON)
+endif()
+
 add_subdirectory(../ui/StatusQ StatusQ)
 
 include(FetchContent)
@@ -64,8 +69,8 @@ file(GLOB_RECURSE STORYBOOK_QML_FILES "stubs/*.qml" "mocks/*.qml" "pages/*.qml"
 
 file(GLOB_RECURSE TEST_QML_FILES "qmlTests/*.qml")
 
-add_executable(
-  ${PROJECT_NAME}
+qt_add_executable(
+  ${PROJECT_NAME} MANUAL_FINALIZATION
   main.cpp
   main.qml
   ${CORE_QML_FILES}
@@ -74,6 +79,7 @@ add_executable(
   README.md
    # Require for loading WalletConnect SDK;
    # TODO #14696: remove this dependency
+   resources.qrc
    storybook-resources.qrc
 )
 
@@ -141,3 +147,6 @@ if (APPLE)
   find_library(Foundation Foundation)
   target_link_libraries(${PROJECT_NAME} PRIVATE ${AppKit} ${Foundation})
 endif()
+
+qt_import_qml_plugins(${PROJECT_NAME})
+qt_finalize_executable(${PROJECT_NAME})

--- a/storybook/README.md
+++ b/storybook/README.md
@@ -2,7 +2,27 @@
 
 For regular usage of **Storybook** it's enough to open `status-desktop/storybook/CMakeLists.txt` in QtCreator. Please **`do not use StoryBook.pro`** which is intended for WebAssembly builds. Please make sure that selected run target is `Storybook`.
 
+Storybook may run in two modes (configurable by `-m`/`--mode` command line argument):
+- **local** - in this mode local filesystem is observed directly and when change detected the page is unloaded, qml cache is cleaned and page is loaded again
+- **remote** - in this mode the both change detection and qml files access is done via http server. It allows exposing local source code to remote devices
+
+On desktop both modes work basically in the same way from the user perspective.
+
+In order to run Storybook it's necessary to use remote mode:
+- connect device
+- start Storybook locally in remote mode
+- set up reverse proxy (`adb reverse tcp:8080 tcp:8080`)
+- run the Storybook on the device
+
+For convenience the setup of reverse proxy can be easily added to the config
+in QtCreator as a deployment step (`Custom Process Step`).
+
+
 # Building Storybook with Webassembly and Qt 5.14
+
+> [!WARNING]
+> Both support for Webassembly and the instruction below are not maintained and
+> won't work out of the box. Please use the standard build/deploy method.
 
 ## Configuring the environment
 ### Install Emscripten v1.38.27

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -77,14 +77,11 @@ int main(int argc, char *argv[])
     registerStatusQTypes();
 
     loadContextPropertiesMocks(QML_IMPORT_ROOT, engine);
-#ifdef Q_OS_WIN
-    const QUrl url(QUrl::fromLocalFile(QML_IMPORT_ROOT + QStringLiteral("/main.qml")));
-#else
-    const QUrl url(QML_IMPORT_ROOT + QStringLiteral("/main.qml"));
-#endif
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
-                     &app, [url](QObject *obj, const QUrl &objUrl) {
-        if (!obj && url == objUrl)
+
+    const QUrl url("qrc:/main.qml");
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
+                     &app, [url](const QUrl &objUrl) {
+        if (url == objUrl)
             QCoreApplication::exit(-1);
     }, Qt::QueuedConnection);
 
@@ -95,12 +92,7 @@ int main(int argc, char *argv[])
     engine.load(url);
 
     qInfo() << "Storybook started, Qt runtime version:" << qVersion() << "; built against version:" << QLibraryInfo::version().toString() <<
-        "installed in:"
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            << QLibraryInfo::path(QLibraryInfo::PrefixPath)
-#else
-            << QLibraryInfo::location(QLibraryInfo::PrefixPath)
-#endif
+        "installed in:" << QLibraryInfo::path(QLibraryInfo::PrefixPath)
             << "; QQC style:" << QQuickStyle::name();
 
     return QGuiApplication::exec();

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -5,6 +5,11 @@ import QtQuick.Controls.Universal
 import StatusQ.Core.Theme
 import Storybook
 
+// Dummy imports to satisfy androiddeployqt according to
+// https://doc.qt.io/qt-6/android-deploy-qt-tool.html#dependencies-detection
+import QtQuick.Dialogs
+import QtMultimedia
+
 ApplicationWindow {
     width: 1450
     height: 840

--- a/storybook/qmlTests/main.cpp
+++ b/storybook/qmlTests/main.cpp
@@ -3,6 +3,8 @@
 
 #include <StatusQ/typesregistration.h>
 
+using namespace Qt::Literals::StringLiterals;
+
 class Setup : public QObject
 {
     Q_OBJECT
@@ -11,19 +13,19 @@ public slots:
     void qmlEngineAvailable(QQmlEngine *engine) {
         Q_INIT_RESOURCE(storybook);
 
-        QGuiApplication::setOrganizationName(QStringLiteral("Status"));
-        QGuiApplication::setOrganizationDomain(QStringLiteral("status.im"));
+        QGuiApplication::setOrganizationName(u"Status"_s);
+        QGuiApplication::setOrganizationDomain(u"status.im"_s);
 
-        qputenv("QT_QUICK_CONTROLS_HOVER_ENABLED", QByteArrayLiteral("1"));
+        qputenv("QT_QUICK_CONTROLS_HOVER_ENABLED", "1"_ba);
         
         const QStringList additionalImportPaths {
             STATUSQ_MODULE_IMPORT_PATH,
-            QStringLiteral("qrc:/"),
-            QML_IMPORT_ROOT + QStringLiteral("/../ui/app"),
-            QML_IMPORT_ROOT + QStringLiteral("/../ui/imports"),
-            QML_IMPORT_ROOT + QStringLiteral("/../ui/StatusQ/tests/qml"),
-            QML_IMPORT_ROOT + QStringLiteral("/stubs"),
-            QML_IMPORT_ROOT + QStringLiteral("/src")
+            u"qrc:/"_s,
+            QML_IMPORT_ROOT u"/../ui/app"_s,
+            QML_IMPORT_ROOT u"/../ui/imports"_s,
+            QML_IMPORT_ROOT u"/../ui/StatusQ/tests/qml"_s,
+            QML_IMPORT_ROOT u"/stubs"_s,
+            QML_IMPORT_ROOT u"/src"_s
         };
 
         for (const auto& path : additionalImportPaths)

--- a/storybook/resources.qrc
+++ b/storybook/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/storybook/validator_main.cpp
+++ b/storybook/validator_main.cpp
@@ -5,33 +5,36 @@
 
 #include <StatusQ/typesregistration.h>
 
+using namespace Qt::Literals::StringLiterals;
+
 int main(int argc, char *argv[])
 {
     Q_INIT_RESOURCE(storybook);
 
     QGuiApplication app(argc, argv);
-    QGuiApplication::setOrganizationName(QStringLiteral("Status"));
-    QGuiApplication::setOrganizationDomain(QStringLiteral("status.im"));
+    QGuiApplication::setOrganizationName(u"Status"_s);
+    QGuiApplication::setOrganizationDomain(u"status.im"_s);
 
-    const QString pagesPath = QML_IMPORT_ROOT + QStringLiteral("/pages");
+    const QString pagesPath = QML_IMPORT_ROOT u"/pages"_s;
     QDir pagesDir(pagesPath);
-    const QFileInfoList files = pagesDir.entryInfoList({QStringLiteral("*Page.qml")},
+    const QFileInfoList files = pagesDir.entryInfoList({u"*Page.qml"_s},
                                                        QDir::Files,
                                                        QDir::Name);
 
     const QStringList additionalImportPaths{STATUSQ_MODULE_IMPORT_PATH,
-                                            QStringLiteral("qrc:/"),
-                                            QML_IMPORT_ROOT + QStringLiteral("/../ui/app"),
-                                            QML_IMPORT_ROOT + QStringLiteral("/../ui/imports"),
-                                            QML_IMPORT_ROOT + QStringLiteral("/src"),
-                                            QML_IMPORT_ROOT + QStringLiteral("/stubs")};
+                                            u"qrc:/"_s,
+                                            QML_IMPORT_ROOT u"/../ui/app"_s,
+                                            QML_IMPORT_ROOT u"/../ui/imports"_s,
+                                            QML_IMPORT_ROOT u"/src"_s,
+                                            QML_IMPORT_ROOT u"/stubs"_s};
 
     int errorCount = 0;
     QStringList warnings;
     QStringList failedPages;
 
-    qInfo() << ">>> StoryBook page verification started; Qt runtime version:" << qVersion() <<
-        "; built against version:" << QLibraryInfo::version().toString();
+    qInfo() << ">>> StoryBook page verification started; Qt runtime version:"
+            << qVersion() << "; built against version:"
+            << QLibraryInfo::version().toString();
 
     registerStatusQTypes();
     
@@ -44,7 +47,8 @@ int main(int argc, char *argv[])
         for (const auto &path : additionalImportPaths)
             engine.addImportPath(path);
 
-        QObject::connect(&engine, &QQmlApplicationEngine::warnings, &app, [&warnings](const QList<QQmlError> &qmlWarnings) {
+        QObject::connect(&engine, &QQmlApplicationEngine::warnings, &app,
+                         [&warnings](const QList<QQmlError> &qmlWarnings) {
             for (const auto &qmlWarning: qmlWarnings)
                 warnings.append(qmlWarning.toString());
         });


### PR DESCRIPTION
# What does the PR do

This PR introduces new approach regarding loading pages and related source code. Instead of loading files from file system directly, Storybook runs HTTP server hosting qml files. It gives ability of hot-reloading on potentially any device with network access.

The approach used so far (direct file system reading) stays in place and remains the default mode for desktop. The new mode is default on Android.

Related PR in `QmlStorybook` repository: https://github.com/status-im/QmlStorybook/pull/1

![20250801_155838](https://github.com/user-attachments/assets/84cfb290-2b97-43fd-aaec-99b88e94c2a6)

To run Storybook in `remote` mode, use `--mode remote` argument.

> [!WARNING]  
> ~~Do not merge until the `QmlStorybook` pr is merged and commit sha updated in the cmake config~~

## Running Storybook on Android:

- connect device
- run `adb reverse tcp:8080 tcp:8080` in order to set up reverse proxy
- run desktop instance in remote mode (it will launch the server)
- run the Storybook on the Android device

**Any changes made in source code on desktop should be immediately reflected in the Storybook app.**

This is initial version for tests, some further improvements.

## Known issues:
- via http it's possible to load files pointed directly or listed in `qmldir`s when lading indirectly (as a dependency of other component). Many files in the project are not listed in qmldir, it may be necessary to amend them to make SB pages run corretly
- the remote app won't start when reverse proxy is not established or desktop server is not running
- it's necessary to setup reverse proxy manually via mentioned command
- Storybook UI is not yet adapted to mobile screens

### Affected areas
`Storybook`
