### PR TITLE
fix(wallet): add unknown connection state

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1363,6 +1363,8 @@ Item {
                             return ""
                     case Constants.ConnectionStatus.Retrying:
                         return qsTr("Retrying connection to POKT Network (grove.city).")
+                    case Constants.ConnectionStatus.Unknown:
+                        return ""
                     default:
                         return ""
                     }
@@ -1413,6 +1415,8 @@ Item {
                             return ""
                     case Constants.ConnectionStatus.Retrying:
                         return qsTr("Retrying connection to collectibles providers...")
+                    case Constants.ConnectionStatus.Unknown:
+                        return ""
                     default:
                         return ""
                     }
@@ -1438,6 +1442,8 @@ Item {
                     }
                     case Constants.ConnectionStatus.Retrying:
                         return qsTr("Retrying connection to CryptoCompare and CoinGecko...")
+                    case Constants.ConnectionStatus.Unknown:
+                        return ""
                     default:
                         return ""
                     }

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -14,7 +14,7 @@ Loader {
     property NetworkConnectionStore networkConnectionStore
     readonly property string jointChainIdString: networkConnectionStore.getChainIdsJointString(chainIdsDown)
     property string websiteDown
-    property int connectionState: Constants.ConnectionStatus.Retrying
+    property int connectionState: Constants.ConnectionStatus.Unknown
     property var chainIdsDown: []
     property bool completelyDown: false
     property double lastCheckedAtUnix: -1
@@ -36,6 +36,12 @@ Loader {
                 item.hide()
             return
         }
+
+        // We show error banners when there's an actual connection problem,
+        // Show "Retrying" banners only when a previously working connection is being retried
+        // Unknown - initial state. After the first real check completes, status changes
+        if (connectionState === Constants.ConnectionStatus.Unknown)
+            return
 
         root.active = true
         if (connectionState === Constants.ConnectionStatus.Failure)

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -762,7 +762,8 @@ QtObject {
     enum ConnectionStatus {
         Success = 0,
         Failure = 1,
-        Retrying = 2
+        Retrying = 2,
+        Unknown = 3
     }
 
     readonly property string defaultTokenIcon: "tokens/DEFAULT-TOKEN"


### PR DESCRIPTION
fixes #19841

demo:
- start without "retrying" banners
- turn off wi-fi
- banners are displayed



https://github.com/user-attachments/assets/b22ed0ed-313f-447f-bc97-e4af65405e59

