### PR TITLE
chore: fix some undefined references

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
@@ -131,7 +131,6 @@ Button {
                 Layout.preferredWidth: userSelectorPanel.width - userSelectorPanel.leftMargin - userSelectorPanel.rightMargin
                 Layout.alignment: Qt.AlignHCenter
                 placeholderText: qsTr("Search")
-                   .arg(root.languageCodes.length).arg(root.currentLanguage).arg(Qt.uiLanguage)
                 input.asset.name: "search"
                 input.clearable: true
                 KeyNavigation.tab: userSelectorPanel

--- a/ui/app/AppLayouts/HomePage/HomePageAdaptor.qml
+++ b/ui/app/AppLayouts/HomePage/HomePageAdaptor.qml
@@ -89,7 +89,7 @@ QObject {
     Component.onCompleted: {
         Qt.callLater(function() {
             d.homePageEntriesModel = filteredCombinedModel // FIXME bug in SFPM or OPM
-            load()
+            root.load()
         })
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1179,7 +1179,7 @@ Item {
         id: statusEmojiPopup
         active: appMain.rootStore.sectionsLoaded
         sourceComponent: StatusEmojiPopup {
-            directParent: root.window.contentItem
+            directParent: appMain.Window.window.contentItem
             height: 440
             settings: appMainLocalSettings
             emojiModel: SQUtils.Emoji.emojiModel
@@ -1190,7 +1190,7 @@ Item {
         id: statusStickersPopupLoader
         active: appMain.rootStore.sectionsLoaded
         sourceComponent: StatusStickersPopup {
-            directParent: root.window.contentItem
+            directParent: appMain.Window.contentItem
             store: appMain.rootChatStore
             isWalletEnabled: appMain.walletProfileStore.isWalletEnabled
             onBuyClicked: popupRequestsHandler.sendModalHandler.buyStickerPack(packId, price)


### PR DESCRIPTION
### What does the PR do

- AppMain: no `root`, `appMain` was meant
- HomePageAdaptor: `load()` is not available in a lambda context
- StatusLanguageSelector: remove some old/invalid `arg()` string arguments

### Affected areas

AppMain

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

N/A

### Impact on end user

none
