### PR TITLE
fix(Community): being unable to use newline in description

### DIFF
--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -10,7 +10,7 @@ ColumnLayout {
     id: root
 
     property string name: "Socks"
-    property string description: "We like the sock. A community of Unisocks wearers we like the sock. Unisocks wearers we like the sock."
+    property string description: "We like the sock. A community of Unisocks wearers we like the sock.\n\nUnisocks wearers we like the sock."
 
     property int membersCount: 184
     property bool amISectionAdmin: true

--- a/storybook/pages/EditSettingsPanelPage.qml
+++ b/storybook/pages/EditSettingsPanelPage.qml
@@ -52,5 +52,5 @@ SplitView {
 }
 
 // category: Panels
-
+// status: good
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?node-id=3132%3A383870&mode=dev

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -382,7 +382,7 @@ Item {
                         color: root.enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
                         wrapMode: root.multiline ? Text.WrapAtWordBoundaryOrAnywhere : TextEdit.NoWrap
 
-                        Keys.onReturnPressed: {
+                        Keys.onReturnPressed: function (event) {
                             event.accepted = !multiline && !acceptReturn
                             // Special case for single line inputs, where we want to accept the return key, but notify the parend
                             // Enter and return can be used to accept the input
@@ -390,7 +390,7 @@ Item {
                                 root.keyPressed(event)
                             }
                         }
-                        Keys.onEnterPressed: {
+                        Keys.onEnterPressed: function (event) {
                             event.accepted = !multiline && !acceptReturn
                             // Special case for single line inputs, where we want to accept the return key, but notify the parend
                             // Enter and return can be used to accept the input

--- a/ui/app/AppLayouts/Communities/controls/DescriptionInput.qml
+++ b/ui/app/AppLayouts/Communities/controls/DescriptionInput.qml
@@ -28,7 +28,7 @@ StatusInput {
                                                 qsTr("community description"))
         },
         StatusRegularExpressionValidator {
-            regularExpression: Constants.regularExpressions.alphanumericalExpanded3
+            regularExpression: Constants.regularExpressions.alphanumericalExpanded4
             errorMessage: Constants.errorMessages.alphanumericalExpanded3RegExp
         }
     ]

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -660,6 +660,8 @@ QtObject {
         readonly property var alphanumericalExpanded2: /^$|^[a-zA-Z0-9\-_\.\u0020\&]+$/
         // Adds dash, underscore, dot, space, comma and ampersand
         readonly property var alphanumericalExpanded3: /^$|^[a-zA-Z0-9\-_\.\,\u0020\&]+$/
+        // Adds a newline (e.g. community description)
+        readonly property var alphanumericalExpanded4: /^$|^[a-zA-Z0-9\-_\.\,\u0020\&\r?\n]+$/
         readonly property var alphanumericalWithSpace: /^$|^[a-zA-Z0-9\s]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/


### PR DESCRIPTION
### What does the PR do

- extend the regexp (validator) with a newline character
- adjust the SB pages a bit and silence some related warnings

Fixes #17571

### Affected areas

Community description

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="3536" height="2380" alt="Snímek obrazovky z 2025-09-16 16-02-22" src="https://github.com/user-attachments/assets/e134c25e-578e-4e78-8524-9f5c8dd69f74" />

SB:
<img width="3136" height="1974" alt="Snímek obrazovky z 2025-09-16 16-00-02" src="https://github.com/user-attachments/assets/8b88f9be-1803-424f-a3c4-20da0be2fa14" />

<img width="3136" height="1974" alt="Snímek obrazovky z 2025-09-16 15-58-53" src="https://github.com/user-attachments/assets/f4189cc2-6e93-48bb-be1c-fe46c096e811" />

### Impact on end user

User can enter a newline when creating or editing a community description

### Risk 

low
