### PR TITLE
feat(@desktop/browser): New tab should be closed once download has started

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -129,6 +129,23 @@ StatusSectionLayout {
             download.accept();
             root.downloadsStore.addDownload(download)
             downloadBar.active = true
+
+            // close the tab launched only for starting download
+            var downloadView = download.view
+            if (!downloadView)
+                return
+
+            // find tab for this view
+            for (var i = 0; i < tabs.count; ++i) {
+                var tab = tabs.getTab(i)
+                // close the “download-only” tab
+                if (tab === downloadView &&
+                        !tab.htmlPageLoaded &&
+                        tab.title === "") {
+                    tabs.removeView(i)
+                    break
+                }
+            }
         }
 
         function determineRealURL(url) {

--- a/ui/app/AppLayouts/Browser/views/BrowserWebEngineView.qml
+++ b/ui/app/AppLayouts/Browser/views/BrowserWebEngineView.qml
@@ -26,6 +26,7 @@ WebEngineView {
     property var determineRealURLFn: function(url){}
     property bool isDownloadView
     property bool enableJsLogs: false
+    property bool htmlPageLoaded: false
 
     signal setCurrentWebUrl(url url)
 
@@ -94,8 +95,20 @@ WebEngineView {
     }
 
     onLoadingChanged: function(loadRequest) {
-        if (loadRequest.status === WebEngineView.LoadStartedStatus)
+        if (loadRequest.status === WebEngineView.LoadStartedStatus) {
+            root.htmlPageLoaded = false
             findBarComp.reset();
+        }
+        if (loadRequest.status === WebEngineView.LoadSucceededStatus) {
+            root.htmlPageLoaded = true
+        }
+    }
+
+    onLoadProgressChanged: function(progress) {
+        if (progress >= 10) {
+            // Some real content rendered
+            htmlPageLoaded = true
+        }
     }
 
     onNavigationRequested: function (request) {


### PR DESCRIPTION
closes #19274

### What does the PR do

Closes a download only tab after download has started

### Affected areas

Download behaviour

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/2cb19e87-e320-4016-98c4-6a09317193b5



### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
