### PR TITLE
fix(ci): replace gitParameter with string parameter

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -19,17 +19,10 @@ pipeline {
   }
 
   parameters {
-    gitParameter(
+    string(
       name: 'GIT_REF',
       description: 'Git branch to checkout.',
-      branchFilter: 'origin/(.*)',
-      branch: '',
-      defaultValue: 'master',
-      quickFilterEnabled: false,
-      selectedValue: 'DEFAULT',
-      sortMode: 'ASCENDING_SMART',
-      tagFilter: '*',
-      type: 'PT_BRANCH'
+      defaultValue: 'master'
     )
     string(
       name: 'BUILD_SOURCE',

--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -8,17 +8,10 @@ pipeline {
   }
 
   parameters {
-    gitParameter(
+    string(
       name: 'GIT_REF',
       description: 'Git branch to checkout.',
-      branchFilter: 'origin/(.*)',
-      branch: '',
-      defaultValue: 'master',
-      quickFilterEnabled: false,
-      selectedValue: 'DEFAULT',
-      sortMode: 'ASCENDING_SMART',
-      tagFilter: '*',
-      type: 'PT_BRANCH'
+      defaultValue: 'master'
     )
     string(
       name: 'BUILD_SOURCE',


### PR DESCRIPTION
Recent upgrade of Jenkins and Git Paramter plugin caused these to appear:
```
[2025-11-07T12:07:08.487Z] Scheduling project: status-desktop » e2e » prs
Invalid parameter value: (StringParameterValue) GIT_REF='6e42ff2a5cb10933332d6722e1c19babc9973c07'
```
Which are caused by recently patched vulnerability in the plugin:
- https://www.jenkins.io/security/advisory/2025-07-09/#SECURITY-3419
- https://github.com/jenkinsci/git-parameter-plugin/releases/tag/444.vca_b_84d3703c2

We could disable this check with:
```
gitParameterDefinition.allowAnyParameterValue=true
```
But just using a String paramater is simpler and more convenient.