### PR TITLE
ci: fix testflight entitlements

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -148,12 +148,36 @@ platform :ios do
     # that resign.sh uses for processing nested apps/extensions
     resign_sh = File.join(Sigh::ROOT, 'lib', 'assets', 'resign.sh')
 
+    # Extract entitlements from provisioning profile and modify NFC entitlement
+    # This fixes "NDEF is disallowed" error with Xcode 16+ / SDK 18.x
+    # We remove NDEF from com.apple.developer.nfc.readersession.formats (keep TAG and PACE)
+    require 'tempfile'
+    entitlements_file = Tempfile.new(['entitlements', '.plist'])
+
+    # Extract entitlements from provisioning profile
+    sh("security cms -D -i #{provisioning_profile.shellescape} | plutil -extract Entitlements xml1 -o #{entitlements_file.path.shellescape} -", log: false)
+
+    # Check if NFC entitlement exists and modify it to remove NDEF
+    nfc_key = "com.apple.developer.nfc.readersession.formats"
+    has_nfc = sh("/usr/libexec/PlistBuddy -c 'Print :#{nfc_key}' #{entitlements_file.path.shellescape} 2>/dev/null || echo ''", log: false).strip
+
+    if has_nfc != ""
+      UI.message("Found NFC entitlements, removing deprecated NDEF value...")
+      # Delete existing NFC array and recreate with only TAG and PACE (no NDEF)
+      sh("/usr/libexec/PlistBuddy -c 'Delete :#{nfc_key}' #{entitlements_file.path.shellescape}", log: false)
+      sh("/usr/libexec/PlistBuddy -c 'Add :#{nfc_key} array' #{entitlements_file.path.shellescape}", log: false)
+      sh("/usr/libexec/PlistBuddy -c 'Add :#{nfc_key}:0 string TAG' #{entitlements_file.path.shellescape}", log: false)
+      sh("/usr/libexec/PlistBuddy -c 'Add :#{nfc_key}:1 string PACE' #{entitlements_file.path.shellescape}", log: false)
+      UI.message("Modified NFC entitlements: removed NDEF, keeping TAG and PACE")
+    end
+
     UI.message("Resigning IPA with resign.sh directly via bash...")
     command = [
       resign_sh.shellescape,
       ipa_path.shellescape,
       signing_identity.shellescape,
       "-p", "#{app_identifier}=#{provisioning_profile}".shellescape,
+      "-e", entitlements_file.path.shellescape,
       "-d", display_name.shellescape,
       "-b", app_identifier.shellescape,
       "-v",

--- a/mobile/ios/Info.plist
+++ b/mobile/ios/Info.plist
@@ -66,5 +66,7 @@
     <string>Log in securely to your account.</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
+    <key>NFCReaderUsageDescription</key>
+    <string>Status uses NFC to read and verify identity cards for secure authentication.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Otherwise apple complains about
```
[ContentDelivery.Uploader.60000246C100] Validation failed (409) Invalid
entitlement for core nfc framework. The sdk version '18.2' and min OS
version '16.0' are not compatible for the entitlement
'com.apple.developer.nfc.readersession.formats' because 'NDEF is
disallowed'. (ID: 04f4f958-23c6-4f84-b7eb-c36e7c795fd3)
[2025-12-25T15:04:18.538Z]
```
and

```
[ContentDelivery.Uploader.60000246C100] Validation failed (409) Missing
purpose string in Info.plist. Your app’s code references one or more
APIs that access sensitive user data, or the app has one or more
entitlements that permit such access. The Info.plist file for the
“Status.app” bundle should contain a NFCReaderUsageDescription key with
a user-facing purpose string explaining clearly and completely why your
app needs the data. If you’re using external libraries or SDKs, they may
reference APIs that require a purpose string. While your app might not
use these APIs, a purpose string is still required. For details, visit:
https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources.
(ID: 788dcfa4-adf8-4e1a-b55c-0a1f1c4181cc)
[2025-12-25T15:04:18.538Z]
```