### PR TITLE
[CHERRY-PICK] fix(windows): fix files from FileDialog having wrong format on Windows

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -29,7 +29,10 @@ QtObject:
     result.setup
 
   proc fromPathUri*(self: Utils, path: string): string {.slot.} =
-    result = uri.decodeUrl(replace(path, "file://", ""), decodePlus=false)
+    var formattedPath = replace(path, "file://", "")
+    # Sometimes the original path only contains `file:` without the `//`
+    formattedPath = replace(formattedPath, "file:", "")
+    result = uri.decodeUrl(formattedPath, decodePlus=false)
     if defined(windows):
       # Windows doesn't work with paths starting with a slash
       result.removePrefix('/')

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -421,9 +421,7 @@ SettingsContentBase {
             title: qsTr("Select your backup file")
             nameFilters: [qsTr("Supported backup formats (%1)").arg("*.bkp")]
             selectMultiple: false
-            onAccepted: {
-                root.devicesStore.importLocalBackupFile(importBackupFileDialog.selectedFile)
-            }
+            onAccepted: root.devicesStore.importLocalBackupFile(importBackupFileDialog.selectedFile)
         }
 
         StatusFolderDialog {


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/18673

Fixes #18622

We added a fix for Mac files in the FileDialog but it broke Windows because it doesn't do all the slashes like other OSes
