### PR TITLE
fix(ios): Adding permissions for local backup path

### DIFF
--- a/mobile/ios/Info.plist
+++ b/mobile/ios/Info.plist
@@ -64,6 +64,10 @@
     <string>Status uses Media Library to save and send Images. The Media Library module internally requires permissions to Apple Music</string>
     <key>NSFaceIDUsageDescription</key>
     <string>Log in securely to your account.</string>
+    <key>UIFileSharingEnabled</key>
+    <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>NFCReaderUsageDescription</key>

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -68,5 +68,7 @@ ios {
     LIBS += -framework LocalAuthentication \
             -framework Security \
             -framework UIKit \
-            -framework Foundation
+            -framework Foundation \
+            -framework UserNotifications
+
 }

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -252,7 +252,7 @@ FetchContent_Declare(
   MobileUI
 
   GIT_REPOSITORY https://github.com/status-im/MobileUI.git
-  GIT_TAG c8ac952179e91ff2643611b731f06dc6af06305c
+  GIT_TAG 341bb4e4ed0d1c818244f61a4d1d9a54443332c5
 )
 FetchContent_MakeAvailable(MobileUI)
 

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
@@ -4,6 +4,7 @@ import QtCore
 
 import StatusQ
 import StatusQ.Core.Utils
+import MobileUI
 
 QObject {
     id: root
@@ -33,6 +34,10 @@ QObject {
         dlg.close()
     }
 
+    MobileUI {
+        id: mobileUI
+    }
+
     QtObject {
         id: d
 
@@ -46,6 +51,10 @@ QObject {
                 return ""
 
             let resolvedLocalFile = UrlUtils.convertUrlToLocalPath(file)
+            // This will reserve the access to the file for the duration of the app
+            if (Utils.isIOS && !mobileUI.startAccessingPath(resolvedLocalFile)) {
+                console.warn("StatusFileDialog failed to start access for selected file")
+            }
             if (!resolvedLocalFile.startsWith("file:"))
                 resolvedLocalFile = "file:" + resolvedLocalFile
             return resolvedLocalFile

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFolderDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFolderDialog.qml
@@ -1,13 +1,15 @@
 import QtQuick
 import QtQuick.Dialogs
 
+import StatusQ
 import StatusQ.Core.Utils
+import MobileUI
 
 QObject {
     id: root
 
     property alias title: dlg.title
-    property alias selectedFolder: dlg.selectedFolder
+    readonly property alias selectedFolder: d.resolvedFolder
     property alias modality: dlg.modality
     property alias currentFolder: dlg.currentFolder
 
@@ -20,6 +22,27 @@ QObject {
 
     function close() {
         dlg.close()
+    }
+
+    MobileUI { id: mobileUI }
+
+    QtObject {
+        id: d
+        property url resolvedFolder: d.resolveFolder(dlg.selectedFolder)
+
+        function resolveFolder(folder) {
+            let resolvedFolder = folder;
+            if (Utils.isIOS) {
+                //Convert from `file://` to local path
+                resolvedFolder = UrlUtils.convertUrlToLocalPath(folder)
+                // This will reserve the access to the folder for the duration of the app
+                const success = mobileUI.startAccessingPath(resolvedFolder)
+                if (!success) {
+                    console.warn("StatusFolderDialog failed to start access for selected folder")
+                }
+            }
+            return resolvedFolder;
+        }
     }
 
     FolderDialog {

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtCore
 import utils
 
 import StatusQ.Core.Utils 0.1 as StatusQUtils
@@ -40,6 +41,18 @@ QtObject {
         readonly property var appSettingsInst: appSettings
         readonly property var localAccountSensitiveSettingsInst: localAccountSensitiveSettings
         readonly property var globalUtilsInst: globalUtils
+
+        /* Migration flow from the old backup path to the new public,writable location on iOS */
+        readonly property url defaultIosBackupPath: StandardPaths.writableLocation(StandardPaths.DocumentsLocation) + "/backups"
+        onAppSettingsInstChanged: d.migrateBackupPathToDefaultIosPath()
+        Component.onCompleted: d.migrateBackupPathToDefaultIosPath()
+
+        function migrateBackupPathToDefaultIosPath() {
+            if (StatusQUtils.Utils.isIOS && !!d.appSettingsInst) {
+                d.appSettingsInst.setBackupPath(d.defaultIosBackupPath)
+            }
+        }
+        /* End of migration flow */
     }
 
     signal localBackupExportCompleted(bool success)
@@ -57,6 +70,10 @@ QtObject {
     }
 
     function setBackupPath(path) {
+        if (SQUtils.Utils.isIOS) {
+            console.warn("setBackupPath on iOS is not supported, using default path")
+            return
+        }
         d.appSettingsInst.setBackupPath(path)
     }
 

--- a/ui/app/AppLayouts/Profile/views/BackupView.qml
+++ b/ui/app/AppLayouts/Profile/views/BackupView.qml
@@ -138,6 +138,9 @@ SettingsContentBase {
                     // We cannot use arbitrary paths on Android without requesting storage permissions
                     return qsTr("Choose a folder to store your backup files in.")
                 }
+                if (SQUtils.Utils.isIOS) {
+                    return qsTr("Backups are stored in the Status folder in Files.")
+                }
                 return qsTr("Choose a folder to store your backup files or use the default one.")
             }
             color: Theme.palette.baseColor1
@@ -153,7 +156,7 @@ SettingsContentBase {
                 text: UrlUtils.displayPathLabel(root.backupPath)
             }
             StatusButton {
-                text: qsTr("Browse")
+                text: SQUtils.Utils.isIOS ? qsTr("Locate in Files") : qsTr("Browse")
                 onClicked: backupPathDialog.open()
             }
         }
@@ -207,9 +210,9 @@ SettingsContentBase {
     StatusFolderDialog {
         id: backupPathDialog
 
-        title: qsTr("Select your backup directory")
+        title: SQUtils.Utils.isIOS ? qsTr("Locate your backup directory in Files") : qsTr("Select your backup directory")
         currentFolder: root.backupPath
-        onAccepted: root.backupPathSet(backupPathDialog.selectedFolder)
+        onAccepted: SQUtils.Utils.isIOS ? console.info("Skipping backup path set on iOS") : root.backupPathSet(backupPathDialog.selectedFolder)
     }
 
     StatusFileDialog {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2495,6 +2495,18 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
         <source>Choose a folder to store your backup files in.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -19260,6 +19272,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <name>main</name>
     <message>
         <source>Status Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hello World</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3060,6 +3060,21 @@
       <comment>BackupView</comment>
       <translation>Choose a folder to store your backup files in.</translation>
     </message>
+    <message>
+      <source>Backups are stored in the Status folder in Files.</source>
+      <comment>BackupView</comment>
+      <translation>Backups are stored in the Status folder in Files.</translation>
+    </message>
+    <message>
+      <source>Locate in Files</source>
+      <comment>BackupView</comment>
+      <translation>Locate in Files</translation>
+    </message>
+    <message>
+      <source>Locate your backup directory in Files</source>
+      <comment>BackupView</comment>
+      <translation>Locate your backup directory in Files</translation>
+    </message>
   </context>
   <context>
     <name>BalanceExceeded</name>
@@ -23436,6 +23451,11 @@
       <source>Status Desktop</source>
       <comment>main</comment>
       <translation>Status Desktop</translation>
+    </message>
+    <message>
+      <source>Hello World</source>
+      <comment>main</comment>
+      <translation>Hello World</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2502,6 +2502,18 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
         <source>Choose a folder to store your backup files in.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -19342,6 +19354,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>Status Desktop</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2498,6 +2498,18 @@ Para respaldar tu frase de recuperación, escríbela y guárdala de forma segura
         <source>Choose a folder to store your backup files in.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -8408,11 +8420,11 @@ Tarifa L2: %2</translation>
     <name>HomePageGridItem</name>
     <message>
         <source>Unpin</source>
-        <translation>Desfijar</translation>
+        <translation type="unfinished">Desfijar</translation>
     </message>
     <message>
         <source>Pin</source>
-        <translation>Fijar</translation>
+        <translation type="unfinished">Fijar</translation>
     </message>
 </context>
 <context>
@@ -19298,6 +19310,10 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <message>
         <source>Status Desktop</source>
         <translation>Escritorio de Status</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2490,6 +2490,18 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
         <source>Choose a folder to store your backup files in.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Backups are stored in the Status folder in Files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Locate your backup directory in Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BalanceExceeded</name>
@@ -19236,6 +19248,10 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>Status Desktop</source>
         <translation>스테이터스 데스크톱</translation>
+    </message>
+    <message>
+        <source>Hello World</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

Cherry-pick https://github.com/status-im/status-app/pull/19870

#### Original info:

Needs: https://github.com/status-im/MobileUI/pull/4

MobileUI adds 2 new APIs to manage the temporary file permissions (`startAccessingPath` and `stopAccessingPath`)

We're using these 2 new APIs in the StatusFolderDialog and StatusFileDialog. Whenever the user picks a public folder or file we'll ask IOS to grant permission access to these files. By default these permissions will be stored for the app lifetime. If needed we can also stop the permissions.

Changes:
- DeviceStore.qml: This store file implements a migration path from the old backup path to a standard public Status folder. This is needed for the existing users where the backup path is already configured somewhere else. The `setBackupPath` is also disabled for IOS. It's probably not the ideal place for such a thing, but for sure it's more isolated than AppMain or other common place.
- BackupView.qml: This view was changed a little bit so that we won't give the impression that the folder picked by the user will be used as a backup folder. Kept all the components visibile and altered just the copy
- StatusFileDialog.qml: When a file is picked by the user we'll ensure `startAccessingPath` is called. The file dialog output will be a local file path (as opposed to a file url)
- StatusFolderDialog.qml: Similar to StatusFileDialog
