### PR TITLE
ci: run qmllint to catch errors

### DIFF
--- a/.qmllint.ini
+++ b/.qmllint.ini
@@ -1,0 +1,53 @@
+[General]
+AdditionalQmlImportPaths=ui,ui/imports,ui/app,ui/StatusQ/src
+DisableDefaultImports=false
+
+[Warnings]
+# CRITICAL - These will fail the build:
+DuplicatedName=warning
+WithStatement=warning
+InheritanceCycle=warning
+InvalidLintDirective=warning
+
+# TYPE RESOLUTION - Set to info (C++ types not exposed to qmllint)
+ImportFailure=info
+IncompatibleType=info
+MissingProperty=info
+MissingType=info
+UnresolvedType=info
+UncreatableType=info
+PropertyAliasCycles=info
+MissingEnumEntry=info
+NonListProperty=info
+BadSignalHandlerParameters=info
+RestrictedType=info
+PrefixedImportType=info
+
+# CODE STYLE - Set to info (not critical for runtime)
+UnqualifiedAccess=info
+UseProperFunction=info
+RequiredProperty=info
+UnusedImports=info
+MultilineStrings=info
+VarUsedBeforeDeclaration=info
+DuplicatePropertyBinding=info
+AccessSingletonViaObject=info
+TopLevelComponent=info
+EnumsAreNotTypes=info
+ReadOnlyProperty=info
+Deprecated=info
+
+# QT QUICK SPECIFIC - Set to info
+Quick.Anchors=info
+Quick.AttachedPropertyType=info
+Quick.ControlsNativeCustomize=info
+Quick.LayoutsPositioning=info
+Quick.PropertyChangesParsed=info
+Quick.UnexpectedVarType=info
+Quick.AttachedPropertyReuse=disable
+Quick.ControlsAttachedPropertyReuse=disable
+
+# COMPILER/PLUGIN - Disable (not applicable)
+CompilerWarnings=disable
+LintPluginWarnings=disable
+AttachedPropertyReuse=disable

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ GIT_ROOT ?= $(shell git rev-parse --show-toplevel 2>/dev/null || echo .)
 	run-statusq-sanity-checker \
 	statusq-tests \
 	run-statusq-tests \
+	qml-lint \
 	storybook-build \
 	run-storybook \
 	run-storybook-tests \
@@ -339,6 +340,13 @@ statusq-clean:
 	echo -e "\033[92mCleaning:\033[39m StatusQ"
 	rm -rf $(STATUSQ_BUILD_PATH)
 	rm -rf $(STATUSQ_INSTALL_PATH)/StatusQ
+
+##
+##	Catch invalid QML
+##
+qml-lint:
+	echo -e "\033[92mRunning:\033[39m QML Lint"
+	./scripts/validate-qml.sh
 
 statusq-sanity-checker:
 	echo -e "\033[92mConfiguring:\033[39m StatusQ SanityChecker"

--- a/ci/Jenkinsfile.tests-ui
+++ b/ci/Jenkinsfile.tests-ui
@@ -77,6 +77,12 @@ pipeline {
         }
       }
     }
+ 
+    stage('QML Lint') {
+      steps {
+        sh 'make qml-lint'
+      }
+    }
 
     stage('Build StatusQ Tests') {
       steps {

--- a/scripts/validate-qml.sh
+++ b/scripts/validate-qml.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ROOT_DIR=$(realpath "$SCRIPT_DIR/..")
+QMLLINT="${QTDIR}/bin/qmllint"
+
+[[ ! -x "$QMLLINT" ]] && QMLLINT="${QTDIR}/libexec/qmllint"
+
+if [[ ! -x "$QMLLINT" ]]; then
+    echo "Error: qmllint not found at $QMLLINT"
+    echo "Set QTDIR environment variable to your Qt installation path"
+    exit 1
+fi
+
+echo "Using qmllint: $QMLLINT"
+echo "Validating QML files in: $ROOT_DIR/ui"
+echo ""
+
+# Use .qmllint.ini config file for warning settings
+# Only pass import paths and max-warnings on command line
+LINT_ARGS=(
+    "-I" "$ROOT_DIR/ui"
+    "-I" "$ROOT_DIR/ui/imports"
+    "-I" "$ROOT_DIR/ui/app"
+    "-I" "$ROOT_DIR/ui/StatusQ/src"
+    "-I" "${QTDIR}/qml"
+    "--max-warnings" "0"
+)
+
+ERRORS=0
+CHECKED=0
+FAILED_FILES=()
+
+while IFS= read -r -d '' qml_file; do
+    CHECKED=$((CHECKED + 1))
+
+    if ! output=$("$QMLLINT" "${LINT_ARGS[@]}" "$qml_file" 2>&1); then
+        # Filter out Info: lines, only show Warning: lines
+        warnings=$(echo "$output" | grep -E "^Warning:" || true)
+        if [[ -n "$warnings" ]]; then
+            echo "FAIL: $qml_file"
+            echo "$warnings" | while IFS= read -r line; do
+                printf "  %s\n" "$line"
+            done
+            echo ""
+        fi
+        FAILED_FILES+=("$qml_file")
+        ERRORS=$((ERRORS + 1))
+    fi
+done < <(find "$ROOT_DIR/ui" -name "*.qml" -print0)
+
+echo "Files checked: $CHECKED"
+echo "Errors found: $ERRORS"
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo ""
+    echo "Failed files:"
+    for f in "${FAILED_FILES[@]}"; do
+        echo "  - $f"
+    done
+    echo ""
+    echo "QML validation failed. Please fix the errors above."
+    exit 1
+fi
+
+echo "QML is validated"
+exit 0


### PR DESCRIPTION
### Summary

I've been often bitten by invalid QML crashing the mobile app and wondered why it was never evaluated at compile time.
I found `qmllint` that can probably catch these kind of issues in CI itself.


