### PR TITLE
[CHERRY_PICK] fix(contacts): fix unknown contacts not having an alias

### DIFF
--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -206,8 +206,8 @@ proc getColorId*(self: Controller, pubkey: string): int =
 proc getAllChats*(self: Controller): seq[ChatDto] =
   result = self.chatService.getAllChats()
 
-proc getContactDetails*(self: Controller, contactId: string, skipBackendCalls: bool): ContactDetails =
-  return self.contactsService.getContactDetails(contactId, skipBackendCalls)
+proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
+  return self.contactsService.getContactDetails(contactId)
 
 proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: seq[ChatDto]): string =
   return self.messageService.getMessagesParsedPlainText(message, communityChats)

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -363,7 +363,7 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
   var sectionName = personalChatSectionName
   if chat.chatType == ChatType.OneToOne:
     # TODO find a way to populate the chat with the contact details and use as single source of truth
-    let contactDetails = self.controller.getContactDetails(chat.id, skipBackendCalls = false)
+    let contactDetails = self.controller.getContactDetails(chat.id)
     chatName = contactDetails.defaultDisplayName
     chatImage = contactDetails.icon
     if not contactDetails.dto.ensVerified:
@@ -428,7 +428,7 @@ method updateChatItems*(self: Module, updatedChats: seq[ChatDto]) =
     self.view.chatSearchModel().updateChatItem(chat.id, chat.name, chat.color, chat.icon, chat.emoji)
 
 method contactUpdated*(self: Module, contactId: string) =
-  let contactDetails = self.controller.getContactDetails(contactId, skipBackendCalls = false)
+  let contactDetails = self.controller.getContactDetails(contactId)
   self.view.chatSearchModel().updateChatItem(contactId, contactDetails.defaultDisplayName, color = "",
     contactDetails.icon, emoji = "")
 

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -125,8 +125,8 @@ proc getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, largeImage: string] =
   return self.contactService.getContactNameAndImage(contactId)
 
-proc getContactDetails*(self: Controller, contactId: string, skipBackendCalls: bool = false): ContactDetails =
-  return self.contactService.getContactDetails(contactId, skipBackendCalls)
+proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
+  return self.contactService.getContactDetails(contactId)
 
 proc getStatusForContact*(self: Controller, contactId: string): StatusUpdateDto =
   return self.contactService.getStatusForContactWithId(contactId)

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -129,7 +129,7 @@ proc processChatMember(self: Module,  member: ChatMember, reset: bool = false): 
     return
 
   let isMe = member.id == singletonInstance.userProfile.getPubKey()
-  let contactDetails = self.controller.getContactDetails(member.id, skipBackendCalls = true)
+  let contactDetails = self.controller.getContactDetails(member.id)
   var status = OnlineStatus.Online
   if isMe:
     let currentUserStatus = intToEnum(singletonInstance.userProfile.getCurrentUserStatus(), StatusType.Unknown)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -565,8 +565,8 @@ proc getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, largeImage: string] =
   return self.contactsService.getContactNameAndImage(contactId)
 
-proc getContactDetails*(self: Controller, contactId: string, skipBackendCalls: bool): ContactDetails =
-  return self.contactsService.getContactDetails(contactId, skipBackendCalls)
+proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
+  return self.contactsService.getContactDetails(contactId)
 
 proc resolveENS*(self: Controller, ensName: string, uuid: string = "", reason: string = "") =
   self.contactsService.resolveENS(ensName, uuid, reason)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1349,7 +1349,7 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string, getVerifi
   ## If includeDetails is true, additional details are calculated, like color hash and that results in higher CPU usage,
   ## that's why by default it is false and we should set it to true only when we really need it.
   if includeDetails:
-    contactDetails = self.controller.getContactDetails(publicKey, skipBackendCalls = false)
+    contactDetails = self.controller.getContactDetails(publicKey)
   else:
     contactDetails.dto = self.controller.getContact(publicKey)
 
@@ -2075,7 +2075,7 @@ proc createMemberItem[T](
     role: MemberRole,
     airdropAddress: string = "",
     ): MemberItem =
-  let contactDetails = self.controller.getContactDetails(memberId, skipBackendCalls = true)
+  let contactDetails = self.controller.getContactDetails(memberId)
   let status = self.controller.getStatusForContactWithId(memberId)
   return createMemberItemFromDtos(
     contactDetails,
@@ -2087,7 +2087,7 @@ proc createMemberItem[T](
   )
 
 method contactUpdated*[T](self: Module[T], contactId: string) =
-  let contactDetails = self.controller.getContactDetails(contactId, skipBackendCalls = false)
+  let contactDetails = self.controller.getContactDetails(contactId)
   self.view.model().updateMemberItemInSections(
     pubKey = contactId,
     displayName = contactDetails.dto.displayName,

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -111,7 +111,7 @@ QtObject:
   proc getContactById*(self: Service, id: string): ContactsDto
   proc saveContact(self: Service, contact: ContactsDto)
   proc requestContactInfo*(self: Service, pubkey: string)
-  proc constructContactDetails(self: Service, contactDto: ContactsDto, isCurrentUser: bool = false, skipBackendCalls: bool = false): ContactDetails
+  proc constructContactDetails(self: Service, contactDto: ContactsDto, isCurrentUser: bool = false): ContactDetails
   proc parseContactsResponse*(self: Service, contacts: JsonNode, fromBackup: bool = false)
 
   proc delete*(self: Service) =
@@ -293,28 +293,27 @@ QtObject:
     if(contactDto.image.large.len > 0):
       result.largeImage = contactDto.image.large
 
-  proc constructContactDetails(self: Service, contactDto: ContactsDto, isCurrentUser: bool = false, skipBackendCalls: bool = false): ContactDetails =
+  proc constructContactDetails(self: Service, contactDto: ContactsDto, isCurrentUser: bool = false): ContactDetails =
     result = ContactDetails()
     let (name, optionalName, icon, _) = self.getContactNameAndImageInternal(contactDto)
     result.defaultDisplayName = name
     result.optionalName = optionalName
     result.icon = icon
-    if not skipBackendCalls:
-      result.colorId = procs_from_visual_identity_service.colorIdOf(contactDto.id)
+    result.colorId = procs_from_visual_identity_service.colorIdOf(contactDto.id)
     result.isCurrentUser = isCurrentUser
     result.dto = contactDto
 
-    if not contactDto.ensVerified and not skipBackendCalls:
+    if not contactDto.ensVerified:
       result.colorHash = procs_from_visual_identity_service.getColorHashAsJson(contactDto.id)
 
-  proc getContactDetails*(self: Service, id: string, skipBackendCalls: bool = false): ContactDetails =
+  proc getContactDetails*(self: Service, id: string): ContactDetails =
     var pubkey = id
 
     if service_conversion.isCompressedPubKey(id):
       pubkey = status_accounts.decompressPk(id).result
 
     if len(pubkey) == 0:
-        return
+      return
 
     ## Returns contact details based on passed id (public key)
     ## If we don't have stored contact localy or in the db then we create it based on public key.
@@ -339,7 +338,6 @@ QtObject:
           bio: self.settingsService.getBio(),
         ),
         isCurrentUser = true,
-        skipBackendCalls,
       )
 
     if not pubkey.startsWith("0x"):
@@ -355,7 +353,7 @@ QtObject:
     let contact = self.constructContactDetails(
       ContactsDto(
         id: pubkey,
-        alias: if skipBackendCalls: "" else: self.generateAlias(pubkey),
+        alias: self.generateAlias(pubkey),
         ensVerified: false,
         added: false,
         blocked: false,
@@ -363,9 +361,9 @@ QtObject:
         trustStatus: TrustStatus.Unknown,
       ),
       isCurrentUser = false,
-      skipBackendCalls,
     )
     self.addContact(contact)
+    self.events.emit(SIGNAL_CONTACT_UPDATED, ContactArgs(contactId: pubkey))
     return contact
 
   proc getContactById*(self: Service, id: string): ContactsDto =


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/18560

Fixes #18548

The problem was that we introduced a mechanism to speed up login by skipping backend calls on contacts on app start. This was fine before because we also relied on the service to get the contact details. However, we now use the contacts model instead, which is faster. So that was empty. Plus, we were storing an empty alias in the contacts table, so the contact never populated.

Now, the fix is simple, we stop using `skipBackendCalls`, because we already stopped loading any member lists on app start, so we no longer need that. Also, we update the contacts model when we save a new contact, making sure there is an alias for them.
