### PR TITLE
fix: Bump nim-chronicles to fix Android logs

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -19,9 +19,9 @@ else
 fi
 
 if [[ "$OS" == "ios" ]]; then
-    PLATFORM_SPECIFIC=(--app:staticlib -d:ios --os:ios -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors])
+    PLATFORM_SPECIFIC=(--app:staticlib -d:ios --os:ios)
 else
-    PLATFORM_SPECIFIC=(--app:lib --os:android -d:android -d:androidNDK -d:chronicles_sinks=textlines[syslog],textlines[nocolors,dynamic],textlines[file,nocolors] \
+    PLATFORM_SPECIFIC=(--app:lib --os:android -d:android -d:androidNDK \
         --passL="-L$LIB_DIR" --passL="-lstatus" --passL="-lStatusQ$LIB_SUFFIX" --passL="-lDOtherSide$LIB_SUFFIX" --passL="-lqrcodegen" --passL="-lqzxing" --passL="-lssl_3" --passL="-lcrypto_3" -d:taskpool)
 fi
 


### PR DESCRIPTION
### What does the PR do

Fixes android GH actions
https://github.com/status-im/status-desktop/actions/runs/17490109130/job/49677830803

nim-chronicles now supports stdout, stderr and syslog. We no longer need special handling in the build script.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Android and IOS logging

### Architecture compliance

- [ ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Logging works with the default settings

```
09-05 15:22:08.375 32453 32524 I chronicles: WRN 2025-09-05 12:22:08.371Z qt warning                                 topics="qt" tid=32524 category=default file=qrc:/app/AppLayouts/Profile/stores/ProfileStore.qml:36 text="Unable to assign [undefined] to QString"
09-05 15:22:08.380 32453 32524 I chronicles: DBG 2025-09-05 12:22:08.375Z NewBE_callPrivateRPC                       topics="rpc" tid=32524 file=core.nim:34 rpc_method=stickers_installed
09-05 15:22:08.433 32453 32524 I chronicles: WRN 2025-09-05 12:22:08.427Z qt warning                                 topics="qt" tid=32524 category=default file=qrc:/imports/shared/status/StatusEmojiPopup.qml:50 text="Error: Cannot assign [undefined] to QStringList"
09-05 15:22:08.725 32453 32524 I chronicles: WRN 2025-09-05 12:22:08.719Z qt warning                                 topics="qt" tid=32524 category=default file=qrc:/app/AppLayouts/Wallet/WalletLayout.qml:319 text="TypeError: Cannot read property 'width' of null"
09-05 15:22:08.729 32453 32524 I chronicles: WRN 2025-09-05 12:22:08.723Z qt warning                                 topics="qt" tid=32524 category=default file=qrc:/app/AppLayouts/Wallet/WalletLayout.qml:336 text="TypeError: Cannot read property 'width' of null"
09-05 15:22:08.885 32453 32524 I chronicles: INF 2025-09-05 12:22:08.879Z qt message                                 topics="qt" tid=32524 category=qt.multimedia.ffmpeg file=:0 text="Using Qt multimedia with FFmpeg version 7.1.1 LGPL version 2.1 or later"
09-05 15:22:08.931 32453 32524 I chronicles: WRN 2025-09-05 12:22:08.927Z qt warning                                 topics="qt" tid=32524 category=default file=:0 text="QSoundEffect(qaudio): Error decoding source qrc:/imports/assets/audio/error.mp3"
```

### How to test

run `make mobile-run` and verify logs

### Risk 

low
