### PR TITLE
[CHERR-PICK] fix(images): sending screenshots by changing the regex to detect base64

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -155,4 +155,4 @@ QtObject:
       result = (conversion.startsWith0x(value) and conversion.isHexFormat(value) and len(value) == 132) or self.isCompressedPubKey(value)
 
   proc isBase64DataUrl*(str: string): bool =
-    return str.match(re2"^data:.*;base64,")
+    return str.match(re2"(?i)^data:[^,]*;base64,[A-Za-z0-9+/=]+$")


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/18671

Fixes #18624

The URI given for base64 images changed when we upgraded to QT6. Hopefully this new Regex is more permissive and shouldn't break on new changes
