### PR TITLE
fix(l10n) Translations missing on LoginScreen

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -355,10 +355,11 @@ proc initializeQmlContext(self: AppController) =
   singletonInstance.engine.setRootContextProperty("localAccountSettings", self.localAccountSettingsVariant)
   singletonInstance.engine.setRootContextProperty("globalUtils", self.globalUtilsVariant)
   singletonInstance.engine.setRootContextProperty("metrics", self.metricsVariant)
-  singletonInstance.engine.load(newQUrl("qrc:///main.qml"))
 
-  # We need to init a language service once qml is loaded
+  # We need to init a language service before qml is loaded
   self.languageService.init()
+
+  singletonInstance.engine.load(newQUrl("qrc:///main.qml"))
 
 proc onboardingDidLoad*(self: AppController) =
   self.initializeQmlContext()


### PR DESCRIPTION
### What does the PR do

- we need to actually set our default language and init the language service _prior_ to loading main.qml (Onboarding & Login Screen) as we don't handle dynamic retranslations yet

Fixes #18883

### Affected areas

Login Screen

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2982" height="1998" alt="Snímek obrazovky z 2025-09-22 12-55-29" src="https://github.com/user-attachments/assets/f2c6056e-cc76-4c81-9302-19207123959e" />

### Impact on end user

Login screen uses the translated texts

### How to test

Just start the app

### Risk 

low
