### PR TITLE
android: create and sign separate bundle ID for PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -919,6 +919,8 @@ ifeq ($(PACKAGE_TYPE),aab)
 	$(MAKE) -C mobile aab
 else ifeq ($(PACKAGE_TYPE),apk)
 	$(MAKE) -C mobile apk
+else ifeq ($(PACKAGE_TYPE),apk-aab)
+	$(MAKE) -C mobile apk-aab
 else
 	$(MAKE) -C mobile all
 endif

--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -1,17 +1,18 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
-def isNightlyBuild = utils.isNightlyBuild()
-def isReleaseBranch = (env.CHANGE_BRANCH ?: env.BRANCH_NAME)?.startsWith('release')
+
+/* Object to store public URLs for description. */
+descLinks = [:]
 
 pipeline {
   agent {
     /* Image with Ubuntu 22.04, QT 6.9.2, Android SDK/NDK, Go, and Nim */
     docker {
       label 'linuxcontainer'
-      image 'harbor.status.im/status-im/status-desktop-build:1.0.6-qt6.9.2-android'
+      image 'harbor.status.im/status-im/status-desktop-build:1.0.8-qt6.9.2-android'
       alwaysPull true
       args '--entrypoint="" ' +
            '--volume=/nix:/nix ' +
@@ -30,11 +31,6 @@ pipeline {
       name: 'VERBOSE',
       description: 'Level of verbosity based on nimbus-build-system setup.',
       choices: ['0','1','2','3']
-    )
-    choice(
-      name: 'PACKAGE_TYPE',
-      description: 'Package type to build.',
-      choices: ['auto', 'apk', 'aab']
     )
   }
 
@@ -68,14 +64,25 @@ pipeline {
     QT_VERSION = "6.9.2"
     QT_ANDROID_PATH = "/opt/qt/${env.QT_VERSION}/android_arm64_v8a"
     QMAKE = "/opt/qt/${env.QT_VERSION}/android_arm64_v8a/bin/qmake"
-    /* override package type if set, otherwise auto-select based on branch */
-    PACKAGE_TYPE = "${params.PACKAGE_TYPE != 'auto' ? params.PACKAGE_TYPE : (isReleaseBranch ? 'aab' : 'apk')}"
-    STATUS_ARTIFACT = "pkg/${utils.pkgFilename(ext: env.PACKAGE_TYPE, arch: 'arm64', version: env.VERSION, type: env.APP_TYPE)}"
-    STATUS_BINARY = "${WORKSPACE}/mobile/bin/android/qt6/Status.${env.PACKAGE_TYPE}"
+    STATUS_ARTIFACT = "pkg/${utils.pkgFilename(ext: 'apk', arch: 'arm64', version: env.VERSION, type: env.APP_TYPE)}"
+    STATUS_AAB_ARTIFACT = "pkg/${utils.pkgFilename(ext: 'aab', arch: 'arm64', version: env.VERSION, type: env.APP_TYPE)}"
     NIM_SDS_SOURCE_DIR = "${env.WORKSPACE_TMP}/nim-sds"
   }
 
   stages {
+
+    stage('Initialize') {
+      steps { script {
+        def gitBranch = env.GIT_BRANCH ?: ''
+        def isRelease = gitBranch.contains('release/')
+        env.IS_RELEASE_BRANCH = isRelease ? 'true' : 'false'
+        env.PACKAGE_TYPE = isRelease ? 'apk-aab' : 'apk'
+        env.BUILD_VARIANT = isRelease ? 'release' : 'pr'
+        env.STATUS_ANDROID_APP_NAME = isRelease ? 'Status' : 'StatusPR'
+        env.STATUS_BINARY = "${env.WORKSPACE}/mobile/bin/android/qt6/${env.STATUS_ANDROID_APP_NAME}.apk"
+        env.STATUS_AAB_BINARY = "${env.WORKSPACE}/mobile/bin/android/qt6/${env.STATUS_ANDROID_APP_NAME}.aab"
+      } }
+    }
 
     stage('Cleanup Workspace') {
       steps {
@@ -90,36 +97,54 @@ pipeline {
     }
 
     stage('Build Android') {
-      steps {
+      steps { 
         script {
-          app.buildSignedAndroid(target='mobile-build PACKAGE_TYPE=' + env.PACKAGE_TYPE, verbose=params.VERBOSE)
-        }
+        app.buildSignedAndroid(target='mobile-build PACKAGE_TYPE=' + env.PACKAGE_TYPE, verbose=params.VERBOSE)
+        } 
       }
     }
 
     stage('Package') {
-      steps {
-        sh 'mkdir -p pkg'
-        sh "cp ${env.STATUS_BINARY} ${env.STATUS_ARTIFACT}"
-        sh "ls -la ${env.STATUS_ARTIFACT}"
+      steps { 
+        script {
+          sh 'mkdir -p pkg'
+          sh "cp -v ${env.STATUS_BINARY} ${env.STATUS_ARTIFACT}"
+          if (env.IS_RELEASE_BRANCH == 'true') {
+            sh "cp -v ${env.STATUS_AAB_BINARY} ${env.STATUS_AAB_ARTIFACT}"
+          }
+        } 
       }
     }
 
     stage('Parallel Upload') {
       parallel {
         stage('Upload') {
-          steps {
+          steps { 
             script {
               env.PKG_URL = s5cmd.upload(env.STATUS_ARTIFACT)
-              jenkins.setBuildDesc([(env.PACKAGE_TYPE.toUpperCase()): env.PKG_URL])
+              descLinks.APK = env.PKG_URL
             }
           }
         }
-        stage('Archive') {
-          steps {
+
+        stage('Upload AAB') {
+          when { expression { env.IS_RELEASE_BRANCH == 'true' } }
+          steps { 
             script {
-              archiveArtifacts env.STATUS_ARTIFACT
-            }
+              env.AAB_URL = s5cmd.upload(env.STATUS_AAB_ARTIFACT)
+              descLinks.AAB = env.AAB_URL
+            } 
+          }
+        }
+      }
+    }
+
+    stage('Archive') {
+      steps { 
+        script {
+          archiveArtifacts env.STATUS_ARTIFACT
+          if (env.IS_RELEASE_BRANCH == 'true') {
+            archiveArtifacts env.STATUS_AAB_ARTIFACT
           }
         }
       }
@@ -127,6 +152,7 @@ pipeline {
   }
 
   post {
+    always { script { jenkins.setBuildDesc(descLinks) } }
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
     cleanup {

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Object to store public URLs for description. */
 urls = [:]
@@ -131,7 +131,12 @@ pipeline {
         } } }
         stage('iOS/aarch64') { steps { script {
           ios_aarch64 = getArtifacts(
-            'iOS/aarch64', jenkins.Build('status-app/systems/ios/arm64/package')
+            'iOS/aarch64', jenkins.Build('status-app/systems/ios/aarch64/package')
+          )
+        } } }
+        stage('Android/arm64') { steps { script {
+          ios_aarch64 = getArtifacts(
+            'Android/arm64', jenkins.Build('status-app/systems/android/arm64/package')
           )
         } } }
       }

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()
@@ -80,6 +80,8 @@ pipeline {
     NWAKU_SOURCE_DIR = "${env.WORKSPACE_TMP}/nwaku"
     /* nim-sds source directory */
     NIM_SDS_SOURCE_DIR = "${env.WORKSPACE_TMP}/nim-sds"
+    /* Build variant: used by mobile/scripts/App.sh and mobile/fastlane/Fastfile */
+    BUILD_VARIANT = "${utils.isReleaseBuild() ? 'release' : 'pr'}"
   }
 
   stages {

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.qt-build
+++ b/ci/Jenkinsfile.qt-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 pipeline {
 

--- a/ci/Jenkinsfile.tests-e2e.windows-benchmark
+++ b/ci/Jenkinsfile.tests-e2e.windows-benchmark
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.31'
+library 'status-jenkins-lib@v1.9.36'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.33'
+library 'status-jenkins-lib@v1.9.36'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -76,7 +76,7 @@ $(NIM_STATUS_CLIENT_LIB): $(STATUS_DESKTOP_NIM_FILES) $(NIM_STATUS_CLIENT_SCRIPT
 $(TARGET): $(APP_SCRIPT) $(STATUS_GO_LIB) $(STATUS_Q_LIB) $(DOTHERSIDE_LIB) $(OPENSSL_LIB) $(QRCODEGEN_LIB) $(NIM_STATUS_CLIENT_LIB) $(STATUS_DESKTOP_RCC) $(WRAPPER_APP_FILES)
 	@echo "Building app"
 ifeq ($(OS),android)
-	@STATUS_DESKTOP=$(STATUS_DESKTOP) BUILD_TYPE=$(PACKAGE_TYPE) BIN_DIR=$(BIN_PATH) BUILD_DIR=$(BUILD_PATH) QT_MAJOR=$(QT_MAJOR) $(APP_SCRIPT) $(HANDLE_OUTPUT)
+	@STATUS_DESKTOP=$(STATUS_DESKTOP) GRADLE_TARGETS="$(GRADLE_TARGETS)" BIN_DIR=$(BIN_PATH) BUILD_DIR=$(BUILD_PATH) QT_MAJOR=$(QT_MAJOR) $(APP_SCRIPT) $(HANDLE_OUTPUT)
 else
 	@STATUS_DESKTOP=$(STATUS_DESKTOP) BIN_DIR=$(BIN_PATH) BUILD_DIR=$(BUILD_PATH) QT_MAJOR=$(QT_MAJOR) $(APP_SCRIPT) $(HANDLE_OUTPUT)
 endif
@@ -93,35 +93,36 @@ compile-translations:
 	@make -C $(STATUS_DESKTOP) compile-translations $(HANDLE_OUTPUT)
 
 .PHONY: apk
+apk:
 ifeq ($(OS),android)
-apk:
-	@$(MAKE) PACKAGE_TYPE=apk $(BIN_PATH)/Status.apk
-	@echo "✓ APK built successfully"
+	@$(MAKE) GRADLE_TARGETS=assembleRelease $(TARGET)
 else
-apk:
-	@echo "Error: APK target is only available for Android"
-	@exit 1
+	$(error APK target is only available for Android)
 endif
 
 .PHONY: aab
+aab:
 ifeq ($(OS),android)
-aab:
-	@$(MAKE) PACKAGE_TYPE=aab $(BIN_PATH)/Status.aab
-	@echo "✓ AAB built successfully"
+	@$(MAKE) GRADLE_TARGETS="assembleRelease bundleRelease" $(TARGET)
 else
-aab:
-	@echo "Error: AAB target is only available for Android"
-	@exit 1
+	$(error AAB target is only available for Android)
+endif
+
+.PHONY: apk-aab
+apk-aab:
+ifeq ($(OS),android)
+	@$(MAKE) GRADLE_TARGETS="assembleRelease bundleRelease" $(TARGET)
+else
+	$(error apk-aab target is only available for Android)
 endif
 
 .PHONY: ios-app
+ios-app:
 ifeq ($(OS),ios)
-ios-app: $(TARGET)
+	@$(MAKE) $(TARGET)
 	@echo "✓ iOS app built successfully"
 else
-ios-app:
-	@echo "Error: iOS app target is only available for iOS"
-	@exit 1
+	$(error iOS app target is only available for iOS)
 endif
 
 .PHONY: all

--- a/mobile/android/qt6/AndroidManifest.xml
+++ b/mobile/android/qt6/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="app.status.mobile"
-    android:installLocation="auto"
-    android:versionCode="-- %%INSERT_VERSION_CODE%% --"
-    android:versionName="-- %%INSERT_VERSION_NAME%% --">
+    android:installLocation="auto">
     <!-- non-dangerous permissions -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.NFC"/>
@@ -60,6 +58,19 @@
           <meta-data
                 android:name="android.app.arguments"
                 android:value="" />
+
+          <!-- Required for Qt6 to properly detect and load native libraries -->
+          <meta-data
+                android:name="android.app.system_libs_prefix"
+                android:value="/system/lib64/" />
+
+          <meta-data
+                android:name="android.app.use_local_qt_libs"
+                android:value="1" />
+
+          <meta-data
+                android:name="android.app.bundle_local_qt_libs"
+                android:value="1" />
         </activity>
 
         <provider

--- a/mobile/android/qt6/build.gradle
+++ b/mobile/android/qt6/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     implementation 'androidx.documentfile:documentfile:1.0.1'
 }
 
+// Allow overriding qtAndroidDir via environment variable (for different Qt installations)
+def qtDir = System.getenv("QT_ANDROID_DIR") ?: qtAndroidDir
+
+// Build variant: 'pr' or 'release' (controls app ID and name)
+def buildVariant = System.getenv("BUILD_VARIANT") ?: "release"
+
 android {
     /*******************************************************
      * The following variables:
@@ -54,9 +60,9 @@ android {
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
-            java.srcDirs = [qtAndroidDir + '/src', 'src', 'java']
-            aidl.srcDirs = [qtAndroidDir + '/src', 'src', 'aidl']
-            res.srcDirs = [qtAndroidDir + '/res', 'res']
+            java.srcDirs = [qtDir + '/src', 'src', 'java']
+            aidl.srcDirs = [qtDir + '/src', 'src', 'aidl']
+            res.srcDirs = [qtDir + '/res', 'res']
             resources.srcDirs = ['resources']
             renderscript.srcDirs = ['src']
             assets.srcDirs = ['assets']
@@ -89,12 +95,25 @@ android {
         ndk.abiFilters = qtTargetAbiList.split(",")
         // Generate unique versionCode based on minutes since epoch
         versionCode = (System.currentTimeMillis() / 60000).toInteger()
+        // Set applicationId and app name based on build variant
+        applicationId = buildVariant == 'release' ? "app.status.mobile" : "app.status.mobile.pr"
+        resValue "string", "app_name", buildVariant == 'release' ? "Status" : "StatusPR"
+    }
+
+    signingConfigs {
+        release {
+            storeFile file(System.getenv("STATUS_APP_KEYSTORE_PATH") ?: "/nonexistent")
+            storePassword System.getenv("STATUS_APP_KEYSTORE_PASSWORD")
+            keyAlias System.getenv("STATUS_APP_KEY_ALIAS")
+            keyPassword System.getenv("STATUS_APP_KEY_PASSWORD")
+        }
     }
 
     buildTypes {
         release {
             debuggable = false
             minifyEnabled = false
+            signingConfig signingConfigs.release
         }
         debug {
             debuggable = true

--- a/mobile/android/qt6/gradle.properties
+++ b/mobile/android/qt6/gradle.properties
@@ -1,0 +1,11 @@
+android.useAndroidX=true
+qtGradlePluginType=com.android.application
+androidPackageName=app.status.mobile
+androidBuildToolsVersion=35.0.0
+androidCompileSdkVersion=android-35
+androidNdkVersion=27.2.12479018
+qtAndroidDir=/opt/qt/6.9.2/android_arm64_v8a/src/android/java
+qtMinSdkVersion=28
+qtTargetSdkVersion=35
+qtTargetAbiList=arm64-v8a
+org.gradle.jvmargs=-Xmx8704M -XX:+UseParallelGC

--- a/mobile/android/qt6/res/xml/qtprovider_paths.xml
+++ b/mobile/android/qt6/res/xml/qtprovider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
+</paths>

--- a/mobile/android/qt6/settings.gradle
+++ b/mobile/android/qt6/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'android-build'

--- a/mobile/docker/Dockerfile
+++ b/mobile/docker/Dockerfile
@@ -337,6 +337,7 @@ ENV ARCH=arm64
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
+    rsync \
     s3cmd \
     fuse \
     tk-dev \
@@ -394,6 +395,13 @@ RUN apt update -yq && apt install -yq software-properties-common \
     --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
  && apt-get -qq clean
 
-ENV PATH="/root/go/bin:${PATH}"
+ARG GRADLE_VERSION=8.11.1
+RUN wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -O /tmp/gradle.zip \
+ && unzip -q /tmp/gradle.zip -d /opt \
+ && ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle \
+ && rm /tmp/gradle.zip
+
+ENV GRADLE_HOME=/opt/gradle
+ENV PATH="/opt/gradle/bin:/root/go/bin:${PATH}"
 
 LABEL description="Build image for the Status Android APK."

--- a/mobile/fastlane/Matchfile
+++ b/mobile/fastlane/Matchfile
@@ -12,7 +12,7 @@ app_identifier([
 ])
 
 # App Store Connect API Key
-api_key_path(ENV["ASC_API_KEY_JSON"]) if ENV["ASC_API_KEY_JSON"]
+api_key_path(ENV["APP_STORE_CONNECT_API_KEY_PATH"]) if ENV["APP_STORE_CONNECT_API_KEY_PATH"]
 
 # Keychain configuration
 keychain_name(ENV["KEYCHAIN_NAME"]) if ENV["KEYCHAIN_NAME"]

--- a/mobile/scripts/Common.mk
+++ b/mobile/scripts/Common.mk
@@ -40,11 +40,9 @@ TARGET_PREFIX := Status
 # Default package type for Android builds
 PACKAGE_TYPE ?= apk
 
-# mobile app extension to be based on OS and PACKAGE_TYPE
+# mobile app extension - always apk for Android (AAB built alongside when requested)
 ifeq ($(OS),ios)
 EXTENSION := app
-else ifeq ($(OS),android)
-EXTENSION := $(PACKAGE_TYPE)
 else
 EXTENSION := apk
 endif

--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -5,146 +5,86 @@ CWD=$(realpath "$(dirname "$0")")
 
 ARCH=${ARCH:-amd64}
 SDK=${SDK:-iphonesimulator}
-JAVA_HOME=${JAVA_HOME:-}
-BIN_DIR=${BIN_DIR:-"$CWD/../bin/ios"}
 BUILD_DIR=${BUILD_DIR:-"$CWD/../build"}
-ANDROID_ABI=${ANDROID_ABI:-"arm64-v8a"}
-BUILD_TYPE=${BUILD_TYPE:-"apk"}
-
-# BUILD_VARIANT controls bundle ID: "pr" = app.status.mobile.pr, "release" = app.status.mobile
-export BUILD_VARIANT=${BUILD_VARIANT:-"release"}
+GRADLE_TARGETS=${GRADLE_TARGETS:-"assembleRelease"}
+BUILD_VARIANT=${BUILD_VARIANT:-"release"}
 
 QMAKE_BIN="${QMAKE:-qmake}"
-QMAKE_CONFIG="CONFIG+=device CONFIG+=release"
+QMAKE_CONFIG=("CONFIG+=device" "CONFIG+=release")
 
-PRO_FILE="$CWD/../wrapperApp/Status.pro"
+# Derive names from variant: pr -> StatusPR, release -> Status
+OUTPUT_NAME="Status"
+[[ "$BUILD_VARIANT" == "pr" ]] && OUTPUT_NAME="StatusPR"
 
-echo "Building wrapperApp for ${OS}, ${ANDROID_ABI}"
-echo "Using project file: $PRO_FILE"
+echo "Building $OUTPUT_NAME for ${OS}, variant: ${BUILD_VARIANT}"
 
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 
 STATUS_DESKTOP=${STATUS_DESKTOP:-"../vendors/status-desktop"}
-DESKTOP_VERSION=$(eval cd "$STATUS_DESKTOP" && git describe --tags --dirty="-dirty" --always | cut -d- -f1 | cut -d. -f1-3 | sed 's/^v//')
+VERSION=$(cd "$STATUS_DESKTOP" && git describe --tags --always | cut -d- -f1 | cut -d. -f1-3 | sed 's/^v//')
+BUILD_VERSION="${CHANGE_ID:+${CHANGE_ID}.}$(($(date +%s) / 60))"
 
-TIMESTAMP=$(($(date +%s) * 1000 / 60000))
-
-if [[ -n "${CHANGE_ID:-}" ]]; then
-  BUILD_VERSION="${CHANGE_ID}.${TIMESTAMP}"
-else
-  BUILD_VERSION="${TIMESTAMP}"
-fi
-
-echo "Using version: $DESKTOP_VERSION; build version: $BUILD_VERSION"
+echo "Version: $VERSION, build: $BUILD_VERSION"
 
 if [[ "${OS}" == "android" ]]; then
-  if [[ -z "${JAVA_HOME}" ]]; then
-    echo "JAVA_HOME is not set. Please set JAVA_HOME to the path of your JDK 11 or later."
-    exit 1
-  fi
+  [[ -z "${JAVA_HOME}" ]] && { echo "JAVA_HOME is not set"; exit 1; }
 
-  echo "Building for Android 35"
-  ANDROID_PLATFORM=android-35
+  # Export BUILD_VARIANT for build.gradle to pick up
+  export BUILD_VARIANT
 
-  "$QMAKE_BIN" "$PRO_FILE" "$QMAKE_CONFIG" -spec android-clang ANDROID_ABIS="$ANDROID_ABI" APP_VARIANT="${APP_VARIANT}" VERSION="$DESKTOP_VERSION" -after
+  "$QMAKE_BIN" "$CWD/../wrapperApp/Status.pro" "${QMAKE_CONFIG[@]}" -spec android-clang \
+    ANDROID_ABIS="${ANDROID_ABI:-arm64-v8a}" VERSION="$VERSION" -after
 
-  # Build the app
   make -j"$(nproc)" apk_install_target
 
-  if [[ "$BUILD_TYPE" == "aab" ]]; then
-    if [[ -z "$KEYSTORE_PATH" || -z "$KEYSTORE_PASSWORD" || -z "$KEY_ALIAS" || -z "$KEY_PASSWORD" ]]; then
-      echo "Error: AAB builds require signing credentials"
-      echo "Required: KEYSTORE_PATH, KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD"
-      exit 1
-    fi
+  androiddeployqt \
+    --input "$BUILD_DIR/android-${OUTPUT_NAME}-deployment-settings.json" \
+    --output "$BUILD_DIR/android-build" \
+    --android-platform android-35 \
+    --verbose --aux-mode
 
-    if [[ ! -f "$KEYSTORE_PATH" ]]; then
-      echo "Error: Keystore file not found at $KEYSTORE_PATH"
-      exit 1
-    fi
+  # Copy custom Android files, preserve Qt-generated libs.xml
+  cp "$CWD/../android/qt${QT_MAJOR}"/{AndroidManifest.xml,build.gradle,settings.gradle,gradle.properties} "$BUILD_DIR/android-build/"
+  rsync -a --exclude='libs.xml' "$CWD/../android/qt${QT_MAJOR}/res/" "$BUILD_DIR/android-build/res/" 2>/dev/null || true
+  rsync -a "$CWD/../android/qt${QT_MAJOR}/src/" "$BUILD_DIR/android-build/src/" 2>/dev/null || true
 
-    echo "Building AAB..."
-    androiddeployqt \
-      --input "$BUILD_DIR/android-Status-deployment-settings.json" \
-      --output "$BUILD_DIR/android-build" \
-      --aab \
-      --release \
-      --android-platform "$ANDROID_PLATFORM"
+  cd "$BUILD_DIR/android-build"
 
-    OUTPUT_FILE="$BUILD_DIR/android-build/build/outputs/bundle/release/android-build-release.aab"
-    if [[ ! -f "$OUTPUT_FILE" ]]; then
-      echo "Error: Could not find generated AAB file at $OUTPUT_FILE"
-      exit 1
-    fi
+  BIN_DIR=${BIN_DIR:-"$CWD/../bin/android/qt6"}
+  mkdir -p "$BIN_DIR"
 
-    # Sign the AAB file (androiddeployqt --sign does not work for AAB files)
-    "$CWD/android/sign.sh" "$OUTPUT_FILE"
+  # Gradle output paths
+  APK_OUT="build/outputs/apk/release/android-build-release.apk"
+  AAB_OUT="build/outputs/bundle/release/android-build-release.aab"
 
-    ANDROID_OUTPUT_DIR="bin/android/qt6"
-    BIN_DIR_ANDROID=${BIN_DIR:-"$CWD/$ANDROID_OUTPUT_DIR"}
-    mkdir -p "$BIN_DIR_ANDROID"
-    cp "$OUTPUT_FILE" "$BIN_DIR_ANDROID/Status.aab"
-    echo "Build succeeded. Signed AAB is available at $BIN_DIR_ANDROID/Status.aab"
-  else
-    # APK build
-    NEEDS_SIGNING="false"
-    if [[ -n "$KEYSTORE_PATH" && -n "$KEYSTORE_PASSWORD" && -n "$KEY_ALIAS" && -n "$KEY_PASSWORD" ]]; then
-      if [[ -f "$KEYSTORE_PATH" ]]; then
-        NEEDS_SIGNING="true"
-      fi
-    fi
+  # Build with specified gradle targets
+  gradle $GRADLE_TARGETS --no-daemon
 
-    if [[ "$NEEDS_SIGNING" == "true" ]]; then
-      echo "Building signed APK..."
-      androiddeployqt \
-        --input "$BUILD_DIR/android-Status-deployment-settings.json" \
-        --output "$BUILD_DIR/android-build" \
-        --apk "$BUILD_DIR/android-build/Status.apk" \
-        --release \
-        --android-platform "$ANDROID_PLATFORM" \
-        --sign "$KEYSTORE_PATH" "$KEY_ALIAS" \
-        --storepass "$KEYSTORE_PASSWORD" \
-        --keypass "$KEY_PASSWORD"
-    else
-      echo "Building unsigned APK..."
-      androiddeployqt \
-        --input "$BUILD_DIR/android-Status-deployment-settings.json" \
-        --output "$BUILD_DIR/android-build" \
-        --apk "$BUILD_DIR/android-build/Status.apk" \
-        --android-platform "$ANDROID_PLATFORM"
-    fi
-
-    ANDROID_OUTPUT_DIR="bin/android/qt6"
-    BIN_DIR_ANDROID=${BIN_DIR:-"$CWD/$ANDROID_OUTPUT_DIR"}
-    mkdir -p "$BIN_DIR_ANDROID"
-    cp ./android-build/Status.apk "$BIN_DIR_ANDROID/Status.apk"
-
-    if [[ "$NEEDS_SIGNING" == "true" ]]; then
-      echo "Build succeeded. Signed APK is available at $BIN_DIR_ANDROID/Status.apk"
-    else
-      echo "Build succeeded. Unsigned APK is available at $BIN_DIR_ANDROID/Status.apk"
-    fi
+  # Copy whichever artifacts were built
+  BUILT=""
+  if [[ -f "$APK_OUT" ]]; then
+    cp "$APK_OUT" "$BIN_DIR/${OUTPUT_NAME}.apk"
+    BUILT="$BIN_DIR/${OUTPUT_NAME}.apk"
   fi
+  if [[ -f "$AAB_OUT" ]]; then
+    cp "$AAB_OUT" "$BIN_DIR/${OUTPUT_NAME}.aab"
+    BUILT="$BUILT $BIN_DIR/${OUTPUT_NAME}.aab"
+  fi
+
+  [[ -z "$BUILT" ]] && { echo "Error: No artifacts produced"; exit 1; }
+  echo "Build succeeded:$BUILT"
+
 else
-  "$QMAKE_BIN" "$PRO_FILE" "$QMAKE_CONFIG" -spec macx-ios-clang CONFIG+="$SDK" VERSION="$DESKTOP_VERSION" -after
+  "$QMAKE_BIN" "$CWD/../wrapperApp/Status.pro" "${QMAKE_CONFIG[@]}" -spec macx-ios-clang CONFIG+="$SDK" VERSION="$VERSION" -after
 
-  if [[ "$BUILD_VARIANT" == "pr" ]]; then
-    TARGET_NAME="StatusPR"
-  else
-    TARGET_NAME="Status"
-  fi
+  XCODE_FLAGS=(-configuration Release -sdk "$SDK" -arch "$ARCH" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CURRENT_PROJECT_VERSION="$BUILD_VERSION")
+  BIN_DIR=${BIN_DIR:-"$CWD/../bin/ios"}
 
-  # Compile resources
-  xcodebuild -configuration Release -target "Qt Preprocess" -sdk "$SDK" -arch "$ARCH" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CURRENT_PROJECT_VERSION=$BUILD_VERSION | xcbeautify
-  # Compile the app
-  xcodebuild -configuration Release -target "$TARGET_NAME" install -sdk "$SDK" -arch "$ARCH" DSTROOT="$BIN_DIR" INSTALL_PATH="/" TARGET_BUILD_DIR="$BIN_DIR" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CURRENT_PROJECT_VERSION=$BUILD_VERSION | xcbeautify
+  xcodebuild "${XCODE_FLAGS[@]}" -target "Qt Preprocess" | xcbeautify
+  xcodebuild "${XCODE_FLAGS[@]}" -target "$OUTPUT_NAME" install DSTROOT="$BIN_DIR" INSTALL_PATH="/" TARGET_BUILD_DIR="$BIN_DIR" | xcbeautify
 
-  if [[ ! -e "${BIN_DIR}/${TARGET_NAME}.app/Info.plist" ]]; then
-    echo "Build failed -> ${BIN_DIR}/${TARGET_NAME}.app not found"
-    exit 1
-  fi
+  [[ ! -e "$BIN_DIR/${OUTPUT_NAME}.app/Info.plist" ]] && { echo "Build failed"; exit 1; }
 
-  # Note: iOS signing is handled by fastlane
-  echo "Build succeeded! unsigned app ready for fastlane signing"
+  echo "Build succeeded: $BIN_DIR/${OUTPUT_NAME}.app"
 fi

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -2,6 +2,11 @@ TEMPLATE = app
 
 QT += quick gui qml webview svg widgets multimedia
 
+BUILD_VARIANT = $$(BUILD_VARIANT)
+TARGET = Status
+equals(BUILD_VARIANT, "pr"): TARGET = StatusPR
+message("Building $$BUILD_VARIANT variant: TARGET = $$TARGET")
+
 equals(QT_MAJOR_VERSION, 6) {
     message("qt 6 config!!")
     QT += core5compat core
@@ -50,19 +55,12 @@ ios {
     QMAKE_ASSET_CATALOGS += $$PWD/../ios/Images.xcassets
     QMAKE_IOS_LAUNCH_SCREEN = $$PWD/../ios/launch-image-universal.storyboard
 
-    # Bundle identifier configuration based on BUILD_VARIANT environment variable
-    # - PR builds (BUILD_VARIANT=pr): app.status.mobile.pr
-    # - Release/Local dev (BUILD_VARIANT unset or "release"): app.status.mobile
-    BUILD_VARIANT_ENV = $$(BUILD_VARIANT)
-    equals(BUILD_VARIANT_ENV, "pr") {
-        TARGET = StatusPR
+    # Bundle identifier: pr -> app.status.mobile.pr, release -> app.status.mobile
+    QMAKE_TARGET_BUNDLE_PREFIX = app.status
+    QMAKE_BUNDLE = mobile
+    equals(BUILD_VARIANT, "pr") {
         QMAKE_TARGET_BUNDLE_PREFIX = app.status.mobile
         QMAKE_BUNDLE = pr
-    } else {
-        # Default for local development and release builds
-        TARGET = Status
-        QMAKE_TARGET_BUNDLE_PREFIX = app.status
-        QMAKE_BUNDLE = mobile
     }
 
     LIBS += -L$$PWD/../lib/$$LIB_PREFIX -lnim_status_client -lDOtherSideStatic -lstatusq -lstatus -lsds -lssl_3 -lcrypto_3 -lqzxing -lresolv -lqrcodegen


### PR DESCRIPTION
- points to `fix-android-signing` branch in status-jenkins-lib
- use gradle build flavours for PR and Release.
- signing config moved to gradle
- depends on 
  - [x] https://github.com/status-im/status-jenkins-lib/pull/126
  - [x] https://github.com/status-im/status-jenkins-lib/pull/128
  - [x] https://github.com/status-im/status-jenkins-lib/pull/129
