### PR TITLE
[CHERRY-PICK] fix(pinned/search popups): use short date format

### DIFF
--- a/storybook/pages/ActivityNotificationTransferOwnershipPage.qml
+++ b/storybook/pages/ActivityNotificationTransferOwnershipPage.qml
@@ -14,8 +14,6 @@ import utils
 ActivityNotificationBaseLayout {
     id: root
 
-    property bool showFullTimestamp
-
     showBaseEditorFields: false
     communityEditorActive: true
     contactEditorActive: false
@@ -24,7 +22,6 @@ ActivityNotificationBaseLayout {
         type: setType(notification)
         communityName: communityEditor.communityMock.name
         communityColor:  communityEditor.communityMock.color
-        showFullTimestamp: root.showFullTimestamp
 
         onFinaliseOwnershipClicked: logs.logEvent("ActivityNotificationTransferOwnership::onFinaliseOwnershipClicked")
         onNavigateToCommunityClicked: logs.logEvent("ActivityNotificationTransferOwnership::onNavigateToCommunityClicked")
@@ -57,12 +54,6 @@ ActivityNotificationBaseLayout {
             RadioButton {
                 text: "No longer control node"
                 onCheckedChanged: if(checked) baseEditor.notificationBaseMock.notificationType = ActivityCenterTypes.ActivityCenterNotificationType.OwnershipLost
-            }
-
-            Switch {
-                text: "Show full timestamp"
-                checked: root.showFullTimestamp
-                onCheckedChanged: root.showFullTimestamp = checked
             }
         }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -267,7 +267,6 @@ Control {
                             onClicked: (sender) => root.senderNameClicked(sender)
                             onResendClicked: root.resendClicked()
                             timestamp: root.timestamp
-                            showFullTimestamp: root.isInPinnedPopup
                             displayNameClickable: root.profileClickable
                             outgoingStatus: root.outgoingStatus
                             showOutgointStatusLabel: root.hovered && !root.isInPinnedPopup
@@ -383,7 +382,7 @@ Control {
 
                     Loader {
                         Layout.fillWidth: true
-                        Layout.rightMargin: 16
+                        Layout.rightMargin: Theme.padding
                         active: root.editMode
                         visible: active
                         sourceComponent: StatusEditMessage {
@@ -418,7 +417,7 @@ Control {
             active: root.hovered && root.quickActions.length > 0
             anchors.right: parent.right
             anchors.rightMargin: Theme.padding
-            anchors.top: root.top
+            anchors.top: parent.top
             sourceComponent: StatusMessageQuickActions {
                 items: root.quickActions
             }

--- a/ui/app/AppLayouts/ActivityCenter/views/ActivityNotificationTransferOwnership.qml
+++ b/ui/app/AppLayouts/ActivityCenter/views/ActivityNotificationTransferOwnership.qml
@@ -23,7 +23,6 @@ ActivityNotificationBase {
     required property string communityName
     required property string communityColor
     required property int type // Possible values [OwnershipState]
-    property bool showFullTimestamp: false
 
     signal finaliseOwnershipClicked
     signal navigateToCommunityClicked

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -116,8 +116,8 @@ Item {
 
     Connections {
         target: Qt.application
-        onStateChanged: {
-            if (Qt.application.state == Qt.ApplicationActive) {
+        function onStateChanged() {
+            if (Qt.application.state === Qt.ApplicationActive) {
                 d.markAllMessagesReadIfMostRecentMessageIsInViewport()
             }
         }

--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -84,7 +84,7 @@ Item {
         searchOptionsPopupMenu: searchPopupMenu
         searchResults: root.store.resultModel
         formatTimestampFn: function (ts) {
-            return LocaleUtils.formatDateTime(parseInt(ts, 10))
+            return LocaleUtils.formatDateTime(parseInt(ts, 10), Locale.ShortFormat)
         }
         onSearchTextChanged: {
             if (searchPopup.searchText !== "") {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -694,7 +694,6 @@ Loader {
                 StatusTimeStampLabel {
                     Layout.alignment: Qt.AlignVCenter
                     timestamp: root.messageTimestamp
-                    showFullTimestamp: false
                 }
             }
         }


### PR DESCRIPTION
Cherry-pick of #19338

### What does the PR do

- use `Locale.ShortFormat` in AppSearch and PinnedMessagesPopup
- fixes message headers overflowing on mobile

Fixes #19334

### Affected areas

AppSearch and PinnedMessagesPopup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

AppSearch:
<img width="1225" height="982" alt="Snímek obrazovky z 2025-11-21 17-09-22" src="https://github.com/user-attachments/assets/10d5cd9a-df02-413d-ab60-38a5ebf54ca8"/>

PinnedMessagesPopup:
<img width="1413" height="753" alt="Snímek obrazovky z 2025-11-21 17-08-05" src="https://github.com/user-attachments/assets/c6e0136f-aaa3-4a10-9c2e-15b8a6a65e46"/>

### Impact on end user

Better UX on mobile