### PR TITLE
feat(@desktop/browser): Fix empty Download bar and issues with states on it

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -126,9 +126,9 @@ StatusSectionLayout {
         }
 
         function onDownloadRequested(download) {
-            downloadBar.isVisible = true
             download.accept();
             root.downloadsStore.addDownload(download)
+            downloadBar.active = true
         }
 
         function determineRealURL(url) {
@@ -277,19 +277,31 @@ StatusSectionLayout {
                                      ogName: favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.name : _internal.currentWebView.title})
             }
         }
-        DownloadBar {
+
+        Loader {
             id: downloadBar
+            active: false
+            width: parent.width
             anchors.bottom: parent.bottom
             z: 60
-            downloadsModel: root.downloadsStore.downloadModel
-            downloadsMenu: downloadMenu
-            onOpenDownloadClicked: function (downloadComplete, index) {
-                if (downloadComplete) {
-                    return root.downloadsStore.openFile(index)
+            sourceComponent: DownloadBar {
+                downloadsModel: root.downloadsStore.downloadModel
+                downloadsMenu: downloadMenu
+                onOpenDownloadClicked: function (downloadComplete, index) {
+                    if (downloadComplete) {
+                        return root.downloadsStore.openFile(index)
+                    }
+                    root.downloadsStore.openDirectory(index)
                 }
-                root.downloadsStore.openDirectory(index)
+                onAddNewDownloadTab: _internal.addNewDownloadTab()
+                onClose: downloadBar.active = false
+                Connections {
+                    target: root.downloadsStore
+                    function onAllItemsOpened() {
+                        downloadBar.active = false
+                    }
+                }
             }
-            onAddNewDownloadTab: _internal.addNewDownloadTab()
         }
 
         FindBar {

--- a/ui/app/AppLayouts/Browser/controls/qmldir
+++ b/ui/app/AppLayouts/Browser/controls/qmldir
@@ -1,0 +1,1 @@
+DownloadElement 1.0 DownloadElement.qml

--- a/ui/app/AppLayouts/Browser/panels/DownloadView.qml
+++ b/ui/app/AppLayouts/Browser/panels/DownloadView.qml
@@ -1,11 +1,12 @@
 import QtQuick
+import QtWebEngine
 
 import StatusQ.Core
 import StatusQ.Core.Theme
 
 import utils
 
-import "../controls"
+import AppLayouts.Browser.controls
 
 Rectangle {
     id: downloadView
@@ -37,6 +38,7 @@ Rectangle {
 
             width: parent.width
             isPaused: downloadItem?.isPaused ?? false
+            isCanceled: downloadItem?.state === WebEngineDownloadRequest.DownloadCancelled ?? false
             primaryText: downloadItem?.downloadFileName ?? ""
             downloadText: {
                 if (isCanceled) {
@@ -48,26 +50,16 @@ Rectangle {
                 return "%1/%2".arg(Qt.locale().formattedDataSize(downloadItem?.receivedBytes ?? 0, 2, Locale.DataSizeTraditionalFormat)) //e.g. 14.4/109 MB
                               .arg(Qt.locale().formattedDataSize(downloadItem?.totalBytes ?? 0, 2, Locale.DataSizeTraditionalFormat))
             }
-            downloadComplete: {
-                // listView.count ensures a value is returned even when index is undefined
-                return listView.count > 0 && !!downloadsModel.downloads && !!downloadItem && downloadItem.receivedBytes >= downloadItem.totalBytes
-            }
+            downloadComplete: downloadItem?.state === WebEngineDownloadRequest.DownloadCompleted ?? false
             onItemClicked: {
                 openDownloadClicked(downloadComplete, index)
             }
             onOptionsButtonClicked: function(xVal) {
                 downloadsMenu.index = index
-                downloadsMenu.downloadComplete = Qt.binding(function() { return downloadElement.downloadComplete })
                 downloadsMenu.parent = downloadElement
                 downloadsMenu.x = xVal
                 downloadsMenu.y = downloadView.y - downloadsMenu.height
                 downloadsMenu.open()
-            }
-            Connections {
-                target: downloadsMenu
-                function onCancelClicked() {
-                    isCanceled = true
-                }
             }
         }
     }

--- a/ui/app/AppLayouts/Browser/popups/DownloadMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/DownloadMenu.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtWebEngine
 
 import StatusQ.Popups
 
@@ -11,8 +12,10 @@ StatusMenu {
     required property BrowserStores.DownloadsStore downloadsStore
 
     property int index: -1
-    property bool downloadComplete: false
     property var download: root.downloadsStore.getDownload(index)
+
+    readonly property bool downloadCancelled: download?.state === WebEngineDownloadRequest.DownloadCancelled ?? false
+    readonly property bool downloadComplete: download?.state === WebEngineDownloadRequest.DownloadCompleted ?? false
 
     signal cancelClicked()
 
@@ -28,7 +31,7 @@ StatusMenu {
         onTriggered: root.downloadsStore.openDirectory(index)
     }
     StatusAction {
-        enabled: !downloadComplete && !!download && !download.isPaused
+        enabled: !downloadComplete && !!download && !download.isPaused && !downloadCancelled
         icon.name: "pause"
         text: qsTr("Pause")
         onTriggered: {
@@ -36,7 +39,7 @@ StatusMenu {
         }
     }
     StatusAction {
-        enabled: !downloadComplete && !!download && download.isPaused
+        enabled: !downloadComplete && !!download && download.isPaused && !downloadCancelled
         icon.name: "play"
         text: qsTr("Resume")
         onTriggered: {
@@ -44,10 +47,10 @@ StatusMenu {
         }
     }
     StatusMenuSeparator {
-        visible: !downloadComplete
+        visible: !downloadComplete && !downloadCancelled
     }
     StatusAction {
-        enabled: !downloadComplete
+        enabled: !downloadComplete && !downloadCancelled
         type: StatusAction.Type.Danger
         icon.name: "block-icon"
         icon.width: 13

--- a/ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
@@ -3,6 +3,8 @@ import QtQuick
 QtObject {
     id: root
 
+    signal allItemsOpened()
+
     property ListModel downloadModel : ListModel {
         property var downloads: []
     }
@@ -26,6 +28,10 @@ QtObject {
     function openFile(index) {
         Qt.openUrlExternally(`file://${downloadModel.downloads[index].downloadDirectory}/${downloadModel.downloads[index].downloadFileName}`)
         root.removeDownloadFromModel(index)
+        // if all items are opened, stop diplaying the bar
+        if(root.downloadModel.count === 0) {
+            root.allItemsOpened()
+        }
     }
     // TODO check if this works in Windows and Mac
     function openDirectory(index) {

--- a/ui/app/AppLayouts/Browser/views/BrowserWebEngineView.qml
+++ b/ui/app/AppLayouts/Browser/views/BrowserWebEngineView.qml
@@ -122,7 +122,7 @@ WebEngineView {
             id: downloadView
             downloadsModel: root.downloadsStore.downloadModel
             downloadsMenu: root.downloadsMenu
-            onOpenDownloadClicked: {
+            onOpenDownloadClicked: function(downloadComplete, index) {
                 if (downloadComplete) {
                     return root.downloadsStore.openFile(index)
                 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -7646,13 +7646,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8933,10 +8926,6 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -9339,14 +9339,6 @@
     </message>
   </context>
   <context>
-    <name>FeeRow</name>
-    <message>
-      <source>Max.</source>
-      <comment>FeeRow</comment>
-      <translation>Max.</translation>
-    </message>
-  </context>
-  <context>
     <name>FeesBox</name>
     <message>
       <source>Fees</source>
@@ -10895,11 +10887,6 @@
       <source>PIN correct</source>
       <comment>KeycardEnterPinPage</comment>
       <translation>PIN correct</translation>
-    </message>
-    <message>
-      <source>Keycard blocked</source>
-      <comment>KeycardEnterPinPage</comment>
-      <translation>Keycard blocked</translation>
     </message>
     <message numerus="yes">
       <source>%n attempt(s) remaining</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -7673,13 +7673,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8969,10 +8962,6 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7619,13 +7619,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8899,10 +8892,6 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN이 올바릅니다</translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
-        <translation type="unfinished">Keycard가 차단됨</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>


### PR DESCRIPTION
fixes #19264

### What does the PR do

Fixes empty download bar
Fixes cancelled state as it was not correctly displayed before

### Affected areas

Browser Downloads bar + Downloads Page

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/4f99247d-e0bb-46ec-b518-b3c6f1543002


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
