### PR TITLE
fix(browser): fix opening downloads folder

### DIFF
--- a/ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/DownloadsStore.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import StatusQ
 
 QtObject {
     id: root
@@ -26,15 +27,17 @@ QtObject {
     }
 
     function openFile(index) {
-        Qt.openUrlExternally(`file://${downloadModel.downloads[index].downloadDirectory}/${downloadModel.downloads[index].downloadFileName}`)
+        const filePath = `${downloadModel.downloads[index].downloadDirectory}/${downloadModel.downloads[index].downloadFileName}`
+        Qt.openUrlExternally(UrlUtils.urlFromUserInput(filePath))
         root.removeDownloadFromModel(index)
         // if all items are opened, stop diplaying the bar
         if(root.downloadModel.count === 0) {
             root.allItemsOpened()
         }
     }
-    // TODO check if this works in Windows and Mac
+
     function openDirectory(index) {
-        Qt.openUrlExternally("file://" + downloadModel.downloads[index].downloadDirectory)
+        const dirPath = downloadModel.downloads[index].downloadDirectory
+        Qt.openUrlExternally(UrlUtils.urlFromUserInput(dirPath))
     }
 }


### PR DESCRIPTION
Fixes #19248

Fixed "Open" and "Show in folder" features not working for browser downloads on Windows.
`Qt.openUrlExternally()` expects a URL. It works good with `UrlUtils.urlFromUserInput()` on all platfroms
Previous implementation used manual string concatenation which didn't work on Windows.