### PR TITLE
fix: proper displaying of recently fetched erc20 tokens

### DIFF
--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -139,6 +139,9 @@ QtObject:
   proc refreshAmountCurrency*(self: Model, currencyService: Service) =
     for i in 0..self.entries.high:
       self.entries[i].resetAmountCurrency(currencyService)
+      let index = self.createIndex(i, 0, nil)
+      defer: index.delete
+      self.dataChanged(index, index, @[ModelRole.ActivityEntryRole.int])
 
   proc delete(self: Model) =
     self.QAbstractListModel.delete


### PR DESCRIPTION
## Description

ERC20 token symbols and decimals were not displaying correctly in the activity list when token metadata was fetched asynchronously after the initial activity load. The UI was showing wrong values (because of not fetched decimals) and no token name.

Fix:
- Token symbol and decimals are done using tokenService instead of cached (and possibly incorrect) data
- refresh UI when new token metadata becomes available

related status-go [PR](https://github.com/status-im/status-go/pull/7063)