### PR TITLE
fix: app doesn't close to tray when [x] is pressed

### DIFF
--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -142,7 +142,8 @@ int main(int argc, char *argv[])
     qInfo() << "Storybook started, Qt runtime version:" << qVersion()
             << "; built against version:" << QLibraryInfo::version().toString()
             << "installed in:" << QLibraryInfo::path(QLibraryInfo::PrefixPath)
-            << "; QQC style:" << QQuickStyle::name();
+            << "; QQC style:" << QQuickStyle::name()
+            << "; QPA:" << qApp->platformName();
 
     return QGuiApplication::exec();
 }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -78,6 +78,7 @@ StatusSectionLayout {
     property bool isKeycardEnabled: true
     property bool isBrowserEnabled: true
     required property bool privacyModeFeatureEnabled
+    required property bool minimizeOnCloseOptionVisible
 
     property var mutualContactsModel
     property var blockedContactsModel
@@ -461,6 +462,7 @@ StatusSectionLayout {
                 walletStore: root.walletStore
                 isFleetSelectionEnabled: fleetSelectionEnabled
                 isBrowserEnabled: root.isBrowserEnabled
+                minimizeOnCloseOptionVisible: root.minimizeOnCloseOptionVisible
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.advanced)
                 contentWidth: d.contentWidth
             }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -38,6 +38,7 @@ SettingsContentBase {
 
     property bool isFleetSelectionEnabled
     property bool isBrowserEnabled: true
+    property bool minimizeOnCloseOptionVisible
 
     Item {
         id: advancedContainer
@@ -73,7 +74,8 @@ SettingsContentBase {
 
             StatusSettingsLineButton {
                 width: parent.width
-                text: qsTr("Minimize on close")
+                visible: root.minimizeOnCloseOptionVisible
+                text: qsTr("Minimize to tray icon on close")
                 isSwitch: true
                 checked: !localAccountSensitiveSettings.quitOnClose
                 onToggled: localAccountSensitiveSettings.quitOnClose = !checked

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls // for Popup.xxx
 
 import StatusQ.Components
 import StatusQ.Controls
@@ -389,7 +390,7 @@ StatusDialog {
                 input.rightPadding: 16
                 input.tabNavItem: addressInput
 
-                onKeyPressed: {
+                onKeyPressed: event => {
                     d.submit(event)
                 }
             }

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -112,7 +112,7 @@ Rectangle {
                 removeAccountConfirmation.active = true
             }
 
-            onHideFromTotalBalanceClicked: {
+            onHideFromTotalBalanceClicked: function (hideFromTotalBalance) {
                 if (!account)
                     return
                 RootStore.updateWatchAccountHiddenFromTotalBalance(account.address, hideFromTotalBalance)
@@ -306,7 +306,7 @@ Rectangle {
                     errorMode: networkConnectionStore.accountBalanceNotAvailable
                     errorIcon.tooltip.maxWidth: 300
                     errorIcon.tooltip.text: networkConnectionStore.accountBalanceNotAvailableText
-                    onClicked: {
+                    onClicked: function(itemId, mouse) {
                         if (mouse.button === Qt.RightButton) {
                             walletAccountContextMenu.active = true
                             walletAccountContextMenu.item.account = model

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -139,6 +139,8 @@ Item {
 
     required property bool isCentralizedMetricsEnabled
 
+    required property bool systemTrayIconAvailable
+
     function showEnableBiometricsFlow() {
         popupRequestsHandler.enableBiometricsPopupHandler.openPopup()
     }
@@ -2135,6 +2137,7 @@ Item {
                         isKeycardEnabled: featureFlagsStore.keycardEnabled
                         isBrowserEnabled: featureFlagsStore.browserEnabled
                         privacyModeFeatureEnabled: featureFlagsStore.privacyModeFeatureEnabled
+                        minimizeOnCloseOptionVisible: appMain.systemTrayIconAvailable
 
                         theme: appMainLocalSettings.theme
                         fontSize: appMainLocalSettings.fontSize

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1195,7 +1195,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Minimize on close</source>
+        <source>Minimize to tray icon on close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7592,6 +7592,13 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -7801,6 +7808,56 @@ Please add it and try again.</source>
     <name>FleetsModal</name>
     <message>
         <source>Fleet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddressMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Already in saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddresses</name>
+    <message>
+        <source>Search for name, ENS or address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your EFP onchain friends will appear here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No following addresses found. Check spelling or whether the address is correct.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8896,6 +8953,10 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -10059,6 +10120,10 @@ access to your funds.</source>
     </message>
     <message>
         <source>Saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18523,6 +18588,21 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>%1 community assets are now visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletFollowingAddressesHeader</name>
+    <message>
+        <source>Add via EFP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Last refreshed %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1459,9 +1459,9 @@
       <translation>System</translation>
     </message>
     <message>
-      <source>Minimize on close</source>
+      <source>Minimize to tray icon on close</source>
       <comment>AdvancedView</comment>
-      <translation>Minimize on close</translation>
+      <translation>Minimize to tray icon on close</translation>
     </message>
     <message>
       <source>Mainnet data verified by Nimbus</source>
@@ -9273,6 +9273,14 @@
     </message>
   </context>
   <context>
+    <name>FeeRow</name>
+    <message>
+      <source>Max.</source>
+      <comment>FeeRow</comment>
+      <translation>Max.</translation>
+    </message>
+  </context>
+  <context>
     <name>FeesBox</name>
     <message>
       <source>Fees</source>
@@ -9528,6 +9536,67 @@
       <source>Fleet</source>
       <comment>FleetsModal</comment>
       <translation>Fleet</translation>
+    </message>
+  </context>
+  <context>
+    <name>FollowingAddressMenu</name>
+    <message>
+      <source>Address copied</source>
+      <comment>FollowingAddressMenu</comment>
+      <translation>Address copied</translation>
+    </message>
+    <message>
+      <source>Copy address</source>
+      <comment>FollowingAddressMenu</comment>
+      <translation>Copy address</translation>
+    </message>
+    <message>
+      <source>Show address QR</source>
+      <comment>FollowingAddressMenu</comment>
+      <translation>Show address QR</translation>
+    </message>
+    <message>
+      <source>View activity</source>
+      <comment>FollowingAddressMenu</comment>
+      <translation>View activity</translation>
+    </message>
+    <message>
+      <source>Already in saved addresses</source>
+      <comment>FollowingAddressMenu</comment>
+      <translation>Already in saved addresses</translation>
+    </message>
+    <message>
+      <source>Add to saved addresses</source>
+      <comment>FollowingAddressMenu</comment>
+      <translation>Add to saved addresses</translation>
+    </message>
+  </context>
+  <context>
+    <name>FollowingAddresses</name>
+    <message>
+      <source>Search for name, ENS or address</source>
+      <comment>FollowingAddresses</comment>
+      <translation>Search for name, ENS or address</translation>
+    </message>
+    <message>
+      <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+      <comment>FollowingAddresses</comment>
+      <translation>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</translation>
+    </message>
+    <message>
+      <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+      <comment>FollowingAddresses</comment>
+      <translation>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</translation>
+    </message>
+    <message>
+      <source>Your EFP onchain friends will appear here</source>
+      <comment>FollowingAddresses</comment>
+      <translation>Your EFP onchain friends will appear here</translation>
+    </message>
+    <message>
+      <source>No following addresses found. Check spelling or whether the address is correct.</source>
+      <comment>FollowingAddresses</comment>
+      <translation>No following addresses found. Check spelling or whether the address is correct.</translation>
     </message>
   </context>
   <context>
@@ -10851,6 +10920,11 @@
       <source>PIN correct</source>
       <comment>KeycardEnterPinPage</comment>
       <translation>PIN correct</translation>
+    </message>
+    <message>
+      <source>Keycard blocked</source>
+      <comment>KeycardEnterPinPage</comment>
+      <translation>Keycard blocked</translation>
     </message>
     <message numerus="yes">
       <source>%n attempt(s) remaining</source>
@@ -12262,6 +12336,11 @@
       <source>Saved addresses</source>
       <comment>LeftTabView</comment>
       <translation>Saved addresses</translation>
+    </message>
+    <message>
+      <source>EFP onchain friends</source>
+      <comment>LeftTabView</comment>
+      <translation>EFP onchain friends</translation>
     </message>
   </context>
   <context>
@@ -22527,6 +22606,24 @@
       <source>%1 community assets are now visible</source>
       <comment>WalletAssetsStore</comment>
       <translation>%1 community assets are now visible</translation>
+    </message>
+  </context>
+  <context>
+    <name>WalletFollowingAddressesHeader</name>
+    <message>
+      <source>Add via EFP</source>
+      <comment>WalletFollowingAddressesHeader</comment>
+      <translation>Add via EFP</translation>
+    </message>
+    <message>
+      <source>EFP onchain friends</source>
+      <comment>WalletFollowingAddressesHeader</comment>
+      <translation>EFP onchain friends</translation>
+    </message>
+    <message>
+      <source>Last refreshed %1</source>
+      <comment>WalletFollowingAddressesHeader</comment>
+      <translation>Last refreshed %1</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1198,7 +1198,7 @@
         <translation type="unfinished">Systémový</translation>
     </message>
     <message>
-        <source>Minimize on close</source>
+        <source>Minimize to tray icon on close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7619,6 +7619,13 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -7828,6 +7835,56 @@ Please add it and try again.</source>
     <name>FleetsModal</name>
     <message>
         <source>Fleet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddressMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Already in saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddresses</name>
+    <message>
+        <source>Search for name, ENS or address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your EFP onchain friends will appear here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No following addresses found. Check spelling or whether the address is correct.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8932,6 +8989,10 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -10100,6 +10161,10 @@ access to your funds.</source>
     <message>
         <source>Saved addresses</source>
         <translation>Uložené adresy</translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -18604,6 +18669,21 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>%1 community assets are now visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WalletFollowingAddressesHeader</name>
+    <message>
+        <source>Add via EFP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Last refreshed %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1195,8 +1195,8 @@
         <translation>Sistema</translation>
     </message>
     <message>
-        <source>Minimize on close</source>
-        <translation>Minimizar al cerrar</translation>
+        <source>Minimize to tray icon on close</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mainnet data verified by Nimbus</source>
@@ -7606,6 +7606,13 @@ Por favor, agrégala e intenta de nuevo.</translation>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -7816,6 +7823,56 @@ Por favor, agrégala e intenta de nuevo.</translation>
     <message>
         <source>Fleet</source>
         <translation>Fleet</translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddressMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished">Dirección copiada</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">Copiar dirección</translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View activity</source>
+        <translation type="unfinished">Ver actividad</translation>
+    </message>
+    <message>
+        <source>Already in saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddresses</name>
+    <message>
+        <source>Search for name, ENS or address</source>
+        <translation type="unfinished">Buscar por nombre, ENS o dirección</translation>
+    </message>
+    <message>
+        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished">Tu búsqueda es demasiado genial (usa solo A-Z y 0-9, un solo espacio en blanco, guiones y guiones bajos)</translation>
+    </message>
+    <message>
+        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished">Tu búsqueda contiene caracteres inválidos (usa solo A-Z y 0-9, un solo espacio en blanco, guiones y guiones bajos)</translation>
+    </message>
+    <message>
+        <source>Your EFP onchain friends will appear here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No following addresses found. Check spelling or whether the address is correct.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8912,6 +8969,10 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN correcto</translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
@@ -10076,6 +10137,10 @@ acceso a tus fondos.</translation>
     <message>
         <source>Saved addresses</source>
         <translation>Direcciones guardadas</translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -18561,6 +18626,21 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <message>
         <source>%1 community assets are now visible</source>
         <translation>%1 activos de comunidad ahora son visibles</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFollowingAddressesHeader</name>
+    <message>
+        <source>Add via EFP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Last refreshed %1</source>
+        <translation type="unfinished">Última actualización %1</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1192,8 +1192,8 @@
         <translation>시스템</translation>
     </message>
     <message>
-        <source>Minimize on close</source>
-        <translation>닫을 때 최소화</translation>
+        <source>Minimize to tray icon on close</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mainnet data verified by Nimbus</source>
@@ -7578,6 +7578,13 @@ Please add it and try again.</source>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -7788,6 +7795,56 @@ Please add it and try again.</source>
     <message>
         <source>Fleet</source>
         <translation>플릿</translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddressMenu</name>
+    <message>
+        <source>Address copied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation type="unfinished">주소 복사</translation>
+    </message>
+    <message>
+        <source>Show address QR</source>
+        <translation type="unfinished">주소 QR 표시</translation>
+    </message>
+    <message>
+        <source>View activity</source>
+        <translation type="unfinished">활동 보기</translation>
+    </message>
+    <message>
+        <source>Already in saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to saved addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FollowingAddresses</name>
+    <message>
+        <source>Search for name, ENS or address</source>
+        <translation type="unfinished">이름, ENS 또는 주소 검색</translation>
+    </message>
+    <message>
+        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished">검색어가 너무 쿨해요 (A-Z, 0-9, 공백 하나, 하이픈, 밑줄만 사용하세요)</translation>
+    </message>
+    <message>
+        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
+        <translation type="unfinished">검색어에 유효하지 않은 문자가 있습니다 (A-Z, 0-9, 단일 공백, 하이픈, 밑줄만 사용)</translation>
+    </message>
+    <message>
+        <source>Your EFP onchain friends will appear here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No following addresses found. Check spelling or whether the address is correct.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8878,6 +8935,10 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN이 올바릅니다</translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
+        <translation type="unfinished">Keycard가 차단됨</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
@@ -10056,6 +10117,10 @@ access to your funds.</source>
     <message>
         <source>Saved addresses</source>
         <translation>저장된 주소</translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -18499,6 +18564,21 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>%1 community assets are now visible</source>
         <translation>%1 커뮤니티 자산이 이제 표시됩니다</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFollowingAddressesHeader</name>
+    <message>
+        <source>Add via EFP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EFP onchain friends</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Last refreshed %1</source>
+        <translation type="unfinished">마지막 새로고침 %1</translation>
     </message>
 </context>
 <context>

--- a/ui/imports/shared/views/AssetsViewAdaptor.qml
+++ b/ui/imports/shared/views/AssetsViewAdaptor.qml
@@ -108,7 +108,7 @@ QObject {
 
             readonly property bool marketDetailsAvailable: !hasCommunityId
             readonly property bool marketDetailsLoading: model.detailsLoading
-            readonly property real marketPrice: marketDetails.currencyPrice.amount ?? 0
+            readonly property real marketPrice: marketDetails.currencyPrice?.amount ?? 0
             readonly property real marketChangePct24hour: marketDetails.changePct24hour ?? 0
 
             readonly property bool visible: {

--- a/ui/imports/shared/views/SyncingEnterCode.qml
+++ b/ui/imports/shared/views/SyncingEnterCode.qml
@@ -41,7 +41,7 @@ ColumnLayout {
             Layout.fillWidth: true
             Layout.leftMargin: Theme.padding
             Layout.rightMargin: Theme.padding
-            Layout.alignment: Qt.AlignHCent
+            Layout.alignment: Qt.AlignHCenter
             currentIndex: 0
 
             StatusSwitchTabButton {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -61,9 +61,9 @@ Window {
     // Both Android and iOS keyboard heights are in physical pixels and need devicePixelRatio conversion
     // iOS: Native code converts (nativePoints × nativeScale) to pixels for Qt to convert to its logical points
     // Android: WindowInsets provides pixels directly
-    property real keyboardHeight: SQUtils.Utils.isAndroid ? SystemUtils.androidKeyboardHeight / Screen.devicePixelRatio :
-                                    SQUtils.Utils.isIOS ? SystemUtils.iosKeyboardHeight / Screen.devicePixelRatio :
-                                    Qt.inputMethod.visible ? Qt.inputMethod.keyboardRectangle.height : 0
+    readonly property real keyboardHeight: SQUtils.Utils.isAndroid ? SystemUtils.androidKeyboardHeight / Screen.devicePixelRatio :
+                                                                     SQUtils.Utils.isIOS ? SystemUtils.iosKeyboardHeight / Screen.devicePixelRatio :
+                                                                                           Qt.inputMethod.visible ? Qt.inputMethod.keyboardRectangle.height : 0
     
     // Calculate additional margin so that total = max(nativeSafeAreaBottom, keyboardHeight)
     // When keyboard shows, we want the keyboard height to replace the native safe area, not add to it
@@ -90,7 +90,6 @@ Window {
         Qt.application.version = aboutModule.getCurrentVersion()
         return Qt.application.displayName
     }
-    visible: false
 
     flags: Qt.platform.os === SQUtils.Utils.windows ? Qt.Window // extending the content in title is buggy on Windows
               : Qt.ExpandedClientAreaHint | Qt.NoTitleBarBackgroundHint
@@ -106,7 +105,6 @@ Window {
         if (SQUtils.Utils.isAndroid) {
             SystemUtils.setAndroidSplashScreenReady()
         }
-        applicationWindow.visible = true
     }
 
     function restoreAppState() {
@@ -132,8 +130,8 @@ Window {
 
             geometry = Qt.rect(0,
                                0,
-                               Math.min(Screen.desktopAvailableWidth - 125, 1400),
-                               Math.min(Screen.desktopAvailableHeight - 125, 840));
+                               Math.min(Screen.desktopAvailableWidth - 125, Theme.portraitBreakpoint.width),
+                               Math.min(Screen.desktopAvailableHeight - 125, Theme.portraitBreakpoint.height));
             geometry.x = (screen.width - geometry.width) / 2;
             geometry.y = (screen.height - geometry.height) / 2;
         }
@@ -167,9 +165,7 @@ Window {
         }
     }
 
-    onWidthChanged: {
-        Qt.callLater(storeAppState)
-    }
+    onWidthChanged: Qt.callLater(storeAppState)
     onHeightChanged: Qt.callLater(storeAppState)
 
     QtObject {
@@ -307,10 +303,14 @@ Window {
             }
         }
         function onClosing(close) {
-            // In case of android, we need to handle moveTaskToBackground explicitly
-            if (SQUtils.Utils.isAndroid) {
+            // on mobile, we minimize to background (no tray icon or quitOnClose setting)
+            if (SQUtils.Utils.isMobile) {
                 close.accepted = false
-                SystemUtils.androidMinimizeToBackground()
+                // In case of android, we need to handle moveTaskToBackground explicitly
+                if (SQUtils.Utils.isAndroid)
+                    SystemUtils.androidMinimizeToBackground()
+                else
+                    applicationWindow.showMinimized()
             // In case not logged in or loading, quit app
             } else if (loader.sourceComponent != app) {
                 close.accepted = true
@@ -320,23 +320,34 @@ Window {
                 close.accepted = true
             }
             else {
-                // The app is already minimized. The user really wants to quit the app
+                // The window is already hidden or minimized.
                 // The user really wants to quit the app
-                if (applicationWindow.visibility === Window.Minimized) {
+                if (applicationWindow.visibility === Window.Minimized || applicationWindow.visibility === Window.Hidden) {
                     close.accepted = true
                     return
                 }
 
-                close.accepted = false
-                /* In case of mac in fullscreen mode, hiding the window leads to black screen.
-                Hence we exit Fullscreen on system close and then the user can perform an actual
-                hide of the app */
-                if(applicationWindow.visibility === Window.FullScreen &&
-                        Qt.platform.os === SQUtils.Utils.mac) {
-                    applicationWindow.showNormal()
+                // special handling for macOS
+                if(Qt.platform.os === SQUtils.Utils.mac) {
+                    /* In case of mac in fullscreen mode, hiding the window leads to black screen.
+                    Hence we exit Fullscreen on system close and then the user can perform an actual
+                    hide of the app */
+                    close.accepted = false
+                    if (applicationWindow.visibility === Window.FullScreen)
+                        applicationWindow.showNormal()
+                    else
+                        applicationWindow.showMinimized()
                     return
                 }
-                applicationWindow.showMinimized()
+
+                // hide the window into the tray, if available; quit otherwise
+                if (systemTray.available) {
+                    close.accepted = false
+                    // WRN 2025-11-26 <snip> file=qrc:/main.qml:26 text="QML QQuickWindowQmlImpl*: Conflicting properties 'visible' and 'visibility'"
+                    applicationWindow.visibility = Window.Hidden
+                } else {
+                    close.accepted = true
+                }
             }
         }
     }
@@ -374,7 +385,7 @@ Window {
 
     Component.onCompleted: {
         
-        console.info(">>> %1 %2 started, using Qt version %3".arg(Qt.application.name).arg(Qt.application.version).arg(SystemUtils.qtRuntimeVersion()))
+        console.info(">>> %1 %2 started, using Qt version %3, QPA: %4".arg(Application.name).arg(Application.version).arg(SystemUtils.qtRuntimeVersion()).arg(Qt.platform.pluginName))
 
         if (languageStore.currentLanguage === "") { // if we haven't configured the language yet...
             // ...and we have a translation for it
@@ -482,6 +493,8 @@ Window {
 
             visible: !startupOnboardingLoader.active
             isCentralizedMetricsEnabled: metricsStore.isCentralizedMetricsEnabled
+
+            systemTrayIconAvailable: systemTray.available
 
             keychain: appKeychain
             Component.onCompleted: {


### PR DESCRIPTION
### What does the PR do

- hide the window instead of minimizing (except when on macOS or mobile)
- hide the advanced "Minimize to tray icon on close" option on mobile, also making the copy explicitly mention the "tray icon"
- fix some runtime warnings
- run `make update-translations`

Fixes #19364

### Affected areas

AppMain/Settings

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1064" height="470" alt="image" src="https://github.com/user-attachments/assets/eeff27cf-8410-4242-8174-25a6eb608064" />

### Impact on end user

Consistent close window behavior

### How to test

- close the window using the [x] window deco button
- quit the app using "Ctrl+Q" kbd shortcut

### Risk 

- mid (needs testing and some e2e tests)
