### PR TITLE
fix(backup): open import file dialog to current setting

### DIFF
--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -420,6 +420,7 @@ SettingsContentBase {
 
             title: qsTr("Select your backup file")
             nameFilters: [qsTr("Supported backup formats (%1)").arg("*.bkp")]
+            currentFolder: root.devicesStore.toFileUri(root.backupPath)
             selectMultiple: false
             onAccepted: root.devicesStore.importLocalBackupFile(importBackupFileDialog.selectedFile)
         }


### PR DESCRIPTION
Opens the file dialog in the directory where the setting currently is, since it will most likely be there that the file will be. It's also less confusing for users

There is only one thing that is a bit confusing. If the user clicks on "Import Local Backup File", then changes the "Directory of local backup files", clicking on "Import" again will show the original path only.
This is a QT "bug". They only take the original path, then it goes back to the last place the user went. So for normal users, it should feel natural, but as a tester, it might look like a bug

[default-dir.webm](https://github.com/user-attachments/assets/a2933591-171d-42f0-a4b6-139de1d135bc)
