### PR TITLE
fix: Keycard is not enabled on IOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -996,16 +996,11 @@ endef
 export PATH := $(call qmkq,QT_INSTALL_BINS):$(call qmkq,QT_HOST_BINS):$(call qmkq,QT_HOST_LIBEXECS):$(PATH)
 export QTDIR := $(call qmkq,QT_INSTALL_PREFIX)
 
-#Force keycard support for mobile builds
-ifeq ($(USE_STATUS_KEYCARD_QT),1)
-	MOBILE_FLAGS += "FLAG_KEYCARD_ENABLED=1"
-endif
-
 mobile-run: deps-common
 	echo -e "\033[92mRunning:\033[39m mobile app"
-	$(MAKE) -C mobile run DEBUG=1 GRADLE_TARGETS=assembleDebug $(MOBILE_FLAGS)
+	$(MAKE) -C mobile run DEBUG=1 GRADLE_TARGETS=assembleDebug
 
-mobile-build: USE_SYSTEM_NIM=1 $(MOBILE_FLAGS)
+mobile-build: USE_SYSTEM_NIM=1
 mobile-build: | deps-common
 	echo -e "\033[92mBuilding:\033[39m mobile app ($(or $(PACKAGE_TYPE),default))"
 ifeq ($(PACKAGE_TYPE),aab)

--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -83,7 +83,6 @@ pipeline {
     NIM_SDS_SOURCE_DIR = "${env.WORKSPACE_TMP}/nim-sds"
     /* Build variant: used by mobile/scripts/App.sh and mobile/fastlane/Fastfile */
     BUILD_VARIANT = "${utils.isReleaseBuild() ? 'release' : 'pr'}"
-    USE_STATUS_KEYCARD_QT = "1"
   }
 
   stages {

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -4,16 +4,12 @@
 STATUS_GO_LIB := $(LIB_PATH)/libstatus$(LIB_EXT)
 
 # FLAG_KEYCARD_ENABLED: Controls NFC/Keycard support
-# - iOS: Default 0 (disabled) - Build without NFC, works with free Apple Developer account
+# - iOS: Default 1 (enabled) - Build with NFC support, works with free Apple Developer account
 # - Android: Default 1 (enabled) - NFC support doesn't require paid account on Android
 # - Set to 1: Build with NFC support (iOS requires paid Apple Developer account)
 # - Set to 0: Build without NFC support
 # Usage: make build-ios FLAG_KEYCARD_ENABLED=1
-ifeq ($(OS),android)
-  FLAG_KEYCARD_ENABLED ?= 1
-else
-  FLAG_KEYCARD_ENABLED ?= 0
-endif
+FLAG_KEYCARD_ENABLED ?= 1
 
 $(info Configuring build system for $(OS) $(ARCH) with QT $(QT_MAJOR))
 


### PR DESCRIPTION
### What does the PR do

Trying to enable keycard on IOS

We've had 2 issues:
- The nfc wasn't declared in the pr build profile. Fixed by @siddarthkay already
- The keycard compilation flag wasn't properly configured. Fixed that by changing the default value to true on IOS

<img width="645" height="1398" alt="Captură de ecran din 2026-02-10 la 18 16 53" src="https://github.com/user-attachments/assets/6f34963f-7e8c-46fa-81f7-d73fb44d8569" />


