### PR TITLE
fix(community): use lowercase for addresses to fix undefined token perms

### DIFF
--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -241,7 +241,7 @@ proc toDiscordImportError*(jsonObj: JsonNode): DiscordImportError =
 
 proc toCommunityTokenAdresses*(jsonObj: JsonNode): Table[int, string] =
   for i in jsonObj.keys():
-    result[parseInt(i)] = jsonObj[i].getStr()
+    result[parseInt(i)] = jsonObj[i].getStr().toLower()
 
 proc toCommunityTokensMetadataDto*(jsonObj: JsonNode): CommunityTokensMetadataDto =
   result = CommunityTokensMetadataDto()
@@ -289,7 +289,7 @@ proc toTokenCriteriaDto*(jsonObj: JsonNode): TokenCriteriaDto =
   if(jsonObj.getProp("contract_addresses", contractAddressesObj) and contractAddressesObj.kind == JObject):
     result.contractAddresses = initTable[int, string]()
     for chainId, contractAddress in contractAddressesObj:
-      result.contractAddresses[parseInt(chainId)] = contractAddress.getStr
+      result.contractAddresses[parseInt(chainId)] = contractAddress.getStr().toLower()
 
   var tokenIdsObj: JsonNode
   if(jsonObj.getProp("tokenIds", tokenIdsObj) and tokenIdsObj.kind == JArray):


### PR DESCRIPTION
### What does the PR do

Fixes #19522

The problem is that we had both lower case and uppercase for addresses in the community tokens, because of old versions vs new. This caused the image and name matching to fail.

Using lowercase everywhere fixes the issue.

### Affected areas

- community DTO

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="701" height="963" alt="image" src="https://github.com/user-attachments/assets/db0a80e9-dc70-49ad-8b68-635129d0aaa8" />

<img width="739" height="595" alt="image" src="https://github.com/user-attachments/assets/6980a166-2a85-40e7-ac49-debcc2a44cf0" />

### Impact on end user

Fixes the issue

### How to test

- Add permissions
- Migrate old accounts that had old permissions

### Risk 

Low
