### PR TITLE
ci: run windows e2e and benchmark in parallel

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -86,7 +86,7 @@ pipeline {
                 }
               }
             }
-            stage('E2E') {
+            stage('Windows E2E Tests') {
               when {
                 expression {
                   env.JOB_NAME.toLowerCase().contains('nightly')
@@ -94,24 +94,30 @@ pipeline {
               }
               steps {
                 script {
-                  windows_e2e = build(
-                    job: 'status-app/systems/windows/x86_64/tests-e2e',
-                    parameters: jenkins.mapToParams([
-                      BUILD_SOURCE:       windows_x86_64.fullProjectName,
-                      TESTRAIL_RUN_NAME:  utils.pkgFilename(),
-                      TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
-                      GIT_REF:            env.BRANCH_NAME,
-                    ]),
-                  )
-                  benchmark_windows_e2e = build(
-                    job: 'status-app/e2e/nightly-benchmark-windows-master',
-                    propagate: false,
-                    parameters: jenkins.mapToParams([
-                      BUILD_SOURCE:      windows_x86_64.fullProjectName,
-                      TESTRAIL_RUN_NAME: utils.pkgFilename(),
-                      TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
-                      GIT_REF:           env.BRANCH_NAME
-                    ]),
+                  parallel(
+                    'E2E': {
+                      windows_e2e = build(
+                        job: 'status-app/systems/windows/x86_64/tests-e2e',
+                        parameters: jenkins.mapToParams([
+                          BUILD_SOURCE:       windows_x86_64.fullProjectName,
+                          TESTRAIL_RUN_NAME:  utils.pkgFilename(),
+                          TEST_SCOPE_FLAG:    utils.isReleaseBuild() ? '-m=critical' : '',
+                          GIT_REF:            env.BRANCH_NAME,
+                        ]),
+                      )
+                    },
+                    'Benchmark': {
+                      benchmark_windows_e2e = build(
+                        job: 'status-app/e2e/nightly-benchmark-windows-master',
+                        propagate: false,
+                        parameters: jenkins.mapToParams([
+                          BUILD_SOURCE:      windows_x86_64.fullProjectName,
+                          TESTRAIL_RUN_NAME: utils.pkgFilename(),
+                          TEST_SCOPE_FLAG:   utils.isReleaseBuild() ? '-m=critical' : '',
+                          GIT_REF:           env.BRANCH_NAME
+                        ]),
+                      )
+                    }
                   )
                 }
               }


### PR DESCRIPTION
## Summary

- The E2E benchmark job should run in parallel and not depend on windows E2E job itself.
- parallel function call with `parallel()` is allowed, just declarative nested parallel syntax is not allowed in `jenkins`.
- [ ] Testing here : https://ci.status.im/blue/organizations/jenkins/status-app%2Fnightly/detail/nightly/1122/pipeline