### PR TITLE
fix(Ens): Search for ENS names doesn't work correctly

### DIFF
--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -323,7 +323,6 @@ StatusSectionLayout {
                 implicitHeight: parent.height
                 ensUsernamesStore: root.ensUsernamesStore
                 walletAssetsStore: root.walletAssetsStore
-                contactsStore: root.contactsStore
                 networkConnectionStore: root.networkConnectionStore
                 profileContentWidth: d.contentWidth
                 onConnectUsernameRequested: (ensName, ownerAddress) => root.connectUsernameRequested(ensName, ownerAddress)

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -9,12 +9,9 @@ import StatusQ.Core.Backpressure
 import StatusQ.Core.Theme
 
 import utils
-import shared
 import shared.panels
 import shared.status
 import shared.controls
-import shared.popups.send
-import shared.stores.send
 
 import AppLayouts.Profile.stores
 
@@ -53,7 +50,7 @@ Item {
         return validationMessage === "";
     }
 
-    function onKeyReleased(ensUsername){
+    function onEnsUsernameChanged(ensUsername){
         if (!validate(ensUsername)) {
             return;
         }
@@ -83,8 +80,7 @@ Item {
                 source: Theme.svg("block-icon-white")
                 width: 20
                 height: 20
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.centerIn: parent
             }
 
             StatusBaseText {
@@ -116,9 +112,9 @@ Item {
             anchors.topMargin: Theme.bigPadding
             anchors.right: btnContinue.left
             anchors.rightMargin: Theme.bigPadding
-            Keys.onReleased: {
-                onKeyReleased(ensUsername.text);
-            }
+
+            onEditingFinished: inputValue => onEnsUsernameChanged(inputValue)
+            onTextEdited: inputValue => onEnsUsernameChanged(inputValue)
 
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -3,11 +3,7 @@ import QtQuick.Layouts
 import QtQuick.Controls
 
 import utils
-
 import shared.popups
-import shared.status
-import shared.popups.send
-import shared.stores.send
 
 import StatusQ
 import StatusQ.Core
@@ -39,7 +35,7 @@ Item {
             model: !!d.sntToken && !!d.sntToken.balances ? d.sntToken.balances: null
             roleName: "balance"
         }
-        property real sntBalance: !!sntToken && !!sntToken.decimals ? aggregator.value/(10 ** sntToken.decimals): 0
+        readonly property real sntBalance: !!sntToken && !!sntToken.decimals ? aggregator.value/(10 ** sntToken.decimals): 0
     }
 
     StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -12,12 +12,9 @@ import StatusQ.Core.Theme
 import utils
 import shared
 import shared.stores as SharedStores
-import shared.popups.send
 
 import AppLayouts.Wallet.stores
-import AppLayouts.stores as AppLayoutStores
-
-import "../stores"
+import AppLayouts.Profile.stores
 
 Item {
     id: ensView
@@ -25,7 +22,6 @@ Item {
     property EnsUsernamesStore ensUsernamesStore
     property WalletAssetsStore walletAssetsStore
 
-    property AppLayoutStores.ContactsStore contactsStore
     property SharedStores.NetworkConnectionStore networkConnectionStore
 
     property int profileContentWidth
@@ -45,10 +41,6 @@ Item {
     signal connectUsernameRequested(string ensName, string ownerAddress)
     signal registerUsernameRequested(string ensName)
     signal releaseUsernameRequested(string ensName, string senderAddress, int chainId)
-
-    Layout.fillHeight: true
-    Layout.fillWidth: true
-    clip: true
 
     QtObject {
         id: d
@@ -252,7 +244,7 @@ Item {
 
             onBackBtnClicked: back()
 
-            onContinueClicked: {
+            onContinueClicked: (output, username) => {
                 if(output === "connected"){
                     connect(username)
                 } else {
@@ -339,7 +331,7 @@ Item {
 
             profileContentWidth: ensView.profileContentWidth
             onAddBtnClicked: next("search")
-            onSelectEns: {
+            onSelectEns: (username, chainId) => {
                 ensView.ensUsernamesStore.ensDetails(chainId, username)
                 selectedUsername = username
                 selectedChainId = chainId
@@ -357,7 +349,7 @@ Item {
 
             onBackBtnClicked: back()
 
-            onReleaseUsernameRequested: {
+            onReleaseUsernameRequested: (senderAddress) => {
                 const name = RootStore.getNameForWalletAddress(senderAddress)
                 if (name === "") {
                     Global.openPopup(noAccountPopupComponent)
@@ -385,8 +377,6 @@ Item {
 
             StatusBaseText {
                 anchors.fill: parent
-                font.pixelSize: Constants.keycard.general.fontSize2
-                color: Theme.palette.directColor1
                 text: qsTr("The account this username was bought with is no longer among active accounts.\nPlease add it and try again.")
             }
 
@@ -400,6 +390,4 @@ Item {
             addedUsername = ensUsername;
         }
     }
-
 }
-


### PR DESCRIPTION
### What does the PR do

- use the standard `textEdited()` and `editingFinished()` TextInput signals instead of catching the key press with `Keys.onRelease` which might be janky with virtual keyboards
- remove some useless props and imports

Fixes #19105

BACKPORT_TO: 2.36

### Affected areas

Settings/ENS

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/ede511d1-1ee0-4759-aeb2-224ccae3a4ac" />


### Impact on end user

- ENS search works on mobile

### How to test

- go to Settings/ENS
- try to start typing some desired ENS username
- should get results immediately, not after submitting

### Risk 

- low
