### PR TITLE
fix(Wallet): Store the wallet panel navigation

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -145,6 +145,14 @@ LayoutChooser {
     property bool invertedLayout: false
 
     /*!
+        \qmlproperty int StatusSectionLayout::currentIndex
+        This property holds the current index of the active panel.
+
+        Noop for landscape mode.
+    */
+    property alias currentIndex: portraitView.currentIndex
+
+    /*!
         \qmlsignal
         This signal is emitted when the back button of the header component
         is pressed.

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtCore
 
 import StatusQ
 import StatusQ.Layout
@@ -325,6 +326,7 @@ Item {
 
     StatusSectionLayout {
         id: walletSectionLayout
+        currentIndex: 1
         anchors.fill: parent
         backButtonName: RootStore.backButtonName
         onBackButtonClicked: {
@@ -473,5 +475,11 @@ Item {
         onLoaded: {
             keypairImport.item.open()
         }
+    }
+
+    Settings {
+        id: walletLocalSettings
+        category: "WalletLocalSettings_%1".arg(root.contactsStore.myPublicKey)
+        property alias selectedPanelIndex: walletSectionLayout.currentIndex
     }
 }


### PR DESCRIPTION
### What does the PR do

Closes [#19842](https://github.com/status-im/status-app/issues/19842)

Persist the wallet panel navigation. It defaults to center panel for new users.

### Affected areas

Wallet

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/c2f01e12-7249-4984-9561-130fba0d50d2

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->


