### PR TITLE
fix: Unbreak mobile app

### DIFF
--- a/ui/app/AppLayouts/Browser/+noWebEngine/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/+noWebEngine/BrowserLayout.qml
@@ -23,6 +23,7 @@ StatusSectionLayout {
 
     required property var connectorController
     property bool isDebugEnabled: false
+    property bool isMobile
 
     signal sendToRecipientRequested(string address)
 }


### PR DESCRIPTION
### What does the PR do

Adding the `isMobile` property to the BrowserLayout stub for no webengine file selector to match the `AppMain` property assignment.

### Affected areas

Mobile app

