### PR TITLE
feat(home): add lastMessage to chatSearchModel to show in the HomePage

### DIFF
--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -85,6 +85,16 @@ proc init*(self: Controller) =
     let args = CommunityChatIdArgs(e)
     self.delegate.chatRemoved(args.chatId)
 
+  self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
+    let args = MessageSendingSuccess(e)
+    self.delegate.updateLastMessage(args.chat.id, args.chat.communityId, args.chat.chatType, args.chat.lastMessage)
+
+  self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
+    let args = MessagesArgs(e)
+    if args.messages.len == 0:
+      return
+    self.delegate.updateLastMessage(args.chatId, args.sectionId, args.chatType, args.messages[0])
+
 proc activeSectionId*(self: Controller): string =
   return self.activeSectionId
 
@@ -198,3 +208,6 @@ proc getAllChats*(self: Controller): seq[ChatDto] =
 
 proc getContactDetails*(self: Controller, contactId: string, skipBackendCalls: bool): ContactDetails =
   return self.contactsService.getContactDetails(contactId, skipBackendCalls)
+
+proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: seq[ChatDto]): string =
+  return self.messageService.getMessagesParsedPlainText(message, communityChats)

--- a/src/app/modules/main/app_search/io_interface.nim
+++ b/src/app/modules/main/app_search/io_interface.nim
@@ -63,3 +63,6 @@ method chatAdded*(self: AccessInterface, chat: ChatDto) {.base.} =
 
 method chatRemoved*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method updateLastMessage*(self: AccessInterface, chatId, communityId: string, chatType: ChatType, lastmessage: MessageDto) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/app_search/models/chat_search_item.nim
+++ b/src/app/modules/main/app_search/models/chat_search_item.nim
@@ -1,5 +1,5 @@
 type
-  Item* = ref object
+  ChatSearchItem* = ref object
     chatId: string
     name: string
     color: string
@@ -10,9 +10,10 @@ type
     colorHash: string
     emoji: string
     chatType: int
+    lastMessageText: string
 
-proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, sectionId, sectionName, emoji: string, chatType: int): Item =
-  result = Item()
+proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, sectionId, sectionName, emoji: string, chatType: int, lastMessageText: string): ChatSearchItem =
+  result = ChatSearchItem()
   result.chatId = chatId
   result.name = name
   result.color = color
@@ -23,48 +24,55 @@ proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, secti
   result.sectionName = sectionName
   result.emoji = emoji
   result.chatType = chatType
+  result.lastMessageText = lastMessageText
 
-proc chatId*(self: Item): string =
+proc chatId*(self: ChatSearchItem): string =
   self.chatId
 
-proc name*(self: Item): string =
+proc name*(self: ChatSearchItem): string =
   self.name
 
-proc `name=`*(self: Item, value: string) =
+proc `name=`*(self: ChatSearchItem, value: string) =
   self.name = value
 
-proc color*(self: Item): string =
+proc color*(self: ChatSearchItem): string =
   self.color
 
-proc `color=`*(self: Item, value: string) =
+proc `color=`*(self: ChatSearchItem, value: string) =
   self.color = value
 
-proc colorId*(self: Item): int =
+proc colorId*(self: ChatSearchItem): int =
   self.colorId
 
-proc icon*(self: Item): string =
+proc icon*(self: ChatSearchItem): string =
   self.icon
 
-proc `icon=`*(self: Item, value: string) =
+proc `icon=`*(self: ChatSearchItem, value: string) =
   self.icon = value
 
-proc colorHash*(self: Item): string =
+proc colorHash*(self: ChatSearchItem): string =
   self.colorHash
 
-proc sectionId*(self: Item): string =
+proc sectionId*(self: ChatSearchItem): string =
   self.sectionId
 
-proc sectionName*(self: Item): string =
+proc sectionName*(self: ChatSearchItem): string =
   self.sectionName
 
-proc `sectionName=`*(self: Item, value: string) =
+proc `sectionName=`*(self: ChatSearchItem, value: string) =
   self.sectionName = value
 
-proc emoji*(self: Item): string =
+proc emoji*(self: ChatSearchItem): string =
   self.emoji
 
-proc `emoji=`*(self: Item, value: string) =
+proc `emoji=`*(self: ChatSearchItem, value: string) =
   self.emoji = value
 
-proc chatType*(self: Item): int =
+proc lastMessageText*(self: ChatSearchItem): string =
+  self.lastMessageText
+
+proc `lastMessageText=`*(self: ChatSearchItem, value: string) =
+  self.lastMessageText = value
+
+proc chatType*(self: ChatSearchItem): int =
   self.chatType

--- a/src/app/modules/main/app_search/models/location_menu_item.nim
+++ b/src/app/modules/main/app_search/models/location_menu_item.nim
@@ -6,7 +6,7 @@ type
   Item* = ref object of BaseItem
     subItems: SubModel
 
-proc initItem*(value, text, image, icon, iconColor: string = ""): Item =
+proc initItem*(value, text, image, icon: string, iconColor: string = ""): Item =
   result = Item()
   result.setup(value, text, image, icon, iconColor)
   result.subItems = newSubModel()

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -340,7 +340,9 @@ method updateSearchLocationIfPointToChatWithId*(self: Module, chatId: string) =
   if self.controller.activeChatId() == chatId:
     self.controller.setSearchLocation(self.controller.activeSectionId(), "")
 
-proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, personalChatSectionName: string): chat_search_item.Item =
+proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, personalChatSectionName: string): ChatSearchItem =
+  var communityChats: seq[ChatDto] = @[]
+
   # skip hidden chats
   if chat.chatType == ChatType.CommunityChat and chat.communityId != "":
     let communityDto = self.controller.getCommunityById(chat.communityId)
@@ -350,6 +352,8 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
         return nil
     else:
       return nil
+
+    communityChats = communityDto.chats
 
   var chatName = chat.name
   var chatImage = chat.icon
@@ -378,14 +382,15 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
     sectionId,
     sectionName,
     chat.emoji,
-    chat.chatType.int
+    chat.chatType.int,
+    lastMessageText = self.controller.getMessagesParsedPlainText(chat.lastMessage, communityChats),
   )
 
 method buildChatSearchModel*(self: Module) =
   if self.chatSearchModelBuilt:
     return
 
-  var items: seq[chat_search_item.Item] = @[]
+  var items: seq[ChatSearchItem] = @[]
 
   let personalChatSectionId = self.delegate.getSectionId(SectionType.Chat)
   let personalChatSectionName = self.delegate.getSectionName(personalChatSectionId)
@@ -445,3 +450,14 @@ method chatAdded*(self: Module, chat: ChatDto) =
 
 method chatRemoved*(self: Module, chatId: string) =
   self.view.chatSearchModel().removeItemById(chatId)
+
+method updateLastMessage*(self: Module, chatId, communityId: string, chatType: ChatType, lastMessage: MessageDto) =
+  var communityChats: seq[ChatDto] = @[]
+  if chatType == ChatType.CommunityChat and communityId != "":
+    let communityDto = self.controller.getCommunityById(communityId)
+    communityChats = communityDto.chats
+
+  self.view.chatSearchModel().updateLastMessageTextOnChatItem(
+    chatId,
+    self.controller.getMessagesParsedPlainText(lastMessage, communityChats)
+  )

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -716,6 +716,9 @@ proc reorderCommunityChat*(self: Controller, categoryId: string, chatId: string,
 proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
   return self.messageService.getRenderedText(parsedTextArray, communityChats)
 
+proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: seq[ChatDto]): string =
+  return self.messageService.getMessagesParsedPlainText(message, communityChats)
+
 proc getColorHash*(self: Controller, pubkey: string): ColorHashDto =
   procs_from_visual_identity_service.colorHashOf(pubkey)
 

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1117,6 +1117,17 @@ proc getRenderedText*(self: Service, parsedTextArray: seq[ParsedText], community
         result = result & "<code>" & escape_html(parsedText.literal) & "</code>"
     result = result.strip()
 
+# Parses the message and returns the plain text representation of it.
+# If the message is a sticker or an image with no text, it returns "🖼️".
+proc getMessagesParsedPlainText*(self: Service, message: MessageDto, communityChats: seq[ChatDto]): string =
+  if message.contentType == ContentType.BridgeMessage:
+    return message.bridgeMessage.content
+  if message.contentType == ContentType.Sticker or (message.contentType == ContentType.Image and len(message.text) == 0):
+    return "🖼️"
+
+  let renderedMessageText = self.getRenderedText(message.parsedText, communityChats)
+  return singletonInstance.utils.plainText(renderedMessageText)
+
 proc deleteMessage*(self: Service, messageId: string) =
   try:
     let response = status_go.deleteMessageAndSend(messageId)

--- a/ui/app/AppLayouts/HomePage/HomePageAdaptor.qml
+++ b/ui/app/AppLayouts/HomePage/HomePageAdaptor.qml
@@ -276,11 +276,12 @@ QObject {
             readonly property string id: model.chatId
             readonly property string name: model.name
             readonly property string icon: model.icon || model.emoji
+            readonly property string lastMessageText: model.lastMessageText
             readonly property color color: model.color || Utils.colorForColorId(model.colorId)
         }
 
-        expectedRoles: ["sectionId", "chatId", "chatType", "name", "sectionName", "emoji", "icon", "color", "colorId"]
-        exposedRoles: ["key", "id", "name", "icon", "color"]
+        expectedRoles: ["sectionId", "chatId", "chatType", "name", "sectionName", "emoji", "icon", "color", "colorId", "lastMessageText"]
+        exposedRoles: ["key", "id", "name", "icon", "color", "lastMessageText"]
     }
 
     ObjectProxyModel {

--- a/ui/app/AppLayouts/HomePage/HomePageGrid.qml
+++ b/ui/app/AppLayouts/HomePage/HomePageGrid.qml
@@ -215,11 +215,10 @@ StatusScrollView {
                     hasNotification: model.hasNotification ?? false
                     notificationsCount: model.notificationsCount ?? 0
                     pinned: model.pinned
+                    sectionName: model.sectionName ?? ""
                     lastMessageText: {
                         if (!!model.lastMessageText)
                             return model.lastMessageText
-                        if (model.sectionType === -1 && model.chatType === Constants.chatType.communityChat)
-                            return model.sectionName
                         return ""
                     }
 

--- a/ui/app/AppLayouts/HomePage/delegates/HomePageGridChatItem.qml
+++ b/ui/app/AppLayouts/HomePage/delegates/HomePageGridChatItem.qml
@@ -13,10 +13,11 @@ HomePageGridItem {
     property int chatType: Constants.chatType.unknown
     property int onlineStatus: Constants.onlineStatus.unknown
     property string lastMessageText
+    property string sectionName
 
     sectionType: Constants.appSection.chat
     subtitle: chatType === Constants.chatType.privateGroupChat ? qsTr("Group Chat")
-                                                               : chatType === Constants.chatType.communityChat ? qsTr("Community Chat")
+                                                               : chatType === Constants.chatType.communityChat ? qsTr("%1 Community").arg(root.sectionName)
                                                                                                                : qsTr("Chat")
     color: Qt.lighter(root.icon.color, 1.33)
 


### PR DESCRIPTION
### What does the PR do

Fixes #18298

### Affected areas

ChatSearchModel
HomePage

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[lastMessage.webm](https://github.com/user-attachments/assets/e37f433e-4834-4b9f-a09b-eda0e44bf3f6)

### Impact on end user

Adds the last message to community chats in the Home page

### How to test

- Be in a community
- Send messages in the chats
- check the Home page

### Risk 

Low
