### PR TITLE
fix: selecting Aragon token for permission creation fails the process

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -706,6 +706,9 @@ proc getTokenByKey*(self: Controller, tokenKey: string): TokenItem =
 proc getTokensByGroupKey*(self: Controller, groupKey: string): seq[TokenItem] =
   return self.tokenService.getTokensByGroupKey(groupKey)
 
+proc getTokenByKeyOrGroupKeyFromAllTokens*(self: Controller, key: string): TokenItem =
+  return self.tokenService.getTokenByKeyOrGroupKeyFromAllTokens(key)
+
 proc createOrEditCommunityTokenPermission*(self: Controller, tokenPermission: CommunityTokenPermissionDto) =
   self.communityService.createOrEditCommunityTokenPermission(self.sectionId, tokenPermission)
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1499,7 +1499,12 @@ method createOrEditCommunityTokenPermission*(self: Module, permissionId: string,
     if tokenCriteriaDto.`type` != TokenType.ENS:
       if not service_common_utils.isTokenKey(key):
         # handle token group
-        let tokens = self.controller.getTokensByGroupKey(key)
+        var tokens = self.controller.getTokensByGroupKey(key)
+        if tokens.len == 0:
+          # fallback to get token by key or group key from all tokens
+          let token = self.controller.getTokenByKeyOrGroupKeyFromAllTokens(key)
+          if not token.isNil:
+            tokens = @[token]
         if tokens.len == 0:
           emitUnexistingKeyError(key)
           return

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -88,7 +88,7 @@ QtObject {
         proxyRoles: [
             FastExpressionRole {
                 function collectibleIcon(icon) {
-                    return !!icon ? icon : Assets.png("tokens/DEFAULT-TOKEN")
+                    return !!icon ? icon : Assets.png(Constants.defaultTokenIcon)
                 }
                 name: "iconSource"
                 expression: collectibleIcon(model.icon)
@@ -101,7 +101,7 @@ QtObject {
             },
             FastExpressionRole {
                 function collectibleIcon(icon) {
-                    return !!icon ? icon : Assets.png("tokens/DEFAULT-TOKEN")
+                    return !!icon ? icon : Assets.png(Constants.defaultTokenIcon)
                 }
                 name: "collectionImageUrl"
                 expression: collectibleIcon(model.icon)

--- a/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
@@ -95,7 +95,7 @@ StatusListView {
 
         name: model.name
         shortName: model.shortName ?? ""
-        iconSource: model.iconSource ? model.iconSource : Assets.png("tokens/DEFAULT-TOKEN")
+        iconSource: model.iconSource ? model.iconSource : Assets.png(Constants.defaultTokenIcon)
         showSubItemsIcon: !!model.subItems && model.subItems.count > 0
         selected: root.checkedKeys.includes(model.key)
         amount: {

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -48,7 +48,7 @@ QtObject {
 
     function getTokenIconByKey(model, isCollectible, key) {
         const item = getTokenByKey(model, isCollectible, key)
-        const defaultIcon = Assets.png("tokens/DEFAULT-TOKEN")
+        const defaultIcon = Assets.png(Constants.defaultTokenIcon)
         if (item)
             return item.iconSource ? item.iconSource : defaultIcon
         return defaultIcon

--- a/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PermissionsSettingsPanel.qml
@@ -24,6 +24,10 @@ StackView {
     required property var assetsModel
     required property var collectiblesModel
     required property var channelsModel
+
+    // Returns token that matches provided key (key can be token or group key). Use it as a last option (may affect app performances, because it fetches all tokens from stautsgo).
+    property var getTokenByKeyOrGroupKeyFromAllTokens: function(key){ return {}}
+
     property bool showChannelSelector: true
     property bool ensCommunityPermissionsEnabled
     property alias initialPage: initialItem
@@ -114,6 +118,8 @@ StackView {
             assetsModel: root.assetsModel
             collectiblesModel: root.collectiblesModel
             channelsModel: allChannelsTransformed
+
+            getTokenByKeyOrGroupKeyFromAllTokens: root.getTokenByKeyOrGroupKeyFromAllTokens
 
             communityDetails: root.communityDetails
 

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -22,11 +22,13 @@ import AppLayouts.Communities.panels
 import AppLayouts.Communities.models
 import AppLayouts.Communities.controls
 import AppLayouts.Communities.stores as CommunitiesStores
+import AppLayouts.Wallet.stores
 
 StatusStackModal {
     id: root
 
     property CommunitiesStores.CommunitiesStore communitiesStore
+    property TokensStore tokensStore
 
     property bool isDiscordImport // creating new or importing from discord?
     property bool isEdit: false
@@ -840,6 +842,9 @@ StatusStackModal {
                     permissionsModel: d.channelEditModel.channelPermissionsModel
                     assetsModel: root.assetsModel
                     collectiblesModel: root.collectiblesModel
+
+                    getTokenByKeyOrGroupKeyFromAllTokens: root.tokensStore.getTokenByKeyOrGroupKeyFromAllTokens
+
                     viewOnlyCanAddReaction: root.viewOnlyCanAddReaction
                     channelsModel: d.channelEditModel.liveChannelsModel
                     communityDetails: d.communityDetails
@@ -935,6 +940,8 @@ StatusStackModal {
             communityDetails: d.communityDetails
             showChannelSelector: false
             ensCommunityPermissionsEnabled: root.ensCommunityPermissionsEnabled
+
+            getTokenByKeyOrGroupKeyFromAllTokens: root.tokensStore.getTokenByKeyOrGroupKeyFromAllTokens
 
             readonly property string nextButtonText: !!currentItem.permissionKeyToEdit ?
                                                          qsTr("Update permission") : qsTr("Create permission")

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -562,6 +562,7 @@ Item {
         id: createChannelPopup
         CreateChannelPopup {
             communitiesStore: root.communitiesStore
+            tokensStore: root.walletAssetsStore.walletTokensStore
             assetsModel: root.store.assetsModel
             collectiblesModel: root.store.collectiblesModel
             ensCommunityPermissionsEnabled: root.ensCommunityPermissionsEnabled

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -373,6 +373,8 @@ StatusSectionLayout {
                 collectiblesModel: rootStore.collectiblesModel
                 channelsModel: rootStore.chatCommunitySectionModule.model
 
+                getTokenByKeyOrGroupKeyFromAllTokens: root.tokensStore.getTokenByKeyOrGroupKeyFromAllTokens
+
                 ensCommunityPermissionsEnabled: root.ensCommunityPermissionsEnabled
 
                 communityDetails: d.communityDetails

--- a/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
+++ b/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
@@ -11,8 +11,12 @@ import StatusQ.Core.Theme
 import utils
 
 SortFilterProxyModel {
+    id: root
+
     property var assetsModel
     property var collectiblesModel
+    // Returns token that matches provided key (key can be token or group key). Use it as a last option (may affect app performances, because it fetches all tokens from stautsgo).
+    property var getTokenByKeyOrGroupKeyFromAllTokens: function(key){ return {}}
 
     readonly property ModelChangeTracker _assetsChanges: ModelChangeTracker {
         model: assetsModel
@@ -45,6 +49,10 @@ SortFilterProxyModel {
                             : collectiblesModel
 
                 let item = PermissionsHelpers.getTokenByKey(model, collectibles, key)
+                if (Object.keys(item).length === 0) {
+                    item = root.getTokenByKeyOrGroupKeyFromAllTokens(key)
+                }
+
                 let name = getName(type, item, key)
                 const decimals = getDecimals(type, item)
 
@@ -75,7 +83,15 @@ SortFilterProxyModel {
                 const model = type === Constants.TokenType.ERC20
                             ? assetsModel : collectiblesModel
 
-                return PermissionsHelpers.getTokenIconByKey(model, collectibles, key)
+                let icon = PermissionsHelpers.getTokenIconByKey(model, collectibles, key)
+                if (Constants.isDefaultTokenIcon(icon)) {
+                    const item = root.getTokenByKeyOrGroupKeyFromAllTokens(key)
+                    if (!!item){
+                        icon = item.logoUri
+                    }
+                }
+
+                return icon
             }
 
             expression: {

--- a/ui/app/AppLayouts/Communities/views/PermissionsView.qml
+++ b/ui/app/AppLayouts/Communities/views/PermissionsView.qml
@@ -30,6 +30,9 @@ ColumnLayout {
     required property var collectiblesModel
     required property var channelsModel
 
+    // Returns token that matches provided key (key can be token or group key). Use it as a last option (may affect app performances, because it fetches all tokens from stautsgo).
+    property var getTokenByKeyOrGroupKeyFromAllTokens: function(key){ return {}}
+
     // id, name, image, color, owner, admin properties expected
     required property QtObject communityDetails
 
@@ -115,6 +118,7 @@ ColumnLayout {
                 sourceModel: model.holdingsListModel
                 assetsModel: root.assetsModel
                 collectiblesModel: root.collectiblesModel
+                getTokenByKeyOrGroupKeyFromAllTokens: root.getTokenByKeyOrGroupKeyFromAllTokens
             }
 
             permissionType: model.permissionType

--- a/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/adaptors/CollectiblesSelectionAdaptor.qml
@@ -112,7 +112,7 @@ QObject {
                 readonly property string key: model.symbol
 
                 readonly property url icon:
-                    model.imageUrl || model.mediaUrl || Assets.png("tokens/DEFAULT-TOKEN")
+                    model.imageUrl || model.mediaUrl || Assets.png(Constants.defaultTokenIcon)
 
                 SortFilterProxyModel { /* 1 */
                     id: ownershipFiltered

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -324,7 +324,7 @@ QtObject {
 
         proxyRoles: FastExpressionRole {
             function collectibleIcon(icon) {
-                return !!icon ? icon : Assets.png("tokens/DEFAULT-TOKEN")
+                return !!icon ? icon : Assets.png(Constants.defaultTokenIcon)
             }
             name: "iconSource"
             expression: collectibleIcon(model.icon)

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -763,6 +763,8 @@ QtObject {
         Retrying = 2
     }
 
+    readonly property string defaultTokenIcon: "tokens/DEFAULT-TOKEN"
+
     readonly property string dummyText: "Dummy"
 
     // Transaction states
@@ -1232,12 +1234,12 @@ QtObject {
             return Assets.png("tokens/" + tmpSymbol)
 
         if (useDefault)
-            return Assets.png("tokens/DEFAULT-TOKEN")
+            return Assets.png(root.defaultTokenIcon)
         return ""
     }
 
     function isDefaultTokenIcon(url) {
-        return url.indexOf("DEFAULT-TOKEN") !== -1
+        return url.indexOf(root.defaultTokenIcon) !== -1
     }
 
     enum RecipientAddressObjectType {


### PR DESCRIPTION
The problem was that the assets list contains tokens of interests (since introduction of a new tokens approach, due to performance reasons) and since Aragon was not there we should fetch it from the backend (statusgo).

These changes require some changes (`getTokenByKeyOrGroupKeyFromAllTokens`) done in the payment requests fix, that's why that branch was used as a base.

Fixes #19597


https://github.com/user-attachments/assets/98876ce3-2517-4527-aec7-fe3e53b47317

