### PR TITLE
StatusDraggableListItem: drag by handler on mobile by default

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusDraggableListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusDraggableListItem.qml
@@ -227,9 +227,10 @@ AbstractButton {
     /*!
        \qmlproperty bool StatusDraggableListItem::dragByHandleOnly
        This property holds if drag is activated only via drag handler (true) or
-       the whole area of the delegate (false)
+       the whole area of the delegate (false). By default false on desktop, true
+       on mobile.
     */
-    property bool dragByHandleOnly: false
+    property bool dragByHandleOnly: Utils.isMobile
 
     /*!
        \qmlproperty bool StatusDraggableListItem::drawBackgroundBorder


### PR DESCRIPTION
### What does the PR do

`dragByHandler` property made true by default on mobile to avoid events interception resulting with no ability to scroll by flick

Effectively it fixes scrolling by flick on mobile in various places:

- account order settings
- profile showcase settings
- tokens management

Closes: #19060

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusDraggableListItem`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/69e2134e-849c-4002-b88e-eedcc71c05dc


https://github.com/user-attachments/assets/c9bf8441-bc37-42eb-a594-1bd302954546


