### PR TITLE
fix(Emoji): unbreak the StatusInputListPopup emoji images

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
@@ -54,7 +54,7 @@ QtObject {
         return (match && match.length >= 2) ? match[1] : undefined;
     }
     function svgImage(unicode) {
-        return `${base}/svg/${unicode}.svg`
+        return `${base}/${unicode}.svg`
     }
     function iconId(text) {
         if (!text) return


### PR DESCRIPTION
### What does the PR do

- fixes the wrong path in `Emoji.svgImage()` by removing the extra `svg/` in the path

Fixes #18575

### Affected areas

StatusInputListPopup,Emoji

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1459" height="1093" alt="Snímek obrazovky z 2025-08-14 16-09-36" src="https://github.com/user-attachments/assets/3a532f02-17a3-4b87-a71e-05c43662891f" />


### Impact on end user

Emojis work in the suggestions popup in chat

### How to test

Type a message, start typing an emoji short code, ie. `:hea...`

### Risk 

low
