### PR TITLE
fix(CollectiblesView/ProfileShowcase): fixup context menus

### DIFF
--- a/storybook/pages/CollectiblesViewPage.qml
+++ b/storybook/pages/CollectiblesViewPage.qml
@@ -122,6 +122,7 @@ SplitView {
         networkFilters: d.networksChainsCurrentlySelected
         addressFilters: d.addressesSelected
         filterVisible: ctrlFilterVisible.checked
+        customOrderAvailable: controller.hasSettings
         onCollectibleClicked: logs.logEvent("onCollectibleClicked", ["chainId", "contractAddress", "tokenId", "uid", "tokenType", "communityId"], arguments)
         onSendRequested: logs.logEvent("onSendRequested", ["symbol", "tokenType", "fromAddress"], arguments)
         onReceiveRequested: logs.logEvent("onReceiveRequested", ["symbol"], arguments)

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -14,7 +14,7 @@ import StatusQ.Core.Utils as StatusQUtils
 import AppLayouts.stores as AppLayoutStores
 import AppLayouts.Profile.stores as ProfileStores
 import AppLayouts.Profile.helpers
-import AppLayouts.Wallet.stores
+import AppLayouts.Wallet.stores as WalletStores
 
 import Storybook
 import Models
@@ -23,6 +23,7 @@ SplitView {
     id: root
 
     property bool globalUtilsReady: false
+    property bool globalCommunitiesModuleInstReady: false
 
     // globalUtilsInst mock
     QtObject {
@@ -42,6 +43,23 @@ SplitView {
         Component.onDestruction: {
             root.globalUtilsReady = false
             Utils.globalUtilsInst = {}
+        }
+    }
+
+    // communitiesModuleInst mock
+    QtObject {
+        function shareCommunityUrlWithData(communityId) {
+            return "https://status.app/0x" + communityId
+        }
+
+        Component.onCompleted: {
+            Utils.communitiesModuleInst = this
+            root.globalCommunitiesModuleInstReady = true
+
+        }
+        Component.onDestruction: {
+            root.globalCommunitiesModuleInstReady = false
+            Utils.communitiesModuleInst = {}
         }
     }
 
@@ -117,7 +135,7 @@ SplitView {
                 clip: true
 
                 Loader {
-                    active: root.globalUtilsReady
+                    active: root.globalUtilsReady && root.globalCommunitiesModuleInstReady
                     width: parent.availableWidth
                     height: parent.availableHeight
 
@@ -125,7 +143,7 @@ SplitView {
                         implicitWidth: 640
 
                         contactDetails: ContactDetails {
-                            publicKey: "0x0000x"
+                            publicKey: "0xdeadbeef"
 
                             displayName: displayNameTextField.text
                             localNickname: localNicknameTextField.text
@@ -134,15 +152,21 @@ SplitView {
                             name: ensNameTextField.text
 
                             isCurrentUser: ownProfileSwitch.checked
+                            isContact: ctrlIsContact.checked
+                            contactRequestState: ctrlContactRequestState.currentValue
 
                             largeImage: userImageCheckBox.checked ? Theme.png("status-logo") : ""
 
                             onlineStatus: onlineStatusComboBox.currentValue
 
+                            trustStatus: ctrlTrustStatus.currentValue
+                            isVerified: ctrlTrustStatus.currentValue === Constants.trustStatus.trusted
+                            isUntrustworthy: ctrlTrustStatus.currentValue === Constants.trustStatus.untrustworthy
                             isBlocked: isBlockedCheckBox.checked
 
                             colorId: colorIdSpinBox.value
 
+                            bio: ctrlBio.text
                         }
 
                         readOnly: ctrlReadOnly.checked
@@ -238,6 +262,7 @@ SplitView {
                         }
 
                         networksStore: SharedStores.NetworksStore {}
+                        walletStore: WalletStores.RootStore
                     }
                 }
             }
@@ -272,6 +297,7 @@ SplitView {
                     Label { text: "localNickname:" }
 
                     TextField {
+                        Layout.preferredWidth: 100
                         id: localNicknameTextField
 
                         text: "Alex"
@@ -283,6 +309,7 @@ SplitView {
                     }
 
                     TextField {
+                        Layout.preferredWidth: 100
                         id: displayNameTextField
 
                         text: "Alex Pella"
@@ -301,6 +328,7 @@ SplitView {
                     }
 
                     TextField {
+                        Layout.preferredWidth: 100
                         id: ensNameTextField
 
                         enabled: ensVerifiedCheckBox.checked
@@ -398,46 +426,10 @@ SplitView {
                 }
                 RowLayout {
                     Layout.fillWidth: true
-
-                    Button {
-                        text: "Send ID request"
-                        onClicked: {
-                            ctrlIsContact.checked = true
-                            ctrlIncomingVerificationStatus.currentIndex = ctrlIncomingVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
-                            ctrlVerificationStatus.currentIndex = ctrlVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
-                        }
-                    }
-                    Button {
-                        text: "Reply to ID request"
-                        onClicked: {
-                            ctrlIsContact.checked = true
-                            ctrlIncomingVerificationStatus.currentIndex = ctrlIncomingVerificationStatus.indexOfValue(Constants.verificationStatus.verifying)
-                            ctrlVerificationStatus.currentIndex = ctrlVerificationStatus.indexOfValue(Constants.verificationStatus.unverified)
-                        }
-                    }
-                    Button {
-                        text: "Pending ID request"
-                        onClicked: {
-                            ctrlIsContact.checked = true
-                            ctrlIncomingVerificationStatus.currentIndex = ctrlIncomingVerificationStatus.indexOfValue(Constants.verificationStatus.verifying)
-                            ctrlVerificationStatus.currentIndex = ctrlVerificationStatus.indexOfValue(Constants.verificationStatus.verifying)
-                        }
-                    }
-                    Button {
-                        text: "Review ID reply"
-                        onClicked: {
-                            ctrlIsContact.checked = true
-                            ctrlIncomingVerificationStatus.currentIndex = ctrlIncomingVerificationStatus.indexOfValue(Constants.verificationStatus.verified)
-                            ctrlVerificationStatus.currentIndex = ctrlVerificationStatus.indexOfValue(Constants.verificationStatus.verifying)
-                        }
-                    }
-                }
-                RowLayout {
-                    Layout.fillWidth: true
                     Label { text: "Bio:" }
                     TextField {
                         Layout.fillWidth: true
-                        id: bio
+                        id: ctrlBio
                         selectByMouse: true
                         text: "
 
@@ -473,4 +465,4 @@ Say hi, or find me on Twitter, GitHub, or Mastodon.
 // https://www.figma.com/file/ibJOTPlNtIxESwS96vJb06/%F0%9F%91%A4-Profile-%7C-Desktop?node-id=6%3A16845&t=h8DUW6Eysawqe5u0-0
 // https://www.figma.com/file/ibJOTPlNtIxESwS96vJb06/%F0%9F%91%A4-Profile-%7C-Desktop?node-id=4%3A25437&t=h8DUW6Eysawqe5u0-0
 
-// status: decent
+// status: good

--- a/storybook/pages/StatusCommunityCardPage.qml
+++ b/storybook/pages/StatusCommunityCardPage.qml
@@ -48,7 +48,7 @@ SplitView {
             }
 
             onClicked: logs.logEvent("StatusCommunityCard::onClicked", ["communityId"], arguments)
-            onRightClicked: logs.logEvent("StatusCommunityCard::onRightClicked", ["communityId"], arguments)
+            onRightClicked: logs.logEvent("StatusCommunityCard::onRightClicked", ["communityId", "x", "y"], arguments)
         }
     }
 

--- a/storybook/src/Models/CommunitiesModel.qml
+++ b/storybook/src/Models/CommunitiesModel.qml
@@ -2,12 +2,14 @@ import QtQuick
 
 import utils
 
+import Models
+
 ListModel {
     Component.onCompleted:
         append([{
                     id: "0x0001",
                     name: "I am 0wner!1!!",
-                    description: "Lorem ipsum dolor sit amet",
+                    description: ModelsData.descriptions.shortLoremIpsum,
                     introMessage: "Welcome to ze club",
                     outroMessage: "Sad to see you go",
                     joined: true,
@@ -19,6 +21,7 @@ ListModel {
                     muted: false,
                     members: [ { pubKey: "0xdeadbeef" } ],
                     membersCount: 1,
+                    activeMembersCount: 1,
                     loading: false,
                     permissionsModel: [],
                     allTokenRequirementsMet: false
@@ -26,7 +29,7 @@ ListModel {
                 {
                     id: "0x0002",
                     name: "Test community 2",
-                    description: "Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat.",
+                    description: ModelsData.descriptions.longLoremIpsum,
                     introMessage: "Welcome to ze club",
                     outroMessage: "Sad to see you go",
                     joined: true,
@@ -38,6 +41,7 @@ ListModel {
                     muted: false,
                     members: [ { pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" } ],
                     membersCount: 3,
+                    activeMembersCount: 3,
                     loading: false,
                     permissionsModel: [],
                     allTokenRequirementsMet: false
@@ -46,7 +50,7 @@ ListModel {
                     id: "0x0003",
                     name: "Free to join",
                     introMessage: "Welcome to ze club",
-                    description: "Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat.",
+                    description: ModelsData.descriptions.longLoremIpsum,
                     outroMessage: "Sad to see you go",
                     joined: false,
                     spectated: true,
@@ -57,6 +61,7 @@ ListModel {
                     muted: false,
                     members: [ { pubKey: "0xdeadbeef" } ],
                     membersCount: 1,
+                    activeMembersCount: 1,
                     loading: false,
                     permissionsModel: PermissionsModel.moreThanTwoInitialShortPermissionsModel,
                     allTokenRequirementsMet: false
@@ -65,7 +70,7 @@ ListModel {
                     id: "0x0004",
                     name: "Muted community",
                     introMessage: "Welcome to ze club",
-                    description: "Lorem ipsum dolor sit amet",
+                    description: ModelsData.descriptions.shortLoremIpsum,
                     outroMessage: "Sad to see you go",
                     joined: true,
                     spectated: false,
@@ -76,6 +81,7 @@ ListModel {
                     muted: true,
                     members: [],
                     membersCount: 0,
+                    activeMembersCount: 0,
                     loading: false,
                     permissionsModel: [],
                     allTokenRequirementsMet: false
@@ -83,7 +89,7 @@ ListModel {
                 {
                     id: "0x0005",
                     name: "Admin test community",
-                    description: "Lorem ipsum dolor sit amet",
+                    description: ModelsData.descriptions.shortLoremIpsum,
                     introMessage: "Welcome to ze club",
                     outroMessage: "Sad to see you go",
                     joined: true,
@@ -95,6 +101,7 @@ ListModel {
                     muted: false,
                     members: [{ pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }],
                     membersCount: 4,
+                    activeMembersCount: 4,
                     loading: false,
                     permissionsModel: [],
                     allTokenRequirementsMet: false
@@ -102,7 +109,7 @@ ListModel {
                 {
                     id: "0x0006",
                     name: "Pending request here",
-                    description: "Lorem ipsum dolor sit amet",
+                    description: ModelsData.descriptions.shortLoremIpsum,
                     introMessage: "Welcome to ze club",
                     outroMessage: "Sad to see you go",
                     joined: false,
@@ -114,6 +121,7 @@ ListModel {
                     muted: false,
                     members: [{ pubKey: "0xdeadbeef" }],
                     membersCount: 1,
+                    activeMembersCount: 1,
                     loading: false,
                     permissionsModel: PermissionsModel.privatePermissionsMemberNotMetModel,
                     allTokenRequirementsMet: false
@@ -121,7 +129,7 @@ ListModel {
                 {
                     id: "0x0007",
                     name: "Token Master Club",
-                    description: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi",
+                    description: ModelsData.descriptions.mediumLoremIpsum,
                     introMessage: "Welcome to ze club",
                     outroMessage: "Sad to see you go",
                     joined: true,
@@ -132,6 +140,7 @@ ListModel {
                     muted: false,
                     members: [{ pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }],
                     membersCount: 2,
+                    activeMembersCount: 2,
                     loading: false,
                     permissionsModel: [],
                     allTokenRequirementsMet: false

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -169,7 +169,7 @@ Rectangle {
         \qmlsignal StatusCommunityCard::rightClicked(string communityId)
         This signal is emitted when the card item is clicked with RMB.
     */
-    signal rightClicked(string communityId)
+    signal rightClicked(string communityId, real x, real y)
 
     QtObject {
         id: d
@@ -525,11 +525,11 @@ Rectangle {
         enabled: root.loaded
         acceptedButtons: Qt.LeftButton
         onTapped: root.clicked(root.communityId)
-        onLongPressed: root.rightClicked(root.communityId)
+        onLongPressed: root.rightClicked(root.communityId, point.pressPosition.x, point.pressPosition.y)
     }
     TapHandler {
         enabled: root.loaded
         acceptedButtons: Qt.RightButton
-        onTapped: root.rightClicked(root.communityId)
+        onTapped: root.rightClicked(root.communityId, point.pressPosition.x, point.pressPosition.y)
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedMedia.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedMedia.qml
@@ -100,18 +100,17 @@ StatusRoundedComponent {
     property bool isEmpty: false
 
     readonly property int componentMediaType: {
-        if (root.mediaType.startsWith("image")) {
+        if (root.mediaType.startsWith("image"))
             return StatusRoundedMedia.MediaType.Image
-        } else if (root.mediaType.startsWith("video")) {
+        if (root.mediaType.startsWith("video"))
             return StatusRoundedMedia.MediaType.Video
-        }
         return StatusRoundedMedia.MediaType.Unknown
     }
 
     signal imageClicked(var image, bool plain)
-    signal videoClicked(var mediaUrl)
-    signal openImageContextMenu(var url, bool isGif)
-    signal openVideoContextMenu(var url)
+    signal videoClicked(url mediaUrl)
+    signal openImageContextMenu(url url, bool isGif, real x, real y)
+    signal openVideoContextMenu(url url, real x, real y)
 
     isLoading: {
         if (mediaLoader.status === Loader.Ready) {
@@ -159,14 +158,14 @@ StatusRoundedComponent {
         if(!!mediaLoader.item && (mediaLoader.item.paintedWidth > 0 || mediaLoader.item.paintedHeight > 0)) {
             return mediaLoader.item.paintedWidth
         }
-        else return root.manualMaxDimension
+        return root.manualMaxDimension
     }
     implicitHeight: {
         // Use Painted height so that the rectangle follows height of the image actually painted
         if(!!mediaLoader.item && (mediaLoader.item.paintedWidth > 0 || mediaLoader.item.paintedHeight > 0)) {
             return mediaLoader.item.paintedHeight
         }
-        else return root.manualMaxDimension
+        return root.manualMaxDimension
     }
 
     StatusMouseArea {
@@ -180,9 +179,9 @@ StatusRoundedComponent {
             }
             if (mouse.button === Qt.RightButton) {
                 if (d.isFallback || componentMediaType === StatusRoundedMedia.MediaType.Image) {
-                    root.openImageContextMenu(mediaLoader.item.source, !!mediaLoader.item.playing)
+                    root.openImageContextMenu(mediaLoader.item.source, !!mediaLoader.item.playing, mouse.x, mouse.y)
                 } else if (componentMediaType === StatusRoundedMedia.MediaType.Video) {
-                    root.openVideoContextMenu(mediaUrl)
+                    root.openVideoContextMenu(mediaUrl, mouse.x, mouse.y)
                 }
 
                 return
@@ -213,7 +212,7 @@ StatusRoundedComponent {
 
     function updateMediaLoader() {
         d.reset()
-        if (root.mediaUrl !== "") {
+        if (root.mediaUrl.toString() !== "") {
             if (componentMediaType === StatusRoundedMedia.MediaType.Image) {
                 mediaLoader.setSource("StatusAnimatedImage.qml",
                                     {
@@ -225,7 +224,7 @@ StatusRoundedComponent {
             } else if (componentMediaType === StatusRoundedMedia.MediaType.Video) {
                 mediaLoader.setSource("StatusVideo.qml",
                                     {
-                                        "player.source": root.mediaUrl,
+                                        "source": root.mediaUrl,
                                         "fillMode": root.fillMode
                                     });
                 return

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -506,13 +506,12 @@ ColumnLayout {
             balance: model.balance ?? 1
 
             onClicked: root.collectibleClicked(model.chainId, model.contractAddress, model.tokenId, model.symbol, model.tokenType, model.communityId ?? "")
-            onRightClicked: {
+            onContextMenuRequested: function(x, y) {
                 const userOwnedAddress = d.getFirstUserOwnedAddress(model.ownership)
-                Global.openMenu(tokenContextMenu, this,
-                                {symbol: model.symbol, chainId: model.chainId, tokenName: model.name, tokenImage: model.imageUrl,
-                                    communityId: model.communityId, communityName: model.communityName,
-                                    communityImage: model.communityImage, tokenType: model.tokenType,
-                                    soulbound: model.soulbound, userOwnedAddress: userOwnedAddress})
+                tokenContextMenu.createObject(this, {symbol: model.symbol, chainId: model.chainId, tokenName: model.name, tokenImage: model.imageUrl,
+                                                  communityId: model.communityId, communityName: model.communityName,
+                                                  communityImage: model.communityImage, tokenType: model.tokenType,
+                                                  soulbound: model.soulbound, userOwnedAddress}).popup(x, y)
             }
             onSwitchToCommunityRequested: (communityId) => root.switchToCommunityRequested(communityId)
         }

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
@@ -51,7 +51,7 @@ Item {
         readonly property string blockExplorerLink: !!collectible ? root.walletRootStore.getExplorerUrl(collectible.networkShortName, collectible.contractAddress, collectible.tokenId): ""
         readonly property var addrFilters: root.addressFilters.split(":").map((addr) => addr.toLowerCase())
         readonly property int imageStackSpacing: 4
-        property bool activityLoading: walletRootStore.tmpActivityController0.status.loadingData
+        readonly property bool activityLoading: walletRootStore.tmpActivityController0.status.loadingData
 
         property Component balanceTag: Component {
             CollectibleBalanceTag {
@@ -366,8 +366,8 @@ Item {
             enabled: interactive
             onImageClicked: (image, plain) => Global.openImagePopup(image, "", plain)
             onVideoClicked: (url) => Global.openVideoPopup(url)
-            onOpenImageContextMenu: (url, isGif) => imageContextMenu.createObject(this, { imageSource: url, isGif: isGif, isVideo: false }).popup()
-            onOpenVideoContextMenu: (url) => imageContextMenu.createObject(this, { imageSource: url, url: url, isVideo: true, isGif: false }).popup()
+            onOpenImageContextMenu: (url, isGif, x, y) => imageContextMenu.createObject(this, { imageSource: url, isGif: isGif, isVideo: false }).popup(x, y)
+            onOpenVideoContextMenu: (url, x, y) => imageContextMenu.createObject(this, { imageSource: url, url: url, isVideo: true, isGif: false }).popup(x, y)
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
@@ -12,7 +12,7 @@ import AppLayouts.Wallet.controls
 
 import utils
 
-Control {
+AbstractButton {
     id: root
 
     objectName: "collectibleViewControl"
@@ -46,8 +46,7 @@ Control {
         readonly property bool unknownCommunityName: root.communityName.startsWith("0x") && root.communityId === root.communityName
     }
 
-    signal clicked
-    signal rightClicked
+    signal contextMenuRequested(real x, real y)
     signal switchToCommunityRequested(string communityId)
 
     background: Rectangle {
@@ -56,15 +55,15 @@ Control {
         visible: !root.isLoading && root.hovered
     }
 
-    TapHandler {
-        acceptedButtons: Qt.LeftButton
-        enabled: !root.isLoading
-        onTapped: root.clicked()
+    ContextMenu.onRequested: function(pos) {
+        if (root.isLoading)
+            return
+        root.contextMenuRequested(pos.x, pos.y)
     }
-    TapHandler {
-        acceptedButtons: Qt.RightButton
-        enabled: !root.isLoading
-        onTapped: root.rightClicked()
+    onPressAndHold: {
+        if (root.isLoading)
+            return
+        root.contextMenuRequested(pressX, pressY)
     }
 
     HoverHandler {

--- a/ui/imports/shared/controls/delegates/InfoCard.qml
+++ b/ui/imports/shared/controls/delegates/InfoCard.qml
@@ -12,7 +12,7 @@ import AppLayouts.Wallet.controls
 
 import utils
 
-Control {
+AbstractButton {
     id: root
 
     padding: 12
@@ -23,7 +23,8 @@ Control {
     property string tagIcon: ""
     property bool loading: false
     property alias rightSideButtons: rightSideButtonsLoader.sourceComponent
-    signal clicked(var mouse)
+
+    signal contextMenuRequested(real x, real y)
     signal communityTagClicked(var mouse)
 
     property StatusAssetSettings asset: StatusAssetSettings {
@@ -32,13 +33,16 @@ Control {
         bgRadius: bgWidth / 2
     }
 
+    ContextMenu.onRequested: pos => root.contextMenuRequested(pos.x, pos.y)
+    onPressAndHold: root.contextMenuRequested(pressX, pressY)
+
     background: Rectangle {
         anchors.fill: parent
         color: Theme.palette.background
         radius: Theme.radius
         border.width: 1
         border.color: Theme.palette.baseColor2
-        layer.enabled: sensor.hovered || root.highlight
+        layer.enabled: root.hovered || root.highlight
         layer.effect: DropShadow {
             horizontalOffset: 0
             verticalOffset: 2
@@ -49,17 +53,7 @@ Control {
         }
     }
 
-    HoverHandler {
-        id: sensor
-    }
-
     contentItem: Item {
-        StatusMouseArea {
-            anchors.fill: parent
-            acceptedButtons: Qt.LeftButton|Qt.RightButton
-            hoverEnabled: true
-            onClicked: mouse => root.clicked(mouse)
-        }
         ColumnLayout {
             id: titleColumn
             anchors.fill: parent

--- a/ui/imports/shared/popups/ImageContextMenu.qml
+++ b/ui/imports/shared/popups/ImageContextMenu.qml
@@ -7,7 +7,7 @@ import utils
 StatusMenu {
     id: root
 
-    property string url
+    property url url
     property string imageSource
     property string domain
     property bool isGif: root.imageSource.toLowerCase().endsWith(".gif")
@@ -15,7 +15,7 @@ StatusMenu {
 
     QtObject {
         id: d
-        readonly property bool isUnfurled: (!!url&&url!=="")
+        readonly property bool isUnfurled: (!!root.url && root.url.toString() !== "")
     }
 
     StatusAction {
@@ -32,7 +32,7 @@ StatusMenu {
         icon.name: "download"
         enabled: !!root.imageSource
         onTriggered: {
-            Global.openDownloadImageDialog(root.imageSource);
+            Global.openDownloadImageDialog(root.imageSource)
         }
     }
 
@@ -40,13 +40,13 @@ StatusMenu {
         text: qsTr("Copy link")
         icon.name: "copy"
         enabled: d.isUnfurled
-        onTriggered: ClipboardUtils.setText(url)
+        onTriggered: ClipboardUtils.setText(root.url.toString())
     }
 
     StatusAction {
         text: qsTr("Open link")
         icon.name: "browser"
         enabled: d.isUnfurled
-        onTriggered: Global.requestOpenLink(root.url)
+        onTriggered: Global.requestOpenLink(root.url.toString())
     }
 }

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -120,12 +120,12 @@ Control {
             },
             FastExpressionRole {
                 name: "marketBalance"
-                expression: balance * marketPrice
+                expression: model.balance * model.marketPrice
                 expectedRoles: ["balance", "marketPrice"]
             },
             FastExpressionRole {
                 name: "change1DayFiat"
-                expression: marketBalance * (1 - (1 / (marketChangePct24hour / 100 + 1)))
+                expression: model.marketBalance * (1 - (1 / (model.marketChangePct24hour / 100 + 1)))
                 expectedRoles: ["marketBalance", "marketChangePct24hour"]
             }
         ]

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -525,10 +525,8 @@ Pane {
                     networksStore: root.networksStore
 
                     onCloseRequested: root.closeRequested()
-                    onCopyToClipboard: ClipboardUtils.setText(text)
-                    onSendToAccountRequested: {
-                        Global.sendToRecipientRequested(recipientAddress)
-                    }
+                    onCopyToClipboard: text => ClipboardUtils.setText(text)
+                    onSendToAccountRequested: recipientAddress => Global.sendToRecipientRequested(recipientAddress)
                 }
             }
         }

--- a/ui/imports/shared/views/profile/ProfileShowcaseAccountsView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseAccountsView.qml
@@ -60,6 +60,15 @@ Item {
             asset.letterSize: 14
             asset.bgColor: Theme.palette.primaryColor3
             asset.isImage: asset.emoji
+
+            function createMenu() {
+                return delegatesActionsMenu.createObject(accountInfoDelegate, {
+                                                             accountAddress: model.address,
+                                                             accountName: model.name,
+                                                             accountColorId: model.colorId
+                                                         })
+            }
+
             rightSideButtons: RowLayout {
                 StatusFlatRoundButton {
                     Layout.preferredWidth: 32
@@ -70,7 +79,6 @@ Item {
                     icon.color: !hovered ? Theme.palette.baseColor1 : Theme.palette.directColor1
                     enabled: root.sendToAccountEnabled
                     onClicked: root.sendToAccountRequested(model.address)
-                    onHoveredChanged: accountInfoDelegate.highlight = hovered
                 }
                 StatusFlatRoundButton {
                     id: moreButton
@@ -79,29 +87,11 @@ Item {
                     visible: accountInfoDelegate.hovered
                     type: StatusFlatRoundButton.Type.Secondary
                     icon.name: "more"
-                    icon.color: (hovered || d.menuOpened) ? Theme.palette.directColor1 : Theme.palette.baseColor1
-                    highlighted: d.menuOpened
-                    onClicked: mouse => {
-                        Global.openMenu(delegatesActionsMenu, accountInfoDelegate, { 
-                            x: moreButton.x, 
-                            y : moreButton.y, 
-                            accountAddress: model.address,
-                            accountName: model.name,
-                            accountColorId: model.colorId
-                        });
-                    }
-                    onHoveredChanged: accountInfoDelegate.highlight = hovered
+                    icon.color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+                    onClicked: accountInfoDelegate.createMenu().popup()
                 }
             }
-            onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                    Global.openMenu(delegatesActionsMenu, this, {
-                        accountAddress: model.address,
-                        accountName: model.name,
-                        accountColorId: model.colorId
-                    });
-                }
-            }
+            onContextMenuRequested: (x, y) => accountInfoDelegate.createMenu().popup(x, y)
         }
     }
 
@@ -113,8 +103,7 @@ Item {
             property string accountName: ""
             property string accountColorId: ""
 
-            onOpened: { d.menuOpened = true; }
-            onClosed: { d.menuOpened = false; }
+            onClosed: destroy()
 
             StatusSuccessAction {
                 id: copyAddressAction
@@ -158,10 +147,5 @@ Item {
                 }
             }
         }
-    }
-
-    QtObject {
-        id: d
-        property bool menuOpened: false
     }
 }

--- a/ui/imports/shared/views/profile/ProfileShowcaseAssetsView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseAssetsView.qml
@@ -89,12 +89,11 @@ Item {
                 root.closeRequested();
             }
             onClicked: {
-                if ((mouse.button === Qt.LeftButton) && (model.communityId !== "")) {
+                if (model.communityId !== "") {
                     root.visitCommunity(model)
-                } else if (mouse.button === Qt.RightButton) {
-                    Global.openMenu(delegatesActionsMenu, this, { accountAddress: model.address, communityId: model.communityId });
                 }
             }
+            onContextMenuRequested: (x, y) => delegatesActionsMenu.createObject(assetsInfoDelegate, { accountAddress: model.address, communityId: model.communityId }).popup(x, y)
         }
     }
 
@@ -105,6 +104,8 @@ Item {
 
             property string communityId
             property string accountAddress: ""
+
+            onClosed: destroy()
 
             StatusAction {
                 text: qsTr("Visit community")

--- a/ui/imports/shared/views/profile/ProfileShowcaseCollectiblesView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseCollectiblesView.qml
@@ -68,6 +68,10 @@ Item {
                 Global.requestOpenLink(link)
             }
 
+            function openContextMenu(x, y) {
+                delegatesActionsMenu.createObject(delegateItem, {communityId: model.communityId, url: getCollectibleURL()}).popup(x, y)
+            }
+
             width: GridView.view.cellWidth - Theme.padding
             height: GridView.view.cellHeight - Theme.padding
 
@@ -75,6 +79,20 @@ Item {
                 id: hoverHandler
                 cursorShape: hovered ? Qt.PointingHandCursor : undefined
             }
+
+            TapHandler {
+                acceptedButtons: Qt.LeftButton
+                onSingleTapped: function (eventPoint, button) {
+                    if (!!model.communityId)
+                        root.visitCommunity(model)
+                    else
+                        delegateItem.openCollectibleURL()
+                }
+                onLongPressed: delegateItem.openContextMenu(point.pressPosition.x, point.pressPosition.y)
+            }
+
+            ContextMenu.onRequested: pos => delegateItem.openContextMenu(pos.x, pos.y)
+
             StatusRoundedImage {
                 id: collectibleImage
                 anchors.fill: parent
@@ -84,21 +102,6 @@ Item {
                 isLoading: image.isLoading || !model.imageUrl
                 image.fillMode: Image.PreserveAspectCrop
                 image.source: model.imageUrl ?? ""
-                TapHandler {
-                    acceptedButtons: Qt.LeftButton | Qt.RightButton
-                    onSingleTapped: function (eventPoint, button) {
-                        if ((button === Qt.LeftButton) && (model.communityId !== "")) {
-                            root.visitCommunity(model)
-                        } else {
-                            if (button === Qt.LeftButton) {
-                                delegateItem.openCollectibleURL()
-                            } else {
-                                Global.openMenu(delegatesActionsMenu, collectibleImage, { communityId: model.communityId, url: getCollectibleURL()});
-                            }
-                        }
-                    }
-                    onLongPressed: Global.openMenu(delegatesActionsMenu, collectibleImage, { communityId: model.communityId, url: getCollectibleURL()});
-                }
             }
 
             Image {
@@ -190,6 +193,8 @@ Item {
 
             property string url
             property string communityId
+
+            onClosed: destroy()
 
             StatusAction {
                 text: qsTr("Visit community")

--- a/ui/imports/shared/views/profile/ProfileShowcaseCommunitiesView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseCommunitiesView.qml
@@ -139,10 +139,10 @@ Item {
                 Global.switchToCommunity(model.id)
                 root.closeRequested()
             }
-            onRightClicked: {
+            onRightClicked: function (communityId, x, y) {
                 if (root.readOnly)
                     return
-                Global.openMenu(delegatesActionsMenu, this, { communityId: model.id, url: Utils.getCommunityShareLink(model.id) })
+                delegatesActionsMenu.createObject(profileDialogCommunityCard, { communityId: model.id, url: Utils.getCommunityShareLink(model.id) }).popup(x, y)
             }
         }
     }

--- a/ui/imports/shared/views/profile/ProfileShowcaseSocialLinksView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseSocialLinksView.qml
@@ -57,12 +57,7 @@ Item {
             asset.bgHeight: 32
             asset.isImage: false
             subTitle: model.url
-            onClicked: mouse => {
-                if (mouse.button === Qt.RightButton) {
-                    Global.openMenu(delegatesActionsMenu, this, { url: model.url });
-                }
-            }
-            highlight: hovered
+            onContextMenuRequested: (x, y) => delegatesActionsMenu.createObject(socialLinksInfoDelegate, { url: model.url }).popup(x,y)
             rightSideButtons: RowLayout {
                 StatusFlatRoundButton {
                     implicitWidth: 24
@@ -120,8 +115,9 @@ Item {
 
             property string url
 
+            onClosed: destroy()
+
             StatusSuccessAction {
-                id: copyAddressAction
                 successText: qsTr("Copied")
                 text: qsTr("Copy link")
                 icon.name: "copy"

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -142,7 +142,7 @@ Control {
             communitiesProxyModel: communitiesProxyModel
 
             onCloseRequested: root.closeRequested()
-            onCopyToClipboard: root.copyToClipboard(text)
+            onCopyToClipboard: text => root.copyToClipboard(text)
         }
 
         ProfileShowcaseAccountsView {
@@ -157,8 +157,8 @@ Control {
             cellWidth: d.delegateWidthM
             cellHeight: d.delegateHeightM
 
-            onCopyToClipboard: root.copyToClipboard(text)
-            onSendToAccountRequested: root.sendToAccountRequested(recipientAddress)
+            onCopyToClipboard: text => root.copyToClipboard(text)
+            onSendToAccountRequested: recipientAddress => root.sendToAccountRequested(recipientAddress)
         }
 
         ProfileShowcaseCollectiblesView {
@@ -174,11 +174,9 @@ Control {
             networksStore: root.networksStore
 
             onCloseRequested: root.closeRequested()
-            onVisitCommunity: {
-                Global.openPopup(visitComunityPopupComponent, {communityId: model.communityId, communityName: model.communityName,
-                                                communityLogo: model.communityImage, tokenName: model.name,
-                                                tokenImage: model.imageUrl, isAssetType: false });
-            }
+            onVisitCommunity: model => visitComunityPopupComponent.createObject(this, {communityId: model.communityId, communityName: model.communityName,
+                                                                                    communityLogo: model.communityImage, tokenName: model.name,
+                                                                                    tokenImage: model.imageUrl, isAssetType: false}).open()
         }
 
         ProfileShowcaseSocialLinksView {
@@ -191,7 +189,7 @@ Control {
             mainDisplayName: d.displayNameVerySmallEmoji
             socialLinksModel: socialLinksProxyModel
 
-            onCopyToClipboard: root.copyToClipboard(text)
+            onCopyToClipboard: text => root.copyToClipboard(text)
         }
     }
 


### PR DESCRIPTION
### What does the PR do

- fixes being unable to open the context menus on the detailed Collectible view, and then staying open forever on a different page
- fixes similar problems, or even crashes when invoking the various context menus inside the Profile Dialog's Showcase<br><br>
- streamline how the context menus are handled in the CollectiblesView and the Profile Showcase
- for mouse events: prefer using the new `ContextMenu` attached property
- for touch events: handle the relevant `pressAndHold` or `longPressed` signals
- adjust the signals to also pass the `x/y` coords, necessary to handle the touch events
- fixup and improve the relevant SB pages
- silence Qt some warnings

Fixes #19039
Fixes #19038

### Affected areas

CollectiblesView, ProfileDialog(Showcase)

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2944" height="1800" alt="image" src="https://github.com/user-attachments/assets/7694eb4e-9058-4624-901b-59168549361b" />

<img width="2884" height="2320" alt="image" src="https://github.com/user-attachments/assets/8aaf3a73-a4f2-4551-a94d-adacebc8afa9" />

### Impact on end user

Context menus working in Collectibles and Profile Showcase views

### How to test

Check the context menus when:
- right clicking an item
- long press (touch) an item

### Risk 

low
