### PR TITLE
fix(ios): Adding permissions for local backup path

### DIFF
--- a/mobile/ios/Info.plist.template
+++ b/mobile/ios/Info.plist.template
@@ -64,6 +64,10 @@
     <string>Status uses Media Library to save and send Images. The Media Library module internally requires permissions to Apple Music</string>
     <key>NSFaceIDUsageDescription</key>
     <string>Log in securely to your account.</string>
+    <key>UIFileSharingEnabled</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <!-- Do not require paid apple accounts to build the app with NFC support -->

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -78,7 +78,8 @@ ios {
     LIBS += -framework LocalAuthentication \
             -framework Security \
             -framework UIKit \
-            -framework Foundation
+            -framework Foundation \
+            -framework UserNotifications
 
     # Base libraries (always included)
     LIBS += -L$$PWD/../lib/$$LIB_PREFIX -lnim_status_client -lDOtherSideStatic -lstatusq -lstatus -lsds -lssl_3 -lcrypto_3 -lqzxing -lresolv -lqrcodegen

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -264,7 +264,8 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
     find_library(Security Security)
     find_library(LocalAuthentication LocalAuthentication)
     find_library(WebKit WebKit)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${UIKit} ${Foundation} ${Security} ${LocalAuthentication} ${WebKit})
+    find_library(UserNotifications UserNotifications)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${UIKit} ${Foundation} ${Security} ${LocalAuthentication} ${WebKit} ${UserNotifications})
     target_sources(StatusQ PRIVATE
         src/ios_utils.mm
         src/keychain_apple.mm
@@ -306,7 +307,7 @@ FetchContent_Declare(
   MobileUI
 
   GIT_REPOSITORY https://github.com/status-im/MobileUI.git
-  GIT_TAG c8ac952179e91ff2643611b731f06dc6af06305c
+  GIT_TAG 341bb4e4ed0d1c818244f61a4d1d9a54443332c5
 )
 FetchContent_MakeAvailable(MobileUI)
 

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
@@ -4,6 +4,7 @@ import QtCore
 
 import StatusQ
 import StatusQ.Core.Utils
+import MobileUI
 
 QObject {
     id: root
@@ -33,6 +34,10 @@ QObject {
         dlg.close()
     }
 
+    MobileUI {
+        id: mobileUI
+    }
+
     QtObject {
         id: d
 
@@ -46,6 +51,10 @@ QObject {
                 return ""
 
             let resolvedLocalFile = UrlUtils.convertUrlToLocalPath(file)
+            // This will reserve the access to the file for the duration of the app
+            if (Utils.isIOS && !mobileUI.startAccessingPath(resolvedLocalFile)) {
+                console.warn("StatusFileDialog failed to start access for selected file")
+            }
             if (!resolvedLocalFile.startsWith("file:"))
                 resolvedLocalFile = "file:" + resolvedLocalFile
             return resolvedLocalFile

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFolderDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFolderDialog.qml
@@ -1,13 +1,15 @@
 import QtQuick
 import QtQuick.Dialogs
 
+import StatusQ
 import StatusQ.Core.Utils
+import MobileUI
 
 QObject {
     id: root
 
     property alias title: dlg.title
-    property alias selectedFolder: dlg.selectedFolder
+    readonly property alias selectedFolder: d.resolvedFolder
     property alias modality: dlg.modality
     property alias currentFolder: dlg.currentFolder
 
@@ -20,6 +22,27 @@ QObject {
 
     function close() {
         dlg.close()
+    }
+
+    MobileUI { id: mobileUI }
+
+    QtObject {
+        id: d
+        property url resolvedFolder: d.resolveFolder(dlg.selectedFolder)
+
+        function resolveFolder(folder) {
+            let resolvedFolder = folder;
+            if (Utils.isIOS) {
+                //Convert from `file://` to local path
+                resolvedFolder = UrlUtils.convertUrlToLocalPath(folder)
+                // This will reserve the access to the folder for the duration of the app
+                const success = mobileUI.startAccessingPath(resolvedFolder)
+                if (!success) {
+                    console.warn("StatusFolderDialog failed to start access for selected folder")
+                }
+            }
+            return resolvedFolder;
+        }
     }
 
     FolderDialog {

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtCore
 import utils
 
 import StatusQ.Core.Utils 0.1 as StatusQUtils
@@ -44,6 +45,18 @@ QtObject {
         readonly property var appSettingsInst: appSettings
         readonly property var localAccountSensitiveSettingsInst: localAccountSensitiveSettings
         readonly property var globalUtilsInst: globalUtils
+
+        /* Migration flow from the old backup path to the new public,writable location on iOS */
+        readonly property url defaultIosBackupPath: StandardPaths.writableLocation(StandardPaths.DocumentsLocation) + "/backups"
+        onAppSettingsInstChanged: d.migrateBackupPathToDefaultIosPath()
+        Component.onCompleted: d.migrateBackupPathToDefaultIosPath()
+
+        function migrateBackupPathToDefaultIosPath() {
+            if (StatusQUtils.Utils.isIOS && !!d.appSettingsInst) {
+                d.appSettingsInst.setBackupPath(d.defaultIosBackupPath)
+            }
+        }
+        /* End of migration flow */
     }
 
     signal localBackupExportCompleted(bool success)
@@ -61,6 +74,10 @@ QtObject {
     }
 
     function setBackupPath(path) {
+        if (SQUtils.Utils.isIOS) {
+            console.warn("setBackupPath on iOS is not supported, using default path")
+            return
+        }
         d.appSettingsInst.setBackupPath(path)
     }
 

--- a/ui/app/AppLayouts/Profile/views/BackupView.qml
+++ b/ui/app/AppLayouts/Profile/views/BackupView.qml
@@ -138,6 +138,9 @@ SettingsContentBase {
                     // We cannot use arbitrary paths on Android without requesting storage permissions
                     return qsTr("Choose a folder to store your backup files in.")
                 }
+                if (SQUtils.Utils.isIOS) {
+                    return qsTr("Backups are stored in the Status folder in Files.")
+                }
                 return qsTr("Choose a folder to store your backup files or use the default one.")
             }
             color: Theme.palette.baseColor1
@@ -153,7 +156,7 @@ SettingsContentBase {
                 text: UrlUtils.displayPathLabel(root.backupPath)
             }
             StatusButton {
-                text: qsTr("Browse")
+                text: SQUtils.Utils.isIOS ? qsTr("Locate in Files") : qsTr("Browse")
                 onClicked: backupPathDialog.open()
             }
         }
@@ -207,9 +210,9 @@ SettingsContentBase {
     StatusFolderDialog {
         id: backupPathDialog
 
-        title: qsTr("Select your backup directory")
+        title: SQUtils.Utils.isIOS ? qsTr("Locate your backup directory in Files") : qsTr("Select your backup directory")
         currentFolder: root.backupPath
-        onAccepted: root.backupPathSet(backupPathDialog.selectedFolder)
+        onAccepted: SQUtils.Utils.isIOS ? console.info("Skipping backup path set on iOS") : root.backupPathSet(backupPathDialog.selectedFolder)
     }
 
     StatusFileDialog {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2537,6 +2537,18 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
         <source>Choose a folder to store your backup files in.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -8407,17 +8419,6 @@ L2 fee: %2</source>
     <name>HomePageGridDAppItem</name>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>HomePageGridItem</name>
-    <message>
-        <source>Unpin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -19449,6 +19450,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3111,6 +3111,21 @@
       <comment>BackupView</comment>
       <translation>Choose a folder to store your backup files in.</translation>
     </message>
+    <message>
+      <source>Backups are stored in the Status folder in Files.</source>
+      <comment>BackupView</comment>
+      <translation>Backups are stored in the Status folder in Files.</translation>
+    </message>
+    <message>
+      <source>Locate in Files</source>
+      <comment>BackupView</comment>
+      <translation>Locate in Files</translation>
+    </message>
+    <message>
+      <source>Locate your backup directory in Files</source>
+      <comment>BackupView</comment>
+      <translation>Locate your backup directory in Files</translation>
+    </message>
   </context>
   <context>
     <name>BalanceExceeded</name>
@@ -10267,19 +10282,6 @@
       <source>Disconnect</source>
       <comment>HomePageGridDAppItem</comment>
       <translation>Disconnect</translation>
-    </message>
-  </context>
-  <context>
-    <name>HomePageGridItem</name>
-    <message>
-      <source>Unpin</source>
-      <comment>HomePageGridItem</comment>
-      <translation>Unpin</translation>
-    </message>
-    <message>
-      <source>Pin</source>
-      <comment>HomePageGridItem</comment>
-      <translation>Pin</translation>
     </message>
   </context>
   <context>
@@ -23665,6 +23667,11 @@
       <source>Status Desktop</source>
       <comment>main</comment>
       <translation>Status Desktop</translation>
+    </message>
+    <message>
+      <source>Hello World</source>
+      <comment>main</comment>
+      <translation>Hello World</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2547,6 +2547,18 @@ Pro zálohování obnovovací fráze si ji zapište a bezpečně uložte na bezp
         <source>Choose a folder to store your backup files in.</source>
         <translation>Vyberte složku pro uložení záložních souborů.</translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -8450,17 +8462,6 @@ L2 poplatek: %2</translation>
     <message>
         <source>Disconnect</source>
         <translation>Odpojit</translation>
-    </message>
-</context>
-<context>
-    <name>HomePageGridItem</name>
-    <message>
-        <source>Unpin</source>
-        <translation>Odepnout</translation>
-    </message>
-    <message>
-        <source>Pin</source>
-        <translation>Připnout</translation>
     </message>
 </context>
 <context>
@@ -19581,6 +19582,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>Status Desktop</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2540,6 +2540,18 @@ Para respaldar tu frase de recuperación, escríbela y guárdala de forma segura
         <source>Choose a folder to store your backup files in.</source>
         <translation>Elige una carpeta para almacenar tus archivos de backup.</translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -8423,17 +8435,6 @@ Tarifa L2: %2</translation>
     <message>
         <source>Disconnect</source>
         <translation>Desconectar</translation>
-    </message>
-</context>
-<context>
-    <name>HomePageGridItem</name>
-    <message>
-        <source>Unpin</source>
-        <translation>Desfijar</translation>
-    </message>
-    <message>
-        <source>Pin</source>
-        <translation>Fijar</translation>
     </message>
 </context>
 <context>
@@ -19487,6 +19488,10 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <message>
         <source>Status Desktop</source>
         <translation>Escritorio de Status</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2532,6 +2532,18 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
         <source>Backups are automatic (every 30 mins), secure (encrypted with your profile private key), and private (your data is stored &lt;b&gt;only&lt;/b&gt; on your device).</source>
         <translation>백업은 자동(30분마다), 안전(프로필 개인 키로 암호화), 그리고 비공개(데이터는 &lt;b&gt;오직&lt;/b&gt; 귀하의 기기에만 저장됨)입니다.</translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -8395,17 +8407,6 @@ L2 수수료: %2</translation>
     <message>
         <source>Disconnect</source>
         <translation>연결 해제</translation>
-    </message>
-</context>
-<context>
-    <name>HomePageGridItem</name>
-    <message>
-        <source>Unpin</source>
-        <translation>고정 해제</translation>
-    </message>
-    <message>
-        <source>Pin</source>
-        <translation>고정</translation>
     </message>
 </context>
 <context>
@@ -19424,6 +19425,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>스테이터스 데스크톱</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Closes: #19829

Needs: https://github.com/status-im/MobileUI/pull/4

MobileUI adds 2 new APIs to manage the temporary file permissions (`startAccessingPath` and `stopAccessingPath`)

We're using these 2 new APIs in the StatusFolderDialog and StatusFileDialog. Whenever the user picks a public folder or file we'll ask IOS to grant permission access to these files. By default these permissions will be stored for the app lifetime. If needed we can also stop the permissions.

Changes:
- DeviceStore.qml: This store file implements a migration path from the old backup path to a standard public Status folder. This is needed for the existing users where the backup path is already configured somewhere else. The `setBackupPath` is also disabled for IOS. It's probably not the ideal place for such a thing, but for sure it's more isolated than AppMain or other common place.
- BackupView.qml: This view was changed a little bit so that we won't give the impression that the folder picked by the user will be used as a backup folder. Kept all the components visibile and altered just the copy
- StatusFileDialog.qml: When a file is picked by the user we'll ensure `startAccessingPath` is called. The file dialog output will be a local file path (as opposed to a file url)
- StatusFolderDialog.qml: Similar to StatusFileDialog
### Affected areas

Status file picker and folder picker
Backup settings

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

https://github.com/user-attachments/assets/62854bae-3a55-48ec-ba93-c4c1519bb54d

### Impact on end user

The suer will be able to backup the messages and to import from a backup file

### How to test

- Open the app with a broken backup path. Hit the backup button. Check the Status folder on the Iphone
- Open the app with a broken backup path. Wait for the periodic backup to kick in. Check the Status folder on the Iphone
- Open the app, choose a backup file produced in a different folder(not Status folder). Use the legacy app or status desktop  to save the backup in a random location
- Open the app, choose a backup file produced by the app

### Risk 

Low
