### PR TITLE
fix(ProfileShowcase): migrate `isFirstShowcaseInteraction` to QML Settings

### DIFF
--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -5,8 +5,6 @@ import ../../constants
 # Local Account Settings keys:
 const LS_KEY_STORE_TO_KEYCHAIN* = "storeToKeychain"
 const DEFAULT_STORE_TO_KEYCHAIN = "notNow"
-const LS_KEY_IS_FIRST_SHOWCASE_INTERACTION* = "isFirstShowcaseInteraction"
-const DEFAULT_IS_FIRST_SHOWCASE_INTERACTION = true
 # Local Account Settings values:
 const LS_VALUE_STORE* = "store"
 const LS_VALUE_NOT_NOW* = "notNow"
@@ -68,23 +66,3 @@ QtObject:
     read = getStoreToKeychainValue
     write = setStoreToKeychainValue
     notify = storeToKeychainValueChanged
-
-  proc isFirstShowcaseInteractionChanged*(self: LocalAccountSettings) {.signal.}
-
-  proc getIsFirstShowcaseInteraction*(self: LocalAccountSettings): bool {.slot.} =
-    if self.settings.isNil:
-        return DEFAULT_IS_FIRST_SHOWCASE_INTERACTION
-    
-    self.settings.value(LS_KEY_IS_FIRST_SHOWCASE_INTERACTION, newQVariant(DEFAULT_IS_FIRST_SHOWCASE_INTERACTION)).boolVal
-
-  proc setIsFirstShowcaseInteraction*(self: LocalAccountSettings, value: bool) =
-    if(self.settings.isNil):
-      return
-
-    self.settings.setValue(LS_KEY_IS_FIRST_SHOWCASE_INTERACTION, newQVariant(value))
-    self.isFirstShowcaseInteractionChanged()
-
-  QtProperty[bool] isFirstShowcaseInteraction:
-    read = getIsFirstShowcaseInteraction
-    write = setIsFirstShowcaseInteraction
-    notify = isFirstShowcaseInteractionChanged

--- a/src/app/modules/main/profile_section/profile/io_interface.nim
+++ b/src/app/modules/main/profile_section/profile/io_interface.nim
@@ -53,9 +53,6 @@ method getProfileShowcaseEntriesLimit*(self: AccessInterface): int {.base.} =
 method requestProfileShowcasePreferences*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setIsFirstShowcaseInteraction*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method loadProfileShowcasePreferences*(self: AccessInterface, preferences: ProfileShowcasePreferencesDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/profile/module.nim
+++ b/src/app/modules/main/profile_section/profile/module.nim
@@ -81,9 +81,6 @@ method getProfileShowcaseSocialLinksLimit*(self: Module): int =
 method getProfileShowcaseEntriesLimit*(self: Module): int =
   return self.controller.getProfileShowcaseEntriesLimit()
 
-method setIsFirstShowcaseInteraction(self: Module) =
-  singletonInstance.localAccountSettings.setIsFirstShowcaseInteraction(false)
-
 proc storeIdentityImage*(self: Module, identityImage: IdentityImage): bool =
   let keyUid = singletonInstance.userProfile.getKeyUid()
   let image = singletonInstance.utils.fromPathUri(identityImage.source)

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -112,9 +112,6 @@ QtObject:
   proc requestProfileShowcasePreferences(self: View) {.slot.} =
     self.delegate.requestProfileShowcasePreferences()
 
-  proc setIsFirstShowcaseInteraction(self: View) {.slot.} =
-    self.delegate.setIsFirstShowcaseInteraction()
-
   proc loadProfileShowcasePreferencesCommunities*(self: View, items: seq[ShowcasePreferencesGenericItem]) =
     self.showcasePreferencesCommunitiesModel.setItems(items)
 

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 import QtQml
 
@@ -55,7 +56,7 @@ QtObject {
     property var ownAccounts
     property var collectibles
 
-    readonly property bool isFirstShowcaseInteraction: localAccountSettings.isFirstShowcaseInteraction
+    readonly property bool isFirstShowcaseInteraction: appMainLocalSettings.isFirstShowcaseInteraction
 
     // TODO: Review if this model shoud come from `CommunitiesStore` or in a more appropriate domain
     readonly property var communitiesList: SortFilterProxyModel {
@@ -86,6 +87,11 @@ QtObject {
             collectiblesSourceModel: root.collectibles
             collectiblesShowcaseModel: root.showcasePreferencesCollectiblesModel
             socialLinksSourceModel: root.showcasePreferencesSocialLinksModel
+        }
+        Settings {
+            id: appMainLocalSettings
+            category: "AppMainLocalSettings_%1".arg(root.pubKey)
+            property bool isFirstShowcaseInteraction: true
         }
     }
 
@@ -140,7 +146,7 @@ QtObject {
     }
 
     function setIsFirstShowcaseInteraction() {
-        root.profileModule.setIsFirstShowcaseInteraction()
+        appMainLocalSettings.isFirstShowcaseInteraction = false
     }
 
     onUserDeclinedBackupBannerChanged: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2143,6 +2143,7 @@ Item {
                             navBar: appMain.navBar
                             isProduction: appMain.rootStore.isProduction
 
+                            activityCenterStore: appMain.activityCenterStore
                             sharedRootStore: appMain.sharedRootStore
                             utilsStore: appMain.utilsStore
                             aboutStore: appMain.aboutStore


### PR DESCRIPTION
### What does the PR do

- reduce the NIM boilerplate settings code for a simple UI bool setting
- add a missing `activityCenterStore` property assignment, fixing a non-functional Activity Center inside the Settings

Fixes #18471

### Affected areas

Settings/Profile

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1718" height="1176" alt="image" src="https://github.com/user-attachments/assets/29f56e59-847d-4b12-afe4-5ffc18fb782b" />


### Impact on end user

low

### How to test

- dismiss the popup
- restart the app
- popup no more visible

### Risk 

low
