### PR TITLE
StatusLabeledSlider: slider and bullet points aligned

### DIFF
--- a/storybook/pages/StatusLabeledSliderPage.qml
+++ b/storybook/pages/StatusLabeledSliderPage.qml
@@ -1,0 +1,27 @@
+import QtQuick
+
+import StatusQ.Controls
+
+Item {
+    StatusLabeledSlider {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.margins: 20
+
+        textRole: "name"
+        valueRole: "value"
+
+        model: ListModel {
+            ListElement { name: qsTr("XS"); value: 1 }
+            ListElement { name: qsTr("S"); value: 2 }
+            ListElement { name: qsTr("M"); value: 3 }
+            ListElement { name: qsTr("L"); value: 4 }
+            ListElement { name: qsTr("XL"); value: 5 }
+            ListElement { name: qsTr("XXL"); value: 6 }
+        }
+    }
+}
+
+// category: Controls
+// status: good

--- a/ui/StatusQ/src/StatusQ/Controls/StatusLabeledSlider.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusLabeledSlider.qml
@@ -40,7 +40,7 @@ StatusSlider {
             model: root.model
 
             Rectangle {
-                x: (background.width - width * 0.5) / (repeater.count - 1) * index
+                x: (parent.width) / (repeater.count - 1) * index - width * 0.5
                 y: (root.bgHeight -height) / 2
                 implicitWidth: root.handleSize
                 implicitHeight: root.handleSize

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSlider.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSlider.qml
@@ -2,9 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Effects
 
-import StatusQ.Core
 import StatusQ.Core.Theme
-import StatusQ.Controls
 
 /*!
   /note beware, the slider processes the mouse events only in its control space. So it must be at least as high
@@ -27,36 +25,37 @@ Slider {
 
     horizontalPadding: 0
 
-    background: Rectangle {
-        id: bgRect
-
-        x: root.leftPadding
-        anchors.verticalCenter: root.verticalCenter
-
-        implicitWidth: 100
-        implicitHeight: bgHeight
-        width: root.availableWidth
-        height: implicitHeight
-        color: root.bgColor
-        radius: 2
-
-        Loader {
-            id: decorationContainer
-            anchors.top: parent.top
-            width: parent.height
-        }
-
+    background: Item {
         Rectangle {
-            width: root.visualPosition * parent.width
-            height: parent.height
-            color: root.fillColor
+            id: bgRect
+
+            anchors.verticalCenter: parent.verticalCenter
+
+            x: root.handle.width / 2
+            width: parent.width - root.handle.width
+            height: root.bgHeight
+
+            color: root.bgColor
             radius: 2
+
+            Loader {
+                id: decorationContainer
+                anchors.top: parent.top
+                width: parent.width
+            }
+
+            Rectangle {
+                width: root.visualPosition * parent.width
+                height: parent.height
+                color: root.fillColor
+                radius: 2
+            }
         }
-    } // background
+    }
 
     handle: Rectangle {
         x: root.leftPadding + root.visualPosition * (root.availableWidth - width)
-        anchors.verticalCenter: bgRect.verticalCenter
+        anchors.verticalCenter: parent.verticalCenter
         color: root.handleColor
         implicitWidth: root.handleSize
         implicitHeight: root.handleSize


### PR DESCRIPTION


### What does the PR do

- fixes `StatusLabeledSlider` - no misalignment between bullet points and indicator
- storybook page added

Closes: #19481

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusLabeledSlider`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="609" height="293" alt="Screenshot from 2025-12-04 00-52-27" src="https://github.com/user-attachments/assets/aca03679-1ae6-44db-8125-e3924d1167e6" />
