### PR TITLE
chore: Enable orc and use malloc on mobile

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -50,7 +50,8 @@ APP_CONFIG_DEFINES=(
 
 # build status-client with feature flags
 env $FEATURE_FLAGS ./vendor/nimbus-build-system/scripts/env.sh nim c "${PLATFORM_SPECIFIC[@]}" "${APP_CONFIG_DEFINES[@]}" ${QML_SERVER_DEFINES}  \
-    --mm:refc \
+    --mm:orc \
+    -d:useMalloc \
     --opt:size \
     -d:lto \
     --cc:clang \


### PR DESCRIPTION
### What does the PR do

Enabling `orc` memory manager for nim and use `malloc` to allocate objects. The memory footprint for the app will decrease up to 300MB with no noticeable downsides in terms of performance.

The only `downside` I've seen so far is that nim objects will be deallocated for real! Meaning that we'll need to be more careful with the lifetime management when sharing objects with QML. The advantage on the other hand is that in such a case a crash is imminent when QML tries to access the QObject.
