### PR TITLE
chore(AppMain): disable dApps in HomePage

### DIFF
--- a/storybook/qmlTests/tests/tst_HomePage.qml
+++ b/storybook/qmlTests/tests/tst_HomePage.qml
@@ -133,5 +133,33 @@ Item {
             compare(dynamicSpy.signalArguments[0][1], gridBtn.sectionType)
             compare(dynamicSpy.signalArguments[0][2], gridBtn.itemId)
         }
+
+        function test_show_hide_dapps_data() {
+            return [
+                        { tag: "dapps enabled", showDapps: true },
+                        { tag: "dapps disabled", showDapps: false },
+                    ]
+        }
+
+        function test_show_hide_dapps(data) {
+            const dAppsVisible = data.showDapps
+            homePageAdaptor.showDapps = dAppsVisible
+
+            const gridView = findChild(controlUnderTest, "homePageGridView")
+            verify(!!gridView)
+            gridView.forceLayout()
+
+            var anyDappsFound = false
+            const count = gridView.count
+            for (var i = 0; i < count; i++) {
+                gridView.positionViewAtIndex(i, GridView.Visible)
+                const gridItem = gridView.itemAtIndex(i)
+                if (!!gridItem && gridItem.item.sectionType === Constants.appSection.dApp) {
+                    anyDappsFound = true
+                }
+            }
+
+            compare(anyDappsFound, dAppsVisible)
+        }
     }
 }

--- a/ui/app/AppLayouts/HomePage/HomePageGrid.qml
+++ b/ui/app/AppLayouts/HomePage/HomePageGrid.qml
@@ -68,6 +68,8 @@ Control {
         StatusGridView {
             id: gridView
 
+            objectName: "homePageGridView"
+
             readonly property int delegateCountPerRow: Math.trunc(parent.width / (root.delegateWidth + root.spacing))
 
             height: parent.height

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1534,6 +1534,7 @@ Item {
                             showEnabledSectionsOnly: true
                             marketEnabled: appMain.featureFlagsStore.marketEnabled
                             browserEnabled: d.isBrowserEnabled
+                            showDapps: false // SEE https://github.com/status-im/status-app/issues/19580
 
                             syncingBadgeCount: d.syncingBadgeCount
                             messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count


### PR DESCRIPTION
### What does the PR do

- fixes a crash when activating it; will be reworked/extended together with the further development of the PrimaryNavSidebar/HomePage combo
- add a QML test

Fixes #19580

### Affected areas

HomePage

### Architecture compliance

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Screencapture of the functionality

N/A

### Impact on end user

no crash

### How to test

- have an active dApp connection
- switch to HomePage
- the respective dApp item is not present in HomePage

### Risk 

low
