### PR TITLE
feat: activities in a browser wallet

### DIFF
--- a/src/app/modules/main/browser_section/view.nim
+++ b/src/app/modules/main/browser_section/view.nim
@@ -1,16 +1,20 @@
 import nimqml
 import io_interface
+import ../wallet_section/activity/controller as activity_controller
 
 QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
+      activityController: activity_controller.Controller
 
   proc setup(self: View)
   proc delete*(self: View)
-  proc newView*(delegate: io_interface.AccessInterface): View =
+  proc newView*(delegate: io_interface.AccessInterface,
+                activityController: activity_controller.Controller): View =
     new(result, delete)
     result.delegate = delegate
+    result.activityController = activityController
     result.setup()
 
   proc load*(self: View) =
@@ -19,6 +23,12 @@ QtObject:
   proc openUrl*(self: View, url: string) {.signal.}
   proc sendOpenUrlSignal*(self: View, url: string) =
     self.openUrl(url)
+
+  proc getActivityController*(self: View): QVariant {.slot.} =
+    return newQVariant(self.activityController)
+
+  QtProperty[QVariant] activityController:
+    read = getActivityController
 
   proc setup(self: View) =
     self.QObject.setup

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -231,7 +231,7 @@ proc newModule*[T](
   result.browserSectionModule = browser_section_module.newModule(
     result, events, bookmarkService, settingsService, networkService,
     dappPermissionsService, walletAccountService,
-    tokenService, currencyService
+    tokenService, currencyService, savedAddressService
   )
   result.profileSectionModule = profile_section_module.newModule(
     result, events, accountsService, settingsService, stickersService,

--- a/storybook/pages/BrowserLayoutPage.qml
+++ b/storybook/pages/BrowserLayoutPage.qml
@@ -15,7 +15,7 @@ import utils
 import AppLayouts.Browser
 import AppLayouts.Browser.stores as BrowserStores
 import AppLayouts.Wallet.stores
-import shared.stores
+import shared.stores as SharedStores
 import shared.stores.send
 
 Item {
@@ -108,6 +108,9 @@ Item {
                     dappBrowserAccount.address = address
                 }
             }
+            browserActivityStore: BrowserStores.BrowserActivityStore {}
+            networksStore: SharedStores.NetworksStore {}
+            currencyStore: SharedStores.CurrenciesStore {}
 
             readonly property var localAccountSensitiveSettings: Settings {
                 property bool devToolsEnabled

--- a/storybook/pages/TransactionDelegatePage.qml
+++ b/storybook/pages/TransactionDelegatePage.qml
@@ -94,7 +94,7 @@ SplitView {
                         }
                     }
                     flatNetworks: NetworksModel.flatNetworks
-                    walletRootStore: WalletStores.RootStore
+                    activityStore: WalletStores.RootStore
                 }
             }
         }

--- a/storybook/stubs/AppLayouts/Browser/stores/BrowserActivityStore.qml
+++ b/storybook/stubs/AppLayouts/Browser/stores/BrowserActivityStore.qml
@@ -1,0 +1,3 @@
+import QtQml
+
+QtObject {}

--- a/storybook/stubs/AppLayouts/Browser/stores/qmldir
+++ b/storybook/stubs/AppLayouts/Browser/stores/qmldir
@@ -1,4 +1,5 @@
 BrowserRootStore 1.0 BrowserRootStore.qml
 BrowserWalletStore 1.0 BrowserWalletStore.qml
+BrowserActivityStore 1.0 BrowserActivityStore.qml
 BookmarksStore 1.0 BookmarksStore.qml
 DownloadsStore 1.0 DownloadsStore.qml

--- a/ui/app/AppLayouts/Browser/stores/BrowserActivityStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/BrowserActivityStore.qml
@@ -1,0 +1,77 @@
+import QtQuick
+
+import utils
+
+QtObject {
+    id: root
+
+    required property var browserWalletStore
+
+    readonly property var activityController: browserSection.activityController
+
+    readonly property string selectedAddress: browserWalletStore.dappBrowserAccount.address
+    readonly property bool isNonArchivalNode: false
+    readonly property bool showAllAccounts: false
+    readonly property var transactionActivityStatus: activityController.status
+    readonly property bool loadingHistoryTransactions: activityController.status.loadingData
+    readonly property bool newDataAvailable: activityController.status.newDataAvailable
+
+    readonly property var historyTransactions: activityController.model
+
+    // Browser view doesn't provide transaction filtering UI
+    readonly property QtObject currentActivityFiltersStore: QtObject {
+        readonly property bool filtersSet: false
+
+        function applyAllFilters() {
+            root.activityController.updateFilter()
+        }
+
+        function updateCollectiblesModel() {
+            root.activityController.updateCollectiblesModel()
+        }
+
+        function updateRecipientsModel() {
+            root.activityController.updateRecipientsModel()
+        }
+    }
+
+    function updateTransactionFilterIfDirty() {
+        if (transactionActivityStatus.isFilterDirty) {
+            activityController.updateFilter()
+        }
+    }
+
+    function fetchMoreTransactions() {
+        if (historyTransactions.count === 0
+                || !historyTransactions.hasMore
+                || loadingHistoryTransactions)
+            return
+        activityController.loadMoreItems()
+    }
+
+    function resetActivityData() {
+        activityController.resetActivityData()
+    }
+
+    function getEtherscanLink(chainID) {
+        return networksModule.getBlockExplorerTxURL(chainID)
+    }
+
+    function getTransactionType(transaction) {
+        if (!transaction) return Constants.TransactionType.Send
+        return transaction.txType
+    }
+
+    function getNameForAddress(address) {
+        const name = walletSectionAccounts.getNameByAddress(address)
+        return name.length > 0 ? name : ""
+    }
+
+    function getDappDetails(chainId, contractAddress) {
+        return Utils.getDappDetails(chainId, contractAddress)
+    }
+
+    function isOwnedAccount(address) {
+        return walletSectionAccounts.isOwnedAccount(address)
+    }
+}

--- a/ui/app/AppLayouts/Browser/stores/BrowserWalletStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/BrowserWalletStore.qml
@@ -8,10 +8,6 @@ QtObject {
     property string defaultCurrency: walletSection.currentCurrency
     property string signingPhrase: walletSection.signingPhrase // FIXME
 
-    function getEtherscanLink(chainID) {
-        return networksModule.getBlockExplorerTxURL(chainID)
-    }
-
     function switchAccountByAddress(address) {
         browserSectionCurrentAccount.switchAccountByAddress(address)
     }

--- a/ui/app/AppLayouts/Browser/stores/qmldir
+++ b/ui/app/AppLayouts/Browser/stores/qmldir
@@ -1,4 +1,5 @@
 BrowserRootStore 1.0 BrowserRootStore.qml
 BrowserWalletStore 1.0 BrowserWalletStore.qml
+BrowserActivityStore 1.0 BrowserActivityStore.qml
 BookmarksStore 1.0 BookmarksStore.qml
 DownloadsStore 1.0 DownloadsStore.qml

--- a/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/SavedAddressActivityPopup.qml
@@ -229,7 +229,7 @@ StatusDialog {
                            isWatchOnlyAccount: false,
                            mixedcaseAddress: d.address
                        })
-            walletRootStore: WalletStore.RootStore
+            activityStore: WalletStore.RootStore
             networksStore: root.networksStore
         }
     }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -482,26 +482,7 @@ QtObject {
     // TODO: https://github.com/status-im/status-app/issues/15329
     // Get DApp data from the backend
     function getDappDetails(chainId, contractAddress) {
-        switch (contractAddress) {
-            case Constants.swap.paraswapV5ApproveContractAddress:
-            case Constants.swap.paraswapV5SwapContractAddress:
-                return {
-                    "icon": Assets.png("swap/%1".arg(Constants.swap.paraswapIcon)),
-                    "url": Constants.swap.paraswapHostname,
-                    "name": Constants.swap.paraswapName,
-                    "approvalContractAddress": Constants.swap.paraswapV5ApproveContractAddress,
-                    "swapContractAddress": Constants.swap.paraswapV5SwapContractAddress,
-                }
-            case Constants.swap.paraswapV6_2ContractAddress:
-                return {
-                    "icon": Assets.png("swap/%1".arg(Constants.swap.paraswapIcon)),
-                    "url": Constants.swap.paraswapUrl,
-                    "name": Constants.swap.paraswapName,
-                    "approvalContractAddress": Constants.swap.paraswapV6_2ContractAddress,
-                    "swapContractAddress": Constants.swap.paraswapV6_2ContractAddress,
-                }
-        }
-        return undefined
+        return Utils.getDappDetails(chainId, contractAddress)
     }
 
     function resetActivityData() {

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -532,7 +532,7 @@ RightTabBaseView {
                     id: historyView
                     HistoryView {
                         overview: RootStore.overview
-                        walletRootStore: RootStore
+                        activityStore: RootStore
                         communitiesStore: root.communitiesStore
                         currencyStore: root.sharedRootStore.currencyStore
                         networksStore: root.networksStore

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
@@ -295,7 +295,7 @@ Item {
                             timeStampText: isModelDataValid ? LocaleUtils.formatRelativeTimestamp(modelData.timestamp * 1000, true) : ""
                             flatNetworks: root.networksStore.allNetworks
                             currenciesStore: root.rootStore.currencyStore
-                            walletRootStore: root.walletRootStore
+                            activityStore: root.walletRootStore
                             showAllAccounts: root.walletRootStore.showAllAccounts
                             displayValues: true
                             community: isModelDataValid && !!communityId && !!root.communitiesStore ? root.communitiesStore.getCommunityDetailsAsJson(communityId) : null

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2066,7 +2066,6 @@ Item {
 
                     sourceComponent: appMain.rootStore.thirdpartyServicesEnabled ? browserLayout: browserPrivacyWall
 
-
                     Component {
                         id: browserPrivacyWall
 
@@ -2091,6 +2090,11 @@ Item {
                             downloadsStore: BrowserStores.DownloadsStore {}
                             browserRootStore: BrowserStores.BrowserRootStore {}
                             browserWalletStore: BrowserStores.BrowserWalletStore {}
+                            browserActivityStore: BrowserStores.BrowserActivityStore {
+                                browserWalletStore: browserLayout.browserWalletStore
+                            }
+                            currencyStore: appMain.currencyStore
+                            networksStore: appMain.networksStore
                             connectorController: WalletStores.RootStore.dappsConnectorController
                             isDebugEnabled: appMain.advancedStore.isDebugEnabled
 

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -9,7 +9,6 @@ import StatusQ.Controls
 import StatusQ.Core.Utils as SQUtils
 
 import AppLayouts.Wallet
-import AppLayouts.Wallet.stores as WalletStores
 
 import utils
 import shared
@@ -31,7 +30,7 @@ import shared.stores as SharedStores
         modelData: model.activityEntry
         flatNetworks: root.flatNetworks
         currenciesStore: root.currencyStore
-        walletRootStore: WalletStores.RootStore
+        activityStore: root.activityStore
         loading: isModelDataValid
     }
    \endqml
@@ -52,7 +51,7 @@ StatusListItem {
     required property var flatNetworks
 
     required property SharedStores.CurrenciesStore currenciesStore
-    required property WalletStores.RootStore walletRootStore
+    required property var activityStore
 
     readonly property bool isModelDataValid: modelData !== undefined && !!modelData
 
@@ -70,8 +69,8 @@ StatusListItem {
     readonly property string networkName: isModelDataValid ? SQUtils.ModelUtils.getByKey(flatNetworks, "chainId", modelData.chainId, "chainName") : ""
     readonly property string networkNameIn: isMultiTransaction ? SQUtils.ModelUtils.getByKey(flatNetworks, "chainId", modelData.chainIdIn, "chainName") : ""
     readonly property string networkNameOut: isMultiTransaction ? SQUtils.ModelUtils.getByKey(flatNetworks, "chainId", modelData.chainIdOut, "chainName") : ""
-    readonly property string addressNameTo: isModelDataValid ? walletRootStore.getNameForAddress(modelData.recipient) : ""
-    readonly property string addressNameFrom: isModelDataValid ? walletRootStore.getNameForAddress(modelData.sender) : ""
+    readonly property string addressNameTo: isModelDataValid ? activityStore.getNameForAddress(modelData.recipient) : ""
+    readonly property string addressNameFrom: isModelDataValid ? activityStore.getNameForAddress(modelData.sender) : ""
     readonly property bool isNFT: isModelDataValid && modelData.isNFT
     readonly property bool isCommunityAssetViaAirdrop: isModelDataValid && !!communityId && d.txType === Constants.TransactionType.Mint
     readonly property string communityId: isModelDataValid && modelData.communityId ? modelData.communityId : ""
@@ -85,10 +84,10 @@ StatusListItem {
             return null
         }
         if (modelData.txType === Constants.TransactionType.Approve) {
-            return walletRootStore.getDappDetails(modelData.chainId, modelData.approvalSpender)
+            return activityStore.getDappDetails(modelData.chainId, modelData.approvalSpender)
         }
         if (modelData.txType === Constants.TransactionType.Swap) {
-            return walletRootStore.getDappDetails(modelData.chainId, modelData.interactedContractAddress)
+            return activityStore.getDappDetails(modelData.chainId, modelData.interactedContractAddress)
         }
         return null
     }
@@ -213,7 +212,7 @@ StatusListItem {
 
         readonly property bool isLightTheme: Theme.palette.name === Constants.lightThemeName
         property color animatedBgColor
-        property int txType: walletRootStore.getTransactionType(root.modelData)
+        readonly property int txType: activityStore.getTransactionType(root.modelData)
 
         readonly property var secondIconAsset: StatusAssetSettings {
             width: root.tokenIconAsset.width

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -871,6 +871,31 @@ QtObject {
         return nativeTokenRawToDecimal(chainID, rawGasPrice)
     }
     
+    // TODO: https://github.com/status-im/status-desktop/issues/15329
+    // Get DApp data from the backend
+    function getDappDetails(chainId, contractAddress) {
+        switch (contractAddress) {
+            case Constants.swap.paraswapV5ApproveContractAddress:
+            case Constants.swap.paraswapV5SwapContractAddress:
+                return {
+                    "icon": Theme.png("swap/%1".arg(Constants.swap.paraswapIcon)),
+                    "url": Constants.swap.paraswapHostname,
+                    "name": Constants.swap.paraswapName,
+                    "approvalContractAddress": Constants.swap.paraswapV5ApproveContractAddress,
+                    "swapContractAddress": Constants.swap.paraswapV5SwapContractAddress,
+                }
+            case Constants.swap.paraswapV6_2ContractAddress:
+                return {
+                    "icon": Theme.png("swap/%1".arg(Constants.swap.paraswapIcon)),
+                    "url": Constants.swap.paraswapUrl,
+                    "name": Constants.swap.paraswapName,
+                    "approvalContractAddress": Constants.swap.paraswapV6_2ContractAddress,
+                    "swapContractAddress": Constants.swap.paraswapV6_2ContractAddress,
+                }
+        }
+        return undefined
+    }
+
     // Leave this function at the bottom of the file as QT Creator messes up the code color after this
     function isPunct(c) {
         return /(!|\@|#|\$|%|\^|&|\*|\(|\)|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)


### PR DESCRIPTION
### What does the PR do

Implements activities list in a browser wallet.

### Affected areas

- Added new instance of activity controller to `browser_section/module.nim`
- `BrowserActivityStore.qml` added for reusing `HistoryView.qml` and `TransactionDelegate.qml`
- In `HistoryView.qml` and `TransactionDelegate.qml` property`walletRootStore` was renamed to `activityStore`, removed wallet-specific imports

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="713" height="486" alt="Screenshot 2025-11-26 at 14 47 25" src="https://github.com/user-attachments/assets/7b7f324c-18af-46ac-b92d-1ee3dc2b2a79" />
<img width="713" height="486" alt="Screenshot 2025-11-26 at 14 47 19" src="https://github.com/user-attachments/assets/94d830d9-0fd2-4130-a353-eff787bc3421" />

Fixes #19273
