### PR TITLE
fix(images): sending screenshots by changing the regex to detect base64

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -158,4 +158,4 @@ QtObject:
       result = (conversion.startsWith0x(value) and conversion.isHexFormat(value) and len(value) == 132) or self.isCompressedPubKey(value)
 
   proc isBase64DataUrl*(str: string): bool =
-    return str.match(re2"^data:.*;base64,")
+    return str.match(re2"(?i)^data:[^,]*;base64,[A-Za-z0-9+/=]+$")


### PR DESCRIPTION
### What does the PR do

Fixes #18624

The URI given for base64 images changed when we upgraded to QT6. Hopefully this new Regex is more permissive and shouldn't break on new changes

### Affected areas

Utils function

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[sendng-screenshots.webm](https://github.com/user-attachments/assets/6c76a73d-70f1-4064-a796-f83c8a9c4a50)


### Impact on end user

Fixes the issue

### How to test

- Send screenshots or copied images (CTRL+V)
- 
### Risk 

Low
