### PR TITLE
fix: Use a more robust bundle identifier detection in ios run script

### DIFF
--- a/mobile/scripts/ios/run.sh
+++ b/mobile/scripts/ios/run.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 CWD=$(realpath "$(dirname "$0")")
 APP=${APP:-"$CWD/../../bin/Applications/Status-tablet.app"}  # Path to the .app bundle
-APPID=${APPID:-$(mdls -name kMDItemCFBundleIdentifier -raw "$APP")} # Bundle identifier of the app
+APPID=${APPID:-$(plutil -extract CFBundleIdentifier raw "$APP/Info.plist")} # Bundle identifier of the app
 SIMULATOR_UDID=${SIMULATOR_UDID:-""}               # Specify to skip interactive selection
 IPHONE_SDK=${IPHONE_SDK:-iphonesimulator}  # Default to simulator if not set
 DEVICE_ID=${DEVICE_ID:-""}                # For physical device selection


### PR DESCRIPTION
### What does the PR do

Sometimes the bundleId is not identified and the app isn't starting. `mdls` returns null. `plutil` seems to be a much better option
