### PR TITLE
feat(ci): update QT pipeline to build both Android and Linux images

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -10,7 +10,7 @@ pipeline {
     /* Image with Ubuntu 22.04, QT 6.9.0, Android SDK/NDK, Go, and Nim */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.0.4-qt6.9.0-android'
+      image 'harbor.status.im/status-im/status-desktop-build:1.0.4-qt6.9.0-android'
       alwaysPull true
     }
   }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -10,7 +10,7 @@ pipeline {
     /* Image with Ubuntu 22.04 and QT 6.9.0 */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:2.0.5-qt6.9.0'
+      image 'harbor.status.im/status-im/status-desktop-build:1.0.4-qt6.9.0'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.qt-build
+++ b/ci/Jenkinsfile.qt-build
@@ -19,38 +19,126 @@ pipeline {
       description: 'Qt version to build'
     )
     string(
-      name: 'DOCKER_TAG',
-      defaultValue: '1.0.3-qt6.9.0-android',
-      description: 'Docker image tag for the final image'
+      name: 'DOCKER_TAG_ANDROID',
+      defaultValue: '1.0.4-qt6.9.0-android',
+      description: 'Docker image tag for the Andorid image'
     )
-    booleanParam(
-      name: 'PUSH_TO_DOCKERHUB',
-      defaultValue: true,
-      description: 'Push the final image to DockerHub'
+    string(
+      name: 'DOCKER_TAG_LINUX',
+      defaultValue: '1.0.4-qt6.9.0',
+      description: 'Docker image tag for the Linux image'
+    )
+    string(
+      name: 'DOCKER_REGISTRY',
+      description: 'Docker registry ',
+      defaultValue: params.DOCKER_REGISTRY ?: 'harbor.status.im',
+    )
+    string(
+      name: 'LINUXDEPLOYQT_VERSION',
+      description: 'Version of Linux Deploy QT present in Digital Ocean Spaces',
+      defaultValue: '20250615-0393b84',
+    )
+    string(
+      name: 'PCSCLITE_VERSION',
+      description: 'PCSC Lite version to bundle for keycard support',
+      defaultValue: '2.2.3',
+    )
+    string(
+      name: 'ANDROID_TARGET_ARCH',
+      description: 'CPU Target Architecture for Android Builds',
+      defaultValue: 'amd64',
+    )
+    string(
+      name: 'JAVA_VERSION',
+      description: 'Java version for Android builds',
+      defaultValue: '17',
+    )
+    string(
+      name: 'ANDROID_API_LEVEL',
+      description: 'Android API level',
+      defaultValue: '35',
+    )
+    string(
+      name: 'ANDROID_NDK_VERSION',
+      description: 'Android NDK version',
+      defaultValue: '27.2.12479018',
+    )
+    string(
+      name: 'GOLANG_VERSION',
+      description: 'Go language version',
+      defaultValue: '1.24.7',
+    )
+    string(
+      name: 'NIM_VERSION',
+      description: 'Nim language version',
+      defaultValue: '2.0.12',
+    )
+    string(
+      name: 'NIX_VERSION',
+      description: 'Nix package manager version',
+      defaultValue: '2.24.11',
     )
   }
 
   environment {
-    DOCKER_REGISTRY = 'statusteam'
-    DOCKER_IMAGE_BASE = 'nim-status-client-build'
-    MOBILE_BUILD_DIR = "${WORKSPACE}/mobile/docker"
+    DOCKER_IMAGE = 'status-im/status-desktop-build'
+    ANDROID_BUILD_DIR = "${WORKSPACE}/mobile/docker"
+    LINUX_BUILD_DIR = "${WORKSPACE}/ci"
   }
 
   stages {
-    stage('Build Docker Images') {
+
+    stage('Build Docker Image for Linux') {
       steps {
         script {
-          dir("${MOBILE_BUILD_DIR}") {
+          dir("${LINUX_BUILD_DIR}") {
             image = docker.build(
-              "${DOCKER_REGISTRY}/${DOCKER_IMAGE_BASE}:${params.DOCKER_TAG}",
+              "${params.DOCKER_REGISTRY}/${DOCKER_IMAGE}:${params.DOCKER_TAG_LINUX}",
+              "--build-arg QT_VERSION=${params.QT_VERSION} " +
+              "--build-arg LINUXDEPLOYQT_VERSION=${params.LINUXDEPLOYQT_VERSION} " +
+              "--build-arg PCSCLITE_VERSION=${params.PCSCLITE_VERSION} " +
+              "."
+            )
+          }
+        }
+      }
+    }
+
+    stage('Test Image for Linux') {
+      steps {
+        script {
+          image.inside('--entrypoint=""') {
+            sh "qmake --version"
+            sh "ls -la /opt/qt/${params.QT_VERSION}/"
+          }
+        }
+      }
+    }
+
+    stage('Push Linux image to Docker registry') {
+      steps {
+        script {
+          withDockerRegistry([credentialsId: 'harbor-status-im-status-desktop-build-robot', url: "https://${params.DOCKER_REGISTRY}"]) {
+            image.push(params.DOCKER_TAG_LINUX)
+          }
+        }
+      }
+    }
+
+    stage('Build Docker Image for Android') {
+      steps {
+        script {
+          dir("${ANDROID_BUILD_DIR}") {
+            image = docker.build(
+              "${params.DOCKER_REGISTRY}/${DOCKER_IMAGE}:${params.DOCKER_TAG_ANDROID}",
               "--build-arg QTVER=${params.QT_VERSION} " +
-              "--build-arg TARGETARCH=amd64 " +
-              "--build-arg JAVA_VERSION=17 " +
-              "--build-arg ANDROID_API_LEVEL=35 " +
-              "--build-arg ANDROID_NDK_VERSION=27.2.12479018 " +
-              "--build-arg GOLANG_VERSION=1.24.7 " +
-              "--build-arg NIM_VERSION=2.0.12 " +
-              "--build-arg NIX_VERSION=2.24.11 " +
+              "--build-arg TARGETARCH=${params.ANDROID_TARGET_ARCH} " +
+              "--build-arg JAVA_VERSION=${params.JAVA_VERSION} " +
+              "--build-arg ANDROID_API_LEVEL=${params.ANDROID_API_LEVEL} " +
+              "--build-arg ANDROID_NDK_VERSION=${params.ANDROID_NDK_VERSION} " +
+              "--build-arg GOLANG_VERSION=${params.GOLANG_VERSION} " +
+              "--build-arg NIM_VERSION=${params.NIM_VERSION} " +
+              "--build-arg NIX_VERSION=${params.NIX_VERSION} " +
               "--target mobile-build ."
             )
           }
@@ -58,33 +146,27 @@ pipeline {
       }
     }
 
-    stage('Test Images') {
-      parallel {
-        stage('Test Mobile Build Image') {
-          steps {
-            script {
-              image.inside('--entrypoint=""') {
-                sh "qmake --version"
-                sh "nim --version"
-                sh "go version"
-                sh "protoc --version"
-                sh "java -version"
-                sh "ls -la /opt/qt/${params.QT_VERSION}/"
-              }
-            }
+    stage('Test Image for Android') {
+      steps {
+        script {
+          image.inside('--entrypoint=""') {
+            sh "qmake --version"
+            sh "nim --version"
+            sh "go version"
+            sh "protoc --version"
+            sh "java -version"
+            sh "ls -la /opt/qt/${params.QT_VERSION}/"
           }
         }
-
       }
     }
 
-    stage('Push to DockerHub') {
-      when {
-        expression { params.PUSH_TO_DOCKERHUB == true }
-      }
+    stage('Push Android image to Docker registry') {
       steps {
         script {
-          image.push()
+          withDockerRegistry([credentialsId: 'harbor-status-im-status-desktop-build-robot', url: "https://${params.DOCKER_REGISTRY}"]) {
+            image.push(params.DOCKER_TAG_ANDROID)
+          }
         }
       }
     }


### PR DESCRIPTION
### What does the PR do

Updates QT pipeline so both status-desktop-build images for Android and Linux are being built and pushed to Harbor.

### Affected areas
CI

### Architecture compliance
- [x ] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Impact on end user

None

### How to test

Run the QT pipeline manually.

### Risk 

None
