### PR TITLE
fix(Wallet): can't access asset details screen

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -417,12 +417,12 @@ RightTabBaseView {
                         onCommunityClicked: Global.switchToCommunity(communityKey)
 
                         onHideRequested: (key) => {
-                                             const token = ModelUtils.getByKey(model, "key", key)
+                                             const token = SQUtils.ModelUtils.getByKey(model, "key", key)
                                              Global.openConfirmHideAssetPopup(token.symbol, token.name, token.icon, !!token.communityId)
                                          }
                         onHideCommunityAssetsRequested:
                             (communityKey) => {
-                                const community = ModelUtils.getByKey(model, "communityId", communityKey)
+                                const community = SQUtils.ModelUtils.getByKey(model, "communityId", communityKey)
                                 confirmHideCommunityAssetsPopup.createObject(root, {
                                                                                  name: community.communityName,
                                                                                  icon: community.communityIcon,
@@ -434,7 +434,7 @@ RightTabBaseView {
                                                      Constants.settingsSubsection.wallet,
                                                      Constants.walletSettingsSubsection.manageAssets)
                         onAssetClicked: (key) => {
-                            const token = ModelUtils.getByKey(model, "key", key)
+                            const token = SQUtils.ModelUtils.getByKey(model, "key", key)
 
                             RootStore.tokensStore.getHistoricalDataForToken(
                                                 token.symbol, RootStore.currencyStore.currentCurrency)
@@ -510,7 +510,7 @@ RightTabBaseView {
                             stack.currentIndex = 1
                         }
                         onSendRequested: (symbol, tokenType, fromAddress) => {
-                                             const collectible = ModelUtils.getByKey(controller.sourceModel, "symbol", symbol)
+                                             const collectible = SQUtils.ModelUtils.getByKey(controller.sourceModel, "symbol", symbol)
                                              if (!!collectible && collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) {
                                                  Global.openTransferOwnershipPopup(collectible.communityId,
                                                                                    collectible.communityName,


### PR DESCRIPTION
### What does the PR do

- fix a recent porting error; prepend the `ModelUtils` with the correct alias (`SQUtils`)

Fixes #18969

### Affected areas

Wallet

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2712" height="1832" alt="Snímek obrazovky z 2025-10-08 15-09-06" src="https://github.com/user-attachments/assets/b7e73675-ddef-4344-b31f-8f38e2239b29" />


### Impact on end user

Users can access and manipulate the asset(s)

### How to test

- go to Wallet
- click any Asset

### Risk 

- low
