### PR TITLE
StatusChatInput: commit preedit text before inserting emoji

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -334,6 +334,9 @@ Rectangle {
         target: emojiPopup
 
         function onEmojiSelected(text: string, atCursor: bool) {
+            // commit any potential preedit text first
+            InputMethod.commit()
+
             insertInTextInput(atCursor ? messageInputField.cursorPosition : messageInputField.length, text)
             emojiBtn.highlighted = false
             messageInputField.forceActiveFocus();


### PR DESCRIPTION
### What does the PR do

This PR eliminates unexpected behavior when inserting emoji in chat input when there is not committed preedit text.

Closes: #19450

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusChatInput`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/f5852eb9-6620-4720-ac63-5fac5a587f8f

