### PR TITLE
ci: fix structure of e2e benchmark jobs

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -86,43 +86,33 @@ pipeline {
                 }
               }
             }
-            stage('E2E Tests') {
+            stage('E2E') {
               when {
                 expression {
                   env.JOB_NAME.toLowerCase().contains('nightly')
                 }
               }
-              parallel {
-                stage('E2E') {
-                  steps {
-                    script {
-                      windows_e2e = build(
-                        job: 'status-app/systems/windows/x86_64/tests-e2e',
-                        parameters: jenkins.mapToParams([
-                          BUILD_SOURCE:       windows_x86_64.fullProjectName,
-                          TESTRAIL_RUN_NAME:  utils.pkgFilename(),
-                          TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
-                          GIT_REF:            env.BRANCH_NAME,
-                        ]),
-                      )
-                    }
-                  }
-                }
-                stage('Benchmark E2E') {
-                  steps {
-                    script {
-                      benchmark_windows_e2e = build(
-                        job: 'status-app/e2e/nightly-benchmark-windows-master',
-                        propagate: false,
-                        parameters: jenkins.mapToParams([
-                          BUILD_SOURCE:      windows_x86_64.fullProjectName,
-                          TESTRAIL_RUN_NAME: utils.pkgFilename(),
-                          TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
-                          GIT_REF:           env.BRANCH_NAME
-                        ]),
-                      )
-                    }
-                  }
+              steps {
+                script {
+                  windows_e2e = build(
+                    job: 'status-app/systems/windows/x86_64/tests-e2e',
+                    parameters: jenkins.mapToParams([
+                      BUILD_SOURCE:       windows_x86_64.fullProjectName,
+                      TESTRAIL_RUN_NAME:  utils.pkgFilename(),
+                      TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
+                      GIT_REF:            env.BRANCH_NAME,
+                    ]),
+                  )
+                  benchmark_windows_e2e = build(
+                    job: 'status-app/e2e/nightly-benchmark-windows-master',
+                    propagate: false,
+                    parameters: jenkins.mapToParams([
+                      BUILD_SOURCE:      windows_x86_64.fullProjectName,
+                      TESTRAIL_RUN_NAME: utils.pkgFilename(),
+                      TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
+                      GIT_REF:           env.BRANCH_NAME
+                    ]),
+                  )
                 }
               }
             }


### PR DESCRIPTION
parallel nesting is not allowed in jenkins, these need to be sequential.

Nightly run with these changes : https://ci.status.im/blue/organizations/jenkins/status-app%2Fnightly/detail/nightly/1119/

