### PR TITLE
chore: Fix nim compilation with ORC/ARC

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -70,11 +70,12 @@ switch("warning", "BareExcept:off")
 # We assume this as a good practive to keep `else` even if all cases are covered
 switch("warning", "UnreachableElse:off")
 
-# Those are popular to miss in our app, and quickly make build log unreadable, so we want to prevent them
-switch("warningAsError", "UseBase:on")
-switch("warningAsError", "UnusedImport:on")
-switch("warningAsError", "Deprecated:on")
-switch("warningAsError", "HoleEnumConv:on")
+when defined(gcRefc):
+  # Those are popular to miss in our app, and quickly make build log unreadable, so we want to prevent them
+  switch("warningAsError", "UseBase:on")
+  switch("warningAsError", "UnusedImport:on")
+  switch("warningAsError", "Deprecated:on")
+  switch("warningAsError", "HoleEnumConv:on")
 
 # Workaround for https://github.com/nim-lang/Nim/issues/23429
 switch("warning", "UseBase:on")

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -40,14 +40,8 @@ QtObject:
 
   proc processNotification(self: NotificationsManager, title: string, message: string, details: NotificationDetails)
 
-  proc setup(self: NotificationsManager, events: EventEmitter, settingsService: settings_service.Service) =
-    self.QObject.setup
-    self.events = events
-    self.settingsService = settingsService
-
-  proc delete*(self: NotificationsManager) =
-    self.QObject.delete
-
+  proc setup(self: NotificationsManager, events: EventEmitter, settingsService: settings_service.Service)
+  proc delete*(self: NotificationsManager)
   proc newNotificationsManager*(events: EventEmitter, settingsService: settings_service.Service): NotificationsManager =
     new(result, delete)
     result.setup(events, settingsService)
@@ -358,3 +352,12 @@ QtObject:
     # MyRequestToJoinCommunityRejected)
     else:
       self.notificationCheck(title, message, details, "")
+
+  proc setup(self: NotificationsManager, events: EventEmitter, settingsService: settings_service.Service) =
+    self.QObject.setup
+    self.events = events
+    self.settingsService = settingsService
+
+  proc delete*(self: NotificationsManager) =
+    self.QObject.delete
+

--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -109,12 +109,12 @@ QtObject:
     self.localBackupEnabled = LOCAL_BACKUP_ENABLED
     self.privacyModeFeatureEnabled = PRIVACY_MODE_FEATURE_ENABLED
 
+  proc newFeatureFlags*(): FeatureFlags =
+    new(result)
+    result.setup()
+
   proc delete*(self: FeatureFlags) =
     self.QObject.delete()
-
-  proc newFeatureFlags*(): FeatureFlags =
-    new(result, delete)
-    result.setup()
 
   proc getDappsEnabled*(self: FeatureFlags): bool {.slot.} =
     return self.dappsEnabled

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -3,15 +3,17 @@ import nimqml
 QtObject:
   type GlobalEvents* = ref object of QObject
 
+  proc setup(self: GlobalEvents)
+  proc delete*(self: GlobalEvents)
+  proc newGlobalEvents*(): GlobalEvents =
+    new(result, delete)
+    result.setup
+
   proc setup(self: GlobalEvents) =
     self.QObject.setup
 
   proc delete*(self: GlobalEvents) =
     self.QObject.delete
-
-  proc newGlobalEvents*(): GlobalEvents =
-    new(result, delete)
-    result.setup
 
   proc showTestNotification*(self: GlobalEvents, title: string, message: string) {.signal.}
 

--- a/src/app/global/loader_deactivator.nim
+++ b/src/app/global/loader_deactivator.nim
@@ -12,17 +12,19 @@ QtObject:
   type LoaderDeactivator* = ref object of QObject
     keepInMemory: Deque[ChatInMemory]
 
+  proc setup(self: LoaderDeactivator)
+  proc delete*(self: LoaderDeactivator)
+  proc newLoaderDeactivator*():
+    LoaderDeactivator =
+    new(result, delete)
+    result.setup
+
   proc setup(self: LoaderDeactivator) =
     self.QObject.setup
     self.keepInMemory = initDeque[ChatInMemory]()
 
   proc delete*(self: LoaderDeactivator) =
     self.QObject.delete
-
-  proc newLoaderDeactivator*():
-    LoaderDeactivator =
-    new(result, delete)
-    result.setup
 
   proc newChatInMemory(sectionId, chatId: string): ChatInMemory =
     (sectionId, chatId)

--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -85,12 +85,8 @@ QtObject:
     settingsFileDir: string
     settings: QSettings
 
-  proc setup(self: LocalAccountSensitiveSettings) =
-    self.QObject.setup
-    self.settingsFileDir = os.joinPath(DATADIR, "qt")
-
-  proc delete*(self: LocalAccountSensitiveSettings) =
-    self.QObject.delete
+  proc setup(self: LocalAccountSensitiveSettings)
+  proc delete*(self: LocalAccountSensitiveSettings)
 
   proc newLocalAccountSensitiveSettings*():
     LocalAccountSensitiveSettings =
@@ -643,3 +639,10 @@ QtObject:
       of LSS_KEY_USER_DECLINED_BACKUP_BANNER: self.userDeclinedBackupBannerChanged()
       of LSS_KEY_GIF_UNFURLING_ENABLED: self.gifUnfurlingEnabledChanged()
       of LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN: self.createCommunityPopupSeenChanged()
+
+  proc setup(self: LocalAccountSensitiveSettings) =
+    self.QObject.setup
+    self.settingsFileDir = os.joinPath(DATADIR, "qt")
+
+  proc delete*(self: LocalAccountSensitiveSettings) =
+    self.QObject.delete

--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -16,12 +16,8 @@ QtObject:
     currentFileName: string
     settings: QSettings
 
-  proc setup(self: LocalAccountSettings) =
-    self.QObject.setup
-    self.settingsFileDir = os.joinPath(DATADIR, "qt")
-
-  proc delete*(self: LocalAccountSettings) =
-    self.QObject.delete
+  proc setup(self: LocalAccountSettings)
+  proc delete*(self: LocalAccountSettings)
 
   proc newLocalAccountSettings*():
     LocalAccountSettings =
@@ -66,3 +62,10 @@ QtObject:
     read = getStoreToKeychainValue
     write = setStoreToKeychainValue
     notify = storeToKeychainValueChanged
+
+  proc setup(self: LocalAccountSettings) =
+    self.QObject.setup
+    self.settingsFileDir = os.joinPath(DATADIR, "qt")
+
+  proc delete*(self: LocalAccountSettings) =
+    self.QObject.delete

--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -33,18 +33,19 @@ QtObject:
   type LocalAppSettings* = ref object of QObject
     settings: QSettings
 
-  proc setup(self: LocalAppSettings) =
-    self.QObject.setup
-
-  proc delete*(self: LocalAppSettings) =
-    self.QObject.delete
-
+  proc setup(self: LocalAppSettings)
+  proc delete*(self: LocalAppSettings)
   proc newLocalAppSettings*(fileName: string): LocalAppSettings =
     new(result, delete)
     result.setup
     let filePath = os.joinPath(DATADIR, "qt", fileName)
     result.settings = newQSettings(filePath, QSettingsFormat.IniFormat)
 
+  proc setup(self: LocalAppSettings) =
+    self.QObject.setup
+  
+  proc delete*(self: LocalAppSettings) =
+    self.QObject.delete
 
   proc languageChanged*(self: LocalAppSettings) {.signal.}
   proc getLanguage*(self: LocalAppSettings): string {.slot.} =

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -20,16 +20,18 @@ QtObject:
     largeImage: string
     currentUserStatus: int
 
+  proc setup(self: UserProfile)
+  proc delete*(self: UserProfile)
+  proc newUserProfile*(localAccountSettings: LocalAccountSettings): UserProfile =
+    new(result, delete)
+    result.setup
+    result.localAccountSettings = localAccountSettings
+
   proc setup(self: UserProfile) =
     self.QObject.setup
 
   proc delete*(self: UserProfile) =
     self.QObject.delete
-
-  proc newUserProfile*(localAccountSettings: LocalAccountSettings): UserProfile =
-    new(result, delete)
-    result.setup
-    result.localAccountSettings = localAccountSettings
 
   proc setFixedData*(self: UserProfile, username: string, keyUid: string, pubKey: string, isKeycardUser: bool) =
     self.username = username

--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -18,15 +18,17 @@ QtObject:
   proc isCompressedPubKey*(self: Utils, publicKey: string): bool
   proc getDecompressedPk*(self: Utils, compressedKey: string): string
 
+  proc setup(self: Utils)
+  proc delete*(self: Utils)
+  proc newUtils*(): Utils =
+    new(result, delete)
+    result.setup
+
   proc setup(self: Utils) =
     self.QObject.setup
 
   proc delete*(self: Utils) =
     self.QObject.delete
-
-  proc newUtils*(): Utils =
-    new(result, delete)
-    result.setup
 
   proc fromPathUri*(self: Utils, path: string): string {.slot.} =
     var formattedPath = replace(path, "file://", "")

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -33,11 +33,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       activityCenterNotifications*: seq[Item]
 
-  proc setup(self: Model) = self.QAbstractListModel.setup
-
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: Model)
+  proc delete(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.activityCenterNotifications = @[]
@@ -244,3 +241,9 @@ QtObject:
     else:
       for activityCenterNotification in activityCenterNotifications:
         self.upsertActivityCenterNotification(activityCenterNotification)
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/activity_center/token_data_item.nim
+++ b/src/app/modules/main/activity_center/token_data_item.nim
@@ -13,12 +13,8 @@ QtObject:
     imageUrl*: string
     tokenType*: int
 
-  proc setup(self: TokenDataItem) =
-    self.QObject.setup
-
-  proc delete*(self: TokenDataItem) =
-    self.QObject.delete
-
+  proc setup(self: TokenDataItem)
+  proc delete*(self: TokenDataItem)
   proc newTokenDataItem*(
     chainId: int,
     txHash: string,
@@ -96,3 +92,10 @@ QtObject:
   proc tokenType*(self: TokenDataItem): int {.slot.} = result = self.tokenType
   QtProperty[int] tokenType:
     read = tokenType
+
+  proc setup(self: TokenDataItem) =
+    self.QObject.setup
+
+  proc delete*(self: TokenDataItem) =
+    self.QObject.delete
+

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -14,9 +14,7 @@ QtObject:
       unreadCount: int
       hasUnseen: bool
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -207,3 +205,7 @@ QtObject:
 
   proc enableInstallationAndSync*(self: View, installationId: string) {.slot.} =
     self.delegate.enableInstallationAndSync(installationId)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/app_search/models/chat_search_model.nim
+++ b/src/app/modules/main/app_search/models/chat_search_model.nim
@@ -22,12 +22,8 @@ QtObject:
     delegate: io_interface.AccessInterface
     built: bool
 
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: Model)
+  proc delete(self: Model)
   proc newModel*(delegate: io_interface.AccessInterface): Model =
     new(result, delete)
     result.setup
@@ -174,4 +170,10 @@ QtObject:
     for item in self.items:
       if item.sectionId == sectionId:
         self.updateSectionNameOnChatItem(item.chatId, sectionName)
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
 

--- a/src/app/modules/main/app_search/models/location_menu_model.nim
+++ b/src/app/modules/main/app_search/models/location_menu_model.nim
@@ -17,12 +17,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup()
@@ -76,3 +72,10 @@ QtObject:
     for i in self.items:
       if (i.value == value):
         return i
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/app_search/models/location_menu_sub_model.nim
+++ b/src/app/modules/main/app_search/models/location_menu_sub_model.nim
@@ -20,12 +20,8 @@ QtObject:
     SubModel* = ref object of QAbstractListModel
       items: seq[SubItem]
 
-  proc delete*(self: SubModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: SubModel) =
-    self.QAbstractListModel.setup
-
+  proc delete*(self: SubModel)
+  proc setup(self: SubModel)
   proc newSubModel*(): SubModel =
     new(result, delete)
     result.setup()
@@ -103,3 +99,10 @@ QtObject:
     for i in self.items:
       if (i.value == value):
         return i
+
+  proc delete*(self: SubModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: SubModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/app_search/models/result_model.nim
+++ b/src/app/modules/main/app_search/models/result_model.nim
@@ -25,12 +25,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       resultList: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup()
@@ -128,3 +124,10 @@ QtObject:
     self.beginResetModel()
     self.resultList = @[]
     self.endResetModel()
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/app_search/view.nim
+++ b/src/app/modules/main/app_search/view.nim
@@ -11,9 +11,7 @@ QtObject:
       chatSearchModel: chat_search_model.Model
       chatSearchModelVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -70,3 +68,7 @@ QtObject:
     return self.chatSearchModelVariant
   QtProperty[QVariant] chatSearchModel:
     read = getChatSearchModel
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/browser_section/bookmark/model.nim
+++ b/src/app/modules/main/browser_section/bookmark/model.nim
@@ -13,13 +13,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.items = @[]
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -116,3 +111,11 @@ QtObject:
     self.items[index] = item
     self.dataChanged(topLeft, bottomRight)
     self.modelChanged()
+
+  proc delete(self: Model) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/browser_section/bookmark/view.nim
+++ b/src/app/modules/main/browser_section/bookmark/view.nim
@@ -10,14 +10,8 @@ QtObject:
       model: Model
       modelVariant: QVariant
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.model.delete
-    self.modelVariant.delete
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.delegate = delegate
@@ -54,3 +48,12 @@ QtObject:
 
   proc updateBookmarkByUrl*(self: View, oldUrl: string, item: Item) =
     self.model.updateItemByUrl(oldUrl, item)
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.model.delete
+    self.modelVariant.delete
+    self.QObject.delete
+

--- a/src/app/modules/main/browser_section/current_account/view.nim
+++ b/src/app/modules/main/browser_section/current_account/view.nim
@@ -17,12 +17,8 @@ QtObject:
       currencyBalance: CurrencyAmount
       emoji: string
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.setup()
@@ -100,22 +96,28 @@ QtObject:
 
   proc connectedAccountDeleted*(self: View) {.signal.}
 
-proc setData*(self: View, item: account_item.Item) =
-    self.name = item.name()
-    self.nameChanged()
-    self.address = item.address()
-    self.addressChanged()
-    self.path = item.path()
-    self.pathChanged()
-    self.colorId = item.colorId()
-    self.colorIdChanged()
-    self.walletType = item.walletType()
-    self.walletTypeChanged()
-    self.currencyBalance = item.currencyBalance()
-    self.currencyBalanceChanged()
-    self.emoji = item.emoji()
-    self.emojiChanged()
+  proc setData*(self: View, item: account_item.Item) =
+      self.name = item.name()
+      self.nameChanged()
+      self.address = item.address()
+      self.addressChanged()
+      self.path = item.path()
+      self.pathChanged()
+      self.colorId = item.colorId()
+      self.colorIdChanged()
+      self.walletType = item.walletType()
+      self.walletTypeChanged()
+      self.currencyBalance = item.currencyBalance()
+      self.currencyBalanceChanged()
+      self.emoji = item.emoji()
+      self.emojiChanged()
 
-proc isAddressCurrentAccount*(self: View, address: string): bool =
-  return self.address == address
+  proc isAddressCurrentAccount*(self: View, address: string): bool =
+    return self.address == address
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
 

--- a/src/app/modules/main/browser_section/dapps/accounts.nim
+++ b/src/app/modules/main/browser_section/dapps/accounts.nim
@@ -13,13 +13,8 @@ QtObject:
     AccountsModel* = ref object of QAbstractListModel
       items: seq[WalletAccountDto]
 
-  proc delete(self: AccountsModel) =
-    self.items = @[]
-    self.QAbstractListModel.delete
-
-  proc setup(self: AccountsModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: AccountsModel)
+  proc setup(self: AccountsModel)
   proc newAccountsModel*(): AccountsModel =
     new(result, delete)
     result.setup
@@ -89,3 +84,11 @@ QtObject:
     self.items = @[]
     self.endResetModel()
     self.countChanged()
+
+  proc delete(self: AccountsModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: AccountsModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/browser_section/dapps/dapps.nim
+++ b/src/app/modules/main/browser_section/dapps/dapps.nim
@@ -11,13 +11,8 @@ QtObject:
     DappsModel* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: DappsModel) =
-    self.items = @[]
-    self.QAbstractListModel.delete
-
-  proc setup(self: DappsModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: DappsModel)
+  proc setup(self: DappsModel)
   proc newDappsModel*(): DappsModel =
     new(result, delete)
     result.setup
@@ -82,3 +77,11 @@ QtObject:
     self.items = @[]
     self.endResetModel()
     self.countChanged()
+
+  proc delete(self: DappsModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: DappsModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/browser_section/dapps/permissions.nim
+++ b/src/app/modules/main/browser_section/dapps/permissions.nim
@@ -9,12 +9,8 @@ QtObject:
     PermissionsModel* = ref object of QAbstractListModel
       items: seq[string]
 
-  proc delete(self: PermissionsModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: PermissionsModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: PermissionsModel)
+  proc setup(self: PermissionsModel)
   proc newPermissionsModel*(): PermissionsModel =
     new(result, delete)
     result.setup
@@ -66,3 +62,10 @@ QtObject:
     self.beginResetModel()
     self.items = @[]
     self.endResetModel()
+
+  proc delete(self: PermissionsModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: PermissionsModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/browser_section/dapps/view.nim
+++ b/src/app/modules/main/browser_section/dapps/view.nim
@@ -10,13 +10,9 @@ QtObject:
       dappsModel: DappsModel
       dappsModelVariant: QVariant
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.dappsModel.delete
-    self.dappsModelVariant.delete
-    self.QObject.delete
+  # Forward declarations for ORC
+  proc setup(self: View)
+  proc delete*(self: View)
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
@@ -24,6 +20,15 @@ QtObject:
     result.dappsModel = newDappsModel()
     result.dappsModelVariant = newQVariant(result.dappsModel)
     result.setup()
+
+  # Implementations after constructor
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.dappsModel.delete
+    self.dappsModelVariant.delete
+    self.QObject.delete
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()

--- a/src/app/modules/main/browser_section/provider/view.nim
+++ b/src/app/modules/main/browser_section/provider/view.nim
@@ -10,9 +10,7 @@ QtObject:
       chainId: int
       chainName: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -88,4 +86,7 @@ QtObject:
 
   proc authenticateToPostMessage*(self: View, payloadMethod: string, requestType: string, message: string) {.slot.} =
     self.delegate.authenticateToPostMessage(payloadMethod, requestType, message)
+
+  proc delete*(self: View) =
+    self.QObject.delete
 

--- a/src/app/modules/main/browser_section/view.nim
+++ b/src/app/modules/main/browser_section/view.nim
@@ -6,12 +6,8 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.delegate = delegate
@@ -23,3 +19,10 @@ QtObject:
   proc openUrl*(self: View, url: string) {.signal.}
   proc sendOpenUrlSignal*(self: View, url: string) =
     self.openUrl(url)
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -6,12 +6,8 @@ QtObject:
   type ActiveItem* = ref object of QObject
     item: ChatItem
 
-  proc setup(self: ActiveItem) =
-    self.QObject.setup
-
-  proc delete*(self: ActiveItem) =
-    self.QObject.delete
-
+  proc setup(self: ActiveItem)
+  proc delete*(self: ActiveItem)
   proc newActiveItem*(): ActiveItem =
     new(result, delete)
     result.setup
@@ -133,3 +129,9 @@ QtObject:
   QtProperty[bool] permissionsCheckOngoing:
     read = getPermissionsCheckOngoing
   
+  proc setup(self: ActiveItem) =
+    self.QObject.setup
+
+  proc delete*(self: ActiveItem) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -31,9 +31,7 @@ QtObject:
     missingEncryptionKey: bool
     requiresPermissions: bool
 
-  proc delete*(self: ChatDetails) =
-    self.QObject.delete
-
+  proc delete*(self: ChatDetails)
   proc newChatDetails*(): ChatDetails =
     new(result, delete)
     result.QObject.setup
@@ -374,3 +372,7 @@ QtObject:
       return
     self.requiresPermissions = value
     self.requiresPermissionsChanged()
+
+  proc delete*(self: ChatDetails) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/chat_content/input_area/preserved_properties.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/preserved_properties.nim
@@ -7,13 +7,8 @@ QtObject:
       replyMessageId: string
       fileUrlsAndSourcesJson: string
 
-  proc setup(self: PreservedProperties) =
-    self.QObject.setup
-    self.fileUrlsAndSourcesJson = "[]"
-
-  proc delete*(self: PreservedProperties) =
-    self.QObject.delete
-
+  proc setup(self: PreservedProperties)
+  proc delete*(self: PreservedProperties)
   proc newPreservedProperties*(): PreservedProperties =
     new(result, delete)
     result.setup
@@ -56,4 +51,11 @@ QtObject:
     read = getFileUrlsAndSourcesJson
     write = setFileUrlsAndSourcesJson
     notify = fileUrlsAndSourcesJsonChanged
+
+  proc setup(self: PreservedProperties) =
+    self.QObject.setup
+    self.fileUrlsAndSourcesJson = "[]"
+
+  proc delete*(self: PreservedProperties) =
+    self.QObject.delete
 

--- a/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/urls_model.nim
@@ -9,12 +9,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[string]
 
-  proc delete*(self: Model) = 
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete*(self: Model)
+  proc setup(self: Model)
   proc newUrlsModel*(): Model =
     new(result, delete)
     result.setup
@@ -91,3 +87,10 @@ QtObject:
       self.endInsertRows()
 
     self.countChanged()
+
+  proc delete*(self: Model) = 
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -25,9 +25,7 @@ QtObject:
 
   proc setSendingInProgress*(self: View, value: bool)
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -189,3 +187,7 @@ QtObject:
 
   proc emitSendingMessageFailure*(self: View) =
     self.setSendingInProgress(false)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -19,9 +19,7 @@ QtObject:
       loading: bool
       keepUnread: bool
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -249,3 +247,7 @@ QtObject:
 
   proc forceLinkPreviewsLocalData*(self: View, messageId: string) {.slot.} =
     self.delegate.forceLinkPreviewsLocalData(messageId)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/chat_content/users/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/view.nim
@@ -9,9 +9,7 @@ QtObject:
       model: Model
       modelVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -53,3 +51,7 @@ QtObject:
 
     if membersRemoved.len > 0:
       self.delegate.removeGroupMembers(membersRemoved)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -15,11 +15,8 @@ QtObject:
       chatDetails: ChatDetails
       chatDetailsVariant: QVariant
 
-  proc chatDetailsChanged*(self:View) {.signal.}
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -28,6 +25,8 @@ QtObject:
     result.pinnedMessagesModelVariant = newQVariant(result.pinnedMessagesModel)
     result.chatDetails = newChatDetails()
     result.chatDetailsVariant = newQVariant(result.chatDetails)
+
+  proc chatDetailsChanged*(self:View) {.signal.}
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -134,3 +133,7 @@ QtObject:
 
   proc updateChatBlocked*(self: View, blocked: bool) =
     self.chatDetails.setBlocked(blocked)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -49,12 +49,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[ChatItem]
 
-  proc delete*(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete*(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -770,3 +766,10 @@ QtObject:
       let modelIndex = self.createIndex(index, 0, nil)
       defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex, @[ModelRole.PermissionsCheckOngoing.int])
+
+  proc delete*(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -38,9 +38,7 @@ QtObject:
       communityMemberReevaluationStatus: int
 
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -543,3 +541,8 @@ QtObject:
 
   proc markAllReadInCommunity*(self: View) {.slot.} =
     self.delegate.markAllReadInCommunity()
+
+  proc delete*(self: View) =
+    echo "[ChatSection][View] Deleting View"
+    self.QObject.delete
+

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -25,12 +25,8 @@ QtObject:
   type CuratedCommunityModel* = ref object of QAbstractListModel
     items: seq[CuratedCommunityItem]
 
-  proc setup(self: CuratedCommunityModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: CuratedCommunityModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: CuratedCommunityModel)
+  proc delete(self: CuratedCommunityModel)
   proc newCuratedCommunityModel*(): CuratedCommunityModel =
     new(result, delete)
     result.setup
@@ -164,3 +160,10 @@ QtObject:
       echo "Tried to set permission items on an item that doesn't exist. Item ID: ", itemId
       return
     self.items[idx].setPermissionModelItems(items)
+
+  proc setup(self: CuratedCommunityModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: CuratedCommunityModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -11,12 +11,8 @@ QtObject:
   type DiscordCategoriesModel* = ref object of QAbstractListModel
     items*: seq[DiscordCategoryItem]
 
-  proc setup(self: DiscordCategoriesModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: DiscordCategoriesModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: DiscordCategoriesModel)
+  proc delete(self: DiscordCategoriesModel)
   proc newDiscordCategoriesModel*(): DiscordCategoriesModel =
     new(result, delete)
     result.setup
@@ -115,3 +111,10 @@ QtObject:
       defer: index.delete
       self.items[i].selected = self.items[i].getId() == id
       self.dataChanged(index, index, @[ModelRole.Selected.int])
+
+  proc setup(self: DiscordCategoriesModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordCategoriesModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -14,12 +14,8 @@ QtObject:
   type DiscordChannelsModel* = ref object of QAbstractListModel
     items*: seq[DiscordChannelItem]
 
-  proc setup(self: DiscordChannelsModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: DiscordChannelsModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: DiscordChannelsModel)
+  proc delete(self: DiscordChannelsModel)
   proc newDiscordChannelsModel*(): DiscordChannelsModel =
     new(result, delete)
     result.setup
@@ -225,3 +221,10 @@ QtObject:
       self.items[i].selected = self.items[i].getId() == id
       self.dataChanged(index, index, @[ModelRole.Selected.int])
     self.hasSelectedItemsChanged()
+
+  proc setup(self: DiscordChannelsModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordChannelsModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -13,12 +13,8 @@ QtObject:
   type DiscordFileListModel* = ref object of QAbstractListModel
     items*: seq[DiscordFileItem]
 
-  proc setup(self: DiscordFileListModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: DiscordFileListModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: DiscordFileListModel)
+  proc delete(self: DiscordFileListModel)
   proc newDiscordFileListModel*(): DiscordFileListModel =
     new(result, delete)
     result.setup
@@ -184,4 +180,10 @@ QtObject:
     self.countChanged()
     self.selectedCountChanged()
     self.selectedFilesValidChanged()
+
+  proc setup(self: DiscordFileListModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordFileListModel) =
+    self.QAbstractListModel.delete
 

--- a/src/app/modules/main/communities/models/discord_import_errors_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_errors_model.nim
@@ -11,12 +11,8 @@ QtObject:
   type DiscordImportErrorsModel* = ref object of QAbstractListModel
     items*: seq[DiscordImportErrorItem]
 
-  proc setup(self: DiscordImportErrorsModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: DiscordImportErrorsModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: DiscordImportErrorsModel)
+  proc delete(self: DiscordImportErrorsModel)
   proc newDiscordDiscordImportErrorsModel*(): DiscordImportErrorsModel =
     new(result, delete)
     result.setup
@@ -57,3 +53,10 @@ QtObject:
     self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
+
+  proc setup(self: DiscordImportErrorsModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordImportErrorsModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -17,12 +17,8 @@ QtObject:
   type DiscordImportTasksModel* = ref object of QAbstractListModel
     items*: seq[DiscordImportTaskItem]
 
-  proc setup(self: DiscordImportTasksModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: DiscordImportTasksModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: DiscordImportTasksModel)
+  proc delete(self: DiscordImportTasksModel)
   proc newDiscordDiscordImportTasksModel*(): DiscordImportTasksmodel =
     new(result, delete)
     result.setup
@@ -123,3 +119,10 @@ QtObject:
     self.beginResetModel()
     self.items = @[]
     self.endResetModel()
+
+  proc setup(self: DiscordImportTasksModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordImportTasksModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -41,12 +41,8 @@ QtObject:
   type TokenModel* = ref object of QAbstractListModel
     items*: seq[TokenItem]
 
-  proc setup(self: TokenModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: TokenModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokenModel)
+  proc delete(self: TokenModel)
   proc newTokenModel*(): TokenModel =
     new(result, delete)
     result.setup
@@ -299,3 +295,10 @@ QtObject:
         result &= fmt"""TokenModel:
         [{i}]:({$self.items[i]})
         """
+
+  proc setup(self: TokenModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -15,12 +15,8 @@ QtObject:
   type TokenOwnersModel* = ref object of QAbstractListModel
     items*: seq[TokenOwnersItem]
 
-  proc setup(self: TokenOwnersModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: TokenOwnersModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokenOwnersModel)
+  proc delete(self: TokenOwnersModel)
   proc newTokenOwnersModel*(): TokenOwnersModel =
     new(result, delete)
     result.setup
@@ -91,3 +87,10 @@ QtObject:
         result &= fmt"""TokenOwnersModel:
         [{i}]:({$self.items[i]})
         """
+
+  proc setup(self: TokenOwnersModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenOwnersModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -12,9 +12,7 @@ QtObject:
   proc load*(self: View) =
     discard
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(communityTokensModule: community_tokens_module_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -99,3 +97,7 @@ QtObject:
 
   proc stopUpdatesForSuggestedRoute*(self: View) {.slot.} =
     self.communityTokensModule.stopUpdatesForSuggestedRoute()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -62,9 +62,7 @@ QtObject:
       keypairsSigningModel: KeyPairModel
       keypairsSigningModelVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -835,3 +833,7 @@ QtObject:
 
   proc promoteSelfToControlNode*(self: View, communityId: string) {.slot.} =
     self.delegate.promoteSelfToControlNode(communityId)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/ephemeral_notification_model.nim
+++ b/src/app/modules/main/ephemeral_notification_model.nim
@@ -21,12 +21,8 @@ QtObject:
   type Model* = ref object of QAbstractListModel
     items*: seq[Item]
 
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: Model)
+  proc delete(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -118,3 +114,10 @@ QtObject:
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
     self.endRemoveRows()
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/gifs/gif_column_model.nim
+++ b/src/app/modules/main/gifs/gif_column_model.nim
@@ -14,10 +14,8 @@ QtObject:
     GifColumnModel* = ref object of QAbstractListModel
       gifs*: seq[GifDto]
 
-  proc setup(self: GifColumnModel) = self.QAbstractListModel.setup
-
-  proc delete(self: GifColumnModel) = self.QAbstractListModel.delete
-
+  proc setup(self: GifColumnModel)
+  proc delete(self: GifColumnModel)
   proc newGifColumnModel*(): GifColumnModel =
     new(result, delete)
     result.gifs = @[]
@@ -52,3 +50,6 @@ QtObject:
       GifRoles.Title.int:"title",
       GifRoles.TinyUrl.int:"tinyUrl",
     }.toTable
+
+  proc setup(self: GifColumnModel) = self.QAbstractListModel.setup
+  proc delete(self: GifColumnModel) = self.QAbstractListModel.delete

--- a/src/app/modules/main/gifs/view.nim
+++ b/src/app/modules/main/gifs/view.nim
@@ -12,9 +12,7 @@ QtObject:
       gifColumnCModel: GifColumnModel
       gifLoading: bool
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -138,3 +136,7 @@ QtObject:
   proc isFavorite*(self: View, id: string): bool {.slot.} =
     let gifItem = self.findGifDto(id)
     return self.delegate.isFavorite(gifItem)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/market_section/market_leaderboard_model.nim
+++ b/src/app/modules/main/market_section/market_leaderboard_model.nim
@@ -19,12 +19,8 @@ QtObject:
   type MarketLeaderboardModel* = ref object of QAbstractListModel
     delegate: io_interface.MarketLeaderboardDataSource
 
-  proc setup(self: MarketLeaderboardModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: MarketLeaderboardModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: MarketLeaderboardModel)
+  proc delete(self: MarketLeaderboardModel)
   proc newMarketLeaderboardModel*(
     delegate: io_interface.MarketLeaderboardDataSource,
     ): MarketLeaderboardModel =
@@ -95,3 +91,10 @@ QtObject:
 
       if changedRoles.len > 0:
         self.dataChanged(modelIndex, modelIndex, changedRoles)
+
+  proc setup(self: MarketLeaderboardModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: MarketLeaderboardModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/market_section/view.nim
+++ b/src/app/modules/main/market_section/view.nim
@@ -10,12 +10,8 @@ QtObject:
       delegate: io_interface.AccessInterface
       marketLeaderboardModel: MarketLeaderboardModel
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.delegate = delegate
@@ -74,3 +70,10 @@ QtObject:
 
   proc updatePage*(self: View, updates: seq[LeaderboardTokenUpdated]) =
     self.marketLeaderboardModel.pageUpdated(updates)
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/network_connection/network_connection_item.nim
+++ b/src/app/modules/main/network_connection/network_connection_item.nim
@@ -7,9 +7,7 @@ QtObject:
     chainIds: string
     lastCheckedAt: int
 
-  proc delete*(self: NetworkConnectionItem) =
-    self.QObject.delete
-
+  proc delete*(self: NetworkConnectionItem)
   proc newNetworkConnectionItem*(completelyDown = false, connectionState = 0, chainIds = "", lastCheckedAt = 0): NetworkConnectionItem =
     new(result, delete)
     result.QObject.setup
@@ -71,3 +69,7 @@ QtObject:
       if self.lastCheckedAt != lastCheckedAt :
         self.lastCheckedAt = lastCheckedAt
         self.lastCheckedAtChanged()
+
+  proc delete*(self: NetworkConnectionItem) =
+    self.QObject.delete
+

--- a/src/app/modules/main/network_connection/view.nim
+++ b/src/app/modules/main/network_connection/view.nim
@@ -12,12 +12,8 @@ QtObject:
       collectiblesNetworkConnection: NetworkConnectionItem
       marketValuesNetworkConnection: NetworkConnectionItem
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.delegate = delegate
@@ -70,4 +66,10 @@ QtObject:
       of MARKET:
         self.marketValuesNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt)
     self.networkConnectionStatusUpdate(website, completelyDown, connectionState, chainIds, float(lastCheckedAt))
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
 

--- a/src/app/modules/main/node_section/view.nim
+++ b/src/app/modules/main/node_section/view.nim
@@ -12,9 +12,7 @@ QtObject:
       stats*: Stats
       peerSize: int
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -105,3 +103,7 @@ QtObject:
 
   proc setWakuV2LightClient*(self: View, enabled: bool) {.slot.} =
     self.delegate.setLightClient(enabled)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/about/view.nim
+++ b/src/app/modules/main/profile_section/about/view.nim
@@ -9,9 +9,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       fetching*: bool
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -53,3 +51,7 @@ QtObject:
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -6,9 +6,7 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -130,3 +128,7 @@ QtObject:
 
   proc setMaxLogBackups*(self: View, value: int) {.slot.} =
     self.delegate.setMaxLogBackups(value)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/communities/view.nim
+++ b/src/app/modules/main/profile_section/communities/view.nim
@@ -8,9 +8,7 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -27,3 +25,7 @@ QtObject:
 
   proc setCommunityMuted*(self: View, communityID: string, mutedType: int) {.slot.} =
     self.delegate.setCommunityMuted(communityID, mutedType)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_accounts_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_accounts_model.nim
@@ -21,12 +21,8 @@ QtObject:
     ShowcaseContactAccountModel* = ref object of QAbstractListModel
       items: seq[ShowcaseContactAccountItem]
 
-  proc delete(self: ShowcaseContactAccountModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: ShowcaseContactAccountModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: ShowcaseContactAccountModel)
+  proc setup(self: ShowcaseContactAccountModel)
   proc newShowcaseContactAccountModel*(): ShowcaseContactAccountModel =
     new(result, delete)
     result.setup
@@ -75,3 +71,10 @@ QtObject:
 
   proc clear*(self: ShowcaseContactAccountModel) {.slot.} =
     self.setItems(@[])
+
+  proc delete(self: ShowcaseContactAccountModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: ShowcaseContactAccountModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_generic_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_generic_model.nim
@@ -15,12 +15,8 @@ QtObject:
     ShowcaseContactGenericModel* = ref object of QAbstractListModel
       items: seq[ShowcaseContactGenericItem]
 
-  proc delete(self: ShowcaseContactGenericModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: ShowcaseContactGenericModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: ShowcaseContactGenericModel)
+  proc setup(self: ShowcaseContactGenericModel)
   proc newShowcaseContactGenericModel*(): ShowcaseContactGenericModel =
     new(result, delete)
     result.setup
@@ -60,3 +56,10 @@ QtObject:
 
   proc clear*(self: ShowcaseContactGenericModel) {.slot.} =
     self.setItems(@[])
+
+  proc delete(self: ShowcaseContactGenericModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: ShowcaseContactGenericModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/contacts/models/showcase_contact_social_links_model.nim
+++ b/src/app/modules/main/profile_section/contacts/models/showcase_contact_social_links_model.nim
@@ -17,12 +17,8 @@ QtObject:
     ShowcaseContactSocialLinkModel* = ref object of QAbstractListModel
       items: seq[ShowcaseContactSocialLinkItem]
 
-  proc delete(self: ShowcaseContactSocialLinkModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: ShowcaseContactSocialLinkModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: ShowcaseContactSocialLinkModel)
+  proc setup(self: ShowcaseContactSocialLinkModel)
   proc newShowcaseContactSocialLinkModel*(): ShowcaseContactSocialLinkModel =
     new(result, delete)
     result.setup
@@ -65,3 +61,10 @@ QtObject:
 
   proc clear*(self: ShowcaseContactSocialLinkModel) {.slot.} =
     self.setItems(@[])
+
+  proc delete(self: ShowcaseContactSocialLinkModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: ShowcaseContactSocialLinkModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -25,9 +25,7 @@ QtObject:
       showcaseContactSocialLinksModelVariant: QVariant
 
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -190,3 +188,7 @@ QtObject:
 
   proc loadProfileShowcaseContactSocialLinks*(self: View, items: seq[ShowcaseContactSocialLinkItem]) =
     self.showcaseContactSocialLinksModel.setItems(items)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -21,13 +21,8 @@ QtObject:
 
   proc updatePairedCount(self: Model)
 
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-    self.pairedCount = 0
-
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: Model)
+  proc delete(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -171,3 +166,11 @@ QtObject:
     if count != self.pairedCount:
       self.pairedCount = count
       self.pairedCountChanged()
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+    self.pairedCount = 0
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/profile_section/devices/view.nim
+++ b/src/app/modules/main/profile_section/devices/view.nim
@@ -13,9 +13,7 @@ QtObject:
       devicesLoadingError: bool
       localPairingStatus: LocalPairingStatus
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -150,3 +148,7 @@ QtObject:
     if error.len == 0:
       self.model.updateItemEnabled(installationId, false)
     return error
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -16,12 +16,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -107,3 +103,10 @@ QtObject:
     let index = self.createIndex(ind, 0, nil)
     defer: index.delete
     self.dataChanged(index, index, @[ModelRole.IsPending.int])
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -12,9 +12,7 @@ QtObject:
       etherscanTxLink: string
       etherscanAddressLink: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -105,3 +103,7 @@ QtObject:
 
   proc ensnameResolverAddress*(self: View, ensUsername: string): string {.slot.} =
     return self.delegate.ensnameResolverAddress(ensUsername)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/keycard/view.nim
+++ b/src/app/modules/main/profile_section/keycard/view.nim
@@ -13,9 +13,7 @@ QtObject:
       keycardDetailsModel: KeycardModel
       keycardDetailsModelVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -129,3 +127,7 @@ QtObject:
 
   proc remainingAccountCapacity*(self: View): int {.slot.} =
     return self.delegate.remainingAccountCapacity()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/language/model.nim
+++ b/src/app/modules/main/profile_section/language/model.nim
@@ -15,12 +15,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -63,3 +59,10 @@ QtObject:
       result = newQVariant(item.flag)
     of ModelRole.State:
       result = newQVariant(item.state.int)
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/language/view.nim
+++ b/src/app/modules/main/profile_section/language/view.nim
@@ -10,9 +10,7 @@ QtObject:
       modelVariant: QVariant
       currentLanguage: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -48,3 +46,7 @@ QtObject:
     if language != self.currentLanguage:
       self.currentLanguage = language
       self.languageChanged()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -22,12 +22,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete*(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete*(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -195,3 +191,10 @@ QtObject:
     let index = self.createIndex(ind, 0, nil)
     defer: index.delete
     self.dataChanged(index, index, roles)
+
+  proc delete*(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/notifications/view.nim
+++ b/src/app/modules/main/profile_section/notifications/view.nim
@@ -9,9 +9,7 @@ QtObject:
       exemptionsModel: Model
       exemptionsModelVariant: QVariant
       
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -45,3 +43,7 @@ QtObject:
   proc saveExemptions*(self: View, itemId: string, muteAllMessages: bool, personalMentions: string, 
     globalMentions: string, otherMessages: string) {.slot.} =
     self.delegate.saveExemptions(itemId, muteAllMessages, personalMentions, globalMentions, otherMessages)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/privacy/view.nim
+++ b/src/app/modules/main/profile_section/privacy/view.nim
@@ -7,9 +7,7 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -93,3 +91,7 @@ QtObject:
     
   proc emitUrlUnfurlingModeUpdated*(self: View, mode: int) =
     self.urlUnfurlingModeChanged()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_generic_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_generic_model.nim
@@ -19,12 +19,8 @@ QtObject:
     ShowcasePreferencesGenericModel* = ref object of QAbstractListModel
       items: seq[ShowcasePreferencesGenericItem]
 
-  proc delete(self: ShowcasePreferencesGenericModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: ShowcasePreferencesGenericModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: ShowcasePreferencesGenericModel)
+  proc setup(self: ShowcasePreferencesGenericModel)
   proc newShowcasePreferencesGenericModel*(): ShowcasePreferencesGenericModel =
     new(result, delete)
     result.setup
@@ -67,3 +63,10 @@ QtObject:
 
   proc clear*(self: ShowcasePreferencesGenericModel) {.slot.} =
     self.setItems(@[])
+
+  proc delete(self: ShowcasePreferencesGenericModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: ShowcasePreferencesGenericModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
+++ b/src/app/modules/main/profile_section/profile/models/showcase_preferences_social_links_model.nim
@@ -17,12 +17,8 @@ QtObject:
     ShowcasePreferencesSocialLinkModel* = ref object of QAbstractListModel
       items: seq[ShowcasePreferencesSocialLinkItem]
 
-  proc delete(self: ShowcasePreferencesSocialLinkModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: ShowcasePreferencesSocialLinkModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: ShowcasePreferencesSocialLinkModel)
+  proc setup(self: ShowcasePreferencesSocialLinkModel)
   proc newShowcasePreferencesSocialLinkModel*(): ShowcasePreferencesSocialLinkModel =
     new(result, delete)
     result.setup
@@ -65,3 +61,10 @@ QtObject:
 
   proc clear*(self: ShowcasePreferencesSocialLinkModel) {.slot.} =
     self.setItems(@[])
+
+  proc delete(self: ShowcasePreferencesSocialLinkModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: ShowcasePreferencesSocialLinkModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -21,9 +21,7 @@ QtObject:
       showcasePreferencesSocialLinksModel: ShowcasePreferencesSocialLinkModel
       showcasePreferencesSocialLinksModelVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -126,3 +124,7 @@ QtObject:
 
   proc loadProfileShowcasePreferencesSocialLinks*(self: View, items: seq[ShowcasePreferencesSocialLinkItem]) =
     self.showcasePreferencesSocialLinksModel.setItems(items)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/sync/model.nim
+++ b/src/app/modules/main/profile_section/sync/model.nim
@@ -10,12 +10,8 @@ QtObject:
   type Model* = ref object of QAbstractListModel
     items*: seq[Item]
 
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: Model)
+  proc delete(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -63,4 +59,10 @@ QtObject:
     self.beginInsertRows(parentModelIndex, first, last)
     self.items.add(items)
     self.endInsertRows()
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
 

--- a/src/app/modules/main/profile_section/sync/view.nim
+++ b/src/app/modules/main/profile_section/sync/view.nim
@@ -18,9 +18,7 @@ QtObject:
       backupImportError: string
       backupDataError: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -144,3 +142,7 @@ QtObject:
     self.setBackupImportState(BackupImportState.InProgress)
     self.setBackupImportError("")
     self.delegate.importLocalBackupFile(filePath)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/view.nim
+++ b/src/app/modules/main/profile_section/view.nim
@@ -7,12 +7,8 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.delegate = delegate
@@ -85,3 +81,10 @@ QtObject:
     return self.delegate.getWalletModule()
   QtProperty[QVariant] walletModule:
     read = getWalletModule
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/waku/view.nim
+++ b/src/app/modules/main/profile_section/waku/view.nim
@@ -7,9 +7,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       activeMailserver: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -31,3 +29,7 @@ QtObject:
   proc onActiveMailserverChanged*(self: View, activeMailserverId: string) =
     self.activeMailserver = activeMailserverId
     self.activeMailserverChanged()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -19,12 +19,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[WalletAccountItem]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -127,3 +123,10 @@ QtObject:
     self.items.insert(@[currentItem], toRow)
     self.endMoveRows()
     return true
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/profile_section/wallet/accounts/view.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/view.nim
@@ -18,9 +18,7 @@ QtObject:
       selectedKeyPair: KeyPairItem
       selectedAccount: KeyPairAccountItem
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -133,3 +131,7 @@ QtObject:
 
   proc updateWatchAccountHiddenFromTotalBalance*(self: View, address: string, hideFromTotalBalance: bool) {.slot.} =
     self.delegate.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/profile_section/wallet/view.nim
+++ b/src/app/modules/main/profile_section/wallet/view.nim
@@ -8,9 +8,7 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -59,3 +57,7 @@ QtObject:
     return self.delegate.getRpcStats()
   proc resetRpcStats(self: View) {.slot.} =
     self.delegate.resetRpcStats()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/shared_urls/view.nim
+++ b/src/app/modules/main/shared_urls/view.nim
@@ -7,9 +7,7 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -26,3 +24,7 @@ QtObject:
 
   proc parseContactSharedUrl*(self: View, url: string): string {.slot.} =
     return self.delegate.parseContactSharedUrl(url)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/stickers/models/sticker_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_list.nim
@@ -13,10 +13,8 @@ QtObject:
       delegate: io_interface.AccessInterface
       stickers*: seq[Item]
 
-  proc setup(self: StickerList) = self.QAbstractListModel.setup
-
-  proc delete(self: StickerList) = self.QAbstractListModel.delete
-
+  proc setup(self: StickerList)
+  proc delete(self: StickerList)
   proc newStickerList*(delegate: io_interface.AccessInterface, stickers: seq[Item] = @[]): StickerList =
     new(result, delete)
     result.delegate = delegate
@@ -74,3 +72,7 @@ QtObject:
     self.beginRemoveRows(modelIndex, idx, idx)
     self.stickers.delete(idx)
     self.endRemoveRows()
+
+  proc setup(self: StickerList) = self.QAbstractListModel.setup
+
+  proc delete(self: StickerList) = self.QAbstractListModel.delete

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -29,20 +29,18 @@ QtObject:
       packs*: seq[StickerPackView]
       foundStickers*: QVariant
 
-  proc setup(self: StickerPackList) = self.QAbstractListModel.setup
-
-  proc delete(self: StickerPackList) = self.QAbstractListModel.delete
-
-  proc clear*(self: StickerPackList) =
-    self.beginResetModel()
-    self.packs = @[]
-    self.endResetModel()
-
+  proc setup(self: StickerPackList)
+  proc delete(self: StickerPackList)
   proc newStickerPackList*(delegate: io_interface.AccessInterface): StickerPackList =
     new(result, delete)
     result.delegate = delegate
     result.packs = @[]
     result.setup()
+
+  proc clear*(self: StickerPackList) =
+    self.beginResetModel()
+    self.packs = @[]
+    self.endResetModel()
 
   method rowCount(self: StickerPackList, index: QModelIndex = nil): int = self.packs.len
 
@@ -140,3 +138,6 @@ QtObject:
 
   proc getFoundStickers*(self: StickerPackList): QVariant {.slot.} =
     return self.foundStickers
+
+  proc setup(self: StickerPackList) = self.QAbstractListModel.setup
+  proc delete(self: StickerPackList) = self.QAbstractListModel.delete

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -14,9 +14,7 @@ QtObject:
       recentStickers*: StickerList
       stickersMarketAddress: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -173,3 +171,7 @@ QtObject:
   proc transactionCompleted(self: View, success: bool, txHash: string, packID: string, trxType: string) {.signal.}
   proc emitTransactionCompletedSignal*(self: View, success: bool, txHash: string, packID: string, trxType: string) =
     self.transactionCompleted(success, txHash, packID, trxType)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -25,9 +25,7 @@ QtObject:
 
   proc activeSectionSet*(self: View, item: SectionItem)
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -418,3 +416,7 @@ QtObject:
   proc loggedInUserAuthenticated(self: View, requestedBy: string, password: string, pin: string, keyUid: string, keycardUid: string) {.signal.}
   proc emitLoggedInUserAuthenticated*(self: View, requestedBy: string, password: string, pin: string, keyUid: string, keycardUid: string) =
     self.loggedInUserAuthenticated(requestedBy, password, pin, keyUid, keycardUid)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -11,7 +11,6 @@ QtObject:
     currencyBalance: CurrencyAmount
     isWallet: bool
     canSend: bool
-
   proc setup*(self: Item,
     name: string,
     address: string,
@@ -30,30 +29,8 @@ QtObject:
     areTestNetworksEnabled: bool,
     hideFromTotalBalance: bool,
     canSend: bool
-  ) =
-    self.QObject.setup
-    self.WalletAccountItem.setup(name,
-      address,
-      mixedcaseAddress,
-      colorId,
-      emoji,
-      walletType,
-      path,
-      keyUid,
-      keycardAccount,
-      position,
-      operability = wa_dto.AccountFullyOperable,
-      areTestNetworksEnabled,
-      hideFromTotalBalance)
-    self.createdAt = createdAt
-    self.assetsLoading = assetsLoading
-    self.currencyBalance = currencyBalance
-    self.isWallet = isWallet
-    self.canSend = canSend
-
-  proc delete*(self: Item) =
-    self.QObject.delete
-
+  )
+  proc delete*(self: Item)
   proc newItem*(
     name: string = "",
     address: string = "",
@@ -131,3 +108,45 @@ QtObject:
 
   proc setHideFromTotalBalance*(self: Item, value: bool) =
     self.hideFromTotalBalance = value
+
+  proc delete*(self: Item) =
+    self.QObject.delete
+
+  proc setup*(self: Item,
+    name: string,
+    address: string,
+    mixedcaseAddress: string,
+    path: string,
+    colorId: string,
+    walletType: string,
+    currencyBalance: CurrencyAmount,
+    emoji: string,
+    keyUid: string,
+    createdAt: int,
+    position: int,
+    keycardAccount: bool,
+    assetsLoading: bool,
+    isWallet: bool,
+    areTestNetworksEnabled: bool,
+    hideFromTotalBalance: bool,
+    canSend: bool
+  ) =
+    self.QObject.setup
+    self.WalletAccountItem.setup(name,
+      address,
+      mixedcaseAddress,
+      colorId,
+      emoji,
+      walletType,
+      path,
+      keyUid,
+      keycardAccount,
+      position,
+      operability = wa_dto.AccountFullyOperable,
+      areTestNetworksEnabled,
+      hideFromTotalBalance)
+    self.createdAt = createdAt
+    self.assetsLoading = assetsLoading
+    self.currencyBalance = currencyBalance
+    self.isWallet = isWallet
+    self.canSend = canSend

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -27,12 +27,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -252,3 +248,10 @@ QtObject:
     if i < 0:
       return false
     return self.items[i].walletType != "watch"
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -14,9 +14,7 @@ QtObject:
       accounts: Model
       accountsVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -77,3 +75,7 @@ QtObject:
 
   proc getWalletAccountAsJson*(self: View, address: string): string {.slot.} =
     return $self.delegate.getWalletAccountAsJson(address)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/activity/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/activity/collectibles_model.nim
@@ -21,12 +21,8 @@ QtObject:
       items: seq[CollectibleItem]
       hasMore: bool
 
-  proc delete(self: CollectiblesModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: CollectiblesModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: CollectiblesModel)
+  proc setup(self: CollectiblesModel)
   proc newCollectiblesModel*(): CollectiblesModel =
     new(result, delete)
     result.setup
@@ -205,3 +201,10 @@ QtObject:
     if chainId > 0 and len(tokenAddress) > 0 and len(tokenId) > 0:
       return $chainId & "+" & tokenAddress & "+" & tokenId
     return ""
+
+  proc delete(self: CollectiblesModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: CollectiblesModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -59,11 +59,37 @@ QtObject:
       # call updateAssetsIdentities after updating chainIds
       chainIds: seq[int]
 
-  proc setup(self: Controller) =
-    self.QObject.setup
+  proc setup(self: Controller)
+  proc delete*(self: Controller)
+  proc setupEventHandlers(self: Controller, events: EventEmitter)
+  proc newController*(currencyService: currency_service.Service,
+                      tokenService: token_service.Service,
+                      savedAddressService: saved_address_service.Service,
+                      networkService: network_service.Service,
+                      events: EventEmitter): Controller =
+    new(result, delete)
 
-  proc delete*(self: Controller) =
-    self.QObject.delete
+    result.model = newModel()
+    result.recipientsModel = newRecipientsModel()
+    result.collectiblesModel = newCollectiblesModel()
+    result.tokenService = tokenService
+    result.savedAddressService = savedAddressService
+    result.networkService = networkService
+    result.currentActivityFilter = backend_activity.getIncludeAllActivityFilter()
+
+    result.eventsHandler = newEventsHandler(events)
+    result.status = newStatus()
+
+    result.currencyService = currencyService
+
+    result.filterTokenCodes = initHashSet[string]()
+
+    result.addresses = @[]
+    result.chainIds = @[]
+
+    result.setup()
+
+    result.setupEventHandlers(events)
 
   proc getModel*(self: Controller): QVariant {.slot.} =
     return newQVariant(self.model)
@@ -304,35 +330,6 @@ QtObject:
         error "Error converting activity entries: ", code = e.msg
     )
 
-  proc newController*(currencyService: currency_service.Service,
-                      tokenService: token_service.Service,
-                      savedAddressService: saved_address_service.Service,
-                      networkService: network_service.Service,
-                      events: EventEmitter): Controller =
-    new(result, delete)
-
-    result.model = newModel()
-    result.recipientsModel = newRecipientsModel()
-    result.collectiblesModel = newCollectiblesModel()
-    result.tokenService = tokenService
-    result.savedAddressService = savedAddressService
-    result.networkService = networkService
-    result.currentActivityFilter = backend_activity.getIncludeAllActivityFilter()
-
-    result.eventsHandler = newEventsHandler(events)
-    result.status = newStatus()
-
-    result.currencyService = currencyService
-
-    result.filterTokenCodes = initHashSet[string]()
-
-    result.addresses = @[]
-    result.chainIds = @[]
-
-    result.setup()
-
-    result.setupEventHandlers(events)
-
   proc setFilterStatus*(self: Controller, statusesArrayJsonString: string) {.slot.} =
     let statusesJson = parseJson(statusesArrayJsonString)
     if statusesJson.kind != JArray:
@@ -510,3 +507,10 @@ QtObject:
 
   proc noLimitTimestamp*(self: Controller): int {.slot.} =
     return backend_activity.noLimitTimestampForPeriod
+
+  proc setup(self: Controller) =
+    self.QObject.setup
+
+  proc delete*(self: Controller) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -41,12 +41,8 @@ QtObject:
       # true for entries that were changed/added in the current session
       highlight: bool
 
-  proc setup(self: ActivityEntry) =
-    self.QObject.setup
-
-  proc delete*(self: ActivityEntry) =
-    self.QObject.delete
-
+  proc setup(self: ActivityEntry)
+  proc delete*(self: ActivityEntry)
   proc isInTransactionType(self: ActivityEntry): bool =
     return self.metadata.activityType == backend.ActivityType.Receive or self.metadata.activityType == backend.ActivityType.Mint
 
@@ -379,3 +375,10 @@ QtObject:
   QtProperty[bool] highlight:
     read = getHighlight
     notify = highlightChanged
+
+  proc setup(self: ActivityEntry) =
+    self.QObject.setup
+
+  proc delete*(self: ActivityEntry) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/activity/events_handler.nim
+++ b/src/app/modules/main/wallet_section/activity/events_handler.nim
@@ -20,12 +20,8 @@ QtObject:
 
       sessionId: Option[int32]
 
-  proc setup(self: EventsHandler) =
-    self.QObject.setup
-
-  proc delete*(self: EventsHandler) =
-    self.QObject.delete
-
+  proc setup(self: EventsHandler)
+  proc delete*(self: EventsHandler)
   proc onFilteringDone*(self: EventsHandler, handler: EventCallbackProc) =
     self.eventHandlers[backend_activity.eventActivityFilteringDone] = handler
 
@@ -85,4 +81,10 @@ QtObject:
 
   proc clearSessionId*(self: EventsHandler) =
     self.sessionId = none(int32)
+
+  proc setup(self: EventsHandler) =
+    self.QObject.setup
+
+  proc delete*(self: EventsHandler) =
+    self.QObject.delete
 

--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -16,12 +16,8 @@ QtObject:
       entries: seq[entry.ActivityEntry]
       hasMore: bool
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
 
@@ -143,3 +139,10 @@ QtObject:
   proc refreshAmountCurrency*(self: Model, currencyService: Service) =
     for i in 0..self.entries.high:
       self.entries[i].resetAmountCurrency(currencyService)
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/activity/recipients_model.nim
+++ b/src/app/modules/main/wallet_section/activity/recipients_model.nim
@@ -12,12 +12,8 @@ QtObject:
       # TODO: store resolved names here along addresses
       hasMore: bool
 
-  proc delete(self: RecipientsModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: RecipientsModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: RecipientsModel)
+  proc setup(self: RecipientsModel)
   proc newRecipientsModel*(): RecipientsModel =
     new(result, delete)
 
@@ -92,4 +88,10 @@ QtObject:
   QtProperty[bool] hasMore:
     read = getHasMore
     notify = hasMoreChanged
+
+  proc delete(self: RecipientsModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: RecipientsModel) =
+    self.QAbstractListModel.setup
 

--- a/src/app/modules/main/wallet_section/activity/status.nim
+++ b/src/app/modules/main/wallet_section/activity/status.nim
@@ -23,11 +23,15 @@ QtObject:
 
       isFilterDirty: bool
 
-  proc setup(self: Status) =
-    self.QObject.setup
+  proc setup(self: Status)
+  proc delete*(self: Status)
+  proc newStatus*(): Status =
+    new(result, delete)
 
-  proc delete*(self: Status) =
-    self.QObject.delete
+    result.errorCode = backend_activity.ErrorCode.ErrorCodeSuccess
+    result.isFilterDirty = false
+
+    result.setup()
 
   proc filterChainsChanged*(self: Status) {.signal.}
 
@@ -65,14 +69,6 @@ QtObject:
   proc setErrorCode*(self: Status, errorCode: int) =
     self.errorCode = backend_activity.ErrorCode(errorCode)
     self.errorCodeChanged()
-
-  proc newStatus*(): Status =
-    new(result, delete)
-
-    result.errorCode = backend_activity.ErrorCode.ErrorCodeSuccess
-    result.isFilterDirty = false
-
-    result.setup()
 
   proc getLoadingData*(self: Status): bool {.slot.} =
     return self.loadingData
@@ -144,3 +140,10 @@ QtObject:
   QtProperty[bool] isFilterDirty:
     read = getIsFilterDirty
     notify = isFilterDirtyChanged
+
+  proc setup(self: Status) =
+    self.QObject.setup
+
+  proc delete*(self: Status) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/activity/transaction_identities_model.nim
+++ b/src/app/modules/main/wallet_section/activity/transaction_identities_model.nim
@@ -13,12 +13,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[backend.TransactionIdentity]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.items = @[]
@@ -70,4 +66,10 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
 

--- a/src/app/modules/main/wallet_section/all_collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/all_collectibles/view.nim
@@ -10,9 +10,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       allCollectiblesModel: collectibles_model.Model
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -68,3 +66,7 @@ QtObject:
       error "Failed to toggle collectibleGroupByCollection"
       return
     self.collectibleGroupByCollectionChanged()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/all_tokens/address_per_chain_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/address_per_chain_model.nim
@@ -12,13 +12,8 @@ QtObject:
     delegate: io_interface.TokenBySymbolModelDataSource
     index: int
 
-  proc setup(self: AddressPerChainModel) =
-    self.QAbstractListModel.setup
-    self.index = 0
-
-  proc delete(self: AddressPerChainModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: AddressPerChainModel)
+  proc delete(self: AddressPerChainModel)
   proc newAddressPerChainModel*(delegate: io_interface.TokenBySymbolModelDataSource, index: int): AddressPerChainModel =
     new(result, delete)
     result.setup
@@ -53,3 +48,11 @@ QtObject:
         result = newQVariant(item.chainId)
       of ModelRole.Address:
         result = newQVariant(item.address)
+
+  proc setup(self: AddressPerChainModel) =
+    self.QAbstractListModel.setup
+    self.index = 0
+
+  proc delete(self: AddressPerChainModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/flat_tokens_model.nim
@@ -40,12 +40,8 @@ QtObject:
     marketValuesDelegate: io_interface.TokenMarketValuesDataSource
     tokenMarketDetails: seq[MarketDetailsItem]
 
-  proc setup(self: FlatTokensModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: FlatTokensModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: FlatTokensModel)
+  proc delete(self: FlatTokensModel)
   proc newFlatTokensModel*(
     delegate: io_interface.FlatTokenModelDataSource,
     marketValuesDelegate: io_interface.TokenMarketValuesDataSource
@@ -185,3 +181,10 @@ QtObject:
       defer: index.delete
       defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Visible.int, ModelRole.Position.int])
+
+  proc setup(self: FlatTokensModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: FlatTokensModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/wallet_section/all_tokens/sources_of_tokens_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/sources_of_tokens_model.nim
@@ -17,12 +17,8 @@ QtObject:
   type SourcesOfTokensModel* = ref object of QAbstractListModel
     delegate: io_interface.SourcesOfTokensModelDataSource
 
-  proc setup(self: SourcesOfTokensModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: SourcesOfTokensModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: SourcesOfTokensModel)
+  proc delete(self: SourcesOfTokensModel)
   proc newSourcesOfTokensModel*(delegate: io_interface.SourcesOfTokensModelDataSource): SourcesOfTokensModel =
     new(result, delete)
     result.setup
@@ -72,3 +68,10 @@ QtObject:
   proc modelsUpdated*(self: SourcesOfTokensModel) =
       self.beginResetModel()
       self.endResetModel()
+
+  proc setup(self: SourcesOfTokensModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: SourcesOfTokensModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/token_by_symbol_model.nim
@@ -40,14 +40,8 @@ QtObject:
     addressPerChainModel: seq[AddressPerChainModel]
     tokenMarketDetails: seq[MarketDetailsItem]
 
-  proc setup(self: TokensBySymbolModel) =
-    self.QAbstractListModel.setup
-    self.addressPerChainModel = @[]
-    self.tokenMarketDetails = @[]
-
-  proc delete(self: TokensBySymbolModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokensBySymbolModel)
+  proc delete(self: TokensBySymbolModel)
   proc newTokensBySymbolModel*(
     delegate: io_interface.TokenBySymbolModelDataSource,
     marketValuesDelegate: io_interface.TokenMarketValuesDataSource
@@ -193,3 +187,12 @@ QtObject:
       defer: index.delete
       defer: lastindex.delete
       self.dataChanged(index, lastindex, @[ModelRole.Visible.int, ModelRole.Position.int])
+
+  proc setup(self: TokensBySymbolModel) =
+    self.QAbstractListModel.setup
+    self.addressPerChainModel = @[]
+    self.tokenMarketDetails = @[]
+
+  proc delete(self: TokensBySymbolModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/wallet_section/all_tokens/view.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/view.nim
@@ -20,9 +20,7 @@ QtObject:
       # of symbol clash when minting community tokens
       tokensBySymbolModel: TokensBySymbolModel
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -231,3 +229,7 @@ QtObject:
   QtProperty[bool] autoRefreshTokensLists:
     read = getAutoRefreshTokensLists
     notify = autoRefreshTokensListsChanged
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/assets/balances_model.nim
+++ b/src/app/modules/main/wallet_section/assets/balances_model.nim
@@ -14,12 +14,8 @@ QtObject:
     delegate: io_interface.GroupedAccountAssetsDataSource
     index: int
 
-  proc setup(self: BalancesModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: BalancesModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: BalancesModel)
+  proc delete(self: BalancesModel)
   proc newBalancesModel*(delegate: io_interface.GroupedAccountAssetsDataSource, index: int): BalancesModel =
     new(result, delete)
     result.setup
@@ -63,3 +59,10 @@ QtObject:
         result = newQVariant(item.balance1DayAgo.toString(10))
       of ModelRole.Account:
         result = newQVariant(item.account)
+
+  proc setup(self: BalancesModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: BalancesModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
+++ b/src/app/modules/main/wallet_section/assets/grouped_account_assets_model.nim
@@ -13,13 +13,8 @@ QtObject:
       delegate: io_interface.GroupedAccountAssetsDataSource
       balancesPerChain: seq[BalancesModel]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-    self.balancesPerChain = @[]
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(delegate: io_interface.GroupedAccountAssetsDataSource): Model =
     new(result, delete)
     result.setup
@@ -72,3 +67,11 @@ QtObject:
         self.balancesPerChain.add(newBalancesModel(self.delegate, balancesPerChainLen+i))
     self.endResetModel()
     self.countChanged()
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+    self.balancesPerChain = @[]
+

--- a/src/app/modules/main/wallet_section/assets/view.nim
+++ b/src/app/modules/main/wallet_section/assets/view.nim
@@ -12,12 +12,8 @@ QtObject:
       hasBalanceCache: bool
       hasMarketValuesCache: bool
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.setup()
@@ -62,3 +58,10 @@ QtObject:
 
   proc modelsUpdated*(self: View) =
     self.groupedAccountAssetsModel.modelsUpdated()
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/model.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/model.nim
@@ -20,12 +20,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       list: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup()
@@ -83,3 +79,10 @@ QtObject:
     self.beginResetModel()
     self.list = items
     self.endResetModel()
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/buy_sell_crypto/view.nim
+++ b/src/app/modules/main/wallet_section/buy_sell_crypto/view.nim
@@ -15,9 +15,7 @@ QtObject:
       modelVariant: QVariant
       isFetching: bool
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -84,3 +82,7 @@ QtObject:
 
   proc onProviderUrlReady*(self: View, uuid: string, url: string) =
     self.providerUrlReady(uuid, url)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/networks/model.nim
+++ b/src/app/modules/main/wallet_section/networks/model.nim
@@ -27,12 +27,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       delegate: io_interface.NetworksDataSource
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(delegate: io_interface.NetworksDataSource): Model =
     new(result, delete)
     result.setup
@@ -161,3 +157,10 @@ QtObject:
           chainIds.add(chainId)
           enable = true
     return (chainIds, enable)
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/networks/rpc_providers_model.nim
+++ b/src/app/modules/main/wallet_section/networks/rpc_providers_model.nim
@@ -22,12 +22,8 @@ QtObject:
   type RpcProvidersModel* = ref object of QAbstractListModel
     delegate: io_interface.NetworksDataSource
 
-  proc setup(self: RpcProvidersModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: RpcProvidersModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: RpcProvidersModel)
+  proc delete(self: RpcProvidersModel)
   proc newRpcProvidersModel*(delegate: io_interface.NetworksDataSource): RpcProvidersModel =
     new(result, delete)
     result.setup
@@ -86,3 +82,10 @@ QtObject:
   proc refreshModel*(self: RpcProvidersModel) =
     self.beginResetModel()
     self.endResetModel()
+
+  proc setup(self: RpcProvidersModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: RpcProvidersModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/main/wallet_section/networks/view.nim
+++ b/src/app/modules/main/wallet_section/networks/view.nim
@@ -11,12 +11,8 @@ QtObject:
       areTestNetworksEnabled: bool
       enabledChainIds: string
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.delegate = delegate
@@ -96,3 +92,10 @@ QtObject:
     self.delegate.fetchChainIdForUrl(url, isMainUrl)
 
   proc chainIdFetchedForUrl*(self: View, url: string, chainId: int, success: bool, isMainUrl: bool) {.signal.}
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/overview/view.nim
+++ b/src/app/modules/main/wallet_section/overview/view.nim
@@ -21,12 +21,8 @@ QtObject:
       isWatchOnlyAccount: bool
       canSend: bool
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.setup()
@@ -150,3 +146,10 @@ QtObject:
     if(self.isAllAccounts != item.getIsAllAccounts()):
       self.isAllAccounts = item.getIsAllAccounts()
       self.isAllAccountsChanged()
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/saved_addresses/model.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/model.nim
@@ -19,12 +19,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -103,3 +99,10 @@ QtObject:
         (item.getIsTest() == isTest):
           return true
     return false
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/saved_addresses/view.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/view.nim
@@ -10,9 +10,7 @@ QtObject:
       model: Model
       modelVariant: QVariant
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -56,3 +54,7 @@ QtObject:
 
   proc remainingCapacityForSavedAddresses*(self: View): int {.slot.} =
     return self.delegate.remainingCapacityForSavedAddresses()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/send/gas_estimate_item.nim
+++ b/src/app/modules/main/wallet_section/send/gas_estimate_item.nim
@@ -10,15 +10,8 @@ QtObject:
     totalFeesInNativeCrypto: float,
     totalTokenFees: float,
     totalTime: int
-  ) =
-    self.QObject.setup
-    self.totalFeesInNativeCrypto = totalFeesInNativeCrypto
-    self.totalTokenFees = totalTokenFees
-    self.totalTime = totalTime
-
-  proc delete*(self: GasEstimateItem) =
-      self.QObject.delete
-
+  )
+  proc delete*(self: GasEstimateItem)
   proc newGasEstimateItem*(
     totalFeesInNativeCrypto: float = 0,
     totalTokenFees: float = 0,
@@ -54,3 +47,16 @@ QtObject:
   QtProperty[int] totalTime:
     read = getTotalTime
     notify = totalTimeChanged
+
+  proc delete*(self: GasEstimateItem) =
+      self.QObject.delete
+
+  proc setup*(self: GasEstimateItem,
+    totalFeesInNativeCrypto: float,
+    totalTokenFees: float,
+    totalTime: int
+  ) =
+    self.QObject.setup
+    self.totalFeesInNativeCrypto = totalFeesInNativeCrypto
+    self.totalTokenFees = totalTokenFees
+    self.totalTime = totalTime

--- a/src/app/modules/main/wallet_section/send/gas_fees_item.nim
+++ b/src/app/modules/main/wallet_section/send/gas_fees_item.nim
@@ -12,28 +12,16 @@ QtObject:
     eip1559Enabled: bool
 
   proc setup*(self: GasFeesItem,
-    gasPrice: float,
-    baseFee: float,
-    maxPriorityFeePerGas: float,
-    maxFeePerGasL: float,
-    maxFeePerGasM: float,
-    maxFeePerGasH: float,
-    l1GasFee: float,
-    eip1559Enabled: bool
-  ) =
-    self.QObject.setup
-    self.gasPrice = gasPrice
-    self.baseFee = baseFee
-    self.maxPriorityFeePerGas = maxPriorityFeePerGas
-    self.maxFeePerGasL = maxFeePerGasL
-    self.maxFeePerGasM = maxFeePerGasM
-    self.maxFeePerGasH = maxFeePerGasH
-    self.l1GasFee = l1GasFee
-    self.eip1559Enabled = eip1559Enabled
-
-  proc delete*(self: GasFeesItem) =
-      self.QObject.delete
-
+      gasPrice: float,
+      baseFee: float,
+      maxPriorityFeePerGas: float,
+      maxFeePerGasL: float,
+      maxFeePerGasM: float,
+      maxFeePerGasH: float,
+      l1GasFee: float,
+      eip1559Enabled: bool
+    )
+  proc delete*(self: GasFeesItem)
   proc newGasFeesItem*(
     gasPrice: float = 0,
     baseFee: float = 0,
@@ -98,3 +86,26 @@ QtObject:
     return self.eip1559Enabled
   QtProperty[bool] eip1559Enabled:
     read = getEip1559Enabled
+
+  proc delete*(self: GasFeesItem) =
+      self.QObject.delete
+
+  proc setup*(self: GasFeesItem,
+    gasPrice: float,
+    baseFee: float,
+    maxPriorityFeePerGas: float,
+    maxFeePerGasL: float,
+    maxFeePerGasM: float,
+    maxFeePerGasH: float,
+    l1GasFee: float,
+    eip1559Enabled: bool
+  ) =
+    self.QObject.setup
+    self.gasPrice = gasPrice
+    self.baseFee = baseFee
+    self.maxPriorityFeePerGas = maxPriorityFeePerGas
+    self.maxFeePerGasL = maxFeePerGasL
+    self.maxFeePerGasM = maxFeePerGasM
+    self.maxFeePerGasH = maxFeePerGasH
+    self.l1GasFee = l1GasFee
+    self.eip1559Enabled = eip1559Enabled

--- a/src/app/modules/main/wallet_section/send/network_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_route_model.nim
@@ -19,12 +19,8 @@ QtObject:
   type NetworkRouteModel* = ref object of QAbstractListModel
     items*: seq[NetworkRouteItem]
 
-  proc delete(self: NetworkRouteModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: NetworkRouteModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: NetworkRouteModel)
+  proc setup(self: NetworkRouteModel)
   proc newNetworkRouteModel*(): NetworkRouteModel =
     new(result, delete)
     result.setup
@@ -202,3 +198,10 @@ QtObject:
       if(self.items[i].getChainId() == chainId):
         self.items[i].isRouteEnabled = true
       self.dataChanged(index, index, @[ModelRole.IsRouteEnabled.int])
+
+  proc delete(self: NetworkRouteModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: NetworkRouteModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/send/suggested_route_item.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_item.nim
@@ -53,35 +53,8 @@ QtObject:
     txL1FeeInWei: string,
     approvalFeeInWei: string,
     approvalL1FeeInWei: string
-  ) =
-    self.QObject.setup
-    self.bridgeName = bridgeName
-    self.fromNetwork = fromNetwork
-    self.toNetwork = toNetwork
-    self.maxAmountIn = maxAmountIn
-    self.amountIn = amountIn
-    self.amountOut = amountOut
-    self.gasAmount = gasAmount
-    self.gasFees = gasFees
-    self.tokenFees = tokenFees
-    self.cost = cost
-    self.estimatedTime = estimatedTime
-    self.amountInLocked = amountInLocked
-    self.isFirstSimpleTx = isFirstSimpleTx
-    self.isFirstBridgeTx = isFirstBridgeTx
-    self.approvalRequired = approvalRequired
-    self.approvalGasFees = approvalGasFees
-    self.approvalAmountRequired = approvalAmountRequired
-    self.approvalContractAddress = approvalContractAddress
-    self.slippagePercentage = slippagePercentage
-    self.txFeeInWei = txFeeInWei
-    self.txL1FeeInWei = txL1FeeInWei
-    self.approvalFeeInWei = approvalFeeInWei
-    self.approvalL1FeeInWei = approvalL1FeeInWei
-
-  proc delete*(self: SuggestedRouteItem) =
-      self.QObject.delete
-
+  )
+  proc delete*(self: SuggestedRouteItem)
   proc newSuggestedRouteItem*(
     bridgeName: string = "",
     fromNetwork: int = 0,
@@ -300,3 +273,56 @@ QtObject:
   QtProperty[string] approvalL1FeeInWei:
     read = getApprovalL1FeeInWei
     notify = approvalL1FeeInWeiChanged
+
+  proc delete*(self: SuggestedRouteItem) =
+      self.QObject.delete
+
+  proc setup*(self: SuggestedRouteItem,
+    bridgeName: string,
+    fromNetwork: int,
+    toNetwork: int,
+    maxAmountIn: string,
+    amountIn: string,
+    amountOut: string,
+    gasAmount: string,
+    gasFees: GasFeesItem,
+    tokenFees: float,
+    cost: float,
+    estimatedTime: int,
+    amountInLocked: bool,
+    isFirstSimpleTx: bool,
+    isFirstBridgeTx: bool,
+    approvalRequired: bool,
+    approvalGasFees: float,
+    approvalAmountRequired: string,
+    approvalContractAddress: string,
+    slippagePercentage: float,
+    txFeeInWei: string,
+    txL1FeeInWei: string,
+    approvalFeeInWei: string,
+    approvalL1FeeInWei: string
+  ) =
+    self.QObject.setup
+    self.bridgeName = bridgeName
+    self.fromNetwork = fromNetwork
+    self.toNetwork = toNetwork
+    self.maxAmountIn = maxAmountIn
+    self.amountIn = amountIn
+    self.amountOut = amountOut
+    self.gasAmount = gasAmount
+    self.gasFees = gasFees
+    self.tokenFees = tokenFees
+    self.cost = cost
+    self.estimatedTime = estimatedTime
+    self.amountInLocked = amountInLocked
+    self.isFirstSimpleTx = isFirstSimpleTx
+    self.isFirstBridgeTx = isFirstBridgeTx
+    self.approvalRequired = approvalRequired
+    self.approvalGasFees = approvalGasFees
+    self.approvalAmountRequired = approvalAmountRequired
+    self.approvalContractAddress = approvalContractAddress
+    self.slippagePercentage = slippagePercentage
+    self.txFeeInWei = txFeeInWei
+    self.txL1FeeInWei = txL1FeeInWei
+    self.approvalFeeInWei = approvalFeeInWei
+    self.approvalL1FeeInWei = approvalL1FeeInWei

--- a/src/app/modules/main/wallet_section/send/suggested_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_model.nim
@@ -11,12 +11,8 @@ QtObject:
     SuggestedRouteModel* = ref object of QAbstractListModel
       items*: seq[SuggestedRouteItem]
 
-  proc delete(self: SuggestedRouteModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: SuggestedRouteModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: SuggestedRouteModel)
+  proc setup(self: SuggestedRouteModel)
   proc newSuggestedRouteModel*(): SuggestedRouteModel =
     new(result, delete)
     result.setup
@@ -67,3 +63,10 @@ QtObject:
     case enumRole:
     of ModelRole.Route:
       result = newQVariant(item)
+
+  proc delete(self: SuggestedRouteModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: SuggestedRouteModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/send/transaction_routes.nim
+++ b/src/app/modules/main/wallet_section/send/transaction_routes.nim
@@ -18,18 +18,8 @@ QtObject:
     amountToReceive: UInt256,
     toNetworksRouteModel: NetworkRouteModel,
     rawPaths: string
-    ) =
-      self.QObject.setup
-      self.uuid = uuid
-      self.suggestedRoutes = suggestedRoutes
-      self.gasTimeEstimate = gasTimeEstimate
-      self.amountToReceive = amountToReceive
-      self.toNetworksRouteModel = toNetworksRouteModel
-      self.rawPaths = rawPaths
-
-  proc delete*(self: TransactionRoutes) =
-      self.QObject.delete
-
+    )
+  proc delete*(self: TransactionRoutes)
   proc newTransactionRoutes*(
     uuid: string = "",
     suggestedRoutes: SuggestedRouteModel = newSuggestedRouteModel(),
@@ -92,3 +82,22 @@ QtObject:
   QtProperty[string] rawPaths:
     read = getRawPaths
     notify = rawPathsChanged
+
+  proc delete*(self: TransactionRoutes) =
+      self.QObject.delete
+
+  proc setup*(self: TransactionRoutes,
+    uuid: string,
+    suggestedRoutes: SuggestedRouteModel,
+    gasTimeEstimate: GasEstimateItem,
+    amountToReceive: UInt256,
+    toNetworksRouteModel: NetworkRouteModel,
+    rawPaths: string
+    ) =
+      self.QObject.setup
+      self.uuid = uuid
+      self.suggestedRoutes = suggestedRoutes
+      self.gasTimeEstimate = gasTimeEstimate
+      self.amountToReceive = amountToReceive
+      self.toNetworksRouteModel = toNetworksRouteModel
+      self.rawPaths = rawPaths

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -33,9 +33,7 @@ QtObject:
   proc updateNetworksDisabledChains(self: View)
   proc updateNetworksTokenBalance(self: View)
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -291,3 +289,7 @@ QtObject:
 
   proc setReceiverAccount*(self: View, address: string) {.slot.} =
     self.setSelectedReceiveAccountAddress(address)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/send_new/path_item.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_item.nim
@@ -116,67 +116,8 @@ QtObject:
     approvalEstimatedTime: int,
     approvalFee: string,
     approvalL1Fee: string
-  ) =
-    self.QObject.setup
-    self.processorName = processorName
-    self.fromChain = fromChain
-    self.fromChainEIP1559Compliant = fromChainEIP1559Compliant
-    self.fromChainNoBaseFee = fromChainNoBaseFee
-    self.fromChainNoPriorityFee = fromChainNoPriorityFee
-    self.toChain = toChain
-    self.fromToken = fromToken
-    self.toToken = toToken
-    self.amountIn = amountIn
-    self.amountInLocked = amountInLocked
-    self.amountOut = amountOut
-    self.suggestedNonEIP1559GasPrice = suggestedNonEIP1559GasPrice
-    self.suggestedNonEIP1559EstimatedTime = suggestedNonEIP1559EstimatedTime
-    self.suggestedMaxFeesPerGasLowLevel = suggestedMaxFeesPerGasLowLevel
-    self.suggestedPriorityFeePerGasLowLevel = suggestedPriorityFeePerGasLowLevel
-    self.suggestedEstimatedTimeLowLevel = suggestedEstimatedTimeLowLevel
-    self.suggestedMaxFeesPerGasMediumLevel = suggestedMaxFeesPerGasMediumLevel
-    self.suggestedPriorityFeePerGasMediumLevel = suggestedPriorityFeePerGasMediumLevel
-    self.suggestedEstimatedTimeMediumLevel = suggestedEstimatedTimeMediumLevel
-    self.suggestedMaxFeesPerGasHighLevel = suggestedMaxFeesPerGasHighLevel
-    self.suggestedPriorityFeePerGasHighLevel = suggestedPriorityFeePerGasHighLevel
-    self.suggestedEstimatedTimeHighLevel = suggestedEstimatedTimeHighLevel
-    self.suggestedMinPriorityFee = suggestedMinPriorityFee
-    self.suggestedMaxPriorityFee = suggestedMaxPriorityFee
-    self.currentBaseFee = currentBaseFee
-    self.suggestedTxNonce = suggestedTxNonce
-    self.suggestedTxGasAmount = suggestedTxGasAmount
-    self.suggestedApprovalTxNonce = suggestedApprovalTxNonce
-    self.suggestedApprovalGasAmount = suggestedApprovalGasAmount
-    self.txNonce = txNonce
-    self.txGasPrice = txGasPrice
-    self.txGasFeeMode = txGasFeeMode
-    self.txMaxFeesPerGas = txMaxFeesPerGas
-    self.txBaseFee = txBaseFee
-    self.txPriorityFee = txPriorityFee
-    self.txGasAmount = txGasAmount
-    self.txBonderFees = txBonderFees
-    self.txTokenFees = txTokenFees
-    self.txEstimatedTime = txEstimatedTime
-    self.txFee = txFee
-    self.txL1Fee = txL1Fee
-    self.txTotalFee = txTotalFee
-    self.approvalRequired = approvalRequired
-    self.approvalAmountRequired = approvalAmountRequired
-    self.approvalContractAddress = approvalContractAddress
-    self.approvalTxNonce = approvalTxNonce
-    self.approvalGasPrice = approvalGasPrice
-    self.approvalGasFeeMode = approvalGasFeeMode
-    self.approvalMaxFeesPerGas = approvalMaxFeesPerGas
-    self.approvalBaseFee = approvalBaseFee
-    self.approvalPriorityFee = approvalPriorityFee
-    self.approvalGasAmount = approvalGasAmount
-    self.approvalEstimatedTime = approvalEstimatedTime
-    self.approvalFee = approvalFee
-    self.approvalL1Fee = approvalL1Fee
-
-  proc delete*(self: PathItem) =
-    self.QObject.delete
-
+  )
+  proc delete*(self: PathItem)
   proc newPathItem*(
     processorName: string,
     fromChain: int,
@@ -522,3 +463,120 @@ QtObject:
     if self.processorName == wallet_constants.PROCESSOR_NAME_BRIDGE_HOP:
       return self.txEstimatedTime + 1
     return self.txEstimatedTime
+
+  proc delete*(self: PathItem) =
+    self.QObject.delete
+
+  proc setup*(self: PathItem,
+    processorName: string,
+    fromChain: int,
+    fromChainEIP1559Compliant: bool,
+    fromChainNoBaseFee: bool,
+    fromChainNoPriorityFee: bool,
+    toChain: int,
+    fromToken: string,
+    toToken: string,
+    amountIn: string,
+    amountInLocked: bool,
+    amountOut: string,
+    suggestedNonEIP1559GasPrice: string,
+    suggestedNonEIP1559EstimatedTime: int,
+    suggestedMaxFeesPerGasLowLevel: string,
+    suggestedPriorityFeePerGasLowLevel: string,
+    suggestedEstimatedTimeLowLevel: int,
+    suggestedMaxFeesPerGasMediumLevel: string,
+    suggestedPriorityFeePerGasMediumLevel: string,
+    suggestedEstimatedTimeMediumLevel: int,
+    suggestedMaxFeesPerGasHighLevel: string,
+    suggestedPriorityFeePerGasHighLevel: string,
+    suggestedEstimatedTimeHighLevel: int,
+    suggestedMinPriorityFee: string,
+    suggestedMaxPriorityFee: string,
+    currentBaseFee: string,
+    suggestedTxNonce: string,
+    suggestedTxGasAmount: string,
+    suggestedApprovalTxNonce: string,
+    suggestedApprovalGasAmount: string,
+    txNonce: string,
+    txGasPrice: string,
+    txGasFeeMode: int,
+    txMaxFeesPerGas: string,
+    txBaseFee: string,
+    txPriorityFee: string,
+    txGasAmount: string,
+    txBonderFees: string,
+    txTokenFees: string,
+    txEstimatedTime: int,
+    txFee: string,
+    txL1Fee: string,
+    txTotalFee: string,
+    approvalRequired: bool,
+    approvalAmountRequired: string,
+    approvalContractAddress: string,
+    approvalTxNonce: string,
+    approvalGasPrice: string,
+    approvalGasFeeMode: int,
+    approvalMaxFeesPerGas: string,
+    approvalBaseFee: string,
+    approvalPriorityFee: string,
+    approvalGasAmount: string,
+    approvalEstimatedTime: int,
+    approvalFee: string,
+    approvalL1Fee: string
+  ) =
+    self.QObject.setup
+    self.processorName = processorName
+    self.fromChain = fromChain
+    self.fromChainEIP1559Compliant = fromChainEIP1559Compliant
+    self.fromChainNoBaseFee = fromChainNoBaseFee
+    self.fromChainNoPriorityFee = fromChainNoPriorityFee
+    self.toChain = toChain
+    self.fromToken = fromToken
+    self.toToken = toToken
+    self.amountIn = amountIn
+    self.amountInLocked = amountInLocked
+    self.amountOut = amountOut
+    self.suggestedNonEIP1559GasPrice = suggestedNonEIP1559GasPrice
+    self.suggestedNonEIP1559EstimatedTime = suggestedNonEIP1559EstimatedTime
+    self.suggestedMaxFeesPerGasLowLevel = suggestedMaxFeesPerGasLowLevel
+    self.suggestedPriorityFeePerGasLowLevel = suggestedPriorityFeePerGasLowLevel
+    self.suggestedEstimatedTimeLowLevel = suggestedEstimatedTimeLowLevel
+    self.suggestedMaxFeesPerGasMediumLevel = suggestedMaxFeesPerGasMediumLevel
+    self.suggestedPriorityFeePerGasMediumLevel = suggestedPriorityFeePerGasMediumLevel
+    self.suggestedEstimatedTimeMediumLevel = suggestedEstimatedTimeMediumLevel
+    self.suggestedMaxFeesPerGasHighLevel = suggestedMaxFeesPerGasHighLevel
+    self.suggestedPriorityFeePerGasHighLevel = suggestedPriorityFeePerGasHighLevel
+    self.suggestedEstimatedTimeHighLevel = suggestedEstimatedTimeHighLevel
+    self.suggestedMinPriorityFee = suggestedMinPriorityFee
+    self.suggestedMaxPriorityFee = suggestedMaxPriorityFee
+    self.currentBaseFee = currentBaseFee
+    self.suggestedTxNonce = suggestedTxNonce
+    self.suggestedTxGasAmount = suggestedTxGasAmount
+    self.suggestedApprovalTxNonce = suggestedApprovalTxNonce
+    self.suggestedApprovalGasAmount = suggestedApprovalGasAmount
+    self.txNonce = txNonce
+    self.txGasPrice = txGasPrice
+    self.txGasFeeMode = txGasFeeMode
+    self.txMaxFeesPerGas = txMaxFeesPerGas
+    self.txBaseFee = txBaseFee
+    self.txPriorityFee = txPriorityFee
+    self.txGasAmount = txGasAmount
+    self.txBonderFees = txBonderFees
+    self.txTokenFees = txTokenFees
+    self.txEstimatedTime = txEstimatedTime
+    self.txFee = txFee
+    self.txL1Fee = txL1Fee
+    self.txTotalFee = txTotalFee
+    self.approvalRequired = approvalRequired
+    self.approvalAmountRequired = approvalAmountRequired
+    self.approvalContractAddress = approvalContractAddress
+    self.approvalTxNonce = approvalTxNonce
+    self.approvalGasPrice = approvalGasPrice
+    self.approvalGasFeeMode = approvalGasFeeMode
+    self.approvalMaxFeesPerGas = approvalMaxFeesPerGas
+    self.approvalBaseFee = approvalBaseFee
+    self.approvalPriorityFee = approvalPriorityFee
+    self.approvalGasAmount = approvalGasAmount
+    self.approvalEstimatedTime = approvalEstimatedTime
+    self.approvalFee = approvalFee
+    self.approvalL1Fee = approvalL1Fee

--- a/src/app/modules/main/wallet_section/send_new/path_model.nim
+++ b/src/app/modules/main/wallet_section/send_new/path_model.nim
@@ -69,12 +69,8 @@ QtObject:
     PathModel* = ref object of QAbstractListModel
       items*: seq[PathItem]
 
-  proc delete(self: PathModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: PathModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: PathModel)
+  proc setup(self: PathModel)
   proc newPathModel*(): PathModel =
     new(result, delete)
     result.setup
@@ -279,3 +275,10 @@ QtObject:
       result = newQVariant(item.estimatedTime)
     else:
       discard
+
+  proc delete(self: PathModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: PathModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/main/wallet_section/send_new/view.nim
+++ b/src/app/modules/main/wallet_section/send_new/view.nim
@@ -14,9 +14,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       pathModel: PathModel
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -108,3 +106,7 @@ QtObject:
 
   proc getEstimatedTime*(self: View, chainId: int, gasPrice: string, maxFeesPerGas: string, priorityFee: string): int {.slot.} =
     return self.delegate.getEstimatedTime(chainId, gasPrice, maxFeesPerGas, priorityFee)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -30,12 +30,8 @@ QtObject:
       isAccountTokensReloading: bool
       lastReloadTimestamp: int64
 
-  proc setup(self: View) =
-    self.QObject.setup
-
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc setup(self: View)
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface,
     activityController: activityc.Controller,
     tmpActivityControllers: ActivityControllerArray,
@@ -288,3 +284,10 @@ QtObject:
 
   proc isChecksumValidForAddress*(self: View, address: string): bool {.slot.} =
     return self.delegate.isChecksumValidForAddress(address)
+
+  proc setup(self: View) =
+    self.QObject.setup
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/onboarding/models/login_account_model.nim
+++ b/src/app/modules/onboarding/models/login_account_model.nim
@@ -19,12 +19,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -93,3 +89,10 @@ QtObject:
       return
 
     return self.items[index]
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/onboarding/view.nim
+++ b/src/app/modules/onboarding/view.nim
@@ -20,9 +20,7 @@ QtObject:
       loginAccountsModelVariant: QVariant
       convertKeycardAccountState: ProgressState
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -196,3 +194,7 @@ QtObject:
 
   proc startKeycardFactoryReset(self: View) {.slot.} =
     self.delegate.startKeycardFactoryReset()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/collectible_ownership_model.nim
+++ b/src/app/modules/shared_models/collectible_ownership_model.nim
@@ -14,12 +14,8 @@ QtObject:
     OwnershipModel* = ref object of QAbstractListModel
       items: seq[backend.AccountBalance]
 
-  proc delete(self: OwnershipModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: OwnershipModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: OwnershipModel)
+  proc setup(self: OwnershipModel)
   proc newOwnershipModel*(): OwnershipModel =
     new(result, delete)
     result.setup
@@ -78,3 +74,10 @@ QtObject:
         balance += item.balance
         break
     return balance
+
+  proc delete(self: OwnershipModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: OwnershipModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/collectible_trait_model.nim
+++ b/src/app/modules/shared_models/collectible_trait_model.nim
@@ -14,12 +14,8 @@ QtObject:
     TraitModel* = ref object of QAbstractListModel
       items: seq[backend.CollectibleTrait]
 
-  proc delete(self: TraitModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: TraitModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: TraitModel)
+  proc setup(self: TraitModel)
   proc newTraitModel*(): TraitModel =
     new(result, delete)
     result.setup
@@ -73,3 +69,10 @@ QtObject:
     self.items = items
     self.endResetModel()
     self.countChanged()
+
+  proc delete(self: TraitModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: TraitModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/collectibles_entry.nim
+++ b/src/app/modules/shared_models/collectibles_entry.nim
@@ -31,12 +31,19 @@ QtObject:
       generatedCollectionId: string
       tokenType: TokenType
 
-  proc setup(self: CollectiblesEntry) =
-    self.QObject.setup
-
-  proc delete*(self: CollectiblesEntry) =
-    self.QObject.delete
-
+  proc setup(self: CollectiblesEntry)
+  proc delete*(self: CollectiblesEntry)
+  proc contractTypeToTokenType(contractType : ContractType): TokenType
+  proc setData(self: CollectiblesEntry, data: backend.Collectible)
+  proc newCollectibleDetailsFullEntry*(data: backend.Collectible, extradata: ExtraData): CollectiblesEntry =
+    new(result, delete)
+    result.id = data.id
+    result.setData(data)
+    result.extradata = extradata
+    result.generatedId = result.id.toString()
+    result.generatedCollectionId = result.id.contractID.toString()
+    result.tokenType = contractTypeToTokenType(data.contractType.get(ContractType.ContractTypeUnknown))
+    result.setup()
   proc setData(self: CollectiblesEntry, data: backend.Collectible) =
     self.data = data
     self.traits = newTraitModel()
@@ -388,16 +395,6 @@ QtObject:
       of ContractType.ContractTypeERC1155: return TokenType.ERC1155
       else: return TokenType.Unknown
 
-  proc newCollectibleDetailsFullEntry*(data: backend.Collectible, extradata: ExtraData): CollectiblesEntry =
-    new(result, delete)
-    result.id = data.id
-    result.setData(data)
-    result.extradata = extradata
-    result.generatedId = result.id.toString()
-    result.generatedCollectionId = result.id.contractID.toString()
-    result.tokenType = contractTypeToTokenType(data.contractType.get(ContractType.ContractTypeUnknown))
-    result.setup()
-
   proc newCollectibleDetailsBasicEntry*(id: backend.CollectibleUniqueID, extradata: ExtraData): CollectiblesEntry =
     new(result, delete)
     result.id = id
@@ -432,3 +429,10 @@ QtObject:
     # Notify changes for all properties
     self.twitterHandleChanged()
     self.websiteChanged()
+
+  proc setup(self: CollectiblesEntry) =
+    self.QObject.setup
+
+  proc delete*(self: CollectiblesEntry) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/collectibles_model.nim
+++ b/src/app/modules/shared_models/collectibles_model.nim
@@ -36,12 +36,8 @@ QtObject:
       isUpdating: bool
       isError: bool
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -339,3 +335,10 @@ QtObject:
     if chainId > 0 and len(tokenAddress) > 0 and len(tokenId) > 0:
       return $chainId & "+" & tokenAddress & "+" & tokenId
     return ""
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/contract_model.nim
+++ b/src/app/modules/shared_models/contract_model.nim
@@ -12,12 +12,8 @@ QtObject:
   type Model* = ref object of QAbstractListModel
     items: seq[Item]
 
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: Model)
+  proc delete(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -56,3 +52,10 @@ QtObject:
     self.beginResetModel()
     self.items = items
     self.endResetModel()
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/shared_models/currency_amount.nim
+++ b/src/app/modules/shared_models/currency_amount.nim
@@ -9,12 +9,8 @@ QtObject:
     displayDecimals: int
     stripTrailingZeroes: bool
 
-  proc setup(self: CurrencyAmount) =
-    self.QObject.setup
-
-  proc delete*(self: CurrencyAmount) =
-    self.QObject.delete
-
+  proc setup(self: CurrencyAmount)
+  proc delete*(self: CurrencyAmount)
   proc newCurrencyAmount*(
     amount: float64,
     symbol: string,
@@ -77,3 +73,10 @@ QtObject:
     discard jsonObj.getProp("symbol", result.symbol)
     discard jsonObj.getProp("displayDecimals", result.displayDecimals)
     discard jsonObj.getProp("stripTrailingZeroes", result.stripTrailingZeroes)
+
+  proc setup(self: CurrencyAmount) =
+    self.QObject.setup
+
+  proc delete*(self: CurrencyAmount) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/derived_address_item.nim
+++ b/src/app/modules/shared_models/derived_address_item.nim
@@ -12,9 +12,7 @@ QtObject:
     detailsLoaded: bool
     errorInScanningActivity: bool
 
-  proc delete*(self: DerivedAddressItem) =
-    self.QObject.delete
-
+  proc delete*(self: DerivedAddressItem)
   proc newDerivedAddressItem*(
     order: int = 0,
     address: string = "",
@@ -160,3 +158,7 @@ QtObject:
     self.setAlreadyCreatedChecked(item.getAlreadyCreatedChecked())
     self.setDetailsLoaded(item.getDetailsLoaded())
     self.setErrorInScanningActivity(item.getErrorInScanningActivity())
+
+  proc delete*(self: DerivedAddressItem) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/derived_address_model.nim
+++ b/src/app/modules/shared_models/derived_address_model.nim
@@ -13,12 +13,8 @@ QtObject:
     DerivedAddressModel* = ref object of QAbstractListModel
       items: seq[DerivedAddressItem]
 
-  proc delete(self: DerivedAddressModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: DerivedAddressModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: DerivedAddressModel)
+  proc setup(self: DerivedAddressModel)
   proc newDerivedAddressModel*(): DerivedAddressModel =
     new(result, delete)
     result.setup
@@ -125,3 +121,10 @@ QtObject:
 
   proc getAllAddresses*(self: DerivedAddressModel): seq[string] =
     return self.items.map(x => x.getAddress())
+
+  proc delete(self: DerivedAddressModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: DerivedAddressModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/discord_message_item.nim
+++ b/src/app/modules/shared_models/discord_message_item.nim
@@ -11,12 +11,8 @@ QtObject:
       content: string
       author: DiscordMessageAuthor
 
-  proc setup(self: DiscordMessageItem) =
-    self.QObject.setup
-
-  proc delete*(self: DiscordMessageItem) =
-    self.QObject.delete
-
+  proc setup(self: DiscordMessageItem)
+  proc delete*(self: DiscordMessageItem)
   proc newDiscordMessageItem*(
       id: string,
       timestamp: string,
@@ -66,3 +62,10 @@ QtObject:
 
   proc author*(self: DiscordMessageItem): DiscordMessageAuthor {.inline.} =
     self.author
+
+  proc setup(self: DiscordMessageItem) =
+    self.QObject.setup
+
+  proc delete*(self: DiscordMessageItem) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/emoji_reactions_model.nim
+++ b/src/app/modules/shared_models/emoji_reactions_model.nim
@@ -11,27 +11,8 @@ QtObject:
     type Model* = ref object of QAbstractListModel
         items: seq[EmojiReactionItem]
 
-    proc delete(self: Model) =
-        self.QAbstractListModel.delete
-
-    # TODO : To make this code scale, we can consider a loop similar to
-    # below code, and rename emoji to just be emojiReactions/emoji_[1 ... n]
-    #
-    # ```nim 
-    #   for i in 1..itemCount:
-    #       items.add(initItem(i, "emojiReactions/emoji_$(i)", false))
-    # ```
-    proc setup(self: Model) =
-        self.items = @[
-            initItem(1, "emojiReactions/heart",      false),
-            initItem(2, "emojiReactions/thumbsUp",   false),
-            initItem(3, "emojiReactions/thumbsDown", false),
-            initItem(4, "emojiReactions/laughing",   false),
-            initItem(5, "emojiReactions/sad",        false),
-            initItem(6, "emojiReactions/angry",      false),
-        ]
-        self.QAbstractListModel.setup
-
+    proc delete(self: Model)
+    proc setup(self: Model)
     proc newEmojiReactionsModel*(): Model =
         new(result, delete)
         result.setup
@@ -81,3 +62,25 @@ QtObject:
     proc setItemDidIReactWithThisEmoji*(self: Model, emojiId: int, didIReactWithThisEmoji: bool) =
         if self.items.len > 0:
             self.items[emojiId - 1].didIReactWithThisEmoji = didIReactWithThisEmoji
+
+    proc delete(self: Model) =
+        self.QAbstractListModel.delete
+
+    # TODO : To make this code scale, we can consider a loop similar to
+    # below code, and rename emoji to just be emojiReactions/emoji_[1 ... n]
+    #
+    # ```nim 
+    #   for i in 1..itemCount:
+    #       items.add(initItem(i, "emojiReactions/emoji_$(i)", false))
+    # ```
+    proc setup(self: Model) =
+        self.items = @[
+            initItem(1, "emojiReactions/heart",      false),
+            initItem(2, "emojiReactions/thumbsUp",   false),
+            initItem(3, "emojiReactions/thumbsDown", false),
+            initItem(4, "emojiReactions/laughing",   false),
+            initItem(5, "emojiReactions/sad",        false),
+            initItem(6, "emojiReactions/angry",      false),
+        ]
+        self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/keypair_account_item.nim
+++ b/src/app/modules/shared_models/keypair_account_item.nim
@@ -20,9 +20,7 @@ QtObject:
     areTestNetworksEnabled: bool
     hideFromTotalBalance: bool
 
-  proc delete*(self: KeyPairAccountItem) =
-    self.QObject.delete
-
+  proc delete*(self: KeyPairAccountItem)
   proc newKeyPairAccountItem*(name = "", path = "", address = "", pubKey = "", emoji = "", colorId = "", icon = "",
     balance = newCurrencyAmount(), balanceFetched = true, operability = wa_dto.AccountFullyOperable,
     isDefaultAccount = false, areTestNetworksEnabled =false, hideFromTotalBalance = false): KeyPairAccountItem =
@@ -181,3 +179,7 @@ QtObject:
   QtProperty[bool] hideFromTotalBalance:
     read = hideFromTotalBalance
     notify = hideFromTotalBalanceChanged
+
+  proc delete*(self: KeyPairAccountItem) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -15,12 +15,8 @@ QtObject:
     KeyPairAccountModel* = ref object of QAbstractListModel
       items: seq[KeyPairAccountItem]
 
-  proc delete(self: KeyPairAccountModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: KeyPairAccountModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: KeyPairAccountModel)
+  proc setup(self: KeyPairAccountModel)
   proc newKeyPairAccountModel*(): KeyPairAccountModel =
     new(result, delete)
     result.setup
@@ -143,3 +139,10 @@ QtObject:
     for i in 0 ..< self.items.len:
       if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
         self.items[i].setHideFromTotalBalance(hideFromTotalBalance)
+
+  proc delete(self: KeyPairAccountModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: KeyPairAccountModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/keypair_item.nim
+++ b/src/app/modules/shared_models/keypair_item.nim
@@ -31,37 +31,20 @@ QtObject:
     ownershipVerified: bool
 
   proc setup*(self: KeyPairItem,
-    keyUid: string,
-    pubKey: string,
-    locked: bool,
-    name: string,
-    image: string,
-    icon: string,
-    pairType: KeyPairType,
-    derivedFrom: string,
-    lastUsedDerivationIndex: int,
-    migratedToKeycard: bool,
-    syncedFrom: string,
-    ownershipVerified: bool
-    ) =
-    self.QObject.setup
-    self.keyUid = keyUid
-    self.pubKey = pubKey
-    self.locked = locked
-    self.name = name
-    self.image = image
-    self.icon = icon
-    self.pairType = pairType
-    self.derivedFrom = derivedFrom
-    self.lastUsedDerivationIndex = lastUsedDerivationIndex
-    self.migratedToKeycard = migratedToKeycard
-    self.syncedFrom = syncedFrom
-    self.ownershipVerified = ownershipVerified
-    self.accounts = newKeyPairAccountModel()
-
-  proc delete*(self: KeyPairItem) =
-    self.QObject.delete
-
+      keyUid: string,
+      pubKey: string,
+      locked: bool,
+      name: string,
+      image: string,
+      icon: string,
+      pairType: KeyPairType,
+      derivedFrom: string,
+      lastUsedDerivationIndex: int,
+      migratedToKeycard: bool,
+      syncedFrom: string,
+      ownershipVerified: bool
+      )
+  proc delete*(self: KeyPairItem)
   proc newKeyPairItem*(keyUid = "",
     pubKey = "",
     locked = false,
@@ -307,3 +290,35 @@ QtObject:
     self.setAccounts(item.getAccountsModel().getItems())
     self.setOwnershipVerified(item.getOwnershipVerified())
     self.setLastAccountAsObservedAccount()
+
+  proc delete*(self: KeyPairItem) =
+    self.QObject.delete
+
+  proc setup*(self: KeyPairItem,
+      keyUid: string,
+      pubKey: string,
+      locked: bool,
+      name: string,
+      image: string,
+      icon: string,
+      pairType: KeyPairType,
+      derivedFrom: string,
+      lastUsedDerivationIndex: int,
+      migratedToKeycard: bool,
+      syncedFrom: string,
+      ownershipVerified: bool
+      ) =
+      self.QObject.setup
+      self.keyUid = keyUid
+      self.pubKey = pubKey
+      self.locked = locked
+      self.name = name
+      self.image = image
+      self.icon = icon
+      self.pairType = pairType
+      self.derivedFrom = derivedFrom
+      self.lastUsedDerivationIndex = lastUsedDerivationIndex
+      self.migratedToKeycard = migratedToKeycard
+      self.syncedFrom = syncedFrom
+      self.ownershipVerified = ownershipVerified
+      self.accounts = newKeyPairAccountModel()

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -14,12 +14,8 @@ QtObject:
     KeyPairModel* = ref object of QAbstractListModel
       items: seq[KeyPairItem]
 
-  proc delete(self: KeyPairModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: KeyPairModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: KeyPairModel)
+  proc setup(self: KeyPairModel)
   proc newKeyPairModel*(): KeyPairModel =
     new(result, delete)
     result.setup
@@ -119,3 +115,10 @@ QtObject:
   proc setBalanceForAddress*(self: KeyPairModel, address: string, balance: CurrencyAmount) =
     for item in self.items:
       item.setBalanceForAddress(address, balance)
+
+  proc delete(self: KeyPairModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: KeyPairModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -42,12 +42,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[Item]
 
-  proc delete*(self: Model) = 
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete*(self: Model)
+  proc setup(self: Model)
   proc newLinkPreviewModel*(linkPreviews: seq[LinkPreview] = @[]): Model =
     new(result, delete)
     result.setup
@@ -350,3 +346,10 @@ QtObject:
     for row, item in self.items:
       if item.linkPreview.getCommunityId() == communityId:
         self.setItemLoadingLocalData(row, item, true)
+
+  proc delete*(self: Model) = 
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -42,12 +42,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[MemberItem]
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: Model)
+  proc setup(self: Model)
   proc newModel*(): Model =
     new(result, delete)
     result.setup
@@ -590,3 +586,10 @@ QtObject:
       airdropAddress = airdropAddress,
       joined = joined,
     )
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -5,12 +5,8 @@ QtObject:
   type MessageItem* = ref object of QObject
     messageItem*: message_item.Item
 
-  proc setup(self: MessageItem) =
-    self.QObject.setup
-
-  proc delete*(self: MessageItem) =
-    self.QObject.delete
-
+  proc setup(self: MessageItem)
+  proc delete*(self: MessageItem)
   proc newMessageItem*(message: message_item.Item): MessageItem =
     new(result, delete)
     result.setup
@@ -201,3 +197,10 @@ QtObject:
   proc albumImagesCount*(self: MessageItem): int {.slot.} = result = ?.self.messageItem.albumImagesCount
   QtProperty[int] albumImagesCount:
     read = albumImagesCount
+
+  proc setup(self: MessageItem) =
+    self.QObject.setup
+
+  proc delete*(self: MessageItem) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -82,16 +82,19 @@ QtObject:
       items*: seq[Item]
       firstUnseenMessageId: string
 
-  proc delete(self: Model) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
+  proc delete(self: Model)
+  proc setup(self: Model)
 
   proc newModel*(): Model =
     new(result, delete)
     result.setup
     result.firstUnseenMessageId = ""
+
+  proc delete(self: Model) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
 
   proc `$`*(self: Model): string =
     result = "MessageModel:\n"

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -15,12 +15,8 @@ QtObject:
     MessageReactionModel* = ref object of QAbstractListModel
       items: seq[MessageReactionItem]
 
-  proc delete(self: MessageReactionModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: MessageReactionModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: MessageReactionModel)
+  proc setup(self: MessageReactionModel)
   proc newMessageReactionModel*(): MessageReactionModel =
     new(result, delete)
     result.setup
@@ -152,3 +148,10 @@ QtObject:
       let index = self.createIndex(ind, 0, nil)
       defer: index.delete
       self.dataChanged(index, index)
+
+  proc delete(self: MessageReactionModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: MessageReactionModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/message_transaction_parameters_item.nim
+++ b/src/app/modules/shared_models/message_transaction_parameters_item.nim
@@ -12,12 +12,8 @@ QtObject:
       commandState: int
       signature: string
 
-  proc setup(self: TransactionParametersItem) =
-    self.QObject.setup
-
-  proc delete*(self: TransactionParametersItem) =
-    self.QObject.delete
-
+  proc setup(self: TransactionParametersItem)
+  proc delete*(self: TransactionParametersItem)
   proc newTransactionParametersItem*(
       id: string,
       fromAddress: string,
@@ -114,3 +110,10 @@ QtObject:
 
   proc signature*(self: TransactionParametersItem): string {.inline.} =
     self.signature
+
+  proc setup(self: TransactionParametersItem) =
+    self.QObject.setup
+
+  proc delete*(self: TransactionParametersItem) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/payment_request_model.nim
+++ b/src/app/modules/shared_models/payment_request_model.nim
@@ -13,12 +13,8 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[PaymentRequest]
 
-  proc delete*(self: Model) = 
-    self.QAbstractListModel.delete
-
-  proc setup(self: Model) =
-    self.QAbstractListModel.setup
-
+  proc delete*(self: Model)
+  proc setup(self: Model)
   proc newPaymentRequestModel*(paymentRequests: seq[PaymentRequest] = @[]): Model =
     new(result, delete)
     result.setup
@@ -97,3 +93,10 @@ QtObject:
     self.beginResetModel()
     self.items = @[]
     self.endResetModel()
+
+  proc delete*(self: Model) = 
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_models/section_details.nim
+++ b/src/app/modules/shared_models/section_details.nim
@@ -7,12 +7,8 @@ QtObject:
     sectionType: SectionType
     joined: bool
 
-  proc setup(self: SectionDetails) =
-    self.QObject.setup
-
-  proc delete*(self: SectionDetails) =
-    self.QObject.delete
-
+  proc setup(self: SectionDetails)
+  proc delete*(self: SectionDetails)
   proc newActiveSection*(): SectionDetails =
     new(result, delete)
     result.setup
@@ -64,3 +60,10 @@ QtObject:
       self.joinedChanged()
     if sectionTypeChanged:
       self.sectionTypeChanged()
+
+  proc setup(self: SectionDetails) =
+    self.QObject.setup
+
+  proc delete*(self: SectionDetails) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -55,15 +55,20 @@ QtObject:
     SectionModel* = ref object of QAbstractListModel
       items: seq[SectionItem]
 
+  # Forward declarations for ORC
+  proc delete(self: SectionModel)
+  proc setup(self: SectionModel)
+
+  proc newModel*(): SectionModel =
+    new(result, delete)
+    result.setup
+
+  # Implementations after constructor
   proc delete(self: SectionModel) =
     self.QAbstractListModel.delete
 
   proc setup(self: SectionModel) =
     self.QAbstractListModel.setup
-
-  proc newModel*(): SectionModel =
-    new(result, delete)
-    result.setup
 
   proc `$`*(self: SectionModel): string =
     for i in 0 ..< self.items.len:

--- a/src/app/modules/shared_models/token_criteria_model.nim
+++ b/src/app/modules/shared_models/token_criteria_model.nim
@@ -18,12 +18,8 @@ QtObject:
   type TokenCriteriaModel* = ref object of QAbstractListModel
     items*: seq[TokenCriteriaItem]
 
-  proc setup(self: TokenCriteriaModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: TokenCriteriaModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokenCriteriaModel)
+  proc delete(self: TokenCriteriaModel)
   proc newTokenCriteriaModel*(): TokenCriteriaModel =
     new(result, delete)
     result.setup
@@ -93,3 +89,10 @@ QtObject:
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
+
+  proc setup(self: TokenCriteriaModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenCriteriaModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -20,12 +20,8 @@ QtObject:
   type TokenListModel* = ref object of QAbstractListModel
     items*: seq[TokenListItem]
 
-  proc setup(self: TokenListModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: TokenListModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokenListModel)
+  proc delete(self: TokenListModel)
   proc newTokenListModel*(): TokenListModel =
     new(result, delete)
     result.setup
@@ -131,3 +127,10 @@ QtObject:
         result = newQVariant(item.getDecimals())
       of ModelRole.PrivilegesLevel:
         result = newQVariant(item.getPrivilegesLevel())
+
+  proc setup(self: TokenListModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenListModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -10,12 +10,8 @@ QtObject:
   type TokenPermissionChatListModel* = ref object of QAbstractListModel
     items*: seq[TokenPermissionChatListItem]
 
-  proc setup(self: TokenPermissionChatListModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: TokenPermissionChatListModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokenPermissionChatListModel)
+  proc delete(self: TokenPermissionChatListModel)
   proc newTokenPermissionChatListModel*(): TokenPermissionChatListModel =
     new(result, delete)
     result.setup
@@ -74,3 +70,10 @@ QtObject:
         defer: index.delete
         self.dataChanged(index, index, @[ModelRole.ChannelName.int])
         return
+
+  proc setup(self: TokenPermissionChatListModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenPermissionChatListModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -19,12 +19,8 @@ QtObject:
   type TokenPermissionsModel* = ref object of QAbstractListModel
     items*: seq[TokenPermissionItem]
 
-  proc setup(self: TokenPermissionsModel) =
-    self.QAbstractListModel.setup
-
-  proc delete(self: TokenPermissionsModel) =
-    self.QAbstractListModel.delete
-
+  proc setup(self: TokenPermissionsModel)
+  proc delete(self: TokenPermissionsModel)
   proc newTokenPermissionsModel*(): TokenPermissionsModel =
     new(result, delete)
     result.setup
@@ -161,3 +157,10 @@ QtObject:
       ModelRole.State.int
     ])
     self.tokenCriteriaUpdated()
+
+  proc setup(self: TokenPermissionsModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenPermissionsModel) =
+    self.QAbstractListModel.delete
+

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -43,15 +43,19 @@ QtObject:
     Model* = ref object of QAbstractListModel
       items: seq[UserItem]
 
+  # Forward declarations for ORC
+  proc delete(self: Model)
+  proc setup(self: Model)
+
+  proc newModel*(): Model =
+    new(result, delete)
+    result.setup
+
   proc delete(self: Model) =
     self.QAbstractListModel.delete
 
   proc setup(self: Model) =
     self.QAbstractListModel.setup
-
-  proc newModel*(): Model =
-    new(result, delete)
-    result.setup
 
   proc countChanged(self: Model) {.signal.}
 

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -33,25 +33,8 @@ QtObject:
     operability: string = wa_dto.AccountFullyOperable,
     areTestNetworksEnabled: bool = false,
     hideFromTotalBalance: bool = true
-    ) =
-      self.QObject.setup
-      self.name = name
-      self.address = address
-      self.mixedcaseAddress = mixedcaseAddress
-      self.colorId = colorId
-      self.emoji = emoji
-      self.walletType = walletType
-      self.path = path
-      self.keyUid = keyUid
-      self.keycardAccount = keycardAccount
-      self.position = position
-      self.operability = operability
-      self.areTestNetworksEnabled = areTestNetworksEnabled
-      self.hideFromTotalBalance = hideFromTotalBalance
-
-  proc delete*(self: WalletAccountItem) =
-      self.QObject.delete
-
+    )
+  proc delete*(self: WalletAccountItem)
   proc newWalletAccountItem*(
     name: string = "",
     address: string = "",
@@ -206,3 +189,35 @@ QtObject:
   proc `hideFromTotalBalance=`*(self: WalletAccountItem, value: bool) {.inline.} =
     self.hideFromTotalBalance = value
     self.hideFromTotalBalanceChanged()
+
+  proc delete*(self: WalletAccountItem) =
+      self.QObject.delete
+  proc setup*(self: WalletAccountItem,
+    name: string = "",
+    address: string = "",
+    mixedcaseAddress: string = "",
+    colorId: string = "",
+    emoji: string = "",
+    walletType: string = "",
+    path: string = "",
+    keyUid: string = "",
+    keycardAccount: bool = false,
+    position: int = 0,
+    operability: string = wa_dto.AccountFullyOperable,
+    areTestNetworksEnabled: bool = false,
+    hideFromTotalBalance: bool = true
+    ) =
+      self.QObject.setup
+      self.name = name
+      self.address = address
+      self.mixedcaseAddress = mixedcaseAddress
+      self.colorId = colorId
+      self.emoji = emoji
+      self.walletType = walletType
+      self.path = path
+      self.keyUid = keyUid
+      self.keycardAccount = keycardAccount
+      self.position = position
+      self.operability = operability
+      self.areTestNetworksEnabled = areTestNetworksEnabled
+      self.hideFromTotalBalance = hideFromTotalBalance

--- a/src/app/modules/shared_modules/add_account/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/add_account/internal/state_wrapper.nim
@@ -5,9 +5,7 @@ QtObject:
   type StateWrapper* = ref object of QObject
     stateObj: State
 
-  proc delete*(self: StateWrapper) =
-    self.QObject.delete
-
+  proc delete*(self: StateWrapper)
   proc newStateWrapper*(): StateWrapper =
     new(result, delete)
     result.QObject.setup()
@@ -60,3 +58,7 @@ QtObject:
   proc quaternaryActionClicked*(self: StateWrapper) {.signal.}
   proc doQuaternaryAction*(self: StateWrapper) {.slot.} =
     self.quaternaryActionClicked()
+
+  proc delete*(self: StateWrapper) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/add_account/view.nim
+++ b/src/app/modules/shared_modules/add_account/view.nim
@@ -35,9 +35,7 @@ QtObject:
       editMode: bool
       disablePopup: bool # unables user to interact with the popup (action buttons are disabled as well as close popup button)
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -361,3 +359,7 @@ QtObject:
 
   proc remainingWatchOnlyAccountCapacity*(self: View): int {.slot.} =
     return self.delegate.remainingWatchOnlyAccountCapacity()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/collectible_details/controller.nim
+++ b/src/app/modules/shared_modules/collectible_details/controller.nim
@@ -24,11 +24,31 @@ QtObject:
 
       dataType: backend_collectibles.CollectibleDataType
 
-  proc setup(self: Controller) =
-    self.QObject.setup
+  proc setup(self: Controller)
+  proc delete*(self: Controller)
+  proc setupEventHandlers(self: Controller) 
+  proc newController*(
+    requestId: int32,
+    networkService: network_service.Service,
+    events: EventEmitter,
+    dataType: backend_collectibles.CollectibleDataType = backend_collectibles.CollectibleDataType.Details
+  ): Controller =
+    new(result, delete)
 
-  proc delete*(self: Controller) =
-    self.QObject.delete
+    result.requestId = requestId
+
+    result.dataType = dataType
+
+    result.networkService = networkService
+
+    result.detailedEntry = newCollectibleDetailsEmptyEntry()
+    result.isDetailedEntryLoading = false
+
+    result.eventsHandler = newEventsHandler(result.requestId, events)
+
+    result.setup()
+
+    result.setupEventHandlers()
 
   proc getDetailedEntry*(self: Controller): QVariant {.slot.} =
     return newQVariant(self.detailedEntry)
@@ -129,25 +149,9 @@ QtObject:
       self.processGetCollectionSocialsResponse(jsonObj)
     )
 
-  proc newController*(
-    requestId: int32,
-    networkService: network_service.Service,
-    events: EventEmitter,
-    dataType: backend_collectibles.CollectibleDataType = backend_collectibles.CollectibleDataType.Details
-  ): Controller =
-    new(result, delete)
+  proc setup(self: Controller) =
+    self.QObject.setup
 
-    result.requestId = requestId
+  proc delete*(self: Controller) =
+    self.QObject.delete
 
-    result.dataType = dataType
-
-    result.networkService = networkService
-
-    result.detailedEntry = newCollectibleDetailsEmptyEntry()
-    result.isDetailedEntryLoading = false
-
-    result.eventsHandler = newEventsHandler(result.requestId, events)
-
-    result.setup()
-
-    result.setupEventHandlers()

--- a/src/app/modules/shared_modules/collectible_details/events_handler.nim
+++ b/src/app/modules/shared_modules/collectible_details/events_handler.nim
@@ -17,12 +17,8 @@ QtObject:
 
       requestId: int32
 
-  proc setup(self: EventsHandler) =
-    self.QObject.setup
-
-  proc delete*(self: EventsHandler) =
-    self.QObject.delete
-
+  proc setup(self: EventsHandler)
+  proc delete*(self: EventsHandler)
   proc onGetCollectiblesDetailsDone*(self: EventsHandler, handler: EventCallbackProc) =
     self.eventHandlers[backend_collectibles.eventGetCollectiblesDetailsDone] = handler
 
@@ -66,3 +62,9 @@ QtObject:
         eventsHandler.handleApiEvents(e)
     )
  
+  proc setup(self: EventsHandler) =
+    self.QObject.setup
+
+  proc delete*(self: EventsHandler) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_wrapper.nim
@@ -5,9 +5,7 @@ QtObject:
   type StateWrapper* = ref object of QObject
     stateObj: State
 
-  proc delete*(self: StateWrapper) =
-    self.QObject.delete
-
+  proc delete*(self: StateWrapper)
   proc newStateWrapper*(): StateWrapper =
     new(result, delete)
     result.QObject.setup()
@@ -64,3 +62,7 @@ QtObject:
   proc tertiaryActionClicked*(self: StateWrapper) {.signal.}
   proc doTertiaryAction*(self: StateWrapper) {.slot.} =
     self.tertiaryActionClicked()
+
+  proc delete*(self: StateWrapper) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
@@ -7,9 +7,7 @@ QtObject:
   type KeycardItem* = ref object of KeyPairItem
     keycardUid: string
 
-  proc delete*(self: KeycardItem) =
-      self.KeyPairItem.delete
-
+  proc delete*(self: KeycardItem)
   proc initKeycardItem*(
       keycardUid = "",
       keyUid = "",
@@ -56,3 +54,7 @@ QtObject:
   proc setItem*(self: KeycardItem, item: KeycardItem) =
     self.setKeycardUid(item.getKeycardUid())
     self.KeyPairItem.setItem(KeyPairItem(item))
+
+  proc delete*(self: KeycardItem) =
+      self.KeyPairItem.delete
+

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
@@ -12,12 +12,8 @@ QtObject:
     KeycardModel* = ref object of QAbstractListModel
       items: seq[KeycardItem]
 
-  proc delete(self: KeycardModel) =
-    self.QAbstractListModel.delete
-
-  proc setup(self: KeycardModel) =
-    self.QAbstractListModel.setup
-
+  proc delete(self: KeycardModel)
+  proc setup(self: KeycardModel)
   proc newKeycardModel*(): KeycardModel =
     new(result, delete)
     result.setup
@@ -168,3 +164,10 @@ QtObject:
           self.items[i].removeAccountByAddress(acc)
         if removeKeycardItemIfHasNoAccounts and self.items[i].getAccountsModel().getCount() == 0:
           self.removeItem(i)
+
+  proc delete(self: KeycardModel) =
+    self.QAbstractListModel.delete
+
+  proc setup(self: KeycardModel) =
+    self.QAbstractListModel.setup
+

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -22,9 +22,7 @@ QtObject:
       keycardData: string # used to temporary store the data coming from keycard, depends on current state different data may be stored
       remainingAttempts: int
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -236,3 +234,7 @@ QtObject:
 
   proc remainingAccountCapacity*(self: View): int {.slot.} =
     return self.delegate.remainingAccountCapacity()
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/keypair_import/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/keypair_import/internal/state_wrapper.nim
@@ -5,9 +5,7 @@ QtObject:
   type StateWrapper* = ref object of QObject
     stateObj: State
 
-  proc delete*(self: StateWrapper) =
-    self.QObject.delete
-
+  proc delete*(self: StateWrapper)
   proc newStateWrapper*(): StateWrapper =
     new(result, delete)
     result.QObject.setup()
@@ -60,3 +58,7 @@ QtObject:
   proc quaternaryActionClicked*(self: StateWrapper) {.signal.}
   proc doQuaternaryAction*(self: StateWrapper) {.slot.} =
     self.quaternaryActionClicked()
+
+  proc delete*(self: StateWrapper) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/keypair_import/view.nim
+++ b/src/app/modules/shared_modules/keypair_import/view.nim
@@ -19,9 +19,7 @@ QtObject:
       connectionString: string
       connectionStringError: string
 
-  proc delete*(self: View) =
-    self.QObject.delete
-
+  proc delete*(self: View)
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
@@ -154,3 +152,7 @@ QtObject:
 
   proc validateConnectionString*(self: View, connectionString: string): string {.slot.} =
     return self.delegate.validateConnectionString(connectionString)
+
+  proc delete*(self: View) =
+    self.QObject.delete
+

--- a/src/app/modules/shared_modules/wallet_connect/controller.nim
+++ b/src/app/modules/shared_modules/wallet_connect/controller.nim
@@ -22,9 +22,7 @@ QtObject:
       walletAccountService: wallet_account_service.Service
       events: EventEmitter
 
-  proc delete*(self: Controller) =
-    self.QObject.delete
-
+  proc delete*(self: Controller)
   proc newController*(
     service: wallet_connect_service.Service,
     walletAccountService: wallet_account_service.Service,
@@ -242,3 +240,7 @@ QtObject:
     except Exception as e:
       error "Failed to convert fees info to hex: ", feesInfoJson=feesInfoJson, ex=e.msg
       return ""
+
+  proc delete*(self: Controller) =
+    self.QObject.delete
+

--- a/src/app_service/service/about/service.nim
+++ b/src/app_service/service/about/service.nim
@@ -32,9 +32,7 @@ QtObject:
       threadpool: ThreadPool
       settingsService: settings_service.Service
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool,
@@ -75,3 +73,6 @@ QtObject:
 
     self.checkForUpdates()
     
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -62,9 +62,7 @@ QtObject:
 
   proc restoreAccountAndLogin(self: Service, request: RestoreAccountRequest): string
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
     new(result, delete)
     result.QObject.setup
@@ -498,3 +496,7 @@ QtObject:
 
   proc getKdfIterations*(self: Service): int =
     return KDF_ITERATIONS
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -71,9 +71,7 @@ QtObject:
   # Forward declaration
   proc asyncActivityNotificationLoad*(self: Service)
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -358,3 +356,7 @@ QtObject:
       self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED, Args())
     except Exception as e:
       error "Error dismissing activity center notification", msg = e.msg
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -128,9 +128,7 @@ QtObject:
     chats: Table[string, ChatDto] # [chat_id, ChatDto]
     contactService: contact_service.Service
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -785,3 +783,7 @@ QtObject:
         communityId: communityId,
         error: errMsg,
       ))
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/collectible/service.nim
+++ b/src/app_service/service/collectible/service.nim
@@ -21,9 +21,7 @@ QtObject:
     events: EventEmitter
     threadpool: ThreadPool
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool
@@ -62,3 +60,7 @@ QtObject:
       error "error: ", procName="updateCollectiblePreferences", errName=e.name, errDesription=e.msg
 
     self.events.emit(SIGNAL_COLLECTIBLE_PREFERENCES_UPDATED, ResultArgs(success: updated))
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -32,9 +32,7 @@ QtObject:
     events: EventEmitter
     eventHandler: EventHandlerFn
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter
   ): Service =
@@ -179,3 +177,7 @@ QtObject:
 
   proc rejectSigning*(self: Service, requestId: string): bool =
     rejectRequest(self, requestId, status_go.sendSignRejectedFinishedRpc, "sendSignRejectedFinishedRpc failed: ")
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -114,9 +114,7 @@ QtObject:
   proc constructContactDetails(self: Service, contactDto: ContactsDto, isCurrentUser: bool = false): ContactDetails
   proc parseContactsResponse*(self: Service, contacts: JsonNode, fromBackup: bool = false)
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -736,3 +734,7 @@ QtObject:
     except Exception as e:
       error "onProfileShowcaseAccountsByAddressFetched", msg = e.msg
     self.events.emit(SIGNAL_CONTACT_SHOWCASE_ACCOUNTS_BY_ADDRESS_FETCHED, data)
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/currency/service.nim
+++ b/src/app_service/service/currency/service.nim
@@ -34,9 +34,7 @@ QtObject:
   proc fetchAllCurrencyFormats(self: Service)
   proc getCachedCurrencyFormats(self: Service): Table[string, CurrencyFormatDto]
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool,
@@ -139,3 +137,7 @@ QtObject:
     if token != nil:
       decimals = token.decimals
     return u256ToFloat(decimals, amountInt)
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -61,9 +61,7 @@ QtObject:
     walletAccountService: wallet_account_service.Service
     localPairingStatus: LocalPairingStatus
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter,
     threadpool: ThreadPool,
     settingsService: settings_service.Service,
@@ -411,3 +409,7 @@ QtObject:
     except Exception as e:
       error "error in pairDevice: ", desription = e.msg
       return e.msg
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -85,9 +85,7 @@ QtObject:
   proc add*(self: Service, chainId: int, username: string): bool
   proc remove*(self: Service, chainId: int, username: string): bool
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -374,3 +372,7 @@ QtObject:
     except Exception as e:
       error "Error getting ENS resourceUrl", username=username, exception=e.msg
       raise
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -31,9 +31,7 @@ QtObject:
     threadpool: ThreadPool
     timeoutInMilliseconds: int
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
     new(result, delete)
     result.QObject.setup
@@ -125,3 +123,7 @@ QtObject:
     except Exception as e:
       error "error:", procName="asyncImportLocalBackupFile", errName = e.name, errDesription = e.msg
       self.events.emit(SIGNAL_LOCAL_BACKUP_IMPORT_COMPLETED, LocalBackupImportArg(error: e.msg))
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -84,10 +84,7 @@ QtObject:
   proc isBusy*(self: Service): bool {.featureGuard(KEYCARD_ENABLED).}  =
     return self.busy
 
-  proc delete*(self: Service) =
-    self.closingApp = true
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service {.featureGuard(KEYCARD_ENABLED).}  =
     new(result, delete)
     result.QObject.setup
@@ -507,3 +504,8 @@ QtObject:
 
   proc resetAPI*(self: Service) {.featureGuard(KEYCARD_ENABLED).} =
     keycard_go.ResetAPI()
+
+  proc delete*(self: Service) =
+    self.closingApp = true
+    self.QObject.delete
+

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -83,9 +83,7 @@ QtObject:
   proc asyncStart*(self: Service, storageDir: string)
   proc onAsyncResponse(self: Service, response: string) {.slot.}
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
     new(result, delete)
     result.QObject.setup
@@ -263,3 +261,7 @@ QtObject:
           raise newException(RpcException, error.message)
     except Exception as e:
       error "error storing metadata", err=e.msg
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/keychain/service.nim
+++ b/src/app_service/service/keychain/service.nim
@@ -23,12 +23,8 @@ QtObject:
     events: EventEmitter
     keychainManager: StatusKeychainManager
 
-  proc setup(self: Service) =
-    self.QObject.setup
-
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc setup(self: Service)
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter): Service =
     new(result, delete)
     result.setup()
@@ -64,3 +60,10 @@ QtObject:
     ## This slot is called in case a password is successfully retrieved from the
     ## Keychain. In this case @data contains required password.
     self.events.emit(SIGNAL_KEYCHAIN_SERVICE_SUCCESS, KeyChainServiceArg(data: data))
+
+  proc setup(self: Service) =
+    self.QObject.setup
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -75,9 +75,7 @@ QtObject:
   # Forward declaration:
   proc doConnect(self: Service)
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool,
     settingsService: settings_service.Service,
     nodeConfigurationService: node_configuration_service.Service): Service =
@@ -131,3 +129,7 @@ QtObject:
       let h = HistoryRequestCompletedSignal(e)
       info "history request completed"
       self.events.emit(SIGNAL_MAILSERVER_HISTORY_REQUEST_COMPLETED, Args())
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/market/service.nim
+++ b/src/app_service/service/market/service.nim
@@ -46,9 +46,7 @@ QtObject:
   proc handlePageDataUpdated(self: Service, data: WalletSignal)
   proc handlePricesUpdated(self: Service, data: WalletSignal)
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     settingsService: settings_service.Service
@@ -160,4 +158,7 @@ QtObject:
       discard backend.unsubscribeFromLeaderboard()
     except Exception as e:
       error "error when calling unsubscribeFromLeaderboard ", msg = e.msg
+
+  proc delete*(self: Service) =
+    self.QObject.delete
 

--- a/src/app_service/service/message/dto/link_preview_thumbnail.nim
+++ b/src/app_service/service/message/dto/link_preview_thumbnail.nim
@@ -8,11 +8,8 @@ QtObject:
     url: string
     dataUri: string
 
-  proc setup*(self: LinkPreviewThumbnail) =
-    self.QObject.setup()
-
-  proc delete*(self: LinkPreviewThumbnail) =
-    self.QObject.delete()
+  proc setup*(self: LinkPreviewThumbnail)
+  proc delete*(self: LinkPreviewThumbnail)
 
   proc update*(self: LinkPreviewThumbnail, width: int, height: int, url: string, dataUri: string)
 
@@ -26,6 +23,12 @@ QtObject:
     new(result, delete)
     result.setup()
     result.update(width, height, url, dataUri)
+
+  proc setup*(self: LinkPreviewThumbnail) =
+    self.QObject.setup()
+
+  proc delete*(self: LinkPreviewThumbnail) =
+    self.QObject.delete()
 
   proc widthChanged*(self: LinkPreviewThumbnail) {.signal.}
   proc getWidth*(self: LinkPreviewThumbnail): int {.slot.} =

--- a/src/app_service/service/message/dto/standard_link_preview.nim
+++ b/src/app_service/service/message/dto/standard_link_preview.nim
@@ -22,13 +22,9 @@ QtObject:
     description: string
     linkType: LinkType
     thumbnail: LinkPreviewThumbnail
-
-  proc setup*(self: StandardLinkPreview) =
-    self.QObject.setup
-    self.thumbnail = newLinkPreviewThumbnail()
-
-  proc delete*(self: StandardLinkPreview) =
-    self.QObject.delete
+  
+  proc setup*(self: StandardLinkPreview)
+  proc delete*(self: StandardLinkPreview)
 
   proc newStandardLinkPreview*(hostname: string, title: string, description: string, thumbnail: LinkPreviewThumbnail, linkType: LinkType): StandardLinkPreview =
     new(result, delete)
@@ -38,6 +34,13 @@ QtObject:
     result.description = description
     result.linkType = linkType
     result.thumbnail.copy(thumbnail)
+
+  proc setup*(self: StandardLinkPreview) =
+    self.QObject.setup
+    self.thumbnail = newLinkPreviewThumbnail()
+
+  proc delete*(self: StandardLinkPreview) =
+    self.QObject.delete
 
   proc hostnameChanged*(self: StandardLinkPreview) {.signal.}
   proc getHostname*(self: StandardLinkPreview): string {.slot.} =

--- a/src/app_service/service/message/dto/status_community_channel_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_channel_link_preview.nim
@@ -12,12 +12,23 @@ QtObject:
     description*: string
     color*: string
     community*: StatusCommunityLinkPreview
+  
+  proc setup*(self: StatusCommunityChannelLinkPreview)
+  proc delete*(self: StatusCommunityChannelLinkPreview)
+  proc toStatusCommunityChannelLinkPreview*(jsonObj: JsonNode): StatusCommunityChannelLinkPreview =
+    new(result, delete)
+    result.setup()
 
-  proc setup*(self: StatusCommunityChannelLinkPreview) =
-    self.QObject.setup()
+    discard jsonObj.getProp("channelUuid", result.channelUuid)
+    discard jsonObj.getProp("emoji", result.emoji)
+    discard jsonObj.getProp("displayName", result.displayName)
+    discard jsonObj.getProp("description", result.description)
+    discard jsonObj.getProp("color", result.color)
+  
+    var communityJsonNode: JsonNode
+    if jsonObj.getProp("community", communityJsonNode):
+      result.community = toStatusCommunityLinkPreview(communityJsonNode)
 
-  proc delete*(self: StatusCommunityChannelLinkPreview) =
-    self.QObject.delete()
 
   proc channelUuidChanged*(self: StatusCommunityChannelLinkPreview) {.signal.}
   proc getChannelUuid*(self: StatusCommunityChannelLinkPreview): string {.slot.} =
@@ -57,19 +68,12 @@ QtObject:
   proc getCommunity*(self: StatusCommunityChannelLinkPreview): StatusCommunityLinkPreview =
     return self.community
 
-  proc toStatusCommunityChannelLinkPreview*(jsonObj: JsonNode): StatusCommunityChannelLinkPreview =
-    new(result, delete)
-    result.setup()
-
-    discard jsonObj.getProp("channelUuid", result.channelUuid)
-    discard jsonObj.getProp("emoji", result.emoji)
-    discard jsonObj.getProp("displayName", result.displayName)
-    discard jsonObj.getProp("description", result.description)
-    discard jsonObj.getProp("color", result.color)
   
-    var communityJsonNode: JsonNode
-    if jsonObj.getProp("community", communityJsonNode):
-      result.community = toStatusCommunityLinkPreview(communityJsonNode)
+  proc setup*(self: StatusCommunityChannelLinkPreview) =
+    self.QObject.setup()
+
+  proc delete*(self: StatusCommunityChannelLinkPreview) =
+    self.QObject.delete()
   
   proc `$`*(self: StatusCommunityChannelLinkPreview): string =
     return fmt"""StatusCommunityChannelLinkPreview(

--- a/src/app_service/service/message/dto/status_community_link_preview.nim
+++ b/src/app_service/service/message/dto/status_community_link_preview.nim
@@ -15,14 +15,34 @@ QtObject:
     banner*: LinkPreviewThumbnail
     encrypted*: bool
     joined*: bool
+  
+  proc setup*(self: StatusCommunityLinkPreview)
+  proc delete*(self: StatusCommunityLinkPreview)
 
-  proc setup*(self: StatusCommunityLinkPreview) =
-    self.QObject.setup()
-    self.icon = newLinkPreviewThumbnail()
-    self.banner = newLinkPreviewThumbnail()
+  proc toStatusCommunityLinkPreview*(jsonObj: JsonNode): StatusCommunityLinkPreview =
+      new(result, delete)
+      result.setup()
 
-  proc delete*(self: StatusCommunityLinkPreview) =
-    self.QObject.delete()
+      var icon: LinkPreviewThumbnail
+      var banner: LinkPreviewThumbnail
+
+      discard jsonObj.getProp("communityId", result.communityId)
+      discard jsonObj.getProp("displayName", result.displayName)
+      discard jsonObj.getProp("description", result.description)
+      discard jsonObj.getProp("membersCount", result.membersCount)
+      discard jsonObj.getProp("activeMembersCount", result.activeMembersCount)
+      discard jsonObj.getProp("color", result.color)
+
+      var iconJson: JsonNode
+      if jsonObj.getProp("icon", iconJson):
+        icon = toLinkPreviewThumbnail(iconJson)
+
+      var bannerJson: JsonNode
+      if jsonObj.getProp("banner", bannerJson):
+        banner = toLinkPreviewThumbnail(bannerJson)
+
+      result.icon.copy(icon)
+      result.banner.copy(banner)
 
   proc communityIdChanged*(self: StatusCommunityLinkPreview) {.signal.}
   proc getCommunityId*(self: StatusCommunityLinkPreview): string {.slot.} =
@@ -88,30 +108,14 @@ QtObject:
     read = getJoined
     notify = joinedChanged
 
-  proc toStatusCommunityLinkPreview*(jsonObj: JsonNode): StatusCommunityLinkPreview =
-    new(result, delete)
-    result.setup()
 
-    var icon: LinkPreviewThumbnail
-    var banner: LinkPreviewThumbnail
+  proc setup*(self: StatusCommunityLinkPreview) =
+    self.QObject.setup()
+    self.icon = newLinkPreviewThumbnail()
+    self.banner = newLinkPreviewThumbnail()
 
-    discard jsonObj.getProp("communityId", result.communityId)
-    discard jsonObj.getProp("displayName", result.displayName)
-    discard jsonObj.getProp("description", result.description)
-    discard jsonObj.getProp("membersCount", result.membersCount)
-    discard jsonObj.getProp("activeMembersCount", result.activeMembersCount)
-    discard jsonObj.getProp("color", result.color)
-
-    var iconJson: JsonNode
-    if jsonObj.getProp("icon", iconJson):
-      icon = toLinkPreviewThumbnail(iconJson)
-
-    var bannerJson: JsonNode
-    if jsonObj.getProp("banner", bannerJson):
-      banner = toLinkPreviewThumbnail(bannerJson)
-
-    result.icon.copy(icon)
-    result.banner.copy(banner)
+  proc delete*(self: StatusCommunityLinkPreview) =
+    self.QObject.delete()
 
   proc `$`*(self: StatusCommunityLinkPreview): string =
     result = fmt"""StatusCommunityLinkPreview(

--- a/src/app_service/service/message/dto/status_contact_link_preview.nim
+++ b/src/app_service/service/message/dto/status_contact_link_preview.nim
@@ -12,13 +12,9 @@ QtObject:
     description: string
     icon: LinkPreviewThumbnail
     emojiHash: string
-
-  proc setup*(self: StatusContactLinkPreview) =
-    self.QObject.setup()
-    self.icon = newLinkPreviewThumbnail()
-
-  proc delete*(self: StatusContactLinkPreview) =
-    self.QObject.delete()
+  
+  proc setup*(self: StatusContactLinkPreview)
+  proc delete*(self: StatusContactLinkPreview)
 
   proc newStatusContactLinkPreview*(publicKey: var string, displayName: string, description: string, icon: LinkPreviewThumbnail, emojiHash: string): StatusContactLinkPreview =
     new(result, delete)
@@ -28,6 +24,13 @@ QtObject:
     result.description = description
     result.icon.copy(icon)
     result.emojiHash = emojiHash
+
+  proc setup*(self: StatusContactLinkPreview) =
+    self.QObject.setup()
+    self.icon = newLinkPreviewThumbnail()
+
+  proc delete*(self: StatusContactLinkPreview) =
+    self.QObject.delete()
 
   proc publicKeyChanged*(self: StatusContactLinkPreview) {.signal.}
   proc getPublicKey*(self: StatusContactLinkPreview): string {.slot.} =

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -174,9 +174,7 @@ QtObject:
 
   proc bulkReplacePubKeysWithDisplayNames(self: Service, messages: var seq[MessageDto])
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool,
@@ -1245,3 +1243,7 @@ proc deleteCommunityMemberMessages*(self: Service, communityId: string, memberPu
 
   except Exception as e:
     error "error: ", procName="deleteCommunityMemberMessages", errName = e.name, errDesription = e.msg
+
+proc delete*(self: Service) =
+  self.QObject.delete
+

--- a/src/app_service/service/metrics/service.nim
+++ b/src/app_service/service/metrics/service.nim
@@ -30,9 +30,7 @@ QtObject:
     threadpool: ThreadPool
     metricsEnabled: bool
 
-  proc delete*(self: MetricsService) =
-    self.QObject.delete
-
+  proc delete*(self: MetricsService)
   proc newService*(threadpool: ThreadPool): MetricsService =
     new(result, delete)
     result.QObject.setup
@@ -89,3 +87,7 @@ QtObject:
         self.centralizedMetricsEnabledChanged()
     except Exception as e:
       error "toggleCentralizedMetrics", exceptionMsg = e.msg
+
+  proc delete*(self: MetricsService) =
+    self.QObject.delete
+

--- a/src/app_service/service/network/network_item.nim
+++ b/src/app_service/service/network/network_item.nim
@@ -29,50 +29,27 @@ QtObject:
     noPriorityFee*: bool
 
   proc setup*(self: NetworkItem,
-    chainId: int,
-    layer: int,
-    chainName: string,
-    iconUrl: string,
-    shortName: string,
-    chainColor: string,
-    rpcProviders: seq[RpcProviderItem],
-    blockExplorerURL: string,
-    nativeCurrencyName: string,
-    nativeCurrencySymbol: string,
-    nativeCurrencyDecimals: int,
-    isTest: bool,
-    isEnabled: bool,
-    relatedChainId: int,
-    isActive: bool,
-    isDeactivatable: bool,
-    eip1559Enabled: bool,
-    noBaseFee: bool,
-    noPriorityFee: bool
-    ) =
-      self.QObject.setup
-      self.chainId = chainId
-      self.layer = layer
-      self.chainName = chainName
-      self.iconUrl = iconUrl
-      self.shortName = shortName
-      self.chainColor = chainColor
-      self.rpcProviders = rpcProviders
-      self.blockExplorerURL = blockExplorerURL
-      self.nativeCurrencyName = nativeCurrencyName
-      self.nativeCurrencySymbol = nativeCurrencySymbol
-      self.nativeCurrencyDecimals = nativeCurrencyDecimals
-      self.isTest = isTest
-      self.isEnabled = isEnabled
-      self.relatedChainId = relatedChainId
-      self.isActive = isActive
-      self.isDeactivatable = isDeactivatable
-      self.eip1559Enabled = eip1559Enabled
-      self.noBaseFee = noBaseFee
-      self.noPriorityFee = noPriorityFee
-
-  proc delete*(self: NetworkItem) =
-      self.QObject.delete
-
+        chainId: int,
+        layer: int,
+        chainName: string,
+        iconUrl: string,
+        shortName: string,
+        chainColor: string,
+        rpcProviders: seq[RpcProviderItem],
+        blockExplorerURL: string,
+        nativeCurrencyName: string,
+        nativeCurrencySymbol: string,
+        nativeCurrencyDecimals: int,
+        isTest: bool,
+        isEnabled: bool,
+        relatedChainId: int,
+        isActive: bool,
+        isDeactivatable: bool,
+        eip1559Enabled: bool,
+        noBaseFee: bool,
+        noPriorityFee: bool
+        )
+  proc delete*(self: NetworkItem)
   proc networkDtoToItem*(network: NetworkDto): NetworkItem =
     new(result, delete)
     let rpcProviders = network.rpcProviders.map(p => rpcProviderDtoToItem(p))
@@ -200,3 +177,48 @@ QtObject:
     return self.isActive
   QtProperty[bool] isActive:
     read = isActive
+
+  proc delete*(self: NetworkItem) =
+      self.QObject.delete
+
+  proc setup*(self: NetworkItem,
+      chainId: int,
+      layer: int,
+      chainName: string,
+      iconUrl: string,
+      shortName: string,
+      chainColor: string,
+      rpcProviders: seq[RpcProviderItem],
+      blockExplorerURL: string,
+      nativeCurrencyName: string,
+      nativeCurrencySymbol: string,
+      nativeCurrencyDecimals: int,
+      isTest: bool,
+      isEnabled: bool,
+      relatedChainId: int,
+      isActive: bool,
+      isDeactivatable: bool,
+      eip1559Enabled: bool,
+      noBaseFee: bool,
+      noPriorityFee: bool
+      ) =
+        self.QObject.setup
+        self.chainId = chainId
+        self.layer = layer
+        self.chainName = chainName
+        self.iconUrl = iconUrl
+        self.shortName = shortName
+        self.chainColor = chainColor
+        self.rpcProviders = rpcProviders
+        self.blockExplorerURL = blockExplorerURL
+        self.nativeCurrencyName = nativeCurrencyName
+        self.nativeCurrencySymbol = nativeCurrencySymbol
+        self.nativeCurrencyDecimals = nativeCurrencyDecimals
+        self.isTest = isTest
+        self.isEnabled = isEnabled
+        self.relatedChainId = relatedChainId
+        self.isActive = isActive
+        self.isDeactivatable = isDeactivatable
+        self.eip1559Enabled = eip1559Enabled
+        self.noBaseFee = noBaseFee
+        self.noPriorityFee = noPriorityFee

--- a/src/app_service/service/network/rpc_provider_item.nim
+++ b/src/app_service/service/network/rpc_provider_item.nim
@@ -19,34 +19,19 @@ QtObject:
     authToken*: string
 
   proc setup*(self: RpcProviderItem,
-    id: int,
-    chainId: int,
-    name: string,
-    url: string,
-    isRpsLimiterEnabled: bool,
-    providerType: RpcProviderType,
-    isEnabled: bool,
-    authType: RpcProviderAuthType,
-    authLogin: string,
-    authPassword: string,
-    authToken: string
-    ) =
-      self.QObject.setup
-      self.id = id
-      self.chainId = chainId
-      self.name = name
-      self.url = url
-      self.isRpsLimiterEnabled = isRpsLimiterEnabled
-      self.providerType = providerType
-      self.isEnabled = isEnabled
-      self.authType = authType
-      self.authLogin = authLogin
-      self.authPassword = authPassword
-      self.authToken = authToken
-
-  proc delete*(self: RpcProviderItem) =
-      self.QObject.delete
-
+      id: int,
+      chainId: int,
+      name: string,
+      url: string,
+      isRpsLimiterEnabled: bool,
+      providerType: RpcProviderType,
+      isEnabled: bool,
+      authType: RpcProviderAuthType,
+      authLogin: string,
+      authPassword: string,
+      authToken: string
+      )
+  proc delete*(self: RpcProviderItem)
   proc rpcProviderDtoToItem*(rpcProvider: RpcProviderDto): RpcProviderItem =
     new(result, delete)
     result.setup(rpcProvider.id, rpcProvider.chainId, rpcProvider.name, rpcProvider.url, rpcProvider.isRpsLimiterEnabled,
@@ -136,3 +121,32 @@ QtObject:
     return self.authToken
   QtProperty[string] authToken:
     read = authToken
+
+  proc delete*(self: RpcProviderItem) =
+      self.QObject.delete
+
+  proc setup*(self: RpcProviderItem,
+      id: int,
+      chainId: int,
+      name: string,
+      url: string,
+      isRpsLimiterEnabled: bool,
+      providerType: RpcProviderType,
+      isEnabled: bool,
+      authType: RpcProviderAuthType,
+      authLogin: string,
+      authPassword: string,
+      authToken: string
+      ) =
+        self.QObject.setup
+        self.id = id
+        self.chainId = chainId
+        self.name = name
+        self.url = url
+        self.isRpsLimiterEnabled = isRpsLimiterEnabled
+        self.providerType = providerType
+        self.isEnabled = isEnabled
+        self.authType = authType
+        self.authLogin = authLogin
+        self.authPassword = authPassword
+        self.authToken = authToken

--- a/src/app_service/service/network_connection/service.nim
+++ b/src/app_service/service/network_connection/service.nim
@@ -72,9 +72,7 @@ QtObject:
   proc getChainStatusTable(message: string): ConnectionStatusNotification
   proc getChainStatusTable(statusPerChain: Table[int, ProviderStatus]): ConnectionStatusNotification
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     walletService: wallet_service.Service,
@@ -284,3 +282,7 @@ QtObject:
         self.connectionStatus[MARKET] = newConnectionStatus()
       if(self.connectionStatus.hasKey(COLLECTIBLES)):
         self.connectionStatus[COLLECTIBLES] = newConnectionStatus()
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/node/service.nim
+++ b/src/app_service/service/node/service.nim
@@ -21,9 +21,7 @@ QtObject:
         peers*: seq[string]
         connected: bool
 
-    proc delete*(self: Service) =
-       self.QObject.delete
-
+    proc delete*(self: Service)
     proc newService*(events: EventEmitter, settingsService: settings_service.Service, nodeConfigurationService: node_configuration_service.Service): Service =
         new(result, delete)
         result.QObject.setup
@@ -82,3 +80,7 @@ QtObject:
       except Exception as e:
         let errDescription = e.msg
         error "error: ", errDescription
+
+    proc delete*(self: Service) =
+       self.QObject.delete
+

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -31,9 +31,7 @@ QtObject:
     accountsService: accounts_service.Service
     threadpool: threadpool.ThreadPool
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, settingsService: settings_service.Service,
     accountsService: accounts_service.Service): Service =
     new(result, delete)
@@ -105,3 +103,7 @@ QtObject:
 
   proc mnemonicWasShown*(self: Service) =
     self.settingsService.mnemonicWasShown()
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/profile/service.nim
+++ b/src/app_service/service/profile/service.nim
@@ -33,9 +33,7 @@ QtObject:
     events: EventEmitter
     settingsService: settings_service.Service
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool, settingsService: settings_service.Service): Service =
     new(result, delete)
     result.QObject.setup
@@ -195,3 +193,7 @@ QtObject:
         return response.result.getInt
     except Exception as e:
       error "Error getting unseen activity center notifications", msg = e.msg
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/ramp/service.nim
+++ b/src/app_service/service/ramp/service.nim
@@ -30,9 +30,7 @@ QtObject:
     events: EventEmitter
     threadpool: ThreadPool
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -76,3 +74,7 @@ QtObject:
       parameters: %parameters,
     )
     self.threadpool.start(arg)
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -37,9 +37,7 @@ QtObject:
     networkService: network_service.Service
     settingsService: settings_service.Service
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(threadpool: ThreadPool, events: EventEmitter, networkService: network_service.Service,
     settingsService: settings_service.Service): Service =
     new(result, delete)
@@ -179,3 +177,7 @@ QtObject:
       return response.result.getInt
     except Exception as e:
       error "error: ", procName="remainingCapacityForSavedAddresses", errName=e.name, errDesription=e.msg
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -70,9 +70,7 @@ QtObject:
   proc getNotificationVolume*(self: Service): int
   proc getNotificationMessagePreview*(self: Service): int
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(events: EventEmitter): Service =
     new(result, delete)
     result.events = events
@@ -1136,3 +1134,7 @@ QtObject:
     read = getThirdpartyServicesEnabled
     write = setThirdpartyServicesEnabled
     notify = thirdpartyServicesEnabledChanged
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -88,9 +88,7 @@ QtObject:
   # Forward declaration
   proc obtainMarketStickerPacks*(self: Service)
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -366,3 +364,7 @@ QtObject:
       discard status_stickers.clearRecentStickers()
     except RpcException:
       error "Error removing recent stickers", message = getCurrentExceptionMsg()
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -66,9 +66,7 @@ QtObject:
   proc rebuildMarketData*(self: Service)
   proc fetchTokenPreferences(self: Service)
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool,
@@ -577,3 +575,7 @@ QtObject:
         self.tokenPriceTable[tokenSymbol] = price
     if anyUpdated:
       self.events.emit(SIGNAL_TOKENS_PRICES_UPDATED, Args())
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -156,9 +156,7 @@ QtObject:
   proc suggestedRoutesReady(self: Service, uuid: string, route: seq[TransactionPathDtoV2], routeRaw: string, errCode: string, errDescription: string)
   proc sendTransactionsSignal(self: Service, sendDetails: SendDetailsDto, sentTransactions: seq[RouterSentTransaction] = @[])
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
@@ -538,3 +536,7 @@ proc reevaluateRouterPath*(self: Service, uuid: string, pathName: string, chainI
     isApprovalTx: isApprovalTx,
   )
   self.threadpool.start(arg)
+
+proc delete*(self: Service) =
+  self.QObject.delete
+

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -73,9 +73,7 @@ QtObject:
   proc tokenBalanceHistoryDataResolved*(self: Service, response: string) {.slot.}
   proc onENSNamesFetched*(self: Service, response: string) {.slot.}
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool,
@@ -110,3 +108,7 @@ QtObject:
   include service_token
   include service_keycard
   include balance_history
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/app_service/service/wallet_connect/service.nim
+++ b/src/app_service/service/wallet_connect/service.nim
@@ -65,9 +65,7 @@ QtObject:
     authenticationCallback: AuthenticationResponseFn
     signCallback: SignResponseFn
 
-  proc delete*(self: Service) =
-    self.QObject.delete
-
+  proc delete*(self: Service)
   proc newService*(
     events: EventEmitter,
     threadpool: ThreadPool,
@@ -334,3 +332,7 @@ QtObject:
       self.events.emit(SIGNAL_ESTIMATED_GAS_RESPONSE, args)
     except Exception as e:
       error "failed to parse estimated gas response", msg = e.msg 
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+

--- a/src/backend/network_types.nim
+++ b/src/backend/network_types.nim
@@ -89,3 +89,27 @@ proc `$`*(self: NetworkDto): string =
 
 proc `%`*(t: NetworkDto): JsonNode {.inline.} =
   result = parseJson(t.toJson)
+
+
+when defined(gcOrc) or defined(gcArc):
+  # The compiler complains that we can't prove the obj is not nil
+  # Keep this workaround for now
+  proc readValue*(r: var JsonReader, value: var seq[RpcProviderDto])
+                  {.raises: [SerializationError, IOError].} =
+    r.parseArray:
+      var tmp: RpcProviderDto
+      readValue(r, tmp)
+      when compiles(move(tmp)):
+        value.add move(tmp)
+      else:
+        value.add tmp
+
+  proc readValue*(r: var JsonReader, value: var seq[NetworkDto])
+                {.raises: [SerializationError, IOError].} =
+    r.parseArray:
+      var tmp: NetworkDto
+      readValue(r, tmp)
+      when compiles(move(tmp)):
+        value.add move(tmp)
+      else:
+        value.add tmp


### PR DESCRIPTION
### What does the PR do

This PR will allow us to compile the app using ORC/ARC.

These changes are mostly about forward declaring the finalizer and setup. The body has been moved after the `new`.
The only intrusive change is in `src/backend/network_types.nim`. I've declared new readers to be used with `ORC` and `ARC`. The default readers will complain that it can't prove the object is not nil.

### How to test

Change the `mm:refc` to `mm:orc` or `mm:arc`.
Compile and run the app

### Risk 

Low
