### PR TITLE
fix(ac): notification not being marked as read when going to community

### DIFF
--- a/storybook/pages/ActivityNotificationCommunityRequestPage.qml
+++ b/storybook/pages/ActivityNotificationCommunityRequestPage.qml
@@ -48,7 +48,7 @@ ActivityNotificationBaseLayout {
             }
         }
 
-        onSetActiveCommunityRequested: (communityId) =>
+        onSetActiveCommunityRequested: (notificationId, communityId) =>
                                        logs.logEvent("ActivityNotificationCommunityRequest::onSetActiveCommunityRequested - " + communityId)
     }
 

--- a/ui/app/AppLayouts/ActivityCenter/ActivityCenterLayout.qml
+++ b/ui/app/AppLayouts/ActivityCenter/ActivityCenterLayout.qml
@@ -358,7 +358,10 @@ StatusSectionLayout {
             notification: parent.notification
             community: notification ? root.store.getCommunityDetailsAsJson(notification.communityId) : null
 
-            onSetActiveCommunityRequested: (communityId) => { root.store.setActiveCommunity(communityId) }
+            onSetActiveCommunityRequested: (notificationId, communityId) => {
+                root.store.setActiveCommunity(communityId)
+                root.activityCenterStore.markActivityCenterNotificationRead(notificationId)
+            }
             onMarkActivityCenterNotificationReadRequested: (notificationId) => {
                                                                root.activityCenterStore.markActivityCenterNotificationRead(notificationId) }
             onMarkActivityCenterNotificationUnreadRequested: (notificationId) => {

--- a/ui/app/AppLayouts/ActivityCenter/views/ActivityNotificationCommunityRequest.qml
+++ b/ui/app/AppLayouts/ActivityCenter/views/ActivityNotificationCommunityRequest.qml
@@ -18,7 +18,7 @@ ActivityNotificationBase {
 
     required property var community
 
-    signal setActiveCommunityRequested(string communityId)
+    signal setActiveCommunityRequested(string notificationId, string communityId)
 
     QtObject {
         id: d
@@ -49,7 +49,7 @@ ActivityNotificationBase {
             communityLinkTextColor: Theme.palette.directColor1
             communityLinkTextPixelSize: Theme.additionalTextSize
             communityLinkTextWeight: Font.Medium
-            onCommunityNameClicked: root.setActiveCommunityRequested(notification.communityId)
+            onCommunityNameClicked: root.setActiveCommunityRequested(notification.id, notification.communityId)
         }
 
         StatusBaseText {


### PR DESCRIPTION
### What does the PR do

Fixes #18119

### Affected areas

AC

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[mark-as-read.webm](https://github.com/user-attachments/assets/109accf0-0f7b-4202-9a53-af290f4cefb4)

### Impact on end user

Fixes the issue. Better UX

### How to test

- Request to join a community
- Get aaccepted
- Click the community link

### Risk 

Low
