### PR TITLE
fix(wallet): address remains the same on custom derivation path

### DIFF
--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -361,6 +361,11 @@ proc setItemForSelectedOrigin[T](self: Module[T], item: KeyPairItem) =
     error "provided item cannot be set as selected origin", keyUid=item.getKeyUid()
     return
 
+  let selectedOrigin = self.view.getSelectedOrigin()
+  if selectedOrigin.getKeyUid() != item.getKeyUid():
+    self.view.derivedAddressModel().reset()
+    self.view.setSelectedDerivedAddress(newDerivedAddressItem())
+
   self.view.setSelectedOrigin(item)
 
   if item.getKeyUid() == Label_OptionAddWatchOnlyAcc:


### PR DESCRIPTION
A real issue was when the user entered a custom derivation path and provided pin/password, but had more key pairs with the same accounts' derivation paths ("last-index" is the same for those key pairs) and went change the selected keypair the change was not triggered cause was compared by the derivation path which was the same. Changes here invalidate the selected derivation path when the selected origin changes.

Fixes: #18642