### PR TITLE
fix(wallet): fix token decimals when displaying activity amounts

### DIFF
--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -49,16 +49,17 @@ QtObject:
   proc isInTransactionType(self: ActivityEntry): bool =
     return self.metadata.activityType == backend_activity.ActivityType.Receive or self.metadata.activityType == backend_activity.ActivityType.Mint
 
-  proc getTokenKey(token: Option[backend_activity.Token], symbol: Option[string]): string =
-    if token.isSome() and token.get().address.isSome():
-      let t = token.get()
+  proc getTokenKey(token: Option[backend_activity.Token]): string =
+    if token.isNone():
+      return ""
+    let t = token.get()
+    if t.address.isSome():
       return common_utils.createTokenKey(t.chainId.int, $t.address.get())
-    return symbol.get("")
+    return common_utils.createNativeTokenKey(t.chainId.int)
 
   proc extractCurrencyAmount(self: ActivityEntry, currencyService: Service): CurrencyAmount =
     let usedToken = if self.isInTransactionType(): self.metadata.tokenIn else: self.metadata.tokenOut
-    let usedSymbol = if self.isInTransactionType(): self.metadata.symbolIn else: self.metadata.symbolOut
-    let tokenKey = getTokenKey(usedToken, usedSymbol)
+    let tokenKey = getTokenKey(usedToken)
     let amount = if self.isInTransactionType(): self.metadata.amountIn else: self.metadata.amountOut
     result = currencyAmountToItem(
       currencyService.getCurrencyValueForToken(tokenKey, amount),
@@ -84,14 +85,14 @@ QtObject:
 
     result.setup()
 
-  proc getConvertedAmount(token: Option[backend_activity.Token], symbol: Option[string], amount: UInt256, currencyService: Service): float64 =
-    if token.isNone() and symbol.isNone() and amount == 0:
+  proc getConvertedAmount(token: Option[backend_activity.Token], amount: UInt256, currencyService: Service): float64 =
+    if token.isNone() and amount == 0:
       return 0.0
-    return currencyService.getCurrencyValueForToken(getTokenKey(token, symbol), amount)
+    return currencyService.getCurrencyValueForToken(getTokenKey(token), amount)
 
   proc buildExtraData(metadata: backend_activity.ActivityEntry, currencyService: Service): ExtraData =
-    result.inAmount = getConvertedAmount(metadata.tokenIn, metadata.symbolIn, metadata.amountIn, currencyService)
-    result.outAmount = getConvertedAmount(metadata.tokenOut, metadata.symbolOut, metadata.amountOut, currencyService)
+    result.inAmount = getConvertedAmount(metadata.tokenIn, metadata.amountIn, currencyService)
+    result.outAmount = getConvertedAmount(metadata.tokenOut, metadata.amountOut, currencyService)
 
   proc newActivityEntry*(backendEntry: backend_activity.ActivityEntry, addresses: seq[string], currencyService: Service): ActivityEntry =
     let extraData = buildExtraData(backendEntry, currencyService)

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -162,6 +162,9 @@ proc isTokenKey*(key: string): bool =
 proc createTokenKey*(chainId: int, address: string): string =
   return $chainId & wallet_constants.TOKEN_KEY_DELIMITER & address.toLower()
 
+proc createNativeTokenKey*(chainId: int): string =
+  return createTokenKey(chainId, wallet_constants.ZERO_ADDRESS)
+
 proc communityKeyToTokenKey*(communityTokenKey: string): string =
   var parts = communityTokenKey.split(wallet_constants.COMMUNITY_TOKEN_KEY_DELIMITER)
   if parts.len < 2:


### PR DESCRIPTION
Transaction amounts in Activity view were displayed as raw values without
applying token decimals (e.g., "10 000 000 000B SNT" instead of "10 SNT").

Since tokens are indexed by tokenKey (format: `chainId-address`), the lookup failed when given a STT symbol. When the token wasn't found, `decimals` defaulted to `0


- Added `getTokenKey` helper to extract tokenKey from Token object
  with fallback to symbol for native tokens
- Added `getConvertedAmount`

https://github.com/user-attachments/assets/d905a69f-07ff-43ec-82b2-3ff666aa39a4


fixes #19653 