### PR TITLE
Storybook: handling pages with Popup-based components fixed

### DIFF
--- a/storybook/PageOverlay.qml
+++ b/storybook/PageOverlay.qml
@@ -8,10 +8,9 @@ import StatusQ.Core.Theme
 Loader {
     id: root
 
-    function setPage(pageName: string, pageItem: Item) {
+    function setPage(pageName: string) {
         active = false
         d.currentPage = pageName
-        d.currentPageItem = pageItem
         active = true
     }
 
@@ -23,7 +22,7 @@ Loader {
         id: d
 
         property string currentPage
-        property Item currentPageItem
+        readonly property Window currentWindow: root.Window.window
     }
 
     active: false
@@ -61,34 +60,34 @@ Loader {
             closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
             PageOverlayPanel {
-                style: d.currentPageItem.Theme.style
-                themePadding: d.currentPageItem.Theme.padding
-                fontSizeOffset: d.currentPageItem.Theme.fontSizeOffset
+                style: d.currentWindow.Theme.style
+                themePadding: d.currentWindow.Theme.padding
+                fontSizeOffset: d.currentWindow.Theme.fontSizeOffset
 
                 onStyleRequested: style => {
-                    d.currentPageItem.Theme.style = style
+                    d.currentWindow.Theme.style = style
                 }
 
                 onPaddingRequested: padding => {
-                    d.currentPageItem.Theme.padding = padding
+                    d.currentWindow.Theme.padding = padding
                 }
 
                 onPaddingFactorRequested: paddingFactor => {
-                    ThemeUtils.setPaddingFactor(d.currentPageItem, paddingFactor)
+                    ThemeUtils.setPaddingFactor(d.currentWindow, paddingFactor)
                 }
 
                 onFontSizeOffsetRequested: fontSizeOffset => {
-                    d.currentPageItem.Theme.fontSizeOffset = fontSizeOffset
+                    d.currentWindow.Theme.fontSizeOffset = fontSizeOffset
                 }
 
                 onFontSizeRequested: fontSize => {
-                    ThemeUtils.setFontSize(d.currentPageItem, fontSize)
+                    ThemeUtils.setFontSize(d.currentWindow, fontSize)
                 }
 
                 onResetRequested: {
-                    d.currentPageItem.Theme.style = undefined
-                    d.currentPageItem.Theme.padding = undefined
-                    d.currentPageItem.Theme.fontSizeOffset = undefined
+                    d.currentWindow.Theme.style = undefined
+                    d.currentWindow.Theme.padding = undefined
+                    d.currentWindow.Theme.fontSizeOffset = undefined
                 }
             }
         }
@@ -97,17 +96,17 @@ Loader {
             if (!settings.initialized) {
                 settings.initialized = true
             } else {
-                d.currentPageItem.Theme.style = settings.style
-                d.currentPageItem.Theme.padding = settings.padding
-                d.currentPageItem.Theme.fontSizeOffset = settings.fontSizeOffset
+                d.currentWindow.Theme.style = settings.style
+                d.currentWindow.Theme.padding = settings.padding
+                d.currentWindow.Theme.fontSizeOffset = settings.fontSizeOffset
             }
 
             settings.style
-                    = Qt.binding(() => d.currentPageItem.Theme.style)
+                    = Qt.binding(() => d.currentWindow.Theme.style)
             settings.padding
-                    = Qt.binding(() => d.currentPageItem.Theme.padding)
+                    = Qt.binding(() => d.currentWindow.Theme.padding)
             settings.fontSizeOffset
-                    = Qt.binding(() => d.currentPageItem.Theme.fontSizeOffset)
+                    = Qt.binding(() => d.currentWindow.Theme.fontSizeOffset)
         }
 
         Settings {

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -19,7 +19,8 @@ ApplicationWindow {
 
     title: "%1 – %2".arg(storybook.currentPage).arg(Qt.application.displayName)
 
-    // cf. Universal theme kept here as the basic light/dark theme for the app itself
+    // cf. Universal theme kept here as the basic light/dark theme for the
+    // Storybook app itself
     Universal.theme: storybook.darkMode ? Universal.Dark : Universal.Light
     font.pixelSize: 13
 
@@ -30,7 +31,7 @@ ApplicationWindow {
 
         onCurrentPageItemChanged: {
             if (currentPageItem)
-                overlay.setPage(currentPage, currentPageItem)
+                overlay.setPage(currentPage)
             else
                 overlay.clear()
         }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -24,7 +24,7 @@ Dialog {
        \qmlproperty color backgroundColor
         This property decides the modal background color
     */
-    property color backgroundColor: Theme.palette.statusModal.backgroundColor
+    property color backgroundColor: contentItem.Theme.palette.statusModal.backgroundColor
 
     /*!
        \qmlproperty var closeHandler

--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls
 
 import StatusQ.Core
-import StatusQ.Core.Theme
 import StatusQ.Controls
 import StatusQ.Popups.Dialog
 


### PR DESCRIPTION
### What does the PR do

Fixes Theme handling in pages instantiating `Popup`-based components.

### Affected areas
`PageOverlay.qml` and others

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[Screencast from 09.01.2026 01:32:11.webm](https://github.com/user-attachments/assets/880e3fd0-0c8f-4464-8437-73775e0f45ec)
