### PR TITLE
browser: enable sandbox and fix v8 snapshot

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -8,7 +8,9 @@ export GST_PLUGIN_SYSTEM_PATH="${APPDIR}/usr/lib/gstreamer-1.0"
 export GST_PLUGIN_SYSTEM_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"
 export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${APPDIR}/usr/lib/nss:${LD_LIBRARY_PATH}"
 export QT_QPA_PLATFORM="xcb"
-export QTWEBENGINE_DISABLE_SANDBOX=1
+# Set Qt WebEngine resources path for V8 snapshot files
+# The resources are copied to usr/libexec/ during build
+export QTWEBENGINE_RESOURCES_PATH="${APPDIR}/usr/libexec"
 
 # Set up pcsc-lite environment
 export PCSC_DRIVERS_DIR="${APPDIR}/usr/lib/pcsc/drivers"

--- a/scripts/init_app_dir.sh
+++ b/scripts/init_app_dir.sh
@@ -42,6 +42,11 @@ if [[ -z "${IN_NIX_SHELL}" ]]; then
     cp /opt/qt/6.9.0/gcc_64/libexec/QtWebEngineProcess "${APP_DIR}/usr/libexec/"
     chmod +x "${APP_DIR}/usr/libexec/QtWebEngineProcess"
 
+    # to fix : [0912/162517.794426:FATAL:v8_initializer.cc(625)] Error loading V8 startup snapshot file
+    echo "Bundling Qt WebEngine resources..."
+    cp /opt/qt/6.9.0/gcc_64/resources/* "${APP_DIR}/usr/libexec/"
+    cp -r /opt/qt/6.9.0/gcc_64/translations/qtwebengine_locales "${APP_DIR}/usr/libexec/"
+
     echo "Bundling pcsc-lite 2.2.3..."
     cp -L /usr/local/lib/x86_64-linux-gnu/libpcsclite.so* "${APP_DIR}/usr/lib/"
     cp -L /usr/local/lib/x86_64-linux-gnu/libpcsclite_real.so* "${APP_DIR}/usr/lib/"


### PR DESCRIPTION
## Summary

To fix Qt WebEngine errors like :
```
[0912/162517.794426:FATAL:v8_initializer.cc(625)] Error loading V8 startup snapshot file
```
and

```
WRN 2025-09-12 08:26:30.061Z qt warning topics="qt" tid=39175 category=qml
 file=qrc:/app/AppLayouts/Browser/views/BrowserWebEngineView.qml:79 
 text="Render process exited with code 1002 (abnormal exit)"
```

