### PR TITLE
Fix/disable swap on ios

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -19,7 +19,7 @@ else
 fi
 
 if [[ "$OS" == "ios" ]]; then
-    PLATFORM_SPECIFIC=(--app:staticlib -d:ios --os:ios)
+    PLATFORM_SPECIFIC=(--app:staticlib -d:ios --os:ios -d:swap_disabled)
 else
     PLATFORM_SPECIFIC=(--app:lib --os:android -d:android -d:androidNDK -d:chronicles_sinks=textlines[logcat],textlines[nocolors,dynamic],textlines[file,nocolors] \
         --passL="-L$LIB_DIR" --passL="-lstatus" --passL="-lStatusQ$LIB_SUFFIX" --passL="-lDOtherSide$LIB_SUFFIX" --passL="-lqrcodegen" --passL="-lqzxing" --passL="-lssl_3" --passL="-lcrypto_3" -d:taskpool)

--- a/src/app/global/feature_flags.nim
+++ b/src/app/global/feature_flags.nim
@@ -16,7 +16,7 @@ macro featureFlag(name: string, defaultValue: bool, buildFlag: static bool = fal
     return quote do:
       let `flagName`* = getEnv("FLAG_" & `name`.toUpper, boolToEnv(`defaultValue`)) != "0"
 
-const DEFAULT_FLAG_SWAP_ENABLED  = true
+const DEFAULT_FLAG_SWAP_ENABLED  = when defined(swap_disabled): false else: true
 const DEFAULT_FLAG_SEND_VIA_PERSONAL_CHAT_ENABLED  = true
 const DEFAULT_FLAG_PAYMENT_REQUEST_ENABLED = true
 const DEFAULT_FLAG_SIMPLE_SEND_ENABLED = true

--- a/ui/app/AppLayouts/Market/MarketLayout.qml
+++ b/ui/app/AppLayouts/Market/MarketLayout.qml
@@ -28,6 +28,8 @@ StatusSectionLayout {
     required property var fnFormatCurrencyAmount
     /** required property holds the current page set from the backend **/
     required property int currentPage
+    /** property to enable/disable swap button **/
+    property bool swapEnabled: true
 
     /** signal to request the launch of Swap Modal **/
     signal requestLaunchSwap()
@@ -68,6 +70,7 @@ StatusSectionLayout {
             Item { Layout.fillWidth: true }
             StatusButton {
                 objectName: "swapButton"
+                visible: root.swapEnabled
                 text: qsTr("Swap")
                 icon.name: "swap"
                 type: StatusBaseButton.Type.Primary

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2216,6 +2216,7 @@ Item {
                             tokensModel: appMain.marketStore.marketLeaderboardModel
                             totalTokensCount: appMain.marketStore.totalLeaderboardCount
                             loading: appMain.marketStore.marketLeaderboardLoading
+                            swapEnabled: featureFlagsStore.swapEnabled
                             currencySymbol: {
                                 const symbol = SQUtils.ModelUtils.getByKey(
                                                  appMain.currencyStore.currenciesModel,


### PR DESCRIPTION
### What does the PR do

Closes #19305

Disabling IOS swaps for this release.
The wallet tab was already hooked to the feature flags. The only missing piece was the market tab.

### Affected areas

IOS - swap
### Architecture compliance

### How to test

Login and try to find the Swap buttons.

### Risk 

low