### PR TITLE
feat(syncing): add checkbox to enable message syncing

### DIFF
--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -258,8 +258,7 @@ SettingsContentBase {
                 }
 
                 StatusButton {
-
-                    objectName: "setupSyncingStatusButton"           
+                    objectName: "setupSyncingStatusButton"
 
                     Layout.alignment: Qt.AlignHCenter
                     normalColor: Theme.palette.primaryColor1
@@ -269,6 +268,30 @@ SettingsContentBase {
                     text: qsTr("Setup Syncing")
                     onClicked: {
                         d.setupSyncing()
+                    }
+                }
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: Theme.halfPadding
+
+                    StatusCheckBox {
+                        objectName: "enableMessageSyncingCheckBox"
+
+                        Layout.fillWidth: true
+                        Layout.maximumWidth: implicitWidth
+                        text: qsTr("Enable message syncing")
+                        leftSide: true
+                        checked: false
+                        onToggled: () => {
+                            console.log("Enable message syncing toggled", checked)
+                        }
+                    }
+
+                    StatusNavBarTabButton {
+                        icon.name: "help"
+                        tooltip.text: qsTr("Enabling this will allow all your messages to be sent to the new device during the local pairing.")
+                        thirdpartyServicesEnabled: thirdpartyServicesCtrl.checked
                     }
                 }
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -12311,13 +12311,6 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>NotificationCard</name>
-    <message>
-        <source>Just now</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>NotificationSelect</name>
     <message>
         <source>Send Alerts</source>
@@ -17171,6 +17164,14 @@ access to your webcam</source>
         <source>Backup messages locally</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable message syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabling this will allow all your messages to be sent to the new device during the local pairing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TagsPanel</name>
@@ -19157,6 +19158,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -12367,13 +12367,6 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>NotificationCard</name>
-    <message>
-        <source>Just now</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>NotificationSelect</name>
     <message>
         <source>Send Alerts</source>
@@ -17246,6 +17239,14 @@ access to your webcam</source>
         <source>Backup messages locally</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable message syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabling this will allow all your messages to be sent to the new device during the local pairing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TagsPanel</name>
@@ -19238,6 +19239,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -12258,13 +12258,6 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>NotificationCard</name>
-    <message>
-        <source>Just now</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>NotificationSelect</name>
     <message>
         <source>Send Alerts</source>
@@ -17099,6 +17092,14 @@ access to your webcam</source>
         <source>Backup messages locally</source>
         <translation>메시지를 로컬에 백업</translation>
     </message>
+    <message>
+        <source>Enable message syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabling this will allow all your messages to be sent to the new device during the local pairing.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TagsPanel</name>
@@ -19083,6 +19084,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>스테이터스 데스크톱</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/18893

Adds a checkbox that is not hooked to anything. It will be used to enable message syncing during the local pairing

### Affected areas

SyncingView

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="666" height="409" alt="image" src="https://github.com/user-attachments/assets/5b66bf41-aaf8-47f7-b5ba-da85897af7b5" />

### Impact on end user

Nothing for now

### How to test

- Storybook

### Risk 

None
