### PR TITLE
feat: Add dynamic scaling for mobile devices

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -196,6 +196,15 @@ proc mainProc() =
   let imageCert = imageServerTLSCert()
   installSelfSignedCertificate(imageCert)
 
+  when defined(android) or defined(ios):
+    # Apply dynamic scaling based on device width and DPI. Defaults to 1 for desktop.
+    proc statusq_getMobileUIScaleFactor(baseWidth: cfloat, baseDpi: cfloat, baseScale: cfloat): cfloat {.importc, cdecl.}
+    var scaleFactor = statusq_getMobileUIScaleFactor(1080.0, 480.0, 0.8)
+    # Clamp scale factor between 0.8 and 1.0
+    scaleFactor = max(0.8, min(1.0, scaleFactor))
+
+    putEnv("QT_SCALE_FACTOR", $scaleFactor)
+
   let app = newQGuiApplication()
 
   # force default language ("en") if not "Settings/Advanced/Enable translations"

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -252,7 +252,7 @@ FetchContent_Declare(
   MobileUI
 
   GIT_REPOSITORY https://github.com/status-im/MobileUI.git
-  GIT_TAG 223b7b1f4ee07521e6ce312e96bcf609c6cdfc37
+  GIT_TAG c8ac952179e91ff2643611b731f06dc6af06305c
 )
 FetchContent_MakeAvailable(MobileUI)
 

--- a/ui/StatusQ/src/externc.cpp
+++ b/ui/StatusQ/src/externc.cpp
@@ -1,11 +1,16 @@
 #include <QtGlobal>
 
 #include <StatusQ/typesregistration.h>
+#include <MobileUI>
 
 extern "C" {
 
 Q_DECL_EXPORT void statusq_registerQmlTypes() {
     registerStatusQTypes();
+}
+
+Q_DECL_EXPORT float statusq_getMobileUIScaleFactor(float baseWidth, float baseDpi, float baseScale) {
+    return MobileUI::getSmartScaleFactor(baseWidth, baseDpi, baseScale);
 }
 
 } // extern "C"


### PR DESCRIPTION
### What does the PR do

Adding a dynamic scaling based on the device screen the app starts on.

I've been taking as a reference a Samsung S21 FE with 0.8 scaling. It has a rough dp value of 360. The scaling is clamped between 0.8 and 1.0.

Note: For foldable phones we can't change the scaling when opening/closing the device. I hope most devices will have large dp values for the rear screen as well. The ones that I've tested on have medium - large dp values. The perfect scaling would be around 0.95. So it was still ok.

### Affected areas

Mobile app scaling


<img width="625" height="966" alt="Screenshot 2025-11-25 at 11 20 04" src="https://github.com/user-attachments/assets/b3c4ef7c-9b95-40ed-9904-1eb2b4f62083" />
<img width="388" height="667" alt="Screenshot 2025-11-25 at 11 20 47" src="https://github.com/user-attachments/assets/49192bec-689c-4043-b867-22d0bd017731" />
<img width="482" height="1028" alt="Screenshot 2025-11-25 at 11 32 34" src="https://github.com/user-attachments/assets/9344774b-ba82-42af-9f3f-66d72dd5125e" />
<img width="445" height="955" alt="Screenshot 2025-11-25 at 11 34 58" src="https://github.com/user-attachments/assets/4e4a9e91-fdf2-4019-a705-b0696e950007" />
<img width="440" height="956" alt="Screenshot 2025-11-25 at 11 14 44" src="https://github.com/user-attachments/assets/75dbb6c0-7066-4cbe-997f-007abd96d625" />
<img width="460" height="933" alt="Screenshot 2025-11-24 at 13 19 29" src="https://github.com/user-attachments/assets/922a89c6-194d-469e-a017-407f2184b30d" />
<img width="446" height="958" alt="Screenshot 2025-11-24 at 13 15 57" src="https://github.com/user-attachments/assets/9c56f893-f9c1-426c-8b09-cd9d14d88ed2" />



