### PR TITLE
Network down banner: show timestamp only if cached

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1589,7 +1589,7 @@ Item {
                                 if(chainIdsDown.length > 2) {
                                     return qsTr("POKT & Infura down for <a href='#'>multiple chains </a>. Token balances for those chains cannot be retrieved.")
                                 }
-                                else if(chainIdsDown.length === 1) {
+                                else if(chainIdsDown.length === 1 && withCache) {
                                     return qsTr("POKT & Infura down for %1. %1 token balances are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)
                                 }
                                 else {


### PR DESCRIPTION
### What does the PR do

Fixes banner text to present timestamp only when balances are cached and therefore valid timestamp is available.

Closes: #18654

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`AppMain`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)