### PR TITLE
ci: add submodule fetch stage

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -38,6 +38,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Build') {
       parallel {
         stage('Linux/x86_64 and E2E') {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -99,6 +99,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -86,6 +86,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Deps') {
       steps { script {
         nix.shell('make update', pure: true)

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -106,6 +106,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -108,6 +108,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Prep') {
       steps { script {
         setNewBuildName()

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -65,6 +65,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -51,6 +51,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Build StatusQ Tests') {
       steps {
         sh 'make statusq-tests'

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -101,6 +101,11 @@ pipeline {
         sh './scripts/clean-git.sh'
       }
     }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
     stage('Deps') {
       steps {
         sh 'make update'


### PR DESCRIPTION
## Summary

Fixes workspace checkout issues by disabling submodule checkout in Jenkins job and adding git submodule checkout after cleanup stage. 

CI hosts would occasionally end up in a dirty state and each PR job would checkout git submodules during checkout phase. Ideally cleanup phase should run before checkout because most of the PR issues happen during checkout phase.

Some errors looked like this : 

```
 > git submodule update --init --recursive vendor/nim-taskpools # timeout=10
ERROR: Checkout failed
hudson.plugins.git.GitException: Command "git submodule update --init --recursive mobile/vendors/openssl" returned status code 1:
stdout: Current branch master is up to date.
Submodule path 'mobile/vendors/openssl/gost-engine': rebased into 'ede3886cc5507c2ba000ab9b057f198da03e8766'
stderr: error: The following untracked working tree files would be overwritten by checkout:
	.github/PULL_REQUEST_TEMPLATE
	BUILD
	BUILD.generated.bzl
	BUILD.generated_tests.bzl
	CMakeLists.txt
	LICENSE
	WORKSPACE
	crypto_test_data.cc
Please move or remove them before you switch branches.
Aborting
fatal: Unable to checkout 'f1c75347daa2ea81a941e953f2263e0a4d970c8d' in submodule path 'mobile/vendors/openssl/cloudflare-quiche/quiche/deps/boringssl'
fatal: Failed to recurse into submodule path 'mobile/vendors/openssl/cloudflare-quiche'
fatal: Failed to recurse into submodule path 'mobile/vendors/openssl'
```

This also means we have to remove this setting from each job and won't have to remember to add it when making new jobs.

<img width="1332" height="680" alt="Screenshot 2025-09-09 at 5 12 39 PM" src="https://github.com/user-attachments/assets/33633b89-6ccb-457e-847d-d7034ca35be9" />

