### PR TITLE
[CHERRY-PICK] fix(LanguageModel): replace “de España” with neutral Spanish

### DIFF
--- a/storybook/pages/StatusLanguageSelectorPage.qml
+++ b/storybook/pages/StatusLanguageSelectorPage.qml
@@ -64,7 +64,7 @@ SplitView {
                 TextField {
                     Layout.fillWidth: true
                     id: ctrlLanguageCodes
-                    text: "de,cs,en,en_CA,ko,ar,fr,fr_CA,pt_BR,pt,uk,ja,el"
+                    text: "es,de,de-CH,cs,en,en_CA,ko,ar,fr,fr_CA,pt_BR,pt,uk,ja,el,xx_XX" // last one is invalid, should not appear in the list
                     placeholderText: "Comma separated list of language codes"
                 }
             }

--- a/ui/StatusQ/src/l10n/languagemodel.cpp
+++ b/ui/StatusQ/src/l10n/languagemodel.cpp
@@ -10,6 +10,8 @@ constexpr auto kLanguageNameRoleName = "name";
 constexpr auto kLanguagenativeNameRoleName = "nativeName";
 }
 
+using namespace Qt::Literals::StringLiterals;
+
 LanguageModel::LanguageModel(QObject* parent) : QAbstractListModel(parent)
 {
 }
@@ -87,10 +89,12 @@ void LanguageModel::rebuildModel()
         data.fullIsoCode = loc.name(); // including country, e.g. "fr_CA"
         data.name = QLocale::languageToString(loc.language()); // english language name, e.g. "French" for "fr"
 
-        if (data.code == "en")
+        if (data.code == "en"_L1)
             data.nativeName = data.name; // just "English"
-        else if (data.code == "pt_BR") // differentiate between "pt" and "pt_BR"
-            data.nativeName = "português brasileiro";
+        else if (data.code == "pt_BR"_L1) // differentiate between "pt" and "pt_BR"
+            data.nativeName = u"português brasileiro"_s;
+        else if (data.code == "es"_L1) // make the "español de España" country neutral
+            data.nativeName = u"español"_s;
         else
             data.nativeName = loc.nativeLanguageName(); // native language name, e.g. "français" for "fr" or "français canadien" for "fr_CA"
 


### PR DESCRIPTION
Backport of https://github.com/status-im/status-desktop/pull/19367

### What does the PR do

Fixes displaying "español de España" for neutral Spanish

Fixes #19359

### Affected areas

Settings/Language

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2944" height="1800" alt="image" src="https://github.com/user-attachments/assets/e062a9fa-b0a2-4850-ac64-06388a7d864b" />

### Impact on end user

Spanish (native) language name presented as neutral

### Risk 

- low
