### PR TITLE
Fix Syncing AC notification showing even when pairing worked + remove useless button

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -335,8 +335,9 @@ method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settin
     self.onAccountLoginError(err2)
     return
 
-  if self.localPairingStatus != nil and self.localPairingStatus.installation != nil and self.localPairingStatus.installation.id != "":
-    # We tried to login by pairing, so finilize the process
+  if self.localPairingStatus != nil and self.localPairingStatus.installation != nil and
+      self.localPairingStatus.installation.id != "" and self.localPairingStatus.state == LocalPairingState.Error:
+    # We tried to login by pairing, so finalize the process
     self.controller.finishPairingThroughSeedPhraseProcess(self.localPairingStatus.installation.id)
 
   # Run any available post-login tasks

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -840,8 +840,8 @@ Item {
 
             // PAGE 5: Profile sync in progress
             page = getCurrentPage(stack, SyncProgressPage)
-            tryCompare(page, "syncState", Onboarding.ProgressState.InProgress)
-            page.syncState = Onboarding.ProgressState.Success // SIMULATION
+            tryCompare(page, "syncState", Onboarding.LocalPairingState.Transferring)
+            page.syncState = Onboarding.LocalPairingState.Finished // SIMULATION
             const btnLogin2 = findChild(page, "btnLogin") // TODO test other flows/buttons here as well
             verify(!!btnLogin2)
             compare(btnLogin2.enabled, true)

--- a/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
+++ b/ui/app/AppLayouts/Onboarding2/pages/SyncProgressPage.qml
@@ -95,10 +95,6 @@ OnboardingPage {
                 target: loginWithSeedphraseButton
                 visible: true
             }
-            PropertyChanges {
-                target: loginAnywayButton
-                visible: true
-            }
         }
     ]
 
@@ -178,16 +174,6 @@ OnboardingPage {
                 visible: false
                 isOutline: true
                 onClicked: root.loginWithSeedphraseRequested()
-            }
-
-            StatusButton {
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 240
-                id: loginAnywayButton
-                text: qsTr("Log in anyway")
-                visible: false
-                isOutline: true
-                onClicked: root.loginToAppRequested()
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18633

We weren't checking to see if the pairing failed, only that a paring happened.

I think the regression happened during the refactor. That code was probably in a code path that could only be reached by restoring using a mnemonic and now we only have one "ending" path (simpler).

Also removes "Log in anyway" button as it's not part of the design and it doesn't work. What would "logging in anyway" do if the pairing failed? We do not have a private key at that point.

### Affected areas

Onboarding module and Syncing Page

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

No AC notif when it's a success:

[no-qac-notif-when-success.webm](https://github.com/user-attachments/assets/c0c05048-2e6d-44ed-b288-65e97c3b15f2)

Show the notif when it's needed (when we had to use the fallback mnemonic):

[ac-notif-when-need.webm](https://github.com/user-attachments/assets/cac36395-e4ee-4b1c-8247-2150fd1d7853)


### Impact on end user

Fixes the issue and removes the confusing and not working button

### How to test

- Test the pairing in a working situation (no AC notif)
- Test the pairing in a not working situation (fake error in status-go or be on different networks)

### Risk 

Low
