### PR TITLE
fix(StatusMessageEmojiReactions): update corner shape and bg color

### DIFF
--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -314,3 +314,4 @@ SplitView {
 
 // category: Components
 // status: good
+// https://www.figma.com/design/SGyfSjxs5EbzimHDXTlj8B/Qt-Responsive---v?node-id=3232-99870&t=Is21W638A25DzExb-0

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
@@ -50,8 +50,6 @@ Flow {
             id: reactionDelegate
 
             size: StatusBaseButton.Size.Small
-            implicitHeight: 32
-
             verticalPadding: Theme.halfPadding / 2
             leftPadding: Theme.halfPadding
             rightPadding: Theme.halfPadding / 2
@@ -59,7 +57,11 @@ Flow {
 
             background: Rectangle {
                 implicitWidth: 36
-                radius: Theme.radius
+                implicitHeight: 32
+                topLeftRadius: 0
+                topRightRadius: 12
+                bottomLeftRadius: 12
+                bottomRightRadius: 12
                 color: {
                     if (reactionDelegate.hovered) {
                         return Theme.palette.statusMessage.emojiReactionBackgroundHovered

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -169,9 +169,9 @@ ThemePalette {
     }
 
     statusMessage: QtObject {
-        property color emojiReactionBackground: "#2d2823"
-        property color emojiReactionBackgroundHovered: "#3d352e"
-        property color emojiReactionBorderHovered: baseColor3
+        property color emojiReactionBackground: baseColor4
+        property color emojiReactionBackgroundHovered: primaryColor3
+        property color emojiReactionBorderHovered: primaryColor2
     }
 
     customisationColors: QtObject {

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -169,9 +169,9 @@ ThemePalette {
     }
 
     statusMessage: QtObject {
-        property color emojiReactionBackground: "#e2e6e9"
-        property color emojiReactionBackgroundHovered: "#E7EAEE"
-        property color emojiReactionBorderHovered: "#A1ABBD"
+        property color emojiReactionBackground: baseColor4
+        property color emojiReactionBackgroundHovered: primaryColor2
+        property color emojiReactionBorderHovered: primaryColor3
     }
 
     customisationColors: QtObject {


### PR DESCRIPTION
### What does the PR do

- align with latest Figma designs

Fixes #19327

### Affected areas

StatusMessage

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Light mode:
<img width="2342" height="2092" alt="image" src="https://github.com/user-attachments/assets/c0ab85d2-37a9-4b09-990b-32eeb7497d7d" />

Dark mode:
<img width="2342" height="2092" alt="image" src="https://github.com/user-attachments/assets/146ec473-c8d4-45d3-a94b-a007f0b28004" />


### Impact on end user

Nicer emoji reactions UI
