### PR TITLE
Tests: add unpair to sync devices test

### DIFF
--- a/test/e2e/gui/components/settings/unpair_confirmation_popup.py
+++ b/test/e2e/gui/components/settings/unpair_confirmation_popup.py
@@ -1,0 +1,17 @@
+import allure
+
+from gui.elements.button import Button
+from gui.elements.object import QObject
+from gui.objects_map import names
+
+
+class UnpairDeviceConfirmationPopup(QObject):
+    def __init__(self):
+        super().__init__(names.confirmationDialog)
+        self.unpair_button = Button(names.unpairButton)
+
+    @allure.step('Confirm unpairing')
+    def confirm_unpairing(self):
+        self.unpair_button.click()
+        return self
+    

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -587,6 +587,7 @@ confirmationDialog = {"container": statusDesktop_mainWindow_overlay, "objectName
                       "type": "PopupItem", "visible": True}
 confirmationDeleteMessagePopup = {"container": statusDesktop_mainWindow_overlay,
                                   "objectName": "DeleteMessageConfirmationPopup", "type": "PopupItem", "visible": True}
+unpairButton =  {"container": statusDesktop_mainWindow_overlay, "id": "confirmButton", "type": "StatusButton", "unnamed": 1, "visible": True}
 
 # Authenticate Popup
 authenticatePopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "KeycardPopup", "type": "PopupItem",

--- a/test/e2e/gui/objects_map/onboarding_names.py
+++ b/test/e2e/gui/objects_map/onboarding_names.py
@@ -106,6 +106,7 @@ mainWindow_SyncingDeviceView_found = {"container": statusDesktop_mainWindow, "ty
 mainWindow_SyncingDeviceView_synced = {"container": statusDesktop_mainWindow, "type": "SyncingDeviceView", "unnamed": 1, "visible": True}
 mainWindow_SyncDeviceResult = {"container": statusDesktop_mainWindow, "type": "SyncDeviceResult", "unnamed": 1, "visible": True}
 synced_StatusBaseText = {"container": statusDesktop_mainWindow, "type": "StatusBaseText", "unnamed": 1, "visible": True}
+doneButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "syncAnewDeviceNextButton", "type": "StatusButton", "visible": True}
 mainWindow_Sign_in_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow, "text": "Sign in", "type": "StatusButton", "unnamed": 1, "visible": True}
 sync_text_item = {"container": statusDesktop_mainWindow, "type": "StatusBaseText", "unnamed": 1, "visible": True}
 

--- a/test/e2e/gui/objects_map/settings_names.py
+++ b/test/e2e/gui/objects_map/settings_names.py
@@ -38,6 +38,8 @@ settings_StatusFlatButton = {"type": "StatusFlatButton", "unnamed": 1, "visible"
 
 # Messaging View
 mainWindow_MessagingView = {"container": statusDesktop_mainWindow, "type": "MessagingView", "unnamed": 1, "visible": True}
+allowNewContactRequestsSection = {"container": statusDesktop_mainWindow, "id": "allowNewContactRequest", "type": "StatusListItem", "unnamed": 1, "visible": True}
+allowNewContactRequestsSectionToggle = {"checkable": True, "container": allowNewContactRequestsSection, "id": "switch3", "type": "StatusSwitch", "unnamed": 1, "visible": True}
 contactsListItem_btn_StatusContactRequestsIndicatorListItem = {"container": statusDesktop_mainWindow, "objectName": "MessagingView_ContactsListItem_btn", "type": "StatusContactRequestsIndicatorListItem"}
 settingsContentBase_ScrollView = {"container": statusDesktop_mainWindow, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
 always_ask_radioButton_StatusRadioButton = {"container": settingsContentBase_ScrollView, "objectName": "MessagingView_AlwaysAsk_RadioButton", "type": "SettingsRadioButton", "visible": True}
@@ -170,6 +172,7 @@ settings_Setup_Syncing_StatusButton = {"container": settingsContentBase_ScrollVi
 settings_Backup_Data_StatusButton = {"container": settingsContentBase_ScrollView, "objectName": "setupSyncBackupDataButton", "type": "StatusButton", "visible": True}
 settings_Sync_New_Device_Header = {"container": settingsContentBase_ScrollView, "objectName": "syncNewDeviceTextLabel", "type": "StatusBaseText", "visible": True}
 settings_Sync_New_Device_SubTitle = {"container": settingsContentBase_ScrollView, "objectName": "syncNewDeviceSubTitleTextLabel", "type": "StatusBaseText", "visible": True}
+unpairButton = {"container": settingsContentBase_ScrollView, "objectName": "unpairStatusButton", "type": "StatusButton", "visible": True}
 
 #Sing out and quit View
 signOutDialog = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmationDialog", "type": "PopupItem", "visible": True}

--- a/test/e2e/gui/screens/home.py
+++ b/test/e2e/gui/screens/home.py
@@ -13,6 +13,9 @@ from gui.screens.community_portal import CommunitiesPortal
 from gui.screens.market import MarketScreen
 from gui.screens.messages import MessagesScreen
 from gui.screens.settings import SettingsScreen
+from gui.screens.settings_messaging import MessagingSettingsView
+from gui.screens.settings_profile import ProfileSettingsView
+from gui.screens.settings_syncing import SyncingSettingsView
 from gui.screens.wallet import WalletScreen
 
 
@@ -92,6 +95,21 @@ class HomeScreen(QObject):
         return driver.waitFor(
             lambda: not self.has_grid_item_by_title(title), timeout_msec
         )
+
+    @allure.step('Open Messaging settings view from home page')
+    def open_messaging_settings_from_grid(self) -> 'MessagingSettingsView':
+        self.click_grid_item_by_title("Messaging")
+        return MessagingSettingsView().wait_until_appears()
+    
+    @allure.step('Open Syncing settings from home page')
+    def open_syncing_settings_from_grid(self) -> 'SyncingSettingsView':
+        self.click_grid_item_by_title("Syncing")
+        return SyncingSettingsView().wait_until_appears()
+
+    @allure.step('Open Profile settings from home page')
+    def open_profile_settings_from_grid(self) -> 'ProfileSettingsView':
+        self.click_grid_item_by_title("Profile")
+        return ProfileSettingsView().wait_until_appears()
 
     @allure.step('Open Communities Portal from home page')
     def open_communities_portal_from_grid(self) -> 'CommunitiesPortal':

--- a/test/e2e/gui/screens/onboarding.py
+++ b/test/e2e/gui/screens/onboarding.py
@@ -157,26 +157,27 @@ class SyncResultView(OnboardingView):
 
     def __init__(self):
         super(SyncResultView, self).__init__(onboarding_names.mainWindow_SyncDeviceResult)
-        self._sync_result = QObject(onboarding_names.mainWindow_SyncDeviceResult)
-        self._sign_in_button = Button(onboarding_names.mainWindow_Sign_in_StatusButton)
-        self._synced_text_item = QObject(onboarding_names.synced_StatusBaseText)
+        self.sync_result = QObject(onboarding_names.mainWindow_SyncDeviceResult)
+        self.sign_in_button = Button(onboarding_names.mainWindow_Sign_in_StatusButton)
+        self.synced_text_item = QObject(onboarding_names.synced_StatusBaseText)
+        self.done_button = Button(onboarding_names.doneButton)
 
     @property
     @allure.step('Get device synced notifications')
     def device_synced_notifications(self) -> typing.List:
         device_synced_notifications = []
-        for obj in driver.findAllObjects(self._synced_text_item.real_name):
+        for obj in driver.findAllObjects(self.synced_text_item.real_name):
             device_synced_notifications.append(str(obj.text))
         return device_synced_notifications
 
     @allure.step('Wait until appears {0}')
     def wait_until_appears(self, timeout_msec: int = 10000):
-        self._sign_in_button.wait_until_appears(timeout_msec)
+        self.sign_in_button.wait_until_appears(timeout_msec)
         return self
 
     @allure.step('Sign in')
     def sign_in(self, attempts: int = 2):
-        self._sign_in_button.click()
+        self.sign_in_button.click()
         try:
             return SplashScreen().wait_until_appears()
         except:

--- a/test/e2e/gui/screens/settings_messaging.py
+++ b/test/e2e/gui/screens/settings_messaging.py
@@ -13,6 +13,7 @@ from gui.components.settings.unblock_user_popup import UnblockUserPopup
 from gui.components.settings.verify_identity_popup import VerifyIdentityPopup
 
 from gui.elements.button import Button
+from gui.elements.check_box import CheckBox
 from gui.elements.list import List
 from gui.objects_map import settings_names
 from gui.screens.messages import MessagesScreen
@@ -24,19 +25,21 @@ class MessagingSettingsView(QObject):
 
     def __init__(self):
         super().__init__(settings_names.mainWindow_MessagingView)
-        self._contacts_button = Button(settings_names.contactsListItem_btn_StatusContactRequestsIndicatorListItem)
-        self._always_ask_button = Button(settings_names.always_ask_radioButton_StatusRadioButton)
-        self._always_show_button = Button(settings_names.always_show_radioButton_StatusRadioButton)
-        self._never_ask_button = Button(settings_names.never_show_radioButton_StatusRadioButton)
+        self.contacts_button = Button(settings_names.contactsListItem_btn_StatusContactRequestsIndicatorListItem)
+        self.always_ask_button = Button(settings_names.always_ask_radioButton_StatusRadioButton)
+        self.always_show_button = Button(settings_names.always_show_radioButton_StatusRadioButton)
+        self.never_ask_button = Button(settings_names.never_show_radioButton_StatusRadioButton)
+        self.allow_contact_requests_section = QObject(settings_names.allowNewContactRequestsSection)
+        self.allow_contact_requests_toggle = CheckBox(settings_names.allowNewContactRequestsSectionToggle)
 
     @allure.step('Open contacts settings')
     def open_contacts_settings(self) -> 'ContactsSettingsView':
-        self._contacts_button.click()
+        self.contacts_button.click()
         return ContactsSettingsView()
 
-    @allure.step('Choose always show previews from website links preview options')
-    def click_always_show(self):
-        self._always_show_button.click()
+    @allure.step('Switch allow new contact requests toggle')
+    def switch_allow_contact_requests_toggle(self, value: bool):
+        self.allow_contact_requests_toggle.set(value)
 
 
 class ContactItem:

--- a/test/e2e/gui/screens/settings_syncing.py
+++ b/test/e2e/gui/screens/settings_syncing.py
@@ -1,12 +1,10 @@
 import logging
-import time
 
 import allure
 
-
-from constants.syncing import SyncingSettings
 from gui.components.authenticate_popup import AuthenticatePopup
 from gui.components.settings.sync_new_device_popup import SyncNewDevicePopup
+from gui.components.settings.unpair_confirmation_popup import UnpairDeviceConfirmationPopup
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.text_label import TextLabel
@@ -14,29 +12,21 @@ from gui.objects_map import settings_names
 
 LOG = logging.getLogger(__name__)
 
+
 class SyncingSettingsView(QObject):
 
     def __init__(self):
         super().__init__(settings_names.mainWindow_SyncingView)
-        self._setup_syncing_button = Button(settings_names.settings_Setup_Syncing_StatusButton)
-        self._backup_data_button = Button(settings_names.settings_Backup_Data_StatusButton)
-        self._sync_new_device_instructions_header = TextLabel(settings_names.settings_Sync_New_Device_Header)
-        self._sync_new_device_instructions_subtitle = TextLabel(settings_names.settings_Sync_New_Device_SubTitle)
+        self.setup_syncing_button = Button(settings_names.settings_Setup_Syncing_StatusButton)
+        self.backup_data_button = Button(settings_names.settings_Backup_Data_StatusButton)
+        self.sync_new_device_instructions_header = TextLabel(settings_names.settings_Sync_New_Device_Header)
+        self.sync_new_device_instructions_subtitle = TextLabel(settings_names.settings_Sync_New_Device_SubTitle)
+        self.unpair_button = Button(settings_names.unpairButton)
 
-    @allure.step('Checking instructions elements: back up button presence')
-    def is_backup_button_present(self):
-        assert self._backup_data_button.is_visible, f"Backup button is not visible"
-
-    @allure.step('Checking instructions elements: header presence')
-    def is_instructions_header_present(self):
-        assert (self._sync_new_device_instructions_header.text
-                == SyncingSettings.SYNC_A_NEW_DEVICE_INSTRUCTIONS_HEADER.value), f"Sync a new device title is incorrect"
-
-    @allure.step('Checking instructions elements: subtitle presence')
-    def is_instructions_subtitle_present(self):
-        assert (self._sync_new_device_instructions_subtitle.text
-                == SyncingSettings.SYNC_A_NEW_DEVICE_INSTRUCTIONS_SUBTITLE.value), \
-            f"Sync a new device subtitle is incorrect"
+    @allure.step('Click Unpair button')
+    def open_unpair_confirmation(self):
+        self.unpair_button.click()
+        return UnpairDeviceConfirmationPopup()
 
     @allure.step('Setup syncing')
     def open_sync_new_device_popup(self, password: str):
@@ -47,14 +37,13 @@ class SyncingSettingsView(QObject):
     @allure.step('Click setup syncing')
     def click_setup_syncing(self, attempts: int = 3):
         last_exception = None
-        for i in range(1, attempts+1):
+        for i in range(1, attempts + 1):
             try:
                 LOG.info(f'Attempt # {i} to open Authentication popup')
-                self._setup_syncing_button.click()
+                self.setup_syncing_button.click()
                 popup = AuthenticatePopup().wait_until_appears()
                 return popup
             except Exception as e:
                 last_exception = e
                 LOG.info(f'Attempt # {i} to open Authentication popup failed with {e}')
         raise LookupError(f'Could not open auth popup with {last_exception}')
-

--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_group_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_group_chat.py
@@ -207,7 +207,7 @@ def test_group_chat_add_contact_in_ac(multiple_instances, community_name, domain
                 messages_screen.group_chat.close_link_preview_popup().confirm_sending_message()
 
             with step('Change preview settings to always show previews in messaging settings'):
-                main_window.left_panel.open_settings().left_panel.open_messaging_settings().click_always_show()
+                main_window.left_panel.open_settings().left_panel.open_messaging_settings().always_show_button.click()
                 main_window.left_panel.open_messages_screen().left_panel.click_chat_by_name(group_chat_new_name)
 
             with step(f'Paste external link again'):

--- a/test/e2e/tests/onboarding/test_onboarding_syncing.py
+++ b/test/e2e/tests/onboarding/test_onboarding_syncing.py
@@ -42,10 +42,10 @@ def test_wrong_sync_code(sync_screen, wrong_sync_code):
 def test_cancel_setup_syncing(main_screen: MainWindow, user_account):
     with step('Open syncing settings'):
         sync_settings_view = main_screen.left_panel.open_settings().left_panel.open_syncing_settings()
-        sync_settings_view.is_instructions_header_present()
-        sync_settings_view.is_instructions_subtitle_present()
-        if configs.DEV_BUILD:
-            sync_settings_view.is_backup_button_present()
+        assert sync_settings_view.sync_new_device_instructions_header.text \
+               == SyncingSettings.SYNC_A_NEW_DEVICE_INSTRUCTIONS_HEADER.value, f"Sync a new device title is incorrect"
+        assert sync_settings_view.sync_new_device_instructions_subtitle.text \
+               == SyncingSettings.SYNC_A_NEW_DEVICE_INSTRUCTIONS_SUBTITLE.value, f"Sync a new device subtitle is incorrect"
 
     with step('Click setup syncing and close authenticate popup'):
         sync_new_device_popup = sync_settings_view.open_sync_new_device_popup(user_account.password)

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -57,6 +57,8 @@ StatusListItem {
 
     components: [
         StatusButton {
+            objectName: "pairStatusButton"
+
             anchors.verticalCenter: parent.verticalCenter
             visible: root.enabled && !root.deviceEnabled && !root.isCurrentDevice
             text: qsTr("Pair")
@@ -66,6 +68,8 @@ StatusListItem {
             }
         },
         StatusButton {
+            objectName: "unpairStatusButton"
+
             anchors.verticalCenter: parent.verticalCenter
             visible: root.enabled && root.deviceEnabled && !root.isCurrentDevice
             text: qsTr("Unpair")


### PR DESCRIPTION
Fixes #18415 

First approach to use display name changes to test it was not successful because of some issues potentially caused by rapid display name changes. 
Now the test is syncing 2 desktop apps via onboarding, then on first app, changes value of `Allow contact requests` toggle -> on second instance checks that the toggle becomes off to (devices) are paired. After that, test unpairs devices and enables the toggle again -> on second instance the toggle should remain the same.

The timeframe for the changes to be synced is 15 seconds (or earlier). If that would not be enough (test starts failing because of this thing), i will change that to different value, however the expectation of the changes to be synced within 5 seconds.