### PR TITLE
fix(SyncingView): fix timestamp formatting

### DIFF
--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -6,6 +7,8 @@ import Storybook
 
 import mainui
 import utils
+
+import StatusQ
 
 import AppLayouts.stores as AppLayoutStores
 import AppLayouts.Profile.views
@@ -35,10 +38,10 @@ SplitView {
 
         isProduction: ctrlIsProduction.checked
         localBackupEnabled: localBackupEnabledSwitch.checked
-        backupPath: "file:///home/dev/status-desktop/backups"
-        toFileUri: function(path) {return path}
+        backupPath: StandardPaths.writableLocation(StandardPaths.TempLocation)
         onBackupPathSet: function(path) {
-            logs.logEvent("SyncingView::onBackupPathSet", path)
+            logs.logEvent("SyncingView::onBackupPathSet", ["path"], arguments)
+            backupPath = path
         }
         advancedStore: ProfileStores.AdvancedStore {
             readonly property bool isDebugEnabled: ctrlDebugEnabled.checked
@@ -46,17 +49,34 @@ SplitView {
 
         devicesStore: ProfileStores.DevicesStore {
             function generateConnectionStringAndRunSetupSyncingPopup() {
-                logs.logEvent("devicesStore::generateConnectionStringAndRunSetupSyncingPopup()")
+                logs.logEvent("devicesStore::generateConnectionStringAndRunSetupSyncingPopup")
             }
 
             function setInstallationName(installationId, name) {
                 logs.logEvent("devicesStore::setInstallationName", ["installationId", "name"], arguments)
             }
 
+            function performLocalBackup() {
+                logs.logEvent("devicesStore::performLocalBackup")
+            }
+
+            function importLocalBackupFile(filePath) {
+                logs.logEvent("devicesStore::importLocalBackupFile", ["filePath"], arguments)
+            }
+
+            function toFileUri(path) {
+                return UrlUtils.urlFromUserInput(path)
+            }
+
             readonly property bool isDeviceSetup: ctrlDevicesLoaded.checked
             readonly property var devicesModule: QtObject {
                 readonly property bool devicesLoading: ctrlDevicesLoading.checked
                 readonly property bool devicesLoadingError: ctrlDevicesLoadingError.checked
+
+                function pairDevice(installationId) {
+                    logs.logEvent("devicesStore::devicesModule::pairDevice", ["installationId"], arguments)
+                }
+                signal openPopupWithConnectionStringSignal(string rawConnectionString)
             }
             readonly property var devicesModel: ListModel {
                 ListElement {
@@ -70,7 +90,7 @@ SplitView {
                 ListElement {
                     name: "Device 2"
                     deviceType: "windows"
-                    timestamp: 123456789123
+                    timestamp: 1234567891232142423
                     isCurrentDevice: false
                     enabled: false
                     installationId: "b"
@@ -98,6 +118,13 @@ SplitView {
                     isCurrentDevice: false
                     enabled: true
                     installationId: "e"
+                }
+                ListElement {
+                    name: "Device 6 (no timestamp)"
+                    deviceType: "desktop"
+                    isCurrentDevice: false
+                    enabled: false
+                    installationId: "f"
                 }
             }
         }
@@ -147,5 +174,5 @@ SplitView {
 }
 
 // category: Views
-
+// status: good
 // https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?type=design&node-id=1592-128606&mode=design&t=1xZLPCet6yRCZCuz-0

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -6,8 +6,6 @@ import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Components
-import StatusQ.Popups
-import StatusQ.Popups.Dialog
 import StatusQ.Core.Utils
 
 StatusListItem {
@@ -34,6 +32,9 @@ StatusListItem {
     subTitle: {
         if (root.isCurrentDevice)
             return qsTr("This device")
+
+        if (root.timestamp <= 0)
+            return qsTr("Never seen online")
 
         if (d.onlineNow)
             return qsTr("Online now")

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -414,7 +414,6 @@ StatusSectionLayout {
                 advancedStore: root.advancedStore
                 localBackupEnabled: root.devicesStore.localBackupEnabled
                 backupPath: root.devicesStore.backupPath
-                toFileUri: root.devicesStore.toFileUri
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.syncingSettings)
                 contentWidth: d.contentWidth
                 onBackupPathSet: function(path) {

--- a/ui/app/AppLayouts/Profile/popups/SyncDeviceCustomizationPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/SyncDeviceCustomizationPopup.qml
@@ -14,13 +14,13 @@ import StatusQ.Core.Utils
 
 import shared.controls
 
-import "../stores"
+import AppLayouts.Profile.stores as ProfileStores
 
 StatusDialog {
     id: root
 
-    property DevicesStore devicesStore
-    property AdvancedStore advancedStore
+    property ProfileStores.DevicesStore devicesStore
+    property ProfileStores.AdvancedStore advancedStore
     property var deviceModel
 
     readonly property string deviceName: d.deviceName

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -93,6 +93,7 @@ QtObject {
     function importLocalBackupFile(filePath: string) {
         root.syncModule.importLocalBackupFile(filePath)
     }
+
     function performLocalBackup() {
         let error = root.syncModule.performLocalBackup()
         console.log("Performing local backup, error:", error)

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -37,7 +37,6 @@ SettingsContentBase {
     required property bool isProduction
     required property bool localBackupEnabled
     required property url backupPath
-    required property var toFileUri // Function to convert a file path to a file URI
 
     signal backupPathSet(url path)
 
@@ -50,7 +49,7 @@ SettingsContentBase {
             id: d
 
             readonly property var instructionsModel: [
-                qsTr("Verify your login with password or KeyCard"),
+                qsTr("Verify your login with password or Keycard"),
                 qsTr("Reveal a temporary QR and Sync Code") + "*",
                 qsTr("Share that information with your new device"),
             ]


### PR DESCRIPTION
### What does the PR do

- ... if the the timestamp is missing or invalid -> display "Never seen online" instead of the Unix epoch
- remove unused `toFileUri` function; we use the one from the DevicesStore
- fix the SB pages to be fully functional, not using random hardcoded paths but the `StandardPaths`

Fixes #18634

### Affected areas

Settings/Syncing

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="5120" height="2822" alt="image" src="https://github.com/user-attachments/assets/489b8868-5a56-4e35-b449-43b5a8ea21e7" />

### Impact on end user

- correct "last online" timestamp formatting

### How to test

- open Settings/Syncing
- pair a new device
- observe the "last online" timestamp formatting

### Risk 

- very low
