### PR TITLE
fix(Settings): unbreak the NetworksView size

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -49,7 +49,7 @@ FetchContent_Declare(
   QmlStorybook
 
   GIT_REPOSITORY https://github.com/status-im/QmlStorybook.git
-  GIT_TAG 153f6886825deb7c6baf2a3cf2fc475ab8f466f9
+  GIT_TAG 6cc84cc5fbafb33398f6d2762c3837b7b18c9a96
 )
 FetchContent_MakeAvailable(QmlStorybook)
 

--- a/storybook/pages/NetworksViewPage.qml
+++ b/storybook/pages/NetworksViewPage.qml
@@ -49,10 +49,10 @@ SplitView {
                 flatNetworks: d.networksModel
                 areTestNetworksEnabled: testModeCheckBox.checked
 
-                onEditNetwork: {
+                onEditNetwork: function (chainId) {
                     console.log("Edit network", chainId)
                 }
-                onSetNetworkActive: {
+                onSetNetworkActive: function (chainId, active) {
                     console.log("Set network active test networks", chainId, active)
                     const index = ModelUtils.indexOf(d.networksModel, "chainId", chainId)
                     d.networksModel.setProperty(index, "isActive", active)

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -2,7 +2,6 @@ import QtCore
 import QtQml
 import QtQuick
 
-import Qt5Compat.GraphicalEffects
 import QtQuick.Controls
 import QtQuick.Layouts
 
@@ -156,13 +155,11 @@ SettingsContentBase {
         Binding on currentIndex {
             value: root.manageTokensViewIndex
             when: priv.isManageTokensSubsection
-            restoreMode: Binding.RestoreNone
         }
 
         Binding on currentIndex {
             value: root.networksViewIndex
-            when: root.settingsSubSubsection === Constants.walletSettingsSubsection.manageNetworks
-            restoreMode: Binding.RestoreNone
+            when: priv.isManageNetworksSubsection
         }
 
         onCurrentIndexChanged: {
@@ -174,18 +171,16 @@ SettingsContentBase {
             root.stickTitleRowComponentLoader = false
             root.titleLayout.spacing = 5
 
-            if (currentIndex == root.mainViewIndex) {
+            if (currentIndex === root.mainViewIndex) {
                 root.titleRowComponentLoader.sourceComponent = addNewAccountButtonComponent
-            }
 
-            if(currentIndex == root.networksViewIndex) {
+            } else if(currentIndex === root.networksViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.sectionTitle = root.networksSectionTitle
 
                 root.titleRowComponentLoader.sourceComponent = toggleTestnetModeSwitchComponent
-            }
 
-            if(currentIndex == root.editNetworksViewIndex) {
+            } else if(currentIndex === root.editNetworksViewIndex) {
                 priv.backButtonName = root.networksSectionTitle
                 root.sectionTitle = qsTr("Edit %1").arg(!!editNetwork.network &&
                                                         !!editNetwork.network.chainName ? editNetwork.network.chainName: "")
@@ -193,23 +188,23 @@ SettingsContentBase {
                 root.titleRowLeftComponentLoader.sourceComponent = networkIcon
                 root.titleLayout.spacing = 12
 
-            } else if(currentIndex == root.accountViewIndex) {
+            } else if(currentIndex === root.accountViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.sectionTitle = ""
 
-            } else if(currentIndex == root.accountOrderViewIndex) {
+            } else if(currentIndex === root.accountOrderViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.sectionTitle = qsTr("Edit account order")
                 root.titleRowComponentLoader.sourceComponent = experimentalTagComponent
                 root.stickTitleRowComponentLoader = true
 
-            } else if(currentIndex == root.manageTokensViewIndex) {
+            } else if(currentIndex === root.manageTokensViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.titleRowLeftComponentLoader.visible = false
                 root.sectionTitle = qsTr("Manage tokens")
                 root.titleRowComponentLoader.sourceComponent = experimentalTagComponent
                 root.stickTitleRowComponentLoader = true
-            } else if(currentIndex == root.savedAddressesViewIndex) {
+            } else if(currentIndex === root.savedAddressesViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.titleRowLeftComponentLoader.visible = false
                 root.sectionTitle = qsTr("Saved addresses")
@@ -275,7 +270,7 @@ SettingsContentBase {
         NetworksView {
             id: networksView
             Layout.fillWidth: true
-            Layout.fillHeight: false
+            Layout.fillHeight: true
 
             flatNetworks: root.networksStore.allNetworks
             areTestNetworksEnabled: root.networksStore.areTestNetworksEnabled
@@ -302,10 +297,8 @@ SettingsContentBase {
             networkRPCChanged: root.networksStore.networkRPCChanged
             rpcProviders: root.networksStore.rpcProviders
             areTestNetworksEnabled: root.networksStore.areTestNetworksEnabled
-            onEvaluateRpcEndPoint: root.networksStore.evaluateRpcEndPoint(url, isMainUrl)
-            onUpdateNetworkValues: {
-                root.networksStore.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl)
-            }
+            onEvaluateRpcEndPoint: (url, isMainUrl) => root.networksStore.evaluateRpcEndPoint(url, isMainUrl)
+            onUpdateNetworkValues: (chainId, newMainRpcInput, newFailoverRpcUrl) => root.networksStore.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl)
         }
 
         AccountOrderView {

--- a/ui/app/AppLayouts/Profile/views/wallet/NetworksView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/NetworksView.qml
@@ -62,7 +62,7 @@ Item {
             sourceModel: root.flatNetworks
             filters: ValueFilter {
                 roleName: "isTest"
-                value: testModeViewTabBar.currentIndex == root.testnetTabIndex
+                value: testModeViewTabBar.currentIndex === root.testnetTabIndex
             }
         }
 


### PR DESCRIPTION
### What does the PR do

- fixes the empty networks view under Settings/Wallet/Networks
- minor cleanups + silence some warnings
- separate (unrelated) commit to update the Storybook QML lib

Fixes https://github.com/status-im/status-desktop/issues/18963

### Affected areas

Settings/Wallet/Networks

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="3082" height="2086" alt="Snímek obrazovky z 2025-10-07 12-20-42" src="https://github.com/user-attachments/assets/bf55afd8-29fe-4b9c-8c94-6866594a7a89" />

### Impact on end user

Users can edit the Networks

### How to test

- go to Settings/Wallet/Networks

### Risk 

low
