### PR TITLE
feat(@desktop/wallet): Fix issue of blank screen when landing on wallet

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -215,6 +215,9 @@ StatusListItem {
                                                      WalletLayout.RightPanelSelection.Activity,
                                                      {savedAddress: menu.address})
             }
+            // TODO: https://github.com/status-im/status-desktop/issues/19410
+            // ENabled after crash is solved
+            enabled: false
         }
 
         StatusMenuSeparator {}

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -266,8 +266,6 @@ RightTabBaseView {
                     }
                     onCurrentIndexChanged: {
                         RootStore.setCurrentViewedHoldingType(walletTabBar.currentIndex === 1 ? Constants.TokenType.ERC721 : Constants.TokenType.ERC20)
-
-                        mainViewLoader.sourceComponent = d.walletViewsMap[walletTabBar.currentIndex]
                     }
                 }
                 StatusFlatButton {
@@ -286,6 +284,7 @@ RightTabBaseView {
                 id: mainViewLoader
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                sourceComponent: d.walletViewsMap[walletTabBar.currentIndex]
 
                 Component {
                     id: assetsView


### PR DESCRIPTION
### What does the PR do

Reverted fix fir crash when trying to launch history tab from wallet settings -> Saved Address -> kebab menu -> view activity and raised a separate bug ti handle it as  the issue not straightforward to solve 

https://github.com/status-im/status-desktop/issues/19410

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/9da39c56-d63b-4b4e-908a-cf4c89400605



### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
