### PR TITLE
StatusChatInput: show send button for not commited text on mobile

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1446,9 +1446,10 @@ Rectangle {
                                 implicitWidth: 32
                                 icon.name: "send"
                                 type: StatusQ.StatusFlatRoundButton.Type.Tertiary
-                                visible: messageInputField.length > 0 || control.fileUrlsAndSources.length > 0 ||
+                                visible: messageInputField.length > 0 || messageInputField.preeditText || control.fileUrlsAndSources.length > 0 ||
                                          (!!control.paymentRequestModel && control.paymentRequestModel.ModelCount.count > 0)
                                 onClicked: {
+                                    InputMethod.commit()
                                     control.onKeyPress({modifiers: d.kbdModifierToSendMessage, key: Qt.Key_Return})
                                 }
                                 tooltip.text: qsTr("Send message")


### PR DESCRIPTION
### What does the PR do

Allow sending any entered text on Android, even if it's in "composing" state and not yet committed.

Closes: #19049

### Affected areas
`StatusChatInput`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/aaf5bf63-6e89-4273-b991-8b41e169dc3b

