### PR TITLE
StatusSearchListPopup: Theme - workaround for QTBUG-142248

### DIFF
--- a/ui/imports/shared/status/StatusSearchListPopup.qml
+++ b/ui/imports/shared/status/StatusSearchListPopup.qml
@@ -26,6 +26,11 @@ StatusDropdown {
     ColumnLayout {
         anchors.fill: parent
 
+        // workaround for QTBUG-142248
+        Theme.style: root.Theme.style
+        Theme.padding: root.Theme.padding
+        Theme.fontSizeOffset: root.Theme.fontSizeOffset
+
         StatusInput {
             id: searchBox
 


### PR DESCRIPTION
### What does the PR do

Fixes style selection for `StatusSearchListPopup` (CTRL+K). The issue was caused by [QTBUG-142248](https://qt-project.atlassian.net/browse/QTBUG-142248

Closes: https://github.com/status-im/status-app/issues/19501

### Affected areas

`StatusSearchListPopup`

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1197" height="802" alt="image" src="https://github.com/user-attachments/assets/1428065e-6eef-4d2d-be09-c878632cb9bd" />


### How to test
1. Log in
2. Ensure Dark Theme
3. Hit CTRL + K (The delegates background should be dark)