### PR TITLE
StatusBaseInput: workaround for unintended multiline on mobile

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -371,6 +371,11 @@ Item {
                         property string previousText: text
                         property var keyEvent
 
+                        // This workaround prevents entering new line on mobile when it's not desired.
+                        // Qt.ImhSensitiveData prevents entering new line, instead Keys.returnPressed
+                        // is emitted and can be handled in a regular way.
+                        inputMethodHints: Utils.isMobile && !multiline ? Qt.ImhSensitiveData : Qt.ImhNone
+
                         topPadding: root.multiline ? 0 : root.topPadding
                         bottomPadding: root.multiline ? 0: root.bottomPadding
                         width: flick.width


### PR DESCRIPTION
### What does the PR do

Prevents entering new line on mobile when it's not desired. `Qt.ImhSensitiveData` prevents entering new line, `Keys.returnPressed` is emitted and can be handled in a regular way (as on desktop).

Affects various text inputs in the app, including search fields, where single line is intended but actual behavior on mobile was that multiline was possible to provide.

Closes: https://github.com/status-im/status-desktop/issues/19080

### Affected areas
`StatusBaseInput`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/0976ce49-335e-4ace-b630-1079923e122b


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test
Test search fields behavior, e.g. add new wallet account popup, account name field.

### Risk 
Medium
