### PR TITLE
fix(@desktop/wallet): properly set up activity entry context menu

### DIFF
--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -356,9 +356,9 @@ ColumnLayout {
                 showAllAccounts: root.showAllAccounts
                 displayValues: root.displayValues
                 community: isModelDataValid && !!communityId && !!root.communitiesStore ? root.communitiesStore.getCommunityDetailsAsJson(communityId) : null
-                onClicked: {
+                onClicked: function(itemId, mouse) {
                     if (mouse.button === Qt.RightButton) {
-                        txContextMenu.createObject(this, { modelData }).popup(mouse)
+                        txContextMenu.createObject(this, { modelData }).popup(mouse.x, mouse.y)
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18658

Fixes context menu for activity entries in Activity tab

The console indicated

```
WRN 2025-08-21 13:42:03.955Z qt warning                                 topics="qt" tid=333491990 text="qrc:/imports/shared/views/HistoryView.qml:359:17 Parameter \"mouse\" is not declared. Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead." category=qt.qml.context file=:0
WRN 2025-08-21 13:42:03.961Z qt warning                                 topics="qt" tid=333491990 text="\"Could not convert argument 0 from QQuickMouseEvent(0x3eb59d968) to QQuickItem*\"" category=default file=:0
WRN 2025-08-21 13:42:03.961Z qt warning                                 topics="qt" tid=333491990 text="\t \"expression for onClicked@qrc:/imports/shared/views/HistoryView.qml:361\"" category=default file=:0
WRN 2025-08-21 13:42:03.961Z qt warning                                 topics="qt" tid=333491990 text="\t \"@qrc:/StatusQ/Components/StatusListItem.qml:150\"" category=default file=:0
WRN 2025-08-21 13:42:03.961Z qt warning                                 topics="qt" tid=333491990 text="TypeError: Passing incompatible arguments to C++ functions from JavaScript is not allowed." category=default file=qrc:/imports/shared/views/HistoryView.qml:361
```
There must've been some change with the Qt6 migration.


<img width="798" height="589" alt="image" src="https://github.com/user-attachments/assets/cdbfb446-12b9-41d9-8ac9-d09c5033bd5c" />

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
