### PR TITLE
feat(@desktop/onboarding): Rename "Not now" button to "Skip sharing"

### DIFF
--- a/ui/app/AppLayouts/Onboarding/pages/HelpUsImproveStatusPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/HelpUsImproveStatusPage.qml
@@ -61,7 +61,7 @@ OnboardingPage {
                 objectName: "btnDontShare"
                 Layout.alignment: Qt.AlignHCenter
                 Layout.preferredWidth: 320
-                text: qsTr("Not now")
+                text: qsTr("Skip sharing")
                 isOutline: true
                 onClicked: root.shareUsageDataRequested(false)
             }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -8187,10 +8187,6 @@ L2 fee: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Not now</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Got it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8224,6 +8220,10 @@ L2 fee: %2</source>
     </message>
     <message>
         <source>Privacy Policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip sharing</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -10000,11 +10000,6 @@
       <translation>Share usage data</translation>
     </message>
     <message>
-      <source>Not now</source>
-      <comment>HelpUsImproveStatusPage</comment>
-      <translation>Not now</translation>
-    </message>
-    <message>
       <source>Got it</source>
       <comment>HelpUsImproveStatusPage</comment>
       <translation>Got it</translation>
@@ -10048,6 +10043,11 @@
       <source>Privacy Policy</source>
       <comment>HelpUsImproveStatusPage</comment>
       <translation>Privacy Policy</translation>
+    </message>
+    <message>
+      <source>Skip sharing</source>
+      <comment>HelpUsImproveStatusPage</comment>
+      <translation>Skip sharing</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -8215,10 +8215,6 @@ L2 poplatek: %2</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Not now</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Got it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8252,6 +8248,10 @@ L2 poplatek: %2</translation>
     </message>
     <message>
         <source>Privacy Policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip sharing</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -8202,10 +8202,6 @@ Tarifa L2: %2</translation>
         <translation>Compartir datos de uso</translation>
     </message>
     <message>
-        <source>Not now</source>
-        <translation>Ahora no</translation>
-    </message>
-    <message>
         <source>Got it</source>
         <translation>Entendido</translation>
     </message>
@@ -8240,6 +8236,10 @@ Tarifa L2: %2</translation>
     <message>
         <source>Privacy Policy</source>
         <translation>Política de privacidad</translation>
+    </message>
+    <message>
+        <source>Skip sharing</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -8174,10 +8174,6 @@ L2 수수료: %2</translation>
         <translation>사용 데이터 공유</translation>
     </message>
     <message>
-        <source>Not now</source>
-        <translation>지금은 아니요</translation>
-    </message>
-    <message>
         <source>Got it</source>
         <translation>확인했습니다</translation>
     </message>
@@ -8212,6 +8208,10 @@ L2 수수료: %2</translation>
     <message>
         <source>Privacy Policy</source>
         <translation>개인 정보 보호 정책</translation>
+    </message>
+    <message>
+        <source>Skip sharing</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
fixes #19662

### What does the PR do

Rename "Not now" button to "Skip sharing" on the Help us Improve Status page

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="1225" height="693" alt="Screenshot 2026-01-06 at 14 23 14" src="https://github.com/user-attachments/assets/d0b9c40d-8d57-4485-99b3-6f75036852a9" />


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
