### PR TITLE
[CHERRY-PICK] fix(AppearanceView): Rename padding factor to layout spacing

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -88,8 +88,13 @@ SettingsContentBase {
         }
 
         StatusSectionHeadline {
-            text: qsTr("Padding factor")
+            text: qsTr("Layout Spacing")
             Layout.topMargin: 2 * Theme.padding
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr("Adjust how compact or spacious the layout looks")
         }
 
         StatusQ.StatusLabeledSlider {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2141,10 +2141,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2158,6 +2154,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     </message>
     <message>
         <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2705,10 +2709,6 @@ Do you wish to override the security check and continue?</source>
     <name>BrowserWalletMenu</name>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wallet info will appear here</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2148,10 +2148,6 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
         <translation>Režim</translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2166,6 +2162,14 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
     <message>
         <source>System</source>
         <translation type="unfinished">Systémový</translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2712,10 +2716,6 @@ Do you wish to override the security check and continue?</source>
     <name>BrowserWalletMenu</name>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wallet info will appear here</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2138,10 +2138,6 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
         <translation>XXL</translation>
     </message>
     <message>
-        <source>Padding factor</source>
-        <translation>Factor de espaciado</translation>
-    </message>
-    <message>
         <source>XXS</source>
         <translation>XXS</translation>
     </message>
@@ -2160,6 +2156,14 @@ de &quot;%1&quot; a &quot;%2&quot;</translation>
     <message>
         <source>System</source>
         <translation>Sistema</translation>
+    </message>
+    <message>
+        <source>Layout Spacing</source>
+        <translation>Factor de espaciado</translation>
+    </message>
+    <message>
+        <source>Adjust how compact or spacious the layout looks</source>
+        <translation>Ajusta qué tan compacto o espacioso se ve el diseño</translation>
     </message>
 </context>
 <context>
@@ -2710,10 +2714,6 @@ Do you wish to override the security check and continue?</source>
     <message>
         <source>Disconnect</source>
         <translation>Desconectar</translation>
-    </message>
-    <message>
-        <source>Wallet info will appear here</source>
-        <translation>La información de la billetera aparecerá aquí</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2656,14 +2656,17 @@ from &quot;%1&quot; to &quot;%2&quot;</source>
 		<translation>시스템</translation>
 	</message>
 	<message>
-		<source>Padding factor</source>
-		<comment>AppearanceView</comment>
-		<translation>여백 계수</translation>
-	</message>
-	<message>
 		<source>XXS</source>
 		<comment>AppearanceView</comment>
 		<translation>XXS</translation>
+	</message>
+	<message>
+		<source>Layout Spacing</source>
+		<translation type="unfinished"></translation>
+	</message>
+	<message>
+		<source>Adjust how compact or spacious the layout looks</source>
+		<translation type="unfinished"></translation>
 	</message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Closes #19315
Backport of https://github.com/status-im/status-desktop/pull/19317

- Renames Padding Factor to Layout Spacing to better reflect its purpose.
- Adds a descriptive subtitle to clarify what this setting controls and improve overall UX clarity.