### PR TITLE
fix(PinnedMessagesPopup): Cannot view pinned messages

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -42,6 +42,7 @@ StatusDialog {
     width: 800
     height: 428
     padding: 0
+    fillHeightOnBottomSheet: true
 
     title: root.messageToPin ? qsTr("Pin limit reached") : qsTr("Pinned messages")
     subtitle: root.messageToPin ? qsTr("Unpin a previous message first")


### PR DESCRIPTION

Fixes #19058

### What does the PR do

It resizes the pinned messages popup accordingly on short screens.

### Affected areas

Chat / Pinned Messages

### Architecture compliance

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/a619daa7-d04c-4000-babb-fc06f265807b

### Impact on end user

Fixes issue with pinned messages on short screens

### How to test

Try to view pinned messages on chats.

### Risk 

Low
