### PR TITLE
fix(StatusSearchPopup): can't close on mobile

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -60,13 +60,13 @@ StatusDialog {
     */
     property alias advancedHeader: advancedHeader.item
     /*!
-       \qmlproperty advancedHeader
+       \qmlproperty advancedFooter
         This property represents the item loaded in footer loader.
         Can be used to read values from the component assigned to the loader.
     */
     property alias advancedFooter: advancedFooter.item
     /*!
-       \qmlproperty advancedHeader
+       \qmlproperty advancedHeaderComponent
         This property can be used to assign a Component to the advanced loader.
         This was introduced to give more control to user on the Modal Header
 
@@ -94,7 +94,7 @@ StatusDialog {
     */
     property alias advancedHeaderComponent: advancedHeader.sourceComponent
     /*!
-       \qmlproperty advancedHeader
+       \qmlproperty advancedFooterComponent
         This property can be used to assign a Component to the advanced loader.
         This was introduced to give more control to user on the Modal Footer.
 
@@ -129,7 +129,7 @@ StatusDialog {
     property alias headerActionButton: headerImpl.actionButton
 
     /*!
-       \qmlproperty header
+       \qmlproperty headerSettings
         type: StatusModalHeaderSettings
         This property exposes the different properties of the standard header.
     */
@@ -156,7 +156,7 @@ StatusDialog {
     */
     property bool showHeader: true
     /*!
-       \qmlproperty showHeader
+       \qmlproperty showFooter
         This property to decides whether the standard footer is shown.
         default value is true
     */

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -96,7 +96,7 @@ StatusModal {
                     id: inputText
                     input.edit.objectName: "searchPopupSearchInput"
                     anchors.left: statusIcon.right
-                    anchors.right: parent.right
+                    anchors.right: closePopupButton.left
                     anchors.verticalCenter: parent.verticalCenter
                     focus: !Utils.isMobile
                     font.pixelSize: Theme.fontSize(28)
@@ -115,6 +115,22 @@ StatusModal {
                         if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)
                             event.accepted = true
                     }
+                }
+
+                StatusFlatRoundButton {
+                    id: closePopupButton
+                    objectName: "headerCloseButton"
+                    anchors.right: parent.right
+                    anchors.rightMargin: 12
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: 32
+                    height: 32
+                    type: StatusFlatRoundButton.Type.Secondary
+                    icon.name: "close"
+                    icon.color: Theme.palette.directColor1
+                    icon.width: 24
+                    icon.height: 24
+                    onClicked: root.close()
                 }
             }
             StatusMenuSeparator {


### PR DESCRIPTION
### What does the PR do
- add a close button, otherwise the user can't close the popup on mobile (the StatusModal has a `showHeader: false`, therefore lacking the standard close button)
- fix some StatusModal docu typos

Fixes #19831

### Affected areas

StatusSearchPopup

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

<img width="2444" height="2604" alt="Snímek obrazovky z 2026-01-30 14-30-29" src="https://github.com/user-attachments/assets/a0022216-26b0-4b59-9d05-aefc177ca53b" />

### Impact on end user

Better UX

### How to test

- open Search popup (Ctrl+F)
- close it

### Risk 

low
