### PR TITLE
fix(SignTransactionModalBase): prevent footer overflow on mobile

### DIFF
--- a/storybook/pages/DAppSignRequestModalPage.qml
+++ b/storybook/pages/DAppSignRequestModalPage.qml
@@ -113,6 +113,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
                 text: "1.54"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: loginType
                 model: [{name: "Password", value: Constants.LoginType.Password}, {name: "Biometrics", value: Constants.LoginType.Biometrics}, {name: "Keycard", value: Constants.LoginType.Keycard}]
                 textRole: "name"
@@ -120,6 +121,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
                 currentIndex: 0
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: contentToSignComboBox
                 model: ["Long content to sign", "Middle content to sign", "Short content to sign", "Empty content to sign"]
                 currentIndex: 0
@@ -137,7 +139,6 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
             CheckBox {
                 id: feesLoading
                 text: "Fees loading"
-                checked: true
             }
             CheckBox {
                 id: hasFees
@@ -150,9 +151,12 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce nibh. Etiam quis
                 checked: false
             }
             TextField {
+                Layout.fillWidth: true
                 id: ctrlExpiration
                 placeholderText: "Expiration in seconds"
             }
         }
     }
 }
+
+// status: good

--- a/storybook/pages/SendSignModalPage.qml
+++ b/storybook/pages/SendSignModalPage.qml
@@ -122,6 +122,7 @@ SplitView {
             Component {
                 id: dlgComponent
                 SendSignModal {
+                    closePolicy: Popup.CloseOnEscape
                     anchors.centerIn: parent
                     destroyOnClose: true
                     modal: false
@@ -281,6 +282,7 @@ SplitView {
                 text: "Selected From Account"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlAccount
                 textRole: "name"
                 valueRole: "address"
@@ -292,6 +294,7 @@ SplitView {
                 text: "Selected Recipient"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlRecipient
                 textRole: "modelName"
                 valueRole: "address"
@@ -303,6 +306,7 @@ SplitView {
                 text: "Selected Network"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlNetwork
                 textRole: "chainName"
                 valueRole: "chainId"
@@ -319,11 +323,13 @@ SplitView {
                 text: "Login Type"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlLoginType
                 model: Constants.authenticationIconByType
             }
 
             TextField {
+                Layout.fillWidth: true
                 id: ctrlExpiration
                 placeholderText: "Expiration in seconds"
             }
@@ -332,5 +338,5 @@ SplitView {
 }
 
 // category: Popups
-
+// status: good
 // https://www.figma.com/design/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=25214-40565&m=dev

--- a/storybook/pages/SwapApproveCapModalPage.qml
+++ b/storybook/pages/SwapApproveCapModalPage.qml
@@ -103,6 +103,10 @@ SplitView {
                     loginType: ctrlLoginType.currentIndex
 
                     feesLoading: ctrlLoading.checked
+
+                    onAccepted: logs.logEvent("accepted")
+                    onRejected: logs.logEvent("rejected")
+                    onClosed: logs.logEvent("closed")
                 }
             }
         }
@@ -182,5 +186,5 @@ SplitView {
 }
 
 // category: Popups
-
+// status: good
 // https://www.figma.com/design/TS0eQX9dAZXqZtELiwKIoK/Swap---Milestone-1?node-id=3517-435657&t=sRX8mAj4irR1bOuT-0

--- a/storybook/pages/SwapSignModalPage.qml
+++ b/storybook/pages/SwapSignModalPage.qml
@@ -159,6 +159,7 @@ SplitView {
                 text: "Selected Account"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlAccount
                 textRole: "name"
                 valueRole: "address"
@@ -170,6 +171,7 @@ SplitView {
                 text: "Selected Network"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlNetwork
                 textRole: "chainName"
                 valueRole: "chainId"
@@ -186,11 +188,13 @@ SplitView {
                 text: "Login Type"
             }
             ComboBox {
+                Layout.fillWidth: true
                 id: ctrlLoginType
                 model: Constants.authenticationIconByType
             }
 
             TextField {
+                Layout.fillWidth: true
                 id: ctrlExpiration
                 placeholderText: "Expiration in seconds"
             }
@@ -199,5 +203,5 @@ SplitView {
 }
 
 // category: Popups
-
+// status: good
 // https://www.figma.com/design/TS0eQX9dAZXqZtELiwKIoK/Swap---Milestone-1?node-id=3542-497191&t=ndwmuh3ZXlycGYWa-0

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -115,7 +115,7 @@ Rectangle {
     color: bgColor
 
     property color bgColor: {
-        if (sensor.containsMouse || statusListItemTitleMouseArea.containsMouse || root.highlighted) {
+        if ((sensor.enabled && (sensor.containsMouse || statusListItemTitleMouseArea.containsMouse)) || root.highlighted) {
             switch(type) {
                 case StatusListItem.Type.Primary:
                     return Theme.palette.baseColor2

--- a/ui/app/AppLayouts/Wallet/panels/SignCollectibleInfoBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SignCollectibleInfoBox.qml
@@ -69,6 +69,7 @@ Control {
     }
 
     contentItem: StatusItemDelegate {
+        cursorShape: Qt.ArrowCursor
         contentItem: RowLayout {
             spacing: 12
             CollectibleMedia {
@@ -86,8 +87,10 @@ Control {
             }
 
             ColumnLayout {
+                Layout.fillWidth: true
                 spacing: 0
                 StatusBaseText {
+                    Layout.fillWidth: true
                     objectName: "primaryText"
                     text: !!root.name ?
                               root.name : ""
@@ -95,6 +98,7 @@ Control {
                     elide: Text.ElideRight
                 }
                 StatusBaseText {
+                    Layout.fillWidth: true
                     objectName: "secondaryText"
                     text: !!root.tokenId ?
                               root.tokenId : ""
@@ -103,7 +107,7 @@ Control {
                 }
             }
 
-            RowLayout {
+            Item {
                 Layout.fillWidth: true
             }
 

--- a/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SignTransactionModalBase.qml
@@ -49,7 +49,8 @@ StatusDialog {
     property bool hasExpiryDate: false
 
     // Close hidden explicitely until we have persistent notifications in place to reopen this dialog from outside
-    property bool headerActionsCloseButtonVisible: false
+    property bool headerActionsCloseButtonVisible: bottomSheet // need the close button as we hide the Reject button
+    closeHandler: reject // close and emit rejected() signal
 
     property ObjectModel leftFooterContents
     property ObjectModel rightFooterContents: ObjectModel {
@@ -59,7 +60,7 @@ StatusDialog {
             StatusFlatButton {
                 objectName: "rejectButton"
                 Layout.preferredHeight: signButton.height
-                visible: !root.hasExpiryDate || !countdownPill.isExpired
+                visible: (!root.hasExpiryDate || !countdownPill.isExpired) && !root.bottomSheet
                 text: qsTr("Reject")
                 onClicked: root.reject() // close and emit rejected() signal
             }
@@ -78,7 +79,7 @@ StatusDialog {
                 id: closeButton
                 visible: root.hasExpiryDate && countdownPill.isExpired
                 text: root.closeButtonText
-                onClicked: root.closeHandler()
+                onClicked: root.close()  // close and emit closed() signal
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SendSignModal.qml
@@ -143,10 +143,10 @@ SignTransactionModalBase {
     }
 
     title: qsTr("Sign Send")
-    //: e.g. (Send) 100 DAI to batista.eth
     subtitle: {
         const tokenToSend = root.isCollectible ? root.collectibleName:
                               "%1 %2".arg(root.tokenAmount).arg(root.tokenSymbol)
+        //: e.g. (Send) 100 DAI to batista.eth
         return qsTr("%1 to %2").
         arg(tokenToSend).
         arg(SQUtils.Utils.elideAndFormatWalletAddress(root.recipientAddress))
@@ -206,7 +206,7 @@ SignTransactionModalBase {
     leftFooterContents: ObjectModel {
         RowLayout {
             Layout.leftMargin: 4
-            spacing: Theme.bigPadding
+            spacing: Theme.padding
             ColumnLayout {
                 spacing: 2
                 RowLayout {

--- a/ui/app/mainui/Handlers/SendModalHandler.qml
+++ b/ui/app/mainui/Handlers/SendModalHandler.qml
@@ -1153,7 +1153,7 @@ QtObject {
                         close()
                     }
 
-                    onUpdateTxSettings: {
+                    onUpdateTxSettings: (selectedFeeMode, customNonce, customGasAmount, gasPrice, maxFeesPerGas, priorityFee) => {
                         let pathName = ""
                         let chainId = 0
                         if (!!txPathUnderReviewEntry.item) {

--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 
 import StatusQ
 import StatusQ.Controls
-import StatusQ.Popups
 import StatusQ.Core
 import StatusQ.Core.Theme
 


### PR DESCRIPTION
### What does the PR do

- the problem was happening with all the derived popups (DAppSignRequestModal, SendSignModal, SwapApproveCapModal and SwapSignModal)
- hide the "Reject" button when we are in the `bottomSheet` mode (ie. on mobile) and make sure we still have the close button available in the topright corner
- make the default `closeHandler` call `Dialog.reject()` which emits the `rejected()` signal and closes the popup (consistent with what the Esc key does)
- improve the SB pages

Fixes #19304

BACKPORT_TO: 2.36

### Affected areas

SignTransactionModalBase and derived popups

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Normal layout (Reject and no Close button)
<img width="2378" height="1958" alt="Snímek obrazovky z 2025-11-21 10-57-27" src="https://github.com/user-attachments/assets/02782042-e168-413e-818d-e9067fe8fa3d" />

Narrow (with bottom sheet, Reject removed, Close added):
<img width="846" height="1958" alt="image" src="https://github.com/user-attachments/assets/daf164a6-8c90-4003-96f4-ab8d45c88020" />


### Impact on end user

Better UX on mobile

### How to test

- run any of these popups on mobile

### Risk 

- low
