### PR TITLE
[CHERRY-PICK] fix(Emoji): unbreak the StatusInputListPopup emoji images

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
@@ -54,7 +54,7 @@ QtObject {
         return (match && match.length >= 2) ? match[1] : undefined;
     }
     function svgImage(unicode) {
-        return `${base}/svg/${unicode}.svg`
+        return `${base}/${unicode}.svg`
     }
     function iconId(text) {
         if (!text) return


### PR DESCRIPTION
- fixes the wrong path in `Emoji.svgImage` by removing the extra `svg/` in the path

Fixes #18575

cherry-pick of https://github.com/status-im/status-desktop/pull/18576