### PR TITLE
fix(Bottom-Sheet): Raise sheet to 85-90% height to reduce keyboard overlap and improve interaction

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
@@ -116,6 +116,7 @@ Button {
         relativeX: root.width - width
         relativeY: root.height + 2
         width: 300
+        fillHeightOnBottomSheet: true
         margins: Theme.halfPadding
 
         padding: 0
@@ -194,6 +195,11 @@ Button {
                         cursorShape: hovered ? Qt.PointingHandCursor : undefined
                     }
                 }
+            }
+
+            // Just a filler
+            Item {
+                Layout.fillHeight: true
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -72,11 +72,24 @@ QC.Popup {
                                             d.windowHeight > d.windowWidth
                                             && d.windowWidth <= Theme.portraitBreakpoint.width
 
+    /*!
+       \qmlproperty bool fillHeightOnBottomSheet
+        This property decides the height of the dialog when `bottomSheet` is active:
+          * If active: it fills the 90% of the screen viewport.
+          * If not active: the height is the minimum value between the implicitHeight and the 90% of the screen viewport.
+    */
+    property bool fillHeightOnBottomSheet: false
+
     QtObject {
        id: d
        readonly property var window: root.contentItem.Window.window
        readonly property int windowWidth: window ? window.width: Screen.width
        readonly property int windowHeight: window ? window.height: Screen.height
+
+       // Set to 85% since some dropdowns are opened as children of Status dialogs.
+       // Keeping a small gap at the top lets users tap to return to the underlying dialog
+       // instead of closing the entire flow.
+       readonly property real bottomSheetHeightRatio: 0.85
     }
 
     Binding {
@@ -108,7 +121,7 @@ QC.Popup {
             x: 0
             y: d.windowHeight - height
             width: d.windowWidth
-            height: Math.min(implicitHeight, d.windowHeight * 0.9)
+            height: root.fillHeightOnBottomSheet ? d.windowHeight * d.bottomSheetHeightRatio : Math.min(implicitHeight, d.windowHeight * d.bottomSheetHeightRatio)
             bottomPadding: !!d.window ? d.window.SafeArea.margins.bottom: 0
             margins: 0
         }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -45,12 +45,22 @@ Dialog {
     readonly property real desiredY: root.bottomSheet ? d.windowHeight - root.height
                                                       : (root.Overlay.overlay.height - root.height) / 2
 
+    /*!
+       \qmlproperty bool fillHeightOnBottomSheet
+        This property decides the height of the dialog when `bottomSheet` is active:
+          * If active: it fills the 90% of the screen viewport.
+          * If not active: the height is the minimum value between the implicitHeight and the 90% of the screen viewport.
+    */
+    property bool fillHeightOnBottomSheet: false
+
     QtObject {
         id: d
 
         // NB: needs to be delayed for the `contentItem` to be not null
         property int windowWidth
         property int windowHeight
+
+        readonly property real bottomSheetHeightRatio: 0.90
     }
 
     onAboutToShow: {
@@ -107,7 +117,8 @@ Dialog {
     }
     Binding on height {
         when: root.bottomSheet && !enterTransition.running
-        value: Math.min(root.implicitHeight, d.windowHeight * 0.9)
+        value: root.fillHeightOnBottomSheet ? d.windowHeight * d.bottomSheetHeightRatio : Math.min(implicitHeight, d.windowHeight * d.bottomSheetHeightRatio)
+
     }
     Binding on y {
         when: root.bottomSheet && !enterTransition.running

--- a/ui/app/AppLayouts/Communities/popups/InDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/InDropdown.qml
@@ -20,6 +20,7 @@ StatusDropdown {
 
     width: 289
     padding: 8
+    fillHeightOnBottomSheet: true
 
     // force keeping within the bounds of the enclosing window
     margins: 0
@@ -227,7 +228,7 @@ StatusDropdown {
             Layout.fillWidth: true
             Layout.minimumHeight: Math.min(d.maxHeightCountNo * d.itemStandardHeight,
                                            contentHeight)
-            Layout.maximumHeight: Layout.minimumHeight
+            Layout.fillHeight: true
             Layout.bottomMargin: d.defaultVMargin
             Layout.topMargin: !root.allowChoosingEntireCommunity
                               && !root.allowChoosingEntireCommunity ? d.defaultVMargin : 0
@@ -338,5 +339,6 @@ StatusDropdown {
                 root.channelsSelected(Array.from(d.selectedChannels.values()))
             }
         }
-    }
+
+   }
 }

--- a/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
@@ -59,6 +59,7 @@ StatusDropdown {
     signal addButtonClicked
 
     width: 295
+    fillHeightOnBottomSheet: true
 
     padding: 11
     bottomPadding: padding + bottomInset
@@ -261,6 +262,11 @@ StatusDropdown {
             }
 
             onClicked: root.addButtonClicked()
+        }
+
+        // Just a filler
+        Item {
+            Layout.fillHeight: true
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
@@ -60,6 +60,7 @@ Control {
 
         width: 448
         height: Math.min(implicitHeight, d.windowHeight - button.mapToItem(null, 0, button.height).y - d.bottomPadding)
+        fillHeightOnBottomSheet: true
 
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
         padding: 0

--- a/ui/app/AppLayouts/Wallet/controls/AssetSelectorCompact.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelectorCompact.qml
@@ -46,6 +46,7 @@ Control {
         directParent: root
         relativeY: root.height + 4
         width: root.width
+        fillHeightOnBottomSheet: true
 
         padding: 0
 

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -73,6 +73,7 @@ Control {
         directParent: root
         relativeY: parent.height + 4
         width: 448
+        fillHeightOnBottomSheet: true
 
         horizontalPadding: 0
         bottomPadding: Theme.halfPadding / 2

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -35,6 +35,7 @@ StatusModal {
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
     width: 477
+    fillHeightOnBottomSheet: true
 
     headerSettings.title: d.editMode? qsTr("Edit saved address") : qsTr("Add new saved address")
     headerSettings.subTitle: d.editMode? d.name : ""

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -473,6 +473,7 @@ StatusDialog {
     padding: 0
     horizontalPadding: Theme.xlPadding
     topMargin: margins + accountSelector.height + Theme.padding
+    fillHeightOnBottomSheet: true
 
     Behavior on height {
         id: modalHeightBehavior

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -39,6 +39,7 @@ StatusDialog {
     objectName: "swapModal"
 
     implicitWidth: 556
+    fillHeightOnBottomSheet: true
     topPadding: Theme.xlPadding
     backgroundColor: Theme.palette.baseColor3
 

--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -78,6 +78,7 @@ Item {
 
     StatusSearchPopup {
         id: searchPopup
+        fillHeightOnBottomSheet: true
         noResultsLabel: qsTr("No results")
         defaultSearchLocationText: qsTr("Anywhere")
         searchOptionsPopupMenu: searchPopupMenu

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -23,6 +23,7 @@ StatusModal {
     property bool isKeycardEnabled: true
 
     width: Constants.addAccountPopup.popupWidth
+    fillHeightOnBottomSheet: true
 
     closePolicy: root.store.disablePopup? Popup.NoAutoClose : Popup.CloseOnEscape | Popup.CloseOnPressOutside
     hasCloseButton: !root.store.disablePopup

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -248,6 +248,7 @@ StatusDialog {
         value: popup.store.selectedSenderAccountAddress
     }
 
+    fillHeightOnBottomSheet: true
     topMargin: margins + accountSelector.height + Theme.padding
     padding: Theme.xlPadding
     background: StatusDialogBackground {


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/19098
Fixes https://github.com/status-im/status-desktop/issues/19064

### What does the PR do
- Set default bottom-sheet height to **90%** of the viewport/screen on specific **dialog** flows (SWAP, SendModal, Bridge..)
- Set default bottom-sheet height to **85%** of the viewport/screen on specific **dropdown** flows (StatusLanguageSelector, Chat search...).
- Improves virtual keyboard overlap on form and search flows.

### Affected areas

Dropdowns and Modals

### Architecture compliance

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

**Here Some of the Improved flows:**
<img width="370" height="884" alt="Screenshot 2025-10-22 at 14 15 21" src="https://github.com/user-attachments/assets/d2b6883d-2868-49d5-b855-35758f3d4c43" />

<img width="370" height="884" alt="Screenshot 2025-10-22 at 14 15 49" src="https://github.com/user-attachments/assets/04f8c690-a66a-4479-a2c2-8d3a50e27417" />

<img width="370" height="884" alt="Screenshot 2025-10-22 at 14 16 18" src="https://github.com/user-attachments/assets/5649153b-4449-4325-a57b-ccf05554eb3d" />

<img width="370" height="884" alt="Screenshot 2025-10-22 at 14 16 32" src="https://github.com/user-attachments/assets/ec8d9114-db2f-4416-ad48-51512fd27b80" />

https://github.com/user-attachments/assets/d65a4898-8291-4da9-a927-cf7045e52e0d

### Impact on end user

Improve UI/UX on short screens for bottom-sheet content.

### How to test

- Send Modal + Token Selection
- SWAP Modal + Token Selection
- Bridge Modal + Token Selection
- Add account
- Edit saved addresses
- Chat search
- Community permissions / In dropdown
- Community airdops / Members dropdown

### Risk 

Some misalignements in some `bottom-sheet` components
