### PR TITLE
fix(ProfileSocialLinksPanel): correct "Personal site link" field caption

### DIFF
--- a/storybook/pages/ProfileSocialLinksPanelPage.qml
+++ b/storybook/pages/ProfileSocialLinksPanelPage.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls
 
 import StatusQ.Core
-import StatusQ.Core.Utils as CoreUtils
 
 import mainui
 import AppLayouts.stores as AppLayoutStores
@@ -118,10 +117,9 @@ SplitView {
 
         logsView.logText: logs.logText
 
-
-        CheckBox {
+        Switch {
             id: emptyModelCheck
-            text: "emptyModel"
+            text: "Empty model"
             checked: false
         }
     }

--- a/ui/app/AppLayouts/Profile/panels/ProfileSocialLinksPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileSocialLinksPanel.qml
@@ -14,8 +14,6 @@ import utils
 
 import AppLayouts.Profile.popups
 
-import SortFilterProxyModel
-
 Control {
     id: root
     
@@ -42,7 +40,7 @@ Control {
         id: addSocialLinkModalComponent
         AddSocialLinkModal {
             containsSocialLink: d.containsSocialLink
-            onAddLinkRequested: root.addSocialLink(linkUrl, linkText)
+            onAddLinkRequested: (linkText, linkUrl, linkType, linkIcon) => root.addSocialLink(linkUrl, linkText)
         }
     }
 
@@ -50,8 +48,8 @@ Control {
         id: modifySocialLinkModal
         ModifySocialLinkModal {
             containsSocialLink: d.containsSocialLink
-            onUpdateLinkRequested: root.updateSocialLink(index, linkUrl, linkText)
-            onRemoveLinkRequested: root.removeSocialLink(index)
+            onUpdateLinkRequested: (index, linkText, linkUrl) => root.updateSocialLink(index, linkUrl, linkText)
+            onRemoveLinkRequested: index => root.removeSocialLink(index)
         }
     }
 

--- a/ui/app/AppLayouts/Profile/popups/AddSocialLinkModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/AddSocialLinkModal.qml
@@ -35,7 +35,7 @@ StatusStackModal {
             root.addLinkRequested(d.selectedLinkTypeText || customTitle.text, // text for custom link, otherwise the link typeId
                                   ProfileUtils.addSocialLinkPrefix(linkTarget.text, d.selectedLinkType),
                                   d.selectedLinkType, d.selectedIcon)
-            root.close();
+            root.close()
         }
     }
     showFooter: currentIndex > 0
@@ -80,7 +80,7 @@ StatusStackModal {
     stackItems: [
         StatusListView {
             width: root.availableWidth
-            height: root.availableHeight
+            height: contentHeight
             model: d.staticLinkTypesModel
             delegate: StatusListItem {
                 width: ListView.view.width
@@ -131,9 +131,7 @@ StatusStackModal {
                                       return !root.containsSocialLink(value,
                                                                       ProfileUtils.addSocialLinkPrefix(linkTarget.text, d.selectedLinkType))
                                   }
-                        errorMessage: d.selectedLinkType === Constants.socialLinkType.custom?
-                                          qsTr("Ttile and link combination already added") :
-                                          qsTr("Username already added")
+                        errorMessage: qsTr("Title and link combination already added")
                     }
                 ]
 
@@ -146,7 +144,13 @@ StatusStackModal {
                 Layout.fillWidth: true
                 Layout.topMargin: customTitle.visible ? Theme.padding : 0
                 placeholderText: ""
-                label: linkType === Constants.socialLinkType.custom ? qsTr("Link") : qsTr("Username")
+                label: {
+                    if (linkType === Constants.socialLinkType.custom)
+                        return qsTr("Link")
+                    if (linkType === Constants.socialLinkType.personalSite)
+                        return qsTr("URL")
+                    return qsTr("Username")
+                }
                 linkType: d.selectedLinkType
                 icon: d.selectedIcon
                 input.tabNavItem: customTitle.input.edit
@@ -165,9 +169,13 @@ StatusStackModal {
                                       return !root.containsSocialLink(d.selectedLinkTypeText || customTitle.text,
                                                                       ProfileUtils.addSocialLinkPrefix(value, d.selectedLinkType))
                                   }
-                        errorMessage: d.selectedLinkType === Constants.socialLinkType.custom?
-                                          qsTr("Title and link combination already added") :
-                                          qsTr("Username already added")
+                        errorMessage: {
+                            if (d.selectedLinkType === Constants.socialLinkType.custom)
+                                return qsTr("Title and link combination already added")
+                            if (d.selectedLinkType === Constants.socialLinkType.personalSite)
+                                return qsTr("URL already added")
+                            return qsTr("Username already added")
+                        }
                     }
                 ]
 

--- a/ui/app/AppLayouts/Profile/popups/ModifySocialLinkModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ModifySocialLinkModal.qml
@@ -95,9 +95,7 @@ StatusDialog {
                                   return !root.containsSocialLink(value,
                                                                   ProfileUtils.addSocialLinkPrefix(linkTarget.text, root.linkType))
                               }
-                    errorMessage: root.linkType === Constants.socialLinkType.custom ?
-                                      qsTr("Title and link combination already added") :
-                                      qsTr("Username already added")
+                    errorMessage: qsTr("Title and link combination already added")
                 }
             ]
 
@@ -130,19 +128,18 @@ StatusDialog {
                                   return !root.containsSocialLink(customTitle.text,
                                                                   ProfileUtils.addSocialLinkPrefix(value, root.linkType))
                               }
-                    errorMessage: root.linkType === Constants.socialLinkType.custom?
-                                      qsTr("Title and link combination already added") :
-                                      qsTr("Username already added")
+                    errorMessage: {
+                        if (root.linkType === Constants.socialLinkType.custom)
+                            return qsTr("Title and link combination already added")
+                        if (root.linkType === Constants.socialLinkType.personalSite)
+                            return qsTr("URL already added")
+                        return qsTr("Username already added")
+                    }
                 }
             ]
 
             onValidChanged: {customTitle.validate(true)}
             onTextChanged: {customTitle.validate(true)}
-        }
-
-        // Filler
-        Item {
-            Layout.fillHeight: true
         }
     }
 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1085,10 +1085,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ttile and link combination already added</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Username already added</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1110,6 +1106,14 @@
     </message>
     <message>
         <source>Title and link combination already added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>URL already added</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11867,6 +11871,10 @@ to load</source>
     </message>
     <message>
         <source>link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>URL already added</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1328,11 +1328,6 @@
       <translation>Invalid title</translation>
     </message>
     <message>
-      <source>Ttile and link combination already added</source>
-      <comment>AddSocialLinkModal</comment>
-      <translation>Ttile and link combination already added</translation>
-    </message>
-    <message>
       <source>Username already added</source>
       <comment>AddSocialLinkModal</comment>
       <translation>Username already added</translation>
@@ -1361,6 +1356,16 @@
       <source>Title and link combination already added</source>
       <comment>AddSocialLinkModal</comment>
       <translation>Title and link combination already added</translation>
+    </message>
+    <message>
+      <source>URL</source>
+      <comment>AddSocialLinkModal</comment>
+      <translation>URL</translation>
+    </message>
+    <message>
+      <source>URL already added</source>
+      <comment>AddSocialLinkModal</comment>
+      <translation>URL already added</translation>
     </message>
   </context>
   <context>
@@ -14451,6 +14456,11 @@
       <source>link</source>
       <comment>ModifySocialLinkModal</comment>
       <translation>link</translation>
+    </message>
+    <message>
+      <source>URL already added</source>
+      <comment>ModifySocialLinkModal</comment>
+      <translation>URL already added</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1085,10 +1085,6 @@
         <translation>Neplatný titulek</translation>
     </message>
     <message>
-        <source>Ttile and link combination already added</source>
-        <translation>Kombinace titulku a odkazu již byla přidána</translation>
-    </message>
-    <message>
         <source>Username already added</source>
         <translation>Uživatelské jméno již přidáno</translation>
     </message>
@@ -1111,6 +1107,14 @@
     <message>
         <source>Title and link combination already added</source>
         <translation>Kombinace titulku a odkazu již byla přidána</translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished">URL</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11964,6 +11968,10 @@ selhalo</translation>
     <message>
         <source>link</source>
         <translation>odkaz</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1085,10 +1085,6 @@
         <translation>Título inválido</translation>
     </message>
     <message>
-        <source>Ttile and link combination already added</source>
-        <translation>La combinación de título y enlace ya fue agregada</translation>
-    </message>
-    <message>
         <source>Username already added</source>
         <translation>Nombre de usuario ya agregado</translation>
     </message>
@@ -1111,6 +1107,14 @@
     <message>
         <source>Title and link combination already added</source>
         <translation>La combinación de título y enlace ya fue agregada</translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished">URL</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11889,6 +11893,10 @@ al cargar</translation>
     <message>
         <source>link</source>
         <translation>enlace</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1085,10 +1085,6 @@
         <translation>제목이 올바르지 않습니다</translation>
     </message>
     <message>
-        <source>Ttile and link combination already added</source>
-        <translation>제목과 링크 조합이 이미 추가되었습니다</translation>
-    </message>
-    <message>
         <source>Username already added</source>
         <translation>사용자명이 이미 추가됨</translation>
     </message>
@@ -1111,6 +1107,14 @@
     <message>
         <source>Title and link combination already added</source>
         <translation>제목과 링크 조합이 이미 추가되었습니다</translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation type="unfinished">URL</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11855,6 +11859,10 @@ to load</source>
     <message>
         <source>link</source>
         <translation>링크</translation>
+    </message>
+    <message>
+        <source>URL already added</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

- use "URL" instead of "Username" for links of type `Constants.socialLinkType.personalSite`
- fix add popup not being scrollable initially
- some (import and warnings) minor cleanups

Fixes #19621

### Affected areas

Settings/Profile/Showcase/Web

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2444" height="1728" alt="image" src="https://github.com/user-attachments/assets/ac434d79-8c95-4a3c-834c-1a067a3a0416" />


### Impact on end user

Minor UI fix

### How to test

Go to Settings/Profile/Showcase/Web

### Risk 

low
