### PR TITLE
ci: hack fix to set params via environment

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -81,7 +81,16 @@ pipeline {
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
-    USE_NWAKU = "${params.USE_NWAKU}"
+    /* Hack fix for params not being set in job on first run */
+    NIMFLAGS =               "${params.NIMFLAGS}"
+    USE_NWAKU =              "${params.USE_NWAKU}"
+    ENTITLEMENTS =           "${params.ENTITLEMENTS}"
+    RELEASE =                "${params.RELEASE}"
+    INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
+    VERBOSE =                "${params.VERBOSE}"
+    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    /* FIXME: figure out why NIMFLAGS are not respected */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}"
   }
 
   stages {

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -69,6 +69,15 @@ pipeline {
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
+    /* Hack fix for params not being set in job on first run */
+    NIMFLAGS =               "${params.NIMFLAGS}"
+    ENTITLEMENTS =           "${params.ENTITLEMENTS}"
+    RELEASE =                "${params.RELEASE}"
+    INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
+    VERBOSE =                "${params.VERBOSE}"
+    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    /* FIXME: figure out why NIMFLAGS are not respected */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -41,6 +41,11 @@ pipeline {
       description: 'Whether to build with nwaku or not',
       defaultValue: params.USE_NWAKU ?: getNWakuMode(),
     )
+    string(
+      name: 'NIMFLAGS',
+      description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
+      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+    )
   }
 
   options {
@@ -83,9 +88,16 @@ pipeline {
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
-    USE_NWAKU = "${params.USE_NWAKU}"
-    /* Redirect Nim's cache to workspace to avoid cache corruption across builds */
-    NIMFLAGS = "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+    /* Hack fix for params not being set in job on first run */
+    NIMFLAGS =               "${params.NIMFLAGS}"
+    USE_NWAKU =              "${params.USE_NWAKU}"
+    ENTITLEMENTS =           "${params.ENTITLEMENTS}"
+    RELEASE =                "${params.RELEASE}"
+    INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
+    VERBOSE =                "${params.VERBOSE}"
+    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    /* FIXME: figure out why NIMFLAGS are not respected */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -92,6 +92,14 @@ pipeline {
 
     /* Set to a non-zero value to make Qt print out diagnostic information about the each (C++) plugin it tries to load. */
     /* QT_DEBUG_PLUGINS = 0 */
+
+    /* Hack fix for params not being set in job on first run */
+    BUILD_SOURCE =      "${params.BUILD_SOURCE}"
+    TEST_NAME =         "${params.TEST_NAME}"
+    TEST_SCOPE_FLAG =   "${params.TEST_SCOPE_FLAG}"
+    TESTRAIL_RUN_NAME = "${params.TESTRAIL_RUN_NAME}"
+    LOG_LEVEL =         "${params.LOG_LEVEL}"
+
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -52,6 +52,11 @@ pipeline {
     QML_DISABLE_DISK_CACHE = "true"
     /* Include library in order to compile the project */
     LD_LIBRARY_PATH = "$QTDIR/lib"
+    /* Hack fix for params not being set in job on first run */
+    NIMFLAGS = "${params.NIMFLAGS}"
+    VERBOSE =  "${params.USE_NWAKU}"
+    /* FIXME: figure out why NIMFLAGS are not respected */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -41,6 +41,8 @@ pipeline {
     /* Makefile assumes the compiler folder is included */
     QTDIR = "/opt/qt/6.9.0/gcc_64"
     PATH = "${env.QTDIR}/bin:${env.PATH}"
+    /* Hack fix for params not being set in job on first run */
+    VERBOSE = "${params.VERBOSE}"
   }
 
   stages {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -84,6 +84,15 @@ pipeline {
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
+    /* Hack fix for params not being set in job on first run */
+    NIMFLAGS =               "${params.NIMFLAGS}"
+    ENTITLEMENTS =           "${params.ENTITLEMENTS}"
+    RELEASE =                "${params.RELEASE}"
+    INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
+    VERBOSE =                "${params.VERBOSE}"
+    USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
+    /* FIXME: figure out why NIMFLAGS are not respected */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {


### PR DESCRIPTION
## Summary
 
Sometimes parameters defined in Jenkins are not available in environment on 1st run of the job causing weird race conditions. This hack fix ensures all params are available in the environment.
