### PR TITLE
fix(communities): fix crash when account signing fails

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -671,6 +671,8 @@ proc signRevealedAddressesForNonKeycardKeypairs(self: Module): bool =
     return true
   # signatures are returned in the same order as signingParams
   let signatures = self.controller.signCommunityRequests(self.joiningCommunityDetails.communityId, signingParams)
+  if signatures.len != signingParams.len:
+    return false
   for i in 0 ..< len(signingParams):
     self.joiningCommunityDetails.addressesToShare[signingParams[i].address].signature = signatures[i]
     self.view.keypairsSigningModel().setOwnershipVerified(self.joiningCommunityDetails.addressesToShare[signingParams[i].address].keyUid, true)

--- a/ui/app/AppLayouts/stores/Messaging/Community/CommunityAccessStore.qml
+++ b/ui/app/AppLayouts/stores/Messaging/Community/CommunityAccessStore.qml
@@ -126,7 +126,7 @@ StatusQUtils.QObject {
         target: d.communitiesModuleInst
 
         function onCommunityAccessFailed(communityId: string, error: string) {
-            root.communityAccessFailed(communityId, error)
+            root.communityAccessFailed(communityId)
         }
 
         function onAllSharedAddressesSigned() {


### PR DESCRIPTION
### What does the PR do

Fixes #19775

The module didn't catch the error correctly and it crashed on trying to access a table index that doesn't exist.

It now correctly shows the error to the user

### Affected areas

communities module

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[error-joining.webm](https://github.com/user-attachments/assets/772e0c8d-8617-4c29-839a-7f4b828692bf)

### Impact on end user

No more crashes

### How to test

- Test joining a community with multiple or only some accounts

### Risk 

Low
