### PR TITLE
StatusChatInput: prevent losing focus when msg is sent

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -353,8 +353,9 @@ Item {
                                  && root.rootStore.sectionDetails.joined
                                  && !root.rootStore.sectionDetails.amIBanned
                                  && root.rootStore.isUserAllowedToSendMessage
-                                 && !d.sendingInProgress
                     }
+
+                    textInput.readOnly: d.sendingInProgress
 
                     usersModel: root.usersModel
                     linkPreviewModel: !!d.activeChatContentModule ? d.activeChatContentModule.inputAreaModule.linkPreviewModel : null


### PR DESCRIPTION
### What does the PR do

Disabling text area when message sending was in progress was causing losing focus for a moment. It was triggering closing and re-opening (in wrong position) on-screen keyboard on mobile.

Closes: #18839

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`ChatColumnView`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/1d979d11-1e58-4fe8-822e-c0b99d3ef151


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Low

### How to test

Use chat on mobile

### Risk 

-
