### PR TITLE
feat(@desktop/browser): Added new tabbar colors when in incognito mode

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -187,5 +187,6 @@ ThemePalette {
         property color camel: "#9F7252"
         property color magenta: "#BD1E56"
         property color yinYang: "#FFFFFF"
+        property color purple2: "#7140FD"
     }
 }

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -187,5 +187,6 @@ ThemePalette {
         property color camel: "#C78F67"
         property color magenta: "#EC266C"
         property color yinYang: "#09101C"
+        property color purple2: "#5A33CA"
     }
 }

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -197,6 +197,7 @@ QtObject {
         property color camel
         property color magenta
         property color yinYang
+        property color purple2
     }
 
     readonly property var customisationColorsArray: [
@@ -227,6 +228,7 @@ QtObject {
 
     property QtObject privacyModeColors: QtObject {
         readonly property color navBarColor: customisationColors.purple
+        readonly property color navBarSecondaryColor: customisationColors.purple2
         readonly property color navButtonColor: getColor('white', 0.4)
         readonly property color navButtonHighlightedColor: getColor('white')
     }

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtWebEngine
 
+import QtModelsToolkit
+
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Layout
@@ -185,6 +187,9 @@ StatusSectionLayout {
             anchors.topMargin: tabs.tabHeight + tabs.anchors.topMargin
             z: 52
             favoriteComponent: favoritesBar
+            favoritesVisible: localAccountSensitiveSettings.shouldShowFavoritesBar &&
+                              root.bookmarksStore.bookmarksModel.ModelCount.count > 0
+            currentTabIncognito: _internal.currentWebView?.profile.offTheRecord ?? false
             currentFavorite: _internal.currentWebView ? root.bookmarksStore.getCurrentFavorite(_internal.currentWebView.url) : null
             dappBrowserAccName: root.browserWalletStore.dappBrowserAccount.name
             dappBrowserAccIcon: Utils.getColorForId(root.browserWalletStore.dappBrowserAccount.colorId)

--- a/ui/app/AppLayouts/Browser/panels/BrowserHeader.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserHeader.qml
@@ -29,6 +29,8 @@ Rectangle {
     property string dappBrowserAccName: ""
     property string dappBrowserAccIcon: ""
     property var settingMenu
+    property bool favoritesVisible: false
+    property bool currentTabIncognito: false
 
     property var browserDappsModel: null
     property int browserDappsCount: 0
@@ -52,7 +54,7 @@ Rectangle {
 
     width: parent.width
     height: barRow.height + (favoritesBarLoader.active ? favoritesBarLoader.height : 0)
-    color: Theme.palette.background
+    color: root.currentTabIncognito ? Theme.palette.privacyModeColors.navBarSecondaryColor: Theme.palette.background
 
     RowLayout {
         id: barRow
@@ -237,7 +239,7 @@ Rectangle {
 
     Loader {
         id: favoritesBarLoader
-        active: localAccountSensitiveSettings.shouldShowFavoritesBar
+        active: root.favoritesVisible
         anchors.top: barRow.bottom
         anchors.left: parent.left
         anchors.leftMargin: Theme.smallPadding

--- a/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
@@ -171,6 +171,7 @@ FocusScope {
             property string tabTitle
 
             readonly property int minWidth: hovered || checked ? d.minTabButtonWidth : d.minTabButtonInactiveWidth
+            readonly property bool incognito: root.getTab(tabButton.TabBar.index)?.profile.offTheRecord ?? false
 
             width: Math.min(Math.max(implicitWidth, minWidth), d.maxTabButtonWidth)
             anchors.top: parent ? parent.top : undefined
@@ -180,7 +181,17 @@ FocusScope {
             verticalPadding: 0
 
             background: Rectangle {
-                color: tabButton.checked ? Theme.palette.background : Theme.palette.baseColor2
+                color: {
+                    if (tabButton.checked) {
+                        if(tabButton.incognito)
+                            return Theme.palette.privacyModeColors.navBarSecondaryColor
+                        return Theme.palette.background
+                    } else  {
+                        if(tabButton.incognito)
+                            return Theme.palette.privacyModeColors.navBarColor
+                        return Theme.palette.baseColor2
+                    }
+                }
             }
 
             contentItem: RowLayout {
@@ -211,14 +222,6 @@ FocusScope {
                     text: tabButton.tabTitle
                 }
 
-                StatusIcon {
-                    Layout.preferredWidth: d.iconSize
-                    Layout.preferredHeight: d.iconSize
-                    Layout.rightMargin: 2
-                    Layout.alignment: Qt.AlignTrailing
-                    icon: "hide"
-                    visible: root.getTab(tabButton.TabBar.index) ? root.getTab(tabButton.TabBar.index).profile.offTheRecord : false
-                }
                 StatusFlatButton {
                     Layout.alignment: Qt.AlignTrailing
                     icon.name: "close"

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2662,6 +2662,10 @@ Do you wish to override the security check and continue?</source>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BrowserTabView</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3260,6 +3260,11 @@
       <comment>BrowserSettingsMenu</comment>
       <translation>Settings</translation>
     </message>
+    <message>
+      <source>Zoom</source>
+      <comment>BrowserSettingsMenu</comment>
+      <translation>Zoom</translation>
+    </message>
   </context>
   <context>
     <name>BrowserTabView</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2669,6 +2669,10 @@ Do you wish to override the security check and continue?</source>
         <source>Settings</source>
         <translation type="unfinished">Nastavení</translation>
     </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BrowserTabView</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2655,6 +2655,10 @@ Do you wish to override the security check and continue?</source>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BrowserTabView</name>


### PR DESCRIPTION
closes #19256

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality
<img width="2056" height="1329" alt="Screenshot 2025-11-14 at 20 58 04" src="https://github.com/user-attachments/assets/6b575409-f7ac-454a-b418-39e07a27587d" />
<img width="2056" height="1329" alt="Screenshot 2025-11-14 at 20 57 51" src="https://github.com/user-attachments/assets/a8014209-9cc5-4276-bf06-43a256f366ae" />

<img width="2056" height="1329" alt="image" src="https://github.com/user-attachments/assets/a76a317e-84a6-44ef-973f-91ec4d66ad5c" />


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
