### PR TITLE
feat(backup): add setting line to enable messages backup

### DIFF
--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -58,6 +58,7 @@ const KEY_NEWS_FEED_ENABLED* = "news-feed-enabled?"
 const KEY_NEWS_NOTIFICATIONS_ENABLED* = "news-notifications-enabled?"
 const KEY_NEWS_RSS_ENABLED* = "news-rss-enabled?"
 const KEY_BACKUP_PATH* = "backup-path"
+const KEY_MESSAGES_BACKUP_ENABLED* = "messages-backup-enabled?"
 const KEY_THIRDPARTY_SERVICES_ENABLED* = "thirdparty_services_enabled"
 
 # Notifications Settings Values
@@ -117,6 +118,7 @@ type
   SettingsDto* = object # There is no point to keep all these info as settings, but we must follow status-go response
     address*: string
     backupPath*: string
+    messagesBackupEnabled*: bool
     currency*: string
     dappsAddress*: string
     eip1581Address*: string
@@ -233,6 +235,7 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(PROFILE_MIGRATION_NEEDED, result.profileMigrationNeeded)
   discard jsonObj.getProp(KEY_AUTO_REFRESH_TOKENS, result.autoRefreshTokens)
   discard jsonObj.getProp(KEY_BACKUP_PATH, result.backupPath)
+  discard jsonObj.getProp(KEY_MESSAGES_BACKUP_ENABLED, result.messagesBackupEnabled)
   discard jsonObj.getProp(KEY_THIRDPARTY_SERVICES_ENABLED, result.thirdpartyServicesEnabled)
 
   var lastTokensUpdate: string

--- a/src/backend/settings.nim
+++ b/src/backend/settings.nim
@@ -114,5 +114,8 @@ proc toggleNewsRSSEnabled*(value: bool): RpcResponse[JsonNode] =
 proc backupPath*(): RpcResponse[JsonNode] =
   return core.callPrivateRPC("settings_backupPath")
 
+proc messagesBackupEnabled*(): RpcResponse[JsonNode] =
+  return core.callPrivateRPC("settings_messagesBackupEnabled")
+
 proc thirdpartyServicesEnabled*(): RpcResponse[JsonNode] =
   return core.callPrivateRPC("settings_thirdpartyServicesEnabled")

--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -39,9 +39,14 @@ SplitView {
         isProduction: ctrlIsProduction.checked
         localBackupEnabled: localBackupEnabledSwitch.checked
         backupPath: StandardPaths.writableLocation(StandardPaths.TempLocation)
+        messagesBackupEnabled: false
         onBackupPathSet: function(path) {
             logs.logEvent("SyncingView::onBackupPathSet", ["path"], arguments)
             backupPath = path
+        }
+        onBackupMessagesEnabledToggled: function(enabled) {
+            logs.logEvent("SyncingView::backupMessagesEnabledToggled", ["enabled"], arguments)
+            messagesBackupEnabled = enabled
         }
         advancedStore: ProfileStores.AdvancedStore {
             readonly property bool isDebugEnabled: ctrlDebugEnabled.checked

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -418,10 +418,14 @@ StatusSectionLayout {
                 advancedStore: root.advancedStore
                 localBackupEnabled: root.devicesStore.localBackupEnabled
                 backupPath: root.devicesStore.backupPath
+                messagesBackupEnabled: root.devicesStore.messagesBackupEnabled
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.syncingSettings)
                 contentWidth: d.contentWidth
                 onBackupPathSet: function(path) {
                     root.devicesStore.setBackupPath(path)
+                }
+                onBackupMessagesEnabledToggled: function(enabled) {
+                    root.devicesStore.setMessagesBackupEnabled(enabled)
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/popups/EnableMessagesBackupDialog.qml
+++ b/ui/app/AppLayouts/Profile/popups/EnableMessagesBackupDialog.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Controls
+import StatusQ.Popups.Dialog
+
+StatusDialog {
+    id: root
+
+    title: qsTr("Enable Local Messages Backup")
+
+    padding: Theme.padding
+    width: 500
+
+    signal enableRequested()
+
+    contentItem: ColumnLayout {
+        spacing: Theme.padding
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            font.pixelSize: Theme.secondaryAdditionalTextSize
+            text: qsTr("Enabling local message backup will store all your messages on your device in an encrypted backup file.")
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            font.pixelSize: Theme.secondaryAdditionalTextSize
+            text: qsTr("Make sure to keep this file secure.")
+        }
+    }
+
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            RowLayout {
+                Layout.rightMargin: Theme.padding
+                spacing: Theme.bigPadding
+                StatusFlatButton {
+                    textColor: Theme.palette.directColor1
+                    text: qsTr("Cancel")
+                    onClicked: root.close()
+                }
+                StatusButton {
+                    text: qsTr("Enable")
+                    onClicked: root.enableRequested()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/popups/qmldir
+++ b/ui/app/AppLayouts/Profile/popups/qmldir
@@ -11,3 +11,4 @@ TokenListPopup 1.0 TokenListPopup.qml
 WalletKeypairAccountMenu 1.0 WalletKeypairAccountMenu.qml
 WalletAddressMenu 1.0 WalletAddressMenu.qml
 ConfirmChangePasswordModal 1.0 ConfirmChangePasswordModal.qml
+EnableMessagesBackupDialog 1.0 EnableMessagesBackupDialog.qml

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -27,6 +27,7 @@ QtObject {
     readonly property string backupImportError: syncModule ? syncModule.backupImportError : ""
     readonly property string backupDataError: syncModule ? syncModule.backupDataError : ""
     readonly property url backupPath: d.appSettingsInst.backupPath
+    readonly property bool messagesBackupEnabled: d.appSettingsInst.messagesBackupEnabled
 
     readonly property QtObject _d: StatusQUtils.QObject {
         id: d
@@ -46,6 +47,10 @@ QtObject {
 
     function setBackupPath(path) {
         d.appSettingsInst.setBackupPath(path)
+    }
+
+    function setMessagesBackupEnabled(enabled) {
+        d.appSettingsInst.setMessagesBackupEnabled(enabled)
     }
 
     function toFileUri(path) {

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -37,9 +37,11 @@ SettingsContentBase {
 
     required property bool isProduction
     required property bool localBackupEnabled
+    required property bool messagesBackupEnabled
     required property url backupPath
 
     signal backupPathSet(url path)
+    signal backupMessagesEnabledToggled(bool enabled)
 
     ColumnLayout {
         id: layout
@@ -290,9 +292,26 @@ SettingsContentBase {
         StatusSettingsLineButton {
             anchors.leftMargin: 0
             anchors.rightMargin: 0
+            visible: root.localBackupEnabled
             text: qsTr("Directory of the local backup files")
             currentValue: root.backupPath
             onClicked: backupPathDialog.open()
+        }
+
+        StatusSettingsLineButton {
+            anchors.leftMargin: 0
+            anchors.rightMargin: 0
+            visible: root.localBackupEnabled
+            text: qsTr("Backup messages locally")
+            isSwitch: true
+            switchChecked: root.messagesBackupEnabled
+            onClicked: {
+                if (root.messagesBackupEnabled) {
+                    root.backupMessagesEnabledToggled(false)
+                    return
+                }
+                Global.openPopup(enableMessagesBackupDialog)
+            }
         }
 
         StatusButton {
@@ -414,6 +433,17 @@ SettingsContentBase {
             id: getSyncCodeInstructionsPopup
             GetSyncCodeInstructionsPopup {
                 destroyOnClose: true
+            }
+        }
+
+        Component {
+            id: enableMessagesBackupDialog
+            EnableMessagesBackupDialog {
+                destroyOnClose: true
+                onEnableRequested: {
+                    root.backupMessagesEnabledToggled(true)
+                    Global.closePopup()
+                }
             }
         }
 


### PR DESCRIPTION
### What does the PR do

Fixes #18530

Adds a setting line in SyncingView to enable local messages backup. Hooks it to the backend setting.

The Setting opens a popup when enabling to let the user know what they are enabling (breaking PFS). Disabling it doesn't have a popup

status-go PR: https://github.com/status-im/status-go/pull/6928

### Affected areas

Settings service and SyncingView

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[message-backup-setting.webm](https://github.com/user-attachments/assets/e90ef571-7a3f-4985-86ad-90d7a31f2604)


### Impact on end user

Let's users enable message backups

### How to test

- Go in Syncing settings and click the line

### Risk 

Low
