### PR TITLE
fix(AppearanceView): Rename padding factor to layout spacing [Cherry-pick]

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -88,8 +88,13 @@ SettingsContentBase {
         }
 
         StatusSectionHeadline {
-            text: qsTr("Padding factor")
+            text: qsTr("Layout Spacing")
             Layout.topMargin: 2 * Theme.padding
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr("Adjust how compact or spacious the layout looks")
         }
 
         StatusQ.StatusLabeledSlider {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2141,10 +2141,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2158,6 +2154,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
     <message>
         <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2705,10 +2709,6 @@ Do you wish to override the security check and continue?</source>
     <name>BrowserWalletMenu</name>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wallet info will appear here</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1894,8 +1894,8 @@
       <source>%n key pair(s) successfully imported</source>
       <comment>AppMain</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>%n key pair successfully imported</numerusform>
+        <numerusform>%n key pairs successfully imported</numerusform>
       </translation>
     </message>
     <message>
@@ -2357,8 +2357,8 @@
       <source>%n issue(s)</source>
       <comment>AppMain</comment>
       <translation>
-        <numerusform></numerusform>
-        <numerusform></numerusform>
+        <numerusform>%n issue</numerusform>
+        <numerusform>%n issues</numerusform>
       </translation>
     </message>
     <message>
@@ -2628,11 +2628,6 @@
       <translation>Mode</translation>
     </message>
     <message>
-      <source>Padding factor</source>
-      <comment>AppearanceView</comment>
-      <translation>Padding factor</translation>
-    </message>
-    <message>
       <source>XXS</source>
       <comment>AppearanceView</comment>
       <translation>XXS</translation>
@@ -2651,6 +2646,16 @@
       <source>System</source>
       <comment>AppearanceView</comment>
       <translation>System</translation>
+    </message>
+    <message>
+      <source>Layout Spacing</source>
+      <comment>AppearanceView</comment>
+      <translation>Layout Spacing</translation>
+    </message>
+    <message>
+      <source>Adjust how compact or spacious the layout looks</source>
+      <comment>AppearanceView</comment>
+      <translation>Adjust how compact or spacious the layout looks</translation>
     </message>
   </context>
   <context>
@@ -3313,11 +3318,6 @@
       <source>Disconnect</source>
       <comment>BrowserWalletMenu</comment>
       <translation>Disconnect</translation>
-    </message>
-    <message>
-      <source>Wallet info will appear here</source>
-      <comment>BrowserWalletMenu</comment>
-      <translation>Wallet info will appear here</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2148,10 +2148,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>Režim</translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2166,6 +2162,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>System</source>
         <translation type="unfinished">Systémový</translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2712,10 +2716,6 @@ Do you wish to override the security check and continue?</source>
     <name>BrowserWalletMenu</name>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wallet info will appear here</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2138,10 +2138,6 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation>XXL</translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation>Factor de espaciado</translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation>XXS</translation>
     </message>
@@ -2160,6 +2156,14 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
     <message>
         <source>System</source>
         <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation>Factor de espaciado</translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
+        <translation>Ajusta qué tan compacto o espacioso se ve el diseño</translation>
     </message>
 </context>
 <context>
@@ -2710,10 +2714,6 @@ Do you wish to override the security check and continue?</source>
     <message>
         <source>Disconnect</source>
         <translation>Desconectar</translation>
-    </message>
-    <message>
-        <source>Wallet info will appear here</source>
-        <translation>La información de la billetera aparecerá aquí</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2146,12 +2146,16 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>시스템</translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation>여백 계수</translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation>XXS</translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7643,13 +7647,6 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
-    <name>FeeRow</name>
-    <message>
-        <source>Max.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -8930,10 +8927,6 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN이 올바릅니다</translation>
-    </message>
-    <message>
-        <source>Keycard blocked</source>
-        <translation type="unfinished">Keycard가 차단됨</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>


### PR DESCRIPTION
Closes #19315

**NOTE**: Needs to be `Cherry-picked` to [release branch](https://github.com/status-im/status-desktop/tree/release/2.36.x)

### What does the PR do

- Renames Padding Factor to Layout Spacing to better reflect its purpose.
- Adds a descriptive subtitle to clarify what this setting controls and improve overall UX clarity.

### Affected areas
Appearance View

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1105" height="830" alt="Screenshot 2025-11-20 at 12 25 11" src="https://github.com/user-attachments/assets/f485a22c-36ac-4831-848a-4cb3b99f46fe" />

### Impact on end user

Better understanding about the feature

### How to test

- Go to `Appearance View` and read new texts!

### Risk 

Low
