### PR TITLE
ci: disable default jenkins checkout

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -24,6 +24,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 45, unit: 'MINUTES')
@@ -52,6 +54,31 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
+    stage('Fetch submodules') {
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
+    }
 
     stage('Build Android APK') {
       steps {

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -9,6 +9,8 @@ pipeline {
   agent { label 'linux' }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     disableConcurrentBuilds()
     disableRestartFromStage()
@@ -33,6 +35,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -50,6 +50,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 30, unit: 'MINUTES')
@@ -75,7 +77,7 @@ pipeline {
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
-    VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
+    VERSION = "${sh(script: 'git fetch origin --tags --force --no-recurse-submodules && git describe --tags', returnStdout: true).trim()}${params.USE_NWAKU ? '-nwaku-experimental' : ''}"
     STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'AppImage', arch: getArch(), version: env.VERSION)}"
     STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'tar.gz', arch: getArch(), version: env.VERSION)}"
     /* prevent sharing cache dir across different jobs */
@@ -94,6 +96,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -38,6 +38,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 30, unit: 'MINUTES')
@@ -63,7 +65,7 @@ pipeline {
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
-    VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
+    VERSION = "${sh(script: 'git fetch origin --tags --force --no-recurse-submodules && git describe --tags', returnStdout: true).trim()}"
     STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'nix.AppImage', arch: getArch(), version: env.VERSION)}"
     STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'nix.tar.gz', arch: getArch(), version: env.VERSION)}"
     /* prevent sharing cache dir across different jobs */
@@ -81,6 +83,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -49,6 +49,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 30, unit: 'MINUTES')
@@ -81,7 +83,7 @@ pipeline {
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
-    VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
+    VERSION = "${sh(script: 'git fetch origin --tags --force --no-recurse-submodules && git describe --tags', returnStdout: true).trim()}${params.USE_NWAKU ? '-nwaku-experimental' : ''}"
     STATUS_CLIENT_DMG = "pkg/${utils.pkgFilename(ext: 'dmg', arch: getArch(), version: env.VERSION)}"
     /* Apple Team ID for Notarization */
     MACOS_NOTARIZE_TEAM_ID = "8B5X2M6H2Y"
@@ -101,6 +103,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.qt-build
+++ b/ci/Jenkinsfile.qt-build
@@ -7,6 +7,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     buildDiscarder(logRotator(numToKeepStr: '20'))
     timestamps()
     timeout(time: 12, unit: 'HOURS')
@@ -87,7 +89,26 @@ pipeline {
   }
 
   stages {
-
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Build Docker Image for Linux') {
       steps {
         script {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -48,6 +48,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 120, unit: 'MINUTES')
@@ -103,6 +105,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -26,6 +26,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 20, unit: 'MINUTES')
@@ -60,6 +62,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -18,6 +18,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 120, unit: 'MINUTES')
@@ -46,6 +48,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -47,6 +47,8 @@ pipeline {
   }
 
   options {
+    /* IMPORTANT: Disable automatic checkout to control submodule handling */
+    skipDefaultCheckout()
     timestamps()
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 60, unit: 'MINUTES')
@@ -75,7 +77,7 @@ pipeline {
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
-    VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
+    VERSION = "${sh(script: 'git fetch origin --tags --force --no-recurse-submodules && git describe --tags', returnStdout: true).trim()}"
     STATUS_CLIENT_EXE = "pkg/${utils.pkgFilename(ext: 'exe', arch: getArch(), version: env.VERSION)}"
     /* 7zip archive filename */
     STATUS_CLIENT_7Z = "pkg/${utils.pkgFilename(ext: '7z', arch: getArch(), version: env.VERSION)}"
@@ -96,6 +98,26 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [
+            [$class: 'SubmoduleOption',
+              disableSubmodules: false,
+              parentCredentials: true,
+              recursiveSubmodules: false,
+              reference: '',
+              trackingSubmodules: false
+            ]
+          ],
+          submoduleCfg: [],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'


### PR DESCRIPTION
## Summary

- disable the default jenkins checkout which also pulls in submodules
- manually perform a clean checkout in a stage
- then update submodules to avoid weird race conditions in PRs

