### PR TITLE
fix(BetaTag): Remove redundant feature-level beta tags

### DIFF
--- a/storybook/pages/StatusSwitchTabBarPage.qml
+++ b/storybook/pages/StatusSwitchTabBarPage.qml
@@ -38,7 +38,6 @@ Item {
                 StatusSwitchTabButton {
                     width: customTabBar.buttonWidth ?? implicitWidth
                     text: "%1 words".arg(modelData)
-                    showBetaTag: index === repeater.count - 1
                 }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSwitchTabButton.qml
@@ -10,8 +10,6 @@ import StatusQ.Core.Theme
 TabButton {
     id: root
 
-    property bool showBetaTag: false
-
     font.pixelSize: Theme.primaryTextFontSize
 
     contentItem: RowLayout {
@@ -28,13 +26,6 @@ TabButton {
             font.weight: Font.Medium
             font.pixelSize: root.font.pixelSize
             elide: Text.ElideRight
-        }
-
-        StatusBetaTag {
-            visible: root.showBetaTag
-            fgColor: root.checked ? Theme.palette.statusSwitchTab.selectedTextColor
-                                  : Theme.palette.baseColor1
-            cursorShape: hovered ? Qt.PointingHandCursor : undefined
         }
     }
 

--- a/ui/app/AppLayouts/ActivityCenter/ActivityCenterLayout.qml
+++ b/ui/app/AppLayouts/ActivityCenter/ActivityCenterLayout.qml
@@ -83,11 +83,6 @@ StatusSectionLayout {
                 Layout.fillWidth: true
             }
 
-            StatusBetaTag {
-                tooltipText: qsTr("Under construction.<br>More notification types to be coming soon.")
-                tooltipOrientation: StatusToolTip.Orientation.Bottom
-            }
-
             StatusFlatRoundButton {
                 id: markAllReadBtn
                 objectName: "markAllReadButton"

--- a/ui/app/AppLayouts/HomePage/HomePageGrid.qml
+++ b/ui/app/AppLayouts/HomePage/HomePageGrid.qml
@@ -178,8 +178,6 @@ StatusScrollView {
                     hasNotification: model.hasNotification
                     notificationsCount: model.notificationsCount
                     pinned: model.pinned
-
-                    isExperimental: model.isExperimental ?? false
                 }
             }
 

--- a/ui/app/AppLayouts/HomePage/delegates/HomePageGridSettingsItem.qml
+++ b/ui/app/AppLayouts/HomePage/delegates/HomePageGridSettingsItem.qml
@@ -11,7 +11,6 @@ HomePageGridItem {
 
     property int membersCount
     property int activeMembersCount
-    property bool isExperimental
 
     sectionType: Constants.appSection.profile
     color: Theme.palette.primaryColor2
@@ -20,9 +19,5 @@ HomePageGridItem {
         asset.name: root.icon.name
         asset.bgWidth: width
         asset.bgHeight: height
-    }
-
-    bottomRowComponent: StatusBetaTag {
-        visible: root.isExperimental
     }
 }

--- a/ui/app/AppLayouts/Onboarding/pages/LoginBySyncingPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/LoginBySyncingPage.qml
@@ -47,8 +47,6 @@ OnboardingPage {
                 Layout.alignment: Qt.AlignHCenter
                 validateConnectionString: root.validateConnectionString
 
-                showBetaTag: false
-
                 onDisplayInstructions: instructionsPopup.createObject(root).open()
                 onProceed: (connectionString) => root.syncProceedWithConnectionString(connectionString)
             }

--- a/ui/app/AppLayouts/Profile/controls/SettingsList.qml
+++ b/ui/app/AppLayouts/Profile/controls/SettingsList.qml
@@ -44,15 +44,7 @@ StatusListView {
         selected: root.currenctSubsection === model.subsection
         badge.value: model.badgeCount
 
-        statusListItemTitleIcons.sourceComponent: model.isExperimental ? betaTagComponent : null
-
-        Component {
-            id: betaTagComponent
-            StatusBetaTag {
-                tooltipText: model.experimentalTooltip
-                cursorShape: Qt.PointingHandCursor
-            }
-        }
+        statusListItemTitleIcons.sourceComponent: null
 
         onClicked: root.clicked(model.subsection)
     }

--- a/ui/app/AppLayouts/Profile/views/EnsAddedView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsAddedView.qml
@@ -23,12 +23,6 @@ Item {
         font.weight: Font.Bold
         font.pixelSize: Theme.fontSize20
         color: Theme.palette.directColor1
-
-        StatusBetaTag {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.right
-            anchors.leftMargin: 7
-        }
     }
 
 

--- a/ui/app/AppLayouts/Profile/views/EnsConnectedView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsConnectedView.qml
@@ -23,12 +23,6 @@ Item {
         font.weight: Font.Bold
         font.pixelSize: Theme.fontSize20
         color: Theme.palette.directColor1
-
-        StatusBetaTag {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.right
-            anchors.leftMargin: 7
-        }
     }
 
 

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -58,12 +58,6 @@ Item {
             font.weight: Font.Bold
             font.pixelSize: Theme.fontSize20
             color: Theme.palette.directColor1
-
-            StatusBetaTag {
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.left: parent.right
-                anchors.leftMargin: 7
-            }
         }
 
         Item {

--- a/ui/app/AppLayouts/Profile/views/EnsRegisteredView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsRegisteredView.qml
@@ -23,12 +23,6 @@ Item {
         font.weight: Font.Bold
         font.pixelSize: Theme.fontSize20
         color: Theme.palette.directColor1
-
-        StatusBetaTag {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.right
-            anchors.leftMargin: 7
-        }
     }
 
 

--- a/ui/app/AppLayouts/Profile/views/EnsReleasedView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsReleasedView.qml
@@ -23,12 +23,6 @@ Item {
         font.weight: Font.Bold
         font.pixelSize: Theme.fontSize20
         color: Theme.palette.directColor1
-
-        StatusBetaTag {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.right
-            anchors.leftMargin: 7
-        }
     }
 
 

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -52,12 +52,6 @@ Item {
         font.weight: Font.Bold
         font.pixelSize: Theme.fontSize20
         color: Theme.palette.directColor1
-
-        StatusBetaTag {
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.right
-            anchors.leftMargin: 7
-        }
     }
 
     // TODO: Replace with StatusModal

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -166,23 +166,14 @@ SettingsContentBase {
             contentItem: ColumnLayout {
                 spacing: Theme.padding
 
-                RowLayout {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignHCenter
-
-                    StatusBaseText {
-                        Layout.preferredWidth: parent.width - betaTag.width - parent.spacing
-                        objectName: "syncNewDeviceTextLabel"
-                        elide: Text.ElideRight
-                        color: Theme.palette.primaryColor1
-                        font.pixelSize: Theme.secondaryAdditionalTextSize
-                        font.weight: Font.Bold
-                        text: qsTr("Sync a New Device")
-                    }
-                    StatusBetaTag {
-                        id: betaTag
-                        tooltipText: qsTr("Connection problems can happen.<br>If they do, please use the Enter a Recovery Phrase feature instead.")
-                    }
+                StatusBaseText {
+                    Layout.preferredWidth: parent.width - betaTag.width - parent.spacing
+                    objectName: "syncNewDeviceTextLabel"
+                    elide: Text.ElideRight
+                    color: Theme.palette.primaryColor1
+                    font.pixelSize: Theme.secondaryAdditionalTextSize
+                    font.weight: Font.Bold
+                    text: qsTr("Sync a New Device")
                 }
 
                 StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -195,14 +195,12 @@ SettingsContentBase {
             } else if(currentIndex === root.accountOrderViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.sectionTitle = qsTr("Edit account order")
-                root.titleRowComponentLoader.sourceComponent = experimentalTagComponent
                 root.stickTitleRowComponentLoader = true
 
             } else if(currentIndex === root.manageTokensViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
                 root.titleRowLeftComponentLoader.visible = false
                 root.sectionTitle = qsTr("Manage tokens")
-                root.titleRowComponentLoader.sourceComponent = experimentalTagComponent
                 root.stickTitleRowComponentLoader = true
             } else if(currentIndex === root.savedAddressesViewIndex) {
                 priv.backButtonName = root.walletSectionTitle
@@ -410,13 +408,6 @@ SettingsContentBase {
                 objectName: "settings_Wallet_MainView_AddNewAccountButton"
                 text: qsTr("Add new account")
                 onClicked: root.walletStore.runAddAccountPopup()
-            }
-        }
-
-        Component {
-            id: experimentalTagComponent
-            StatusBetaTag {
-                tooltipText: qsTr("Under construction, you might experience some minor issues")
             }
         }
 

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -145,15 +145,6 @@ Column {
                 color: Theme.palette.baseColor1
             }
         ]
-
-        StatusBetaTag {
-            id: accountOrderBetaTag
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.left
-            anchors.leftMargin: accountOrderItem.statusListItemTitle.width + parent.leftPadding + Theme.bigPadding
-            tooltipText: qsTr("Under construction, you might experience some minor issues")
-            cursorShape: Qt.PointingHandCursor
-        }
     }
 
     Separator {}
@@ -172,15 +163,6 @@ Column {
                 color: Theme.palette.baseColor1
             }
         ]
-
-        StatusBetaTag {
-            id: manageTokensBetaTag
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.left: parent.left
-            anchors.leftMargin: manageTokensItem.statusListItemTitle.width + parent.leftPadding + Theme.bigPadding
-            tooltipText: qsTr("Under construction, you might experience some minor issues")
-            cursorShape: Qt.PointingHandCursor
-        }
     }
 
     Separator {}

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -257,16 +257,6 @@ RightTabBaseView {
                         rightPadding: 0
                         width: implicitWidth
                         text: qsTr("Activity")
-
-                        StatusBetaTag {
-                            // TODO remove me when Activity is no longer experimental
-                            // Keep Activity as the last tab for now as the Experimental tag don't flow
-                            anchors.top: parent.top
-                            anchors.topMargin: parent.verticalPadding
-                            anchors.left: parent.right
-                            anchors.leftMargin: 5
-                            cursorShape: Qt.PointingHandCursor
-                        }
                     }
                     onCurrentIndexChanged: {
                         RootStore.setCurrentViewedHoldingType(walletTabBar.currentIndex === 1 ? Constants.TokenType.ERC721 : Constants.TokenType.ERC20)

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -245,10 +245,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Under construction.&lt;br&gt;More notification types to be coming soon.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Mark all as Read</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7692,13 +7688,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8979,10 +8968,6 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -10646,10 +10631,6 @@ to load</source>
     </message>
     <message>
         <source>Account order</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Under construction, you might experience some minor issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -17153,10 +17134,6 @@ access to your webcam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Connection problems can happen.&lt;br&gt;If they do, please use the Enter a Recovery Phrase feature instead.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>You own your data. Sync it among your devices.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19090,10 +19067,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>Add new account</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Under construction, you might experience some minor issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -299,11 +299,6 @@
       <translation>Notifications</translation>
     </message>
     <message>
-      <source>Under construction.&lt;br&gt;More notification types to be coming soon.</source>
-      <comment>ActivityCenterLayout</comment>
-      <translation>Under construction.&lt;br&gt;More notification types to be coming soon.</translation>
-    </message>
-    <message>
       <source>Mark all as Read</source>
       <comment>ActivityCenterLayout</comment>
       <translation>Mark all as Read</translation>
@@ -9395,14 +9390,6 @@
     </message>
   </context>
   <context>
-    <name>FeeRow</name>
-    <message>
-      <source>Max.</source>
-      <comment>FeeRow</comment>
-      <translation>Max.</translation>
-    </message>
-  </context>
-  <context>
     <name>FeesBox</name>
     <message>
       <source>Fees</source>
@@ -10951,11 +10938,6 @@
       <source>PIN correct</source>
       <comment>KeycardEnterPinPage</comment>
       <translation>PIN correct</translation>
-    </message>
-    <message>
-      <source>Keycard blocked</source>
-      <comment>KeycardEnterPinPage</comment>
-      <translation>Keycard blocked</translation>
     </message>
     <message numerus="yes">
       <source>%n attempt(s) remaining</source>
@@ -12961,11 +12943,6 @@
       <source>Account order</source>
       <comment>MainView</comment>
       <translation>Account order</translation>
-    </message>
-    <message>
-      <source>Under construction, you might experience some minor issues</source>
-      <comment>MainView</comment>
-      <translation>Under construction, you might experience some minor issues</translation>
     </message>
     <message>
       <source>Manage Tokens</source>
@@ -20863,11 +20840,6 @@
       <translation>Sync a New Device</translation>
     </message>
     <message>
-      <source>Connection problems can happen.&lt;br&gt;If they do, please use the Enter a Recovery Phrase feature instead.</source>
-      <comment>SyncingView</comment>
-      <translation>Connection problems can happen.&lt;br&gt;If they do, please use the Enter a Recovery Phrase feature instead.</translation>
-    </message>
-    <message>
       <source>You own your data. Sync it among your devices.</source>
       <comment>SyncingView</comment>
       <translation>You own your data. Sync it among your devices.</translation>
@@ -23227,11 +23199,6 @@
       <source>Add new account</source>
       <comment>WalletView</comment>
       <translation>Add new account</translation>
-    </message>
-    <message>
-      <source>Under construction, you might experience some minor issues</source>
-      <comment>WalletView</comment>
-      <translation>Under construction, you might experience some minor issues</translation>
     </message>
     <message>
       <source>Testnet mode</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -245,10 +245,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Under construction.&lt;br&gt;More notification types to be coming soon.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Mark all as Read</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7719,13 +7715,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -9015,10 +9004,6 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -10695,10 +10680,6 @@ to load</source>
     </message>
     <message>
         <source>Account order</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Under construction, you might experience some minor issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -17228,10 +17209,6 @@ access to your webcam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Connection problems can happen.&lt;br&gt;If they do, please use the Enter a Recovery Phrase feature instead.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>You own your data. Sync it among your devices.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19172,10 +19149,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Add new account</source>
         <translation>Přidat nový účet</translation>
-    </message>
-    <message>
-        <source>Under construction, you might experience some minor issues</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Testnet mode</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -245,10 +245,6 @@
         <translation>알림</translation>
     </message>
     <message>
-        <source>Under construction.&lt;br&gt;More notification types to be coming soon.</source>
-        <translation>공사 중입니다.&lt;br&gt;더 많은 알림 유형이 곧 제공될 예정입니다.</translation>
-    </message>
-    <message>
         <source>Mark all as Read</source>
         <translation>모두 읽은 것으로 표시</translation>
     </message>
@@ -7665,13 +7661,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8945,10 +8934,6 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN이 올바릅니다</translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
-        <translation>Keycard가 차단됨</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
@@ -10602,10 +10587,6 @@ to load</source>
     <message>
         <source>Account order</source>
         <translation>계정 순서</translation>
-    </message>
-    <message>
-        <source>Under construction, you might experience some minor issues</source>
-        <translation>공사 중입니다. 일부 작은 문제가 발생할 수 있어요</translation>
     </message>
     <message>
         <source>Manage Tokens</source>
@@ -17082,10 +17063,6 @@ access to your webcam</source>
         <translation>새 기기 동기화</translation>
     </message>
     <message>
-        <source>Connection problems can happen.&lt;br&gt;If they do, please use the Enter a Recovery Phrase feature instead.</source>
-        <translation>연결 문제가 발생할 수 있어요.&lt;br&gt;그럴 경우, 대신 복구 문구 입력 기능을 사용해주세요.</translation>
-    </message>
-    <message>
         <source>You own your data. Sync it among your devices.</source>
         <translation>데이터는 내 소유. 내 기기들끼리 동기화하세요.</translation>
     </message>
@@ -19007,10 +18984,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Add new account</source>
         <translation>새 계정 추가</translation>
-    </message>
-    <message>
-        <source>Under construction, you might experience some minor issues</source>
-        <translation>공사 중입니다. 약간의 문제를 겪을 수 있습니다</translation>
     </message>
     <message>
         <source>Testnet mode</source>

--- a/ui/imports/shared/views/SyncingEnterCode.qml
+++ b/ui/imports/shared/views/SyncingEnterCode.qml
@@ -19,7 +19,6 @@ ColumnLayout {
     property string  syncQrErrorMessage: qsTr("This does not look like a pairing QR code")
     property string  syncCodeErrorMessage: qsTr("This does not look like a pairing code")
     property string  syncCodeLabel: qsTr("Type or paste pairing code")
-    property alias showBetaTag: betaTag.visible
 
     property var validateConnectionString: function(stringValue) { return false }
 
@@ -52,10 +51,6 @@ ColumnLayout {
                 objectName: "secondTab_StatusSwitchTabButton"
                 text: root.secondTabName
             }
-        }
-
-        StatusBetaTag {
-            id: betaTag
         }
     }
 


### PR DESCRIPTION
Fixes #19068

### What does the PR do

- Not necessary to display the `Beta Tag` for specific features anymore, since the entire app is in beta.
- Removes all feature-level `Beta Tags` to simplify UI and reduce visual clutter.

### Affected areas

Beta tag

### Architecture compliance

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Beta tag not shown anymore

### How to test

Review flows where the `Beta Tag` was shown:
- Wallet settings
- Wallet activity center
- ENS settings
- Activity Center

### Risk 

Low
