### PR TITLE
InlineSelectorPanel: behavior fixes for mobile

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -254,6 +254,8 @@ ColumnLayout {
 
                         property bool pasteOperation: false
 
+                        inputMethodHints: Qt.ImhSensitiveData | Qt.ImhNoPredictiveText
+
                         width: Math.max(Math.min(implicitWidth, membersFlick.width + 2 * Theme.padding),
                                         2 * Theme.smallPadding)
                         height: 30
@@ -327,6 +329,7 @@ ColumnLayout {
             propagateComposedEvents: true
             onPressed: {
                 edit.forceActiveFocus()
+                InputMethod.show()
                 mouse.accepted = false
             }
         }


### PR DESCRIPTION
### What does the PR do

- easy re-invoking keyboard by clicking on any place within the selector
- search working on any device by disabling predictive input

Closes: #19063


### Affected areas
`InlineSelectorPanel`


### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/59f9f967-43a5-472b-8c2e-a5cf6683d48e" />
