### PR TITLE
fix(StatusDialog) theme/color not propagated correctly

### DIFF
--- a/storybook/pages/EnableBiometricsPopupPage.qml
+++ b/storybook/pages/EnableBiometricsPopupPage.qml
@@ -34,9 +34,6 @@ SplitView {
             modal: false
             closePolicy: Popup.CloseOnEscape
 
-            SplitView.fillWidth: true
-            SplitView.fillHeight: true
-
             loading: loadingctrl.checked
             errorText: ""
 

--- a/storybook/pages/EnableFullMessageHistoryPopupPage.qml
+++ b/storybook/pages/EnableFullMessageHistoryPopupPage.qml
@@ -33,6 +33,7 @@ SplitView {
                 id: dialog
 
                 anchors.centerIn: parent
+                modal: false
 
                 onAccepted: logs.logEvent("EnableFullMessageHistoryPopup::onAccepted")
                 onClosed: logs.logEvent("EnableFullMessageHistoryPopup::onClosed")
@@ -57,3 +58,4 @@ SplitView {
 }
 
 // category: Popups
+// status: good

--- a/storybook/pages/EnableMessageBackupPopupPage.qml
+++ b/storybook/pages/EnableMessageBackupPopupPage.qml
@@ -14,11 +14,8 @@ SplitView {
 
     orientation: Qt.Vertical
 
-    property var dialog
-
     function createAndOpenDialog() {
-        dialog = dlgComponent.createObject(popupBg)
-        dialog.open()
+        dlgComponent.createObject(popupBg).open()
     }
 
     Component.onCompleted: createAndOpenDialog()
@@ -41,13 +38,14 @@ SplitView {
 
         Component {
             id: dlgComponent
-                EnableMessageBackupPopup {
+            EnableMessageBackupPopup {
                 anchors.centerIn: parent
                 visible: true
+                modal: false
                 onAccepted: logs.logEvent("EnableMessageBackupPopup::onAccepted")
                 onClosed: logs.logEvent("EnableMessageBackupPopup::onClosed")
 
-                destroyOnClose: false
+                destroyOnClose: true
             }
         }
     }

--- a/storybook/pages/MetricsEnablePopupPage.qml
+++ b/storybook/pages/MetricsEnablePopupPage.qml
@@ -68,7 +68,8 @@ SplitView {
                         Constants.metricsEnablePlacement.unknown,
                         Constants.metricsEnablePlacement.welcome,
                         Constants.metricsEnablePlacement.privacyAndSecurity,
-                        Constants.metricsEnablePlacement.startApp
+                        Constants.metricsEnablePlacement.startApp,
+                        Constants.metricsEnablePlacement.onboarding
                     ]
                 }
             }

--- a/storybook/pages/QRCodeScannerDialogPage.qml
+++ b/storybook/pages/QRCodeScannerDialogPage.qml
@@ -9,11 +9,9 @@ Item {
 
     QRCodeScannerDialog {
         id: qrCodeScannerDialog
-        // workaround for QTBUG-142248
-        Theme.style: root.Theme.style
-        Theme.padding: root.Theme.padding
-        Theme.fontSizeOffset: root.Theme.fontSizeOffset
         visible: true
+        modal: false
+        closePolicy: Dialog.CloseOnEscape
     }
 
     Button {

--- a/storybook/pages/StatusDialogPage.qml
+++ b/storybook/pages/StatusDialogPage.qml
@@ -22,10 +22,8 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        Rectangle {
-            color: "lightgray"
+        PopupBackground {
             anchors.fill: parent
-
             Button {
                 anchors.centerIn: parent
                 text: "Reopen"

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -24,7 +24,7 @@ Dialog {
        \qmlproperty color backgroundColor
         This property decides the modal background color
     */
-    property color backgroundColor: contentItem.Theme.palette.statusModal.backgroundColor
+    property color backgroundColor: Theme.palette.statusModal.backgroundColor
 
     /*!
        \qmlproperty var closeHandler
@@ -54,7 +54,7 @@ Dialog {
     property bool fillHeightOnBottomSheet: false
 
     /*!
-       \qmlproperty bool fullScreen
+       \qmlproperty bool fullScreenSheet
         This property decides whether the dialog should take the full screen size.
     */
     property bool fullScreenSheet: false
@@ -166,9 +166,7 @@ Dialog {
         color: Theme.palette.backdropColor
     }
 
-    background: StatusDialogBackground {
-        color: root.backgroundColor
-    }
+    background: StatusDialogBackground {}
 
     header: StatusDialogHeader {
         visible: root.title || root.subtitle

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -885,7 +885,7 @@ Item {
 
     Settings {
         id: appMainLocalSettings
-        category: "AppMainLocalSettings_%1".arg(allContacsAdaptor.selfPubKey)
+        category: "AppMainLocalSettings_%1".arg(allContacsAdaptor.selfContactDetails.publicKey)
         property var whitelistedUnfurledDomains: []
         property bool introduceYourselfPopupSeen
         property bool enableMessageBackupPopupSeen

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -192,7 +192,7 @@ QtObject {
 
     function maybeDisplayEnableMessageBackupPopup() {
         if (!appMainLocalSettings.enableMessageBackupPopupSeen && !appMain.devicesStore.messagesBackupEnabled) {
-            enableMessageBackupPopupComponent.createObject(appMain).open()
+            enableMessageBackupPopupComponent.createObject(popupParent).open()
             return true
         }
         return false

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1455,10 +1455,6 @@ QtObject {
             id: qrCodeScannerDialogComponent
 
             QRCodeScannerDialog {
-                // workaround for QTBUG-142248
-                Theme.style: popupParent.Theme.style
-                Theme.padding: popupParent.Theme.padding
-                Theme.fontSizeOffset: popupParent.Theme.fontSizeOffset
                 destroyOnClose: true
                 onTagFound: (tagType, tag) => {
                     if (tagType === QRCodeScannerDialog.TagType.Address) {


### PR DESCRIPTION
### What does the PR do

- fix the bug where a _lot_ of popups would have a wrong text color (dark on dark), or even white on white in the dark mode
- removed the workaround for QTBUG-142248 by not passing the backgroundColor directly from StatusDialog to the background and not using the contentItem too early
- the `backgroundColor` can still be changed/used but by doing so, we always provide a custom `StatusDialogBackground` (actually we never use the bg color directly anywhere in our code)
- fix a recent regression with `appMainLocalSettings` by passing the correct pubKey
- fixup/improve the popup related SB pages

Fixes #19794

### Affected areas

Popups in dark mode

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2660" height="1948" alt="Snímek obrazovky z 2026-01-27 09-51-29" src="https://github.com/user-attachments/assets/8ba82b37-4297-4cbc-90d5-333747a42bfe" />

<img width="2660" height="1948" alt="Snímek obrazovky z 2026-01-27 09-32-06" src="https://github.com/user-attachments/assets/81305c24-7de2-40d3-9c95-272262b15293" />

### Impact on end user

Correct text and bg color for popups in dark mode

### Risk 

low
