### PR TITLE
fix(settings): fix the naming of "Allow new contact requests" setting

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -51,7 +51,7 @@ SettingsContentBase {
             Layout.fillWidth: true
             implicitHeight: 64
 
-            title: qsTr("Allow new contact requests")
+            title: qsTr("Receive community messages & requests from non-contacts")
 
             components: [
                 StatusSwitch {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -11386,10 +11386,6 @@ to load</source>
 <context>
     <name>MessagingView</name>
     <message>
-        <source>Allow new contact requests</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Contacts, Requests, and Blocked Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11415,6 +11411,10 @@ to load</source>
     </message>
     <message>
         <source>Never show previews</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Receive community messages &amp; requests from non-contacts</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -13862,11 +13862,6 @@
   <context>
     <name>MessagingView</name>
     <message>
-      <source>Allow new contact requests</source>
-      <comment>MessagingView</comment>
-      <translation>Allow new contact requests</translation>
-    </message>
-    <message>
       <source>Contacts, Requests, and Blocked Users</source>
       <comment>MessagingView</comment>
       <translation>Contacts, Requests, and Blocked Users</translation>
@@ -13900,6 +13895,11 @@
       <source>Never show previews</source>
       <comment>MessagingView</comment>
       <translation>Never show previews</translation>
+    </message>
+    <message>
+      <source>Receive community messages &amp; requests from non-contacts</source>
+      <comment>MessagingView</comment>
+      <translation>Receive community messages &amp; requests from non-contacts</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -11476,10 +11476,6 @@ selhalo</translation>
 <context>
     <name>MessagingView</name>
     <message>
-        <source>Allow new contact requests</source>
-        <translation>Povolit nové žádosti o kontakt</translation>
-    </message>
-    <message>
         <source>Contacts, Requests, and Blocked Users</source>
         <translation>Kontakty, žádosti a blokovaní uživatelé</translation>
     </message>
@@ -11506,6 +11502,10 @@ selhalo</translation>
     <message>
         <source>Never show previews</source>
         <translation>Nikdy nezobrazovat náhledy</translation>
+    </message>
+    <message>
+        <source>Receive community messages &amp; requests from non-contacts</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -11403,10 +11403,6 @@ al cargar</translation>
 <context>
     <name>MessagingView</name>
     <message>
-        <source>Allow new contact requests</source>
-        <translation>Permitir nuevas solicitudes de contacto</translation>
-    </message>
-    <message>
         <source>Contacts, Requests, and Blocked Users</source>
         <translation>Contactos, solicitudes y usuarios bloqueados</translation>
     </message>
@@ -11433,6 +11429,10 @@ al cargar</translation>
     <message>
         <source>Never show previews</source>
         <translation>Nunca mostrar vistas previas</translation>
+    </message>
+    <message>
+        <source>Receive community messages &amp; requests from non-contacts</source>
+        <translation>Recibe mensajes de comunidades y solicitudes, incluso de no contactos</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -11371,10 +11371,6 @@ to load</source>
 <context>
     <name>MessagingView</name>
     <message>
-        <source>Allow new contact requests</source>
-        <translation>새 연락처 요청 허용</translation>
-    </message>
-    <message>
         <source>Contacts, Requests, and Blocked Users</source>
         <translation>연락처, 요청, 차단된 사용자</translation>
     </message>
@@ -11401,6 +11397,10 @@ to load</source>
     <message>
         <source>Never show previews</source>
         <translation>미리 보기를 표시하지 않기</translation>
+    </message>
+    <message>
+        <source>Receive community messages &amp; requests from non-contacts</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

We found this issue with Volo. He was only able to see my messages in the Status app. At first, we thought it was a problem with the store nodes, but it happened so much that I realized that something must be wrong.
Turns out he had deactivated the `Allow new contact requests` switch while testing and I checked and that switch is actually very badly named, as it stops **all** messages from non-contacts.

The setting was named "Allow new contact requests", but the setting itself is named `MessagesFromContactsOnly`, so turning it off affected all messages.

We think that this is an old setting that dated to when we didn't have communities, but now that we do have them, it also stops receiving messages from non-contacts in the community as well.

Renaming the label makes it clear what the setting does.

### Affected areas

Setting label

### Screencapture of the functionality

<img width="632" height="156" alt="image" src="https://github.com/user-attachments/assets/54f4b53b-8946-425f-bcc5-1d3418eb54d9" />

### Impact on end user

Understandable setting

### Risk 

None
