### PR TITLE
Chat: EmptyChatPanel adapting to any size

### DIFF
--- a/storybook/pages/EmptyChatPanelPage.qml
+++ b/storybook/pages/EmptyChatPanelPage.qml
@@ -1,0 +1,13 @@
+import QtQuick
+
+import AppLayouts.Chat.panels
+
+Item {
+    EmptyChatPanel {
+        anchors.fill: parent
+        onShareChatKeyClicked: console.log("share chat key clicked!")
+    }
+}
+
+// category: Panels
+// status: good

--- a/ui/app/AppLayouts/Chat/panels/EmptyChatPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/EmptyChatPanel.qml
@@ -1,104 +1,80 @@
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 
 import StatusQ.Core
 import StatusQ.Core.Theme
 
-import shared
-import shared.panels
 import shared.popups
 
 import utils
 
-Item {
-    id: element
-    Layout.fillHeight: true
-    Layout.fillWidth: true
+ColumnLayout {
+    id: root
 
     signal shareChatKeyClicked()
 
+    spacing: 0
+
     Image {
-        id: walkieTalkieImage
+        id: placeholderImage
+
         objectName: "emptyChatPanelImage"
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
+
+        fillMode: Image.PreserveAspectFit
+
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.maximumHeight: Math.min(width, implicitHeight)
+
+        Layout.topMargin: {
+            const remainingHeight = root.height - height
+
+            return Math.max(0, remainingHeight / 2 -
+                            Math.max(0, baseText.implicitHeight -
+                                     remainingHeight / 2)) / 2
+        }
+
         source: Theme.png("chat/chat@2x")
     }
 
-    Item {
-        id: links
-        anchors.top: walkieTalkieImage.bottom
-        anchors.horizontalCenter: walkieTalkieImage.horizontalCenter
-        height: shareKeyLink.height
-        width: childrenRect.width
+    StatusBaseText {
+        id: baseText
 
-        StyledText {
-            id: shareKeyLink
-            text: qsTr("Share your chat key")
-            font.pixelSize: Theme.primaryTextFontSize
-            color: Theme.palette.primaryColor1
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.minimumHeight: implicitHeight
 
-            StatusMouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                hoverEnabled: true
-                onEntered: {
-                    parent.font.underline = true
-                }
-                onExited: {
-                    parent.font.underline = false
-                }
-                onClicked: shareChatKeyClicked()
-            }
-        }
+        text: qsTr("%1 or %2<br>friends to start messaging in Status")
+          .arg(Utils.getStyledLink(qsTr("Share your chat key"), "#share", hoveredLink,
+                Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
+          .arg(Utils.getStyledLink(qsTr("invite"), "#invite", hoveredLink,
+                Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
 
-        StyledText {
-            id: orText
-            text: qsTr("or")
-            font.pixelSize: Theme.primaryTextFontSize
-            color: Theme.palette.secondaryText
-            anchors.left: shareKeyLink.right
-            anchors.leftMargin: 2
-            anchors.bottom: shareKeyLink.bottom
-        }
+        horizontalAlignment: Text.AlignHCenter
 
-        StyledText {
-            id: inviteLink
-            text: qsTr("invite")
-            font.pixelSize: Theme.primaryTextFontSize
-            color: Theme.palette.primaryColor1
-            anchors.left: orText.right
-            anchors.leftMargin: 2
-            anchors.bottom: shareKeyLink.bottom
-
-            StatusMouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                hoverEnabled: true
-                onEntered: {
-                    parent.font.underline = true
-                }
-                onExited: {
-                    parent.font.underline = false
-                }
-                onClicked: {
-                    Global.openPopup(inviteFriendsPopup)
-                }
-            }
-        }
-    }
-
-    StyledText {
-        text: qsTr("friends to start messaging in Status")
-        font.pixelSize: Theme.primaryTextFontSize
         color: Theme.palette.secondaryText
-        anchors.horizontalCenter: walkieTalkieImage.horizontalCenter
-        anchors.top: links.bottom
+        font.pixelSize: Theme.primaryTextFontSize
+        wrapMode: Text.Wrap
+        elide: Text.ElideRight
+        maximumLineCount: 3
+        textFormat: Text.RichText
+
+        onLinkActivated: link => {
+            if (link === "#share")
+                shareChatKeyClicked()
+            else
+                Global.openPopup(inviteFriendsPopup)
+        }
+
+        HoverHandler {
+            // Qt CSS doesn't support custom cursor shape
+            cursorShape: !!parent.hoveredLink ? Qt.PointingHandCursor : undefined
+        }
     }
 
     Component {
         id: inviteFriendsPopup
+
         InviteFriendsPopup {
             destroyOnClose: true
         }

--- a/ui/app/AppLayouts/Chat/panels/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/qmldir
@@ -1,4 +1,5 @@
+ChatAnchorButtonsPanel 1.0 ChatAnchorButtonsPanel.qml
+EmptyChatPanel 1.0 EmptyChatPanel.qml
+InlineSelectorPanel 1.0 InlineSelectorPanel.qml
 SuggestionBoxPanel 1.0 SuggestionBoxPanel.qml
 UserListPanel 1.0 UserListPanel.qml
-ChatAnchorButtonsPanel 1.0 ChatAnchorButtonsPanel.qml
-InlineSelectorPanel 1.0 InlineSelectorPanel.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6705,15 +6705,11 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>or</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>invite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>friends to start messaging in Status</source>
+        <source>%1 or %2&lt;br&gt;friends to start messaging in Status</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -8189,19 +8189,14 @@
       <translation>Share your chat key</translation>
     </message>
     <message>
-      <source>or</source>
-      <comment>EmptyChatPanel</comment>
-      <translation>or</translation>
-    </message>
-    <message>
       <source>invite</source>
       <comment>EmptyChatPanel</comment>
       <translation>invite</translation>
     </message>
     <message>
-      <source>friends to start messaging in Status</source>
+      <source>%1 or %2&lt;br&gt;friends to start messaging in Status</source>
       <comment>EmptyChatPanel</comment>
-      <translation>friends to start messaging in Status</translation>
+      <translation>%1 or %2&lt;br&gt;friends to start messaging in Status</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6729,15 +6729,11 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>or</source>
-        <translation type="unfinished">nebo</translation>
-    </message>
-    <message>
         <source>invite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>friends to start messaging in Status</source>
+        <source>%1 or %2&lt;br&gt;friends to start messaging in Status</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6681,16 +6681,12 @@ Remember your password and don&apos;t share it with anyone.</source>
         <translation>채팅 키를 공유</translation>
     </message>
     <message>
-        <source>or</source>
-        <translation>또는</translation>
-    </message>
-    <message>
         <source>invite</source>
         <translation>초대</translation>
     </message>
     <message>
-        <source>friends to start messaging in Status</source>
-        <translation>친구들이 Status에서 메시지를 시작하도록</translation>
+        <source>%1 or %2&lt;br&gt;friends to start messaging in Status</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Makes the placeholder (image + text) adaptive to available space.

Closes: #18835

### Affected areas
`EmptyChatPanel`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="329" height="754" alt="Screenshot from 2025-10-06 18-45-12" src="https://github.com/user-attachments/assets/e1221b90-c1b0-407a-aeeb-888df5834e09" />
<img width="765" height="754" alt="Screenshot from 2025-10-06 18-45-01" src="https://github.com/user-attachments/assets/5a5a7b19-ad83-4aee-bddd-0ec03b0c4342" />

