### PR TITLE
fix(ci): show more info on bottle fetch errors

### DIFF
--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -10,7 +10,10 @@ function get_gh_pkgs_token() {
 }
 
 function get_bottle_json() {
-    brew info --json=v1 "${1}" | jq ".[0].bottle.stable.files[\"${2}\"]"
+    BOTTLE_INFO=$(brew info --json=v1 "${1}")
+    {
+        echo "${BOTTLE_INFO}" | jq ".[0].bottle.stable.files[\"${2}\"]"
+    } || echo -e "Failed to get bottle files from:\n${BOTTLE_INFO}"
 }
 
 function fetch_bottle() {


### PR DESCRIPTION
Otherwise we just get non-descript stuff like:
```
13:29:48  jq: parse error: Invalid numeric literal at line 1, column 7
13:29:48  Error: Broken pipe @ rb_sys_fail_on_write - <STDOUT>
13:29:48  make: *** [/Users/jenkins/workspace/s_aarch64_package-nwaku_PR-19217/bottles/openssl@3] Error 5
```