### PR TITLE
fix(StatusMenu): add SafeArea to margins

### DIFF
--- a/storybook/pages/MessageContextMenuViewPage.qml
+++ b/storybook/pages/MessageContextMenuViewPage.qml
@@ -24,12 +24,12 @@ SplitView {
         Rectangle {
             SplitView.fillWidth: true
             SplitView.fillHeight: true
-            color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+            color: Theme.palette.background
 
             Button {
                 anchors.centerIn: parent
                 text: "Reopen"
-                onClicked: messageContextMenuView.open()
+                onClicked: messageContextMenuView.popup()
             }
 
             MessageContextMenuView {
@@ -39,6 +39,7 @@ SplitView {
                 closePolicy: Popup.NoAutoClose
 
                 messageId: "Oxdeadbeef"
+                messageSenderId: "foobar"
                 emojiModel: SortFilterProxyModel {
                     sourceModel: StatusQUtils.Emoji.emojiModel
                 }
@@ -54,11 +55,12 @@ SplitView {
                 onUnpinMessage: logs.logEvent(`onUnpinMessage: ${messageContextMenuView.messageId}`)
                 onPinnedMessagesLimitReached: logs.logEvent(`onPinnedMessagesLimitReached: ${messageContextMenuView.messageId}`)
                 onMarkMessageAsUnread: logs.logEvent(`onMarkMessageAsUnread: ${messageContextMenuView.messageId}`)
-                onToggleReaction: (emoji) => logs.logEvent("onToggleReaction", ["emoji"], [emoji])
+                onToggleReaction: (hexcode) => logs.logEvent("onToggleReaction", ["hexcode"], [hexcode])
                 onDeleteMessage: logs.logEvent(`onDeleteMessage: ${messageContextMenuView.messageId}`)
                 onEditClicked: logs.logEvent(`onEditClicked: ${messageContextMenuView.messageId}`)
                 onShowReplyArea: (senderId) => logs.logEvent("onShowReplyArea", ["senderId"], [senderId])
                 onCopyToClipboard: (text) => logs.logEvent("onCopyToClipboard", ["text"], [text])
+                onOpenEmojiPopup: logs.logEvent("onOpenEmojiPopup")
             }
         }
     }
@@ -100,3 +102,4 @@ SplitView {
 }
 
 // category: Views
+// status: good

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -70,7 +70,16 @@ Menu {
     closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
     verticalPadding: Theme.halfPadding
     horizontalPadding: 0
-    margins: Theme.padding
+
+    QtObject {
+        id: d
+        readonly property var window: root.contentItem.Window.window
+    }
+
+    leftMargin: Theme.padding + (d.window?.SafeArea.margins.left ?? 0)
+    rightMargin: Theme.padding + (d.window?.SafeArea.margins.right ?? 0)
+    topMargin: Theme.padding + (d.window?.SafeArea.margins.top ?? 0)
+    bottomMargin: Theme.padding + (d.window?.SafeArea.margins.bottom ?? 0)
 
     onOpened: {
         if (typeof openHandler === "function") {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -78,6 +78,14 @@
         <source>Decline and block</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AccountAddressSelection</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -95,6 +95,16 @@
       <comment>AcceptRejectOptionsButtonsPanel</comment>
       <translation>Decline and block</translation>
     </message>
+    <message>
+      <source>Decline</source>
+      <comment>AcceptRejectOptionsButtonsPanel</comment>
+      <translation>Decline</translation>
+    </message>
+    <message>
+      <source>Accept</source>
+      <comment>AcceptRejectOptionsButtonsPanel</comment>
+      <translation>Accept</translation>
+    </message>
   </context>
   <context>
     <name>AccountAddressSelection</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -78,6 +78,14 @@
         <source>Decline and block</source>
         <translation>Zamítnout a blokovat</translation>
     </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">Přijmout</translation>
+    </message>
 </context>
 <context>
     <name>AccountAddressSelection</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -78,6 +78,14 @@
         <source>Decline and block</source>
         <translation>Rechazar y bloquear</translation>
     </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">Aceptar</translation>
+    </message>
 </context>
 <context>
     <name>AccountAddressSelection</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -78,6 +78,14 @@
         <source>Decline and block</source>
         <translation>거절하고 차단</translation>
     </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished">수락</translation>
+    </message>
 </context>
 <context>
     <name>AccountAddressSelection</name>

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -9,8 +9,6 @@ import StatusQ.Components
 import utils
 import shared.controls.chat
 
-import SortFilterProxyModel
-
 StatusMenu {
     id: root
 


### PR DESCRIPTION
### What does the PR do

- to make StatusMenu avoid unreachable (system reserved) areas

Fixes #19732

### Affected areas

MessageView (popup menus)

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

Message ctx menu:
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/fe66e0c5-5d0b-403f-b6d6-b58b0607b798" />

Profile ctx menu:
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/540f80e0-a562-4cfe-9f1d-5d3005b7cb7e" />

### Impact on end user

Improved menus UX on mobile

### How to test

- open e.g. a message context menu near the bottom edge
- the menu avoids the bottom system (navigation) area

### Risk 

- low
