### PR TITLE
chore: don't enforce the HomePage as the start section

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -701,6 +701,8 @@ method load*[T](
       enabled = true,
     )
     self.view.model().addItem(homePageSectionItem)
+    if activeSectionId == homePageSectionItem.id:
+      activeSection = homePageSectionItem
 
   # Communities Portal Section
   let communitiesPortalSectionItem = initSectionItem(
@@ -863,8 +865,9 @@ method load*[T](
   self.marketModule.load()
 
   # If the home page is enabled, we default to it as the opening section
-  if homePageEnabled:
-    activeSection = homePageSectionItem
+  # (disabled for 2.35 as per https://github.com/status-im/status-desktop/issues/18664, revisit after)
+  #if homePageEnabled:
+  #  activeSection = homePageSectionItem
 
   # Set active section on app start
   # If section is empty or profile wait until chats are loaded
@@ -979,8 +982,8 @@ method onChatsLoaded*[T](
 
   self.events.emit(SIGNAL_MAIN_LOADED, Args())
 
-  # Set active section if it is one of the channel sections and the home page is not enabled
-  if not singletonInstance.featureFlags().getHomePageEnabled() and not activeSection.isEmpty():
+  # Set active section if it is one of the channel sections
+  if not activeSection.isEmpty():
     self.setActiveSection(activeSection)
 
   self.view.sectionsLoaded()

--- a/test/e2e/gui/main_window.py
+++ b/test/e2e/gui/main_window.py
@@ -179,9 +179,9 @@ class MainWindow(Window):
         splash_screen.wait_until_appears()
         splash_screen.wait_until_hidden(APP_LOAD_TIMEOUT_MSEC)
 
-        # Navigate from home to settings first
         # since we now struggle with 3 words names, I need to change display name first
-        settings_screen = self.home.open_from_dock(DockButtons.SETTINGS.value)
+        left_panel = MainLeftPanel()
+        settings_screen = left_panel.open_settings()
         profile = settings_screen.left_panel.open_profile_settings()
         profile.set_name(user_account.name)
         profile.save_changes_button.click()

--- a/test/e2e/helpers/settings_helper.py
+++ b/test/e2e/helpers/settings_helper.py
@@ -2,7 +2,6 @@ from constants.dock_buttons import DockButtons
 
 
 def enable_testnet_mode(main_window):
-    main_window.home.open_from_dock(DockButtons.SETTINGS.value)
     wallet_settings = main_window.left_panel.open_settings().left_panel.open_wallet_settings()
     test_mode_popup = wallet_settings.open_networks().switch_testnet_mode_toggle()
     test_mode_popup.turn_on_testnet_mode()

--- a/test/e2e/tests/communities/test_communities_categories.py
+++ b/test/e2e/tests/communities/test_communities_categories.py
@@ -6,7 +6,6 @@ import constants
 from allure_commons._allure import step
 
 from constants import RandomCommunity
-from constants.dock_buttons import DockButtons
 from tests import test_data
 from gui.components.context_menu import ContextMenu
 from gui.main_window import MainWindow
@@ -22,7 +21,6 @@ from gui.main_window import MainWindow
 def test_member_role_cannot_add_edit_or_delete_category(main_screen, user_data, user_account):
 
     with step('Choose community user is not owner of'):
-        main_screen.home.open_from_dock(DockButtons.WALLET.value)
         community_screen = main_screen.left_panel.select_community('Community with 2 users')
 
     with step('Verify that member cannot add category'):

--- a/test/e2e/tests/communities/test_communities_channels.py
+++ b/test/e2e/tests/communities/test_communities_channels.py
@@ -84,7 +84,6 @@ def test_create_edit_remove_community_channel(main_screen, channel_name, channel
 def test_member_role_cannot_add_edit_and_delete_channels(main_screen: MainWindow):
 
     with step('Choose community user is not owner of'):
-        main_screen.home.open_from_dock(DockButtons.WALLET.value)
         community_screen = main_screen.left_panel.select_community('Community with 2 users')
     with step('Verify that member cannot add new channel'):
         with step('Verify that create channel or category button is not present'):

--- a/test/e2e/tests/crtitical_tests_prs/test_add_edit_restart_add_delete_generated_account.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_add_edit_restart_add_delete_generated_account.py
@@ -65,7 +65,7 @@ def test_add_edit_restart_add_delete_generated_account(aut: AUT, main_screen: Ma
         main_screen.authorize_user(user_account)
 
     with step('Add second generated wallet account'):
-        wallet = main_screen.home.open_from_dock(DockButtons.WALLET.value)
+        wallet = main_screen.left_panel.open_wallet()
         account_popup = wallet.left_panel.open_add_account_popup()
         account_popup.set_name(name2).save_changes()
 

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_import_seed.py
@@ -32,7 +32,7 @@ def test_import_and_reimport_random_seed(
             import_seed_and_log_in(create_your_profile_view, seed_phrase, user_account)
 
     with step('Verify that restored account reveals correct status wallet address'):
-        profile = main_window.home.open_from_dock(DockButtons.SETTINGS.value).left_panel.open_profile_settings()
+        profile = main_window.left_panel.open_settings().left_panel.open_profile_settings()
         profile.set_name(user_account.name)
         profile.save_changes_button.click()
 

--- a/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_onboarding_sync_with_code.py
@@ -75,11 +75,9 @@ def test_sync_devices_during_onboarding_change_settings_unpair(multiple_instance
             SplashScreen().wait_until_hidden(APP_LOAD_TIMEOUT_MSEC)
 
             with step('Verify user details are the same with user in first instance'):
-                home = HomeScreen()
-                online_identifier = home.open_online_identifier_from_home_screen()
+                online_identifier = main_window.left_panel.open_online_identifier()
                 assert online_identifier.get_user_name == user.name, \
                     f'Name in online identifier and display name do not match'
-                main_window.home.click()
                 main_window.hide()
 
         with step(f'Open first instance {aut_one.aut_id} and verify it is synced, click done'):
@@ -90,6 +88,7 @@ def test_sync_devices_during_onboarding_change_settings_unpair(multiple_instance
                 lambda: 'Device synced!' in sync_device_found.device_synced_notifications, 23000)
             assert user.name in sync_device_found.device_synced_notifications
             sync_device_found.done_button.click()
+
         # TODO: https://github.com/status-im/status-desktop/issues/18680
         # with step('Change Allow contact requests toggle state to OFF'):
         #     home = main_window.left_panel.open_home_screen()
@@ -129,3 +128,4 @@ def test_sync_devices_during_onboarding_change_settings_unpair(multiple_instance
         #     assert driver.waitFor(
         #         lambda: not msg_stngs.allow_contact_requests_toggle.object.checked, 15000), \
         #         f'Toggle state should remain unchecked becase devices are not paired'
+

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -34,6 +34,6 @@ def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_accou
                                                password=new_password))
 
     with step('Verify that the user logged in correctly'):
-        online_identifier = main_screen.home.open_online_identifier_from_home_screen()
+        online_identifier = main_screen.left_panel.open_online_identifier()
         profile_popup = online_identifier.open_profile_popup_from_online_identifier()
         assert profile_popup.user_name == user_account.name

--- a/test/e2e/tests/wallet_main_screen/wallet_load_time/test_wallet_loading_time.py
+++ b/test/e2e/tests/wallet_main_screen/wallet_load_time/test_wallet_loading_time.py
@@ -22,7 +22,7 @@ def test_wallet_loading_time(main_screen, user_data, user_account, tmp_path):
     os.environ['STATUS_RUNTIME_TEST_MODE'] = 'True'  # to omit banners
 
     with step('Open wallet after login'):
-        main_screen.home.open_from_dock(DockButtons.WALLET.value)
+        main_screen.left_panel.open_wallet()
 
     load_times = []
     report_lines = []


### PR DESCRIPTION
### What does the PR do

- treat the HomePage as any other section

Fixes #18664

### Affected areas

AppMain

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/bda4de84-49b6-49e3-9e71-d1cb878fa1d5

### Impact on end user

No more special treatment of the HomePage, last active section will always be the one we start with the next time

### How to test

- navigate to some section
- quit & restart the app
- the app should start with the last active section

### Risk 

- low
