### PR TITLE
Bugfix/12746 Node management window is not scrollable

### DIFF
--- a/src/backend/shared_urls.nim
+++ b/src/backend/shared_urls.nim
@@ -11,16 +11,10 @@ proc shareCommunityUrlWithData*(communityId: string): RpcResponse[JsonNode] =
   return callPrivateRPC("shareCommunityURLWithData".prefix, %*[communityId])
 
 proc shareCommunityChannelUrlWithChatKey*(communityId: string, channelId: string): RpcResponse[JsonNode] =
-  return callPrivateRPC("shareCommunityChannelURLWithChatKey".prefix, %*[{
-    "communityId": communityId,
-    "channelId": channelId
-  }])
+  return callPrivateRPC("shareCommunityChannelURLWithChatKey".prefix, %*[communityId, channelId])
 
 proc shareCommunityChannelUrlWithData*(communityId: string, channelId: string): RpcResponse[JsonNode] =
-  return callPrivateRPC("shareCommunityChannelURLWithData".prefix, %*[{
-    "communityId": communityId,
-    "channelId": channelId
-  }])
+  return callPrivateRPC("shareCommunityChannelURLWithData".prefix, %*[communityId, channelId])
 
 proc shareUserUrlWithData*(pubkey: string): RpcResponse[JsonNode] =
   result = callPrivateRPC("shareUserURLWithData".prefix, %*[pubkey])


### PR DESCRIPTION
### What does the PR do

In Node management the fields Mailserver interactions, Logs, and JSON-RPC will resize to the available space in the window, keeping roughly 1/3 of the space for themselves.

Fixes https://github.com/status-im/status-desktop/issues/12746

### Affected areas

Node management

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

![fix12746](https://github.com/user-attachments/assets/72945f10-b018-4982-84de-bb0ba19a14c6)

### Impact on end user

Before: If the window was small, the user didn't see all the fields
After: If the window is small, the fields will shrink/grow to the available space in the window.

### How to test

1. Select Node Management in the left pane.
2. Resize the window such that its vertical dimension is low.
3. Follow resize of the fields, on smallest size of the window all fields must be visible.

### Risk 

Cosmetic changes. Minimal risk.
