### PR TITLE
ios: upgrade to SDK 26 and use Xcode 26 in CI

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -8,7 +8,7 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
 
-  agent { label "macos && arm64 && nix-2.24 && xcode-16.2 && qt-${QT_VERSION}" }
+  agent { label "macos && arm64 && nix-2.24 && xcode-26.4 && qt-${QT_VERSION}" }
 
   parameters {
     booleanParam(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -9,7 +9,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-${QT_VERSION} && go-1.24 && xcode-16.2"
+    label "${getAgentLabels().join(' && ')} && qt-${QT_VERSION} && go-1.24 && xcode-26.4"
   }
 
   parameters {

--- a/mobile/DEV_SETUP.md
+++ b/mobile/DEV_SETUP.md
@@ -144,12 +144,12 @@ The build system uses several environment variables to control the build process
 
 #### iOS-specific Variables
 - `IPHONE_SDK`: iOS SDK to use (`iphoneos` or `iphonesimulator`)
-- `IOS_TARGET`: Minimum iOS version (16 for Qt6)
+- `IOS_TARGET`: Minimum iOS version (26 for Qt6)
 
 ### Qt Version Compatibility
 
 #### Qt6
-- iOS minimum deployment target: iOS 16
+- iOS minimum deployment target: iOS 26
 - iOS simulator: iPad Pro
 - Android target: Android 35
 - Android NDK: 27.2.12479018

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -150,13 +150,13 @@ platform :ios do
     # https://github.com/fastlane/fastlane/blob/512a047abd596a5c2c0e0156e9f52e111552a727/sigh/lib/assets/resign.sh#L177C1-L177C9
     FileUtils.rm_rf("_floatsignTemp")
 
-    # Call resign.sh directly with /bin/bash instead of using the resign action
-    # Ruby backticks use /bin/sh which doesn't support bash process substitution < <(...)
-    # that resign.sh uses for processing nested apps/extensions
+    # Invoke resign.sh via /bin/bash directly: fastlane's `resign` action runs it through
+    # Ruby backticks (/bin/sh), which doesn't support the `< <(...)` process substitution
+    # resign.sh uses for nested apps/extensions.
     resign_sh = File.join(Sigh::ROOT, 'lib', 'assets', 'resign.sh')
 
     # Extract entitlements from provisioning profile and modify NFC entitlement
-    # This fixes "NDEF is disallowed" error with Xcode 16+ / SDK 18.x
+    # This fixes "NDEF is disallowed" error,
     # We remove NDEF from com.apple.developer.nfc.readersession.formats (keep TAG and PACE)
     require 'tempfile'
     entitlements_file = Tempfile.new(['entitlements', '.plist'])

--- a/mobile/fastlane/flake.nix
+++ b/mobile/fastlane/flake.nix
@@ -40,6 +40,17 @@
               export PATH="$GEM_HOME/bin:$PATH"
               export LANG="en_US.UTF-8"
 
+              unset BUNDLE_PATH
+              unset BUNDLE_GEMFILE
+
+              echo "Ruby $(ruby --version)"
+              echo "Bundler $(bundle --version)"
+              echo ""
+              echo "Installing fastlane dependencies..."
+              # Build native gem extensions against nix's apple-sdk, NOT host Xcode.
+              # Host Xcode 26 SDK headers break Ruby 3.1's mkmf probes.
+              ( unset DEVELOPER_DIR SDKROOT; bundle install )
+
               export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
 
               # fastlane resign needs xcode tools in shell
@@ -48,15 +59,6 @@
                 ln -sf /usr/bin/$tool "$XCODE_WRAPPER_DIR/$tool" 2>/dev/null || true
               done
               export PATH="$XCODE_WRAPPER_DIR:$PATH"
-
-              unset BUNDLE_PATH
-              unset BUNDLE_GEMFILE
-
-              echo "Ruby $(ruby --version)"
-              echo "Bundler $(bundle --version)"
-              echo ""
-              echo "Installing fastlane dependencies..."
-              bundle install
             '';
           };
         }

--- a/mobile/scripts/EnvVariables.mk
+++ b/mobile/scripts/EnvVariables.mk
@@ -30,7 +30,7 @@ ifeq ($(OS), ios)
     # iOS
     #SDKs: iphonesimulator, iphoneos
     IPHONE_SDK?=iphonesimulator
-    IOS_TARGET?=16
+    IOS_TARGET?=26
 
     ifeq ($(IPHONE_SDK), iphoneos)
         ARCH=arm64

--- a/mobile/scripts/commonCmakeConfig.sh
+++ b/mobile/scripts/commonCmakeConfig.sh
@@ -22,7 +22,7 @@ if [[ "$OS" == "ios" ]]; then
     COMMON_CMAKE_CONFIG+=(
         -DCMAKE_OSX_ARCHITECTURES:STRING="$ARCH"
         -DCMAKE_OSX_SYSROOT="$SDK"
-        -DCMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET=12.0
+        -DCMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET=26.0
     )
 elif [[ "$OS" == "android" ]]; then
     if [[ "$ARCH" == "arm64" ]]; then

--- a/mobile/scripts/ios/clangWrap.sh
+++ b/mobile/scripts/ios/clangWrap.sh
@@ -3,7 +3,7 @@
 SDK=${SDK:-"iphonesimulator"}
 XCODE_SDK_PATH=$(xcrun --sdk "$SDK" --show-sdk-path)
 CLANG=$(xcrun --sdk "$SDK" --find clang)
-IOS_TARGET=${IOS_TARGET:-12}
+IOS_TARGET=${IOS_TARGET:-26}
 ARCH=${ARCH:-"amd64"}
 
 EXTRA_ARGS=()

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -68,7 +68,8 @@ ios {
     QMAKE_CFLAGS += -Wno-implicit-function-declaration
 
     QMAKE_INFO_PLIST = $$OUT_PWD/Info.plist
-    QMAKE_IOS_DEPLOYMENT_TARGET=16.0
+    QMAKE_IOS_DEPLOYMENT_TARGET=26.0
+
     QMAKE_ASSET_CATALOGS += $$PWD/../ios/Images.xcassets
     QMAKE_IOS_LAUNCH_SCREEN = $$PWD/../ios/launch-image-universal.storyboard
 


### PR DESCRIPTION
needed because Apple now expects iOS apps to be built with Xcode 26.
