### PR TITLE
chore(ci): remove artifacts older than 30d, keep 1 per PR

### DIFF
--- a/ci/Jenkinsfile.android
+++ b/ci/Jenkinsfile.android
@@ -42,7 +42,8 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '3',
+      artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -39,7 +39,8 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '3',
+      artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -63,6 +63,7 @@ pipeline {
       numToKeepStr: '10',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -57,6 +57,7 @@ pipeline {
       numToKeepStr: '10',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -55,6 +55,7 @@ pipeline {
       numToKeepStr: '10',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '1',
+      artifactDaysToKeepStr: '30'
     ))
     /* Allows combined build to copy */
     copyArtifactPermission('/status-app/*')


### PR DESCRIPTION
### What does the PR do

Set Jenkins job build discarder to remove with following rules:
```groovy
artifactNumToKeepStr: '1',
artifactDaysToKeepStr: '30'
```

Keep 1 per PR, but not older than 30 days.