### PR TITLE
fix(CreateCommunityPopup): fix the erratic autoscroll

### DIFF
--- a/storybook/pages/CreateCommunityPopupPage.qml
+++ b/storybook/pages/CreateCommunityPopupPage.qml
@@ -176,7 +176,7 @@ SplitView {
 }
 
 // category: Popups
-
+// status: good
 // https://www.figma.com/design/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?node-id=52741-266926&node-type=frame&t=PkDxeWSXoiZbIQXv-0
 // https://www.figma.com/design/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?node-id=2636-359221&node-type=frame&t=PkDxeWSXoiZbIQXv-0
 // https://www.figma.com/design/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?node-id=52741-267155&node-type=frame&t=PkDxeWSXoiZbIQXv-0

--- a/ui/StatusQ/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -48,7 +48,7 @@ Item {
     */
     property bool interactive: true
     /*!
-        \qmlproperty bool StatusImageCrop::margins
+        \qmlproperty int StatusImageCrop::margins
         Space to keep around the control borders and crop area
     */
     property int margins: 10
@@ -224,7 +224,7 @@ Item {
                 onMouseXChanged: (mouse) => updateDrag(Qt.point(mouse.x, mouse.y))
                 onMouseYChanged: (mouse) => updateDrag(Qt.point(mouse.x, mouse.y))
 
-                onWheel: {
+                onWheel: function (wheel) {
                     const delta = wheel.angleDelta.y / 120
                     cropEditor.setCropRect(cropEditor.getZoomRect(cropEditor.zoomScale + delta * root.scrollZoomFactor))
                 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusImageCropPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusImageCropPanel.qml
@@ -269,8 +269,7 @@ Item {
                 from: cropEditor.minZoomScale
                 to: cropEditor.maxZoomScale
                 value: cropEditor.zoomScale
-                live: false
-                onMoved: cropEditor.setCropRect(cropEditor.getZoomRect(valueAt(visualPosition)))
+                onMoved: cropEditor.setCropRect(cropEditor.getZoomRect(valueAt(position)))
             }
             StatusIcon {
                 icon: "add-circle"

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
@@ -1,8 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
 
-import Qt5Compat.GraphicalEffects
-
 import StatusQ.Core.Utils
 import StatusQ.Core.Theme
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRoundButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRoundButton.qml
@@ -180,9 +180,9 @@ Rectangle {
             } // Indicator
         } // Loader
 
-        onClicked: statusRoundButton.clicked(mouse)
-        onPressed: statusRoundButton.pressed(mouse)
-        onReleased: statusRoundButton.released(mouse)
-        onPressAndHold: statusRoundButton.pressAndHold(mouse)
+        onClicked: mouse => statusRoundButton.clicked(mouse)
+        onPressed: mouse => statusRoundButton.pressed(mouse)
+        onReleased: mouse => statusRoundButton.released(mouse)
+        onPressAndHold: mouse => statusRoundButton.pressAndHold(mouse)
     } // Sensor
 } // Rectangle

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSlider.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSlider.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
+import QtQuick.Effects
 
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -61,16 +61,17 @@ Slider {
         implicitWidth: root.handleSize
         implicitHeight: root.handleSize
         radius: root.handleSize / 2
+
         layer.enabled: true
-        layer.effect: DropShadow {
-            width: parent.width
-            height: parent.height
-            visible: true
-            verticalOffset: 2
-            samples: 15
-            fast: true
-            cached: true
-            color: Theme.palette.dropShadow
+        layer.effect: MultiEffect {
+            autoPaddingEnabled: true
+            shadowEnabled: true
+            shadowVerticalOffset: 2
+            shadowColor: Theme.palette.dropShadow3
         }
+    }
+
+    HoverHandler {
+        cursorShape: root.pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusWarningBox.qml
@@ -49,7 +49,7 @@ Control {
     */
     property color iconColor: "transparent"
     /*!
-        \qmlproperty var StatusWarningBox::iconAlignment
+        \qmlproperty int StatusWarningBox::iconAlignment
         This property allows setting the position of the icon inside the warning box component.
     */
     property int iconAlignment: Qt.AlignTop

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -68,6 +68,7 @@ ThemePalette {
 
     dropShadow: getColor('black', 0.08)
     dropShadow2: getColor('blue8', 0.02)
+    dropShadow3: getColor('blue8', 0.05) // suitable for MultiEffect
 
     statusFloatingButtonHighlight: getColor('blue4', 0.3)
 

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -68,6 +68,7 @@ ThemePalette {
 
     dropShadow: Qt.rgba(0, 34/255, 51/255, 0.03)
     dropShadow2: getColor('blue7', 0.02)
+    dropShadow3: getColor('black', 0.15) // suitable for MultiEffect
 
     statusFloatingButtonHighlight: getColor('blueHijab')
 

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -16,6 +16,7 @@ QtObject {
 
     property color dropShadow
     property color dropShadow2
+    property color dropShadow3 // suitable for MultiEffect
     property color backdropColor: getColor('black', 0.4)
 
     property color baseColor1

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialogFooter.qml
@@ -55,7 +55,7 @@ Control {
         Repeater {
             Layout.topMargin: 4
             model: root.errorTags
-            onItemAdded: {
+            onItemAdded: function(index, item) {
                 item.Layout.fillHeight = true
                 item.Layout.fillWidth = true
             }
@@ -79,7 +79,7 @@ Control {
 
             Repeater {
                 model: root.leftButtons
-                onItemAdded: (index, item) => {
+                onItemAdded: function(index, item) {
                     item.Layout.fillHeight = true
                     item.Layout.fillWidth = Qt.binding(() => root.width < root.implicitWidth)
                 }
@@ -91,7 +91,7 @@ Control {
 
             Repeater {
                 model: root.rightButtons
-                onItemAdded: (index, item) => {
+                onItemAdded: function(index, item) {
                     item.Layout.fillHeight = true
                     item.Layout.fillWidth = Qt.binding(() => root.width < root.implicitWidth)
                 }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -9,7 +9,7 @@ StatusModal {
     id: root
 
     property string stackTitle: qsTr("StackModal")
-    property int subHeaderPadding: 16
+    property int subHeaderPadding: Theme.padding
 
     property alias stackItems: stackLayout.children
     property alias currentIndex: stackLayout.currentIndex
@@ -69,7 +69,7 @@ StatusModal {
 
     headerSettings.title: replaceLoader.item && typeof(replaceLoader.item.title) != "undefined"
                                                 ? replaceLoader.item.title : stackTitle
-    padding: 16
+    padding: Theme.padding
 
     leftButtons: [ backButton ]
 

--- a/ui/StatusQ/src/StatusQ/Popups/statusModal/StatusModalFooter.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/statusModal/StatusModalFooter.qml
@@ -3,10 +3,8 @@ import QtQuick.Layouts
 
 import StatusQ.Core
 import StatusQ.Core.Theme
-import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Popups
-
 
 Rectangle {
     id: root
@@ -15,7 +13,7 @@ Rectangle {
     property list<StatusBaseButton> rightButtons
     property bool showFooter: true
 
-    radius: 8
+    radius: Theme.radius
 
     color: Theme.palette.statusModal.backgroundColor
 
@@ -45,20 +43,20 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.leftMargin: 16
-        anchors.rightMargin: 18
+        anchors.leftMargin: Theme.padding
+        anchors.rightMargin: Theme.padding
 
         RowLayout {
             id: leftButtonsLayout
             Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
             visible: root.showFooter
 
-            spacing: 16
+            spacing: Theme.padding
         }
 
         Item {
             Layout.fillWidth: true
-            Layout.minimumWidth: 16
+            Layout.minimumWidth: Theme.padding
         }
 
         RowLayout {
@@ -66,7 +64,7 @@ Rectangle {
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
             visible: root.showFooter
 
-            spacing: 16
+            spacing: Theme.padding
         }
     }
 

--- a/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
@@ -24,7 +24,7 @@ Item {
 
     readonly property bool hasSelectedImage: localAppSettings.testEnvironment ? true : editor.userSelectedImage
 
-    implicitHeight: layout.childrenRect.height
+    implicitHeight: layout.implicitHeight
 
     function validate() {
         editor.isError = !hasSelectedImage

--- a/ui/app/AppLayouts/Communities/controls/EditCommunitySettingsForm.qml
+++ b/ui/app/AppLayouts/Communities/controls/EditCommunitySettingsForm.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 
 import utils
 
+import StatusQ.Core.Theme
 import StatusQ.Popups
 
 import AppLayouts.Communities.controls
@@ -55,7 +56,7 @@ Control {
     }
 
     contentItem: ColumnLayout {
-        spacing: 16
+        spacing: Theme.padding
 
         NameInput {
             id: nameInput

--- a/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
@@ -24,7 +24,7 @@ Item {
 
     readonly property bool hasSelectedImage: localAppSettings.testEnvironment ? true : editor.userSelectedImage
 
-    implicitHeight: layout.childrenRect.height
+    implicitHeight: layout.implicitHeight
 
     function validate() {
         editor.isError = !hasSelectedImage

--- a/ui/app/AppLayouts/Communities/controls/Options.qml
+++ b/ui/app/AppLayouts/Communities/controls/Options.qml
@@ -28,30 +28,16 @@ ColumnLayout {
         readonly property string aboutPermissionsLink: Constants.statusHelpLinkPrefix + "communities/set-up-your-community-permissions"
     }
 
-    ColumnLayout {
+    StatusCheckBox {
+        id: requestToJoinToggle
         Layout.fillWidth: true
-        spacing: 4
-
-        StatusCheckBox {
-            id: requestToJoinToggle
-            Layout.fillWidth: true
-            Layout.preferredHeight: d.optionHeight
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("Request to join required")
-            leftSide: false
-            padding: 0
-            spacing: 0
-        }
-
-        StatusBaseText {
-            Layout.fillWidth: true
-            Layout.rightMargin: 64
-            visible: requestToJoinToggle.checked
-            wrapMode: Text.WordWrap
-            text: qsTr("Warning: Only token gated communities (or token gated channels inside non-token gated community) are encrypted")
-            font.pixelSize: Theme.tertiaryTextFontSize
-            color: Theme.palette.warningColor1
-        }
+        Layout.topMargin: Theme.padding
+        Layout.preferredHeight: d.optionHeight
+        text: checked ? qsTr("Request to join required") + "<br><font size='-1' color='%1'>".arg(Theme.palette.warningColor1) +
+                        qsTr("Warning: Only token gated communities (or token gated channels inside non-token gated community) are encrypted") + "</font>"
+                      : qsTr("Request to join required")
+        leftSide: false
+        padding: 0
     }
 
     Item {
@@ -80,7 +66,7 @@ ColumnLayout {
                     textColor: Theme.palette.directColor5
                     textHoverColor: Theme.palette.primaryColor1
                     icon.name: "info"
-                    onClicked: Global.openPopup(messageHistoryInfoPopupComponent)
+                    onClicked: messageHistoryInfoPopupComponent.createObject(root).open()
                 }
 
                 StatusBaseText {
@@ -122,14 +108,13 @@ ColumnLayout {
         text: qsTr("You can token-gate your community and channels anytime after creation using existing tokens or by minting new ones in the community admin area.")
         extraContentComponent: RowLayout {
             spacing: 0
-            StatusSelectableText {
+            StatusLinkText {
                 Layout.fillWidth: true
-                defaultLinkColor: Theme.palette.primaryColor1
-                hoveredLinkColor: Theme.palette.primaryColor1
-                text: "<p><a style='text-decoration:none' href=' '>%1</a></p>".arg(qsTr("Learn more about token-gating"))
-
-                onLinkActivated: Global.openLinkWithConfirmation(d.aboutPermissionsLink,
-                                                                 StatusQUtils.StringUtils.extractDomainFromLink(d.aboutPermissionsLink))
+                text: qsTr("Learn more about token-gating")
+                font.pixelSize: Theme.primaryTextFontSize
+                normalColor: linkColor
+                onClicked: Global.openLinkWithConfirmation(d.aboutPermissionsLink,
+                                                           StatusQUtils.StringUtils.extractDomainFromLink(d.aboutPermissionsLink))
             }
 
             StatusIcon {
@@ -155,6 +140,7 @@ ColumnLayout {
 
         EnableFullMessageHistoryPopup {
             onAccepted: Global.openLinkWithConfirmation(d.aboutHistoryServiceLink, StatusQUtils.StringUtils.extractDomainFromLink(d.aboutHistoryServiceLink))
+            onClosed: destroy()
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/TagsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TagsPanel.qml
@@ -125,7 +125,7 @@ StatusScrollView {
         StatusCommunityTags {
             model: d.tagsModel
             mode: StatusCommunityTags.ShowSelectedOnly
-            onClicked: {
+            onClicked: function(item) {
                 d.countSelectedTags--;
                 item.selected = false;
             }

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -37,7 +37,6 @@ StatusStackModal {
 
     nextButton: StatusButton {
         objectName: "createCommunityNextBtn"
-        font.weight: Font.Medium
         text: typeof currentItem.nextButtonText !== "undefined" ? currentItem.nextButtonText : qsTr("Next")
         enabled: typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext
         loading: root.store.discordDataExtractionInProgress
@@ -52,7 +51,6 @@ StatusStackModal {
 
     finishButton: StatusButton {
         objectName: "createCommunityFinalBtn"
-        font.weight: Font.Medium
         text: root.isDiscordImport ? qsTr("Start Discord import") : qsTr("Create Community")
         enabled: typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext
         onClicked: {
@@ -64,7 +62,6 @@ StatusStackModal {
     }
 
     readonly property var clearFilesButton: StatusButton {
-        font.weight: Font.Medium
         text: qsTr("Clear all")
         type: StatusBaseButton.Type.Danger
         visible: root.currentItem.objectName === "discordFileListView" // no better way to address the current item in the stack :/
@@ -161,7 +158,7 @@ StatusStackModal {
                         Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Qt.AlignHCenter
                         text: qsTr("Export your Discord JSON data using %1").arg("<a href='https://github.com/Tyrrrz/DiscordChatExporter/releases/tag/2.40.4'>DiscordChatExporter</a>")
-                        onLinkActivated: Global.openLink(link)
+                        onLinkActivated: link => Global.openLink(link)
                         HoverHandler {
                             id: handler1
                         }
@@ -175,7 +172,7 @@ StatusStackModal {
                         Layout.alignment: Qt.AlignHCenter
                         horizontalAlignment: Qt.AlignHCenter
                         text: qsTr("Refer to this <a href='https://github.com/Tyrrrz/DiscordChatExporter/blob/master/.docs/Readme.md'>documentation</a> if you have any queries")
-                        onLinkActivated: Global.openLink(link)
+                        onLinkActivated: link => Global.openLink(link)
                         HoverHandler {
                             id: handler2
                         }

--- a/ui/app/AppLayouts/Communities/popups/EnableFullMessageHistoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/EnableFullMessageHistoryPopup.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls // for the Popup.xxx enums
 import QtQuick.Layouts
 import QtQml.Models
 

--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -194,7 +194,7 @@ Item {
             ImageCropWorkflow {
                 id: imageCropWorkflow
 
-                onImageCropped: {
+                onImageCropped: function (image, cropRect) {
                     croppedPreview.source = image
                     croppedPreview.setCropRect(cropRect)
                     root.userSelectedImage = true
@@ -208,7 +208,7 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            visible: root.state == d.backgroundComponentState
+            visible: root.state === d.backgroundComponentState
 
             sourceComponent: root.backgroundComponent
         }


### PR DESCRIPTION
### What does the PR do

- when checking the "Request to join required" option; make the warning text part of the control

Fixes https://github.com/status-im/status-desktop/issues/18448

- another commit to fix the barely visible handle in StatusSlider

Fixes #18598

(See the individual commits for more details)

### Affected areas

CreateCommunityPopup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/e2dec488-86ac-4585-8264-38576c37894e

StatusSlider fixed:
<img width="884" height="943" alt="Snímek obrazovky z 2025-08-17 18-38-36" src="https://github.com/user-attachments/assets/7e372e91-7208-4812-b6ff-a6b71266ad75" />


### Impact on end user

- easier to create the community

### How to test

- invoke the CreateCommunityPopup
- click the "Request to join required" option
- should not autoscroll to the very top

### Risk 

- low
