### PR TITLE
fix(dapps): properly report connection rejection

### DIFF
--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsModule.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsModule.qml
@@ -192,7 +192,7 @@ SQUtils.QObject {
             root.dappsMetrics.logConnectionProposalAccepted(dappUrl, approvedChainIds, connectorId)
         }
 
-        function rejectAndLog() {
+        function rejectAndLog(key) {
             const dappUrl = dappConnections.getDAppUrl(key)
             const connectorId = dappConnections.getConnectorId(key)
             dappConnections.reject(key)


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18660

Clicking "Reject" in the Dapps connection request popup showed error
```
WRN 2025-08-22 12:54:37.248Z qt warning                                 topics="qt" tid=340708152 text="ReferenceError: key is not defined" category=default file=qrc:/app/AppLayouts/Wallet/services/dapps/DAppsModule.qml:196

```

Rejection wasn't actually signaled to the backend, so it remained stuck in a loop waiting for a response, blocking any future request until it timed out 20 mins later.

This PR fixes that

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
