### PR TITLE
chore: rename status-desktop to status-app

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,24 +3,39 @@
 
 This guide provides step-by-step instructions to build Status Desktop from source on **Windows**, **Linux**, and **macOS**.
 
+If you're looking for instructions to build Status Mobile instead, go [here](/mobile/README.md).
 
 ## 📑 Table of Contents
 
-- [1️⃣ Prerequisites](#1️⃣-prerequisites)
-  - [Windows](#windows)
-  - [Linux](#linux)
-    - [Ubuntu](#ubuntu)
-    - [Fedora](#fedora)
-  - [macOS](#macos)
-- [2️⃣ Install Qt](#2️⃣-install-qt)
-  - [Windows & Linux](#windows--linux)
-  - [Linux (Alternative)](#linux-alternative)
-- [3️⃣ Configure Environment](#3️⃣-configure-environment)
-  - [Windows](#windows-1)
-  - [Linux](#linux-1)
-- [4️⃣ Build the App](#4️⃣-build-the-app)
-- [🐞 Troubleshooting](#-troubleshooting)
-- [📬 Need Further Help?](#-need-further-help)
+- [🛠️ Status Desktop Build Guide](#️-status-desktop-build-guide)
+  - [📑 Table of Contents](#-table-of-contents)
+  - [1️⃣ Prerequisites](#1️⃣-prerequisites)
+    - [Windows](#windows)
+      - [Install Chocolatey](#install-chocolatey)
+      - [Install Required Packages](#install-required-packages)
+      - [Install Go 1.24](#install-go-124)
+    - [Linux](#linux)
+      - [Ubuntu](#ubuntu)
+      - [Fedora](#fedora)
+    - [macOS](#macos)
+      - [Install Homebrew](#install-homebrew)
+      - [Install Required Packages](#install-required-packages-1)
+      - [Export GITHUB\_USER and GITHUB\_TOKEN environment variables](#export-github_user-and-github_token-environment-variables)
+      - [Install Node.js](#install-nodejs)
+      - [Install Python Dependencies](#install-python-dependencies)
+  - [2️⃣ Install Qt](#2️⃣-install-qt)
+    - [Windows \& Linux](#windows--linux)
+    - [Linux (Alternative)](#linux-alternative)
+      - [Ubuntu](#ubuntu-1)
+      - [Fedora](#fedora-1)
+  - [3️⃣ Configure Environment](#3️⃣-configure-environment)
+    - [Windows](#windows-1)
+    - [Linux](#linux-1)
+  - [4️⃣ Build the App](#4️⃣-build-the-app)
+  - [🐞 Troubleshooting](#-troubleshooting)
+    - [Qt Not Found](#qt-not-found)
+    - [Application doesn't build](#application-doesnt-build)
+  - [📬 Need Further Help?](#-need-further-help)
 
 ## 1️⃣ Prerequisites
 
@@ -249,7 +264,7 @@ export PATH="${QTDIR}/bin:${PATH}"
 Clone the repository:
 
 ```bash
-git clone https://github.com/status-im/status-desktop.git
+git clone https://github.com/status-im/status-app.git
 cd status-desktop
 ```
 
@@ -304,5 +319,5 @@ make run V=1
 If you get stuck or something doesn't work:
 
 - Ask in `#feedback-desktop` channel on [Status](https://status.app/cc/G-EAAORobqgnsUPSVCLaSJr855iXTIdQiY1Q0ckBe8dWWEBpUAs9s8DTjWEpvsmpE83Izx1JWQuZrWWKUoxiXCwdtB-wPBzyvv_n9a0F61xTaPZE7BEJDC7Ly_WcmQ4tHRAKnPfXE_JUtEX_3NhnXQN0eh4ue0D77dWvaDpDrSi0U0CaGLZ-pqD_iV0z9RMFE2LKulDZdwL40etJ8lxjyTFoxS0lUhdWKinIOk8qBmJJpCmsqMrSklEU#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9)
-- Open an [issue on GitHub](https://github.com/status-im/status-desktop/issues)
+- Open an [issue on GitHub](https://github.com/status-im/status-app/issues/new/choose)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,31 @@
-# Contributing to Status Desktop
+# Contributing to the Status App
 
 ## Table of Contents
-- [🛠️ Developing](#️-developing)
-- [🪲 Desktop Status App Community Testing](#-desktop-status-app-community-testing)
-  - [Important Backup Information](#1-important)
-  - [Download the Release Candidate Build](#2-download-the-release-candidate-build)
-  - [Install the Release Candidate](#3-install-the-release-candidate)
-  - [Create a Test Profile First](#4-create-a-test-profile-first)
-  - [Test Regular Usage Flows](#5-test-regular-usage-flows)
-  - [Collaborate on Testing](#6-collaborate-on-testing-release-candidates)
-  - [Reporting Bugs](#7-reporting-bugs)
-  - [Recovering Your Real Status Account](#8-recovering-your-real-status-account)
+- [Contributing to the Status App](#contributing-to-the-status-app)
+  - [Table of Contents](#table-of-contents)
+  - [🛠️ Developing](#️-developing)
+  - [🪲 Status App Community Testing](#-status-app-community-testing)
+    - [Disclaimer](#disclaimer)
+    - [**🛠️ Testing Instructions for Status Release Candidate Build**](#️-testing-instructions-for-status-release-candidate-build)
+      - [1. Important!](#1-important)
+      - [2. Download the Release Candidate Build](#2-download-the-release-candidate-build)
+      - [3. Install the Release Candidate](#3-install-the-release-candidate)
+      - [4. Create a Test Profile First](#4-create-a-test-profile-first)
+      - [5. Test Regular Usage Flows](#5-test-regular-usage-flows)
+      - [6. Collaborate on Testing Release Candidates:](#6-collaborate-on-testing-release-candidates)
+      - [7. Reporting Bugs](#7-reporting-bugs)
+      - [8. Recovering Your Real Status Account](#8-recovering-your-real-status-account)
 
 ## 🛠️ Developing
 
-- [Building from Source](BUILDING.md)
+- [Building Desktop from Source](BUILDING.md)
+- [Building Mobile from Source](/mobile/README.md)
 - Check our [Architecture Docs](docs/architecture.md).
 - Read our [QML Architecture Guidelines](guidelines/QML_ARCHITECTURE_GUIDE.md).
-- Check out [good first issues](https://github.com/status-im/status-desktop/contribute) to get involved.
-- Join the [#feedback-desktop](https://status.app/cc/G-EAAORobqgnsUPSVCLaSJr855iXTIdQiY1Q0ckBe8dWWEBpUAs9s8DTjWEpvsmpE83Izx1JWQuZrWWKUoxiXCwdtB-wPBzyvv_n9a0F61xTaPZE7BEJDC7Ly_WcmQ4tHRAKnPfXE_JUtEX_3NhnXQN0eh4ue0D77dWvaDpDrSi0U0CaGLZ-pqD_iV0z9RMFE2LKulDZdwL40etJ8lxjyTFoxS0lUhdWKinIOk8qBmJJpCmsqMrSklEU#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) channel on Status.
+- Check out [good first issues](https://github.com/status-im/status-app/contribute) to get involved.
+- Join the [#feedback-desktop](https://status.app/cc/G-EAAORobqgnsUPSVCLaSJr855iXTIdQiY1Q0ckBe8dWWEBpUAs9s8DTjWEpvsmpE83Izx1JWQuZrWWKUoxiXCwdtB-wPBzyvv_n9a0F61xTaPZE7BEJDC7Ly_WcmQ4tHRAKnPfXE_JUtEX_3NhnXQN0eh4ue0D77dWvaDpDrSi0U0CaGLZ-pqD_iV0z9RMFE2LKulDZdwL40etJ8lxjyTFoxS0lUhdWKinIOk8qBmJJpCmsqMrSklEU#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) and [#feedback-mobile](https://status.app/cc/G-EAAOTgmsumqFvQZ-DSRkmf6xZuG-jQBrqnB6ytivISS1qeYURpfrzeMMePtpp7Inw_qy_cLdpZLJNUgOmfMHIZ4n2zSTr-n9u34C4yZa7c4JGLz9U6GIfjPqa0J0Ng2GC_Pu76QxgM-1v0z8V0PxxAf3fdHNbQXy-vfqWhK2iF0E6AaaJMh3sCmp_YpfFwR0DPmDIORPwdI_5ot4VZpkSb9FCkBwJO0xKNc5zI4oYpjfAhZVAyNWIHJs0D#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) channels on Status.
 
-## 🪲 Desktop Status App Community Testing
+## 🪲 Status App Community Testing
 
 ### Disclaimer
 
@@ -39,10 +44,10 @@ If you plan to test using your **existing/real** Status profile, **make sure you
 #### 2. Download the Release Candidate Build
 
 Get the latest release candidate build (look for versions with “**<code>-rc"</code>** in the name) from: \
- 👉[ https://github.com/status-im/status-desktop/releases](https://github.com/status-im/status-desktop/releases).
+ 👉[https://github.com/status-im/status-app/releases](https://github.com/status-im/status-app/releases).
  
 Refer to the table below to see which file you should use for your operating system.
-* **Known issues:** users on **macOS with Intel chips** should **NOT** upgrade to version v2.33 or higher to test release candidate builds due to a critical bug causing app crashes (more details: [#15730](https://github.com/status-im/status-desktop/issues/15730)).
+* **Known issues:** users on **macOS with Intel chips** should **NOT** upgrade to version v2.33 or higher to test release candidate builds due to a critical bug causing app crashes (more details: [#15730](https://github.com/status-im/status-app/issues/15730)).
 
 <table>
   <tr>
@@ -90,7 +95,7 @@ Refer to the table below to see which file you should use for your operating sys
 
 Follow the [instructions here](README.md#-download--install) to know how to install. 
 
-The test build will be installed **over your current Desktop Status App**, replacing the existing installation. 
+The test build will be installed **over your current Status App**, replacing the existing installation. 
 
     ⚠️ Note: upgrading to a Release Candidate (RC) build may damage your current app state or cause unexpected behavior. Please note that while restoring your profile using a Recovery Phrase will recover all your wallets and funds (i.e. your funds will not be affected), some user data may not be recovered. Proceed with caution and ensure you read the disclaimer above before installing.
 
@@ -122,17 +127,16 @@ Use the app as you normally would.
 
 #### 6. Collaborate on Testing Release Candidates:
 
-If you have questions, need more information, or want to stay in the loop and collaborate on Release Candidate testing, please use the [#feedback-desktop channel](https://status.app/cc/G-EAAORqbagnsUXSq0S0kTT5vWNeMtMJlRbohIpODtg7tsICSoNa6JkFnm4MS_FNTp1oRn7uSMpayGwtU5RiFONi6aD9gOXhkPf9369PLVjnmkKzJ2KPSGBwWV6u58x0aOmAUOC8v56Qp6It-ufGPusaoNPzcNkD2m-vfkXTGWpFoZ0C0sSw9TMF_U_smqmfKJgQU9aFyn4TwI9eT5LnGkuOQStuKZG6sFJJQdZ5UjEQSyJNYUVVlpaMogA=#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9 ) in the Status App.
+If you have questions, need more information, or want to stay in the loop and collaborate on Release Candidate testing, please use the [#feedback-desktop](https://status.app/cc/G-EAAORqbagnsUXSq0S0kTT5vWNeMtMJlRbohIpODtg7tsICSoNa6JkFnm4MS_FNTp1oRn7uSMpayGwtU5RiFONi6aD9gOXhkPf9369PLVjnmkKzJ2KPSGBwWV6u58x0aOmAUOC8v56Qp6It-ufGPusaoNPzcNkD2m-vfkXTGWpFoZ0C0sSw9TMF_U_smqmfKJgQU9aFyn4TwI9eT5LnGkuOQStuKZG6sFJJQdZ5UjEQSyJNYUVVlpaMogA=#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) and [#feedback-mobile](https://status.app/cc/G-EAAOTgmsumqFvQZ-DSRkmf6xZuG-jQBrqnB6ytivISS1qeYURpfrzeMMePtpp7Inw_qy_cLdpZLJNUgOmfMHIZ4n2zSTr-n9u34C4yZa7c4JGLz9U6GIfjPqa0J0Ng2GC_Pu76QxgM-1v0z8V0PxxAf3fdHNbQXy-vfqWhK2iF0E6AaaJMh3sCmp_YpfFwR0DPmDIORPwdI_5ot4VZpkSb9FCkBwJO0xKNc5zI4oYpjfAhZVAyNWIHJs0D#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) channels in the Status App.
 
 #### 7. Reporting Bugs
 
 If you encounter what seems to be a bug:
 
   * First, **search** the GitHub issues page to check if it's already reported: \
-🔎[ https://github.com/status-im/status-desktop/issues \
-](https://github.com/status-im/status-desktop/issues)
+🔎 [https://github.com/status-im/status-app/issues](https://github.com/status-im/status-app/issues)
   * If it’s not listed, please **open a new issue** using the bug report template: \
-🐛[ https://github.com/status-im/status-desktop/issues/new?template=bug.md](https://github.com/status-im/status-desktop/issues/new?template=bug.md)
+🐛 [https://github.com/status-im/status-app/issues/new?template=bug.md](https://github.com/status-im/status-app/issues/new?template=bug.md)
       * To help us further, provide the logs from the app along with the issue
       * You can find the logs in the following locations (get the latest one):
           * Windows: `%LOCALAPPDATA%\Status\logs` 
@@ -145,6 +149,5 @@ If you encounter an irrecoverable issue while testing with your real Status prof
 
 * **Delete the app data folder** or **fully uninstall the app** (recommended if you're unsure how to delete the app data folder manually).
 * **Reinstall** the app from the latest official release: \
- 👉[ https://github.com/status-im/status-desktop/releases \
-](https://github.com/status-im/status-desktop/releases)
+ 👉 [https://github.com/status-im/status-app/releases](https://github.com/status-im/status-app/releases)
 * **Launch** the app, select **“Recover profile”**, and use the **recovery phrase** you backed up in Step 1.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,38 @@
 <div align="center">
     <img src="status.png" alt="status logo" width="200" />
 
-[![Download](https://img.shields.io/github/v/release/status-im/status-desktop?label=Download)](https://github.com/status-im/status-desktop/releases/latest)
+[![Download](https://img.shields.io/github/v/release/status-im/status-app?label=Download)](https://github.com/status-im/status-app/releases/latest)
 
 </div>
 
-# Status Desktop
+# Status App
 
-[**Status**](https://status.app/) Desktop is a privacy-first, decentralised messenger built with [Nim](https://nim-lang.org/) and [Qt/QML](https://doc.qt.io/qt-5/qmlapplications.html). It offers end-to-end encrypted messaging, community chats, and Ethereum wallet integration — all without requiring a phone number or email.
+The [**Status App**](https://status.app/) is a privacy-first, decentralised messenger built with [Nim](https://nim-lang.org/) and [Qt/QML](https://doc.qt.io/qt-5/qmlapplications.html). It offers end-to-end encrypted messaging, community chats, and Ethereum wallet integration — all without requiring a phone number or email.
 
 ![Status Desktop Screenshot](screenshot.png)
 
 
 ## 📑 Table of Contents
 
-- [🚀 Download & Install](#-download--install)
-  - [macOS](#macos)
-  - [Windows](#windows)
-  - [Linux](#linux)
-- [🛠️ Build from Source](#%EF%B8%8F-build-from-source)
-- [📱 Build for Mobile](mobile/README.md)
-- [🤝 Contributing](#-contributing)
-- [📚 Documentation](#-documentation)
+- [Status App](#status-app)
+  - [📑 Table of Contents](#-table-of-contents)
+  - [🚀 Download \& Install](#-download--install)
+    - [Supported Versions](#supported-versions)
+    - [Windows](#windows)
+    - [Linux](#linux)
+    - [macOS](#macos)
+  - [🛠️ Build from Source](#️-build-from-source)
+    - [Building Mobile](#building-mobile)
+  - [🤝 Contributing](#-contributing)
+  - [📚 Documentation](#-documentation)
 
 ## 🚀 Download & Install
 
 Get the latest release for your platform:
 
-- **Windows**: [Download EXE](https://github.com/status-im/status-desktop/releases/latest)
-- **Linux**: [Download Tarball](https://github.com/status-im/status-desktop/releases/latest)
-- **macOS**: [Download DMG](https://github.com/status-im/status-desktop/releases/latest)
+- **Windows**: [Download EXE](https://github.com/status-im/status-app/releases/latest)
+- **Linux**: [Download Tarball](https://github.com/status-im/status-app/releases/latest)
+- **macOS**: [Download DMG](https://github.com/status-im/status-app/releases/latest)
 
 ### Supported Versions
 
@@ -41,13 +44,13 @@ Get the latest release for your platform:
 
 ### Windows
 
-1. [Download](https://github.com/status-im/status-desktop/releases/latest) the `.exe` file.
+1. [Download](https://github.com/status-im/status-app/releases/latest) the `.exe` file.
 2. Run the `.exe` installer.
 3. Launch the installed app 🎉
 
 ### Linux
 
-1. [Download](https://github.com/status-im/status-desktop/releases/latest) the `.tar.gz` file.
+1. [Download](https://github.com/status-im/status-app/releases/latest) the `.tar.gz` file.
 2. Extract the tarball file (replace `*` with the version)
     ```shell
     cd ~/Downloads
@@ -58,14 +61,21 @@ Get the latest release for your platform:
 
 ### macOS
 
-1. [Download](https://github.com/status-im/status-desktop/releases/latest) the `.dmg` file.
+1. [Download](https://github.com/status-im/status-app/releases/latest) the `.dmg` file.
 2. Open it and drag `Status.app` to the Applications folder.
 3. Open the Applications folder and double-click the Status icon 🎉
 
 
 ## 🛠️ Build from Source
 
-To build Status Desktop from source, follow the instructions specific to your operating system. Detailed build instructions are available in the [official documentation](BUILDING.md).
+To build Status from source, follow the instructions specific to your operating system. Detailed build instructions are available in the official documentation:
+
+- [Building Desktop](BUILDING.md)
+- [Building Mobile](/mobile/README.md)
+
+### Building Mobile
+
+To build Status Mobile from source, follow the instructions specific to your operating system. Detailed build instructions are available in the [official documentation](BUILDING.md).
 
 ## 🤝 Contributing
 
@@ -76,17 +86,18 @@ We welcome contributions from the community! To get started:
 <!-- TODO Create a guide per persona in the contributing guide -->
 
 - Read our [Contributing Guidelines](CONTRIBUTING.md).
-  - [Developing Status Desktop](CONTRIBUTING.md#️-developing)
-  - [Testing Status Desktop](CONTRIBUTING.md#-desktop-status-app-community-testing)
-- Check out [good first issues](https://github.com/status-im/status-desktop/contribute) to get involved.
-- Join the [#feedback-desktop](https://status.app/cc/G-EAAORobqgnsUPSVCLaSJr855iXTIdQiY1Q0ckBe8dWWEBpUAs9s8DTjWEpvsmpE83Izx1JWQuZrWWKUoxiXCwdtB-wPBzyvv_n9a0F61xTaPZE7BEJDC7Ly_WcmQ4tHRAKnPfXE_JUtEX_3NhnXQN0eh4ue0D77dWvaDpDrSi0U0CaGLZ-pqD_iV0z9RMFE2LKulDZdwL40etJ8lxjyTFoxS0lUhdWKinIOk8qBmJJpCmsqMrSklEU#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) channel on Status.
+  - [Developing Status](CONTRIBUTING.md#️-developing)
+  - [Testing Status](CONTRIBUTING.md#-desktop-status-app-community-testing)
+- Check out [good first issues](https://github.com/status-im/status-app/contribute) to get involved.
+- Join the [#feedback-desktop](https://status.app/cc/G-EAAORobqgnsUPSVCLaSJr855iXTIdQiY1Q0ckBe8dWWEBpUAs9s8DTjWEpvsmpE83Izx1JWQuZrWWKUoxiXCwdtB-wPBzyvv_n9a0F61xTaPZE7BEJDC7Ly_WcmQ4tHRAKnPfXE_JUtEX_3NhnXQN0eh4ue0D77dWvaDpDrSi0U0CaGLZ-pqD_iV0z9RMFE2LKulDZdwL40etJ8lxjyTFoxS0lUhdWKinIOk8qBmJJpCmsqMrSklEU#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) and [#feedback-mobile](https://status.app/cc/G-EAAOTgmsumqFvQZ-DSRkmf6xZuG-jQBrqnB6ytivISS1qeYURpfrzeMMePtpp7Inw_qy_cLdpZLJNUgOmfMHIZ4n2zSTr-n9u34C4yZa7c4JGLz9U6GIfjPqa0J0Ng2GC_Pu76QxgM-1v0z8V0PxxAf3fdHNbQXy-vfqWhK2iF0E6AaaJMh3sCmp_YpfFwR0DPmDIORPwdI_5ot4VZpkSb9FCkBwJO0xKNc5zI4oYpjfAhZVAyNWIHJs0D#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9) channels on Status.
 
 
 ## 📚 Documentation
 
 - [📘 User Help documentation](https://status.app/help)
 - [🛠️ Installation Guide](https://status.app/help/getting-started#for-new-users)
-- [🏗️ Building from Source](BUILDING.md)
+- [🏗️ Building Desktop from Source](BUILDING.md)
+- [📱 Building Mobile from Source](/mobile/README.md)
 - [🏛️ Architecture Docs](docs/architecture.md)
 - [🤝 Contributing Guide](CONTRIBUTING.md)
 - [💡 You have an idea for a cool feature or improvement?](https://discuss.status.app/c/features/51)

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -25,7 +25,7 @@ FROM ubuntu:22.04 AS pcsc-build
 
 ARG PCSCLITE_VERSION
 
-# To fix: https://github.com/status-im/status-desktop/issues/16768
+# To fix: https://github.com/status-im/status-app/issues/16768
 # https://blog.apdu.fr/posts/2024/05/pcsc-lite-now-uses-meson-build-tool/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -171,5 +171,5 @@ RUN curl -s https://nixos.org/releases/nix/nix-2.24.11/install | sh -s -- --no-d
 ENV PATH="/home/jenkins/.nix-profile/bin:${PATH}"
 
 LABEL maintainer="jakub@status.im"
-LABEL source="https://github.com/status-im/status-desktop"
+LABEL source="https://github.com/status-im/status-app"
 LABEL description="Build image for the Status Desktop client written in Nim."

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -283,7 +283,7 @@ def updateGitHubStatus() {
     github.statusUpdate(
       context: 'jenkins/prs/tests/e2e-new',
       commit: jenkins.getJobCommitByPath(params.BUILD_SOURCE),
-      repo_url: 'https://github.com/status-im/status-desktop'
+      repo_url: 'https://github.com/status-im/status-app'
     )
   }
 }

--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -275,7 +275,7 @@ def updateGitHubStatus() {
     github.statusUpdate(
       context: 'jenkins/prs/tests/e2e-new.windows',
       commit: jenkins.getJobCommitByPath(params.BUILD_SOURCE),
-      repo_url: 'https://github.com/status-im/status-desktop'
+      repo_url: 'https://github.com/status-im/status-app'
     )
   }
 }

--- a/ci/tests.Dockerfile
+++ b/ci/tests.Dockerfile
@@ -25,7 +25,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor --ba
 USER jenkins
 
 LABEL maintainer="marko@status.im"
-LABEL source="https://github.com/status-im/status-desktop"
+LABEL source="https://github.com/status-im/status-app"
 LABEL description="Build image for the Status Desktop e2e tests with Squish and Qt."
 
 ENTRYPOINT [""]

--- a/docs/FURPS/dapp-browser.md
+++ b/docs/FURPS/dapp-browser.md
@@ -1,4 +1,4 @@
-# Dapp Browser Reintroduction FURPS ([#17970](https://github.com/status-im/status-desktop/issues/17970))
+# Dapp Browser Reintroduction FURPS ([#17970](https://github.com/status-im/status-app/issues/17970))
 
 ## Functionality
 - Reintegrate a Dapp browser into the app, allowing users to open and interact with decentralized applications.

--- a/docs/FURPS/jump-to-screen-shell.md
+++ b/docs/FURPS/jump-to-screen-shell.md
@@ -1,4 +1,4 @@
-# Jump to screen (Home Page) FURPS ([#17971](https://github.com/status-im/status-desktop/issues/17971))
+# Jump to screen (Home Page) FURPS ([#17971](https://github.com/status-im/status-app/issues/17971))
 
 ## Functionality
 - Support navigation to communities, chats, accounts, or dApps through a unified launcher interface.

--- a/docs/FURPS/local-user-backups.md
+++ b/docs/FURPS/local-user-backups.md
@@ -1,4 +1,4 @@
-# Local User Backup FURPS ([#18106](https://github.com/status-im/status-desktop/issues/18106))
+# Local User Backup FURPS ([#18106](https://github.com/status-im/status-app/issues/18106))
 
 ## Functionality
 - Replace remote Waku-based storage with local file-based backup for user data (settings, contacts, chat IDs, etc.).

--- a/docs/FURPS/mobile-build.md
+++ b/docs/FURPS/mobile-build.md
@@ -1,4 +1,4 @@
-# Mobile Build FURPS ([#18082](https://github.com/status-im/status-desktop/issues/18082))
+# Mobile Build FURPS ([#18082](https://github.com/status-im/status-app/issues/18082))
 
 ## Functionality
 - Full feature parity with tablet builds expected

--- a/docs/FURPS/privacy-mode.md
+++ b/docs/FURPS/privacy-mode.md
@@ -1,4 +1,4 @@
-# Privacy Mode FURPS ([#17619](https://github.com/status-im/status-desktop/issues/17619))
+# Privacy Mode FURPS ([#17619](https://github.com/status-im/status-app/issues/17619))
 
 ## Functionality
 - Implement a **Privacy Mode toggle** to disable all third-party integrations globally.

--- a/docs/FURPS/tablet-build.md
+++ b/docs/FURPS/tablet-build.md
@@ -1,4 +1,4 @@
-# Tablet Build FURPS ([#17941](https://github.com/status-im/status-desktop/issues/17941))
+# Tablet Build FURPS ([#17941](https://github.com/status-im/status-app/issues/17941))
 
 ## Functionality
 - Partial feature parity with desktop app expected - no keycard, biometrics and dapps. To be added later.

--- a/docs/FURPS/ui-modularization.md
+++ b/docs/FURPS/ui-modularization.md
@@ -1,4 +1,4 @@
-# UI Modular Architecture ([#17872](https://github.com/status-im/status-desktop/issues/17872))
+# UI Modular Architecture ([#17872](https://github.com/status-im/status-app/issues/17872))
 
 ## Functionality
 - Establish a clean separation between UI and backend through a layered architecture (Services → Modules → Stores → Adaptors → UI Components).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 
-# Architecture of Status Desktop
+# Architecture of the Status App
 
 
 ## Top level architecture
@@ -27,11 +27,11 @@ flowchart LR
       hexagon{{"Out of repo libraries"}}
       barbox[["External providers"]]
     end
-    click qml "https://github.com/status-im/status-desktop/tree/master/ui" "Link to the UI folder containing the QML code"
-    click statusq "https://github.com/status-im/status-desktop/tree/master/ui/StatusQ" "Link to the StatusQ folder"
+    click qml "https://github.com/status-im/status-app/tree/master/ui" "Link to the UI folder containing the QML code"
+    click statusq "https://github.com/status-im/status-app/tree/master/ui/StatusQ" "Link to the StatusQ folder"
     click dotherside "https://github.com/status-im/dotherside" "Link to the DOtherSide repo"
     click nimqml "https://github.com/status-im/nimqml" "Link to the NimQML repo"
-    click nim "https://github.com/status-im/status-desktop/tree/master/src" "Link to the Nim code"
+    click nim "https://github.com/status-im/status-app/tree/master/src" "Link to the Nim code"
     click statusgo "https://github.com/status-im/status-go" "Link to the Status-Go repo"
     click waku "https://github.com/waku-org" "Link to the Waku org"
     click nimstatusgo "https://github.com/status-im/nim-status-go" "Link to nim-status-go repo"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,59 +17,59 @@
 
 ### 2.35
 
-Release Epic: https://github.com/status-im/status-desktop/issues/17966
+Release Epic: https://github.com/status-im/status-app/issues/17966
 
 #### Features
 
-- [QT6 migration](https://github.com/status-im/status-desktop/issues/17622)
+- [QT6 migration](https://github.com/status-im/status-app/issues/17622)
   - No provided FURPS at the moment
     - This is about maintaing the same level of quality as with QT5 but with QT6 instead.
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [Tablet Build](https://github.com/status-im/status-desktop/issues/17941)
+- [Tablet Build](https://github.com/status-im/status-app/issues/17941)
   - [FURPS](/docs/FURPS/tablet-build.md)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [Jump to screen (Shell)](https://github.com/status-im/status-desktop/issues/17971)
+- [Jump to screen (Shell)](https://github.com/status-im/status-app/issues/17971)
   - [FURPS](/docs/FURPS/jump-to-screen-shell.md)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [Backup user data locally](https://github.com/status-im/status-desktop/issues/18106)
+- [Backup user data locally](https://github.com/status-im/status-app/issues/18106)
   - [FURPS](/docs/FURPS/local-user-backups.md)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
 
 ### 2.36
 
-Release Epic: https://github.com/status-im/status-desktop/issues/18029
+Release Epic: https://github.com/status-im/status-app/issues/18029
 
 Estimated release: End of November
 
 #### Features
 
-- [Mobile build](https://github.com/status-im/status-desktop/issues/18082)
+- [Mobile build](https://github.com/status-im/status-app/issues/18082)
   - [FURPS](/docs/FURPS/mobile-build.md)
   - Progress is also inherited from the Tablet Epic above
   - In Progress ⏳ 🟩🟩🟩🟩⬜ 83%
-- [Memory and Performance improvements](https://github.com/status-im/status-desktop/issues/18296)
+- [Memory and Performance improvements](https://github.com/status-im/status-app/issues/18296)
   - No provided FURPS at the moment as this is mostly about profiling and fixing issues found.
   - In Progress ⏳ 🟩🟩🟩⬜⬜ 64%
-- [Dapp Browser](https://github.com/status-im/status-desktop/issues/19246)
+- [Dapp Browser](https://github.com/status-im/status-app/issues/19246)
   - [FURPS](/docs/FURPS/dapp-browser.md)
   - In Progress ⏳ 🟩🟩🟨⬜⬜ 55%
-- [Local Backup finishing touches](https://github.com/status-im/status-desktop/issues/18583)
+- [Local Backup finishing touches](https://github.com/status-im/status-app/issues/18583)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [Opt-in Messages local backup](https://github.com/status-im/status-desktop/issues/18527)
+- [Opt-in Messages local backup](https://github.com/status-im/status-app/issues/18527)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [Opt-in Messages Sync during local pairing](https://github.com/status-im/status-desktop/issues/18892)
+- [Opt-in Messages Sync during local pairing](https://github.com/status-im/status-app/issues/18892)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [External Activity fetching](https://github.com/status-im/status-desktop/issues/17188)
+- [External Activity fetching](https://github.com/status-im/status-app/issues/17188)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
-- [Translation initiative](https://github.com/status-im/status-desktop/issues/18293)
+- [Translation initiative](https://github.com/status-im/status-app/issues/18293)
   - In Progress ⏳ 🟩🟩🟩🟩⬜ 82%
-- [Full Emoji list in Reactions](https://github.com/status-im/status-desktop/issues/18766)
+- [Full Emoji list in Reactions](https://github.com/status-im/status-app/issues/18766)
   - Done ✅ 🟩🟩🟩🟩🟩 100%
 
 
 ### 2.37
 
-Release Epic: https://github.com/status-im/status-desktop/issues/18528
+Release Epic: https://github.com/status-im/status-app/issues/18528
 
 Estimated release: Mid-December
 
@@ -80,16 +80,16 @@ Estimated release: Mid-December
   - No API changes are expected until the Chat SDK is integrated
   - [Roadmap, Documentation and FURPS](https://zealous-polka-dc7.notion.site/Backend-Refactoring-2078f96fb65c80d8954ae8fc651b3a33)
   - In Progress ⏳ 🟩🟩🟨⬜⬜ 55% (estimated progress as not all subtasks are created)
-- [Privacy mode](https://github.com/status-im/status-desktop/issues/17619)
+- [Privacy mode](https://github.com/status-im/status-app/issues/17619)
   - [FURPS](/docs/FURPS/privacy-mode.md)
   - In Progress ⏳ 🟩🟩🟩🟩⬜ 88%
 - Improve Token List and Support custom tokens
   - In Progress ⏳
 - Private Transactions
-- [Ethereum Follow Protocol](https://github.com/status-im/status-desktop/issues/18685)
+- [Ethereum Follow Protocol](https://github.com/status-im/status-app/issues/18685)
   - In Progress ⏳ 🟨⬜⬜⬜⬜ 10%
 - Keycard Shell Integration
-- [UI modularization](https://github.com/status-im/status-desktop/issues/17872)
+- [UI modularization](https://github.com/status-im/status-app/issues/17872)
   - [FURPS](/docs/FURPS/ui-modularization.md)
   - In Progress ⏳ 🟩⬜⬜⬜⬜ 27%
 

--- a/guidelines/QML_ARCHITECTURE_GUIDE.md
+++ b/guidelines/QML_ARCHITECTURE_GUIDE.md
@@ -573,7 +573,7 @@ button in the bottom bar. `Storybook` discovers tests by naming convention
 
 - Cryptocurrency balances should be always handled as a big integer strings and
   converted to localized human-friendly form only for displaying. Some basic rationale is
-  provided in [this ticket](https://github.com/status-im/status-desktop/issues/11376).
+  provided in [this ticket](https://github.com/status-im/status-app/issues/11376).
 
 ## Useful links
 

--- a/mobile/docker/Dockerfile
+++ b/mobile/docker/Dockerfile
@@ -319,7 +319,7 @@ WORKDIR /home/jenkins
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 
 LABEL maintainer="status-team"
-LABEL source="https://github.com/status-im/status-desktop"
+LABEL source="https://github.com/status-im/status-app"
 
 # =============================================================================
 # Stage 5: Mobile Build Stage - extends nim-runtime with mobile specific deps

--- a/scripts/bump-status-go.sh
+++ b/scripts/bump-status-go.sh
@@ -124,7 +124,7 @@ git push
 git checkout ${STATUS_DESKTOP_MAIN_BRANCH}
 git branch -D ${BRANCH_NAME}
 
-STATUS_DESKTOP_PR_LINK="https://github.com/status-im/status-desktop/compare/$STATUS_DESKTOP_MAIN_BRANCH}...${BRANCH_NAME}"
+STATUS_DESKTOP_PR_LINK="https://github.com/status-im/status-app/compare/$STATUS_DESKTOP_MAIN_BRANCH}...${BRANCH_NAME}"
 STATUS_DESKTOP_PR_LINK="${STATUS_DESKTOP_PR_LINK}?quick_pull=1&title=chore:+bump+status-go&body=update+status+go"
 
 cat << EOF

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -9,7 +9,7 @@ if [[ -n "${CHANGE_ID:-}" ]]; then
   echo "PR #${CHANGE_ID} - ${SHORT_COMMIT}"
   echo "Build: #${BUILD_NUMBER}"
   echo ""
-  echo "View PR: https://github.com/status-im/status-desktop/pull/${CHANGE_ID}"
+  echo "View PR: https://github.com/status-im/status-app/pull/${CHANGE_ID}"
 elif [[ "${BRANCH_NAME}" == release* ]]; then
   # Release branch build
   echo "Release ${VERSION}"

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -97,7 +97,7 @@ method getModuleAsVariant*(self: Module): QVariant =
 
 proc createMessageItemsFromMessageDtos(self: Module, messages: seq[MessageDto], reactions: seq[ReactionDto] = @[]): seq[Item] =
   for message in messages:
-    # https://github.com/status-im/status-desktop/issues/7632 will introduce deleteFroMe feature.
+    # https://github.com/status-im/status-app/issues/7632 will introduce deleteFroMe feature.
     # Now we just skip deleted messages
     if message.deletedForMe:
       continue

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -223,8 +223,8 @@ method updateMembersList*(self: Module, membersToReset: seq[ChatMember] = @[]) =
         members = myCommunity.members
       else:
         # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
-        # see log here: https://github.com/status-im/status-desktop/issues/14442#issuecomment-2120756598
-        # should be resolved in https://github.com/status-im/status-desktop/issues/11694
+        # see log here: https://github.com/status-im/status-app/issues/14442#issuecomment-2120756598
+        # should be resolved in https://github.com/status-im/status-app/issues/11694
         let myChatId = self.controller.getMyChatId()
         let chat = myCommunity.getCommunityChat(myChatId)
         if not chat.tokenGated:

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -435,7 +435,7 @@ proc getChatsAndBuildUI*(self: Controller) =
     community = self.getMyCommunity()
     let normalChats = self.chatService.getChatsForCommunity(community.id)
 
-    # TODO remove this once we do this refactor https://github.com/status-im/status-desktop/issues/11694
+    # TODO remove this once we do this refactor https://github.com/status-im/status-app/issues/11694
     var fullChats: seq[ChatDto] = @[]
     for communityChat in community.chats:
       for chat in normalChats:

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -884,7 +884,7 @@ method load*[T](
   self.marketModule.load()
 
   # If the home page is enabled, we default to it as the opening section
-  # (disabled for 2.35 as per https://github.com/status-im/status-desktop/issues/18664, revisit after)
+  # (disabled for 2.35 as per https://github.com/status-im/status-app/issues/18664, revisit after)
   #if homePageEnabled:
   #  activeSection = homePageSectionItem
 

--- a/src/app/modules/onboarding/post_onboarding/keycard_replacement_task.nim
+++ b/src/app/modules/onboarding/post_onboarding/keycard_replacement_task.nim
@@ -49,7 +49,7 @@ proc run*(self: KeycardReplacementTask,
   )
   discard walletAccountService.addKeycardOrAccounts(keycard, password = "")
 
-  # FIXME: store metadata to a Keycard - https://github.com/status-im/status-desktop/issues/17128
+  # FIXME: store metadata to a Keycard - https://github.com/status-im/status-app/issues/17128
   # let accountsPathsToStore = keypair.accounts.filter(acc => not acc.isChat).map(acc => acc.path)
   # keycardServiceV2.asyncStoreMetadata(keypair.name, self.startupModule.getPin(), accountsPathsToStore)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
@@ -89,7 +89,7 @@ proc ensureReaderAndCardPresenceAndResolveNextState*(state: State, keycardFlowTy
     ## since that flow is developed and available in `master` branch, but other flows are affected by
     ## the cahnge made in that one.
     ## That flow is not a subject of MVP and will be handled after MVP accross app properly,
-    ## issue: https://github.com/status-im/status-desktop/issues/8065
+    ## issue: https://github.com/status-im/status-app/issues/8065
     if keycardFlowType == ResponseTypeValueEnterPairing and
       keycardEvent.error.len > 0:
       if keycardEvent.error == ErrorPairing:

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -61,7 +61,7 @@ type MemberRole* {.pure} = enum
   TokenMaster
 
 # TODO: consider refactor MembershipRequestState to MembershipState and use both for request to join and kick/ban actions
-# Issue: https://github.com/status-im/status-desktop/issues/11842
+# Issue: https://github.com/status-im/status-app/issues/11842
 type MembershipRequestState* {.pure} = enum
   None = 0,
   Pending = 1,

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -281,7 +281,7 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
       result.chatType = ChatType(chatTypeInt)
 
   # Default those properties to true as they are only provided for community chats
-  # To be refactored with https://github.com/status-im/status-desktop/issues/11694
+  # To be refactored with https://github.com/status-im/status-app/issues/11694
   result.canPostReactions = true
   result.canPost = true
   result.canView = true

--- a/src/app_service/service/currency/service.nim
+++ b/src/app_service/service/currency/service.nim
@@ -123,7 +123,7 @@ QtObject:
   # TODO: left this for activity controller as it uses token symbol
   # which may not be unique needs to be refactored. Also needed for
   # hasGas api which also needs to be rethought
-  # https://github.com/status-im/status-desktop/issues/13505
+  # https://github.com/status-im/status-app/issues/13505
   proc parseCurrencyValue*(self: Service, symbol: string, amountInt: UInt256): float64 =
     let token = self.tokenService.findTokenBySymbol(symbol)
     var decimals: int = 0

--- a/src/app_service/service/keycardV2/service.nim
+++ b/src/app_service/service/keycardV2/service.nim
@@ -96,7 +96,7 @@ QtObject:
     debug "KeycardServiceV2 init"
     # Do not remove the sleep 700, this sleep prevents a crash on intel MacOS
     # with errors like bad flushGen 12 in prepareForSweep; sweepgen 0
-    # More details: https://github.com/status-im/status-desktop/pull/15194
+    # More details: https://github.com/status-im/status-app/pull/15194
     if status_const.IS_MACOS and status_const.IS_INTEL:
       sleep 700
     self.initializeRPC()

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -274,7 +274,7 @@ QtObject:
         raise newException(Exception, "Error in response of getting supported tokens list")
 
       # Create a copy of the tokenResultStr to avoid exceptions in `decode`
-      # Workaround for https://github.com/status-im/status-desktop/issues/17398
+      # Workaround for https://github.com/status-im/status-app/issues/17398
       let tokenResultStr = $tokensResult
       let tokenList =  Json.decode(tokenResultStr, TokenListDto, allowUnknownFields = true)
 
@@ -463,7 +463,7 @@ QtObject:
 
   # TODO: needed in token permission right now, and activity controller which needs
   # to consider that token symbol may not be unique
-  # https://github.com/status-im/status-desktop/issues/13505
+  # https://github.com/status-im/status-app/issues/13505
   proc findTokenBySymbol*(self: Service, symbol: string): TokenBySymbolItem =
     for token in self.tokenBySymbolList:
       if token.symbol == symbol:
@@ -472,7 +472,7 @@ QtObject:
 
   # TODO: remove this call once the activty filter mechanism uses tokenKeys instead of the token
   # symbol as we may have two tokens with the same symbol in the future. Only tokensKey will be unqiue
-  # https://github.com/status-im/status-desktop/issues/13505
+  # https://github.com/status-im/status-app/issues/13505
   proc findTokenBySymbolAndChainId*(self: Service, symbol: string, chainId: int): TokenBySymbolItem =
     for token in self.tokenBySymbolList:
       if token.symbol == symbol:

--- a/storybook/pages/StatusScrollViewPage.qml
+++ b/storybook/pages/StatusScrollViewPage.qml
@@ -203,7 +203,7 @@ SplitView {
                     Layout.fillWidth: true
                     wrapMode: Text.WordWrap
                     textFormat: Text.MarkdownText
-                    text: "Please, read our [contributing guide](https://github.com/status-im/status-desktop/blob/master/ui/StatusQ/src/contributing.md#StatusScrollView) (or checkout a [presenation](https://docs.google.com/presentation/d/1ZZeg9j2fZMV-iHreu_Wsl1u6D9POH7SlUO78ZXNj-AI)) about using `StatusScrollView`"
+                    text: "Please, read our [contributing guide](https://github.com/status-im/status-app/blob/master/ui/StatusQ/src/contributing.md#StatusScrollView) (or checkout a [presenation](https://docs.google.com/presentation/d/1ZZeg9j2fZMV-iHreu_Wsl1u6D9POH7SlUO78ZXNj-AI)) about using `StatusScrollView`"
                     onLinkActivated: (link) => {
                         Qt.openUrlExternally(link)
                     }

--- a/test/e2e/constants/links.py
+++ b/test/e2e/constants/links.py
@@ -1,5 +1,5 @@
 # Links for link preview tests
-external_link = 'https://github.com/status-im/status-desktop'
+external_link = 'https://github.com/status-im/status-app'
 link_to_status_community = 'https://status.app/c/G4IAAMSIuU08Lm3oHzSz695ImidijVBxyoFDGEiSYAvADsk9ZVOKYlT2b' \
                            '-lHStyz1MqqkK2Xa4FwoUiq3LBgWsYI_ht6hWXCyLu0TGAk0dGu8IyQWtDSdIXOQ3hWscLjkTo5Vg5' \
                            '-eyUuV8jOVv7khJ_uTofT_TijN-sB#zQ3shZeEJqTC1xhGUjxuS4rtHSrhJ8vUYp64v6qWkLpvdy9L9'

--- a/test/e2e/gui/components/authenticate_popup.py
+++ b/test/e2e/gui/components/authenticate_popup.py
@@ -20,7 +20,7 @@ class AuthenticatePopup(QObject):
     @allure.step('Authenticate actions with password {0}')
     def authenticate(self, password: str):
         self._password_text_edit.type_text(password)
-        # TODO https://github.com/status-im/status-desktop/issues/15345
+        # TODO https://github.com/status-im/status-app/issues/15345
         self._primary_button.click()
 
     @allure.step('Check if authenticate button is present')

--- a/test/e2e/gui/components/change_password_popup.py
+++ b/test/e2e/gui/components/change_password_popup.py
@@ -20,7 +20,7 @@ class ChangePasswordPopup(QObject):
         the process of re-hashing DB initiated. Taking into account the user is new , so DB is relatively small
         I assume, 30 seconds should be enough to finish re-hashing and show the Restart button
         This time is not really predictable, especially for huge DBs.
-        In case it does not please check https://github.com/status-im/status-desktop/issues/13013 for context
+        In case it does not please check https://github.com/status-im/status-app/issues/13013 for context
         """
         self.re_encrypt_data_restart_button.click()
         assert driver.waitForObject(self.re_encryption_complete_element.real_name, 30000), \

--- a/test/e2e/gui/components/settings/confirm_switch_waku_mode_popup.py
+++ b/test/e2e/gui/components/settings/confirm_switch_waku_mode_popup.py
@@ -19,5 +19,5 @@ class SwitchWakuModePopup(BasePopup):
 
     @allure.step('Click i understand button')
     def confirm(self):
-        # TODO https://github.com/status-im/status-desktop/issues/15345
+        # TODO https://github.com/status-im/status-app/issues/15345
         self._i_understand_button.click()

--- a/test/e2e/gui/components/settings/sign_out_popup.py
+++ b/test/e2e/gui/components/settings/sign_out_popup.py
@@ -15,7 +15,7 @@ class SignOutPopup(QObject):
     @allure.step('Click sign out and quit button')
     def sign_out_and_quit(self, attempts: int = 2):
         try:
-            # TODO https://github.com/status-im/status-desktop/issues/15345
+            # TODO https://github.com/status-im/status-app/issues/15345
             self._sign_out_and_quit_button.click()
         except Exception as ec:
             if attempts:

--- a/test/e2e/gui/components/wallet/wallet_account_popups.py
+++ b/test/e2e/gui/components/wallet/wallet_account_popups.py
@@ -169,7 +169,7 @@ class AccountPopup(QObject):
 
     @allure.step('Click confirmation (add account / save changes) button')
     def save_changes(self):
-        # TODO https://github.com/status-im/status-desktop/issues/15345
+        # TODO https://github.com/status-im/status-app/issues/15345
         self._add_save_account_confirmation_button.click()
         return self
 
@@ -269,7 +269,7 @@ class AddNewAccountPopup(QObject):
 
     @allure.step('Click continue')
     def click_continue(self):
-        # TODO https://github.com/status-im/status-desktop/issues/15345
+        # TODO https://github.com/status-im/status-app/issues/15345
         self._continue_button.click()
         return self
 
@@ -283,7 +283,7 @@ class AddNewAccountPopup(QObject):
 
     @allure.step('Enter new seed phrase')
     def enter_new_seed_phrase(self, seed_phrase_words: list):
-        # TODO https://github.com/status-im/status-desktop/issues/15345
+        # TODO https://github.com/status-im/status-app/issues/15345
         self._import_seed_phrase_button.click()
         if len(seed_phrase_words) == 12:
             self._seed_phrase_12_words_button.click()

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -125,7 +125,7 @@ class QObject:
 
         # if timeout is not None:
         #     pass
-        # TODO: enable after fixing https://github.com/status-im/status-desktop/issues/15345
+        # TODO: enable after fixing https://github.com/status-im/status-app/issues/15345
         # if not isFrozen(timeout):
         #    pass
 

--- a/test/e2e/gui/objects_map/home_names.py
+++ b/test/e2e/gui/objects_map/home_names.py
@@ -28,7 +28,7 @@ home_regular_dock_button_messages = {"container": statusDesktop_mainWindow, "obj
 home_regular_dock_button_communities = {"container": statusDesktop_mainWindow, "objectName": "regularDockButtonCommunities Portal", "type": "HomePageDockButton", "visible": True}
 home_regular_dock_button_settings = {"container": statusDesktop_mainWindow, "objectName": "regularDockButtonSettings", "type": "HomePageDockButton", "visible": True}
 
-# TODO: Methods for pinned dock buttons https://github.com/status-im/status-desktop/issues/18239
+# TODO: Methods for pinned dock buttons https://github.com/status-im/status-app/issues/18239
 home_pinned_dock_button_ = {"container": statusDesktop_mainWindow, "objectName": "pinnedDockButton", "type": "HomePageDockButton", "visible": True}
 
 # Generic Dock Button Locators

--- a/test/e2e/gui/screens/home.py
+++ b/test/e2e/gui/screens/home.py
@@ -165,6 +165,6 @@ class HomeScreen(QObject):
 
     @allure.step('Wait for home UI to be fully loaded')
     def wait_for_home_ui_loaded(self):
-        # TODO: https://github.com/status-im/status-desktop/issues/18325
+        # TODO: https://github.com/status-im/status-app/issues/18325
         time.sleep(0.5)
         return self

--- a/test/e2e/gui/screens/market.py
+++ b/test/e2e/gui/screens/market.py
@@ -7,5 +7,5 @@ from gui.objects_map.names import statusDesktop_mainWindow
 class MarketScreen(QObject):
 
     def __init__(self):
-        # TODO: Add support for Market screen (https://github.com/status-im/status-desktop/issues/18235)
+        # TODO: Add support for Market screen (https://github.com/status-im/status-app/issues/18235)
         super().__init__(statusDesktop_mainWindow)

--- a/test/e2e/scripts/utils/decorators.py
+++ b/test/e2e/scripts/utils/decorators.py
@@ -43,7 +43,7 @@ def open_with_retries(screen_class, attempts: int = 3, delay: float = 0.5):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
             last_exception = None
-            # TODO: https://github.com/status-im/status-desktop/issues/18888
+            # TODO: https://github.com/status-im/status-app/issues/18888
             # Workaround for app freeze when opening settings
             is_settings_screen = screen_class.__name__ == 'SettingsScreen'
             

--- a/test/e2e_appium/scripts/generate_test_summary.py
+++ b/test/e2e_appium/scripts/generate_test_summary.py
@@ -93,7 +93,7 @@ def main():
         "parallel_execution": args.parallel_execution or "false",
         "pytest_args": args.pytest_args or "unknown",
         "build_run_id": args.build_run_id,
-        "repo_url": args.repo_url or "https://github.com/status-im/status-desktop",
+        "repo_url": args.repo_url or "https://github.com/status-im/status-app",
     }
 
     summary = generate_summary(results, config)

--- a/test/ui-test/testSuites/suite_communities/tst_communityMessageFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityMessageFlows/test.feature
@@ -122,7 +122,7 @@ Feature: Status Desktop community messages
         Then the image "<image_url>" is unfurled in the chat
         Examples:
            | image_url                                                                                      |
-           | https://github.com/status-im/status-desktop/raw/master/test/ui-test/fixtures/images/doggo.jpeg |
+           | https://github.com/status-im/status-app/raw/master/test/ui-test/fixtures/images/doggo.jpeg |
 
    Scenario: The user is able to use emoji suggestions
         Given the user types "hello :thumbs"

--- a/test/ui-test/testSuites/suite_settings/tst_mainSettingsSection/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_mainSettingsSection/test.feature
@@ -50,7 +50,7 @@ Feature: Status Desktop Main Settings Section
     	Then the user lands on the signed in app
     	Then the user status is automatic
 
-	# https://github.com/status-im/status-desktop/issues/10287
+	# https://github.com/status-im/status-app/issues/10287
 	@mayfail
 	Scenario: The user can change the password and login with new password
     	When the user changes the password from TesTEr16843/!@00 to NewPassword@12345

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_savedAddresses/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_savedAddresses/test.feature
@@ -30,7 +30,7 @@ Background:
             | Saved address | 0x8397bc3c5a60a1883174f722403d63a8833312b7 |Saved addressNew |
             | Ens name      | nastya.stateofus.eth                       |Ens nameNew      |
 
-           # | foo  | nastya.stateofus.eth | bar | https://github.com/status-im/status-desktop/issues/11090
+           # | foo  | nastya.stateofus.eth | bar | https://github.com/status-im/status-app/issues/11090
      # TODO: actions from burger menu
      # TODO: enhance edit actions to change networks
      # TODO: test for Share button

--- a/ui/app/AppLayouts/Browser/stores/BrowserRootStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/BrowserRootStore.qml
@@ -63,7 +63,7 @@ QtObject {
     }
 
     // ENS resolution functions (stubbed until connector integration)
-    // See: https://github.com/status-im/status-desktop/issues/19137
+    // See: https://github.com/status-im/status-app/issues/19137
     function determineRealURL(text) {
         const url = UrlUtils.urlFromUserInput(text)
         // TODO: ENS resolution will be handled by connector in next PR

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -209,7 +209,7 @@ StatusSectionLayout {
             text: qsTr("Create New Community")
             type: StatusBaseButton.Type.Primary
             onClicked: {
-                // Global.openPopup(chooseCommunityCreationTypePopupComponent) // hidden as part of https://github.com/status-im/status-desktop/issues/17726
+                // Global.openPopup(chooseCommunityCreationTypePopupComponent) // hidden as part of https://github.com/status-im/status-app/issues/17726
                 root.communitiesStore.setCreateCommunityPopupSeen()
                 Global.createCommunityPopupRequested(false /*isDiscordImport*/)
             }

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -667,7 +667,7 @@ StackView {
             }
 
             onViewMessagesRequested: {
-                // TODO: https://github.com/status-im/status-desktop/issues/11860
+                // TODO: https://github.com/status-im/status-app/issues/11860
                 console.warn("View Messages is not implemented yet")
             }
 

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPanel.qml
@@ -260,7 +260,7 @@ Control {
                 }
 
                 sorters: [
-                    // FIXME add sort token-relevant accounts first; https://github.com/status-im/status-desktop/issues/14192
+                    // FIXME add sort token-relevant accounts first; https://github.com/status-im/status-app/issues/14192
                     RoleSorter {
                         roleName: "tokenCount"
                         sortOrder: Qt.DescendingOrder

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -137,7 +137,7 @@ Item {
             onTriggered: Global.openPopup(createChannelPopup)
         }
 
-        // hidden as part of https://github.com/status-im/status-desktop/issues/17726
+        // hidden as part of https://github.com/status-im/status-app/issues/17726
         // StatusAction {
         //     objectName: "importCommunityChannelBtn"
         //     text: qsTr("Create channel via Discord import")
@@ -231,7 +231,7 @@ Item {
                     onTriggered: Global.openPopup(createChannelPopup)
                 }
 
-                // hidden as part of https://github.com/status-im/status-desktop/issues/17726
+                // hidden as part of https://github.com/status-im/status-app/issues/17726
                 // StatusAction {
                 //     objectName: "importCommunityChannelBtn"
                 //     text: qsTr("Create channel via Discord import")

--- a/ui/app/AppLayouts/Profile/views/AboutView.qml
+++ b/ui/app/AppLayouts/Profile/views/AboutView.qml
@@ -76,8 +76,8 @@ SettingsContentBase {
                 normalColor: Theme.palette.directColor1
                 text: root.currentVersion
                 onClicked: {
-                    const link = root.isProduction ? "https://github.com/status-im/status-desktop/releases/tag/%1".arg(root.currentVersion) :
-                                                     "https://github.com/status-im/status-desktop/commit/%1".arg(root.gitCommit)
+                    const link = root.isProduction ? "https://github.com/status-im/status-app/releases/tag/%1".arg(root.currentVersion) :
+                                                     "https://github.com/status-im/status-app/commit/%1".arg(root.gitCommit)
 
                     root.openLink(link)
                 }
@@ -131,8 +131,8 @@ SettingsContentBase {
                 text: qsTr("Release Notes")
                 visible: root.isProduction
                 onClicked: {
-                    const link = root.isProduction ? "https://github.com/status-im/status-desktop/releases/tag/%1".arg(root.currentVersion) :
-                                                     "https://github.com/status-im/status-desktop/commit/%1".arg(root.gitCommit)
+                    const link = root.isProduction ? "https://github.com/status-im/status-app/releases/tag/%1".arg(root.currentVersion) :
+                                                     "https://github.com/status-im/status-app/commit/%1".arg(root.gitCommit)
 
                     root.openLink(link)
                 }
@@ -169,7 +169,7 @@ SettingsContentBase {
 
             LinkItem {
                 title: qsTr("status-desktop")
-                onClicked: root.openLink("https://github.com/status-im/status-desktop")
+                onClicked: root.openLink("https://github.com/status-im/status-app")
             }
 
             LinkItem {
@@ -179,7 +179,7 @@ SettingsContentBase {
 
             LinkItem {
                 title: qsTr("StatusQ")
-                onClicked: root.openLink("https://github.com/status-im/status-desktop/tree/master/ui/StatusQ")
+                onClicked: root.openLink("https://github.com/status-im/status-app/tree/master/ui/StatusQ")
             }
 
             LinkItem {
@@ -213,7 +213,7 @@ SettingsContentBase {
 
             LinkItem {
                 title: qsTr("Software License")
-                onClicked: root.openLink("https://github.com/status-im/status-desktop/blob/master/LICENSE.md")
+                onClicked: root.openLink("https://github.com/status-im/status-app/blob/master/LICENSE.md")
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/ManageTokensView.qml
@@ -184,7 +184,7 @@ Item {
 
                 spacing: 8
                 StatusListItem {
-                    // Temporarily disabled, refer to https://github.com/status-im/status-desktop/issues/15955 for details.
+                    // Temporarily disabled, refer to https://github.com/status-im/status-app/issues/15955 for details.
                     visible: false
 
                     Layout.fillWidth: true

--- a/ui/app/AppLayouts/Wallet/WalletUtils.qml
+++ b/ui/app/AppLayouts/Wallet/WalletUtils.qml
@@ -40,7 +40,7 @@ QtObject {
       This logic is here to make sure there is enough eth to pay for the gas.
       Context, when making a transaction, whatever the type: swap/bridge/send, you need eth to pay for the gas.
 
-      rationale: https://github.com/status-im/status-desktop/pull/14959#discussion_r1627110880
+      rationale: https://github.com/status-im/status-app/pull/14959#discussion_r1627110880
       */
     function calculateMaxSafeSendAmount(value, symbol, chainId, cryptoFeesToReserve = "") {
         if (!value) {

--- a/ui/app/AppLayouts/Wallet/controls/EditSlippagePanel.qml
+++ b/ui/app/AppLayouts/Wallet/controls/EditSlippagePanel.qml
@@ -66,7 +66,7 @@ Control {
             color: Theme.palette.directColor5
         }
         /* TODO: error conditions for custom enteries missing will be done under -
-        https://github.com/status-im/status-desktop/issues/15017 */
+        https://github.com/status-im/status-app/issues/15017 */
         SlippageSelector {
             id: slippageSelector
             objectName: "slippageSelector"

--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -219,7 +219,7 @@ StatusListItem {
                                                      WalletLayout.RightPanelSelection.Activity,
                                                      {savedAddress: menu.address})
             }
-            // TODO: https://github.com/status-im/status-desktop/issues/19410
+            // TODO: https://github.com/status-im/status-app/issues/19410
             // ENabled after crash is solved
             enabled: false
         }

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -678,7 +678,7 @@ StatusDialog {
                         }
                         markAsInvalid: amountToSend.markAsInvalid
                         /** TODO: Remove below customisations after
-                        https://github.com/status-im/status-desktop/issues/15709
+                        https://github.com/status-im/status-app/issues/15709
                         and make the button clickable **/
                         enabled: false
                         background: Rectangle {

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapApproveCapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapApproveCapModal.qml
@@ -45,7 +45,7 @@ SignTransactionModalBase {
     property string serviceProviderName: Constants.swap.paraswapName
     property string serviceProviderHostname: Constants.swap.paraswapHostname
     property string serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl
-    property string serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-desktop/issues/15329
+    property string serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-app/issues/15329
     property string serviceProviderContractAddress: Constants.swap.paraswapV6_2ContractAddress
     property string serviceProviderIcon: Assets.png("swap/%1".arg(Constants.swap.paraswapIcon)) // FIXME svg
 

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -281,7 +281,7 @@ StatusDialog {
 
                     /* TODO: keep this input as disabled until the work for adding a param to handle to
                     and from tokens inputed is supported by backend under
-                    https://github.com/status-im/status-desktop/issues/15095 */
+                    https://github.com/status-im/status-app/issues/15095 */
                     interactive: false
                 }
 
@@ -593,8 +593,8 @@ StatusDialog {
             estimatedTime: root.swapAdaptor.swapOutputData.estimatedTime
 
             serviceProviderName: Constants.swap.paraswapName
-            serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-desktop/issues/15329
-            serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl // TODO https://github.com/status-im/status-desktop/issues/15329
+            serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-app/issues/15329
+            serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl // TODO https://github.com/status-im/status-app/issues/15329
             serviceProviderIcon: Assets.png("swap/%1".arg(Constants.swap.paraswapIcon)) // FIXME svg
             serviceProviderContractAddress: root.swapAdaptor.swapOutputData.approvalContractAddress
             serviceProviderHostname: Constants.swap.paraswapHostname
@@ -662,8 +662,8 @@ StatusDialog {
             slippage: root.swapInputParamsForm.selectedSlippage
 
             serviceProviderName: Constants.swap.paraswapName
-            serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-desktop/issues/15329
-            serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl // TODO https://github.com/status-im/status-desktop/issues/15329
+            serviceProviderURL: Constants.swap.paraswapUrl // TODO https://github.com/status-im/status-app/issues/15329
+            serviceProviderTandCUrl: Constants.swap.paraswapTermsAndConditionUrl // TODO https://github.com/status-im/status-app/issues/15329
 
             onRejected: root.addMetricsEvent("rejected sign")
             onAccepted: {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -485,7 +485,7 @@ QtObject {
         return address1.toUpperCase() === address2.toUpperCase()
     }
 
-    // TODO: https://github.com/status-im/status-desktop/issues/15329
+    // TODO: https://github.com/status-im/status-app/issues/15329
     // Get DApp data from the backend
     function getDappDetails(chainId, contractAddress) {
         switch (contractAddress) {

--- a/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/TokensStore.qml
@@ -119,7 +119,7 @@ QtObject {
 
     // Property and methods below are used to apply advanced token management settings to the SendModal
 
-    // Temporarily disabled, refer to https://github.com/status-im/status-desktop/issues/15955 for details.
+    // Temporarily disabled, refer to https://github.com/status-im/status-app/issues/15955 for details.
     readonly property bool showCommunityAssetsInSend: true //root._allTokensModule.showCommunityAssetWhenSendingTokens
     readonly property bool displayAssetsBelowBalance: root._allTokensModule.displayAssetsBelowBalance
     readonly property bool autoRefreshTokensLists: root._allTokensModule.autoRefreshTokensLists

--- a/ui/imports/shared/controls/StatusSyncCodeInput.qml
+++ b/ui/imports/shared/controls/StatusSyncCodeInput.qml
@@ -8,7 +8,7 @@ import StatusQ.Controls
 StatusInput {
     id: root
 
-    // TODO: Use https://github.com/status-im/status-desktop/issues/6136
+    // TODO: Use https://github.com/status-im/status-app/issues/6136
 
     enum Mode {
         WriteMode,

--- a/ui/imports/shared/popups/DownloadPage.qml
+++ b/ui/imports/shared/popups/DownloadPage.qml
@@ -16,7 +16,7 @@ Rectangle {
     property string currentVersion: "0.0.0"
     property string newVersion: "0.0.0"
     property bool newVersionAvailable: true
-    property string downloadURL: "https://github.com/status-im/status-desktop/releases/latest"
+    property string downloadURL: "https://github.com/status-im/status-app/releases/latest"
     signal closed()
 
     anchors.fill: parent

--- a/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
+++ b/ui/imports/shared/popups/walletconnect/DAppsListPopup.qml
@@ -78,7 +78,7 @@ StatusDropdown {
             // after status app upgrades to
             // a Qt version that has ListView scrolling with mouse wheel and
             // touchpad fixed.
-            // https://github.com/status-im/status-desktop/issues/15595
+            // https://github.com/status-im/status-app/issues/15595
             // Layout.maximumHeight: 290
             Layout.fillHeight: true
 

--- a/ui/imports/shared/views/SyncingDisplayCode.qml
+++ b/ui/imports/shared/views/SyncingDisplayCode.qml
@@ -152,7 +152,7 @@ ColumnLayout {
 
     // TODO: Extract this to a component.
     //       Also used in `PasswordView` and several other files.
-    //       https://github.com/status-im/status-desktop/issues/6136
+    //       https://github.com/status-im/status-app/issues/6136
 
     StyledText {
         id: inputLabel

--- a/ui/imports/shared/views/profile/ProfileShowcaseCollectiblesView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseCollectiblesView.qml
@@ -121,7 +121,7 @@ Item {
                 anchors.leftMargin: 12
                 anchors.top: parent.top
                 anchors.topMargin: 12
-                //TODO TBD, https://github.com/status-im/status-desktop/issues/13782
+                //TODO TBD, https://github.com/status-im/status-app/issues/13782
                 visible: (model.userHas > 1)
 
                 background: Rectangle {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1480,7 +1480,7 @@ QtObject {
     }
 
     readonly property QtObject swap: QtObject {
-        /* TODO: https://github.com/status-im/status-desktop/issues/15329
+        /* TODO: https://github.com/status-im/status-app/issues/15329
         This is only added temporarily until we have an api from the backend in order to get
         this list dynamically */
         readonly property string paraswapName: "Velora"


### PR DESCRIPTION
Adapts the docs and different mentions of the repo from status-desktop to status-app

Also adapts the docs to talk about the Status App and not just Status Dekstop. Adds links to the Mobile build too.