### PR TITLE
feat(@desktop/wallet): Added same color for Navbar + Navbar Button when Privacy mode is on

### DIFF
--- a/storybook/pages/StatusNavBarTabButtonPage.qml
+++ b/storybook/pages/StatusNavBarTabButtonPage.qml
@@ -19,7 +19,7 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        color: thirdpartyServicesCtrl.checked ? Theme.palette.statusAppNavBar.backgroundColor: Theme.palette.privacyModeColor
+        color: thirdpartyServicesCtrl.checked ? Theme.palette.statusAppNavBar.backgroundColor: Theme.palette.privacyModeColors.navBarColor
 
         Column {
             id: column

--- a/ui/StatusQ/src/StatusQ/Controls/StatusNavBarTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusNavBarTabButton.qml
@@ -18,10 +18,10 @@ StatusIconTabButton {
     identicon.asset.color: (statusNavBarTabButton.hovered || highlighted || statusNavBarTabButton.checked) ?
                                statusNavBarTabButton.thirdpartyServicesEnabled ?
                                    Theme.palette.primaryColor1 :
-                                   Theme.palette.indirectColor1 :
+                                   Theme.palette.privacyModeColors.navButtonHighlightedColor :
                                  statusNavBarTabButton.thirdpartyServicesEnabled ?
                                     Theme.palette.baseColor1 :
-                                    Theme.palette.indirectColor3
+                                    Theme.palette.privacyModeColors.navButtonColor
 
     StatusToolTip {
         id: statusTooltip

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -226,7 +226,11 @@ QtObject {
         customisationColors.camel
     ]
 
-    readonly property color privacyModeColor: customisationColors.purple
+    property QtObject privacyModeColors: QtObject {
+        readonly property color navBarColor: customisationColors.purple
+        readonly property color navButtonColor: getColor('white', 0.4)
+        readonly property color navButtonHighlightedColor: getColor('white')
+    }
 
     function alphaColor(color, alpha) {
         let actualColor = Qt.darker(color, 1)

--- a/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -30,7 +30,7 @@ Rectangle {
     implicitWidth: 78
 
     color: root.thirdpartyServicesEnabled ? Theme.palette.statusAppNavBar.backgroundColor :
-                                            Theme.palette.privacyModeColor
+                                            Theme.palette.privacyModeColors.navBarColor
 
     QtObject {
         id: d

--- a/ui/imports/shared/panels/PrivacyWallCarousel.qml
+++ b/ui/imports/shared/panels/PrivacyWallCarousel.qml
@@ -117,7 +117,7 @@ Control {
             Layout.alignment: Qt.AlignHCenter
 
             type: StatusBaseButton.Type.Primary
-            normalColor: Theme.palette.privacyModeColor
+            normalColor: Theme.palette.privacyModeColors.navBarColor
             textColor: Theme.palette.white
 
             text: qsTr("Enable third-party services")

--- a/ui/imports/shared/popups/ThirdpartyServicesPopup.qml
+++ b/ui/imports/shared/popups/ThirdpartyServicesPopup.qml
@@ -124,7 +124,7 @@ StatusDialog {
         rightButtons: ObjectModel {
             StatusButton {
                 type: StatusBaseButton.Type.Primary
-                normalColor: Theme.palette.privacyModeColor
+                normalColor: Theme.palette.privacyModeColors.navBarColor
                 textColor: Theme.palette.white
                 text: {
                     if(root.thirdPartyServicesEnabled) {


### PR DESCRIPTION
fixes #18999

### What does the PR do

Same color for navbar and nabber buttons when privacy mode is on in dark and light mode to keep correct contrast.

### Affected areas

StatusNavBar in Privacy mode
### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1463" height="895" alt="Screenshot 2025-10-14 at 18 33 29" src="https://github.com/user-attachments/assets/24234079-b539-4504-8846-f4096f687ace" />
<img width="1463" height="895" alt="Screenshot 2025-10-14 at 18 33 22" src="https://github.com/user-attachments/assets/43436541-7142-4fe2-acf1-da1c285b95c1" />



### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
