### PR TITLE
Fix banners on Mac

### DIFF
--- a/scripts/clean-git.sh
+++ b/scripts/clean-git.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # Extracted from Makefile to avoid nimbus-build-system blocking use.
 git clean -qfdx
-git submodule foreach --recursive git reset -q --hard
-git submodule foreach --recursive git clean -qfdx
-# to get rid of lingering DOtherSide
-git clean -xdf vendor
-git clean -xdf mobile/vendor
+# nuke vendor, they're regenerated anyways
+rm -rf vendor
+rm -rf mobile/vendors

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1457,8 +1457,8 @@ Item {
                 Layout.fillWidth: true
 
                 // apply left/right margins when we remove the window titlebar
-                Layout.leftMargin: Qt.platform.os === SQUtils.Utils.mac ? appMain.Window.SafeArea.margins.left : 0
-                Layout.rightMargin: Qt.platform.os === SQUtils.Utils.mac ? appMain.Window.SafeArea.margins.right : 0
+                Layout.leftMargin: Qt.platform.os === SQUtils.Utils.mac ? appMain.SafeArea.margins.left : 0
+                Layout.rightMargin: Qt.platform.os === SQUtils.Utils.mac ? appMain.SafeArea.margins.right : 0
 
                 Layout.maximumHeight: implicitHeight
                 spacing: 1

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Components
+import StatusQ.Core.Utils as SQUtils
 
 import utils
 
@@ -25,6 +26,9 @@ Item {
     property alias closeBtnVisible: closeImg.visible
     property string iconName
     property bool delay: true
+
+    // extra margin that can be used to avoid overlapping with window buttons
+    property int extraInnerLeftMargin: Qt.platform.os === SQUtils.Utils.mac ? 60 : 0
 
     signal clicked()
     signal closeClicked()
@@ -141,12 +145,18 @@ Item {
 
             spacing: Theme.halfPadding
             anchors.fill: parent
-            anchors.leftMargin: Theme.halfPadding
+            anchors.leftMargin: Theme.halfPadding + root.extraInnerLeftMargin
             anchors.rightMargin: Theme.halfPadding
+
+            Item {
+                Layout.fillWidth: true
+                Layout.horizontalStretchFactor: 1
+            }
 
             StatusRoundIcon {
                 Layout.preferredHeight: 16
                 Layout.preferredWidth: 16
+
                 visible: !!root.iconName
                 asset.name: root.iconName
                 asset.bgColor: Theme.palette.indirectColor1
@@ -154,8 +164,11 @@ Item {
             }
 
             StatusBaseText {
-                objectName: "bannerText"
                 Layout.fillWidth: true
+                Layout.horizontalStretchFactor: 0
+
+                objectName: "bannerText"
+
                 elide: Text.ElideRight
                 horizontalAlignment: Text.AlignHCenter
                 text: root.text
@@ -167,6 +180,11 @@ Item {
                 HoverHandler {
                     cursorShape: hovered && parent.hoveredLink ? Qt.PointingHandCursor : undefined
                 }
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.horizontalStretchFactor: 1
             }
 
             StatusBaseText {
@@ -230,8 +248,8 @@ Item {
             StatusIcon {
                 id: closeImg
                 objectName: "closeButton"
-                height: 20
-                width: 20
+                Layout.preferredWidth: 20
+                Layout.preferredHeight: 20
                 icon: "close-circle"
                 color: Theme.palette.indirectColor1
                 opacity: closeButtonMouseArea.containsMouse ? 1 : 0.7

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -557,11 +557,12 @@ StatusWindow {
         MouseArea {
             id: headerMouseArea
             enabled: d.macOSWindowed
-            preventStealing: true
             propagateComposedEvents: true
             onPressed: {
                 applicationWindow.startSystemMove()
+                mouse.accepted = false
             }
+
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

This PR fixes two issues regarding banners on mac:
- action buttons are not clickable
- icon / text overlapping with os window buttons (min/max/close)

Closes: #18555 

### Affected areas
`main`, `AppMain`, `ModuleWarning`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1200" height="240" alt="Screenshot 2025-08-12 at 16 01 52" src="https://github.com/user-attachments/assets/573c9f8c-713a-4a88-a32a-1215dc7beef8" />

<img width="1200" height="522" alt="Screenshot 2025-08-12 at 16 01 59" src="https://github.com/user-attachments/assets/152c4218-829c-47b7-a8c1-d59e6f31c2f4" />

