### PR TITLE
fix(HoldingsDropdown): speed up and unfreeze the Collectibles Tab

### DIFF
--- a/storybook/pages/EditPermissionViewPage.qml
+++ b/storybook/pages/EditPermissionViewPage.qml
@@ -7,6 +7,8 @@ import AppLayouts.Communities.views
 import Storybook
 import Models
 
+import SortFilterProxyModel
+
 SplitView {
     orientation: Qt.Vertical
     SplitView.fillWidth: true
@@ -29,8 +31,19 @@ SplitView {
 
             assetsModel: AssetsModel {}
             collectiblesModel: CollectiblesModel {}
-            channelsModel: ChannelsModel {}
-
+            channelsModel: SortFilterProxyModel {
+                sourceModel: ChannelsModel {}
+                proxyRoles: [
+                    JoinRole {
+                        name: "key"
+                        roleNames: ["itemId"]
+                    },
+                    JoinRole {
+                        name: "text"
+                        roleNames: ["name"]
+                    }
+                ]
+            }
             communityDetails: QtObject {
                 readonly property string id: "id_sox"
                 readonly property string name: "Socks"
@@ -106,5 +119,5 @@ SplitView {
 }
 
 // category: Views
-
+// status: good
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22253%3A486103&t=JrCIfks1zVzsk3vn-0

--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -162,7 +162,7 @@ StatusFlowSelector {
                     enabled: root.itemsClickable
                     cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
-                    onClicked: root.itemClicked(parent, model.index, mouse)
+                    onClicked: (mouse) => root.itemClicked(parent, model.index, mouse)
                 }
             }
         }

--- a/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenPanel.qml
@@ -136,7 +136,7 @@ ColumnLayout {
         multiplierIndex: !!networksComboBoxLoader.item
                          ? networksComboBoxLoader.item.currentMultiplierIndex : 0
 
-        onKeyPressed: {
+        onKeyPressed: function (event) {
             if(!addOrUpdateButton.enabled)
                 return
 

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -137,8 +137,6 @@ StatusDropdown {
         // By design values:
         readonly property int padding: 8
         readonly property int defaultWidth: 289
-        readonly property int tabBarHeight: 36
-        readonly property int tabBarTextSize: 13
         readonly property int backButtonWidth: 56
         readonly property int backButtonHeight: 24
         readonly property int backButtonToContentSpace: 8
@@ -197,7 +195,6 @@ StatusDropdown {
             id: tabBar
 
             visible: !backButton.visible
-            Layout.preferredHeight: d.tabBarHeight
             Layout.fillWidth: true
             Layout.leftMargin: d.padding
             Layout.rightMargin: d.padding
@@ -233,7 +230,7 @@ StatusDropdown {
 
                 StatusSwitchTabButton {
                     text: modelData
-                    font.pixelSize: d.tabBarTextSize
+                    font.pixelSize: Theme.additionalTextSize
                 }
             }
         }
@@ -315,7 +312,7 @@ StatusDropdown {
 
             onTypeChanged: forceActiveFocus()
 
-            onItemClicked: {
+            onItemClicked: function (key, name, iconSource) {
                 d.assetAmountText = ""
                 d.collectibleAmountText = ""
 
@@ -348,8 +345,10 @@ StatusDropdown {
                     if((!item.infiniteSupply && (item.supply && item.supply.toString() === "1")
                             || (item.remainingSupply && item.remainingSupply.toString() === "1"))) {
                         root.collectibleAmount = "1"
-                        d.updateSelected ? root.updateCollectible(root.collectibleKey, "1")
-                                         : root.addCollectible(root.collectibleKey, "1")
+                        if (d.updateSelected)
+                            root.updateCollectible(root.collectibleKey, "1")
+                        else
+                            root.addCollectible(root.collectibleKey, "1")
                         return
                     }
                 }
@@ -357,7 +356,7 @@ StatusDropdown {
                 statesStack.push(HoldingsDropdown.FlowType.Selected)
             }
 
-            onNavigateDeep: {
+            onNavigateDeep: function (key, subItems) {
                 d.currentSubItems = subItems
                 d.currentItemKey = key
                 statesStack.push(HoldingsDropdown.FlowType.List_Deep2)

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -284,7 +284,7 @@ StatusScrollView {
                     usedEnsNames = d.dirtyValues.getEnsNames().filter(item => item !== ensDomainName)
                 }
 
-                onAddAsset: {
+                onAddAsset: function (key, amount) {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.assetsModel, key)
 
@@ -292,7 +292,7 @@ StatusScrollView {
                     dropdown.close()
                 }
 
-                onAddCollectible: {
+                onAddCollectible: function (key, amount) {
                     const modelItem = PermissionsHelpers.getTokenByKey(
                                         root.collectiblesModel, key)
 
@@ -352,7 +352,7 @@ StatusScrollView {
                 editedIndex = -1
             }
 
-            onItemClicked: {
+            onItemClicked: function (item, index, mouse) {
                 if (mouse.button !== Qt.LeftButton)
                     return
 
@@ -437,7 +437,7 @@ StatusScrollView {
                     anchors.fill: parent
                     cursorShape: Qt.PointingHandCursor
 
-                    onClicked: {
+                    onClicked: function (mouse) {
                         permissionsDropdown.mode = PermissionsDropdown.Mode.Update
                         permissionsDropdown.directParent = parent
                         permissionsDropdown.relativeX = mouse.x + d.dropdownHorizontalOffset
@@ -456,7 +456,7 @@ StatusScrollView {
                 initialPermissionType: d.dirtyValues.permissionType
                 enableAdminPermission: root.communityDetails.owner
 
-                onDone: {
+                onDone: function(permissionType) {
                     if (d.dirtyValues.permissionType === permissionType) {
                         permissionsDropdown.close()
                         return
@@ -554,7 +554,7 @@ StatusScrollView {
                 communityImage: root.communityDetails.image
                 communityColor: root.communityDetails.color
 
-                onChannelsSelected: {
+                onChannelsSelected: function (channels) {
                     d.dirtyValues.selectedChannelsModel.clear()
                     inSelector.model = 0
                     inSelector.wholeCommunitySelected = false

--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -110,9 +110,7 @@ Item {
             onEditingFinished: inputBox.editingFinished(inputBox.text)
             onTextEdited: inputBox.textEdited(inputBox.text)
 
-            Keys.onPressed: {
-                inputBox.keyPressed(event);
-            }
+            Keys.onPressed: (event) => inputBox.keyPressed(event)
         }
 
         SVGImage {


### PR DESCRIPTION
### What does the PR do

- extract the `getCategoryLabelForType()` function outside of the `categoryLabel` expression; fixes the endless warnings spam
- use `FastExpressionRole` instead for the above
- use `SearchFilter` for the search function
- unbreak the InDropdown (channel selector) in the EditPermissionView SB page
- cleanup and silence some warnings

Fixes #18921

### Affected areas

EditPermissionView,HoldingsDropdown

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/dc391dfa-e949-4651-b86e-07b11803ab19

### Impact on end user

Adding/editing permissions (namely adding a collectible) should be much faster
