### PR TITLE
feat(qr): support scanning walletconnect codes

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusQrCodeCapture.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusQrCodeCapture.qml
@@ -56,7 +56,7 @@ Item {
         camera: camera
         scanning: true
 
-        captureRect: captureRect
+        captureRect: captureRectangle
 
         onCapturedChanged: (tag) => {
             d.lastTag = tag
@@ -82,7 +82,7 @@ Item {
     }
 
     Rectangle {
-        id: captureRect
+        id: captureRectangle
         width: root.captureRectWidth
         height: root.captureRectHeight
         anchors.centerIn: parent

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -952,6 +952,17 @@ Item {
             }
         }
         onTransferOwnershipRequested: (tokenId, senderAddress) => popupRequestsHandler.sendModalHandler.transferOwnership(tokenId, senderAddress)
+        onWcUriScanned: uri => {
+            if (!dAppsServiceLoader.active || !dAppsServiceLoader.item) {
+                return
+            }
+            function pairingHandler() {
+                dAppsServiceLoader.item.dappsModule.pair(uri)
+                dAppsServiceLoader.item.pairingValidated.disconnect(pairingHandler)
+            }
+            dAppsServiceLoader.item.pairingValidated.connect(pairingHandler)
+            dAppsServiceLoader.item.validatePairingUri(uri)
+        }
     }
 
     HandlersManager {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -24,6 +24,7 @@ import AppLayouts.Wallet.popups.buy
 import AppLayouts.Wallet.popups
 import AppLayouts.Communities.stores
 import AppLayouts.Profile.helpers
+import AppLayouts.Wallet.services.dapps
 
 import AppLayouts.Wallet.stores as WalletStores
 import AppLayouts.Chat.stores as ChatStores
@@ -75,6 +76,7 @@ QtObject {
     signal saveDomainToUnfurledWhitelist(string domain)
     signal ownershipDeclined(string communityId, string communityName)
     signal transferOwnershipRequested(string tokenId, string senderAddress)
+    signal wcUriScanned(string uri)
 
     property var activePopupComponents: []
 
@@ -1477,6 +1479,8 @@ QtObject {
                             return
                         }
                         Global.requestOpenLink(tag)
+                    } else if (tagType === QRCodeScannerDialog.TagType.WCUri) {
+                        root.wcUriScanned(tag)
                     }
                 }
             }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -14429,11 +14429,11 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WalletConnect to connect dApps</source>
+        <source>We cannot read that QR code.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>We cannot read that QR code.</source>
+        <source>WalletConnect to connect to dApps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -19548,10 +19548,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>Report a bug on GitHub</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -17577,14 +17577,14 @@
       <translation>Open WEB links</translation>
     </message>
     <message>
-      <source>WalletConnect to connect dApps</source>
-      <comment>QRCodeScannerDialog</comment>
-      <translation>WalletConnect to connect dApps</translation>
-    </message>
-    <message>
       <source>We cannot read that QR code.</source>
       <comment>QRCodeScannerDialog</comment>
       <translation>We cannot read that QR code.</translation>
+    </message>
+    <message>
+      <source>WalletConnect to connect to dApps</source>
+      <comment>QRCodeScannerDialog</comment>
+      <translation>WalletConnect to connect to dApps</translation>
     </message>
   </context>
   <context>
@@ -23787,11 +23787,6 @@
       <source>Report a bug on GitHub</source>
       <comment>main</comment>
       <translation>Report a bug on GitHub</translation>
-    </message>
-    <message>
-      <source>Hello World</source>
-      <comment>main</comment>
-      <translation>Hello World</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -14536,11 +14536,11 @@ selhalo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WalletConnect to connect dApps</source>
+        <source>We cannot read that QR code.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>We cannot read that QR code.</source>
+        <source>WalletConnect to connect to dApps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -19679,10 +19679,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>Report a bug on GitHub</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -14452,11 +14452,11 @@ al cargar</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WalletConnect to connect dApps</source>
+        <source>We cannot read that QR code.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>We cannot read that QR code.</source>
+        <source>WalletConnect to connect to dApps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -19584,10 +19584,6 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     </message>
     <message>
         <source>Report a bug on GitHub</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -14409,11 +14409,11 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>WalletConnect to connect dApps</source>
+        <source>We cannot read that QR code.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>We cannot read that QR code.</source>
+        <source>WalletConnect to connect to dApps</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -19522,10 +19522,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>Report a bug on GitHub</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/imports/shared/popups/QRCodeScannerDialog.qml
+++ b/ui/imports/shared/popups/QRCodeScannerDialog.qml
@@ -9,6 +9,8 @@ import StatusQ.Components
 import StatusQ.Controls.Validators
 import StatusQ.Popups.Dialog
 
+import AppLayouts.Wallet.services.dapps
+
 import utils
 import "./common"
 
@@ -32,13 +34,15 @@ StatusDialog {
 
     enum TagType {
         Link,
-        Address
+        Address,
+        WCUri
     }
 
     QtObject {
         id: d
 
         property string validTag: ""
+        property int validTagType
     }
 
     contentItem: ColumnLayout {
@@ -57,11 +61,7 @@ StatusDialog {
                 running: !!d.validTag
                 repeat: false
                 onTriggered: {
-                    if (Utils.isURL(d.validTag)) {
-                        root.tagFound(QRCodeScannerDialog.TagType.Link, d.validTag)
-                    } else if (Utils.isValidAddress(d.validTag)) {
-                        root.tagFound(QRCodeScannerDialog.TagType.Address, d.validTag)
-                    }
+                    root.tagFound(d.validTagType, d.validTag)
                     root.close()
                 }
             }
@@ -71,8 +71,20 @@ StatusDialog {
                     name: "isValidQR"
                     errorMessage: qsTr("We cannot read that QR code.")
                     validate: function (tag) {
-                        // We accept URLs and addresses
-                        return Utils.isURL(tag) || Utils.isValidAddress(tag)
+                        // We accept URLs, addresses and WalletConnect URIs
+                        if (Utils.isURL(tag)) {
+                            d.validTagType = QRCodeScannerDialog.TagType.Link
+                            return true
+                        }
+                        if (Utils.isValidAddress(tag)) {
+                            d.validTagType = QRCodeScannerDialog.TagType.Address
+                            return true
+                        }
+                        if (DAppsHelpers.validURI(tag)) {
+                            d.validTagType = QRCodeScannerDialog.TagType.WCUri
+                            return true
+                        }
+                        return false
                     }
                 }
             ]
@@ -107,7 +119,7 @@ StatusDialog {
 
         IconRow {
             width: parent.width
-            text: qsTr("WalletConnect to connect dApps")
+            text: qsTr("WalletConnect to connect to dApps")
             icon: "wallet"
         }
     }


### PR DESCRIPTION
### What does the PR do

Part of https://github.com/status-im/status-app/issues/19678
Based on top of https://github.com/status-im/status-app/pull/19811

Adds the QML code needed to connect a Dapp using a WalletConnect QR code

### Affected areas

- AppMain
- QR components

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[wc-connect.webm](https://github.com/user-attachments/assets/3b44376b-0f0a-4053-afc7-cbf973419cb4)

(I didn't press accept because there is [an issue](https://github.com/status-im/status-app/issues/19813) where it crashes the app)

### Impact on end user

Makes it possible to connect to WalletConnect using a QR code

### How to test

- Have a WalletConnect QR code
- Scan it
- Press accept at your risk and perils

### Risk 

Low
