### PR TITLE
Feat/19535

### DIFF
--- a/storybook/pages/StatusSectionLayoutPage.qml
+++ b/storybook/pages/StatusSectionLayoutPage.qml
@@ -33,6 +33,11 @@ Page {
                 text: "Show Right Panel"
                 checked: true
             }
+            CheckBox {
+                id: inverted
+                text: "Inverted"
+                checked: true
+            }
             Button {
                 text: "Next Panel"
                 onClicked: sectionLayout.goToNextPanel()
@@ -133,6 +138,7 @@ Page {
             clip: true
             implicitWidth: 800
             implicitHeight: 400
+            invertedLayout: inverted.checked
             leftPanel: leftPanelCheckBox.checked ? leftPanel : null
             centerPanel: centerPanelCheckBox.checked ? centerPanel : null
             rightPanel: rightPanel

--- a/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import StatusQ.Core
+import StatusQ.Core.Theme
 import StatusQ.Controls
 
 ToolBar {
@@ -15,10 +16,7 @@ ToolBar {
     signal backButtonClicked()
 
     objectName: "statusToolBar"
-    leftPadding: 4
-    rightPadding: 10
-    topPadding: 8
-    bottomPadding: 4
+    padding: Theme.halfPadding
     background: null
 
     contentItem: RowLayout {
@@ -36,7 +34,7 @@ ToolBar {
             id: headerContentItem
             Layout.fillWidth: !!headerContent
             Layout.fillHeight: !!headerContent
-            Layout.leftMargin: 8
+            Layout.margins: root.padding
             background: null
             contentItem: (!!headerContent) ? headerContent : null
         }

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -103,7 +103,18 @@ LayoutChooser {
         Default value is true.
     */
     property bool showHeader: true
-
+    /*!
+        \qmlproperty bool StatusSectionLayout::showFooter
+        This property sets the footer component's visibility to true/false.
+        Default value is true.
+    */
+    property bool showFooter: true
+    /*!
+        \qmlproperty int StatusSectionLayout::headerPadding
+        This property sets the padding for the header component
+        Default value is Theme.halfPadding.
+    */
+    property int headerPadding: Theme.halfPadding
     /*!
         \qmlproperty string StatusSectionLayout::backButtonName
         This property holds a reference to the backButtonName property of the
@@ -123,6 +134,12 @@ LayoutChooser {
         the section
     */
     property color backgroundColor: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+    /*!
+        \qmlproperty bool StatusSectionLayout::invertedLayout
+        This property sets the flow to  Footer - Center - Header
+        when true, otherwise  Header - Center - Footer
+    */
+    property bool invertedLayout: false
 
     /*!
         \qmlsignal
@@ -171,6 +188,8 @@ LayoutChooser {
         showRightPanel: root.showRightPanel
         rightPanelWidth: root.rightPanelWidth
         showHeader: root.showHeader
+        headerPadding: root.headerPadding
+        showFooter: root.showFooter
         backButtonName: root.backButtonName
         headerContent: root.headerContent
         backgroundColor: root.backgroundColor
@@ -190,9 +209,12 @@ LayoutChooser {
         showRightPanel: root.showRightPanel
         rightPanelWidth: root.rightPanelWidth
         showHeader: root.showHeader
+        headerPadding: root.headerPadding
+        showFooter: root.showFooter
         backButtonName: root.backButtonName
         headerContent: root.headerContent
         backgroundColor: root.backgroundColor
+        invertedLayout: root.invertedLayout
 
         property int currentIndexCache
 

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutLandscape.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutLandscape.qml
@@ -99,6 +99,20 @@ SplitView {
     property bool showHeader: true
 
     /*!
+        \qmlproperty bool StatusSectionLayout::showFooter
+        This property sets the footer component's visibility to true/false.
+        Default value is true.
+    */
+    property bool showFooter: true
+
+    /*!
+        \qmlproperty int StatusSectionLayout::headerPadding
+        This property sets the padding for the header component
+        Default value is Theme.halfPadding.
+    */
+    property int headerPadding: Theme.halfPadding
+
+    /*!
         \qmlproperty alias StatusSectionLayout::backButtonName
         This property holds a reference to the backButtonName property of the
         header component.
@@ -172,6 +186,7 @@ SplitView {
                 width: visible ? parent.width : 0
                 height: visible ? implicitHeight : 0
                 visible: root.showHeader
+                padding: root.headerPadding
                 headerContent: LayoutItemProxy {
                     id: headerContentProxy
                     target: root.headerContent
@@ -191,10 +206,10 @@ SplitView {
             LayoutItemProxy {
                 id: footerSlot
                 width: parent.width
-                height: root.footer ? root.footer.height : 0
+                height: visible ? implicitHeight : 0
                 anchors.bottom: parent.bottom
                 target: root.footer
-                visible: !!target
+                visible: root.showFooter && !!target
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutPortrait.qml
@@ -92,7 +92,18 @@ SwipeView {
         Default value is true.
     */
     property bool showHeader: true
-
+    /*!
+        \qmlproperty int StatusSectionLayout::headerPadding
+        This property sets the padding for the header component
+        Default value is Theme.halfPadding.
+    */
+    property bool showFooter: true
+    /*!
+        \qmlproperty int StatusSectionLayout::headerPadding
+        This property sets the padding for the header component
+        Default value is Theme.halfPadding.
+    */
+    property int headerPadding: Theme.halfPadding
     /*!
         \qmlproperty alias StatusSectionLayout::backButtonName
         This property holds a reference to the backButtonName property of the
@@ -112,6 +123,12 @@ SwipeView {
         the section
     */
     property color backgroundColor: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+    /*!
+        \qmlproperty bool StatusSectionLayoutPortrait::invertedLayout
+        This property sets the flow to  Footer - Center - Header
+        when true, otherwise  Header - Center - Footer
+    */
+    property bool invertedLayout: false
 
     /*!
         \qmlsignal
@@ -193,13 +210,20 @@ SwipeView {
         backgroundColor: root.backgroundColor
         implicitIndex: 1
         inView: !!root.centerPanel
-        target: ColumnLayout {
+
+        target: GridLayout {
             objectName: "centerPanelLayout"
             anchors.fill: parent
-            spacing: 0
+            columns: 1
+            rowSpacing: 0
+
+            // Header
             Item {
+                id: headerItem
                 Layout.fillWidth: true
-                implicitHeight: headerBackgroundProxy.implicitHeight
+                implicitHeight: statusToolBar.implicitHeight
+                Layout.row: root.invertedLayout ? 2 : 0
+
                 LayoutItemProxy {
                     id: headerBackgroundProxy
                     anchors.fill: parent
@@ -216,19 +240,25 @@ SwipeView {
                     }
                 }
             }
+
+            // Central
             LayoutItemProxy {
                 id: centerPanelProxy
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.topMargin: statusToolBar.height - headerBackgroundProxy.height
+                Layout.row: 1
                 implicitHeight: centerPanel ? centerPanel.implicitHeight : 0
                 implicitWidth: centerPanel ? centerPanel.implicitWidth : 0
             }
+
+            // Footer
             LayoutItemProxy {
                 id: footerProxy
                 Layout.fillWidth: true
-                Layout.preferredHeight: footer ? footer.implicitHeight : 0
-                Layout.alignment: Qt.AlignBottom
+                Layout.preferredHeight: visible ? implicitHeight : 0
+                Layout.row: root.invertedLayout ? 0 : 2
+
+                visible: root.showFooter && !!target
             }
         }
     }
@@ -254,6 +284,7 @@ SwipeView {
 
     component BaseToolBar: StatusToolBar {
         visible: root.showHeader
+        padding: root.headerPadding
         backButtonVisible: root.currentIndex !== 0
         onBackButtonClicked: d.handleBackAction() 
     }

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -126,7 +126,7 @@ StatusSectionLayout {
         function onDownloadRequested(download) {
             download.accept();
             root.downloadsStore.addDownload(download)
-            downloadBar.active = true
+            root.showFooter = true
 
             // close the tab launched only for starting download
             if (!download.view)
@@ -155,6 +155,9 @@ StatusSectionLayout {
         }
     }
 
+    invertedLayout: SQUtils.Utils.isMobile
+    showFooter: false
+    headerPadding: 0
     backgroundColor: Theme.palette.statusAppNavBar.backgroundColor
 
     headerContent: ColumnLayout {
@@ -182,7 +185,7 @@ StatusSectionLayout {
         BrowserHeader {
             id: browserHeader
 
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
 
             favoriteComponent: favoritesBar
             favoritesVisible: localAccountSensitiveSettings.shouldShowFavoritesBar &&
@@ -275,26 +278,12 @@ StatusSectionLayout {
     }
 
     footer: Loader {
-        id: downloadBar
-        active: false
-        height: active ? implicitHeight: 0
-        sourceComponent: DownloadBar {
-            downloadsModel: root.downloadsStore.downloadModel
-            downloadsMenu: downloadMenuInst
-            onOpenDownloadClicked: function (downloadComplete, index) {
-                if (downloadComplete) {
-                    return root.downloadsStore.openFile(index)
-                }
-                root.downloadsStore.openDirectory(index)
-            }
-            onAddNewDownloadTab: _internal.addNewDownloadTab()
-            onClose: downloadBar.active = false
-        }
+        sourceComponent: downloadBar
     }
 
     centerPanel: ColumnLayout {
         id: mainView
-
+        spacing: 0
         StackLayout {
             id: webStackView
             currentIndex: tabs.currentIndex
@@ -703,6 +692,22 @@ StatusSectionLayout {
         id: browserDappsProvider
         connectorController: root.connectorController
         clientId: connectorBridge.clientId  // "status-desktop/dapp-browser"
+    }
+
+    Component {
+        id: downloadBar
+        DownloadBar {
+            downloadsModel: root.downloadsStore.downloadModel
+            downloadsMenu: downloadMenuInst
+            onOpenDownloadClicked: function (downloadComplete, index) {
+                if (downloadComplete) {
+                    return root.downloadsStore.openFile(index)
+                }
+                root.downloadsStore.openDirectory(index)
+            }
+            onAddNewDownloadTab: _internal.addNewDownloadTab()
+            onClose: root.showFooter = false
+        }
     }
 
     Connections {

--- a/ui/app/AppLayouts/Browser/panels/DownloadBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/DownloadBar.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Layouts
 import QtWebEngine
 
 import StatusQ.Core
@@ -24,35 +25,19 @@ Rectangle {
     border.width: 1
     border.color: Theme.palette.border
 
-    // This container is to contain the downloaded elements between the parent buttons and hide the overflow
-    Item {
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
-        anchors.leftMargin: Theme.smallPadding
-        anchors.right: showAllBtn.left
-        anchors.rightMargin: Theme.smallPadding
-        height: listView.height
-        clip: true
+    RowLayout {
+        anchors.fill: parent
 
         StatusListView {
             id: listView
 
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredHeight: currentItem ? currentItem.height : 0
+
             orientation: ListView.Horizontal
             model: downloadsModel
-            height: currentItem ? currentItem.height : 0
-            // This makes it show the newest on the right
-            layoutDirection: Qt.RightToLeft
             spacing: Theme.smallPadding
-            anchors.left: parent.left
-            width: {
-                // Children rect shows a warning but this works ¯\_(ツ)_/¯
-                let w = 0
-                for (let i = 0; i < count; i++) {
-                    w += this.itemAtIndex(i).width + this.spacing
-                }
-                return w
-            }
-            interactive: false
             delegate: DownloadElement {
                 id: downloadElement
 
@@ -70,7 +55,7 @@ Rectangle {
                         return qsTr("Paused")
                     }
                     return "%1/%2".arg(Qt.locale().formattedDataSize(downloadItem?.receivedBytes ?? 0, 2, Locale.DataSizeTraditionalFormat)) //e.g. 14.4/109 MB
-                                  .arg(Qt.locale().formattedDataSize(downloadItem?.totalBytes ?? 0, 2, Locale.DataSizeTraditionalFormat))
+                    .arg(Qt.locale().formattedDataSize(downloadItem?.totalBytes ?? 0, 2, Locale.DataSizeTraditionalFormat))
                 }
                 onItemClicked: {
                     openDownloadClicked(downloadComplete, index)
@@ -83,30 +68,35 @@ Rectangle {
                     downloadsMenu.open()
                 }
             }
-        }
-    }
 
-    StatusButton {
-        id: showAllBtn
-        size: StatusBaseButton.Size.Small
-        text: qsTr("Show All")
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.right: closeBtn.left
-        anchors.rightMargin: Theme.padding
-        onClicked: {
-            addNewDownloadTab()
+            onCountChanged: positionViewAtEnd()
+            Component.onCompleted: positionViewAtEnd()
         }
-    }
 
-    StatusFlatRoundButton {
-        id: closeBtn
-        width: 32
-        height: 32
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.right: parent.right
-        anchors.rightMargin: Theme.smallPadding
-        icon.name: "close"
-        type: StatusFlatRoundButton.Type.Quaternary
-        onClicked: root.close()
+        StatusButton {
+            id: showAllBtn
+
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            Layout.rightMargin: Theme.padding
+
+            size: StatusBaseButton.Size.Small
+            text: qsTr("Show All")
+            onClicked: {
+                addNewDownloadTab()
+            }
+        }
+
+        StatusFlatRoundButton {
+            id: closeBtn
+
+            Layout.preferredWidth: 32
+            Layout.preferredHeight: 32
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            Layout.rightMargin: Theme.smallPadding
+
+            icon.name: "close"
+            type: StatusFlatRoundButton.Type.Quaternary
+            onClicked: root.close()
+        }
     }
 }


### PR DESCRIPTION
### What does the PR do


1. Creates a flag to invert position of footer and header in the StatusSectionLayout in Portrait mode to be used in the browser
2. As a first step we add a condition to simply set this property to true on mobile for the BrowserLayout. 
3. Other condition such as the download bar not being available on mobile will be handled in specific tasks
4. DownloadBar.qml has only been touch because of errors and downloads not being visible will be reworked in its own task if needed

### Affected areas

StatusSectionLayout
BrowserLayout

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality


https://github.com/user-attachments/assets/746e4c13-3275-4897-8c74-09eb29d0cd15



### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

- <!-- How should one proceed with testing this PR. -->
- <!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
