### PR TITLE
feat: Push notifications permissions - UI

### DIFF
--- a/mobile/android/qt6/build.gradle
+++ b/mobile/android/qt6/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }
@@ -10,6 +11,7 @@ buildscript {
 }
 
 repositories {
+    mavenLocal()
     google()
     mavenCentral()
 }
@@ -29,6 +31,8 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    
+    implementation 'im.status:mobileui-android:0.0.0-local'
 }
 
 // Allow overriding qtAndroidDir via environment variable (for different Qt installations)

--- a/mobile/ios/Info.plist.template
+++ b/mobile/ios/Info.plist.template
@@ -87,6 +87,12 @@
     <true/>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
+    <!-- Push Notifications Background Modes -->
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>remote-notification</string>
+        <string>fetch</string>
+    </array>
     <!-- Do not require paid apple accounts to build the app with NFC support -->
     <!-- KEYCARD_NFC_START
         <key>NFCReaderUsageDescription</key>

--- a/mobile/ios/Status-NoKeycard.entitlements
+++ b/mobile/ios/Status-NoKeycard.entitlements
@@ -6,7 +6,12 @@
 	<array>
 		<string>applinks:status.app</string>
 	</array>
-	<!-- No NFC capability - allows building without paid Apple Developer account -->
+    <!-- Push Notifications Entitlement -->
+    <!-- NOTE: This works with a FREE Apple Developer account! -->
+    <key>aps-environment</key>
+    <string>development</string>
+    
+    <!-- NOTE: NO NFC entitlement here - NFC requires paid Apple Developer account -->
+    <!-- This version can be used with a free account for testing -->
 </dict>
 </plist>
-

--- a/mobile/ios/Status.entitlements
+++ b/mobile/ios/Status.entitlements
@@ -6,15 +6,15 @@
 	<array>
 		<string>applinks:status.app</string>
 	</array>
-	<!-- NFC Tag Reading Capability -->
-	<!-- Required for reading NFC tags (Keycard) on iOS -->
-	<key>com.apple.developer.nfc.readersession.formats</key>
-	<array>
-		<string>TAG</string>
-	</array>
+    <!-- Push Notifications Entitlement -->
+    <key>aps-environment</key>
+    <string>development</string>
+    
+    <!-- NFC Capability (for Keycard support) -->
+    <!-- NOTE: Requires PAID Apple Developer account -->
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+        <string>TAG</string>
+    </array>
 </dict>
 </plist>
-
-
-
-

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -21,7 +21,7 @@ equals(QT_MAJOR_VERSION, 6) {
 }
 
 SOURCES += \
-        sources/main.cpp
+    sources/main.cpp
 
 # Add all status-desktop qrc files
 RESOURCES += \

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -9,6 +9,8 @@ import StatusQ.Controls
 import StatusQ.Components
 import StatusQ.Popups
 
+import MobileUI
+
 import utils
 import shared.panels
 import shared.controls
@@ -193,15 +195,48 @@ SettingsContentBase {
             }
         }
 
+        Control {
+            id: mobileHelperBanner
+            Layout.preferredWidth: root.contentWidth
+            visible: SQUtils.Utils.isMobile &&
+                    d.notificationsSettings.notifSettingAllowNotifications &&
+                    PushNotifications.status !== PushNotifications.Granted
+
+            padding: Theme.defaultPadding
+
+            background: Rectangle {
+                color: Theme.palette.primaryColor3
+                radius: Constants.settingsSection.radius
+                TapHandler {
+                    cursorShape: Qt.PointingHandCursor
+                    onTapped: PushNotifications.openSettings()
+                }
+            }
+
+            contentItem: StatusBaseText {
+                text: qsTr("<font color='%1'>Enable Push notifications in your device Settings</font><br><br>Before enabling mobile push notifications in the app below, enable them in <font color='%1'>your device settings</font> first.").arg(Theme.palette.primaryColor1)
+                font.pixelSize: d.infoFontSize
+                lineHeight: d.infoLineHeight
+                lineHeightMode: Text.FixedHeight
+                color: Theme.palette.baseColor1
+                wrapMode: Text.WordWrap
+            }
+        }
+
         StatusListItem {
             Layout.preferredWidth: root.contentWidth
-            title: qsTr("Allow Notification Bubbles")
+            title: SQUtils.Utils.isMobile
+                   ? qsTr("Enable mobile push notifications in the app")
+                   : qsTr("Allow Notification Bubbles")
             components: [
                 StatusSwitch {
                     id: allowNotifSwitch
                     checked: d.notificationsSettings.notifSettingAllowNotifications
                     onClicked: {
                         d.notificationsSettings.notifSettingAllowNotifications = !d.notificationsSettings.notifSettingAllowNotifications
+                        if (d.notificationsSettings.notifSettingAllowNotifications) {
+                            PushNotifications.request()
+                        }
                     }
                 }
             ]

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1113,6 +1113,15 @@ Item {
     }
 
     Connections {
+        target: appMain.rootStore
+
+        function onSectionsLoadedChanged() {
+            if (!appMain.rootStore.sectionsLoaded) return
+            popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup()
+        }
+    }
+
+    Connections {
         target: appMain.communitiesStore
 
         function onImportingCommunityStateChanged(communityId, state, errorMsg) {

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -3,6 +3,7 @@ import QtQuick
 import StatusQ
 import StatusQ.Core.Utils as SQUtils
 import StatusQ.Core.Backpressure
+import StatusQ.Core.Theme
 import StatusQ.Core
 
 import shared.stores as SharedStores
@@ -17,6 +18,9 @@ import AppLayouts.Profile.stores as ProfileStores
 import AppLayouts.Wallet.popups.buy
 import AppLayouts.Wallet.popups.swap
 import utils
+
+
+import MobileUI
 
 // Public API for this object are ONLY `stores` + the main `popupParent`
 QtObject {
@@ -47,6 +51,7 @@ QtObject {
     required property ProfileStores.PrivacyStore privacyStore
 
     required property Keychain keychain
+
 
     readonly property SwapModalHandler swapModalHandler: SwapModalHandler {
 
@@ -200,6 +205,64 @@ QtObject {
             return true
         }
         return false
+    }
+
+    readonly property Component enablePushNotificationsPopupComponent: Component {
+        EnablePushNotificationsPopup {
+            id: enablePushNotificationsPopup
+            destroyOnClose: true
+            hasPermission: PushNotifications.status === PushNotifications.Granted
+
+            onContinueRequested: {
+                PushNotifications.request()
+
+                enablePushNotificationsPopup.loading = true
+            }
+
+            onOpenSettingsRequested: {
+                PushNotifications.openSettings()
+                enablePushNotificationsPopup.close()
+            }
+
+
+            Connections {
+                target: PushNotifications
+
+                function onStatusChanged() {
+                    enablePushNotificationsPopup.loading = false
+                    enablePushNotificationsPopup.hasPermission = PushNotifications.status === PushNotifications.Granted
+
+                    if (PushNotifications.status === PushNotifications.Granted) {
+                        Global.displayToastMessage(
+                            qsTr("Push notifications enabled"),
+                            "",
+                            "checkmark-circle",
+                            false,
+                            Constants.ephemeralNotificationType.success,
+                            ""
+                        )
+                        enablePushNotificationsPopup.close()
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    function showEnablePushNotificationsPopup() {
+        enablePushNotificationsPopupComponent.createObject(root.popupParent).open()
+    }
+
+    function maybeDisplayEnablePushNotificationsPopup() {
+        if (!SQUtils.Utils.isMobile) {
+            return false
+        }
+
+        if (PushNotifications.status === PushNotifications.Granted) {
+            return false
+        }
+
+        showEnablePushNotificationsPopup()
     }
 
     readonly property EnableBiometricsPopupHandler enableBiometricsPopupHandler: EnableBiometricsPopupHandler {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -6906,6 +6906,37 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
 </context>
 <context>
+    <name>EnablePushNotificationsPopup</name>
+    <message>
+        <source>Enable push notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnsAddedView</name>
     <message>
         <source>ENS usernames</source>
@@ -8286,6 +8317,10 @@ L2 fee: %2</source>
     </message>
     <message>
         <source>Swap is not available in the testnet mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Push notifications enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12640,6 +12675,14 @@ to load</source>
     </message>
     <message>
         <source>Most recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable mobile push notifications in the app</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -19564,6 +19607,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>Report a bug on GitHub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -8433,6 +8433,44 @@
     </message>
   </context>
   <context>
+    <name>EnablePushNotificationsPopup</name>
+    <message>
+      <source>Enable push notifications</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Enable push notifications</translation>
+    </message>
+    <message>
+      <source>Maybe later</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Maybe later</translation>
+    </message>
+    <message>
+      <source>Done</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Done</translation>
+    </message>
+    <message>
+      <source>Open settings</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Open settings</translation>
+    </message>
+    <message>
+      <source>Continue</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Continue</translation>
+    </message>
+    <message>
+      <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</translation>
+    </message>
+    <message>
+      <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
+      <comment>EnablePushNotificationsPopup</comment>
+      <translation>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</translation>
+    </message>
+  </context>
+  <context>
     <name>EnsAddedView</name>
     <message>
       <source>ENS usernames</source>
@@ -10120,6 +10158,11 @@
       <source>Swap is not available in the testnet mode.</source>
       <comment>HandlersManager</comment>
       <translation>Swap is not available in the testnet mode.</translation>
+    </message>
+    <message>
+      <source>Push notifications enabled</source>
+      <comment>HandlersManager</comment>
+      <translation>Push notifications enabled</translation>
     </message>
   </context>
   <context>
@@ -15396,6 +15439,16 @@
       <source>Most recent</source>
       <comment>NotificationsView</comment>
       <translation>Most recent</translation>
+    </message>
+    <message>
+      <source>&lt;font color=&#39;%1&#39;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&#39;%1&#39;&gt;your device settings&lt;/font&gt; first.</source>
+      <comment>NotificationsView</comment>
+      <translation>&lt;font color=&#39;%1&#39;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&#39;%1&#39;&gt;your device settings&lt;/font&gt; first.</translation>
+    </message>
+    <message>
+      <source>Enable mobile push notifications in the app</source>
+      <comment>NotificationsView</comment>
+      <translation>Enable mobile push notifications in the app</translation>
     </message>
   </context>
   <context>
@@ -23808,6 +23861,11 @@
       <source>Report a bug on GitHub</source>
       <comment>main</comment>
       <translation>Report a bug on GitHub</translation>
+    </message>
+    <message>
+      <source>Hello World</source>
+      <comment>main</comment>
+      <translation>Hello World</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -6943,6 +6943,37 @@ Pamatujte si své heslo a s nikým ho nesdílejte.</translation>
     </message>
 </context>
 <context>
+    <name>EnablePushNotificationsPopup</name>
+    <message>
+        <source>Enable push notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">Možná později</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">Hotovo</translation>
+    </message>
+    <message>
+        <source>Open settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Pokračovat</translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnsAddedView</name>
     <message>
         <source>ENS usernames</source>
@@ -8329,6 +8360,10 @@ L2 poplatek: %2</translation>
     <message>
         <source>Swap is not available in the testnet mode.</source>
         <translation>Směna není k dispozici v režimu testnet.</translation>
+    </message>
+    <message>
+        <source>Push notifications enabled</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12736,6 +12771,14 @@ selhalo</translation>
     <message>
         <source>Most recent</source>
         <translation>Nejnovější</translation>
+    </message>
+    <message>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable mobile push notifications in the app</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19675,7 +19718,11 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
-        <translation>Status Desktop</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Share logs or report a bug?</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -6919,6 +6919,37 @@ Recuerda tu contraseña y no la compartas con nadie.</translation>
     </message>
 </context>
 <context>
+    <name>EnablePushNotificationsPopup</name>
+    <message>
+        <source>Enable push notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">Quizás más tarde</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">Listo</translation>
+    </message>
+    <message>
+        <source>Open settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnsAddedView</name>
     <message>
         <source>ENS usernames</source>
@@ -8301,6 +8332,10 @@ Tarifa L2: %2</translation>
     </message>
     <message>
         <source>Swap is not available in the testnet mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Push notifications enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12658,6 +12693,14 @@ al cargar</translation>
     <message>
         <source>Most recent</source>
         <translation>Más reciente</translation>
+    </message>
+    <message>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable mobile push notifications in the app</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19580,7 +19623,11 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <name>main</name>
     <message>
         <source>Status Desktop</source>
-        <translation>Escritorio de Status</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Share logs or report a bug?</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -6894,6 +6894,37 @@ Remember your password and don&apos;t share it with anyone.</source>
     </message>
 </context>
 <context>
+    <name>EnablePushNotificationsPopup</name>
+    <message>
+        <source>Enable push notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation type="unfinished">나중에</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished">완료</translation>
+    </message>
+    <message>
+        <source>Open settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">계속</translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications &amp; Sounds.&lt;br&gt;&lt;br&gt;Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EnsAddedView</name>
     <message>
         <source>ENS usernames</source>
@@ -8273,6 +8304,10 @@ L2 수수료: %2</translation>
     </message>
     <message>
         <source>Swap is not available in the testnet mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Push notifications enabled</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12621,6 +12656,14 @@ to load</source>
     <message>
         <source>Most recent</source>
         <translation>최신순</translation>
+    </message>
+    <message>
+        <source>&lt;font color=&apos;%1&apos;&gt;Enable Push notifications in your device Settings&lt;/font&gt;&lt;br&gt;&lt;br&gt;Before enabling mobile push notifications in the app below, enable them in &lt;font color=&apos;%1&apos;&gt;your device settings&lt;/font&gt; first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable mobile push notifications in the app</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19518,7 +19561,11 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
-        <translation>스테이터스 데스크톱</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Share logs or report a bug?</source>

--- a/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
+++ b/ui/imports/shared/popups/EnablePushNotificationsPopup.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import StatusQ.Core
+import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
+import StatusQ.Popups.Dialog
+import StatusQ.Controls
+import StatusQ.Components
+
+import utils
+
+StatusDialog {
+    id: root
+
+    // Presentation-only inputs (no store access here)
+    property bool hasPermission: false
+    property bool attemptedRequest: false
+    property bool loading: false
+
+    signal continueRequested()
+    signal openSettingsRequested()
+
+    width: 480
+    title: qsTr("Enable push notifications")
+    modal: true
+    closePolicy: Popup.NoAutoClose
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.topMargin: Theme.defaultPadding
+            Layout.bottomMargin: Theme.defaultPadding
+            wrapMode: Text.WordWrap
+            text: SQUtils.Utils.isIOS
+                  ? qsTr("Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications & Sounds.<br><br>Status uses Apple (APNs) push services only to deliver notifications. No one — including Apple or Status — can access or read your messages. They remain private.")
+                  : qsTr("Notifications include alerts, sounds, and icon badges, and can be configured in Settings / Notifications & Sounds.<br><br>Status uses a device-local service to deliver notifications, ensuring they remain private and do not pass through any third-party or centralized servers.")
+        }
+    }
+
+    footer: StatusDialogFooter {
+        dropShadowEnabled: true
+        bottomPadding: Theme.padding + root.parent.SafeArea.margins.bottom
+        leftButtons: ObjectModel {
+            StatusFlatButton {
+                objectName: "btnPushNotificationsLater"
+                text: qsTr("Maybe later")
+                onClicked: root.close()
+            }
+        }
+        rightButtons: ObjectModel {
+            StatusButton {
+                objectName: "btnPushNotificationsPrimary"
+                loading: root.loading
+                text: {
+                    if (root.hasPermission) return qsTr("Done")
+                    if (root.attemptedRequest) return qsTr("Open settings")
+                    return qsTr("Continue")
+                }
+                onClicked: {
+                    if (root.hasPermission) {
+                        root.close()
+                        return
+                    }
+                    if (root.attemptedRequest) {
+                        root.openSettingsRequested()
+                        return
+                    }
+
+                    root.attemptedRequest = true
+                    root.continueRequested()
+                }
+            }
+        }
+    }
+}
+

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -11,6 +11,7 @@ DeleteMessageConfirmationPopup 1.0 DeleteMessageConfirmationPopup.qml
 DownloadModal 1.0 DownloadModal.qml
 DownloadPage 1.0 DownloadPage.qml
 EnableMessageBackupPopup 1.0 EnableMessageBackupPopup.qml
+EnablePushNotificationsPopup 1.0 EnablePushNotificationsPopup.qml
 GetSyncCodeInstructionsPopup 1.0 GetSyncCodeInstructionsPopup.qml
 ImageContextMenu 1.0 ImageContextMenu.qml
 ImageCropWorkflow 1.0 ImageCropWorkflow.qml


### PR DESCRIPTION
### What does the PR do

Closes #19686

Implements https://github.com/status-im/MobileUI/pull/2

Adding the possibility for the user to interact with the OS push notification permissions.

1. Adding a `EnablePushNotificationsPopup` component. This component will be shown at start-up. The user can use it to request push notifications permissions or to navigate to OS settings if the permissions cannot be enabled from within the app
2. Hook the push notifications permissions to NotificationsView. The `Enable push notifications` toggle will also ask for push notifications permissions if possible. Otherwise it will show an additional section guiding the user to enable push notifications from OS settings.

### Affected areas

Notifications settings
Log in
App settings
Push notifications

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/f0f94df5-9483-45e9-8e43-49dce50b4f4c


https://github.com/user-attachments/assets/ff14e87f-376d-4b5f-8923-eefec419c4ec


### Impact on end user

The user can manage OS permissions for push notifications

### How to test

Login -> The push notifications popup should appear -> Allow/don't allow

### Risk 

Low
