### PR TITLE
fix(@desktop/biometrics): Simplified user flow for enabling/disabling biometric login from settings screen.

### DIFF
--- a/ui/StatusQ/src/keychain_android.cpp
+++ b/ui/StatusQ/src/keychain_android.cpp
@@ -273,6 +273,13 @@ static void jni_nativeCredentialError(JNIEnv*, jobject, jint code, jstring jMsg)
 
     const QString msg = QJniObject(jMsg).toString();
 
+    if (code == -11) { // "User cancelled"
+        QMetaObject::invokeMethod(s_keychain, [msg]{
+            emit s_keychain->getCredentialRequestCompleted(Keychain::StatusCancelled, QString());
+        }, Qt::QueuedConnection);
+        return;
+    }
+
     QMetaObject::invokeMethod(s_keychain, [msg]{
         emit s_keychain->getCredentialRequestCompleted(Keychain::StatusGenericError, QString());
     }, Qt::QueuedConnection);

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2842,30 +2842,6 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable biometrics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Do you want to enable biometrics for login and transaction authentication?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Are you sure you want to disable biometrics for login and transaction authentication?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Yes, enable biometrics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Yes, disable biometrics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Biometric login and transaction authentication disabled for this device</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3478,36 +3478,6 @@
       <translation>Biometric login and transaction authentication</translation>
     </message>
     <message>
-      <source>Disable biometrics</source>
-      <comment>ChangePasswordView</comment>
-      <translation>Disable biometrics</translation>
-    </message>
-    <message>
-      <source>Do you want to enable biometrics for login and transaction authentication?</source>
-      <comment>ChangePasswordView</comment>
-      <translation>Do you want to enable biometrics for login and transaction authentication?</translation>
-    </message>
-    <message>
-      <source>Are you sure you want to disable biometrics for login and transaction authentication?</source>
-      <comment>ChangePasswordView</comment>
-      <translation>Are you sure you want to disable biometrics for login and transaction authentication?</translation>
-    </message>
-    <message>
-      <source>Cancel</source>
-      <comment>ChangePasswordView</comment>
-      <translation>Cancel</translation>
-    </message>
-    <message>
-      <source>Yes, enable biometrics</source>
-      <comment>ChangePasswordView</comment>
-      <translation>Yes, enable biometrics</translation>
-    </message>
-    <message>
-      <source>Yes, disable biometrics</source>
-      <comment>ChangePasswordView</comment>
-      <translation>Yes, disable biometrics</translation>
-    </message>
-    <message>
       <source>Biometric login and transaction authentication disabled for this device</source>
       <comment>ChangePasswordView</comment>
       <translation>Biometric login and transaction authentication disabled for this device</translation>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2850,30 +2850,6 @@ Do you wish to override the security check and continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable biometrics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Do you want to enable biometrics for login and transaction authentication?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Are you sure you want to disable biometrics for login and transaction authentication?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Zrušit</translation>
-    </message>
-    <message>
-        <source>Yes, enable biometrics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Yes, disable biometrics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Biometric login and transaction authentication disabled for this device</source>
         <translation type="unfinished"></translation>
     </message>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2834,30 +2834,6 @@ Do you wish to override the security check and continue?</source>
         <translation>생체 인증 로그인과 트랜잭션 인증</translation>
     </message>
     <message>
-        <source>Disable biometrics</source>
-        <translation>생체 인증 비활성화</translation>
-    </message>
-    <message>
-        <source>Do you want to enable biometrics for login and transaction authentication?</source>
-        <translation>로그인 및 트랜잭션 인증에 생체인식을 활성화할까요?</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to disable biometrics for login and transaction authentication?</source>
-        <translation>로그인 및 트랜잭션 인증을 위한 생체인증을 비활성화하시겠어요?</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>취소</translation>
-    </message>
-    <message>
-        <source>Yes, enable biometrics</source>
-        <translation>예, 생체 인증 사용</translation>
-    </message>
-    <message>
-        <source>Yes, disable biometrics</source>
-        <translation>예, 생체인식 비활성화</translation>
-    </message>
-    <message>
         <source>Biometric login and transaction authentication disabled for this device</source>
         <translation>이 기기에서 생체 로그인과 거래 인증이 비활성화되었습니다</translation>
     </message>


### PR DESCRIPTION
Also change treatment of user cancelled event on android to Cancelled from Genric Error

fixes #19011, fixed #18996

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Bioemtric Login
Password Settings

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

**IOS** Biometrics settings
https://github.com/user-attachments/assets/d1ce1565-0305-4a89-b57d-f23b743a3d05

**IOS** Cancel Biometrics flow
https://github.com/user-attachments/assets/2eb47baa-1177-40d6-8387-e9c08af8bdfc

**Android** Biometrics settings
https://github.com/user-attachments/assets/8bb040a0-d5f9-4c82-ae15-46e33d6c4f47

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
