### PR TITLE
fix(i18n): bundle the translations into resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ nim_status_client.log
 .flatpak-builder
 /ui/StatusQ/sandbox/android/.gradle/
 .qmake_previous
+*.qm
 
 # Squish test ================================================================
 
@@ -51,7 +52,6 @@ CMakeCache.txt
 CMakeFiles
 CMakeScripts
 Testing
-Makefile
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ endif
 
 UI_RESOURCES := resources.rcc
 
-$(UI_RESOURCES): $(UI_SOURCES) | check-qt-dir
+$(UI_RESOURCES): $(UI_SOURCES) | check-qt-dir compile-translations
 	echo -e $(BUILD_MSG) "resources.rcc"
 	rm -f ./resources.rcc
 	rm -f ./ui/resources.qrc
@@ -605,7 +605,7 @@ $(NIM_STATUS_CLIENT): update-qmake-previous
 endif
 
 $(NIM_STATUS_CLIENT): NIM_PARAMS += $(RESOURCES_LAYOUT)
-$(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSGO) $(STATUSKEYCARDGO) $(QRCODEGEN) rcc compile-translations deps
+$(NIM_STATUS_CLIENT): $(NIM_SOURCES) | statusq dotherside check-qt-dir $(STATUSGO) $(STATUSKEYCARDGO) $(QRCODEGEN) rcc deps
 	echo -e $(BUILD_MSG) "$@"
 	$(ENV_SCRIPT) nim c $(NIM_PARAMS) \
 		--mm:refc \
@@ -735,8 +735,6 @@ $(STATUS_CLIENT_DMG): nim_status_client
 	cp status.icns $(MACOS_OUTER_BUNDLE)/Contents/Resources/
 	cp status-macos.svg $(MACOS_OUTER_BUNDLE)/Contents/
 	cp -R resources.rcc $(MACOS_OUTER_BUNDLE)/Contents/
-	mkdir -p $(MACOS_OUTER_BUNDLE)/Contents/i18n
-	cp bin/i18n/* $(MACOS_OUTER_BUNDLE)/Contents/i18n
 
 	echo -e $(BUILD_MSG) "app"
 	MAC_QTQMLDIR=$(shell $(QMAKE) -query QT_INSTALL_QML) && \
@@ -785,10 +783,9 @@ $(STATUS_CLIENT_EXE): OUTPUT := tmp/windows/dist/Status
 $(STATUS_CLIENT_EXE): INSTALLER_OUTPUT := pkg
 $(STATUS_CLIENT_EXE): compile_windows_resources nim_status_client nim_windows_launcher
 	rm -rf pkg/*.exe tmp/windows/dist
-	mkdir -p $(OUTPUT)/bin $(OUTPUT)/resources $(OUTPUT)/vendor $(OUTPUT)/resources/i18n $(OUTPUT)/bin/plugins/tls
+	mkdir -p $(OUTPUT)/bin $(OUTPUT)/resources $(OUTPUT)/vendor $(OUTPUT)/bin/plugins/tls
 	cat windows-install.txt | unix2dos > $(OUTPUT)/INSTALL.txt
 	cp status.ico status.png resources.rcc $(OUTPUT)/resources/
-	cp bin/i18n/* $(OUTPUT)/resources/i18n
 	cp cacert.pem $(OUTPUT)/bin/cacert.pem
 	cp bin/nim_status_client.exe $(OUTPUT)/bin/Status.exe
 	cp bin/nim_windows_launcher.exe $(OUTPUT)/Status.exe

--- a/mobile/CONTRIBUTING.md
+++ b/mobile/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 When contributing to the build system:
 1. Test changes on both iOS and Android platforms
-2. Qt6 compatibility is mandatory. Qt5 is nice to have for now
+2. Qt6 compatibility is mandatory
 3. Update this README if necessary
 4. Follow the existing build system patterns

--- a/mobile/DEV_SETUP.md
+++ b/mobile/DEV_SETUP.md
@@ -4,7 +4,7 @@ This section is for developers who want full control over the build environment.
 
 ### iOS Development Setup
 
-### Prerequisites
+#### Prerequisites
 
 - Python 3.x
 - Qt 6.9.2
@@ -50,7 +50,7 @@ make mobile-run
 Note: It's best to install the qt architecture matching the system architecture
 
 ```bash
-# For Qt6 (includesdesktoptools)
+# For Qt6 (includes desktop tools)
 # arm host
 aqt install-qt mac android 6.9.2 android_arm64_v8a -O $HOME/qt -m all --autodesktop
 # x64 host
@@ -71,8 +71,7 @@ export ANDROID_NDK_ROOT=/path/to/android-ndk/27.2.12479018
 # Add Android tools to PATH
 export PATH="$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/tools/bin:$ANDROID_SDK_ROOT/platform-tools:$PATH"
 
-
-# Add Qt to PATH. Qt6 needs both ios bin and host libexec and host bin (in this order!)
+# Add Qt to PATH. Qt6 needs both android bin and host libexec and host bin (in this order!)
 export QTDIR='/your/Qt/Preferred/Folder' # CHANGE ME
 export QTTARGET='yourQtHostTarget' # CHANGE ME
 export PATH="$QTDIR/6.9.2/$QTTARGET/bin:$QTDIR/6.9.2/$QTTARGET/libexec:$QTDIR/6.9.2/$QTTARGET/bin:${PATH}"
@@ -106,8 +105,10 @@ The build system uses several environment variables to control the build process
 - `USE_SYSTEM_NIM=1`: Use system-installed Nim instead of building from source. Make sure `nim` and `nimble` are available
 
 #### Platform Configuration
-- `OS`: Target platform (`ios` or `android`) - qmake driven
-- `ARCH`: Target architecture - defaults to host arch for android and `x86_64` for ios simulator
+- `OS`: Target platform (`ios` or `android`)
+	- qmake driven
+- `ARCH`: Target architecture
+	- defaults to host arch for android and `x86_64` for ios simulator
 	- iOS: `arm64` (device) or `x86_64` (simulator)
 	- Android: `arm64` (arm64-v8a), `arm` (armeabi-v7a), `x86_64`, or `x86`
 - `PATH`: Should contain the path to Android or iOS Qt installation `bin` folder

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -58,7 +58,7 @@ $(QRCODEGEN_LIB): $(QRCODEGEN_FILES)
 	@QRCODEGEN=$(QRCODEGEN) $(QRCODEGEN_SCRIPT) $(HANDLE_OUTPUT)
 	@echo "QRCodeGen built $(QRCODEGEN_LIB)"
 
-$(STATUS_DESKTOP_RCC): $(STATUS_DESKTOP_UI_FILES)
+$(STATUS_DESKTOP_RCC): $(STATUS_DESKTOP_UI_FILES) compile-translations
 	@echo "Building Status Desktop rcc"
 	@make -C $(STATUS_DESKTOP) rcc $(HANDLE_OUTPUT)
 	@echo "Status Desktop rcc built"
@@ -78,6 +78,11 @@ $(TARGET): $(APP_SCRIPT) $(STATUS_GO_LIB) $(STATUS_Q_LIB) $(DOTHERSIDE_LIB) $(OP
 .PHONY: makedir
 makedir:
 	@mkdir -p $(BIN_PATH) $(LIB_PATH) $(BUILD_PATH)
+
+.PHONY: compile-translations
+compile-translations:
+	@echo "Building translations"
+	@make -C $(STATUS_DESKTOP) compile-translations $(HANDLE_OUTPUT)
 
 .PHONY: all
 all: $(TARGET)

--- a/mobile/TROUBLESHOOTING.md
+++ b/mobile/TROUBLESHOOTING.md
@@ -5,11 +5,11 @@
 1. **CMake Qt5 Error**
 ```
 CMake Error at CMakeLists.txt:36 (find_package):
-By not providing "FindQt5.cmake" in CMAKE_MODULE_PATH this project has
-asked CMake to find a package configuration file provided by "Qt5", but
+By not providing "FindQt6.cmake" in CMAKE_MODULE_PATH this project has
+asked CMake to find a package configuration file provided by "Qt6", but
 CMake did not find one.
 ```
-**Fix**: Ensure `QTDIR` environment variable points to the Qt installation folder.
+**Fix**: Ensure `QTDIR` environment variable points to the Qt 6 installation folder.
 
 2. **Python Interpreter Error**
 ```

--- a/mobile/scripts/Common.mk
+++ b/mobile/scripts/Common.mk
@@ -47,7 +47,6 @@ STATUS_DESKTOP_UI_FILES := $(shell find $(STATUS_DESKTOP)/ui -type f \( -iname '
 STATUS_Q_FILES := $(shell find $(STATUSQ) -type f \( -iname '*.cpp' -o -iname '*.h' \) -not -iname '*.qrc' -not -iname '*.qml')
 STATUS_Q_UI_FILES := $(shell find $(STATUSQ) -type f \( -iname '*.qml' -o -iname '*.qrc' \))
 STATUS_GO_FILES := $(shell find $(STATUS_GO) -type f \( -iname '*.go' \))
-STATUS_GO_SCRIPT := $(SCRIPTS_PATH)/buildStatusGo.sh
 DOTHERSIDE_FILES := $(shell find $(DOTHERSIDE) -type f \( -iname '*.cpp' -o -iname '*.h' \))
 OPENSSL_FILES := $(shell find $(OPENSSL) -type f \( -iname '*.c' -o -iname '*.h' \))
 QRCODEGEN_FILES := $(shell find $(QRCODEGEN) -type f \( -iname '*.c' -o -iname '*.h' \))

--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -35,7 +35,7 @@ if [[ "${OS}" == "android" ]]; then
 
     # call androiddeployqt
     androiddeployqt --input "$BUILD_DIR/android-Status-tablet-deployment-settings.json" --output "$BUILD_DIR/android-build" --apk "$BUILD_DIR/android-build/Status-tablet.apk" --android-platform "$ANDROID_PLATFORM"
-   
+
     ANDROID_OUTPUT_DIR="bin/android/qt6"
     BIN_DIR_ANDROID=${BIN_DIR:-"$CWD/$ANDROID_OUTPUT_DIR"}
     mkdir -p "$BIN_DIR_ANDROID"

--- a/mobile/wrapperApp/Status-tablet.pro
+++ b/mobile/wrapperApp/Status-tablet.pro
@@ -12,7 +12,7 @@ SOURCES += \
 
 # Add all status-desktop qrc files
 RESOURCES += \
-    ../../ui/resources.qrc
+    $$PWD/../../ui/resources.qrc
 
 QML_IMPORT_PATH += $$PWD/../../ui/imports \
                    $$PWD/../../ui/app \
@@ -22,8 +22,8 @@ QMLPATHS += $$QML_IMPORT_PATH
 LIB_PREFIX = $$(APP_VARIANT)
 
 android {
-    message("cofiguring for android $${QT_ARCH}, $$(ANDROID_ABI)")
-    
+    message("Configuring for android $${QT_ARCH}, $$(ANDROID_ABI)")
+
     ANDROID_PACKAGE_SOURCE_DIR = $$PWD/../android/qt$$QT_MAJOR_VERSION
 
     LIBS += -L$$PWD/../lib/$$LIB_PREFIX -lnim_status_client

--- a/mobile/wrapperApp/sources/main.cpp
+++ b/mobile/wrapperApp/sources/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[])
     Q_INIT_RESOURCE(resources);
     qputenv("QT_FILE_SELECTORS", "noWebEngine");
     qputenv("QT_SCALE_FACTOR", "0.8");
-    
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     qmlRegisterModule("Qt.labs.settings", 1, 1);
     qmlRegisterModule("Qt.labs.settings", 1, 0);
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
     qmlRegisterModuleImport("Qt.labs.settings", QQmlModuleImportModuleAny,
                        "QtCore", QQmlModuleImportLatest);
 #endif
-    
+
     NimMain();
     return 0;
 }

--- a/scripts/init_app_dir.sh
+++ b/scripts/init_app_dir.sh
@@ -8,7 +8,6 @@ mkdir -p \
   "${APP_DIR}/usr/bin" \
   "${APP_DIR}/usr/lib" \
   "${APP_DIR}/usr/qml" \
-  "${APP_DIR}/usr/i18n" \
   "${APP_DIR}/usr/plugins/platforminputcontexts" \
   "${APP_DIR}/etc/reader.conf.d" \
   "${APP_DIR}/usr/lib/pcsc/drivers" \
@@ -21,7 +20,6 @@ cp nim-status.desktop "${APP_DIR}/."
 cp status.png "${APP_DIR}/status.png"
 cp status.png "${APP_DIR}/usr/"
 cp -R resources.rcc "${APP_DIR}/usr/"
-cp bin/i18n/* "${APP_DIR}/usr/i18n"
 cp vendor/status-go/build/bin/libstatus.so "${APP_DIR}/usr/lib/"
 cp vendor/status-go/build/bin/libstatus.so.0 "${APP_DIR}/usr/lib/"
 cp "${STATUSKEYCARDGO}" "${APP_DIR}/usr/lib/"

--- a/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Universal
 import QtQuick.Layouts
 
 import StatusQ
@@ -119,7 +120,7 @@ Button {
 
         padding: 0
 
-        onOpened: searchField.forceActiveFocus()
+        onOpened: if (!Utils.isMobile) searchField.forceActiveFocus()
         onClosed: searchField.input.edit.clear()
 
         contentItem: ColumnLayout {
@@ -130,6 +131,7 @@ Button {
                 Layout.preferredWidth: userSelectorPanel.width - userSelectorPanel.leftMargin - userSelectorPanel.rightMargin
                 Layout.alignment: Qt.AlignHCenter
                 placeholderText: qsTr("Search")
+                   .arg(root.languageCodes.length).arg(root.currentLanguage).arg(Qt.uiLanguage)
                 input.asset.name: "search"
                 input.clearable: true
                 KeyNavigation.tab: userSelectorPanel

--- a/ui/StatusQ/src/l10n/languageservice.cpp
+++ b/ui/StatusQ/src/l10n/languageservice.cpp
@@ -1,51 +1,15 @@
 #include "languageservice.h"
 
 #include <QDir>
-#include <QGuiApplication>
 
 Q_LOGGING_CATEGORY(languageService, "status.languageService", QtInfoMsg)
 
-LanguageService::LanguageService(QQmlEngine *engine, QObject *parent)
-    : m_engine(engine)
+using namespace Qt::Literals::StringLiterals;
+
+LanguageService::LanguageService(QObject *parent)
+    : QObject(parent)
 {
     fetchAvailableLanguages();
-}
-
-bool LanguageService::setLanguage(const QString &newCurrentLanguage, bool shouldRetranslate)
-{
-    if (m_currentLanguage == newCurrentLanguage)
-        return false;
-    m_currentLanguage = newCurrentLanguage;
-
-    qCDebug(languageService) << Q_FUNC_INFO << m_currentLanguage << shouldRetranslate;
-
-    if (shouldRetranslate) {
-        if (m_translator && !m_translator->isEmpty()) {
-            qCDebug(languageService) << "!!! REMOVING PREV TRANSLATION:" << m_translator->language();
-            bool result = qApp->removeTranslator(m_translator.get());
-            qCDebug(languageService) << "!!! REMOVED OLD TRANSLATION:" << result;
-        }
-        m_translator.reset(new QTranslator);
-        const auto qmFile = QStringLiteral("%1/qml_%2.qm").arg(m_qmDirPath, m_currentLanguage);
-        qCDebug(languageService) << "!!! LOADING" << m_currentLanguage << "from:" << qmFile;
-
-        if (!m_translator->load(qmFile))
-            return false;
-
-        qCDebug(languageService) << "!!! LOADED:" << qmFile;
-
-        bool success = qApp->installTranslator(m_translator.get());
-        qCDebug(languageService) << "!!! TRANSLATOR INSTALLED:" << success;
-        if (!success)
-            return false;
-
-        if (m_engine) {
-            m_engine->retranslate();
-            qCDebug(languageService) << "!!! RETRANSLATED !!!";
-        }
-    }
-
-    return true;
 }
 
 QStringList LanguageService::availableLanguages() const
@@ -57,33 +21,23 @@ void LanguageService::fetchAvailableLanguages()
 {
     m_availableLanguages.clear();
 
-    const auto appDirPath = qApp->applicationDirPath();
+    QDir qmDir(":/i18n"_L1); // default prefix for QQmlApplicationEngine
 
-    qCDebug(languageService) << Q_FUNC_INFO << "!!! appDirPath BIN PATH:" << appDirPath;
+    qCDebug(languageService) << Q_FUNC_INFO << "!!! Probing" << qmDir.absolutePath() << "for translations";
 
-    QDir qmDir(appDirPath);
-    const auto pathsToProbe = {"i18n", "../i18n", "../resources/i18n"};
+    const auto qmFiles = qmDir.entryInfoList({"*.qm"_L1}, QDir::Files | QDir::Readable);
+    if (!qmFiles.isEmpty()) {
+        qCDebug(languageService) << Q_FUNC_INFO << "!!! Found translations:" << qmFiles << "in" << qmDir.absolutePath();
 
-    for (const auto& probePath: pathsToProbe) {
-        qmDir.setPath(appDirPath % '/' % probePath);
-        qCDebug(languageService) << Q_FUNC_INFO << "!!! Probing" << qmDir.absolutePath() << "for translations";
-        if (!qmDir.exists())
-            continue;
-
-        const auto qmFiles = qmDir.entryInfoList({"*.qm"}, QDir::Files | QDir::Readable);
-        if (!qmFiles.isEmpty()) {
-            m_qmDirPath = qmDir.absolutePath();
-            qCDebug(languageService) << Q_FUNC_INFO << "!!! Found translations:" << qmFiles << "in" << m_qmDirPath;
-
-            for (const auto& qmFile: qmFiles) {
-                const auto langCode = qmFile.baseName().section('_', 1);
-                qCDebug(languageService) << Q_FUNC_INFO << "!!! Adding language:" << langCode;
-                m_availableLanguages.append(langCode);
-            }
-            break;
+        for (const auto& qmFile: qmFiles) {
+            const auto langCode = qmFile.baseName().section('_', 1);
+            qCDebug(languageService) << Q_FUNC_INFO << "!!! Adding language:" << langCode;
+            m_availableLanguages.append(langCode);
         }
     }
 
     if (m_availableLanguages.isEmpty())
-        qCWarning(languageService) << Q_FUNC_INFO << "!!! Didn't find any translation files to offer in" << pathsToProbe;
+        qCWarning(languageService) << Q_FUNC_INFO << "!!! Didn't find any translation files to offer";
+
+    emit availableLanguagesChanged();
 }

--- a/ui/StatusQ/src/l10n/languageservice.h
+++ b/ui/StatusQ/src/l10n/languageservice.h
@@ -2,32 +2,23 @@
 
 #include <QLoggingCategory>
 #include <QObject>
-#include <QQmlEngine>
-#include <QTranslator>
-
-#include <memory>
 
 Q_DECLARE_LOGGING_CATEGORY(languageService)
 
 class LanguageService : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QStringList availableLanguages READ availableLanguages CONSTANT FINAL)
+    Q_PROPERTY(QStringList availableLanguages READ availableLanguages NOTIFY availableLanguagesChanged FINAL)
 
 public:
-    explicit LanguageService(QQmlEngine *engine, QObject* parent = nullptr);
+    explicit LanguageService(QObject* parent = nullptr);
 
-    Q_INVOKABLE bool setLanguage(const QString &newCurrentLanguage, bool shouldRetranslate = false);
+    Q_INVOKABLE void fetchAvailableLanguages();
+
+signals:
+    void availableLanguagesChanged();
 
 private:
-    QString m_currentLanguage;
-
     QStringList m_availableLanguages;
     QStringList availableLanguages() const;
-    void fetchAvailableLanguages();
-
-    QString m_qmDirPath;
-
-    std::unique_ptr<QTranslator> m_translator;
-    QQmlEngine* m_engine;
 };

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -45,8 +45,8 @@ void registerStatusQTypes() {
     qmlRegisterType<ManageTokensModel>("StatusQ.Models", 0, 1, "ManageTokensModel");
 
     qmlRegisterType<LanguageModel>("StatusQ.Models", 0, 1, "LanguageModel");
-    qmlRegisterSingletonType<LanguageService>("StatusQ", 0, 1, "LanguageService", [](QQmlEngine* engine, QJSEngine*) {
-        return new LanguageService(engine);
+    qmlRegisterSingletonType<LanguageService>("StatusQ", 0, 1, "LanguageService", [](QQmlEngine*, QJSEngine*) {
+        return new LanguageService;
     });
 
     qmlRegisterType<NetworkChecker>("StatusQ", 0, 1, "NetworkChecker");

--- a/ui/app/AppLayouts/Profile/stores/LanguageStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/LanguageStore.qml
@@ -9,9 +9,12 @@ QtObject {
     readonly property var availableLanguages: LanguageService.availableLanguages
 
     function changeLanguage(languageCode, shouldRetranslate = false) {
-        const result = LanguageService.setLanguage(languageCode, shouldRetranslate)
-        if (result)
-            localAppSettings.language = languageCode
-        return result
+        localAppSettings.language = languageCode
+
+        if (shouldRetranslate) {
+            // let the QQmlApplicationEngine handle the retranslation, as our QM files are in the expected `:/i18n` prefix
+            Qt.uiLanguage = languageCode
+        }
+        return true
     }
 }

--- a/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Universal
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 

--- a/ui/i18n/CMakeLists.txt
+++ b/ui/i18n/CMakeLists.txt
@@ -33,9 +33,9 @@ qt6_add_lrelease(
         ${CMAKE_SOURCE_DIR}/qml_en.ts
         ${CMAKE_SOURCE_DIR}/qml_cs.ts
         ${CMAKE_SOURCE_DIR}/qml_ko.ts
-    QM_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../../bin/i18n
+    QM_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}
     MERGE_QT_TRANSLATIONS
-    QT_TRANSLATION_CATALOGS qtbase qtmultimedia qtwebengine
+    QT_TRANSLATION_CATALOGS qtbase qtmultimedia qtwebengine qtdeclarative
 )
 
 # Ideally at the toplevel it could be done sth like this in one pass/target:

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -327,10 +327,12 @@ StatusWindow {
     Component.onCompleted: {
         console.info(">>> %1 %2 started, using Qt version %3".arg(Qt.application.name).arg(Qt.application.version).arg(SystemUtils.qtRuntimeVersion()))
 
-        if (languageStore.currentLanguage === "" && // if we haven't configured the language yet...
-                languageStore.availableLanguages.includes(Qt.uiLanguage)) { // ...and we have a translation for it
-            // set the language to the user's OS default
-            languageStore.changeLanguage(Qt.uiLanguage, true /*shouldRetranslate*/)
+        if (languageStore.currentLanguage === "") { // if we haven't configured the language yet...
+            // ...and we have a translation for it
+            if (languageStore.availableLanguages.includes(Qt.uiLanguage)) {
+                // set the language to the user's OS default
+                languageStore.changeLanguage(Qt.uiLanguage, true /*shouldRetranslate*/)
+            }
         } else {
             // set the configured language
             languageStore.changeLanguage(languageStore.currentLanguage, true /*shouldRetranslate*/)


### PR DESCRIPTION
### What does the PR do

- simplify the process or deploing the translations by treating the QM files just like any other resource, and compile/bundle them with the binary
- remove manual copying of the QM files in Makefile and other scripts
- greatly simplify the LanguageService discovery, as the QM files are now in a uniform prefix (`:/i18n`) on any platform
- because of the uniform prefix/location, the retranslation now happens automatically by `QQmlApplicationEngine`, by just setting/getting the `Qt.uiLanguage` property
- automatically detect user's locale on first startup (when we don't have any configured language yet)

Fixes #18914
Fixes https://github.com/status-im/status-desktop/issues/18191

### Affected areas

App

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

First start, :czech_republic: is automatically detected as it's my locale:
<img width="2932" height="2102" alt="image" src="https://github.com/user-attachments/assets/245f38c4-37ee-4d2b-bce5-7e31cf7dbd80" />

Switching back to English...
<img width="2932" height="2102" alt="Snímek obrazovky z 2025-10-14 18-52-55" src="https://github.com/user-attachments/assets/df912da4-a77d-4542-aadc-a7a4d122f695" />

... and to Korean:
<img width="2932" height="2102" alt="Snímek obrazovky z 2025-10-14 17-48-07" src="https://github.com/user-attachments/assets/de52476c-5dd0-4d3c-b320-60e7bb2682b5" />

Settings:
<img width="2932" height="2102" alt="image" src="https://github.com/user-attachments/assets/2ce069db-664d-4313-9ce0-2a20d2769a1b" />

### Impact on end user

App is translated

### How to test

- start the app
- verify the language selector is not empty
- try changing to one of the provided languages
  - login/onboarding: the UI should retranslate on the fly
  - app (Settings/Language & Currency): a restart is required

### Risk 

low
