### PR TITLE
fix: Setting the qml parent for the gif popup

### DIFF
--- a/ui/app/mainui/Handlers/StatusGifPopupHandler.qml
+++ b/ui/app/mainui/Handlers/StatusGifPopupHandler.qml
@@ -26,7 +26,7 @@ QtObject {
         _d.popupParent = params.popupParent
         _d.closeAfterSelection = params.closeAfterSelection
 
-        let gifPopupInst = gifPopupComponent.createObject()
+        let gifPopupInst = gifPopupComponent.createObject(_d.popupParent)
         gifPopupInst.open()
     }
 


### PR DESCRIPTION
### What does the PR do

This fixes the gif popup and a crash related to the gif popup.
The prerequisite for the crash was to try to open the gif popup. Then it would randomly crash on some other actions like sending messages, opening other popups, switching sections.

closes: #19055, 
closes: https://github.com/status-im/status-desktop/issues/19057, 
closes: https://github.com/status-im/status-desktop/issues/19048

### Affected areas

Gif popup

![Screenshot_20251021_130318_Status](https://github.com/user-attachments/assets/f0f17ee2-1477-471c-b9af-5edc90f05531)

