### PR TITLE
fix(browser): Fix signing typed data

### DIFF
--- a/src/app_service/service/connector/async_tasks.nim
+++ b/src/app_service/service/connector/async_tasks.nim
@@ -8,12 +8,12 @@ logScope:
 type
   ConnectorCallRPCTaskArg* = ref object of QObjectTaskArg
     requestId*: int
-    message*: string
+    message*: JsonNode
 
 proc connectorCallRPCTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ConnectorCallRPCTaskArg](argEncoded)
   try:
-    let rpcResponse = status_go.connectorCallRPC(arg.message)
+    let rpcResponse = status_go.connectorCallRPC($arg.message)
     let responseJson = %* {
       "requestId": arg.requestId,
       "result": rpcResponse.result,


### PR DESCRIPTION
### What does the PR do

Closes #19559

The signing issue was caused by double escaping of the typed data string.

- eth_signTypedData_v4 requires params[1] to be a JSON **string** (typed data)
- When encoding ConnectorCallRPCTaskArg, the message field (string) was
  double-escaped by toJson(), turning \" into \\", causing parse errors
- Error: "input(1, 207) Error: } expected" in threadpool.nim. It failed to start the async task.


### Affected areas

Browser rpc requests


### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/14694bdd-3ca6-4bde-893f-d6a21efb0370



### Impact on end user

The user can now sign typed data


### How to test

Open browser, go to SNT vote, try to vote a proposal

### Risk 

low
