### PR TITLE
fix(app_search): update ctrl+k menu when chat color changes or is left

### DIFF
--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -64,6 +64,10 @@ proc init*(self: Controller) =
     var args = ChatUpdateArgs(e)
     self.delegate.updateChatItems(args.chats)
 
+  self.events.on(SIGNAL_COMMUNITY_CHANNEL_EDITED) do(e: Args):
+    let args = CommunityChatArgs(e)
+    self.delegate.updateChatItems(@[args.chat])
+
   self.events.on(SIGNAL_CONTACT_UPDATED) do(e: Args):
     let args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
@@ -83,6 +87,10 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_COMMUNITY_CHANNEL_DELETED) do(e:Args):
     let args = CommunityChatIdArgs(e)
+    self.delegate.chatRemoved(args.chatId)
+
+  self.events.on(SIGNAL_CHAT_LEFT) do(e:Args):
+    let args = ChatArgs(e)
     self.delegate.chatRemoved(args.chatId)
 
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):


### PR DESCRIPTION
Fixes #18630 and #18631

[ctrl-k-menu-fix.webm](https://github.com/user-attachments/assets/fc78a0f9-5fb7-4aed-b74b-9c83aec9954a)

There is a small bug where the list items have the wrong background on first open. Not sure why, but probably because of the Theme change. I'll open a new issue