### PR TITLE
fix(AddEditSavedAddressPopup): Improve checksum validation UX

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -222,7 +222,11 @@ Item {
         This property sets the visibility of the background. Default value is true.
     */
     property bool showBackground: true
-
+    /*!
+        \qmlproperty bool StatusBaseInput::warningMode
+        This property sets warning mode on the input
+    */
+    property bool warningMode: false
     /*!
         \qmlproperty StatusAssetSettings StatusBaseInput::icon
         This property holds a set of settings for the icon of the StatusBaseInput.
@@ -305,6 +309,9 @@ Item {
             }
             if (!root.valid && root.dirty) {
                 return Theme.palette.dangerColor1
+            }
+            if(root.warningMode) {
+                return Theme.palette.warningColor1
             }
             if (edit.cursorVisible) {
                 return Theme.palette.primaryColor1

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -233,6 +233,16 @@ Control {
         This property sets the pending validators to be considered.
     */
     property var pendingValidators: []
+    /*!
+        \qmlproperty bool StatusInput::warningMode
+        This property sets warning mode on the input
+    */
+    property bool warningMode: false
+    /*!
+        \qmlproperty string StatusInput::warningMessage
+        This property sets the warning message text.
+    */
+    property string warningMessage: ""
 
     /*!
         \qmlsignal
@@ -522,6 +532,7 @@ Control {
             Layout.bottomMargin: bottomRow.height > 0 ? labelPadding : 0
             maximumLength: root.charLimit
             font: root.font
+            warningMode: root.warningMode
             onTextChanged: root.validate()
             Keys.forwardTo: [root]
             onIconClicked: root.iconClicked()
@@ -586,7 +597,18 @@ Control {
                 color: Theme.palette.dangerColor1
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignRight
-            }            
+            }
+
+            StatusBaseText {
+                id: warningMessage
+                Layout.fillWidth: true
+                visible: !!text && root.warningMode && !errorMessage.visible
+                font.pixelSize: Theme.tertiaryTextFontSize
+                color: Theme.palette.warningColor1
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignRight
+                text: root.warningMessage
+            }
 
             StatusBaseText {
                 id: bottomLabelMessageRight

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -102,8 +102,11 @@ StatusModal {
                                       || !d.editMode
                                       || d.colorId.toUpperCase() !== d.storedColorId.toUpperCase()
 
-        property bool incorrectChecksum: false
-
+        property bool incorrectChecksum: {
+            if (d.addressInputIsAddress) {
+                d.incorrectChecksum = !root.store.isChecksumValidForAddress(d.address)
+            }
+        }
 
         readonly property bool addressInputIsENS: !!d.ens &&
                                                   Utils.isValidEns(d.ens)
@@ -208,13 +211,6 @@ StatusModal {
             addressInput.errorMessageCmp.visible = true
         }
 
-        function checkIfAddressChecksumIsValid() {
-            d.incorrectChecksum = false
-            if (d.addressInputIsAddress) {
-                d.incorrectChecksum = !root.store.isChecksumValidForAddress(d.address)
-            }
-        }
-
         function checkForAddressInputErrorsWarnings() {
             addressInput.errorMessageCmp.visible = false
             addressInput.errorMessageCmp.color = Theme.palette.dangerColor1
@@ -244,7 +240,6 @@ StatusModal {
 
             if (d.addressInputIsAddress) {
                 d.checkForAddressInputOwningErrorsWarnings()
-                d.checkIfAddressChecksumIsValid()
                 return
             }
 
@@ -430,7 +425,7 @@ StatusModal {
                 enabled: !(d.editMode || d.addAddress)
                 input.edit.textFormat: TextEdit.RichText
                 input.rightComponent: (d.resolvingEnsNameInProgress || d.checkingContactsAddressInProgress) ?
-                    loadingIndicator : d.incorrectChecksum? incorrectChecksumComponent : null
+                                          loadingIndicator : null
                 input.asset.name: d.addressInputValid && !d.editMode ? "checkbox" : ""
                 input.asset.color: enabled ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
                 input.asset.width: 17
@@ -438,6 +433,9 @@ StatusModal {
                 input.rightPadding: 16
                 input.leftIcon: false
                 input.tabNavItem: nameInput
+
+                warningMode: d.incorrectChecksum
+                warningMessage: qsTr("Checksum of the entered address is incorrect")
 
                 multiline: true
 
@@ -447,18 +445,6 @@ StatusModal {
                     id: loadingIndicator
 
                     StatusLoadingIndicator {}
-                }
-
-                Component {
-                    id: incorrectChecksumComponent
-
-                    StatusIconWithTooltip {
-                        icon: "warning"
-                        width: 20
-                        height: 20
-                        color: Theme.palette.warningColor1
-                        tooltipText: qsTr("Checksum of the entered address is incorrect")
-                    }
                 }
 
                 onTextChanged: {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2707,10 +2707,6 @@ Do you wish to override the security check and continue?</source>
         <source>Disconnect</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Wallet info will appear here</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>BrowserWebEngineView</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1894,8 +1894,8 @@
       <source>%n key pair(s) successfully imported</source>
       <comment>AppMain</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>%n key pair successfully imported</numerusform>
+        <numerusform>%n key pairs successfully imported</numerusform>
       </translation>
     </message>
     <message>
@@ -2357,8 +2357,8 @@
       <source>%n issue(s)</source>
       <comment>AppMain</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>%n issue</numerusform>
+        <numerusform>%n issues</numerusform>
       </translation>
     </message>
     <message>
@@ -3313,11 +3313,6 @@
       <source>Disconnect</source>
       <comment>BrowserWalletMenu</comment>
       <translation>Disconnect</translation>
-    </message>
-    <message>
-      <source>Wallet info will appear here</source>
-      <comment>BrowserWalletMenu</comment>
-      <translation>Wallet info will appear here</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2714,10 +2714,6 @@ Do you wish to override the security check and continue?</source>
         <source>Disconnect</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Wallet info will appear here</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>BrowserWebEngineView</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2711,10 +2711,6 @@ Do you wish to override the security check and continue?</source>
         <source>Disconnect</source>
         <translation>Desconectar</translation>
     </message>
-    <message>
-        <source>Wallet info will appear here</source>
-        <translation>La información de la billetera aparecerá aquí</translation>
-    </message>
 </context>
 <context>
     <name>BrowserWebEngineView</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7643,13 +7643,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8930,10 +8923,6 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN이 올바릅니다</translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
-        <translation type="unfinished">Keycard가 차단됨</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>

--- a/ui/imports/shared/popups/addaccount/panels/WatchOnlyAddressSection.qml
+++ b/ui/imports/shared/popups/addaccount/panels/WatchOnlyAddressSection.qml
@@ -60,27 +60,16 @@ Column {
         label: qsTr("Ethereum address or ENS name")
         placeholderText: qsTr("Type or paste ETH address")
         input.multiline: true
-        input.rightComponent: Row {
-            spacing: 8
-
-            StatusIconWithTooltip {
-                visible: d.incorrectChecksum
-                icon: "warning"
-                width: 20
-                height: 20
-                color: Theme.palette.warningColor1
-                tooltipText: qsTr("Checksum of the entered address is incorrect")
-            }
-
-            StatusButton {
-                anchors.verticalCenter: parent.verticalCenter
-                borderColor: Theme.palette.primaryColor1
-                size: StatusBaseButton.Size.Tiny
-                text: qsTr("Paste")
-                onClicked: {
-                    addressInput.text = ""
-                    addressInput.input.edit.paste()
-                }
+        warningMode: d.incorrectChecksum
+        warningMessage: qsTr("Checksum of the entered address is incorrect")
+        input.rightComponent: StatusButton {
+            anchors.verticalCenter: parent.verticalCenter
+            borderColor: Theme.palette.primaryColor1
+            size: StatusBaseButton.Size.Tiny
+            text: qsTr("Paste")
+            onClicked: {
+                addressInput.text = ""
+                addressInput.input.edit.paste()
             }
         }
         validators: [


### PR DESCRIPTION
Closes #19081

### What does the PR do

As discused with designer and team [here](https://www.figma.com/design/SGyfSjxs5EbzimHDXTlj8B/Qt-Responsive---v?node-id=3085-41994&m=dev):
- Removed tooltip from checksum indicator on all platforms.
- Checksum mismatch is now treated as a standard error instead of a tooltip hint.
- Prevents adding an address with an invalid checksum.

### Affected areas

Wallet / Saved addresses popup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/a128ac39-cfb1-4420-bbd5-265be25d6bdc

<img width="2056" height="1329" alt="Screenshot 2025-11-20 at 09 49 16" src="https://github.com/user-attachments/assets/df9ec77c-f35f-40a4-8474-065f9494381f" />

https://github.com/user-attachments/assets/4ac46bb7-d163-4c1e-b195-b9d0c1fbcad9

### Impact on end user

Save address checksum validation improved

### How to test

Use the same steps than shown in the video shared.

### Risk 

Low
