### PR TITLE
fix(ImportCommunityPopup): The input is just 5 characters wide

### DIFF
--- a/storybook/pages/ImportCommunityPopupPage.qml
+++ b/storybook/pages/ImportCommunityPopupPage.qml
@@ -119,7 +119,7 @@ SplitView {
 
         function requestCommunityInfo(communityId) {
             // Dynamically create a timer to be able to simulate overlapping requests
-            let timer = Qt.createQmlObject("import QtQuick 2.0; Timer {}", root)
+            let timer = Qt.createQmlObject("import QtQml; Timer {}", root)
             timer.interval = 1000
             timer.repeat = false
             timer.triggered.connect(() => {
@@ -173,7 +173,6 @@ SplitView {
             anchors.fill: parent
 
             sourceComponent: ImportCommunityPopup {
-                anchors.centerIn: parent
                 modal: false
                 closePolicy: Popup.NoAutoClose
                 destroyOnClose: false
@@ -295,3 +294,4 @@ SplitView {
 }
 
 // category: Popups
+// status: good

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -56,10 +56,10 @@ TextArea {
     */
     property bool valid: true
 
-    leftPadding: 16
-    rightPadding: 16
-    topPadding: 10
-    bottomPadding: 10
+    leftPadding: Theme.padding
+    rightPadding: Theme.padding
+    topPadding: Theme.smallPadding
+    bottomPadding: Theme.smallPadding
 
     color: Theme.palette.directColor1
     selectedTextColor: color
@@ -79,7 +79,7 @@ TextArea {
     KeyNavigation.priority: KeyNavigation.BeforeItem
 
     background: Rectangle {
-        radius: 8
+        radius: Theme.radius
         color: root.readOnly ? "transparent" : root.enabled ? Theme.palette.baseColor2 : Theme.palette.baseColor4
         border.width: 1
         border.color: {

--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 import QtQml.Models
 
 import utils
@@ -137,18 +136,17 @@ StatusDialog {
     StatusScrollView {
         id: scrollContent
         anchors.fill: parent
-        anchors.leftMargin: Theme.halfPadding
-        contentWidth: (root.width-Theme.bigPadding-Theme.padding)
+        contentWidth: availableWidth
         padding: 0
 
         ColumnLayout {
-            width: (scrollContent.width-Theme.padding)
+            width: scrollContent.availableWidth
             spacing: Theme.halfPadding
 
             StatusBaseText {
                 id: infoText1
                 Layout.fillWidth: true
-                text: qsTr("Enter the public key of the community you wish to access")
+                text: qsTr("Enter the public key of, or a link to the community you wish to access")
                 wrapMode: Text.WordWrap
                 font.pixelSize: Theme.additionalTextSize
                 color: Theme.palette.baseColor1
@@ -165,9 +163,8 @@ StatusDialog {
                 Layout.preferredHeight: 108
                 StatusTextArea {
                     id: keyInput
-                    anchors.fill: parent
-                    placeholderText: "zQ3..."
-                    wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
+                    placeholderText: qsTr("Link or (compressed) public key...")
+                    wrapMode: TextEdit.Wrap
                     onTextChanged: d.importErrorMessage = ""
                 }
             }


### PR DESCRIPTION
### What does the PR do

- no need to set width or anchors to the StatusTextArea when wrapped in a scroll view
- fix the scroll views sizing
- adjust the info text a bit to cover to possible types of input
- some minor fixes to the SB page and the text area component itself

Fixes #18502

### Affected areas

ImportCommunityPopup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/245fb247-6b6d-4876-808e-318ad911b3ac

### Impact on end user

- user can enter key longer than a few characters (w/o wrapping)

### How to test

- try to input some key/link into the text area

### Risk 

- low
