### PR TITLE
fix(ci): bump protobuf from 3.20.0 to 3.20.1

### DIFF
--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -34,7 +34,7 @@ function Install-Dependencies {
         scoop bucket add extras
     }
     scoop install --global go@1.23.10
-    scoop install --global protobuf@3.20.0
+    scoop install --global protobuf@3.20.1
     scoop install --global vcredist2022
     scoop install --global cmake@3.31.6
     scoop install --global `


### PR DESCRIPTION
Otherwise installation using `scoop` fails with:
```
Test-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At C:\Users\admin\scoop\apps\scoop\current\lib\manifest.ps1:95 char:31
+                 if (Test-Path $app) {
+                               ~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException   
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.Po  
   werShell.Commands.TestPathCommand

Couldn't find manifest for ''.
```