### PR TITLE
feat(IOS): Managing the local network permissions for onboarding with pair

### DIFF
--- a/mobile/ios/Info.plist
+++ b/mobile/ios/Info.plist
@@ -50,6 +50,10 @@
         <string>UIInterfaceOrientationLandscapeLeft</string>
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_lnp._tcp.</string>
+    </array>
     <key>NSHighResolutionCapable</key>
     <string>True</string>
     <key>NSCameraUsageDescription</key>

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -161,6 +161,7 @@ add_library(StatusQ ${LIB_TYPE}
         include/StatusQ/formatteddoubleproperty.h
         include/StatusQ/genericvalidator.h
         include/StatusQ/keychain.h
+        include/StatusQ/localnetworkpermission.h
         include/StatusQ/networkchecker.h
         include/StatusQ/permissionutilsinternal.h
         include/StatusQ/rxvalidator.h
@@ -182,6 +183,7 @@ add_library(StatusQ ${LIB_TYPE}
         src/formatteddoubleproperty.cpp
         src/genericvalidator.cpp
         src/keychain.cpp
+        src/localnetworkpermission.cpp
         src/networkchecker.cpp
         src/permissionutilsinternal.cpp
         src/rxvalidator.cpp
@@ -227,6 +229,7 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
     target_sources(StatusQ PRIVATE
         src/ios_utils.mm
         src/keychain_apple.mm
+        src/localnetworkpermission_ios.mm
     )
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
     target_sources(StatusQ PRIVATE

--- a/ui/StatusQ/include/StatusQ/localnetworkpermission.h
+++ b/ui/StatusQ/include/StatusQ/localnetworkpermission.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QObject>
+#include <QElapsedTimer>
+#include <memory>
+
+class LocalNetworkPermissionBackend;
+
+class LocalNetworkPermission : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(PermissionStatus status READ status NOTIFY statusChanged FINAL)
+
+public:
+    enum PermissionStatus {
+        Unknown = 0,
+        Granted = 1,
+        Denied  = 2,
+    };
+    Q_ENUM(PermissionStatus)
+
+    explicit LocalNetworkPermission(QObject* parent = nullptr);
+    ~LocalNetworkPermission() override;
+
+    PermissionStatus status() const;
+
+    // Triggers a best-effort local-network probe. On first use, iOS may show the
+    // Local Network permission prompt (driven by NSLocalNetworkUsageDescription).
+    Q_INVOKABLE void request();
+
+    Q_INVOKABLE void cancel();
+
+signals:
+    void statusChanged();
+
+private:
+    std::unique_ptr<LocalNetworkPermissionBackend> m_backend;
+
+    PermissionStatus m_status{PermissionStatus::Unknown};
+
+    void setStatus(PermissionStatus status);
+
+    friend class LocalNetworkPermissionBackend;
+};
+

--- a/ui/StatusQ/src/localnetworkpermission.cpp
+++ b/ui/StatusQ/src/localnetworkpermission.cpp
@@ -1,0 +1,60 @@
+#include "StatusQ/localnetworkpermission.h"
+
+#include "localnetworkpermission_backend.h"
+
+#ifdef Q_OS_IOS
+std::unique_ptr<LocalNetworkPermissionBackend> createLNPermissionIOS(LocalNetworkPermission* owner);
+#endif
+
+#ifndef Q_OS_IOS
+namespace {
+struct StubBackend final : LocalNetworkPermissionBackend {
+    using LocalNetworkPermissionBackend::LocalNetworkPermissionBackend;
+
+    void request() override {
+        postStatus(LocalNetworkPermission::Granted);
+    }
+
+    void cancel() override {}
+};
+}
+#endif
+
+LocalNetworkPermission::LocalNetworkPermission(QObject* parent)
+    : QObject(parent)
+{
+#ifdef Q_OS_IOS
+    m_backend = createLNPermissionIOS(this);
+#else
+    m_backend = std::make_unique<StubBackend>(this);
+#endif
+}
+
+LocalNetworkPermission::~LocalNetworkPermission()
+{
+    cancel();
+}
+
+LocalNetworkPermission::PermissionStatus LocalNetworkPermission::status() const
+{
+    return m_status;
+}
+
+void LocalNetworkPermission::setStatus(PermissionStatus status)
+{
+    if (m_status == status)
+        return;
+
+    m_status = status;
+    emit statusChanged();
+}
+
+void LocalNetworkPermission::request()
+{
+    if (m_backend) m_backend->request();
+}
+
+void LocalNetworkPermission::cancel()
+{
+    if (m_backend) m_backend->cancel();
+}

--- a/ui/StatusQ/src/localnetworkpermission_backend.h
+++ b/ui/StatusQ/src/localnetworkpermission_backend.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "StatusQ/localnetworkpermission.h"
+
+#include <QMetaObject>
+#include <QPointer>
+
+class LocalNetworkPermissionBackend
+{
+public:
+    explicit LocalNetworkPermissionBackend(LocalNetworkPermission* owner)
+        : m_owner(owner)
+    {}
+
+    virtual ~LocalNetworkPermissionBackend() = default;
+
+    virtual void request() = 0;
+    virtual void cancel() = 0;
+
+protected:
+    QPointer<LocalNetworkPermission> m_owner;
+
+    void postStatus(LocalNetworkPermission::PermissionStatus status)
+    {
+        if (!m_owner)
+            return;
+        // Update on the Qt thread.
+        QMetaObject::invokeMethod(m_owner.data(), [o = m_owner, status]() {
+            if (!o)
+                return;
+            o->setStatus(status);
+        }, Qt::QueuedConnection);
+    }
+};
+

--- a/ui/StatusQ/src/localnetworkpermission_ios.mm
+++ b/ui/StatusQ/src/localnetworkpermission_ios.mm
@@ -1,0 +1,203 @@
+#include "StatusQ/localnetworkpermission.h"
+
+#ifdef Q_OS_IOS
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#include <QMetaObject>
+#include <QPointer>
+#include <QTimer>
+
+#include <dns_sd.h>
+
+#include "localnetworkpermission_backend.h"
+
+namespace {
+static NSString* const kDomain = @"local.";
+static NSString* const kType = @"_lnp._tcp.";
+static const int kPort = 1100;
+}
+
+namespace {
+class IOSBackend;
+}
+
+@interface LNPServiceDelegate : NSObject <NSNetServiceDelegate>
+- (instancetype)initWithBackend:(IOSBackend*)backend;
+@end
+
+namespace {
+class IOSBackend final : public LocalNetworkPermissionBackend {
+public:
+    explicit IOSBackend(LocalNetworkPermission* owner)
+        : LocalNetworkPermissionBackend(owner)
+    {}
+
+    ~IOSBackend() override { cancel(); }
+
+    // Request permission from IOS.
+    // If the permission is granted or denied already we'll just update the status.
+    void request() override
+    {
+        ensureTimer();
+        doProbe();
+    }
+
+    // This backend will poll the permissions until it's cancelled or deleted.
+    void cancel() override
+    {
+        stopTimer();
+        cleanupService();
+    }
+
+    void onDidPublish()
+    {
+        postStatus(LocalNetworkPermission::Granted);
+        cleanupService();
+    }
+
+    void onDidNotPublish(int domain, int code)
+    {
+        Q_UNUSED(domain);
+        if (code == kDNSServiceErr_PolicyDenied) {
+            postStatus(LocalNetworkPermission::Denied);
+            cleanupService();
+        } else {
+            // Inconclusive. Cannot deterime wheter the permission was denied.
+            cleanupService();
+        }
+    }
+
+    void tick()
+    {
+        doProbe();
+    }
+
+private:
+    QTimer* m_timer{nullptr};
+    QElapsedTimer m_publishElapsed;
+    QElapsedTimer m_cycleCooldown;
+    bool m_publishAttempted{false};
+
+    NSNetService* m_service{nil};
+    LNPServiceDelegate* m_delegate{nil};
+
+    void ensureTimer()
+    {
+        if (!m_owner) return;
+        if (m_timer) return;
+
+        m_timer = new QTimer(m_owner.data());
+        // Poll every 500ms for permission changes.
+        m_timer->setInterval(500);
+        QObject::connect(m_timer, &QTimer::timeout, m_owner.data(), [this]() {
+            this->tick();
+        });
+        m_timer->start();
+    }
+
+    void stopTimer()
+    {
+        if (m_timer) {
+            m_timer->stop();
+            delete m_timer;
+            m_timer = nullptr;
+        }
+    }
+
+    void doProbe()
+    {
+        if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive)
+            return;
+
+        if (m_publishAttempted && m_publishElapsed.isValid() && m_publishElapsed.elapsed() > 1500) {
+            postStatus(LocalNetworkPermission::Denied);
+            cleanupService();
+            return;
+        }
+
+        if (m_cycleCooldown.isValid() && m_cycleCooldown.elapsed() < 1500)
+            return;
+
+        if (m_publishAttempted)
+            return;
+
+        m_publishAttempted = true;
+        m_publishElapsed.restart();
+        if (!m_cycleCooldown.isValid()) m_cycleCooldown.start(); else m_cycleCooldown.restart();
+
+        IOSBackend* backend = this;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Create a unique name to avoid collision errors.
+            NSString* name = [NSString stringWithFormat:@"LocalNetworkPrivacy-%@", [NSUUID UUID].UUIDString];
+            NSNetService* svc = [[NSNetService alloc] initWithDomain:kDomain type:kType name:name port:kPort];
+            svc.includesPeerToPeer = YES;
+
+            LNPServiceDelegate* delegate = [[LNPServiceDelegate alloc] initWithBackend:backend];
+            svc.delegate = delegate;
+            [svc scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+            [svc publish];
+
+            backend->m_service = svc;
+            backend->m_delegate = delegate;
+        });
+    }
+
+    void cleanupService()
+    {
+        m_publishAttempted = false;
+        m_publishElapsed.invalidate();
+
+        if (m_service) {
+            [m_service stop];
+            [m_service removeFromRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+            [m_service release];
+            m_service = nil;
+        }
+        if (m_delegate) {
+            [m_delegate release];
+            m_delegate = nil;
+        }
+    }
+};
+} // namespace
+
+@implementation LNPServiceDelegate
+{
+    IOSBackend* _backend;
+}
+
+- (instancetype)initWithBackend:(IOSBackend*)backend
+{
+    self = [super init];
+    if (self) {
+        _backend = backend;
+    }
+    return self;
+}
+
+- (void)netServiceDidPublish:(NSNetService *)sender
+{
+    Q_UNUSED(sender);
+    if (_backend) _backend->onDidPublish();
+}
+
+- (void)netService:(NSNetService *)sender didNotPublish:(NSDictionary<NSString *,NSNumber *> *)errorDict
+{
+    Q_UNUSED(sender);
+    if (!_backend) return;
+    const int code = errorDict[NSNetServicesErrorCode].intValue;
+    const int domain = errorDict[NSNetServicesErrorDomain].intValue;
+    _backend->onDidNotPublish(domain, code);
+}
+
+@end
+
+std::unique_ptr<LocalNetworkPermissionBackend> createLNPermissionIOS(LocalNetworkPermission* owner)
+{
+    return std::make_unique<IOSBackend>(owner);
+}
+
+#endif // Q_OS_IOS
+

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -8,6 +8,7 @@
 #include "StatusQ/formatteddoubleproperty.h"
 #include "StatusQ/genericvalidator.h"
 #include "StatusQ/keychain.h"
+#include "StatusQ/localnetworkpermission.h"
 #include "StatusQ/networkchecker.h"
 #include "StatusQ/permissionutilsinternal.h"
 #include "StatusQ/rxvalidator.h"
@@ -90,6 +91,8 @@ void registerStatusQTypes() {
         "StatusQ.Internal", 0, 1, "PermissionUtils", [](QQmlEngine*, QJSEngine*) {
             return new PermissionUtilsInternal;
         });
+
+    qmlRegisterType<LocalNetworkPermission>("StatusQ.Core", 0, 1, "LocalNetworkPermission");
 
     // onboarding
     qmlRegisterSingletonType<OnboardingEnums>("AppLayouts.Onboarding.enums", 1, 0,

--- a/ui/app/AppLayouts/Onboarding/pages/NewAccountLoginPage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/NewAccountLoginPage.qml
@@ -5,6 +5,7 @@ import QtQml.Models
 
 import StatusQ
 import StatusQ.Core
+import StatusQ.Core.Utils as SQUtils
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Core.Theme
@@ -133,11 +134,19 @@ OnboardingPage {
         id: loginWithSyncAck
         StatusDialog {
             objectName: "loginWithSyncAckPopup"
+            id: loginWithSyncAckPopup
             title: qsTr("Log in by syncing")
             width: 480
             padding: 20
             destroyOnClose: true
-            onOpened: if (root.networkChecksEnabled) netChecker.checkNetwork()
+
+            LocalNetworkPermission {
+                id: localNetworkPermission
+                onStatusChanged: {
+                    iosLocalNetworkSwitch.checked = (localNetworkPermission.status === LocalNetworkPermission.Granted)
+                }
+            }
+
             contentItem: ColumnLayout {
                 spacing: 20
                 StatusBaseText {
@@ -166,6 +175,42 @@ OnboardingPage {
                         id: ack3
                         text: qsTr("Disable the firewall and VPN on both devices")
                     }
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.padding
+                        visible: SQUtils.Utils.isIOS
+
+                        StatusSwitch {
+                            objectName: "iosLocalNetworkSwitch"
+                            id: iosLocalNetworkSwitch
+                            Layout.fillWidth: true
+                            text: qsTr("Local network access")
+                            enabled: localNetworkPermission.status === LocalNetworkPermission.Unknown
+                            Binding {
+                                target: iosLocalNetworkSwitch
+                                property: "checked"
+                                value: localNetworkPermission.status === LocalNetworkPermission.Granted
+                                restoreMode: Binding.RestoreBinding
+                            }
+                            onToggled: {
+                                if (checked) {
+                                    // The switch should be checked only by the permission request.
+                                    checked = false
+                                    localNetworkPermission.request()
+                                }
+                            }
+                        }
+                        StatusBaseText {
+                            Layout.fillWidth: true
+                            wrapMode: Text.Wrap
+                            color: Theme.palette.baseColor1
+                            textFormat: Text.RichText
+                            text: qsTr("Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.").arg(`<a href="app-settings:">`).arg(`</a>`)
+                            onLinkActivated: (link) => {
+                                Qt.openUrlExternally(link)
+                            }
+                        }
+                    }
                 }
             }
             footer: StatusDialogFooter {
@@ -178,7 +223,10 @@ OnboardingPage {
                     StatusButton {
                         objectName: "btnContinue"
                         text: qsTr("Continue")
-                        enabled: ack1.checked && ack2.checked && ack3.checked
+                        enabled: ack1.checked
+                                 && ack2.checked
+                                 && ack3.checked
+                                 && (!SQUtils.Utils.isIOS || localNetworkPermission.status === LocalNetworkPermission.Granted)
                         onClicked: {
                             if (root.networkChecksEnabled && !netChecker.isOnline) {
                                 networkCheckPopup.createObject(root, {netChecker}).open()

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -12222,6 +12222,14 @@ to load</source>
         <source>Verifying</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Local network access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewMessagesMarker</name>
@@ -19260,6 +19268,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -14885,6 +14885,16 @@
       <comment>NewAccountLoginPage</comment>
       <translation>Verifying</translation>
     </message>
+    <message>
+      <source>Local network access</source>
+      <comment>NewAccountLoginPage</comment>
+      <translation>Local network access</translation>
+    </message>
+    <message>
+      <source>Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.</source>
+      <comment>NewAccountLoginPage</comment>
+      <translation>Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.</translation>
+    </message>
   </context>
   <context>
     <name>NewMessagesMarker</name>
@@ -23436,6 +23446,11 @@
       <source>Status Desktop</source>
       <comment>main</comment>
       <translation>Status Desktop</translation>
+    </message>
+    <message>
+      <source>Hello World</source>
+      <comment>main</comment>
+      <translation>Hello World</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -12276,6 +12276,14 @@ to load</source>
         <source>Verifying</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Local network access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewMessagesMarker</name>
@@ -19342,6 +19350,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>Status Desktop</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -12243,6 +12243,14 @@ al cargar</translation>
         <source>Verifying</source>
         <translation>Verificando</translation>
     </message>
+    <message>
+        <source>Local network access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewMessagesMarker</name>
@@ -19298,6 +19306,10 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <message>
         <source>Status Desktop</source>
         <translation>Escritorio de Status</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -12209,6 +12209,14 @@ to load</source>
         <source>Verifying</source>
         <translation>검증 중</translation>
     </message>
+    <message>
+        <source>Local network access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable access to local network to pair with your other device in your network. Local network permissions can be managed in %1iOS Settings → Status → Local Network%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NewMessagesMarker</name>
@@ -19236,6 +19244,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>스테이터스 데스크톱</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Closes #19754

Managing the local network permissions on IOS isn't really straightforward because Apple doesn't provide an API for this permission. Instead what they recommend is to probe the local network. If permission denied error is received it means the permission has not been granted. If it succeeds it means the permission has been granted.

1. Adding a QML friendly API to verify the local network permissions. StatusQ.Core.LocalNetworkPermission This API will support a permission `status` property and request/cancel invokables. The mechanism to check for permission is through polling. Every 500 ms we'll create and publish a `NSNetService`. (approach inspired by https://stackoverflow.com/a/65800221)

2. Hook `LocalNetworkPermission` to NewAccountLoginPage. We'll show a new section in the `loginWithSyncAckPopup` (on IOS only). This section has a switch and a text description. When the user enables the switch we start the `LocalNetworkPermission` permission loop. The `LocalNetworkPermission.status` will control the switch checked state.

NOTE: The `StatusQ.Core.LocalNetworkPermission` should really belong in `MobileUI`. Didn't add it there at this point because I'd like to avoid bumping any other lib in this release branch. It should be done the right way for master.

### Affected areas

Onboarding on IOS

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/bcbbbd9a-76de-4a9e-979a-898def978cb7

### Impact on end user

The user can successfully finalize the onboarding with pair in the first attempt. Otherwise the user needs to attempt once, allow the network permission, return and attempt a second time.

### How to test

Make sure to have a clean installation. Try the `Login` flow with pair/sync.

### Risk 

low