### PR TITLE
WIP - fix(Bottom-Sheet): Disabled bottom-sheet behavior in certain flows

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLanguageSelector.qml
@@ -120,6 +120,8 @@ Button {
 
         padding: 0
 
+        bottomSheetAllowed: false
+
         onOpened: if (!Utils.isMobile) searchField.forceActiveFocus()
         onClosed: searchField.input.edit.clear()
 

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -39,8 +39,17 @@ Dialog {
     */
     property string okButtonText: qsTr("OK")
 
-    readonly property bool bottomSheet: d.windowHeight > d.windowWidth
-                                        && d.windowWidth <= Theme.portraitBreakpoint.width // The max width of a phone in portrait mode
+    /*!
+        \qmlproperty bool StatusDropdown::bottomSheetAllowed
+        Controls whether the dropdown may switch to a bottom-sheet presentation when vertical
+        space is limited. Set to false to force classic anchored dropdown behavior.
+        Default: true.
+    */
+    property bool bottomSheetAllowed: true
+
+    readonly property bool bottomSheet: !bottomSheetAllowed ? false:
+                                                              d.windowHeight > d.windowWidth
+                                                              && d.windowWidth <= Theme.portraitBreakpoint.width // The max width of a phone in portrait mode
 
     readonly property real desiredY: root.bottomSheet ? d.windowHeight - root.height
                                                       : (root.Overlay.overlay.height - root.height) / 2

--- a/ui/app/AppLayouts/Communities/popups/InDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/InDropdown.qml
@@ -49,6 +49,8 @@ StatusDropdown {
         d.selectedChannelsChanged()
     }
 
+    bottomSheetAllowed: false
+
     onAboutToHide: {
         searcher.text = ""
         listView.positionViewAtBeginning()

--- a/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
@@ -63,6 +63,8 @@ StatusDropdown {
     padding: 11
     bottomPadding: padding + bottomInset
 
+    bottomSheetAllowed: false
+
     onOpened: {
         listView.positionViewAtBeginning()
         filterInput.text = ""

--- a/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelector.qml
@@ -64,6 +64,8 @@ Control {
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
         padding: 0
 
+        bottomSheetAllowed: false
+
         contentItem: SearchableAssetsPanel {
             id: searchableAssetsPanel
 

--- a/ui/app/AppLayouts/Wallet/controls/AssetSelectorCompact.qml
+++ b/ui/app/AppLayouts/Wallet/controls/AssetSelectorCompact.qml
@@ -47,6 +47,8 @@ Control {
         relativeY: root.height + 4
         width: root.width
 
+        bottomSheetAllowed: false
+
         padding: 0
 
         contentItem: SearchableAssetsPanel {

--- a/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/TokenSelector.qml
@@ -79,6 +79,8 @@ Control {
 
         onClosed: tokenSelectorPanel.clear()
 
+        bottomSheetAllowed: false
+
         contentItem: Item {
             implicitHeight: Math.min(tokenSelectorPanel.implicitHeight, d.maxPopupHeight)
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -41,6 +41,7 @@ StatusDialog {
     implicitWidth: 556
     topPadding: Theme.xlPadding
     backgroundColor: Theme.palette.baseColor3
+    bottomSheetAllowed: false
 
     QtObject {
         id: d

--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -82,6 +82,7 @@ Item {
         defaultSearchLocationText: qsTr("Anywhere")
         searchOptionsPopupMenu: searchPopupMenu
         searchResults: root.store.resultModel
+        bottomSheetAllowed: false
         formatTimestampFn: function (ts) {
             return LocaleUtils.formatDateTime(parseInt(ts, 10))
         }

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -77,6 +77,8 @@ StatusDialog {
 
     readonly property string uuid: d.uuid
 
+    bottomSheetAllowed: false
+
     QtObject {
         id: d
 


### PR DESCRIPTION
WIP - TEST

### What does the PR do

Here the flows where the `bottom-sheet` behavior has been disabled so that the default desktop flow is used (or combobox or modal):
- Chat search
- Send Modal and Tokens Selector
- SWAP Modal and Assets Selector
- Language Selector
- Community admin: Permissions --> In dropdown / Airdrop --> To Members search
