### PR TITLE
ci: use python venv in windows e2e

### DIFF
--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -120,8 +120,8 @@ pipeline {
       steps { script { dir('test/e2e') {
           bat """
             python310 -m venv ${VIRTUAL_ENV}
-            python310 -m pip install --upgrade pip
-            python310 -m pip install -r requirements.txt
+            ${VIRTUAL_ENV}\\Scripts\\python.exe -m pip install --upgrade pip
+            ${VIRTUAL_ENV}\\Scripts\\python.exe -m pip install -r requirements.txt
           """
       } } }
     }
@@ -188,7 +188,7 @@ pipeline {
 
                   """
                   bat"""
-                    python310 -m pytest -m "not keycard" -v --reruns=1 --timeout=300 ${flagStr} --disable-warnings --alluredir=./allure-results -o timeout_func_only=true
+                    ${VIRTUAL_ENV}\\Scripts\\python.exe -m pytest -m "not keycard" -v --reruns=1 --timeout=300 ${flagStr} --disable-warnings --alluredir=./allure-results -o timeout_func_only=true
                   """
                 }
               }


### PR DESCRIPTION
We already did create venv but never actually used it, thus we had so much of warnings in windows-e2e CI:
```
19:15:55  WARNING: Ignoring invalid distribution -26 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -25 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -24 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -23 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -22 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -19 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -18 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -17 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -16 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -15 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -14 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -13 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -12 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -11 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -9p (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -9 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -09 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -8p (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -8 (c:\programdata\scoop\persist\python310\lib\site-packages)
19:15:55  WARNING: Ignoring invalid distribution -08 (c:\programdata\scoop\persist\python310\lib\site-packages)
```