### PR TITLE
fix(contacts): trust status not signaled when modified on paired device

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -171,14 +171,20 @@ QtObject:
 
   proc doConnect(self: Service) =
     self.events.on(SignalType.Message.event) do(e:Args):
-      var receivedData = MessageSignal(e)
-      if(receivedData.statusUpdates.len > 0):
+      let receivedData = MessageSignal(e)
+
+      if receivedData.updatedProfileShowcaseContactIDs.len > 0:
+        for contactId in receivedData.updatedProfileShowcaseContactIDs:
+          self.events.emit(SIGNAL_CONTACT_PROFILE_SHOWCASE_UPDATED,
+            ProfileShowcaseContactIdArgs(contactId: contactId))
+
+      if receivedData.statusUpdates.len > 0:
         self.updateAndEmitStatuses(receivedData.statusUpdates)
 
       if receivedData.contacts.len > 0:
         for c in receivedData.contacts:
           let localContact = self.getContactById(c.id)
-          var receivedContact = c
+          let receivedContact = c
 
           self.saveContact(receivedContact)
 
@@ -192,16 +198,9 @@ QtObject:
           let data = ContactArgs(contactId: c.id)
           self.events.emit(SIGNAL_CONTACT_UPDATED, data)
 
-    self.events.on(SignalType.Message.event) do(e: Args):
-      let receivedData = MessageSignal(e)
-      if receivedData.updatedProfileShowcaseContactIDs.len > 0:
-        for contactId in receivedData.updatedProfileShowcaseContactIDs:
-          self.events.emit(SIGNAL_CONTACT_PROFILE_SHOWCASE_UPDATED,
-            ProfileShowcaseContactIdArgs(contactId: contactId))
-
     self.events.on(SignalType.StatusUpdatesTimedout.event) do(e:Args):
-      var receivedData = StatusUpdatesTimedoutSignal(e)
-      if(receivedData.statusUpdates.len > 0):
+      let receivedData = StatusUpdatesTimedoutSignal(e)
+      if receivedData.statusUpdates.len > 0:
         self.updateAndEmitStatuses(receivedData.statusUpdates)
 
   proc setImageServerUrl(self: Service) =


### PR DESCRIPTION
### What does the PR do

Fixes #19590

The fix itself is in status-go. The service changes are just clean ups found along the way

### Affected areas

- contacts service (clean up)
- status go (PR: https://github.com/status-im/status-go/pull/7278)

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

See Status-go PR above

### Impact on end user

Fixes the issue

### How to test

- Pair two devices
- Mark someone as untrusted or change that status on one device
- see that it propagates to the other one

### Risk 

Low
