### PR TITLE
chore: fix release job to find artefacts after rename

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -16,7 +16,7 @@ pipeline {
       args '--entrypoint="" ' +
            '--volume=/nix:/nix ' +
            '--volume=/etc/nix:/etc/nix '
-      customWorkspace "/home/jenkins/workspace/status-desktop-android/${env.BUILD_NUMBER}"
+      customWorkspace "/home/jenkins/workspace/status-app-android/${env.BUILD_NUMBER}"
     }
   }
 
@@ -49,7 +49,7 @@ pipeline {
       artifactNumToKeepStr: '3',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(abortPrevious: isPRBuild)
     disableRestartFromStage()

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Object to store public URLs for description. */
 urls = [:]
@@ -28,7 +28,7 @@ pipeline {
       artifactNumToKeepStr: '10',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
   }
 
   parameters {
@@ -53,7 +53,7 @@ pipeline {
               steps {
                 script {
                   linux_x86_64 = getArtifacts(
-                    'Linux', jenkins.Build('status-desktop/systems/linux/x86_64/package')
+                    'Linux', jenkins.Build('status-app/systems/linux/x86_64/package')
                   )
                 }
               }
@@ -62,7 +62,7 @@ pipeline {
               steps {
                 script {
                   linux_e2e = build(
-                    job: 'status-desktop/systems/linux/x86_64/tests-e2e',
+                    job: 'status-app/systems/linux/x86_64/tests-e2e',
                     parameters: jenkins.mapToParams([
                       BUILD_SOURCE:       linux_x86_64.fullProjectName,
                       TESTRAIL_RUN_NAME:  utils.pkgFilename(),
@@ -81,7 +81,7 @@ pipeline {
               steps {
                 script {
                   windows_x86_64 = getArtifacts(
-                    'Windows', jenkins.Build('status-desktop/systems/windows/x86_64/package')
+                    'Windows', jenkins.Build('status-app/systems/windows/x86_64/package')
                   )
                 }
               }
@@ -95,7 +95,7 @@ pipeline {
               steps {
                 script {
                   windows_e2e = build(
-                    job: 'status-desktop/systems/windows/x86_64/tests-e2e',
+                    job: 'status-app/systems/windows/x86_64/tests-e2e',
                     parameters: jenkins.mapToParams([
                       BUILD_SOURCE:       windows_x86_64.fullProjectName,
                       TESTRAIL_RUN_NAME:  utils.pkgFilename(),
@@ -110,7 +110,7 @@ pipeline {
         }
         stage('MacOS/aarch64') { steps { script {
           macos_aarch64 = getArtifacts(
-            'MacOS/aarch64', jenkins.Build('status-desktop/systems/macos/aarch64/package')
+            'MacOS/aarch64', jenkins.Build('status-app/systems/macos/aarch64/package')
           )
         } } }
       }
@@ -118,7 +118,7 @@ pipeline {
     stage('Publish') {
       when { expression { params.PUBLISH } }
       steps { script {
-        github.publishReleaseFiles(repo: 'status-desktop');
+        github.publishReleaseFiles(repo: 'status-app');
       } }
     }
   }
@@ -151,7 +151,7 @@ pipeline {
  * - A user explicitly specified a value
  * Since release builds create and re-create GitHub drafts every time. */
 def Boolean getPublishDefault(Boolean previousValue) {
-  if (env.JOB_NAME.startsWith('status-desktop/release')) { return true }
+  if (env.JOB_NAME.startsWith('status-app/release')) { return true }
   if (previousValue != null) { return previousValue }
   return false
 }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -42,7 +42,7 @@ pipeline {
       artifactNumToKeepStr: '3',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(abortPrevious: isPRBuild)
     disableRestartFromStage()

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -65,7 +65,7 @@ pipeline {
       artifactNumToKeepStr: '1',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild
@@ -155,7 +155,7 @@ pipeline {
       when { expression { utils.isPRBuild() && !(params.USE_NWAKU ?: false) } }
       steps { script {
         build(
-          job: 'status-desktop/e2e/prs',
+          job: 'status-app/e2e/prs',
           wait: false,
           parameters: jenkins.mapToParams([
             GIT_REF: env.CHANGE_BRANCH ?: env.BRANCH_NAME,

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -48,7 +48,7 @@ pipeline {
       artifactNumToKeepStr: '1',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -59,7 +59,7 @@ pipeline {
       artifactNumToKeepStr: '1',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild

--- a/ci/Jenkinsfile.qt-build
+++ b/ci/Jenkinsfile.qt-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 pipeline {
   agent {
@@ -256,7 +256,7 @@ pipeline {
 def setNewBuildName() {
   if (currentBuild.upstreamBuilds) {
     def parent = utils.parentOrCurrentBuild()
-    currentBuild.displayName = parent.getFullDisplayName().minus('status-desktop » ')
+    currentBuild.displayName = parent.getFullDisplayName().minus('status-app » ')
   }
 }
 
@@ -299,7 +299,7 @@ def getDefaultBuildSource() {
 }
 
 def getDefaultTestScopeFlag() {
-  if (JOB_NAME == "status-desktop/systems/linux/x86_64/tests-e2e") {
+  if (JOB_NAME == "status-app/systems/linux/x86_64/tests-e2e") {
     return ''
   } else {
     return '-m=critical'

--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 pipeline {
 
@@ -296,7 +296,7 @@ def getDefaultBuildSource() {
 }
 
 def getDefaultTestScopeFlag() {
-  if (JOB_NAME == "status-desktop/systems/windows/x86_64/tests-e2e") {
+  if (JOB_NAME == "status-app/systems/windows/x86_64/tests-e2e") {
     return ''
   } else {
     return '-m=critical'

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.30'
+library 'status-jenkins-lib@v1.9.31'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -57,7 +57,7 @@ pipeline {
       artifactNumToKeepStr: '1',
     ))
     /* Allows combined build to copy */
-    copyArtifactPermission('/status-desktop/*')
+    copyArtifactPermission('/status-app/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild
@@ -160,7 +160,7 @@ pipeline {
       when { expression { utils.isPRBuild() } }
       steps { script {
         build(
-          job: 'status-desktop/e2e/prs-windows',
+          job: 'status-app/e2e/prs-windows',
           wait: false,
           parameters: jenkins.mapToParams([
             GIT_REF: env.CHANGE_BRANCH ?: env.BRANCH_NAME,


### PR DESCRIPTION
Needed to find correct artefacts after repo rename which happened here : https://github.com/status-im/status-app/commit/7a1455be962e143903bb290b8c88d4c03087a4c9

