### PR TITLE
cherry-pick: fix(browser): Fix signing typed data

### DIFF
--- a/src/app_service/service/connector/async_tasks.nim
+++ b/src/app_service/service/connector/async_tasks.nim
@@ -8,12 +8,12 @@ logScope:
 type
   ConnectorCallRPCTaskArg* = ref object of QObjectTaskArg
     requestId*: int
-    message*: string
+    message*: JsonNode
 
 proc connectorCallRPCTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[ConnectorCallRPCTaskArg](argEncoded)
   try:
-    let rpcResponse = status_go.connectorCallRPC(arg.message)
+    let rpcResponse = status_go.connectorCallRPC($arg.message)
     let responseJson = %* {
       "requestId": arg.requestId,
       "result": rpcResponse.result,


### PR DESCRIPTION
### What does the PR do

Cherry-picks: https://github.com/status-im/status-app/pull/19598

Closes: #19559

The signing issue was caused by double escaping for the typed data string repr of the json.

- eth_signTypedData_v4 requires params[1] to be a JSON string (typed data)
- When encoding ConnectorCallRPCTaskArg, the message field (string) was double-escaped by toJson(), turning \" into \\", causing parse errors
- Error: "input(1, 207) Error: } expected" in threadpool.nim

