### PR TITLE
fix(EnterSeedPhrase): fix three letter words with multiple suggestions

### DIFF
--- a/ui/imports/shared/panels/EnterSeedPhrase.qml
+++ b/ui/imports/shared/panels/EnterSeedPhrase.qml
@@ -376,6 +376,12 @@ Control {
                                 inputModel.setEntry(index, text, d.isInDictionary(text))
                                 d.filteringPrefix = ""
                             }
+                        } else if (suggestionsModel.count > 1 && text.length === 3 && text === suggestionsModel.takeFirst()) {
+                            // Some valid words have only three letters, but they have more than one suggestion
+                            // In that case, we set it as an entry to possibly enable the user to submit without further input
+                            // This also fixes the e2e test
+                            // If the valid word is longer, the user can still finish typing or select from suggestions
+                            inputModel.setEntry(index, suggestionsModel.takeFirst(), true)
                         }
                     }
                 }


### PR DESCRIPTION
### What does the PR do

Fixes ##19119

The issue appeared when the last word was a three letter word that has more than one suggestion. In that case, we didn't submit it for validation and the button remained grey.

The solution is to check if there are more than 1 suggestion and that the first suggestion is the same word. In that case, we set it as an entry. This triggers the evaluation if it's  the last word. Worst case, it's not the right word and the user can just continue typing or select  the suggestion in the box, in which case, the new word is set and re-evaluated.

### Affected areas

EnterSeedPhrase.qml

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[seed-phrase-three-letters.webm](https://github.com/user-attachments/assets/179c2879-43b5-411c-8ef1-cad889e744ff)


### Impact on end user

Not much. It speeds them up if their last word is a three letter word since it evaluates without pressing tab.

This mostly fixes the "flaky" test, since it could fail if the last word was a three letter word.

### How to test

- Test the seed phrase provided in the issue
- Test writing out words to see if they feel as usual

### Risk 

Low
