### PR TITLE
fix(StatusRoundedMedia): make the Loader sync

### DIFF
--- a/storybook/qmlTests/tests/tst_SendSignModal.qml
+++ b/storybook/qmlTests/tests/tst_SendSignModal.qml
@@ -210,9 +210,8 @@ Item {
             verify(!contextMenu.opened)
 
             contractInfoButtonWithMenu.clicked(0)
-            verify(contextMenu.opened)
-
-            compare(contextMenu.contentModel.count, 2)
+            tryCompare(contextMenu, "opened", true)
+            tryCompare(contextMenu, "count", 2)
 
             const externalLink = findChild(contextMenu, "externalLink")
             verify(!!externalLink)
@@ -320,7 +319,8 @@ Item {
 
             const loadingComponent = findChild(collectibleMedia, "loadingComponent")
             verify(!!loadingComponent)
-            verify(loadingComponent.visible)
+            if ((!!collectibleMedia.mediaUrl || !!collectibleMedia.fallbackImageUrl) && (collectibleMedia.isLoading || collectibleMedia.isCollectibleLoading))
+                verify(loadingComponent.visible)
 
             const accountSmartIdenticon = findChild(controlUnderTest.contentItem, "accountSmartIdenticon")
             verify(!!accountSmartIdenticon)
@@ -430,10 +430,9 @@ Item {
             verify(!!contextMenu)
             verify(!contextMenu.opened)
 
-            recipientInfoButtonWithMenu.clicked(0)
-            verify(contextMenu.opened)
-
-            compare(contextMenu.contentModel.count, 2)
+            recipientInfoButtonWithMenu.clicked()
+            tryCompare(contextMenu, "opened", true)
+            tryCompare(contextMenu, "count", 2)
 
             const externalLink = findChild(contextMenu, "externalLink")
             verify(!!externalLink)
@@ -445,7 +444,7 @@ Item {
                     "%1/%2/%3".arg(controlUnderTest.networkBlockExplorerUrl).arg(Constants.networkExplorerLinks.addressPath).arg(controlUnderTest.recipientAddress))
             verify(!contextMenu.opened)
 
-            recipientInfoButtonWithMenu.clicked(0)
+            recipientInfoButtonWithMenu.clicked()
             verify(contextMenu.opened)
 
             const copyButton = findChild(contextMenu, "copyButton")

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedMedia.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedMedia.qml
@@ -206,7 +206,6 @@ StatusRoundedComponent {
         // In case manualMaxDimension is not defined then use parent width and height instead
         width: root.manualMaxDimension === 0 ? parent.width : root.manualMaxDimension
         height: root.manualMaxDimension === 0 ? parent.height : root.manualMaxDimension
-        asynchronous: true
         visible: !root.isError && !root.isLoading
     }
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
@@ -12,7 +12,6 @@ import AppLayouts.Wallet
 import AppLayouts.Wallet.panels
 import AppLayouts.Wallet.views
 import AppLayouts.Wallet.popups
-import AppLayouts.Wallet
 
 import utils
 


### PR DESCRIPTION
### What does the PR do

Unbreaks the Wallet/Collectibles view

- making it `asynchronous` wreaks havoc now that we can fully utilize it; moreover, it makes little sense as `(Animated)Image` will set its own `asynchronous` property to `true` when loading from remote URLs anyway
- fix the tests
- remove dupe import

Fixes #19291

### Affected areas

Wallet/Collectibles

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Impact on end user

Wallet/Collectibles usable again

### Risk 

low
