### PR TITLE
fix(navBar): The swipe area will eat hover and clicked events from the navbar on linux and windows

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/NativeSwipeHandlerHelper.java
+++ b/mobile/android/qt6/src/app/status/mobile/NativeSwipeHandlerHelper.java
@@ -183,9 +183,7 @@ public class NativeSwipeHandlerHelper {
                         contentView.addView(touchOverlayView);
                     }
                 }
-                // If a swipe is active, don't move/resize the overlay underneath the finger.
-                // The view will continue receiving events anyway once it has captured ACTION_DOWN.
-                if (active) return;
+
                 ViewGroup.LayoutParams lp = touchOverlayView.getLayoutParams();
                 if (lp != null) {
                     lp.width = (int) Math.max(1, handlerWidth);

--- a/ui/StatusQ/src/StatusQ/Controls/NativeIndicator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/NativeIndicator.qml
@@ -33,7 +33,7 @@ Item {
 
     QtObject {
         id: d
-        readonly property bool useNative: SQUtils.isMobile || SQUtils.isMacOS
+        readonly property bool useNative: SQUtils.Utils.isMobile || SQUtils.Utils.isMacOS
         property var implItem: null
 
         function destroyImpl() {

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -457,7 +457,8 @@ Control {
     NativeSwipeHandler {
         id: navSwipeHandler
         anchors.verticalCenter: swipeIndicatorWrapper.verticalCenter
-        width: 2 * root.width
+        anchors.left: contentItem.right
+        width: root.width
         // Max 200px is allowed on Android
         height: swipeIndicatorWrapper.height * 2
         openDistance: root.width


### PR DESCRIPTION
### What does the PR do

The swipe area will steal event from the navbar when running Linux or windows in portrait mode.

Unfortunately I couldn't make the qml implementation of NativeSwipeHandler work reliably in transparency mode for hover, cursorShape and click.
But anyways, this is a much better approach. To anchor the swipe area to the right of the navbar instead of drawing half the swipe area out of the screen.

Found a bug on Android though where the swipe area position wasn't getting updated on fast swipe moves. That's fixed as well.


