### PR TITLE
fix(ci): use correct nwaku version

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -50,7 +50,7 @@ pipeline {
     booleanParam(
       name: 'USE_NWAKU',
       description: 'Whether to build with nwaku or not',
-      defaultValue: params.USE_NWAKU ?: getNWakuMode(),
+      defaultValue: getNWakuMode(),
     )
   }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -39,7 +39,7 @@ pipeline {
     booleanParam(
       name: 'USE_NWAKU',
       description: 'Whether to build with nwaku or not',
-      defaultValue: params.USE_NWAKU ?: getNWakuMode(),
+      defaultValue: getNWakuMode(),
     )
     string(
       name: 'NIMFLAGS',


### PR DESCRIPTION
## Summary

- fixes nwaku experimental naming in builds
- [x] ~~depends on https://github.com/status-im/status-go/pull/7306~~
