### PR TITLE
fix(message): show Copy message option when image has text too

### DIFF
--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -84,7 +84,9 @@ StatusMenu {
         text: qsTr("Copy message")
         icon.name: "copy"
         onTriggered: root.copyToClipboard(root.unparsedText)
-        enabled: root.messageContentType === Constants.messageContentType.messageType && replyToMenuItem.enabled
+        enabled: (root.messageContentType === Constants.messageContentType.messageType ||
+                (root.messageContentType === Constants.messageContentType.imageType && root.unparsedText != "")) &&
+                replyToMenuItem.enabled
     }
 
     StatusAction {


### PR DESCRIPTION
### What does the PR do

Fixes #18786

If a message has text, show the button even if it's an image

### Affected areas

MessageContextMenu

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[copy-msg.webm](https://github.com/user-attachments/assets/b9f9581b-9179-472f-93cf-94af1594c9c1)


### Impact on end user

fixes the issue

### How to test

- right click messages 

### Risk 

low
