### PR TITLE
fix(StatusEmojiPopup): Emoji search is slow on Android

### DIFF
--- a/storybook/pages/StatusEmojiPopupPage.qml
+++ b/storybook/pages/StatusEmojiPopupPage.qml
@@ -50,13 +50,18 @@ SplitView {
             id: emojiPopup
 
             directParent: topPane
+            relativeX: (parent.width - width) / 2
+            relativeY: (parent.height - height) / 2
 
             height: 440
             visible: true
             modal: false
             settings: settings
             emojiModel: StatusQUtils.Emoji.emojiModel
-            onEmojiSelected: (emoji) => d.lastSelectedEmoji = emoji
+            onEmojiSelected: function(emoji, atCu, hexcode) {
+                logs.logEvent("onEmojiSelected", ["emoji", "atCu", "hexcode"], arguments)
+                d.lastSelectedEmoji = emoji
+            }
         }
     }
 

--- a/ui/StatusQ/include/StatusQ/statusemojimodel.h
+++ b/ui/StatusQ/include/StatusQ/statusemojimodel.h
@@ -9,6 +9,7 @@ class StatusEmojiModel : public QAbstractListModel
     Q_PROPERTY(QJsonArray emojiJson READ emojiJson WRITE setEmojiJson NOTIFY emojiJsonChanged
                    REQUIRED FINAL)
     Q_PROPERTY(QStringList categories READ categories CONSTANT FINAL)
+    Q_PROPERTY(QStringList categoryIcons READ categoryIcons CONSTANT FINAL)
     Q_PROPERTY(QStringList recentEmojis READ recentEmojis WRITE setRecentEmojis NOTIFY
                    recentEmojisChanged FINAL)
     Q_PROPERTY(QString recentCategoryName READ recentCategoryName CONSTANT FINAL)
@@ -49,6 +50,7 @@ private:
     QJsonArray m_emojiJson;
 
     QStringList categories() const;
+    QStringList categoryIcons() const;
 
     QStringList recentEmojis() const;
     void setRecentEmojis(const QStringList &newRecentEmojis);

--- a/ui/StatusQ/src/StatusQ/Core/Utils/emojiList.js
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/emojiList.js
@@ -1,17 +1,5 @@
 .pragma library
 
-const emojiCategories = [
-    "time",
-    "smileys-and-people",
-    "animals-and-nature",
-    "food-and-drinks",
-    "activity",
-    "travel-and-places",
-    "objects",
-    "symbols",
-    "flags",
-]
-
 const emoji_json =
 [
     {

--- a/ui/StatusQ/src/statusemojimodel.cpp
+++ b/ui/StatusQ/src/statusemojimodel.cpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <algorithm>
 
+using namespace Qt::Literals::StringLiterals;
+
 namespace {
 constexpr auto kAliases = "aliases";
 constexpr auto kAliasesAscii = "aliases_ascii";
@@ -24,7 +26,7 @@ const auto skinColors = std::array<const char*, 5>{"1f3fb", "1f3fc", "1f3fd", "1
 
 constexpr auto MAX_EMOJI_NUMBER = 36;
 
-constexpr auto kRecentCategoryName = "recent";
+constexpr auto kRecentCategoryName = "recent"_L1;
 }
 
 StatusEmojiModel::StatusEmojiModel(QObject *parent)
@@ -33,7 +35,7 @@ StatusEmojiModel::StatusEmojiModel(QObject *parent)
 
 int StatusEmojiModel::rowCount(const QModelIndex &parent) const
 {
-    return m_recentEmojis.size() + m_emojiJson.size();
+    return m_recentEmojiJson.size() + m_emojiJson.size();
 }
 
 QVariant StatusEmojiModel::data(const QModelIndex &index, int role) const
@@ -151,15 +153,32 @@ int StatusEmojiModel::getCategoryOffset(int categoryIndex) const {
 QStringList StatusEmojiModel::categories() const
 {
     static const QStringList categories{kRecentCategoryName,
-                                        QStringLiteral("smileys, people & body"),
-                                        QStringLiteral("animals & nature"),
-                                        QStringLiteral("food & drink"),
-                                        QStringLiteral("travel & places"),
-                                        QStringLiteral("activities"),
-                                        QStringLiteral("objects"),
-                                        QStringLiteral("symbols"),
-                                        QStringLiteral("flags")};
+        "smileys, people & body"_L1,
+        "animals & nature"_L1,
+        "food & drink"_L1,
+        "travel & places"_L1,
+        "activities"_L1,
+        "objects"_L1,
+        "symbols"_L1,
+        "flags"_L1
+    };
     return categories;
+}
+
+QStringList StatusEmojiModel::categoryIcons() const
+{
+    static const QStringList categoryIcons{
+        "time"_L1,
+        "smileys-and-people"_L1,
+        "animals-and-nature"_L1,
+        "food-and-drinks"_L1,
+        "activity"_L1,
+        "travel-and-places"_L1,
+        "objects"_L1,
+        "symbols"_L1,
+        "flags"_L1
+    };
+    return categoryIcons;
 }
 
 QStringList StatusEmojiModel::recentEmojis() const


### PR DESCRIPTION
### What does the PR do

- use dedicated `SearchFilter`s instead of the slow `*ExpressionFilter`, also eliminating the need to lower case everything
- restore a removed line that broke adding to recent emojis on selection
- increase the delegate size and spacing a bit to make it easier to tap on using a touch screen
- move the icon categories list to the model; it has nothing to do with the upstream emojiJSON

Fixes #19079

### Affected areas

Emoji popup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/e725910c-0b96-40c5-9b7f-6beecbd28326

### Impact on end user

- faster emoji search, esp. on mobile
- easier to operate with a touch screen

### Risk 

low
