### PR TITLE
ci: generate experimental nwaku builds

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -158,6 +158,10 @@ RUN sudo groupadd -g 1001 jenkins \
 USER jenkins
 ENV HOME="/home/jenkins"
 
+# Rust is needed for nwaku builds
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
+
 # Access to tools installed by Go.
 ENV PATH="${HOME}/go/bin:${PATH}"
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT 6.9.0 */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.4-qt6.9.0'
+      image 'statusteam/nim-status-client-build:2.0.3-qt6.9.0'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }
@@ -41,6 +41,11 @@ pipeline {
       name: 'USE_MOCKED_KEYCARD_LIB',
       description: 'Decides whether the mocked status-keycard-go library is built.',
       defaultValue: false
+    )
+    booleanParam(
+      name: 'USE_NWAKU',
+      description: 'Whether to build with nwaku or not',
+      defaultValue: params.USE_NWAKU ?: getNWakuMode(),
     )
   }
 
@@ -76,6 +81,7 @@ pipeline {
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
+    USE_NWAKU = "${params.USE_NWAKU}"
   }
 
   stages {
@@ -93,12 +99,14 @@ pipeline {
 
     stage('status-go') {
       steps {
+        sh "echo USE_NWAKU is ${USE_NWAKU}"
         sh 'make status-go'
       }
     }
 
     stage('Package') {
       steps { script {
+        sh "echo USE_NWAKU is ${USE_NWAKU}"
         linux.bundle('tgz-linux')
       } }
     }
@@ -145,4 +153,13 @@ def getArch() {
   for (def arch in ['x86_64', 'aarch64']) {
     if (tokens.contains(arch)) { return arch }
   }
+}
+/* We extract the name of the job from currentThread because
+ * before an agent is picked env is not available. */
+def getJobPathTokens() {
+    return Thread.currentThread().getName().split('/')
+}
+
+def getNWakuMode() {
+    return getJobPathTokens().contains('package-nwaku')
 }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -69,7 +69,7 @@ pipeline {
   }
 
   environment {
-    PLATFORM = "linux/${getArch()}"
+    PLATFORM = "linux/${getArch()}${params.USE_NWAKU ? '-nwaku' : ''}"
     /* Improve make performance */
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* Avoid weird bugs caused by stale cache. */

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -128,7 +128,7 @@ pipeline {
     }
 
     stage('E2E') {
-      when { expression { utils.isPRBuild() } }
+      when { expression { utils.isPRBuild() && !params.USE_NWAKU } }
       steps { script {
         build(
           job: 'status-desktop/e2e/prs',

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -68,7 +68,7 @@ pipeline {
   }
 
   environment {
-    PLATFORM = "macos/${getArch()}"
+    PLATFORM = "linux/${getArch()}${params.USE_NWAKU ? '-nwaku' : ''}"
     /* Improve make performance */
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     QT_VERSION="6.9.0"

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -41,6 +41,11 @@ pipeline {
       description: 'Select app entitlements. Squish requires extra entitlements.',
       choices: ['resources/Entitlements.plist', 'resources/Entitlements_squish.plist']
     )
+    booleanParam(
+      name: 'USE_NWAKU',
+      description: 'Whether to build with nwaku or not',
+      defaultValue: params.USE_NWAKU ?: getNWakuMode(),
+    )
   }
 
   options {
@@ -83,6 +88,7 @@ pipeline {
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
+    USE_NWAKU = "${params.USE_NWAKU}"
   }
 
   stages {
@@ -108,12 +114,14 @@ pipeline {
 
     stage('status-go') {
       steps {
+        sh "echo USE_NWAKU is ${USE_NWAKU}"
         sh 'make status-go'
       }
     }
 
     stage('Package') {
       steps { script {
+        sh "echo USE_NWAKU is ${USE_NWAKU}"
         macos.bundle('pkg-macos')
       } }
     }
@@ -168,4 +176,14 @@ def getArch() {
     for (def arch in ['x86_64', 'aarch64']) {
       if (tokens.contains(arch)) { return arch }
     }
+}
+
+/* We extract the name of the job from currentThread because
+ * before an agent is picked env is not available. */
+def getJobPathTokens() {
+    return Thread.currentThread().getName().split('/')
+}
+
+def getNWakuMode() {
+    return getJobPathTokens().contains('package-nwaku')
 }

--- a/scripts/init_app_dir.sh
+++ b/scripts/init_app_dir.sh
@@ -25,6 +25,9 @@ cp bin/i18n/* "${APP_DIR}/usr/i18n"
 cp vendor/status-go/build/bin/libstatus.so "${APP_DIR}/usr/lib/"
 cp vendor/status-go/build/bin/libstatus.so.0 "${APP_DIR}/usr/lib/"
 cp "${STATUSKEYCARDGO}" "${APP_DIR}/usr/lib/"
+if [ "${USE_NWAKU}" = "true" ]; then
+  cp vendor/status-go/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.so "${APP_DIR}/usr/lib/"
+fi
 cp "${FCITX5_QT}" "${APP_DIR}/usr/plugins/platforminputcontexts/"
 
 # Copy dependencies, which linuxdeployqt can't manage from nix store or system (FHS)

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-git describe --tags
+echo "$(git describe --tags)${USE_NWAKU:+-nwaku-experimental}"


### PR DESCRIPTION
## Summary
- Adds 2 CI jobs that build `status-desktop` with `nwaku` enabled status-go.
- These jobs will be optional.