### PR TITLE
fix(account): fix account rename being reset by binding

### DIFF
--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -798,7 +798,7 @@ addAccountPopup_PrivateKeyName_StatusInput = {"container": statusDesktop_mainWin
                                               "visible": True}
 
 # Edit Account from settings popup
-renameAccountModal = {"container": statusDesktop_mainWindow_overlay, "objectName": "RenameAccontModal",
+renameAccountModal = {"container": statusDesktop_mainWindow_overlay, "objectName": "RenameAccountModal",
                       "type": "PopupItem", "visible": True}
 editWalletSettings_renameButton = {"container": statusDesktop_mainWindow_overlay,
                                    "objectName": "renameAccountModalSaveBtn", "type": "StatusButton"}

--- a/ui/app/AppLayouts/Profile/popups/qmldir
+++ b/ui/app/AppLayouts/Profile/popups/qmldir
@@ -4,7 +4,7 @@ AddSocialLinkModal 1.0 AddSocialLinkModal.qml
 ModifySocialLinkModal 1.0 ModifySocialLinkModal.qml
 ProfileShowcaseInfoPopup 1.0 ProfileShowcaseInfoPopup.qml
 RenameKeypairPopup 1.0 RenameKeypairPopup.qml
-RenameAccontModal 1.0 RenameAccontModal.qml
+RenameAccountModal 1.0 RenameAccountModal.qml
 RemoveKeypairPopup 1.0 RemoveKeypairPopup.qml
 SendContactRequestToChatKeyModal 1.0 SendContactRequestToChatKeyModal.qml
 TokenListPopup 1.0 TokenListPopup.qml

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -78,7 +78,11 @@ ColumnLayout {
             objectName: "walletAccountViewEditAccountButton"
             text: d.watchOnlyAccount ? qsTr("Edit watched address") : qsTr("Edit account")
             icon.name: "edit_pencil"
-            onClicked: Global.openPopup(renameAccountModalComponent)
+            onClicked: Global.openPopup(renameAccountModalComponent, {
+                accountName: !!root.account ? root.account.name : "",
+                accountEmoji: !!root.account ? root.account.emoji : "",
+                accountColorId: !!root.account ? root.account.colorId : ""
+            })
         }
     }
 
@@ -305,10 +309,18 @@ ColumnLayout {
 
     Component {
         id: renameAccountModalComponent
-        RenameAccontModal {
-            account: root.account
+        RenameAccountModal {
+            onRenameAccountRequested: function(newName, newColorId, newEmoji) {
+                const error = root.walletStore.updateAccount(root.account.address, newName, newColorId, newEmoji);
+
+                if (error) {
+                    Global.playErrorSound();
+                    changeError.text = error
+                    changeError.open()
+                    return
+                }
+            }
             onClosed: destroy()
-            walletStore: root.walletStore
             emojiPopup: root.emojiPopup
         }
     }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14478,7 +14478,7 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>RenameAccontModal</name>
+    <name>RenameAccountModal</name>
     <message>
         <source>Rename %1</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -17633,20 +17633,20 @@
     </message>
   </context>
   <context>
-    <name>RenameAccontModal</name>
+    <name>RenameAccountModal</name>
     <message>
       <source>Rename %1</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>Rename %1</translation>
     </message>
     <message>
       <source>Enter an account name...</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>Enter an account name...</translation>
     </message>
     <message numerus="yes">
       <source>Account name must be at least %n character(s)</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>
         <numerusform>Account name must be at least %n character</numerusform>
         <numerusform>Account name must be at least %n characters</numerusform>
@@ -17654,22 +17654,22 @@
     </message>
     <message>
       <source>This is not a valid account name</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>This is not a valid account name</translation>
     </message>
     <message>
       <source>COLOUR</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>COLOUR</translation>
     </message>
     <message>
       <source>Change Name</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>Change Name</translation>
     </message>
     <message>
       <source>Changing settings failed</source>
-      <comment>RenameAccontModal</comment>
+      <comment>RenameAccountModal</comment>
       <translation>Changing settings failed</translation>
     </message>
   </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14541,7 +14541,7 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>RenameAccontModal</name>
+    <name>RenameAccountModal</name>
     <message>
         <source>Rename %1</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -571,7 +571,7 @@
     </message>
 </context>
 <context>
-    <name>RenameAccontModal</name>
+    <name>RenameAccountModal</name>
     <message numerus="yes">
         <source>Account name must be at least %n character(s)</source>
         <translation>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14419,14 +14419,14 @@ to load</source>
     </message>
 </context>
 <context>
-    <name>RenameAccontModal</name>
+    <name>RenameAccountModal</name>
     <message>
         <source>Rename %1</source>
         <translation>%1 이름 변경</translation>
     </message>
     <message>
         <source>Enter an account name...</source>
-        <translation>계정 이름을 입력하세요...</translation>
+        <translation>계정 이름 입력...</translation>
     </message>
     <message numerus="yes">
         <source>Account name must be at least %n character(s)</source>


### PR DESCRIPTION
### What does the PR do

Fixes #19174

The problem was that the popup was being binded to the selected account, so when a signal was triggered in the background from an async task, it would retrigger the binding and reset the popup.

Passing the account properties directly is cleaner and fixes the issue.

I also renamed the Component because there was a type (missing `u`)

### Affected areas

-RenameAccountModal
- AccountView

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

In this video, I show that the popup's field doesn't get reset when the signals get triggered (see the console):

[account-popup-reset.webm](https://github.com/user-attachments/assets/5145fdca-d7d9-4110-bcb7-fdda4bb6eab4)


### Impact on end user

Fixes the issue (mostly annoying for the e2e tests)

### How to test

- Open the app and go to the Settings fast
- Click Wallet and select an account (fast)
- Update the name (fast)
- Wait for the signals to be triggered

### Risk 

Low
