### PR TITLE
chore: Update kdf iter to 3200 on mobile

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -33,8 +33,20 @@ cd "$STATUS_DESKTOP"
 # setting compile time feature flags
 FEATURE_FLAGS="FLAG_DAPPS_ENABLED=0 FLAG_CONNECTOR_ENABLED=0 FLAG_KEYCARD_ENABLED=0 FLAG_SINGLE_STATUS_INSTANCE_ENABLED=0"
 
+# app configuration defines
+APP_CONFIG_DEFINES=(
+    --outdir:./bin
+    -d:KDF_ITERATIONS=3200
+    -d:DESKTOP_VERSION="$DESKTOP_VERSION"
+    -d:STATUSGO_VERSION="$STATUSGO_VERSION"
+    -d:GIT_COMMIT="$(git log --pretty=format:'%h' -n 1)"
+    -d:chronicles_runtime_filtering=on
+    -d:chronicles_default_output_device=file
+    -d:chronicles_log_level=trace
+)
+
 # build status-client with feature flags
-env $FEATURE_FLAGS ./vendor/nimbus-build-system/scripts/env.sh nim c "${PLATFORM_SPECIFIC[@]}" --outdir:./bin -d:DESKTOP_VERSION="$DESKTOP_VERSION" -d:STATUSGO_VERSION="$STATUSGO_VERSION" -d:GIT_COMMIT="$(git log --pretty=format:'%h' -n 1)" -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=file -d:chronicles_log_level=trace \
+env $FEATURE_FLAGS ./vendor/nimbus-build-system/scripts/env.sh nim c "${PLATFORM_SPECIFIC[@]}" "${APP_CONFIG_DEFINES[@]}" ${QML_SERVER_DEFINES}  \
     --mm:refc \
     --opt:size \
     -d:lto \


### PR DESCRIPTION
### What does the PR do

There's been an investigation on the old mobile app and 3200 kdf iter seems to be a reasonable iteration count to balance performance and security.

Notes can be found here.
https://notes.status.im/i8Y_l7ccTiOYq09HVgoFwA

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Mobile DB encryption 

### Impact on end user

Low login time

