### PR TITLE
fix(StatusMenu): display shortcuts in native format

### DIFF
--- a/ui/StatusQ/src/stringutilsinternal.cpp
+++ b/ui/StatusQ/src/stringutilsinternal.cpp
@@ -64,5 +64,5 @@ QString StringUtilsInternal::shortcutToText(const QVariant &shortcut)
 
     if (seq.isEmpty())
         return {};
-    return seq.toString();
+    return seq.toString(QKeySequence::NativeText);
 }


### PR DESCRIPTION
Backport of https://github.com/status-im/status-desktop/pull/19486 to 2.36

### What does the PR do

- translates kbd shortcut labels on macOS (Ctrl->Cmd, etc)

Fixes #19480

### Affected areas

StatusMenu/StatusAction

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Linux:
<img width="2944" height="1800" alt="Snímek obrazovky z 2025-12-04 00-21-14" src="https://github.com/user-attachments/assets/c391bc11-1744-4e95-8490-4fd59dfac5b5" />

macOS:
<img width="556" height="858" alt="image" src="https://github.com/user-attachments/assets/3687524a-2158-45d3-ac0b-e33787c36459" />

Windows:
<img width="2433" height="980" alt="image" src="https://github.com/user-attachments/assets/f09649ee-3cac-4bcf-9c4e-5cd66fead7a7" />

### Impact on end user

Nicer UX on macOS

### How to test

- open Browser section
- check the "..." menu and the shortcuts

### Risk 

low
