### PR TITLE
[CHERRY-PICK] fix(AccountSelectorHeader): set to purse emoji by default to fix squished height

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusLetterIdenticon.qml
@@ -37,7 +37,7 @@ Rectangle {
     radius: width / 2
 
     StatusEmoji {
-        visible: root.emoji
+        visible: !!root.emoji
         anchors.centerIn: parent
         width: Math.round(parent.width / 2)
         height: Math.round(parent.height / 2)

--- a/ui/imports/shared/controls/AccountSelectorHeader.qml
+++ b/ui/imports/shared/controls/AccountSelectorHeader.qml
@@ -34,13 +34,12 @@ AccountSelector {
         StatusSmartIdenticon {
             id: assetContent
             objectName: "assetContent"
-            asset.emoji: currentAccount.emoji ?? ""
+            asset.emoji: !!currentAccount.emoji ? currentAccount.emoji : "👛" // Default to purse emoji
             asset.color: d.headerStyleBackgroundColor
             asset.width: 32
             asset.height: asset.width
-            asset.isLetterIdenticon: !!currentAccount.emoji
+            asset.isLetterIdenticon: true
             asset.bgColor: Theme.palette.primaryColor3
-            visible: !!currentAccount.emoji
         }
 
         StatusBaseText {


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/19407

Fixes #19353

I couldn't reproduce the original issue, but I saw that with no selected emoji, the account selector was squished, hence hard to click. The easiest solution is to use a default emoji. The purse one makes sense, since there is no wallet emoji.
