### PR TITLE
StatusBaseInput: make TextEdit filling whole component to position vkeyboard correctly

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -350,8 +350,8 @@ Item {
                     id: flick
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.topMargin: root.topPadding
-                    Layout.bottomMargin: root.bottomPadding
+                    Layout.topMargin: root.multiline ? root.topPadding : 0
+                    Layout.bottomMargin: root.multiline ? root.bottomPadding : 0
 
                     contentWidth: edit.paintedWidth
                     contentHeight: edit.paintedHeight
@@ -370,6 +370,9 @@ Item {
                         id: edit
                         property string previousText: text
                         property var keyEvent
+
+                        topPadding: root.multiline ? 0 : root.topPadding
+                        bottomPadding: root.multiline ? 0: root.bottomPadding
                         width: flick.width
                         height: multiline ? implicitHeight : flick.height
                         verticalAlignment: TextEdit.AlignVCenter


### PR DESCRIPTION
### What does the PR do

For single line input TextField is filling whole component to assure proper positioning of on-screen keyboard. For multiline the old padding is preserved to keep proper behavior of outer Flickable.

Closes: #19005


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusBaseInput`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

![Screenshot_2025-10-15-11-33-08-44_e349fe4ff9441aaf74d9ac7580838a5f](https://github.com/user-attachments/assets/782a555f-f449-4e42-bb2a-f163df0287e4)
![Screenshot_2025-10-15-11-31-38-64_e349fe4ff9441aaf74d9ac7580838a5f](https://github.com/user-attachments/assets/98751833-c707-43c0-abe2-80a9a7e76e8d)

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
