### PR TITLE
ci: validate secrets refactor

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.27'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Object to store public URLs for description. */
 urls = [:]

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.27'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -94,12 +94,12 @@ pipeline {
   }
 
   stages {
-    stage('Cleanup Workspace') {
+    stage('Clean') {
       steps {
         sh './scripts/clean-git.sh'
       }
     }
-    stage('Fetch submodules') {
+    stage('Submodules') {
       steps {
         sh 'git submodule update --init --recursive'
       }
@@ -111,7 +111,7 @@ pipeline {
       }
     }
 
-    stage('status-go') {
+    stage('Status-go') {
       steps {
         sh "echo USE_NWAKU is ${USE_NWAKU}"
         sh 'make status-go'
@@ -125,7 +125,27 @@ pipeline {
       } }
     }
 
-    stage('Parallel Upload') {
+    stage('Audit') {
+      steps { script {
+        sh "tar -xzf ${env.STATUS_CLIENT_TARBALL} -C ${env.WORKSPACE_TMP}"
+
+        def appImagePath = sh(
+          script: "basename ${env.STATUS_CLIENT_APPIMAGE}",
+          returnStdout: true
+        ).trim()
+
+        sh "chmod +x ${env.WORKSPACE_TMP}/${appImagePath}"
+
+        desktop.withCommonCredentials([]) {
+          sh(
+            script: "${env.WORKSPACE_TMP}/${appImagePath} --verify-credentials"
+          )
+        }
+
+      } }
+    }
+
+    stage('Publish') {
       parallel {
         stage('Upload') {
           steps { script {

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.27'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.27'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -101,12 +101,12 @@ pipeline {
   }
 
   stages {
-    stage('Cleanup Workspace') {
+    stage('Clean') {
       steps {
         sh './scripts/clean-git.sh'
       }
     }
-    stage('Fetch submodules') {
+    stage('Submodules') {
       steps {
         sh 'git submodule update --init --recursive'
       }
@@ -126,7 +126,7 @@ pipeline {
       }
     }
 
-    stage('status-go') {
+    stage('Status-go') {
       steps {
         sh "echo USE_NWAKU is ${USE_NWAKU}"
         sh 'make status-go'
@@ -140,6 +140,21 @@ pipeline {
       } }
     }
 
+    stage('Audit') {
+      steps { script {
+        sh "hdiutil attach ${env.STATUS_CLIENT_DMG} -mountpoint /tmp/status-mount"
+
+        desktop.withCommonCredentials([]) {
+          sh(
+            script: "/tmp/status-mount/Status.app/Contents/MacOS/nim_status_client --verify-credentials"
+          )
+        }
+
+        sh "hdiutil detach /tmp/status-mount"
+
+      } }
+    }
+
     stage('Notarize') {
       when { expression { utils.isReleaseBuild() } }
       steps { script {
@@ -147,7 +162,7 @@ pipeline {
       } }
     }
 
-    stage('Parallel Upload') {
+    stage('Publish') {
       parallel {
         stage('Upload') {
           steps { script {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.16'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 pipeline {
 

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.16'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.16'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.27'
+library 'status-jenkins-lib@refactor-common-secrets'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -96,12 +96,12 @@ pipeline {
   }
 
   stages {
-    stage('Cleanup Workspace') {
+    stage('Clean') {
       steps {
         sh './scripts/clean-git.sh'
       }
     }
-    stage('Fetch submodules') {
+    stage('Submodules') {
       steps {
         sh 'git submodule update --init --recursive'
       }
@@ -113,7 +113,7 @@ pipeline {
       }
     }
 
-    stage('status-go') {
+    stage('Status-go') {
       steps {
         sh 'make status-go'
       }
@@ -125,7 +125,25 @@ pipeline {
       } }
     }
 
-    stage('Parallel Upload') {
+    stage('Audit') {
+      steps { script {
+        sh "7z x ${env.STATUS_CLIENT_7Z} -o${env.WORKSPACE_TMP}/extracted"
+
+        def exeName = sh(
+          script: "basename ${env.STATUS_CLIENT_EXE}",
+          returnStdout: true
+        ).trim()
+
+        desktop.withCommonCredentials([]) {
+          sh(
+            script: "${env.WORKSPACE_TMP}/extracted/${exeName} --verify-credentials"
+          )
+        }
+
+      } }
+    }
+
+    stage('Publish') {
       /* Uploads on Windows are slow. */
       parallel {
         stage('Upload 7Z') {

--- a/src/app/core/credential_verifier.nim
+++ b/src/app/core/credential_verifier.nim
@@ -1,0 +1,28 @@
+import os, strutils, sequtils
+
+proc runCredentialVerification*(): int =
+  echo "Starting credential verification"
+
+  let thingsToCheck = getEnv("THINGS_TO_CHECK")
+  if thingsToCheck.len == 0:
+    echo "ERROR: THINGS_TO_CHECK environment variable not set"
+    return 1
+
+  let credNames = thingsToCheck.splitLines().mapIt(it.strip()).filterIt(it.len > 0)
+  if credNames.len == 0:
+    echo "ERROR: No credentials to check"
+    return 1
+
+  var missingCreds: seq[string] = @[]
+
+  for credName in credNames:
+    if not existsEnv(credName):
+      missingCreds.add(credName)
+      echo "ERROR: Missing environment variable: ", credName
+
+  if missingCreds.len > 0:
+    echo "ERROR: Credential verification failed. Missing ", missingCreds.len, " out of ", credNames.len, " credentials"
+    return 1
+  else:
+    echo "SUCCESS: All ", credNames.len, " credentials verified successfully"
+    return 0

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -296,6 +296,11 @@ type StatusDesktopConfig = object
     desc: "Sets address for prometheus metrics"
     name: "METRICS_ADDRESS"
     abbr: "metrics-address" .}: string
+  verifyCredentials* {.
+    defaultValue: false
+    desc: "Verify that all required credentials are present and exit"
+    name: "VERIFY_CREDENTIALS"
+    abbr: "verify-credentials" .}: bool
 
 # On macOS the first time when a user gets the "App downloaded from the
 # internet" warning, and clicks the Open button, the OS passes a unique process
@@ -310,4 +315,4 @@ else:
 if defined(macosx):
   cliParams.keepIf(proc(p: string): bool = not p.startsWith("-psn_"))
 
-let desktopConfig = StatusDesktopConfig.load(cmdLine = cliParams, envVarsPrefix = RUN_TIME_PREFIX)
+let desktopConfig* = StatusDesktopConfig.load(cmdLine = cliParams, envVarsPrefix = RUN_TIME_PREFIX)


### PR DESCRIPTION
## Summary

Introduces `--verify-credentials` flag which can be passed to status app and it will check for all the necessary credentials provided by `status-jenkins-lib`.
related changes are here : https://github.com/status-im/status-jenkins-lib/pull/120

Adds an `Audit` stage in jenkins which checks for these credentials, this is an integration test in CI to ensure that bundled app has all the necessary secrets.