### PR TITLE
fix(collectibles): crash on backing up collectible bc of missing enum

### DIFF
--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -123,6 +123,9 @@ QtObject:
       of OwnershipStateError:
         self.model.setIsUpdating(false)
         self.model.setIsError(true)
+      of OwnershipStateNotAvailable:
+        self.model.setIsUpdating(false)
+        self.model.setIsError(false)
 
   proc resetOwnershipStatus(self: Controller) =
     # Initialize state table
@@ -200,37 +203,38 @@ QtObject:
     self.tempItems.add(newItems)
 
   proc processGetOwnedCollectiblesResponse(self: Controller, response: JsonNode) =
-    let res = fromJson(response, backend_collectibles.GetOwnedCollectiblesResponse)
-
-    let isError = res.errorCode != backend_collectibles.ErrorCodeSuccess
-
-    if isError:
-      error "error fetching collectibles entries: ", code = res.errorCode
-      self.model.setIsError(true)
-      self.model.setIsFetching(false)
-      return
-
     try: 
+      let res = fromJson(response, backend_collectibles.GetOwnedCollectiblesResponse)
+
+      let isError = res.errorCode != backend_collectibles.ErrorCodeSuccess
+
+      if isError:
+        error "error fetching collectibles entries: ", code = res.errorCode
+        self.model.setIsError(true)
+        self.model.setIsFetching(false)
+        return
+
       let items = res.collectibles.map(header => (block:
         let extradata = self.getExtraData(header.id.contractID.chainID)
         newCollectibleDetailsFullEntry(header, extradata)
       ))
+      
       if self.loadType.isPaginated():
         self.model.setItems(items, res.offset, res.hasMore)
       else:
         self.setTempItems(items, res.offset)
-        # If we reached the end of the list, commit the items to the model
         if not res.hasMore:
           self.model.updateItems(self.tempItems)
           self.tempItems = @[]
+
+      self.model.setIsFetching(false)
+      self.setOwnershipStatus(res.ownershipStatus)
+
+      if self.loadType.isAutoLoad() and res.hasMore:
+        self.loadMoreItems()
+      
     except Exception as e:
       error "Error converting activity entries: ", error = e.msg
-
-    self.model.setIsFetching(false)
-    self.setOwnershipStatus(res.ownershipStatus)
-
-    if self.loadType.isAutoLoad() and res.hasMore:
-      self.loadMoreItems()
 
   proc updateTempItems(self: Controller, updates: seq[backend_collectibles.Collectible]) =
     for i in countdown(self.tempItems.high, 0):

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -40,7 +40,8 @@ type
     OwnershipStateIdle = 1,
     OwnershipStateDelayed,
     OwnershipStateUpdating,
-    OwnershipStateError
+    OwnershipStateError,
+    OwnershipStateNotAvailable
 
   # Mirrors services/wallet/collectibles/service.go OwnershipState
   OwnershipStatus* = ref object


### PR DESCRIPTION
### What does the PR do

Fixes #19873

The problem was that we were missing an enum value. status-go was updated but not the Nim code. I also improved the try/catch to better guard against such crashes.

### Affected areas

collectibles controller and backend

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

[fix-bkp.webm](https://github.com/user-attachments/assets/4303416d-95e5-425b-82c8-cb3fe46b5dc5)

### Impact on end user

Fixes the crash

### How to test

- Backup an account with collectibles
- import that backup file during onboarding

### Risk 

Low
