### PR TITLE
fix: git rev-parse to get the branch name for testflight changelog

### DIFF
--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+BRANCH_NAME="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+
 if [[ -n "${CHANGE_ID:-}" ]]; then
   # PR build
   SHORT_COMMIT="${GIT_COMMIT:0:7}"
@@ -8,7 +10,7 @@ if [[ -n "${CHANGE_ID:-}" ]]; then
   echo "Build: #${BUILD_NUMBER}"
   echo ""
   echo "View PR: https://github.com/status-im/status-desktop/pull/${CHANGE_ID}"
-elif [[ "${BRANCH_NAME:-}" == release* ]]; then
+elif [[ "${BRANCH_NAME}" == release* ]]; then
   # Release branch build
   echo "Release ${VERSION}"
   echo "Build: #${BUILD_NUMBER}"


### PR DESCRIPTION
### Summary

To fix the branch name fetching for setting testflight changelog