### PR TITLE
feat(@desktop/biometrics): Show Enable biometrics after onboarding when Logging in via syncing

### DIFF
--- a/storybook/pages/EnableBiometricsPopupPage.qml
+++ b/storybook/pages/EnableBiometricsPopupPage.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import shared.popups
+
+import Storybook
+
+import utils
+
+SplitView {
+    Logs { id: logs }
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: popup.open()
+        }
+
+        EnableBiometricsPopup {
+            id: popup
+
+            modal: false
+            closePolicy: Popup.CloseOnEscape
+
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            loading: loadingctrl.checked
+            errorText: ""
+
+            onEnableBiometricsRequested: () => {
+                logs.logEvent("EnableBiometricsRequested")
+            }
+        }
+
+        Component.onCompleted: popup.open()
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        Switch {
+            id: loadingctrl
+
+            text: "loading"
+            checked: false
+        }
+    }
+}
+
+// category: Popups
+// status: good

--- a/storybook/qmlTests/tests/tst_OnboardingLayout.qml
+++ b/storybook/qmlTests/tests/tst_OnboardingLayout.qml
@@ -854,24 +854,12 @@ Item {
             compare(btnLogin2.enabled, true)
             mouseClick(btnLogin2)
 
-            // PAGE 6: Enable Biometrics
-            if (data.biometrics) {
-                page = getCurrentPage(stack, EnableBiometricsPage)
-
-                const enableBioButton = findChild(controlUnderTest, data.bioEnabled ? "btnEnableBiometrics" : "btnDontEnableBiometrics")
-                dynamicSpy.setup(page, "enableBiometricsRequested")
-                mouseClick(enableBioButton)
-                tryCompare(dynamicSpy, "count", 1)
-                compare(dynamicSpy.signalArguments[0][0], data.bioEnabled)
-            }
-
             // FINISH
             tryCompare(finishedSpy, "count", 1)
             compare(finishedSpy.signalArguments[0][0], Onboarding.OnboardingFlow.LoginWithSyncing)
             const resultData = finishedSpy.signalArguments[0][1]
             verify(!!resultData)
             compare(resultData.password, "")
-            compare(resultData.enableBiometrics, data.biometrics && data.bioEnabled)
             compare(resultData.keycardPin, "")
             compare(resultData.seedphrase, "")
         }

--- a/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingFlow.qml
@@ -80,6 +80,8 @@ OnboardingStackView {
     required property bool thirdpartyServicesEnabled
     signal toggleThirdpartyServicesEnabledRequested()
 
+    signal skippedBiometricFlow()
+
     function restart() {
         replace(null, loginAccountsModel.ModelCount.empty ? welcomePage : loginScreenComponent)
     }
@@ -104,6 +106,12 @@ OnboardingStackView {
         }
 
         function pushOrSkipBiometricsPage() {
+            if (d.flow === Onboarding.OnboardingFlow.LoginWithSyncing) {
+                root.skippedBiometricFlow()
+                root.finished(d.flow)
+                return
+            }
+
             if (root.biometricsAvailable) {
                 root.replace(null, enableBiometricsPage)
             } else {

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -46,6 +46,7 @@ Page {
     signal changeLanguageRequested(string newLanguageCode)
 
     signal shareUsageDataRequested(bool enabled)
+    signal skippedBiometricFlow()
 
     // flow: Onboarding.OnboardingFlow
     signal finished(int flow, var data)
@@ -222,6 +223,8 @@ Page {
         onToggleThirdpartyServicesEnabledRequested: {
             d.thirdpartyServicesEnabled = !d.thirdpartyServicesEnabled
         }
+
+        onSkippedBiometricFlow: root.skippedBiometricFlow()
     }
 
     // needs to be on top of the stack

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -139,6 +139,10 @@ Item {
 
     required property bool isCentralizedMetricsEnabled
 
+    function showEnableBiometricsFlow() {
+        popupRequestsHandler.enableBiometricsPopupHandler.openPopup()
+    }
+
     AllContactsAdaptor {
         id: allContacsAdaptor
 
@@ -933,6 +937,7 @@ Item {
         rootChatStore: appMain.rootChatStore
         ensUsernamesStore: appMain.ensUsernamesStore
         privacyStore: appMain.privacyStore
+        keychain: appMain.keychain
     }
 
     Connections {

--- a/ui/app/mainui/Handlers/EnableBiometricsPopupHandler.qml
+++ b/ui/app/mainui/Handlers/EnableBiometricsPopupHandler.qml
@@ -1,0 +1,75 @@
+import QtQuick
+
+import StatusQ
+
+import AppLayouts.Profile.stores as ProfileStores
+
+import shared.popups
+import utils
+
+QtObject {
+    id: root
+
+    required property var popupParent
+    required property ProfileStores.PrivacyStore privacyStore
+    required property Keychain keychain
+
+    function openPopup() {
+        let enableBiometricsPopupInst = enableBiometricsPopup.createObject(popupParent)
+        enableBiometricsPopupInst.open()
+    }
+
+    function showSuccessToast() {
+        Global.displayToastMessage(
+        qsTr("Biometric login and transaction authentication enabled for this device"),
+        "", "checkmark-circle", false, Constants.ephemeralNotificationType.success, "")
+    }
+
+    readonly property Component enableBiometricsPopup: Component {
+        EnableBiometricsPopup {
+            id: popup
+
+            onEnableBiometricsRequested: () => {
+                // Enable Biometrics flow
+                popup.loading = true
+                root.privacyStore.tryStoreToKeyChain()
+            }
+
+            Connections {
+                target: root.privacyStore.privacyModule
+
+                function onSaveBiometricsRequested(keyUid, credential) {
+                    // If Password not retrieved
+                    if (keyUid === "" || credential === "") {
+                        popup.loading = false
+                        popup.errorText = qsTr("Biometric setup failed. Try again.")
+                        return
+                    }
+
+                    const status = keychain.saveCredential(keyUid, credential)
+
+                    if (status !== Keychain.StatusSuccess) {
+                        popup.loading = false
+                        popup.errorText = qsTr("Biometric setup failed. Try again.")
+                    }
+                }
+            }
+            Connections {
+                target: keychain
+
+                function onCredentialSaved(account: string) {
+                    popup.loading = false
+                    popup.close()
+                    root.showSuccessToast()
+                }
+
+                function onGetCredentialRequestCompleted(status, secret) {
+                    if (status !== Keychain.StatusSuccess) {
+                        popup.loading = false
+                        popup.errorText = qsTr("Biometric setup failed. Try again.")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -1,5 +1,6 @@
 import QtQuick
 
+import StatusQ
 import StatusQ.Core.Utils as SQUtils
 import StatusQ.Core.Backpressure
 import StatusQ.Core
@@ -44,6 +45,8 @@ QtObject {
 
     required property ProfileStores.EnsUsernamesStore ensUsernamesStore
     required property ProfileStores.PrivacyStore privacyStore
+
+    required property Keychain keychain
 
     readonly property SwapModalHandler swapModalHandler: SwapModalHandler {
 
@@ -188,5 +191,11 @@ QtObject {
             return true
         }
         return false
+    }
+
+    readonly property EnableBiometricsPopupHandler enableBiometricsPopupHandler: EnableBiometricsPopupHandler {
+        popupParent: root.popupParent
+        privacyStore: root.privacyStore
+        keychain: root.keychain
     }
 }

--- a/ui/app/mainui/Handlers/qmldir
+++ b/ui/app/mainui/Handlers/qmldir
@@ -2,3 +2,4 @@ HandlersManager 1.0 HandlersManager.qml
 SendModalHandler 1.0 SendModalHandler.qml
 StatusGifPopupHandler 1.0 StatusGifPopupHandler.qml
 SwapModalHandler 1.0 SwapModalHandler.qml
+EnableBiometricsPopupHandler 1.0 EnableBiometricsPopupHandler.qml

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6732,6 +6732,36 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
 </context>
 <context>
+    <name>EnableBiometricsPopup</name>
+    <message>
+        <source>Enable biometrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Would you like to enable biometrics to fill in your password? You will use biometrics for signing in to Status and for signing transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes, use biometrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnableBiometricsPopupHandler</name>
+    <message>
+        <source>Biometric login and transaction authentication enabled for this device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Biometric setup failed. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnableFullMessageHistoryPopup</name>
     <message>
         <source>Enable full message history</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -8221,6 +8221,42 @@
     </message>
   </context>
   <context>
+    <name>EnableBiometricsPopup</name>
+    <message>
+      <source>Enable biometrics</source>
+      <comment>EnableBiometricsPopup</comment>
+      <translation>Enable biometrics</translation>
+    </message>
+    <message>
+      <source>Would you like to enable biometrics to fill in your password? You will use biometrics for signing in to Status and for signing transactions.</source>
+      <comment>EnableBiometricsPopup</comment>
+      <translation>Would you like to enable biometrics to fill in your password? You will use biometrics for signing in to Status and for signing transactions.</translation>
+    </message>
+    <message>
+      <source>Maybe later</source>
+      <comment>EnableBiometricsPopup</comment>
+      <translation>Maybe later</translation>
+    </message>
+    <message>
+      <source>Yes, use biometrics</source>
+      <comment>EnableBiometricsPopup</comment>
+      <translation>Yes, use biometrics</translation>
+    </message>
+  </context>
+  <context>
+    <name>EnableBiometricsPopupHandler</name>
+    <message>
+      <source>Biometric login and transaction authentication enabled for this device</source>
+      <comment>EnableBiometricsPopupHandler</comment>
+      <translation>Biometric login and transaction authentication enabled for this device</translation>
+    </message>
+    <message>
+      <source>Biometric setup failed. Try again.</source>
+      <comment>EnableBiometricsPopupHandler</comment>
+      <translation>Biometric setup failed. Try again.</translation>
+    </message>
+  </context>
+  <context>
     <name>EnableFullMessageHistoryPopup</name>
     <message>
       <source>Enable full message history</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6756,6 +6756,36 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
 </context>
 <context>
+    <name>EnableBiometricsPopup</name>
+    <message>
+        <source>Enable biometrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Would you like to enable biometrics to fill in your password? You will use biometrics for signing in to Status and for signing transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes, use biometrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EnableBiometricsPopupHandler</name>
+    <message>
+        <source>Biometric login and transaction authentication enabled for this device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Biometric setup failed. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnableFullMessageHistoryPopup</name>
     <message>
         <source>Enable full message history</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6708,6 +6708,36 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
 </context>
 <context>
+    <name>EnableBiometricsPopup</name>
+    <message>
+        <source>Enable biometrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Would you like to enable biometrics to fill in your password? You will use biometrics for signing in to Status and for signing transactions.</source>
+        <translation type="unfinished">비밀번호 입력을 생체인증으로 자동 채우게 할까요? 앞으로 Status 로그인과 트랜잭션 서명에 생체인증을 사용하게 됩니다.</translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">나중에</translation>
+    </message>
+    <message>
+        <source>Yes, use biometrics</source>
+        <translation type="unfinished">네, 생체인증 사용</translation>
+    </message>
+</context>
+<context>
+    <name>EnableBiometricsPopupHandler</name>
+    <message>
+        <source>Biometric login and transaction authentication enabled for this device</source>
+        <translation type="unfinished">이 기기에서 생체인증 로그인과 트랜잭션 인증이 활성화되었습니다</translation>
+    </message>
+    <message>
+        <source>Biometric setup failed. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnableFullMessageHistoryPopup</name>
     <message>
         <source>Enable full message history</source>

--- a/ui/imports/shared/popups/EnableBiometricsPopup.qml
+++ b/ui/imports/shared/popups/EnableBiometricsPopup.qml
@@ -1,0 +1,67 @@
+import QtQuick
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Popups.Dialog
+import StatusQ.Controls
+import StatusQ.Components
+
+StatusDialog {
+    id: root
+
+    property string errorText
+    property bool loading
+
+    signal enableBiometricsRequested()
+
+    implicitWidth: 480
+    title: qsTr("Enable biometrics")
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: Theme.bigPadding
+
+        StatusImage {
+            Layout.preferredWidth: 270
+            Layout.preferredHeight: 260
+            Layout.alignment: Qt.AlignHCenter
+            mipmap: true
+            smooth: false
+            source: Theme.png("onboarding/enable_biometrics")
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: root.errorText
+            color: Theme.palette.dangerColor1
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr("Would you like to enable biometrics to fill in your password? You will use biometrics for signing in to Status and for signing transactions.")
+            color: Theme.palette.baseColor1
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+        }
+    }
+
+    footer: StatusDialogFooter {
+        dropShadowEnabled: true
+        rightButtons: ObjectModel {
+            StatusButton {
+                objectName: "btnDontEnableBiometrics"
+                borderColor: Theme.palette.baseColor2
+                normalColor: "transparent"
+                text: qsTr("Maybe later")
+                onClicked: root.close()
+            }
+            StatusButton {
+                objectName: "btnEnableBiometrics"
+                text: qsTr("Yes, use biometrics")
+                loading: root.loading
+                onClicked: root.enableBiometricsRequested()
+            }
+        }
+    }
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -36,3 +36,4 @@ SettingsDirtyToastMessage 1.0 SettingsDirtyToastMessage.qml
 UnblockContactConfirmationDialog 1.0 UnblockContactConfirmationDialog.qml
 UserStatusContextMenu 1.0 UserStatusContextMenu.qml
 ThirdpartyServicesPopup 1.0 ThirdpartyServicesPopup.qml
+EnableBiometricsPopup 1.0 EnableBiometricsPopup.qml

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -186,6 +186,8 @@ StatusWindow {
         }
 
         property int lastNonMinVisibility
+
+        property bool showSkippedBiometricFlow: false
     }
 
     Binding {
@@ -392,12 +394,20 @@ StatusWindow {
         Behavior on opacity { NumberAnimation { duration: 120 }}
         /* only unload splash screen once appmain is loaded else we see
         an empty screen for a sec until it is loaded */
-        onLoaded: startupOnboardingLoader.active = false
+        onLoaded: {
+            startupOnboardingLoader.active = false
+            if (item && item.objectName === "appMain" && d.showSkippedBiometricFlow) {
+                // IN case of Login via syncing, request to show Biometrics Page after onboarding
+                item.showEnableBiometricsFlow()
+            }
+        }
     }
 
     Component {
         id: app
         AppMain {
+            objectName: "appMain"
+
             utilsStore: applicationWindow.utilsStore
             featureFlagsStore: applicationWindow.featureFlagsStore
             languageStore: applicationWindow.languageStore
@@ -521,6 +531,10 @@ StatusWindow {
                     Global.addCentralizedMetricIfEnabled("navigation", {viewId: currentPageName})
                 }
             }
+
+            onSkippedBiometricFlow: () => {
+                                        d.showSkippedBiometricFlow = true
+                                    }
 
             Component.onCompleted: {
                 applicationWindow.contentLoaded()


### PR DESCRIPTION
Show Enable biometrics after onboarding when Logging in via syncing because raw password id not available in this flow

closes #19041

### What does the PR do

New flow for biometrics when Logging in via Syncing
1. Skip Enable Biometrics on onboarding
2. Land on homescreen (wallet)
3. Show enable biometrics popup so that user can enter password

### Affected areas

Login Via Syncing Flow

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

MacOS:

https://github.com/user-attachments/assets/f86d379b-639c-40b2-965b-3cb995ac7398

Android:

https://github.com/user-attachments/assets/04520eee-7c40-4922-8f89-d9813aa68164

https://github.com/user-attachments/assets/bc6e3a96-f44d-4139-8edc-8955db33c5b8

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
