### PR TITLE
feat(QRCodeScanner): show camera straight away instead of using the btn

### DIFF
--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14384,6 +14384,26 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>QRCodeScanner</name>
+    <message>
+        <source>Enable access to your camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>To scan a QR, Status needs
+access to your webcam</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Camera access denied. Please enable it in system settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ensure that the QR code is in focus to scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QRCodeScannerDialog</name>
     <message>
         <source>Scan QR</source>
@@ -16596,26 +16616,6 @@ to load</source>
     </message>
     <message>
         <source>Very strong</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>StatusQRCodeScanner</name>
-    <message>
-        <source>Enable access to your camera</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>To scan a QR, Status needs
-access to your webcam</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ensure that the QR code is in focus to scan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Camera access denied. Please enable it in system settings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -17522,6 +17522,29 @@
     </message>
   </context>
   <context>
+    <name>QRCodeScanner</name>
+    <message>
+      <source>Enable access to your camera</source>
+      <comment>QRCodeScanner</comment>
+      <translation>Enable access to your camera</translation>
+    </message>
+    <message>
+      <source>To scan a QR, Status needs&#xA;access to your webcam</source>
+      <comment>QRCodeScanner</comment>
+      <translation>To scan a QR, Status needs&#xA;access to your webcam</translation>
+    </message>
+    <message>
+      <source>Camera access denied. Please enable it in system settings.</source>
+      <comment>QRCodeScanner</comment>
+      <translation>Camera access denied. Please enable it in system settings.</translation>
+    </message>
+    <message>
+      <source>Ensure that the QR code is in focus to scan</source>
+      <comment>QRCodeScanner</comment>
+      <translation>Ensure that the QR code is in focus to scan</translation>
+    </message>
+  </context>
+  <context>
     <name>QRCodeScannerDialog</name>
     <message>
       <source>Scan QR</source>
@@ -20194,29 +20217,6 @@
       <source>Very strong</source>
       <comment>StatusPasswordStrengthIndicator</comment>
       <translation>Very strong</translation>
-    </message>
-  </context>
-  <context>
-    <name>StatusQRCodeScanner</name>
-    <message>
-      <source>Enable access to your camera</source>
-      <comment>StatusQRCodeScanner</comment>
-      <translation>Enable access to your camera</translation>
-    </message>
-    <message>
-      <source>To scan a QR, Status needs&#xA;access to your webcam</source>
-      <comment>StatusQRCodeScanner</comment>
-      <translation>To scan a QR, Status needs&#xA;access to your webcam</translation>
-    </message>
-    <message>
-      <source>Ensure that the QR code is in focus to scan</source>
-      <comment>StatusQRCodeScanner</comment>
-      <translation>Ensure that the QR code is in focus to scan</translation>
-    </message>
-    <message>
-      <source>Camera access denied. Please enable it in system settings.</source>
-      <comment>StatusQRCodeScanner</comment>
-      <translation>Camera access denied. Please enable it in system settings.</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14491,6 +14491,27 @@ selhalo</translation>
     </message>
 </context>
 <context>
+    <name>QRCodeScanner</name>
+    <message>
+        <source>Enable access to your camera</source>
+        <translation>Povolit přístup k fotoaparátu</translation>
+    </message>
+    <message>
+        <source>To scan a QR, Status needs
+access to your webcam</source>
+        <translation>Pro naskenování QR kódu potřebuje Status
+přístup k vaší webkameře</translation>
+    </message>
+    <message>
+        <source>Camera access denied. Please enable it in system settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ensure that the QR code is in focus to scan</source>
+        <translation>Ujistěte se, že je QR kód zaostřený pro naskenování</translation>
+    </message>
+</context>
+<context>
     <name>QRCodeScannerDialog</name>
     <message>
         <source>Scan QR</source>
@@ -16715,27 +16736,6 @@ selhalo</translation>
     <message>
         <source>Very strong</source>
         <translation>Velmi silné</translation>
-    </message>
-</context>
-<context>
-    <name>StatusQRCodeScanner</name>
-    <message>
-        <source>Enable access to your camera</source>
-        <translation>Povolit přístup k fotoaparátu</translation>
-    </message>
-    <message>
-        <source>To scan a QR, Status needs
-access to your webcam</source>
-        <translation>Pro naskenování QR kódu potřebuje Status
-přístup k vaší webkameře</translation>
-    </message>
-    <message>
-        <source>Ensure that the QR code is in focus to scan</source>
-        <translation>Ujistěte se, že je QR kód zaostřený pro naskenování</translation>
-    </message>
-    <message>
-        <source>Camera access denied. Please enable it in system settings.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -14407,6 +14407,27 @@ al cargar</translation>
     </message>
 </context>
 <context>
+    <name>QRCodeScanner</name>
+    <message>
+        <source>Enable access to your camera</source>
+        <translation>Habilitar acceso a tu cámara</translation>
+    </message>
+    <message>
+        <source>To scan a QR, Status needs
+access to your webcam</source>
+        <translation>Para escanear un QR, Status necesita
+acceso a tu cámara web</translation>
+    </message>
+    <message>
+        <source>Camera access denied. Please enable it in system settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ensure that the QR code is in focus to scan</source>
+        <translation>Asegúrate de que el código QR esté enfocado para escanear</translation>
+    </message>
+</context>
+<context>
     <name>QRCodeScannerDialog</name>
     <message>
         <source>Scan QR</source>
@@ -16621,27 +16642,6 @@ al cargar</translation>
     <message>
         <source>Very strong</source>
         <translation>Muy fuerte</translation>
-    </message>
-</context>
-<context>
-    <name>StatusQRCodeScanner</name>
-    <message>
-        <source>Enable access to your camera</source>
-        <translation>Habilitar acceso a tu cámara</translation>
-    </message>
-    <message>
-        <source>To scan a QR, Status needs
-access to your webcam</source>
-        <translation>Para escanear un QR, Status necesita
-acceso a tu cámara web</translation>
-    </message>
-    <message>
-        <source>Ensure that the QR code is in focus to scan</source>
-        <translation>Asegúrate de que el código QR esté enfocado para escanear</translation>
-    </message>
-    <message>
-        <source>Camera access denied. Please enable it in system settings.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14364,6 +14364,26 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>QRCodeScanner</name>
+    <message>
+        <source>Enable access to your camera</source>
+        <translation>카메라 접근을 허용하세요</translation>
+    </message>
+    <message>
+        <source>To scan a QR, Status needs
+access to your webcam</source>
+        <translation>QR를 스캔하려면 Status가 웹캠에 접근할 수 있어야 합니다</translation>
+    </message>
+    <message>
+        <source>Camera access denied. Please enable it in system settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ensure that the QR code is in focus to scan</source>
+        <translation>QR 코드를 선명하게 맞춰 스캔하세요</translation>
+    </message>
+</context>
+<context>
     <name>QRCodeScannerDialog</name>
     <message>
         <source>Scan QR</source>
@@ -16568,26 +16588,6 @@ to load</source>
     <message>
         <source>Very strong</source>
         <translation>매우 강함</translation>
-    </message>
-</context>
-<context>
-    <name>StatusQRCodeScanner</name>
-    <message>
-        <source>Enable access to your camera</source>
-        <translation>카메라 접근을 허용하세요</translation>
-    </message>
-    <message>
-        <source>To scan a QR, Status needs
-access to your webcam</source>
-        <translation>QR를 스캔하려면 Status가 웹캠에 접근할 수 있어야 합니다</translation>
-    </message>
-    <message>
-        <source>Ensure that the QR code is in focus to scan</source>
-        <translation>QR 코드를 선명하게 맞춰 스캔하세요</translation>
-    </message>
-    <message>
-        <source>Camera access denied. Please enable it in system settings.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/imports/shared/controls/QRCodeScanner.qml
+++ b/ui/imports/shared/controls/QRCodeScanner.qml
@@ -151,7 +151,15 @@ Column {
         wrapMode: Text.WordWrap
         color: Theme.palette.dangerColor1
         horizontalAlignment: Text.AlignHCenter
-        text: d.errorMessage || cameraPermission.status === Qt.Denied ? qsTr("Camera access denied. Please enable it in system settings.") : ""
+        text: {
+            if (!!d.errorMessage) {
+                return d.errorMessage
+            }
+            if (cameraPermission.status === Qt.Denied) {
+                return qsTr("Camera access denied. Please enable it in system settings.")
+            }
+            return ""
+        }
     }
 
     StatusBaseText {

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -38,7 +38,7 @@ ShapeRectangle 1.0 ShapeRectangle.qml
 SlippageSelector 1.0 SlippageSelector.qml
 SocialLinkPreview 1.0 SocialLinkPreview.qml
 StatusSyncCodeInput 1.0 StatusSyncCodeInput.qml
-StatusQRCodeScanner 1.0 StatusQRCodeScanner.qml
+QRCodeScanner 1.0 QRCodeScanner.qml
 StatusSyncingInstructions 1.0 StatusSyncingInstructions.qml
 StyledTextEdit 1.0 StyledTextEdit.qml
 StyledTextEditWithLoadingState 1.0 StyledTextEditWithLoadingState.qml

--- a/ui/imports/shared/popups/QRCodeScannerDialog.qml
+++ b/ui/imports/shared/popups/QRCodeScannerDialog.qml
@@ -40,7 +40,7 @@ StatusDialog {
     Component {
         id: cameraComponent
 
-        StatusQRCodeScanner {
+        QRCodeScanner {
             id: syncQr
             
             Layout.fillWidth: true

--- a/ui/imports/shared/views/SyncingEnterCode.qml
+++ b/ui/imports/shared/views/SyncingEnterCode.qml
@@ -65,7 +65,7 @@ ColumnLayout {
         // StackLayout doesn't support alignment, so we create an `Item` wrappers
 
         Item {
-            StatusQRCodeScanner {
+            QRCodeScanner {
                 id: syncQr
                 anchors {
                     left: parent.left


### PR DESCRIPTION
### What does the PR do

Fixes #19694

### Affected areas

StatusQRCodeScanner

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[story-book-qr-code.webm](https://github.com/user-attachments/assets/830c6b3b-63eb-40f8-948d-3bc5c7b26182)

[storybook-sync-login.webm](https://github.com/user-attachments/assets/649616a1-dbc9-4346-963c-d32846b42bbf)

### Impact on end user

One less click

### How to test

- In Storybook
- Using the QR Scanner button in Chat or the Syncing flow in onboarding

### Risk 

Low
