### PR TITLE
ci: fix nwaku version in settings and filename

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -69,21 +69,24 @@ pipeline {
   }
 
   environment {
-    PLATFORM = "linux/${getArch()}${params.USE_NWAKU ? '-nwaku' : ''}"
+    PLATFORM = "linux/${getArch()}${(params.USE_NWAKU ?: false) ? '-nwaku' : ''}"
     /* Improve make performance */
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
-    /* Control output the filename */
+    /* Set USE_NWAKU before VERSION since version.sh uses it */
+    USE_NWAKU = "${params.USE_NWAKU}"
+    /* sets App Version in Settings */  
     VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
-    STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'AppImage', arch: getArch(), version: env.VERSION)}"
-    STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'tar.gz', arch: getArch(), version: env.VERSION)}"
+    /* Control output the filename */
+    APP_TYPE = "${utils.getAppType() + (params.USE_NWAKU ? '-experimental' : '')}"
+    STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'AppImage', arch: getArch(), version: env.VERSION, type: env.APP_TYPE)}"
+    STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'tar.gz', arch: getArch(), version: env.VERSION, type: env.APP_TYPE)}"
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
     /* Hack fix for params not being set in job on first run */
     NIMFLAGS =               "${params.NIMFLAGS}"
-    USE_NWAKU =              "${params.USE_NWAKU}"
     ENTITLEMENTS =           "${params.ENTITLEMENTS}"
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
@@ -113,14 +116,12 @@ pipeline {
 
     stage('status-go') {
       steps {
-        sh "echo USE_NWAKU is ${USE_NWAKU}"
         sh 'make status-go'
       }
     }
 
     stage('Package') {
       steps { script {
-        sh "echo USE_NWAKU is ${USE_NWAKU}"
         linux.bundle('tgz-linux')
       } }
     }
@@ -142,7 +143,7 @@ pipeline {
     }
 
     stage('E2E') {
-      when { expression { utils.isPRBuild() && !params.USE_NWAKU } }
+      when { expression { utils.isPRBuild() && !(params.USE_NWAKU ?: false) } }
       steps { script {
         build(
           job: 'status-desktop/e2e/prs',

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -68,7 +68,7 @@ pipeline {
   }
 
   environment {
-    PLATFORM = "macos/${getArch()}${params.USE_NWAKU ? '-nwaku' : ''}"
+    PLATFORM = "macos/${getArch()}${(params.USE_NWAKU ?: false) ? '-nwaku' : ''}"
     /* Improve make performance */
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     QT_VERSION="6.9.0"
@@ -80,9 +80,13 @@ pipeline {
     PATH = "${env.QTDIR}/bin:${env.QTDIR}/libexec:${env.HOME}/go/bin:/usr/local/go/bin:${env.PATH}"
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
-    /* Control output the filename */
+    /* Set USE_NWAKU before VERSION since version.sh uses it */
+    USE_NWAKU = "${params.USE_NWAKU}"
+    /* Controls the App version in Settings */
     VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
-    STATUS_CLIENT_DMG = "pkg/${utils.pkgFilename(ext: 'dmg', arch: getArch(), version: env.VERSION)}"
+    /* Control output the filename */
+    APP_TYPE = "${utils.getAppType() + ( params.USE_NWAKU ? '-experimental' : '' )}"
+    STATUS_CLIENT_DMG = "pkg/${utils.pkgFilename(ext: 'dmg', arch: getArch(), version: env.VERSION, type: env.APP_TYPE)}"
     /* Apple Team ID for Notarization */
     MACOS_NOTARIZE_TEAM_ID = "8B5X2M6H2Y"
     /* prevent sharing cache dir across different jobs */
@@ -90,7 +94,6 @@ pipeline {
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
     /* Hack fix for params not being set in job on first run */
     NIMFLAGS =               "${params.NIMFLAGS}"
-    USE_NWAKU =              "${params.USE_NWAKU}"
     ENTITLEMENTS =           "${params.ENTITLEMENTS}"
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
@@ -128,14 +131,12 @@ pipeline {
 
     stage('status-go') {
       steps {
-        sh "echo USE_NWAKU is ${USE_NWAKU}"
         sh 'make status-go'
       }
     }
 
     stage('Package') {
       steps { script {
-        sh "echo USE_NWAKU is ${USE_NWAKU}"
         macos.bundle('pkg-macos')
       } }
     }

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-echo "$(git describe --tags)${USE_NWAKU:+-nwaku-experimental}"
+set -e
+git fetch origin --tags --force --no-recurse-submodules
+git describe --tags
+


### PR DESCRIPTION
## Summary

Fixes this bug where App's version shows "-nwaku-experimental" even when `USE_NWAKU` is not set to `true`

<img width="578" height="293" alt="Screenshot 2025-09-13 at 9 55 42 AM" src="https://github.com/user-attachments/assets/6db671da-d146-493a-b4ac-23563410a03b" />

This can confuse users if they're not even using the nwaku version.

Screenshot After the fix for non nwaku builds
<img width="721" height="347" alt="Screenshot 2025-09-13 at 4 18 32 PM" src="https://github.com/user-attachments/assets/208b5fd4-3e10-44e6-a99d-c00f4b991eed" />

We also add "experimental" in filename of package.

<img width="517" height="64" alt="Screenshot 2025-09-13 at 4 21 09 PM" src="https://github.com/user-attachments/assets/0efb0803-f6ac-4a4d-bee3-7c97c5f943cd" />

