### PR TITLE
fix(ac): stop opening AC when it was the last section opened

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -678,7 +678,7 @@ method load*[T](
 
   # Default to Wallet section if no active section is set or if the active section is the settings section
   # or if the active section is the home page section but home page is not enabled
-  if activeSectionId == "" or activeSectionId == SETTINGS_SECTION_ID or
+  if activeSectionId == "" or activeSectionId == SETTINGS_SECTION_ID or activeSectionId == ACTIVITYCENTER_SECTION_ID or
     (activeSectionId == HOMEPAGE_SECTION_ID and not homePageEnabled):
     activeSectionId = WALLET_SECTION_ID
 
@@ -889,8 +889,8 @@ method load*[T](
   #  activeSection = homePageSectionItem
 
   # Set active section on app start
-  # If section is empty or profile wait until chats are loaded
-  if not activeSection.isEmpty() and activeSection.sectionType != SectionType.ProfileSettings:
+  # If section is empty wait until chats are loaded
+  if not activeSection.isEmpty():
     self.setActiveSection(activeSection)
 
 proc isEverythingLoaded[T](self: Module[T]): bool =


### PR DESCRIPTION
### What does the PR do

Fixes #18788

Opens the wallet section is the last section was the AC

### Affected areas

Main module

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[persisted-ac.webm](https://github.com/user-attachments/assets/72348ac4-b736-4f5e-9a97-7838d89efed1)


### How to test

- close the app when on the AC. Reopen

### Risk 

Low
