### PR TITLE
fix(Onboarding): improve error message for Keycard + Yubikey

### DIFF
--- a/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
+++ b/ui/app/AppLayouts/Onboarding/components/LoginKeycardBox.qml
@@ -61,7 +61,7 @@ Control {
     }
 
     background: Rectangle {
-        color: "transparent"
+        color: StatusColors.transparent
         border.width: 1
         border.color: Theme.palette.baseColor2
         radius: Theme.radius
@@ -84,6 +84,7 @@ Control {
             horizontalAlignment: Qt.AlignHCenter
             elide: Text.ElideRight
             color: Theme.palette.baseColor1
+            wrapMode: Text.Wrap
             linkColor: hoveredLink ? Theme.palette.hoverColor(color) : color
             visible: text !== ""
             HoverHandler {
@@ -201,7 +202,7 @@ Control {
             PropertyChanges {
                 target: infoText
                 color: Theme.palette.dangerColor1
-                text: qsTr("Issue detecting Keycard.<br>Remove and re-insert reader and Keycard.")
+                text: qsTr("Issue detecting Keycard.<br>Remove and re-insert reader and Keycard, check no other security keys are plugged in.")
             }
         },
         State {


### PR DESCRIPTION
### What does the PR do

- mention "other security keys" in the warning message
- wrap the content

Fixes #18220

### Affected areas

Onboarding/Login

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="3296" height="2002" alt="image" src="https://github.com/user-attachments/assets/7e01dccf-6907-4777-a08d-927cd68711e1" />

### Impact on end user

Better Keycard UX w/ e.g. Yubikey

### How to test

- have both a keycard and e.g. a Yubikey plugged in at the same time

### Risk 

- low
