### PR TITLE
fix: use nim version of `isBase64DataUrl`

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -12,6 +12,9 @@ include ../../app_service/service/accounts/utils
 
 const URL_STATUS_OK* = "200 OK"
 
+proc isBase64DataUrl*(str: string): bool {.slot.} =
+  return str.match(re2"(?i)^data:[^,]*;base64,[A-Za-z0-9+/=]+$")
+
 QtObject:
   type Utils* = ref object of QObject
 
@@ -160,5 +163,5 @@ QtObject:
   proc isChatKey*(self: Utils, value: string): bool {.slot.} =
     result = (self.isHexFormat(value) and len(value) == 132) or self.isCompressedPubKey(value)
 
-  proc isBase64DataUrl*(str: string): bool =
-    return str.match(re2"(?i)^data:[^,]*;base64,[A-Za-z0-9+/=]+$")
+  proc isBase64DataUrl*(self: Utils, str: string): bool {.slot.} =
+    return isBase64DataUrl(str)

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -122,6 +122,7 @@ const asyncSendImagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
 
     for imagePathOrSource in images.mitems:
       if utils.isBase64DataUrl(imagePathOrSource):
+      if isBase64DataUrl(imagePathOrSource):
         let imagePath = save_byte_image_to_file(imagePathOrSource, arg.tempDir)
         if imagePath != "":
           imagePaths.add(imagePath)

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -871,7 +871,7 @@ QtObject {
     }
 
     function isBase64DataUrl(str) {
-        return /^data:.*;base64,/.test(str);
+        return globalUtilsInst.isBase64DataUrl(str)
     }
 
     function toBase64(buffer) {


### PR DESCRIPTION
# Description

QML was using its own version of `isBase64DataUrl`. Redirected it to the Nim one