### PR TITLE
Fix: Android GH Action + qml server

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -86,16 +86,19 @@ run: makedir $(TARGET)
 clean-status-go:
 	@rm -f $(STATUS_GO_LIB)
 	@rm -rf $(STATUS_GO)/build
+	@make -C $(STATUS_DESKTOP) status-go-clean
 
 .PHONY: clean-statusq
 clean-statusq:
 	@rm -f $(STATUS_Q_LIB)
 	@rm -rf $(STATUSQ)/build
+	@make -C $(STATUS_DESKTOP) statusq-clean
 
 .PHONY: clean-dotherside
 clean-dotherside:
 	@rm -f $(DOTHERSIDE_LIB)
 	@rm -rf $(DOTHERSIDE)/build
+	@make -C $(STATUS_DESKTOP) dotherside-clean
 
 .PHONY: clean-openssl
 clean-openssl:
@@ -110,7 +113,6 @@ clean-qrcodegen:
 clean-nim-status-client:
 	@rm -f $(NIM_STATUS_CLIENT_LIB)
 	@rm -rf $(STATUS_DESKTOP)/nimcache
-	@make -C $(STATUS_DESKTOP) clean
 
 .PHONY: clean-status-desktop-rcc
 clean-status-desktop-rcc:

--- a/mobile/scripts/Common.mk
+++ b/mobile/scripts/Common.mk
@@ -11,16 +11,16 @@ endif
 
 # compile macros
 ifeq ($(USE_QML_SERVER),)
-  export APP_VARIANT := default
+  export APP_VARIANT := $(OS)/qt$(QT_MAJOR)
 else
-  export APP_VARIANT := qmlserver-$(USE_QML_SERVER)
+  export APP_VARIANT := $(OS)/qt$(QT_MAJOR)/qmlserver-$(USE_QML_SERVER)
 endif
 
 # path macros
 ROOT_DIR := $(STATUS_DESKTOP)/mobile
-BIN_PATH := $(ROOT_DIR)/bin/$(OS)/qt$(QT_MAJOR)/$(APP_VARIANT)
-LIB_PATH := $(ROOT_DIR)/lib/$(OS)/qt$(QT_MAJOR)/$(APP_VARIANT)
-BUILD_PATH := $(ROOT_DIR)/build/$(OS)/qt$(QT_MAJOR)/$(APP_VARIANT)
+BIN_PATH := $(ROOT_DIR)/bin/$(APP_VARIANT)
+LIB_PATH := $(ROOT_DIR)/lib/$(APP_VARIANT)
+BUILD_PATH := $(ROOT_DIR)/build/$(APP_VARIANT)
 
 SCRIPTS_PATH := $(ROOT_DIR)/scripts
 

--- a/mobile/wrapperApp/Status-tablet.pro
+++ b/mobile/wrapperApp/Status-tablet.pro
@@ -19,21 +19,21 @@ QML_IMPORT_PATH += $$PWD/../../ui/imports \
                    $$PWD/../../ui/StatusQ/src
 
 QMLPATHS += $$QML_IMPORT_PATH
-LIB_PREFIX = qt$$QT_MAJOR_VERSION/$$(APP_VARIANT)
+LIB_PREFIX = $$(APP_VARIANT)
 
 android {
     message("cofiguring for android $${QT_ARCH}, $$(ANDROID_ABI)")
     
     ANDROID_PACKAGE_SOURCE_DIR = $$PWD/../android/qt$$QT_MAJOR_VERSION
 
-    LIBS += -L$$PWD/../lib/android/$$LIB_PREFIX -lnim_status_client
+    LIBS += -L$$PWD/../lib/$$LIB_PREFIX -lnim_status_client
     ANDROID_EXTRA_LIBS += \
-                        $$PWD/../lib/android/$$LIB_PREFIX/libssl_3.so \
-                        $$PWD/../lib/android/$$LIB_PREFIX/libcrypto_3.so \
-                        $$PWD/../lib/android/$$LIB_PREFIX/libnim_status_client.so \
-                        $$PWD/../lib/android/$$LIB_PREFIX/libDOtherSide$$(LIB_SUFFIX)$$(LIB_EXT) \
-                        $$PWD/../lib/android/$$LIB_PREFIX/libstatus.so \
-                        $$PWD/../lib/android/$$LIB_PREFIX/libStatusQ$$(LIB_SUFFIX)$$(LIB_EXT)
+                        $$PWD/../lib/$$LIB_PREFIX/libssl_3.so \
+                        $$PWD/../lib/$$LIB_PREFIX/libcrypto_3.so \
+                        $$PWD/../lib/$$LIB_PREFIX/libnim_status_client.so \
+                        $$PWD/../lib/$$LIB_PREFIX/libDOtherSide$$(LIB_SUFFIX)$$(LIB_EXT) \
+                        $$PWD/../lib/$$LIB_PREFIX/libstatus.so \
+                        $$PWD/../lib/$$LIB_PREFIX/libStatusQ$$(LIB_SUFFIX)$$(LIB_EXT)
 }
 
 ios {
@@ -45,10 +45,5 @@ ios {
     QMAKE_BUNDLE = status$${QMAKE_BUNDLE_SUFFIX}
     QMAKE_ASSET_CATALOGS += $$PWD/../ios/Images.xcassets
 
-    LIBS += -L$$PWD/../lib/ios/$$LIB_PREFIX -lnim_status_client -lDOtherSideStatic -lstatusq -lstatus -lssl_3 -lcrypto_3 -lqzxing -lresolv -lqrcodegen
+    LIBS += -L$$PWD/../lib/$$LIB_PREFIX -lnim_status_client -lDOtherSideStatic -lstatusq -lstatus -lssl_3 -lcrypto_3 -lqzxing -lresolv -lqrcodegen
 }
-
-DESTDIR=$$PWD/../bin/$$LIB_PREFIX
-
-target.path = $$PWD/../lib/$$LIB_PREFIX
-INSTALLS += target

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -27,6 +27,23 @@ when defined(macosx) and defined(arm64):
 when defined(windows):
     {.link: "../status.o".}
 
+when defined(USE_QML_SERVER):
+  # get the host OS and localhost IP
+  # the host OS is the OS that compiles the app, not the OS that runs the app
+  const USE_QML_SERVER{.strdefine.} = "8081"
+  const isWindows = gorgeEx("wmic os get Caption").exitCode == 0
+  const isMacOS = gorge("sw_vers -productName") == "macOS"
+  const localhost = staticExec(
+    when isWindows:
+      "powershell -Command \"(Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias (Get-NetConnectionProfile).InterfaceAlias).IPAddress\""
+    elif isMacOS:
+      "ipconfig getifaddr en0"
+    else:
+      "hostname -I | cut -d' ' -f1"
+  ).strip()
+
+  const remoteImportPath = "http://" & localhost & ":" & USE_QML_SERVER
+
 logScope:
   topics = "status-app"
 
@@ -206,9 +223,6 @@ proc mainProc() =
   installMessageHandler(logHandlerCallback)
 
   when defined(USE_QML_SERVER):
-    const USE_QML_SERVER{.strdefine.} = "8081"
-    const remoteImportPath = "http://localhost:" & USE_QML_SERVER
-
     echo "Setting remote import path: ", remoteImportPath
     singletonInstance.engine.addImportPath(remoteImportPath);
   else:


### PR DESCRIPTION
### What does the PR do

Fixing the GH Action for Android. It was failing because the app artifacts path had an extra `default` folder whenever the app was not compiled with qml server enabled. I think that's not necessary and the default should as simple as possible.
I've kept the separate build and bin folder for the app that runs with the qml server enabled.

+ Simplify a bit the APP_VARIANT. It is determined once in the common makefile and reused in the pro file
+ Remove the redundant INSTALL target. It was creating multiple installation folders in `bin`
+ Avoid cleaning the nim compiler on `make mobile-clean`. It's a waste of time for the dev environment 
+ Fix the QML server for Android and IOS. Now it's possible to run the app on device with qml server enabled, over wifi. The device doesn't need to have port forwarding configured. The host IP will be determined at compilation time and the app running on device needs to have access to the configured IP:PORT of the fileserver.


### Affected areas

Mobile builds
Android GH Actions
QML file server


GH action triggered on this branch:

https://github.com/status-im/status-desktop/actions/runs/17428777261
