### PR TITLE
fix: IOS crash with `lto` enabled

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -76,7 +76,7 @@ NIM_FLAGS=(
 if [ "$DEBUG" -eq 1 ]; then
     NIM_FLAGS+=(-d:debug -d:nimTypeNames)
 else
-    NIM_FLAGS+=(-d:release -d:lto -d:production)
+    NIM_FLAGS+=(-d:release -d:production)
 fi
 
 # build status-client with feature flags


### PR DESCRIPTION
### What does the PR do

Fixing IOS crash on login.

When `lto` and release with debug symbols is used the ios build crashes in `compressPK` when trying to verify if the jsonResponse has an error field. But I think that's not the root cause. The root cause seems to be related to nim_Status_client vs nim-sds symbols. Maybe nimrtl issues.

What's clear is that disabling the lto for nim_status_client will fix the issue.

