### PR TITLE
fix(HomePage): Crash when clicking the Dapp icon in the Home Page

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1792,6 +1792,7 @@ Item {
                             showEnabledSectionsOnly: true
                             marketEnabled: appMain.featureFlagsStore.marketEnabled
                             browserEnabled: d.isBrowserEnabled
+                            showDapps: false // temp fix for https://github.com/status-im/status-app/issues/19580
 
                             syncingBadgeCount: appMain.devicesStore.devicesModel.count - appMain.devicesStore.devicesModel.pairedCount
                             messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count


### PR DESCRIPTION
### What does the PR do

- disable showing dApps for 2.36.x; master will have either a proper solution for the crash in WC SDK, or the whole HomePage hidden for now

Fixes #19580

### Affected areas

AppMain, HomePage

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### How to test

- open HomePage
- click some dApp
- no crash

### Risk 

- low
