### PR TITLE
fix(Wallet): Ensure `StatusListItemTag` height is stable across screen sizes

### DIFF
--- a/ui/imports/shared/popups/addaccount/panels/SelectOrigin.qml
+++ b/ui/imports/shared/popups/addaccount/panels/SelectOrigin.qml
@@ -46,7 +46,7 @@ StatusSelect {
 
         tagsDelegate: StatusListItemTag {
             bgColor: Utils.getColorForId(model.account.colorId)
-            height: Theme.bigPadding
+            height: 24
             bgRadius: 6
             tagClickable: false
             closeButtonVisible: false
@@ -104,7 +104,7 @@ StatusSelect {
 
         tagsDelegate: StatusListItemTag {
             bgColor: Utils.getColorForId(model.account.colorId)
-            height: Theme.bigPadding
+            height: 24
             bgRadius: 6
             tagClickable: false
             closeButtonVisible: false


### PR DESCRIPTION
Fixes #18199

### What does the PR do

The tag height was previously tied to `Theme.bigPadding`, which caused it to resize dynamically with screen size and appear cut off on smaller devices. It is now set to a fixed value to maintain consistent visual appearance.

### Affected areas

Wallet / Create New Account

### Architecture compliance

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="413" height="687" alt="Screenshot 2025-09-26 at 15 54 07" src="https://github.com/user-attachments/assets/70b8c887-a1ac-47f4-bf77-f78838e5cba2" />

### Impact on end user

Account tag has now better appearance.

### How to test

Go to create new account and look at the already created account tags.

### Risk 

None
