### PR TITLE
fix(community): fix 0 count in join community popup

### DIFF
--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -533,7 +533,7 @@ QtObject:
           "amIBanned": item.isBanned,
           "access": item.access,
           "ensOnly": item.ensOnly,
-          "nbMembers": item.members.getCount(),
+          "nbMembers": item.joinedMembersCount,
           "encrypted": item.encrypted,
         }
         return $jsonObj


### PR DESCRIPTION
Fixes #19643

<img width="691" height="412" alt="image" src="https://github.com/user-attachments/assets/ab2f5c4a-bf22-474f-b0f3-3e9ad98022d5" />
