### PR TITLE
fix(MarketTab): Improve layout to fit on small displays

### DIFF
--- a/ui/app/AppLayouts/Market/MarketLayout.qml
+++ b/ui/app/AppLayouts/Market/MarketLayout.qml
@@ -42,6 +42,9 @@ StatusSectionLayout {
         id: d
         readonly property int pageSize: 100
         property int startIndex: ((root.currentPage - 1) * d.pageSize) + 1
+
+        // Read-only flag that turns true when the component enters a “compact” layout automatically on resize.
+        readonly property bool compactMode: root.width < 600
     }
 
     onCurrentPageChanged: listView.positionViewAtBeginning()
@@ -86,6 +89,7 @@ StatusSectionLayout {
 
             headerPositioning: ListView.OverlayHeader
             header: MarketTokenHeader {
+                compactMode: d.compactMode
                 width: listView.width
             }
 
@@ -98,6 +102,7 @@ StatusSectionLayout {
                 onSwitchPage: root.fetchMarketTokens(pageNumber, d.pageSize)
                 visible: listView.count > 0 && !root.loading
                 height: visible ? implicitHeight : 0
+                compactMode: d.compactMode
             }
 
             model: root.loading ? loadingModel: regularModel
@@ -128,6 +133,7 @@ StatusSectionLayout {
             delegate: MarketTokenDelegate {
                 width: listView.width
 
+                compactMode: d.compactMode
                 indexString: d.startIndex + index
                 tokenName: model.name
                 tokenSymbol: model.symbol.toUpperCase()

--- a/ui/app/AppLayouts/Market/controls/MarketFooter.qml
+++ b/ui/app/AppLayouts/Market/controls/MarketFooter.qml
@@ -15,6 +15,8 @@ Control {
     /** required property representing current page set from outside **/
     required property int currentPage
 
+    property bool compactMode
+
     /** signla to update next page **/
     signal switchPage(int pageNumber)
 
@@ -71,6 +73,7 @@ Control {
             pageSize: root.pageSize
             totalCount: root.totalCount
             currentPage: root.currentPage
+            compactMode: root.compactMode
             onRequestPage: root.switchPage(pageNumber)
         }
     }

--- a/ui/app/AppLayouts/Market/controls/MarketTokenDelegate.qml
+++ b/ui/app/AppLayouts/Market/controls/MarketTokenDelegate.qml
@@ -35,14 +35,18 @@ StatusItemDelegate {
     /** Input property holding if token is last item in the list **/
     property bool isLastItem
 
+    property bool compactMode: false
+
     QtObject {
         id: d
 
-        // Split into 5 different columns of equal width
+        property int columnNum: root.compactMode ? 2 : 5
+
+        // Split into 2 or 5 different columns of equal width
         readonly property int columnWidth:
-            (root.width - indexText.width - icon.width - Theme.xlPadding) /5
+            (root.width - indexText.width - icon.width - Theme.xlPadding) / d.columnNum
         // Minimum width of a column
-        readonly property int minColumnWidth: 130
+        readonly property int minColumnWidth: root.compactMode ? 80 : 130
     }
 
     implicitHeight: 76
@@ -157,6 +161,7 @@ StatusItemDelegate {
 
             // Change 24 Hour
             StatusTextWithLoadingState {
+                visible: !root.compactMode
                 objectName: "changePct24HrText"
 
                 Layout.preferredWidth: d.columnWidth
@@ -174,6 +179,7 @@ StatusItemDelegate {
 
             // 24 hour Volume
             StatusTextWithLoadingState {
+                visible: !root.compactMode
                 objectName: "volume24HrText"
 
                 Layout.preferredWidth: d.columnWidth
@@ -190,6 +196,7 @@ StatusItemDelegate {
 
             // Market Cap
             StatusTextWithLoadingState {
+                visible: !root.compactMode
                 objectName: "marketCapText"
 
                 Layout.preferredWidth: d.columnWidth

--- a/ui/app/AppLayouts/Market/controls/MarketTokenHeader.qml
+++ b/ui/app/AppLayouts/Market/controls/MarketTokenHeader.qml
@@ -10,14 +10,18 @@ import StatusQ.Components
 Control {
     id: root
 
+    property bool compactMode: false
+
     QtObject {
         id: d
 
-        // Split into 5 different columns of equal width
+        property int columnNum: root.compactMode ? 2 : 5
+
+        // Split into 2 or 5 different columns of equal width
         readonly property int columnWidth:
-            (root.width - indexText.width - iconWidth - Theme.xlPadding) / 5
+            (root.width - indexText.width - iconWidth - Theme.xlPadding) / d.columnNum
         // Minimum width of a column
-        readonly property int minColumnWidth: 130
+        readonly property int minColumnWidth: root.compactMode ? 80 : 130
         // Derived from MarketTokenDelegate
         readonly property int iconWidth: 32
     }
@@ -95,6 +99,7 @@ Control {
                 Layout.preferredWidth: d.columnWidth
                 Layout.minimumWidth: d.minColumnWidth
 
+                visible: !root.compactMode
                 text: qsTr("24hr")
                 color: Theme.palette.baseColor1
                 font.weight: Font.Medium
@@ -109,6 +114,7 @@ Control {
                 Layout.preferredWidth: d.columnWidth
                 Layout.minimumWidth: d.minColumnWidth
 
+                visible: !root.compactMode
                 text: qsTr("24hr Volume")
                 color: Theme.palette.baseColor1
                 font.weight: Font.Medium
@@ -123,6 +129,7 @@ Control {
                 Layout.preferredWidth: d.columnWidth
                 Layout.minimumWidth: d.minColumnWidth
                 Layout.preferredHeight: childrenRect.height
+                visible: !root.compactMode
 
                 StatusSortableColumnHeader {
                     anchors.right: parent.right

--- a/ui/app/AppLayouts/Market/controls/Paginator.qml
+++ b/ui/app/AppLayouts/Market/controls/Paginator.qml
@@ -15,6 +15,8 @@ Control {
     /** required property representing current page set from outside **/
     required property int currentPage
 
+    property bool compactMode: false
+
     signal requestPage(int pageNumber)
 
     QtObject {
@@ -32,6 +34,31 @@ Control {
                     pages = [1, "...", totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
                 } else {
                     pages = [1, "...", root.currentPage - 1, root.currentPage, root.currentPage + 1, "...", totalPages];
+
+                }
+            }
+            return pages;
+        }
+        function getCompactPagesModel() {
+            let pages = [];
+            if (totalPages <= 3) {
+                for (let i = 1; i <= totalPages; i++) pages.push(i);
+            } else {
+                if (root.compactMode) {
+                    // --- COMPACT MODE ---
+                    if (root.currentPage == 1 || root.currentPage == totalPages) {
+                        // At first page or at the last page
+                        pages = [1, "...", totalPages];
+                    } else if (root.currentPage === 2) {
+                        // Near the beginning
+                        pages = [1, 2, "...", totalPages];
+                    } else if (root.currentPage === totalPages - 1) {
+                        // Near the end
+                        pages = [1, "...", totalPages - 1, totalPages];
+                    } else {
+                        // Somewhere in the middle
+                        pages = [1, "...", root.currentPage, "...", totalPages];
+                    }
                 }
             }
             return pages;
@@ -60,7 +87,7 @@ Control {
         Repeater {
             objectName: "pageNumbersRepeater"
 
-            model: d.getPagesModel()
+            model: root.compactMode ? d.getCompactPagesModel() : d.getPagesModel()
             delegate: StatusButton {
                 objectName: "numberButton_"+ index
 
@@ -68,6 +95,7 @@ Control {
                 normalColor: Theme.palette.transparent
                 hoverColor: Theme.palette.primaryColor3
                 disabledColor: Theme.palette.transparent
+                size: root.compactMode ? StatusBaseButton.Size.Small : StatusBaseButton.Size.Large
 
                 text: modelData
                 enabled: modelData !== "..."


### PR DESCRIPTION
Fixes #18968

### What does the PR do

The market tab layout wasn't fitting properly on smaller screens. This change introduces a more dynamic approach with a new `compact mode`, featuring a 2-column layout, smaller page row, and compact pagination logic.

### Affected areas

Market tab

### Architecture compliance

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/fdd29a88-a422-40bb-97c6-2ca74d0c8e3d

<img width="404" height="967" alt="Screenshot 2025-10-24 at 11 46 47" src="https://github.com/user-attachments/assets/11a6ce68-7932-4c4c-bebd-4f69395aedd6" />

### Impact on end user

None

### How to test

Market tab on desktop and on mobile screens

### Risk 

Low
