### PR TITLE
test(e2e-mobile): Add wallet account rename

### DIFF
--- a/test/e2e_appium/locators/wallet/accounts_locators.py
+++ b/test/e2e_appium/locators/wallet/accounts_locators.py
@@ -15,6 +15,9 @@ class WalletAccountsLocators(BaseLocators):
     ACCOUNT_MENU_DELETE = BaseLocators.xpath(
         "//*[@content-desc='Delete' or contains(@resource-id,'AccountMenu-DeleteAction')]"
     )
+    ACCOUNT_MENU_EDIT = BaseLocators.xpath(
+        "//*[@content-desc='Edit' or contains(@resource-id,'AccountMenu-EditAction')]"
+    )
     KEYCARD_POPUP = BaseLocators.xpath(
         "//*[contains(@resource-id,'KeycardPopup')]"
     )
@@ -47,8 +50,8 @@ class WalletAccountsLocators(BaseLocators):
     ACCOUNT_NAME_INPUT = BaseLocators.content_desc_exact(
         "Account name [tid:statusBaseInput]"
     )
-    ADD_ACCOUNT_PRIMARY = BaseLocators.content_desc_exact(
-        "Add account [tid:AddAccountPopup-PrimaryButton]"
+    ADD_ACCOUNT_PRIMARY = BaseLocators.content_desc_contains(
+        "[tid:AddAccountPopup-PrimaryButton]"
     )
     EDIT_DERIVATION_BUTTON = BaseLocators.content_desc_exact(
         "Edit [tid:AddAccountPopup-EditDerivationPath]"

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -324,6 +324,40 @@ class BasePage:
         except Exception:
             return True
 
+    def _clear_input_field(self, locator: tuple, timeout: int = 5) -> bool:
+        """Clear text from an input field using select-all + delete.
+
+        Uses Ctrl+A to select all text, then Backspace to delete.
+        More reliable than element.clear() for Qt/QML fields.
+
+        Args:
+            locator: Element locator tuple.
+            timeout: Timeout for finding the element.
+
+        Returns:
+            bool: True if clearing was attempted, False if element not found.
+        """
+        from selenium.webdriver.common.keys import Keys
+
+        element = self.find_element_safe(locator, timeout=timeout)
+        if not element:
+            return False
+
+        try:
+            element.click()
+
+            # Select all with Ctrl+A, then delete (Ctrl is correct for Android)
+            actions = ActionChains(self.driver)
+            actions.key_down(Keys.CONTROL).send_keys("a").key_up(Keys.CONTROL)
+            actions.send_keys(Keys.BACKSPACE)
+            actions.perform()
+
+            self.logger.debug("Cleared input field via Ctrl+A + Backspace")
+            return True
+        except Exception as exc:
+            self.logger.debug(f"Select-all clear failed: {exc}")
+            return False
+
     def long_press_element(self, element, duration: int = 800) -> bool:
         """Perform long-press gesture on element to trigger context menu.
 

--- a/test/e2e_appium/pages/wallet/add_edit_account_modal.py
+++ b/test/e2e_appium/pages/wallet/add_edit_account_modal.py
@@ -12,7 +12,18 @@ class AddEditAccountModal(BasePage):
     def is_displayed(self, timeout: Optional[int] = 10) -> bool:
         return self.is_element_visible(self.locators.ADD_ACCOUNT_MODAL, timeout=timeout)
 
-    def set_name(self, name: str) -> bool:
+    def set_name(self, name: str, clear_existing: bool = False) -> bool:
+        """Set account name in the modal.
+
+        Args:
+            name: The account name to set.
+            clear_existing: If True, clears existing text before typing (for edit flow).
+                          If False, relies on qt_safe_input's native clear (for add flow).
+        """
+        if clear_existing:
+            if not self._clear_input_field(self.locators.ACCOUNT_NAME_INPUT):
+                self.logger.error("Failed to clear existing account name")
+                return False
         return self.qt_safe_input(self.locators.ACCOUNT_NAME_INPUT, name, verify=False)
 
     def save_changes(self) -> bool:

--- a/test/e2e_appium/tests/test_wallet_accounts_basic.py
+++ b/test/e2e_appium/tests/test_wallet_accounts_basic.py
@@ -43,10 +43,21 @@ class TestWalletAccountsBasic(StepMixin):
                 f"Before: {before}, After: {after_add}"
             )
 
+        async with self.step(self.device, "Rename account via context menu"):
+            renamed_name = generate_account_name(16)
+            assert panel.edit_account_via_menu(
+                renamed_name, index=-1
+            ), f"Failed to rename account '{name}' via context menu"
+
+        async with self.step(self.device, "Verify account renamed"):
+            assert panel.wait_for_account_name(renamed_name, timeout=10), (
+                f"Renamed account '{renamed_name}' not visible in account list"
+            )
+
         async with self.step(self.device, "Delete account"):
             assert panel.delete_latest_account_via_menu(
                 auth_password=user_password
-            ), f"Failed to delete generated account '{name}' via context menu"
+            ), f"Failed to delete generated account '{renamed_name}' via context menu"
 
         async with self.step(self.device, "Verify account deleted"):
             toast = app.wait_for_toast(


### PR DESCRIPTION
## Summary
- Add `ACCOUNT_MENU_EDIT` locator for Edit context menu action
- Add `edit_account_via_menu()` method to `WalletLeftPanel`
- Add `_clear_input_field()` to `BasePage` for Qt/QML input clearing
- Extend `test_add_and_delete_generated_account` with rename verification
- Make `ADD_ACCOUNT_PRIMARY` locator flexible for both "Add account" and "Save changes" button text

## Test Flow
The extended test now covers the complete account lifecycle:
1. **Add account** - Creates a new generated account via modal
2. **Verify added** - Confirms success toast and account count increased
3. **Rename account** - Long-press → Edit → Clear existing name → Enter new name → Save (NEW)
4. **Verify renamed** - Confirms new name appears in account list (NEW)
5. **Delete account** - Long-press → Delete → Confirm → Authenticate
6. **Verify deleted** - Confirms removal toast and account count decreased

## Test plan
- [x] Test passes on BrowserStack Android

https://github.com/user-attachments/assets/d341210a-3f59-4e5e-b9cb-f45b6c947298

Closes #19776
