### PR TITLE
chore: remove "Fake loading screen" advanced setting

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -453,6 +453,8 @@ proc finishAppLoading*(self: AppController) =
 
   self.mainModule.checkAndPerformProfileMigrationIfNeeded()
 
+  self.notificationsManager.onAppReady()
+
 proc logout*(self: AppController) =
   self.generalService.logout()
 

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -52,7 +52,7 @@ QtObject:
     new(result, delete)
     result.setup(events, settingsService)
 
-  proc onAppReady(self: NotificationsManager) =
+  proc onAppReady*(self: NotificationsManager) =
     self.osNotification = newStatusOSNotification()
 
     signalConnect(self.osNotification, "notificationClicked(QString)", self, "onOSNotificationClicked(QString)", 2)
@@ -88,8 +88,7 @@ QtObject:
     self.notificationSetUp = true
 
   proc init*(self: NotificationsManager) =
-    self.events.once(FAKE_LOADING_SCREEN_FINISHED) do(e:Args):
-      self.onAppReady()
+    discard
 
   proc showOSNotification(self: NotificationsManager, title: string, message: string, identifier: string) =
     if defined(windows):

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -40,7 +40,6 @@ type
     userId*: string # can be public key or ens name
 
 const SIGNAL_STATUS_URL_ACTIVATED* = "statusUrlActivated"
-const FAKE_LOADING_SCREEN_FINISHED* = "fakeLoadingScreenFinished"
 
 const SIGNAL_MAIN_LOADED* = "signalMainLoaded"
 

--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -13,8 +13,6 @@ const DEFAULT_SCROLL_VELOCITY = 0 # unset
 const DEFAULT_SCROLL_DECELERATION = 0 # unset
 const LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED = "global/custom_mouse_scroll_enabled"
 const DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED = false
-const LAS_KEY_FAKE_LOADING_SCREEN_ENABLED = "global/fake_loading_screen"
-let DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and not TEST_MODE_ENABLED #enabled in production, disabled in development and e2e tests
 const LAS_KEY_SHARDED_COMMUNITIES_ENABLED = "global/sharded_communities"
 const DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED = false
 const LAS_KEY_TRANSLATIONS_ENABLED = "global/translations_enabled"
@@ -129,19 +127,6 @@ QtObject:
   proc displayMockedKeycardWindow*(self: LocalAppSettings): bool {.slot.} =
     return DISPLAY_MOCKED_KEYCARD_WINDOW
 
-  proc fakeLoadingScreenEnabledChanged*(self: LocalAppSettings) {.signal.}
-  proc getFakeLoadingScreenEnabled*(self: LocalAppSettings): bool {.slot.} =
-    self.settings.value(LAS_KEY_FAKE_LOADING_SCREEN_ENABLED, newQVariant(DEFAULT_FAKE_LOADING_SCREEN_ENABLED)).boolVal
-
-  proc setFakeLoadingScreenEnabled*(self: LocalAppSettings, enabled: bool) {.slot.} =
-    self.settings.setValue(LAS_KEY_FAKE_LOADING_SCREEN_ENABLED, newQVariant(enabled))
-    self.fakeLoadingScreenEnabledChanged()
-
-  QtProperty[bool] fakeLoadingScreenEnabled:
-    read = getFakeLoadingScreenEnabled
-    write = setFakeLoadingScreenEnabled
-    notify = fakeLoadingScreenEnabledChanged
-
   proc refreshTokenEnabledChanged*(self: LocalAppSettings) {.signal.}
   proc getRefreshTokenEnabled*(self: LocalAppSettings): bool {.slot.} =
     self.settings.value(LAS_KEY_REFRESH_TOKEN_ENABLED, newQVariant(false)).boolVal
@@ -194,7 +179,6 @@ QtObject:
       of LAS_KEY_SCROLL_VELOCITY: self.scrollVelocityChanged()
       of LAS_KEY_SCROLL_DECELERATION: self.scrollDecelerationChanged()
       of LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED: self.isCustomMouseScrollingEnabledChanged()
-      of LAS_KEY_FAKE_LOADING_SCREEN_ENABLED: self.fakeLoadingScreenEnabledChanged()
       of LAS_KEY_SHARDED_COMMUNITIES_ENABLED: self.wakuV2ShardedCommunitiesEnabledChanged()
       of LAS_KEY_TRANSLATIONS_ENABLED: self.translationsEnabledChanged()
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -440,9 +440,6 @@ method insertMockedKeycardAction*(self: AccessInterface, cardIndex: int) {.base.
 method removeMockedKeycardAction*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method fakeLoadingScreenFinished*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onCommunityTokensDetailsLoaded*(self: AccessInterface, communityId: string,
     communityTokens: seq[CommunityTokenDto], communityTokenJsonItems: JsonNode) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2122,9 +2122,6 @@ method insertMockedKeycardAction*[T](self: Module[T], cardIndex: int) =
 method removeMockedKeycardAction*[T](self: Module[T]) =
   self.keycardService.removeMockedKeycardAction()
 
-method fakeLoadingScreenFinished*[T](self: Module[T]) =
-  self.events.emit(FAKE_LOADING_SCREEN_FINISHED, Args())
-
 method addressWasShown*[T](self: Module[T], address: string) =
   if address.len == 0:
     return

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -383,9 +383,6 @@ QtObject:
   proc removeMockedKeycardAction*(self: View) {.slot.} =
     self.delegate.removeMockedKeycardAction()
 
-  proc fakeLoadingScreenFinished*(self: View) {.slot.} =
-    self.delegate.fakeLoadingScreenFinished()
-
   ## Address was shown is added here because it will be used from many different parts of the app
   ## and "mainModule" is accessible from everywhere
   proc addressWasShown*(self: View, address: string) {.slot.} =

--- a/storybook/pages/DidYouKnowSplashScreenPage.qml
+++ b/storybook/pages/DidYouKnowSplashScreenPage.qml
@@ -20,6 +20,7 @@ SplitView {
             SplitView.fillWidth: true
             progress: progressSlider.position
             messagesEnabled: ctrlMessagesEnabled.checked
+            infiniteLoading: ctrlInfinite.checked
         }
     }
 
@@ -33,10 +34,15 @@ SplitView {
             }
             Slider {
                 id: progressSlider
+                enabled: !ctrlInfinite.checked
             }
             Switch {
                 id: ctrlMessagesEnabled
                 text: "Messages enabled"
+            }
+            Switch {
+                id: ctrlInfinite
+                text: "Infinite loading"
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -22,7 +22,6 @@ QtObject {
 
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
-    readonly property bool isFakeLoadingScreenEnabled: localAppSettings.fakeLoadingScreenEnabled ?? false
     property bool isManageCommunityOnTestModeEnabled: false
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string browser: "browser"
@@ -127,13 +126,6 @@ QtObject {
         else if (feature === experimentalFeatures.onlineUsers) {
             localAccountSensitiveSettings.showOnlineUsers = !localAccountSensitiveSettings.showOnlineUsers
         }
-    }
-
-    function toggleFakeLoadingScreen() {
-        if(!localAppSettings)
-            return
-
-        localAppSettings.fakeLoadingScreenEnabled = !localAppSettings.fakeLoadingScreenEnabled
     }
 
     function toggleArchiveProtocolEnabled() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -408,17 +408,6 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
-                text: qsTr("Fake loading screen")
-                isSwitch: true
-                switchChecked: root.advancedStore.isFakeLoadingScreenEnabled
-                onClicked: {
-                    root.advancedStore.toggleFakeLoadingScreen()
-                }
-            }
-
-            StatusSettingsLineButton {
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
                 objectName: "manageCommunitiesOnTestnetButton"
                 text: qsTr("Manage communities on testnet")
                 isSwitch: true

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1299,10 +1299,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fake loading screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Manage communities on testnet</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1292,10 +1292,6 @@
         <comment>AdvancedView</comment><translation>Auto message</translation>
     </message>
     <message>
-        <source>Fake loading screen</source>
-        <comment>AdvancedView</comment><translation>Fake loading screen</translation>
-    </message>
-    <message>
         <source>Manage communities on testnet</source>
         <comment>AdvancedView</comment><translation>Manage communities on testnet</translation>
     </message>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1302,10 +1302,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fake loading screen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Manage communities on testnet</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1296,10 +1296,6 @@
         <translation>자동 메시지</translation>
     </message>
     <message>
-        <source>Fake loading screen</source>
-        <translation>가짜 로딩 화면</translation>
-    </message>
-    <message>
         <source>Manage communities on testnet</source>
         <translation>Testnet에서 커뮤니티 관리</translation>
     </message>

--- a/ui/imports/shared/panels/DidYouKnowSplashScreen.qml
+++ b/ui/imports/shared/panels/DidYouKnowSplashScreen.qml
@@ -13,6 +13,7 @@ import shared.panels.private
 Pane {
     id: root
 
+    property alias infiniteLoading: splashScreen.infiniteLoading
     property alias progress: splashScreen.progress
     property alias splashScreenText: splashScreen.text
     property alias splashScreenSecondaryText: splashScreen.secondaryText
@@ -28,7 +29,7 @@ Pane {
             id: content
             anchors.bottom: parent.bottom
             width: parent.width
-            visible: root.progress !== 0 && root.messagesEnabled
+            visible: root.messagesEnabled
             Behavior on visible {
                 SequentialAnimation {
                     PropertyAction { target: content; property: "opacity"; value: visible ? 0 : didYouKnowText.opacity }                        //set opacity to 0 if the visible property changed to true

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -229,8 +229,6 @@ StatusWindow {
     }
 
     function moveToAppMain() {
-        mainModule.fakeLoadingScreenFinished()
-
         Global.appIsReady = true
 
         loader.sourceComponent = app
@@ -249,7 +247,7 @@ StatusWindow {
         target: SystemUtils
         enabled: SQUtils.Utils.mac
 
-        onQuit: (spontaneous) => {
+        function onQuit(spontaneous) {
             if (spontaneous)
                 Qt.exit(0)
         }
@@ -391,7 +389,7 @@ StatusWindow {
         visible: (opacity > 0.0001)
         Behavior on opacity { NumberAnimation { duration: 120 }}
         /* only unload splash screen once appmain is loaded else we see
-        an empty screen for a sec until it is laoded */
+        an empty screen for a sec until it is loaded */
         onLoaded: startupOnboardingLoader.active = false
     }
 
@@ -414,15 +412,9 @@ StatusWindow {
         DidYouKnowSplashScreen {
             objectName: "splashScreenV2"
             readonly property bool backAvailableHint: false
-            readonly property string pageClassName: "Splash"
             property bool runningProgressAnimation
             messagesEnabled: true
-            NumberAnimation on progress {
-                from: 0.0
-                to: 1
-                duration: !!localAppSettings && localAppSettings.fakeLoadingScreenEnabled ? 30000 : 3000
-                running: runningProgressAnimation
-            }
+            infiniteLoading: runningProgressAnimation
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- removes the UI element from Settings/Advanced
- adjusts the splash screen to show a loading animation instead of the progress bar, as we don't have an overall duration now
- remove the backend "fakeLoadingScreenFinished" method; use the `appLoaded` NIM signal to remove the splash screen, once moving to `AppMain`

Fixes #18828

### Affected areas

Settings/Advanced, SplashScreen

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2844" height="1800" alt="Snímek obrazovky z 2025-09-18 14-00-38" src="https://github.com/user-attachments/assets/ed6b63df-3d52-4090-8881-e1cc6cfc194a" />

Storybook:
<img width="2944" height="1800" alt="Snímek obrazovky z 2025-09-18 14-05-53" src="https://github.com/user-attachments/assets/106f6683-3713-43e1-9dbc-064eeb4777b6" />

### Impact on end user

None

### How to test

- start the app, watch the splash screen
- AppMain should get loaded as before

### Risk 

- low
