### PR TITLE
fix(ci): explicitly remove workspace tmp directory

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -126,9 +126,11 @@ pipeline {
   }
 
   post {
-      success { script { github.notifyPR(true) } }
-      failure { script { github.notifyPR(false) } }
-      cleanup { cleanWs(disableDeferredWipeout: true) }
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
-

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -6,7 +6,7 @@ library 'status-jenkins-lib@v1.9.30'
 urls = [:]
 
 pipeline {
-  agent { 
+  agent {
     docker {
       label 'linuxcontainer'
       image 'harbor.status.im/infra/ci-build-containers:linux-base-1.0.1'
@@ -87,10 +87,10 @@ pipeline {
               }
             }
             stage('E2E') {
-              when { 
-                expression { 
-                  env.JOB_NAME.toLowerCase().contains('nightly') 
-                } 
+              when {
+                expression {
+                  env.JOB_NAME.toLowerCase().contains('nightly')
+                }
               }
               steps {
                 script {
@@ -139,7 +139,10 @@ pipeline {
         cred: 'discord-status-desktop-webhook',
       )
     } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -151,9 +151,12 @@ pipeline {
   }
 
   post {
-      success { script { github.notifyPR(true) } }
-      failure { script { github.notifyPR(false) } }
-      cleanup { cleanWs(disableDeferredWipeout: true) }
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -83,7 +83,7 @@ pipeline {
     USE_NWAKU = "${params.USE_NWAKU}"
     /* nwaku source directory */
     NWAKU_SOURCE_DIR = "${env.WORKSPACE_TMP}/nwaku"
-    /* sets App Version in Settings */  
+    /* sets App Version in Settings */
     VERSION = sh(script: "./scripts/version.sh", returnStdout: true).trim()
     /* Control output the filename */
     APP_TYPE = "${utils.getAppType() + (params.USE_NWAKU ? '-experimental' : '')}"
@@ -166,7 +166,10 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -130,7 +130,10 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -169,7 +169,10 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.qt-build
+++ b/ci/Jenkinsfile.qt-build
@@ -173,8 +173,11 @@ pipeline {
   }
 
   post {
-    always { cleanWs() }
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -246,7 +246,10 @@ pipeline {
         cred: 'discord-status-desktop-e2e-webhook',
       )
     } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -240,6 +240,7 @@ pipeline {
         '''
       }
       cleanWs(disableDeferredWipeout: true)
+      powershell "Remove-Item -Path '${env.WORKSPACE_TMP}' -Recurse -Force"
     }
   }
 }

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -88,6 +88,9 @@ pipeline {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
     always  { script { env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText" } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -162,7 +162,10 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
   }
 }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -175,7 +175,10 @@ pipeline {
     // Windows workspace often becomes broken if stoped during checkout.
     // Post cleanup will fail too.
     // Use 'Wipe out repository and force clone' manual UI option to prevent it.
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      powershell "Remove-Item -Path '${env.WORKSPACE_TMP}' -Recurse -Force"
+    }
   }
 }
 


### PR DESCRIPTION
Currently the `cleanWs()` function does not remove `@tmp` dirs:

- https://github.com/jenkinsci/ws-cleanup-plugin/pull/36
- https://issues.jenkins.io/browse/JENKINS-41805

So we have to explicitly remove them ourselves.

Otherwise this happens:

<img width="1188" height="329" alt="image" src="https://github.com/user-attachments/assets/81bb6c21-763a-4a91-99c0-61974d1edcad" />