### PR TITLE
fix(AccountSelectorHeader): set to purse emoji by default to fix squished height

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -37,7 +37,7 @@ Rectangle {
     radius: width / 2
 
     StatusEmoji {
-        visible: root.emoji
+        visible: !!root.emoji
         anchors.centerIn: parent
         width: Math.round(parent.width / 2)
         height: Math.round(parent.height / 2)

--- a/ui/imports/shared/controls/AccountSelectorHeader.qml
+++ b/ui/imports/shared/controls/AccountSelectorHeader.qml
@@ -34,13 +34,12 @@ AccountSelector {
         StatusSmartIdenticon {
             id: assetContent
             objectName: "assetContent"
-            asset.emoji: currentAccount.emoji ?? ""
+            asset.emoji: !!currentAccount.emoji ? currentAccount.emoji : "👛" // Default to purse emoji
             asset.color: d.headerStyleBackgroundColor
             asset.width: 32
             asset.height: asset.width
-            asset.isLetterIdenticon: !!currentAccount.emoji
+            asset.isLetterIdenticon: true
             asset.bgColor: Theme.palette.primaryColor3
-            visible: !!currentAccount.emoji
         }
 
         StatusBaseText {


### PR DESCRIPTION
## What does the PR do

Fixes #19353

I couldn't reproduce the original issue, but I saw that with no selected emoji, the account selector was squished, hence hard to click. The easiest solution is to use a default emoji. The purse one makes sense, since there is no wallet emoji.

### Affected areas

- AccountSelectorHeader

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


Before:
<img width="282" height="173" alt="image" src="https://github.com/user-attachments/assets/3171acb4-c791-41e5-aedd-d4574902be18" />


After:
<img width="282" height="173" alt="image" src="https://github.com/user-attachments/assets/3a93b6c0-abaa-472a-876c-f1d617b7e401" />

### Impact on end user

Fixes the squished selector

### How to test

- Create a new account and press Send

### Risk 

None
