### PR TITLE
feat(ci): set e2e and tests-ui pipeline to use dockerfile for build steps

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -2,21 +2,19 @@
 library 'status-jenkins-lib@v1.9.16'
 
 pipeline {
-
   agent {
-    /* Image with Ubuntu 22.04 and QT 6.9.2 */
-    docker {
+    dockerfile {
       label 'linuxcontainer'
-      image 'harbor.status.im/status-im/status-desktop-build:1.0.5-qt6.9.2'
-      /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
-      args '--entrypoint="" ' +
-          '--network=host ' +
-          '--cap-add=SYS_ADMIN ' +
-          '--security-opt=apparmor:unconfined ' +
-          '--device=/dev/fuse ' +
-          '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
-          '--volume=/home/jenkins/.squish-license:/home/jenkins/.squish-license ' +
-          '--volume=/opt/squish-runner-9.0.1-qt-6.9:/opt/squish-runner-9.0.1-qt-6.9'
+      filename 'tests.Dockerfile'
+      dir 'ci'
+      args '--network=host ' +
+           '--cap-add=SYS_ADMIN ' +
+           '--security-opt=apparmor:unconfined ' +
+           '--device=/dev/fuse ' +
+           '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
+           '--volume=/home/jenkins/.squish-license:/home/jenkins/.squish-license ' +
+           '--volume=/opt/squish-runner-9.0.1-qt-6.9:/opt/squish-runner-9.0.1-qt-6.9 ' +
+           '--user jenkins'
     }
   }
 

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -6,15 +6,16 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
   agent {
-    /* Image with Ubuntu 22.04 and QT 6.9.2 */
-    docker {
+    dockerfile {
       label 'linuxcontainer'
-      image 'harbor.status.im/status-im/status-desktop-build:1.0.5-qt6.9.2'
-      /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
-      args '--entrypoint="" ' +
-          '--cap-add SYS_ADMIN ' +
-          '--security-opt apparmor:unconfined ' +
-          '--device /dev/fuse'
+      filename 'tests.Dockerfile'
+      dir 'ci'
+      args '--cap-add SYS_ADMIN ' +
+           '--security-opt apparmor:unconfined ' +
+           '--device /dev/fuse ' +
+           '--volume=/var/run/docker.sock:/var/run/docker.sock ' +
+           '--network=host ' +
+           '--user jenkins'
     }
   }
 

--- a/ci/tests.Dockerfile
+++ b/ci/tests.Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends --fix-missing 
     sudo \
     curl wget gnupg ca-certificates lsb-release python3-pip python3-venv
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor --batch --yes -o /etc/apt/keyrings/docker.gpg \
 && gpg --no-default-keyring --keyring /etc/apt/keyrings/docker.gpg --fingerprint \
       | grep -q "9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88" \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
@@ -27,3 +27,5 @@ USER jenkins
 LABEL maintainer="marko@status.im"
 LABEL source="https://github.com/status-im/status-desktop"
 LABEL description="Build image for the Status Desktop e2e tests with Squish and Qt."
+
+ENTRYPOINT [""]


### PR DESCRIPTION
With this we avoid maintaining separately and tagging the test docker image.

Referenced issue:
* https://github.com/status-im/infra-ci/issues/188

### What does the PR do

Fixes tests-ui pipeline and makes both tests-ui and e2e build an image for the build itself out of the dockerfile in the repo.

### Affected areas

Linux e2e tests pipeline.

### Architecture compliance

- [ x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
