### PR TITLE
ci: fix pcsc run dir

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -39,7 +39,7 @@ RUN tar -xJf /tmp/pcsc.tar.xz -C /pcsc --strip-components=1
 
 WORKDIR /pcsc
 
-RUN meson setup builddir -Dpolkit=false -Dlibsystemd=false -Dserial=false -Dipcdir=/pcscd/run
+RUN meson setup builddir -Dpolkit=false -Dlibsystemd=false -Dserial=false -Dipcdir=/tmp/pcscd/run
 RUN cd builddir && ninja
 RUN cp builddir/pcsclite.h src/PCSC
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT 6.9.0 */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.3-qt6.9.0'
+      image 'statusteam/nim-status-client-build:2.0.4-qt6.9.0'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }


### PR DESCRIPTION
## Summary

fixes path to ipcdir for pcscd, to solve errors like these: 

```
$ ./StatusIm-Desktop-2.35.0-rc.4-e8083a-x86_64.AppImage 
starting pcscd with /tmp/.mount_StatusMlBcBD/usr/bin/pcscd -f &
00000000 [138400321718208] ../src/pcscdaemon.c:629:main() cannot create /pcscd/run: No such file or directory
qt.core.qobject.connect: QObject::connect(QObject, Unknown): invalid nullptr parameter
```

fixes: https://github.com/status-im/status-desktop/issues/18635
