### PR TITLE
fix(reactions): fix reactions blocked on readonly chats

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -875,7 +875,7 @@ Loader {
                 onSenderNameClicked: (sender) => root.openProfileContextMenu(sender.x, sender.y)
 
                 onToggleReactionClicked: (hexcode) => {
-                    if (root.isChatBlocked)
+                    if (!d.addReactionAllowed)
                         return
 
                     if (!root.messageStore) {


### PR DESCRIPTION
### What does the PR do

Fixes  #19822

### Affected areas

MessageView

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[fix-reactions.webm](https://github.com/user-attachments/assets/863e476b-b658-4bf7-bfc7-ece66e194b4d)

### Impact on end user

Fixes the issue

### How to test

- Go to a readonly channel
- click on reactions that were posted by someone else

### Risk 

Low
