### PR TITLE
test(e2e-mobile): wallet account settings

### DIFF
--- a/test/e2e_appium/locators/base_locators.py
+++ b/test/e2e_appium/locators/base_locators.py
@@ -1,6 +1,42 @@
 from appium.webdriver.common.appiumby import AppiumBy
 
 
+def xpath_string(value: str) -> str:
+    """Escape a string for safe use in XPath 1.0 expressions.
+    
+    XPath 1.0 does not support backslash escaping. Strings must be quoted
+    with single or double quotes. If a string contains both quote types,
+    it must be constructed using concat().
+    
+    Args:
+        value: The string to escape.
+        
+    Returns:
+        A string safe for embedding in XPath (includes outer quotes or concat()).
+        
+    Output examples (as XPath literals):
+        "hello"           -> "hello"
+        "don't"           -> "don't"           (single quote inside double quotes)
+        'he said "hi"'    -> 'he said "hi"'    (double quote inside single quotes)
+        "it's a \"test\"" -> concat("it's a ", '"', "test", '"')
+    """
+    if '"' not in value:
+        return f'"{value}"'
+    if "'" not in value:
+        return f"'{value}'"
+    
+    # Contains both quote types - use concat()
+    # Split on double quotes and insert literal '"' (single-quoted) between parts
+    parts = value.split('"')
+    xpath_parts = []
+    for i, part in enumerate(parts):
+        if part:
+            xpath_parts.append(f'"{part}"')
+        if i < len(parts) - 1:
+            xpath_parts.append("'\"'")  # XPath literal: double quote in single quotes
+    return f"concat({', '.join(xpath_parts)})"
+
+
 class BaseLocators:
     BY_ACCESSIBILITY_ID = AppiumBy.ACCESSIBILITY_ID
     BY_ID = AppiumBy.ID

--- a/test/e2e_appium/locators/settings/settings_locators.py
+++ b/test/e2e_appium/locators/settings/settings_locators.py
@@ -12,7 +12,9 @@ class SettingsLocators(BaseLocators):
     # SettingsList.qml sets objectName: model.subsection + "-MenuItem"; backUpSeed subsection is 19
     BACKUP_RECOVERY_MENU_ITEM = BaseLocators.content_desc_contains("[tid:101-MenuItem]")
 
-    PROFILE_MENU_ITEM = BaseLocators.xpath("//*[contains(@resource-id,'0-MenuItem')]")
+    PROFILE_MENU_ITEM = BaseLocators.xpath(
+        "//*[contains(@content-desc, '[tid:0-MenuItem]') or contains(@resource-id,'0-MenuItem')]"
+    )
     PASSWORD_MENU_ITEM = BaseLocators.content_desc_contains("[tid:1-MenuItem]")
     PASSWORD_MENU_ITEM_TEXT = BaseLocators.text_contains("Password")
     MESSAGING_MENU_ITEM = BaseLocators.content_desc_contains("[tid:4-MenuItem]")

--- a/test/e2e_appium/locators/settings/wallet_settings_locators.py
+++ b/test/e2e_appium/locators/settings/wallet_settings_locators.py
@@ -1,0 +1,43 @@
+from ..base_locators import BaseLocators, xpath_string
+
+
+class WalletSettingsLocators(BaseLocators):
+    """Locators for the Wallet Settings view (Settings → Wallet)."""
+
+    # Navigation - Wallet menu item in settings
+    # Prefer the stable tid selector; keep resource-id fallback for older builds.
+    WALLET_MENU_ITEM = BaseLocators.xpath(
+        "//*[contains(@content-desc, '[tid:5-MenuItem]') or contains(@resource-id, '5-MenuItem')]"
+    )
+
+    # Add new account button in wallet settings main view
+    ADD_ACCOUNT_BUTTON = BaseLocators.resource_id_contains(
+        "settings_Wallet_MainView_AddNewAccountButton"
+    )
+
+    # Account list - Repeater containing keypair delegates
+    GENERATED_ACCOUNTS = BaseLocators.resource_id_contains("generatedAccounts")
+
+    # Individual keypair delegate row
+    KEYPAIR_DELEGATE = BaseLocators.resource_id_contains("walletKeyPairDelegate")
+
+    # Wallet settings menu items
+    NETWORKS_ITEM = BaseLocators.resource_id_contains("networksItem")
+    ACCOUNT_ORDER_ITEM = BaseLocators.resource_id_contains("accountOrderItem")
+    MANAGE_TOKENS_ITEM = BaseLocators.resource_id_contains("manageTokensItem")
+    SAVED_ADDRESSES_ITEM = BaseLocators.resource_id_contains("savedAddressesItem")
+
+    @staticmethod
+    def account_row_by_name(name: str) -> tuple:
+        """Locator for an account row by name in the wallet settings list.
+
+        WalletAccountDelegate has objectName: account.name, which maps to resource-id.
+        The title is also exposed via Accessible.name (content-desc). We check both
+        for robustness.
+
+        Uses xpath_string() for proper XPath 1.0 quote escaping.
+        """
+        escaped = xpath_string(name)
+        return BaseLocators.xpath(
+            f"//*[contains(@resource-id, {escaped}) or contains(@content-desc, {escaped})]"
+        )

--- a/test/e2e_appium/locators/wallet/account_details_locators.py
+++ b/test/e2e_appium/locators/wallet/account_details_locators.py
@@ -1,0 +1,48 @@
+from ..base_locators import BaseLocators
+
+
+class AccountDetailsLocators(BaseLocators):
+    """Locators for the Account Details view (Settings → Wallet → Account)."""
+
+    # Account header
+    ACCOUNT_NAME = BaseLocators.resource_id_contains("walletAccountViewAccountName")
+    ACCOUNT_IMAGE = BaseLocators.resource_id_contains("walletAccountViewAccountImage")
+    EDIT_BUTTON = BaseLocators.resource_id_contains("walletAccountViewEditAccountButton")
+    
+    # Alternative edit button locator using content-desc
+    EDIT_BUTTON_ALT = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'Edit account') or contains(@content-desc, 'Edit watched')]"
+    )
+    
+    # Alternative: Account name is displayed as large colored text near the edit button.
+    # Note: This uses preceding-sibling which depends on DOM structure. If layout changes
+    # and the account name element moves, this locator may break. Prefer ACCOUNT_NAME.
+    ACCOUNT_NAME_ALT = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'Edit account') or contains(@content-desc, 'Edit watched')]"
+        "/preceding-sibling::*[1]"
+    )
+
+    # Account details section label
+    ACCOUNT_DETAILS_LABEL = BaseLocators.resource_id_contains("AccountDetails_TextLabel")
+    
+    # Alternative: look for "Account details" text directly
+    ACCOUNT_DETAILS_TEXT = BaseLocators.xpath(
+        "//*[contains(@text, 'Account details') or contains(@content-desc, 'Account details')]"
+    )
+
+    # Account details rows
+    BALANCE_ROW = BaseLocators.resource_id_contains("Balance_ListItem")
+    ADDRESS_ROW = BaseLocators.resource_id_contains("Address_ListItem")
+    KEYPAIR_LABEL = BaseLocators.resource_id_contains("Keypair_TextLabel")
+    KEYPAIR_ITEM = BaseLocators.resource_id_contains("KeyPair_Item")
+    ORIGIN_ROW = BaseLocators.resource_id_contains("Origin_ListItem")
+    DERIVATION_PATH_ROW = BaseLocators.resource_id_contains("DerivationPath_ListItem")
+    STORED_ROW = BaseLocators.resource_id_contains("Stored_ListItem")
+
+    # Watch-only specific
+    INCLUDE_TOTAL_BALANCE_TOGGLE = BaseLocators.resource_id_contains(
+        "includeTotalBalanceListItem"
+    )
+
+    # Delete account button
+    DELETE_BUTTON = BaseLocators.resource_id_contains("deleteAccountButton")

--- a/test/e2e_appium/locators/wallet/receive_modal_locators.py
+++ b/test/e2e_appium/locators/wallet/receive_modal_locators.py
@@ -4,8 +4,8 @@ from ..base_locators import BaseLocators
 class ReceiveModalLocators(BaseLocators):
     """Locators for the Receive Modal (QR code / address popup)."""
 
-    # Modal container - uses the AlertDialog resource-id from the hierarchy
-    MODAL_CONTAINER = BaseLocators.resource_id_contains("ReceiveModal")
+    # Modal container - objectName in QML is "receiveModal" (lowercase 'm')
+    MODAL_CONTAINER = BaseLocators.resource_id_contains("receiveModal")
 
     # QR code image - uses Accessible.name which maps to content-desc on Android
     QR_CODE_IMAGE = BaseLocators.content_desc_contains("QR code for wallet address")

--- a/test/e2e_appium/pages/app.py
+++ b/test/e2e_appium/pages/app.py
@@ -50,6 +50,11 @@ class App(BasePage):
         self.logger.info("Clicking Messages button")
         return self.safe_click(self.locators.LEFT_NAV_MESSAGES)
 
+    def click_wallet_button(self) -> bool:
+        self.logger.info("Clicking Wallet button")
+        self._ensure_main_nav_visible()
+        return self.safe_click(self.locators.LEFT_NAV_WALLET, timeout=10)
+
     def _ensure_main_nav_visible(self) -> bool:
         if self.is_portrait_mode() and self.is_element_visible(
             self.locators.TOOLBAR_BACK_BUTTON, timeout=2

--- a/test/e2e_appium/pages/settings/settings_page.py
+++ b/test/e2e_appium/pages/settings/settings_page.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from ..base_page import BasePage
 from locators.settings.settings_locators import SettingsLocators
+from locators.settings.wallet_settings_locators import WalletSettingsLocators
 from .backup_seed_modal import BackupSeedModal
 from .password_change_page import PasswordChangePage
 from locators.wallet.saved_addresses_locators import SavedAddressesLocators
@@ -10,6 +11,7 @@ from .messaging_page import MessagingSettingsPage
 from .contacts_page import ContactsSettingsPage
 from .profile_page import ProfileSettingsPage
 from .share_profile_dialog import ShareProfileDialog
+from .wallet_settings_page import WalletSettingsPage
 
 
 class SettingsPage(BasePage):
@@ -91,6 +93,28 @@ class SettingsPage(BasePage):
             return None
         page = SavedAddressesPage(self.driver)
         return page if page.is_loaded(timeout=10) else None
+
+    def open_wallet_settings(self, timeout: int = 10) -> Optional[WalletSettingsPage]:
+        """Navigate to Settings → Wallet.
+        
+        Opens the wallet settings view from the main settings menu.
+        
+        Args:
+            timeout: Maximum wait time for page load.
+            
+        Returns:
+            WalletSettingsPage if opened successfully, None otherwise.
+        """
+        wallet_locators = WalletSettingsLocators()
+        if not self.safe_click(wallet_locators.WALLET_MENU_ITEM, timeout=timeout):
+            self.logger.error("Failed to click Wallet menu item in settings")
+            return None
+        
+        page = WalletSettingsPage(self.driver)
+        if page.is_loaded(timeout=timeout):
+            return page
+        self.logger.error("Wallet settings page did not load")
+        return None
 
     def open_messaging_settings(self) -> Optional[MessagingSettingsPage]:
         if self.safe_click(

--- a/test/e2e_appium/pages/settings/wallet_settings_page.py
+++ b/test/e2e_appium/pages/settings/wallet_settings_page.py
@@ -1,0 +1,245 @@
+from typing import Optional, List
+
+from selenium.webdriver.remote.webelement import WebElement
+
+from ..base_page import BasePage
+from locators.settings.wallet_settings_locators import WalletSettingsLocators
+from pages.wallet.add_edit_account_modal import AddEditAccountModal
+from pages.wallet.keycard_auth_modal import KeycardAuthenticationModal
+
+
+class WalletSettingsPage(BasePage):
+    """Page object for Wallet Settings view (Settings → Wallet)."""
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locators = WalletSettingsLocators()
+
+    def is_loaded(self, timeout: Optional[int] = 10) -> bool:
+        """Verify wallet settings view is displayed.
+        
+        Checks for the Add Account button as indicator the main view is loaded.
+        """
+        return self.is_element_visible(
+            self.locators.ADD_ACCOUNT_BUTTON, timeout=timeout
+        )
+
+    def open_add_account_popup(self, timeout: int = 10) -> Optional[AddEditAccountModal]:
+        """Click the Add Account button and return the modal.
+        
+        Returns:
+            AddEditAccountModal if opened successfully, None otherwise.
+        """
+        if not self.safe_click(self.locators.ADD_ACCOUNT_BUTTON, timeout=timeout):
+            self.logger.error("Failed to click Add Account button")
+            return None
+
+        modal = AddEditAccountModal(self.driver)
+        if modal.is_displayed(timeout=timeout):
+            return modal
+        self.logger.error("Add Account modal did not appear")
+        return None
+
+    def _swipe_up(self, duration_ms: int = 300) -> bool:
+        """Swipe up to scroll the wallet settings list.
+
+        Uses window size to avoid hard-coded coordinates that vary per device.
+        """
+        try:
+            size = self.driver.get_window_size()
+            x = int(size["width"] * 0.5)
+            start_y = int(size["height"] * 0.8)
+            end_y = int(size["height"] * 0.3)
+            self.driver.swipe(
+                start_x=x,
+                start_y=start_y,
+                end_x=x,
+                end_y=end_y,
+                duration=duration_ms,
+            )
+            return True
+        except Exception as e:
+            self.logger.warning(f"Swipe up failed: {e}")
+            return False
+
+    def _scroll_until_visible(
+        self,
+        locator: tuple,
+        *,
+        scroll_attempts: int = 3,
+        per_attempt_timeout: int = 2,
+    ) -> bool:
+        """Scroll until an element becomes visible."""
+        if self.is_element_visible(locator, timeout=per_attempt_timeout):
+            return True
+
+        for attempt in range(scroll_attempts):
+            self.logger.debug(f"Element not visible, scrolling (attempt {attempt + 1})")
+            if not self._swipe_up():
+                break
+            if self.is_element_visible(locator, timeout=per_attempt_timeout):
+                return True
+
+        return False
+
+    def get_account_rows(self, timeout: int = 10) -> List[WebElement]:
+        """Return list of account row elements in the wallet settings.
+        
+        Note: This returns the keypair delegate containers which may contain
+        multiple accounts. Use find_account_by_name for specific accounts.
+        """
+        try:
+            # Best-effort wait for list to be present
+            self.is_element_visible(self.locators.KEYPAIR_DELEGATE, timeout=timeout)
+            return self.driver.find_elements(*self.locators.KEYPAIR_DELEGATE)
+        except Exception as e:
+            self.logger.debug(f"get_account_rows failed: {e}")
+            return []
+
+    def find_account_by_name(
+        self, name: str, timeout: int = 10, scroll_attempts: int = 3
+    ) -> Optional[WebElement]:
+        """Find an account element by its name.
+        
+        Args:
+            name: The account name to search for.
+            timeout: Maximum wait time in seconds.
+            scroll_attempts: Number of scroll attempts to find off-screen accounts.
+            
+        Returns:
+            WebElement if found, None otherwise.
+        """
+        locator = self.locators.account_row_by_name(name)
+        
+        # First try without scrolling
+        element = self.find_element_safe(locator, timeout=min(timeout, 3))
+        if element:
+            return element
+        
+        # Try scrolling down to find the account
+        for attempt in range(scroll_attempts):
+            self.logger.debug(
+                f"Account '{name}' not found, scrolling down (attempt {attempt + 1})"
+            )
+            if not self._swipe_up():
+                break
+            element = self.find_element_safe(locator, timeout=3)
+            if element:
+                return element
+        
+        return None
+
+    def select_account_by_name(self, name: str, timeout: int = 10) -> bool:
+        """Click on an account to open its details view.
+        
+        Args:
+            name: The account name to select.
+            timeout: Maximum wait time in seconds.
+            
+        Returns:
+            bool: True if account was clicked successfully.
+        """
+        locator = self.locators.account_row_by_name(name)
+
+        if not self._scroll_until_visible(
+            locator,
+            scroll_attempts=3,
+            per_attempt_timeout=min(2, timeout),
+        ):
+            self.logger.error(f"Account '{name}' not visible in wallet settings list")
+            return False
+        
+        try:
+            self.safe_click(locator, timeout=timeout, max_attempts=2)
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to click account '{name}': {e}")
+            return False
+
+    def select_account_by_index(self, index: int = 0, timeout: int = 10) -> bool:
+        """Click on an account at the specified index.
+        
+        Args:
+            index: The index of the account to select (0-based).
+            timeout: Maximum wait time in seconds.
+            
+        Returns:
+            bool: True if account was clicked successfully.
+        """
+        rows = self.get_account_rows(timeout=timeout)
+        if not rows:
+            self.logger.error("No account rows found in wallet settings")
+            return False
+        
+        if index < 0:
+            index = len(rows) + index
+            
+        if index >= len(rows) or index < 0:
+            self.logger.error(f"Account index {index} out of range (0-{len(rows)-1})")
+            return False
+        
+        try:
+            rows[index].click()
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to click account at index {index}: {e}")
+            return False
+
+    def add_account(
+        self,
+        name: str,
+        auth_password: Optional[str] = None,
+        timeout: int = 10,
+    ) -> bool:
+        """Add a new account with the given name.
+        
+        Args:
+            name: The name for the new account.
+            auth_password: Password for authentication if required.
+            timeout: Maximum wait time for each operation.
+            
+        Returns:
+            bool: True if account was added successfully.
+        """
+        modal = self.open_add_account_popup(timeout=timeout)
+        if not modal:
+            return False
+
+        if not modal.set_name(name):
+            self.logger.error(f"Failed to set account name to '{name}'")
+            return False
+
+        if not modal.save_changes():
+            self.logger.error("Failed to save account changes")
+            return False
+
+        # Handle authentication if required
+        auth_modal = KeycardAuthenticationModal(self.driver)
+        if not auth_modal.is_displayed(timeout=5):
+            # No authentication required, wait for modal to close
+            if not modal.wait_until_hidden(timeout=timeout):
+                self.logger.error("Add account modal did not close and no auth prompt appeared")
+                return False
+            return True
+
+        # Authentication modal appeared - password is required
+        if not auth_password:
+            self.logger.error("Authentication required but no password provided")
+            return False
+        if not auth_modal.authenticate(auth_password):
+            self.logger.error("Authentication failed")
+            return False
+
+        return True
+
+    def account_exists(self, name: str, timeout: int = 5) -> bool:
+        """Check if an account with the given name exists.
+        
+        Args:
+            name: The account name to check for.
+            timeout: Maximum wait time in seconds.
+            
+        Returns:
+            bool: True if account exists.
+        """
+        return self.find_account_by_name(name, timeout=timeout) is not None

--- a/test/e2e_appium/pages/wallet/account_details_page.py
+++ b/test/e2e_appium/pages/wallet/account_details_page.py
@@ -1,0 +1,258 @@
+import re
+from typing import Optional
+
+from ..base_page import BasePage
+from locators.wallet.account_details_locators import AccountDetailsLocators
+from .remove_account_modal import RemoveAccountConfirmationModal
+from .keycard_auth_modal import KeycardAuthenticationModal
+
+
+class AccountDetailsPage(BasePage):
+    """Page object for Account Details view (Settings → Wallet → Account)."""
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locators = AccountDetailsLocators()
+
+    def is_loaded(self, timeout: Optional[int] = 10) -> bool:
+        """Verify account details view is displayed.
+        
+        Checks multiple indicators to determine if the view is loaded.
+        Uses multiple locator strategies for robustness.
+        """
+        # Primary check: Edit account button by content-desc (most reliable)
+        if self.is_element_visible(self.locators.EDIT_BUTTON_ALT, timeout=timeout):
+            return True
+        # Alternative: Edit button by resource-id
+        if self.is_element_visible(self.locators.EDIT_BUTTON, timeout=3):
+            return True
+        # Fallback: delete/remove button (visible for non-default accounts)
+        if self.is_element_visible(self.locators.DELETE_BUTTON, timeout=3):
+            return True
+        # Alternative: "Account details" label
+        if self.is_element_visible(self.locators.ACCOUNT_DETAILS_LABEL, timeout=3):
+            return True
+        # Final fallback: account name element
+        return self.is_element_visible(self.locators.ACCOUNT_NAME, timeout=3)
+
+    def get_account_name(self, timeout: int = 10) -> Optional[str]:
+        """Get the displayed account name.
+
+        
+        Returns:
+            Account name string or None if not found.
+        """
+        element = self.find_element_safe(self.locators.ACCOUNT_NAME, timeout=timeout)
+        if element:
+            name = (
+                element.get_attribute("content-desc")
+                or element.get_attribute("text")
+                or element.text
+            )
+            if name and name.strip():
+                return name.strip()
+        return None
+
+    def _get_row_subtitle(self, row_locator: tuple, timeout: int = 10) -> Optional[str]:
+        """Extract the subtitle/value text from a details row.
+        
+        Account detail rows use StatusListItem with Accessible.name format:
+        "Title: Subtitle" (e.g., "Address: 0x1234...")
+        """
+        row = self.find_element_safe(row_locator, timeout=timeout)
+        if not row:
+            return None
+        
+        # Primary strategy: Parse content-desc with format "Title: Value"
+        content_desc = row.get_attribute("content-desc")
+        if content_desc:
+            content_desc = content_desc.strip()
+            # Check for "Title: Value" format
+            if ": " in content_desc:
+                # Split on first ": " to get value part
+                parts = content_desc.split(": ", 1)
+                if len(parts) == 2:
+                    value = parts[1].strip()
+                    if value and "[tid:" not in value:
+                        return value
+        
+        # Fallback: Find text elements within the row
+        try:
+            text_elements = row.find_elements("xpath", ".//android.widget.TextView")
+            if len(text_elements) >= 2:
+                # Second element should be subtitle
+                subtitle = text_elements[1]
+                text = subtitle.text or subtitle.get_attribute("content-desc")
+                if text and text.strip():
+                    return text.strip()
+        except Exception as e:
+            self.logger.debug(f"Text element extraction failed: {e}")
+        
+        # Last resort: Get row text directly
+        if row.text:
+            return row.text.strip()
+        
+        return None
+
+    def get_account_address(self, timeout: int = 10) -> Optional[str]:
+        """Get the wallet address from the Address row.
+        
+        Returns:
+            Wallet address (0x...) or None if not found.
+        """
+        value = self._get_row_subtitle(self.locators.ADDRESS_ROW, timeout=timeout)
+        # Extract address if it's combined with other text
+        if value and "0x" in value:
+            # Find the address portion (starts with 0x)
+            for part in value.split():
+                if part.startswith("0x"):
+                    return part
+            # If no space separation, try to extract 0x... pattern
+            idx = value.find("0x")
+            if idx >= 0:
+                # Take from 0x to next space or end
+                end_idx = value.find(" ", idx)
+                return value[idx:] if end_idx < 0 else value[idx:end_idx]
+        return value
+
+    def get_origin_value(self, timeout: int = 10) -> Optional[str]:
+        """Get the origin/source text from the Origin row.
+        
+        Expected values:
+        - "Derived from your default Status key pair" (generated accounts)
+        - "Imported from recovery phrase" (seed import)
+        - "Imported from private key" (private key import)
+        - "Watched address" (watch-only)
+        
+        Returns:
+            Origin text or None if not found.
+        """
+        return self._get_row_subtitle(self.locators.ORIGIN_ROW, timeout=timeout)
+
+    def get_derivation_path(self, timeout: int = 10) -> Optional[str]:
+        """Get the derivation path from the Derivation Path row.
+        
+        Expected format: m/44'/60'/0'/0/N where N is the account index.
+        
+        Returns:
+            Derivation path string or None if not found/visible.
+        """
+        if not self.is_element_visible(self.locators.DERIVATION_PATH_ROW, timeout=2):
+            # Derivation path not shown for private key imports or watch-only
+            return None
+        return self._get_row_subtitle(self.locators.DERIVATION_PATH_ROW, timeout=timeout)
+
+    def get_storage_value(self, timeout: int = 10) -> Optional[str]:
+        """Get the storage location from the Stored row.
+        
+        Expected values:
+        - "On device" (stored locally)
+        - Keycard-related values if migrated
+        
+        The row content-desc format may be:
+        - "Stored: On device" (simple)
+        - "Stored: zQ3…7zDSDb<font size='3'>  &#x2022; </font>On device" (with keypair)
+        
+        Returns:
+            Storage text or None if not found/visible.
+        """
+        if not self.is_element_visible(self.locators.STORED_ROW, timeout=2):
+            return None
+        
+        value = self._get_row_subtitle(self.locators.STORED_ROW, timeout=timeout)
+        if not value:
+            return None
+        
+        # Handle HTML bullet separator format: "keypair<font...>&#x2022;</font>storage"
+        # Extract the part after the HTML bullet point
+        html_bullet_pattern = r'<font[^>]*>\s*&#x2022;\s*</font>'
+        if re.search(html_bullet_pattern, value):
+            parts = re.split(html_bullet_pattern, value)
+            if len(parts) >= 2:
+                storage = parts[-1].strip()
+                self.logger.debug(f"Extracted storage '{storage}' from compound value")
+                return storage
+        
+        # Fallback: check for known storage values at the end
+        known_values = ["On device", "On this device", "On Keycard"]
+        for known in known_values:
+            if value.endswith(known):
+                return known
+        
+        return value
+
+    def get_balance(self, timeout: int = 10) -> Optional[str]:
+        """Get the account balance from the Balance row.
+        
+        Returns:
+            Balance string (e.g., "$0.00") or None if not found.
+        """
+        return self._get_row_subtitle(self.locators.BALANCE_ROW, timeout=timeout)
+
+    def click_delete_button(self, timeout: int = 10) -> bool:
+        """Click the delete/remove account button.
+        
+        Returns:
+            bool: True if click succeeded.
+        """
+        return self.safe_click(self.locators.DELETE_BUTTON, timeout=timeout)
+
+    def open_delete_confirmation(
+        self, timeout: int = 10
+    ) -> Optional[RemoveAccountConfirmationModal]:
+        """Click delete and return the confirmation modal.
+        
+        Returns:
+            RemoveAccountConfirmationModal if opened successfully, None otherwise.
+        """
+        if not self.click_delete_button(timeout=timeout):
+            self.logger.error("Failed to click delete button")
+            return None
+
+        modal = RemoveAccountConfirmationModal(self.driver)
+        if modal.is_displayed(timeout=timeout):
+            return modal
+        self.logger.error("Remove account confirmation modal did not appear")
+        return None
+
+    def delete_account(
+        self, auth_password: Optional[str] = None, timeout: int = 10
+    ) -> bool:
+        """Delete the account from this details view.
+        
+        Handles the full deletion flow including confirmation and authentication.
+        
+        Args:
+            auth_password: Password for authentication (required for non-watch accounts).
+            timeout: Maximum wait time for each operation.
+            
+        Returns:
+            bool: True if account was deleted successfully.
+        """
+        confirmation = self.open_delete_confirmation(timeout=timeout)
+        if not confirmation:
+            return False
+
+        if not confirmation.confirm_removal(timeout=timeout):
+            self.logger.error("Failed to confirm account removal")
+            return False
+
+        # Handle authentication if required (not needed for watch-only)
+        auth_modal = KeycardAuthenticationModal(self.driver)
+        if auth_modal.is_displayed(timeout=5):
+            if not auth_password:
+                self.logger.error("Authentication required but no password provided")
+                return False
+            if not auth_modal.authenticate(auth_password):
+                self.logger.error("Authentication failed during deletion")
+                return False
+
+        return True
+
+    def click_edit_button(self, timeout: int = 10) -> bool:
+        """Click the edit account button.
+        
+        Returns:
+            bool: True if click succeeded.
+        """
+        return self.safe_click(self.locators.EDIT_BUTTON, timeout=timeout)

--- a/test/e2e_appium/pages/wallet/receive_modal.py
+++ b/test/e2e_appium/pages/wallet/receive_modal.py
@@ -1,3 +1,5 @@
+import base64
+import re
 from typing import Optional
 
 from pages.base_page import BasePage
@@ -7,9 +9,39 @@ from locators.wallet.receive_modal_locators import ReceiveModalLocators
 class ReceiveModal(BasePage):
     """Page object for the Receive Modal displaying QR code and wallet address."""
 
+    _ETH_ADDRESS_RE = re.compile(r"0x[0-9a-fA-F]{40}")
+
     def __init__(self, driver):
         super().__init__(driver)
         self.locators = ReceiveModalLocators()
+
+    @staticmethod
+    def _extract_eth_address(value: str | None) -> Optional[str]:
+        """Extract an Ethereum address (0x + 40 hex chars) from a string."""
+        if not value:
+            return None
+        value = value.strip().replace("×", "x")
+        match = ReceiveModal._ETH_ADDRESS_RE.search(value)
+        return match.group(0) if match else None
+
+    @staticmethod
+    def _normalize_clipboard_text(value: str | None) -> Optional[str]:
+        """Return clipboard text as a usable string.
+
+        Some providers return base64 from `mobile: getClipboard`; handle both raw
+        plaintext and base64.
+        """
+        if not value:
+            return None
+        raw = value.strip().replace("×", "x")
+        if raw.startswith("0x"):
+            return raw
+        try:
+            decoded = base64.b64decode(raw).decode("utf-8", errors="ignore").strip()
+            decoded = decoded.replace("×", "x")
+            return decoded if decoded.startswith("0x") else None
+        except Exception:
+            return None
 
     def is_displayed(self, timeout: Optional[int] = 10) -> bool:
         """Check if the receive modal is visible."""
@@ -31,14 +63,10 @@ class ReceiveModal(BasePage):
         """
         element = self.find_element_safe(self.locators.ADDRESS_TEXT, timeout=timeout)
         if element:
-            # Address is in content-desc (from Accessible.name)
-            address = element.get_attribute("content-desc") or element.text
+            raw = element.get_attribute("content-desc") or element.text
+            address = self._extract_eth_address(raw)
             if address:
-                address = address.strip()
-                # Normalize multiplication sign to 'x' if present
-                address = address.replace("×", "x")
-                if address.startswith("0x"):
-                    return address
+                return address
         self.logger.warning("Address text element not found in accessibility tree")
         return None
 
@@ -48,19 +76,59 @@ class ReceiveModal(BasePage):
         Returns:
             The wallet address from clipboard, or None if copy failed.
         """
+        expected_address = self.get_address(timeout=2)
+
+        clipboard_reset = False
+        before_clipboard: Optional[str] = None
+        try:
+            before_clipboard = (self.driver.get_clipboard_text() or "").strip()
+        except Exception:
+            before_clipboard = None
+
+        try:
+            self.driver.set_clipboard_text("")
+            clipboard_reset = True
+            before_clipboard = ""
+        except Exception as exc:
+            self.logger.debug("Unable to reset clipboard before copy: %s", exc)
+
         if not self.safe_click(self.locators.COPY_BUTTON, timeout=timeout):
             self.logger.error("Failed to click copy address button")
             return None
         
-        try:
-            # Small delay to ensure clipboard is updated
-            import time
-            time.sleep(0.3)
-            clipboard_text = self.driver.get_clipboard_text()
-            if clipboard_text:
-                return clipboard_text.strip()
-        except Exception as e:
-            self.logger.error(f"Failed to get clipboard content: {e}")
+        clipboard_result = [None]
+        last_seen_clipboard: dict[str, Optional[str]] = {"value": None}
+        
+        def check_clipboard():
+            try:
+                raw_text = self.driver.get_clipboard_text()
+                text = self._normalize_clipboard_text(raw_text)
+                if not text:
+                    return False
+                last_seen_clipboard["value"] = text
+
+                # If we can read the displayed address, require clipboard to match it.
+                if expected_address and text.lower() != expected_address.lower():
+                    return False
+
+                # Otherwise, require clipboard to change when we couldn't reset it.
+                if not clipboard_reset and before_clipboard and text == before_clipboard:
+                    return False
+
+                clipboard_result[0] = text
+                return True
+            except Exception:
+                pass
+            return False
+        
+        if self.wait_for_condition(check_clipboard, timeout=3, poll_interval=0.1):
+            return clipboard_result[0]
+        
+        self.logger.error(
+            "Clipboard did not contain a valid address after copy (expected=%s, last=%s)",
+            expected_address,
+            last_seen_clipboard["value"],
+        )
         return None
 
     def close(self) -> bool:

--- a/test/e2e_appium/pages/wallet/wallet_left_panel.py
+++ b/test/e2e_appium/pages/wallet/wallet_left_panel.py
@@ -1,3 +1,4 @@
+import base64
 from typing import List, Optional
 
 from ..base_page import BasePage
@@ -32,19 +33,59 @@ class WalletLeftPanel(BasePage):
         if not self.open_context_menu_for_row(index=index):
             self.logger.error(f"Failed to open context menu for account at index {index}")
             return None
+
+        clipboard_reset = False
+        before_clipboard: Optional[str] = None
+        try:
+            before_clipboard = (self.driver.get_clipboard_text() or "").strip()
+        except Exception:
+            before_clipboard = None
+
+        try:
+            self.driver.set_clipboard_text("")
+            clipboard_reset = True
+            before_clipboard = ""
+        except Exception as exc:
+            self.logger.debug("Unable to reset clipboard before copy: %s", exc)
         
         if not self.safe_click(self.locators.ACCOUNT_MENU_COPY_ADDRESS, timeout=timeout):
             self.logger.error("Failed to click Copy Address in context menu")
             return None
         
-        try:
-            import time
-            time.sleep(0.3)  # Small delay for clipboard update
-            clipboard_text = self.driver.get_clipboard_text()
-            if clipboard_text:
-                return clipboard_text.strip()
-        except Exception as e:
-            self.logger.error(f"Failed to get clipboard content: {e}")
+        clipboard_result = [None]
+        
+        def check_clipboard():
+            try:
+                raw_text = self.driver.get_clipboard_text()
+                if not raw_text:
+                    return False
+                text = raw_text.strip().replace("×", "x")
+                if not text.startswith("0x"):
+                    # Some providers return base64 for getClipboard
+                    try:
+                        decoded = (
+                            base64.b64decode(text)
+                            .decode("utf-8", errors="ignore")
+                            .strip()
+                            .replace("×", "x")
+                        )
+                        if not decoded.startswith("0x"):
+                            return False
+                        text = decoded
+                    except Exception:
+                        return False
+                if not clipboard_reset and before_clipboard and text == before_clipboard:
+                    return False
+                clipboard_result[0] = text
+                return True
+            except Exception:
+                pass
+            return False
+        
+        if self.wait_for_condition(check_clipboard, timeout=3, poll_interval=0.1):
+            return clipboard_result[0]
+        
+        self.logger.error("Clipboard did not contain a valid address after copy")
         return None
 
     def open_receive_modal(self, timeout: Optional[int] = 10) -> Optional[ReceiveModal]:
@@ -213,10 +254,11 @@ class WalletLeftPanel(BasePage):
         Returns:
             WebElement if found, None otherwise.
         """
-        escaped = name.replace("'", "\\'")
+        from locators.base_locators import xpath_string
+        escaped = xpath_string(name)
         locator = (
             "xpath",
-            f"//*[contains(@resource-id,'walletAccountListItem') and starts-with(@content-desc, \"{escaped}\")]"
+            f"//*[contains(@resource-id,'walletAccountListItem') and starts-with(@content-desc, {escaped})]"
         )
         return self.find_element_safe(locator, timeout=timeout)
 

--- a/test/e2e_appium/tests/test_wallet_account_from_settings.py
+++ b/test/e2e_appium/tests/test_wallet_account_from_settings.py
@@ -1,0 +1,182 @@
+"""Test wallet account management through Settings → Wallet → Account Details.
+
+This test ports the desktop test that manages wallet accounts through the Settings
+path rather than the wallet left panel context menu.
+
+Reference: test/e2e/tests/crtitical_tests_prs/test_add_delete_account_from_settings.py
+"""
+
+import pytest
+
+from pages.app import App
+from pages.settings.settings_page import SettingsPage
+from pages.wallet.account_details_page import AccountDetailsPage
+from pages.wallet.wallet_left_panel import WalletLeftPanel
+from utils.generators import generate_account_name
+from utils.multi_device_helpers import StepMixin
+
+
+# Expected values matching desktop test constants (test/e2e/constants/wallet.py)
+EXPECTED_ORIGIN = "Derived from your default Status key pair"
+EXPECTED_DERIVATION_PATH = "m / 44' / 60' / 0' / 0 / 1"
+EXPECTED_STORAGE = "On device"
+
+
+class TestWalletAccountFromSettings(StepMixin):
+    """Test wallet account management via Settings → Wallet flow."""
+
+    UI_TIMEOUT = 12
+
+    @pytest.mark.wallet
+    @pytest.mark.critical
+    @pytest.mark.smoke
+    async def test_add_view_delete_account_from_settings(self):
+        """Add account via settings, verify details, then delete.
+        
+        Test flow:
+        1. Navigate to Settings → Wallet
+        2. Add new account with generated name
+        3. Authenticate with password
+        4. Open account details view
+        5. Verify account info (name, address, origin, derivation path, storage)
+        6. Delete account from details view
+        7. Authenticate deletion
+        8. Verify toast message
+        9. Verify account removed from wallet
+        """
+        app = App(self.device.driver)
+        user_password = self.device.user.password
+        account_name = generate_account_name(15)
+
+        async with self.step(self.device, "Navigate to Settings"):
+            assert app.click_settings_button(), "Failed to open settings"
+            settings_page = SettingsPage(self.device.driver)
+            assert settings_page.is_loaded(timeout=self.UI_TIMEOUT), (
+                "Settings page did not load"
+            )
+
+        async with self.step(self.device, "Open Wallet settings"):
+            wallet_settings = settings_page.open_wallet_settings(timeout=self.UI_TIMEOUT)
+            assert wallet_settings is not None, "Failed to open wallet settings"
+            assert wallet_settings.is_loaded(timeout=self.UI_TIMEOUT), (
+                "Wallet settings view did not load"
+            )
+
+        async with self.step(self.device, "Add new account from wallet settings"):
+            assert wallet_settings.add_account(
+                name=account_name,
+                auth_password=user_password,
+                timeout=self.UI_TIMEOUT,
+            ), f"Failed to add account '{account_name}'"
+
+        async with self.step(self.device, "Verify account added toast"):
+            toast = app.wait_for_toast(
+                expected_substring="successfully added",
+                timeout=10,
+                stability=0.2,
+            )
+            if toast:
+                assert "successfully added" in toast.lower(), (
+                    f"Expected success toast. Got: '{toast}'"
+                )
+            else:
+                self.device.logger.warning(
+                    "No toast detected after adding account '%s'", account_name
+                )
+
+        async with self.step(self.device, "Verify account appears in settings list"):
+            # The account list may need scrolling to find newly added accounts
+            assert wallet_settings.account_exists(account_name, timeout=15), (
+                f"Account '{account_name}' not found in wallet settings after creation"
+            )
+
+        async with self.step(self.device, "Open account details view"):
+            assert wallet_settings.select_account_by_name(
+                account_name, timeout=self.UI_TIMEOUT
+            ), f"Failed to select account '{account_name}'"
+
+            account_details = AccountDetailsPage(self.device.driver)
+            assert account_details.is_loaded(timeout=self.UI_TIMEOUT), (
+                "Account details view did not load"
+            )
+
+        async with self.step(self.device, "Verify account name in details"):
+            displayed_name = account_details.get_account_name(timeout=self.UI_TIMEOUT)
+            assert displayed_name is not None, "Account name not found in details view"
+            assert displayed_name == account_name, (
+                f"Account name mismatch. Expected '{account_name}', got '{displayed_name}'"
+            )
+            self.device.logger.info(f"Account name verified: {displayed_name}")
+
+        async with self.step(self.device, "Verify account address exists"):
+            address = account_details.get_account_address(timeout=self.UI_TIMEOUT)
+            assert address is not None, "Account address not found in details view"
+            assert address.startswith("0x"), (
+                f"Account address should start with '0x', got: {address}"
+            )
+            self.device.logger.info(f"Account address: {address}")
+
+        async with self.step(self.device, "Verify account origin"):
+            origin = account_details.get_origin_value(timeout=self.UI_TIMEOUT)
+            assert origin is not None, "Account origin not found in details view"
+            assert origin == EXPECTED_ORIGIN, (
+                f"Account origin mismatch. Expected '{EXPECTED_ORIGIN}', got: '{origin}'"
+            )
+            self.device.logger.info(f"Account origin verified: {origin}")
+
+        async with self.step(self.device, "Verify derivation path"):
+            derivation_path = account_details.get_derivation_path(timeout=self.UI_TIMEOUT)
+            assert derivation_path is not None, (
+                "Derivation path not found in details view"
+            )
+            assert derivation_path == EXPECTED_DERIVATION_PATH, (
+                f"Derivation path mismatch. Expected '{EXPECTED_DERIVATION_PATH}', "
+                f"got: '{derivation_path}'"
+            )
+            self.device.logger.info(f"Derivation path verified: {derivation_path}")
+
+        async with self.step(self.device, "Verify storage location"):
+            storage = account_details.get_storage_value(timeout=self.UI_TIMEOUT)
+            assert storage is not None, "Storage value not found in details view"
+            assert storage == EXPECTED_STORAGE, (
+                f"Storage value mismatch. Expected '{EXPECTED_STORAGE}', got: '{storage}'"
+            )
+            self.device.logger.info(f"Storage location verified: {storage}")
+
+        async with self.step(self.device, "Delete account from details view"):
+            assert account_details.delete_account(
+                auth_password=user_password, timeout=self.UI_TIMEOUT
+            ), f"Failed to delete account '{account_name}'"
+
+        async with self.step(self.device, "Verify deletion toast"):
+            # Desktop test expects: f'"{account_name}" successfully removed'
+            expected_toast = f'"{account_name}" successfully removed'
+            toast = app.wait_for_toast(
+                expected_substring="successfully removed",
+                timeout=10,
+                stability=0.2,
+            )
+            assert toast is not None, "Expected toast after removing account"
+            assert expected_toast in toast, (
+                f"Toast message mismatch. Expected '{expected_toast}' in toast. "
+                f"Got: '{toast}'"
+            )
+
+        async with self.step(self.device, "Verify account removed from wallet"):
+            # Navigate to wallet to verify account is gone
+            assert app.click_wallet_button(), "Failed to navigate to wallet"
+            wallet_panel = WalletLeftPanel(self.device.driver)
+            assert wallet_panel.is_loaded(timeout=self.UI_TIMEOUT), (
+                "Wallet panel did not load"
+            )
+
+            # Verify account no longer exists
+            account_element = wallet_panel.find_account_element_by_name(
+                account_name, timeout=5
+            )
+            assert account_element is None, (
+                f"Account '{account_name}' still visible in wallet after deletion"
+            )
+            self.device.logger.info(
+                f"Verified account '{account_name}' removed from wallet"
+            )

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -64,6 +64,8 @@ ColumnLayout {
                 font.weight: Font.Bold
                 font.pixelSize: Theme.fontSize(28)
                 color: !!root.account? Utils.getColorForId(Theme.palette, root.account.colorId) : Theme.palette.directColor1
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
             }
             StatusEmoji {
                 id: accountImage


### PR DESCRIPTION
### What does the PR do

Ports the critical desktop test `test_add_delete_account_from_settings` to the e2e_appium framework. This adds mobile E2E coverage for wallet account management through the Settings → Wallet flow.

**Test flow:**
1. Navigate to Settings → Wallet
2. Add new account with randomly generated name
3. Authenticate with password
4. Verify toast: "successfully added"
5. Open account details view
6. Verify account name, address, origin, derivation path, storage
7. Delete account with authentication
8. Verify toast: `"<name>" successfully removed`
9. Verify account removed from wallet left panel

### Affected areas

- `test/e2e_appium/` - New test, page objects, and locators
- `ui/app/AppLayouts/Profile/views/wallet/AccountView.qml` - Accessibility attributes

### How to test

`pytest tests/ -m smoke --env=browserstack -n=5 -s -v`

### Changes

**New files:**
- `tests/test_wallet_account_from_settings.py` - Full test implementation
- `pages/settings/wallet_settings_page.py` - Wallet settings view with scrolling and add account flow
- `pages/wallet/account_details_page.py` - Account details with property getters and delete flow
- `locators/settings/wallet_settings_locators.py` - Menu, add button, account row locators
- `locators/wallet/account_details_locators.py` - Name, detail rows, edit/delete button locators

**Modified files:**
- `locators/base_locators.py` - Added `xpath_string()` for XPath 1.0 string escaping
- `pages/settings/settings_page.py` - Added `open_wallet_settings()` navigation
- `pages/app.py` - Added `click_wallet_button()`
- `ui/app/AppLayouts/Profile/views/wallet/AccountView.qml` - Added `Accessible.name` to expose account name


https://github.com/user-attachments/assets/b4b36445-707a-40f7-8712-997f3430a595

