### PR TITLE
feat(collectibles): add NFT proxy config

### DIFF
--- a/src/app_service/service/accounts/dto/wallet_secretes_config.nim
+++ b/src/app_service/service/accounts/dto/wallet_secretes_config.nim
@@ -20,6 +20,11 @@ type
     ethRpcProxyUser*: string
     ethRpcProxyPassword*: string
     ethRpcProxyUrl*: string
+    nftProxyUrl*: string
+    nftProxyStageName*: string
+    nftProxyUser*: string
+    nftProxyPassword*: string
+    nftProxyUsePuzzleAuth*: bool
 
 proc toJson*(self: WalletSecretsConfig): JsonNode =
   return %* {
@@ -41,4 +46,9 @@ proc toJson*(self: WalletSecretsConfig): JsonNode =
     "ethRpcProxyUser": self.ethRpcProxyUser,
     "ethRpcProxyPassword": self.ethRpcProxyPassword,
     "ethRpcProxyUrl": self.ethRpcProxyUrl,
+    "nftProxyUrl": self.nftProxyUrl,
+    "nftProxyStageName": self.nftProxyStageName,
+    "nftProxyUser": self.nftProxyUser,
+    "nftProxyPassword": self.nftProxyPassword,
+    "nftProxyUsePuzzleAuth": self.nftProxyUsePuzzleAuth,
   }

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -164,6 +164,12 @@ QtObject:
       ethRpcProxyUser: ETH_RPC_PROXY_USER_RESOLVED,
       ethRpcProxyPassword: ETH_RPC_PROXY_PASSWORD_RESOLVED,
       ethRpcProxyUrl: ETH_RPC_PROXY_URL_RESOLVED,
+      nftProxyUrl: NFT_PROXY_URL_RESOLVED,
+      nftProxyStageName: NFT_PROXY_STAGE_NAME_RESOLVED,
+      nftProxyUser: NFT_PROXY_USER_RESOLVED,
+      nftProxyPassword: NFT_PROXY_PASSWORD_RESOLVED,
+      nftProxyUsePuzzleAuth: NFT_PROXY_USE_PUZZLE_AUTH_RESOLVED,
+
     )
 
   proc buildWalletConfig(): WalletConfig =

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -68,6 +68,11 @@ let
   ETH_RPC_PROXY_USER_RESOLVED* = desktopConfig.ethRpcProxyUser
   ETH_RPC_PROXY_PASSWORD_RESOLVED* = desktopConfig.ethRpcProxyPassword
   ETH_RPC_PROXY_URL_RESOLVED* = desktopConfig.ethRpcProxyUrl
+  NFT_PROXY_URL_RESOLVED* = desktopConfig.nftProxyUrl
+  NFT_PROXY_STAGE_NAME_RESOLVED* = desktopConfig.nftProxyStageName
+  NFT_PROXY_USER_RESOLVED* = desktopConfig.nftProxyUser
+  NFT_PROXY_PASSWORD_RESOLVED* = desktopConfig.nftProxyPassword
+  NFT_PROXY_USE_PUZZLE_AUTH_RESOLVED* = desktopConfig.nftProxyUsePuzzleAuth
 
   WALLET_CONNECT_PROJECT_ID* = BUILD_WALLET_CONNECT_PROJECT_ID
   MIXPANEL_APP_ID* = desktopConfig.mixpanelAppId

--- a/src/env_cli_vars.nim
+++ b/src/env_cli_vars.nim
@@ -37,6 +37,11 @@ const BASE_NAME_API_LOGGING = "API_LOGGING"
 const BASE_NAME_ETH_RPC_PROXY_USER = "ETH_RPC_PROXY_USER"
 const BASE_NAME_ETH_RPC_PROXY_PASSWORD = "ETH_RPC_PROXY_PASSWORD"
 const BASE_NAME_ETH_RPC_PROXY_URL = "ETH_RPC_PROXY_URL"
+const BASE_NAME_NFT_PROXY_URL = "NFT_PROXY_URL"
+const BASE_NAME_NFT_PROXY_STAGE_NAME = "NFT_PROXY_STAGE_NAME"
+const BASE_NAME_NFT_PROXY_USER = "NFT_PROXY_USER"
+const BASE_NAME_NFT_PROXY_PASSWORD = "NFT_PROXY_PASSWORD"
+const BASE_NAME_NFT_PROXY_USE_PUZZLE_AUTH = "NFT_PROXY_USE_PUZZLE_AUTH"
 
 
 ################################################################################
@@ -75,6 +80,11 @@ const BUILD_MARKET_DATA_PRICES_REFRESH_INTERVAL = getEnv(BUILD_TIME_PREFIX & BAS
 const BUILD_ETH_RPC_PROXY_USER = getEnv(BUILD_TIME_PREFIX & BASE_NAME_ETH_RPC_PROXY_USER)
 const BUILD_ETH_RPC_PROXY_PASSWORD = getEnv(BUILD_TIME_PREFIX & BASE_NAME_ETH_RPC_PROXY_PASSWORD)
 const BUILD_ETH_RPC_PROXY_URL = getEnv(BUILD_TIME_PREFIX & BASE_NAME_ETH_RPC_PROXY_URL)
+const BUILD_NFT_PROXY_URL = getEnv(BUILD_TIME_PREFIX & BASE_NAME_NFT_PROXY_URL)
+const BUILD_NFT_PROXY_STAGE_NAME = getEnv(BUILD_TIME_PREFIX & BASE_NAME_NFT_PROXY_STAGE_NAME)
+const BUILD_NFT_PROXY_USER = getEnv(BUILD_TIME_PREFIX & BASE_NAME_NFT_PROXY_USER)
+const BUILD_NFT_PROXY_PASSWORD = getEnv(BUILD_TIME_PREFIX & BASE_NAME_NFT_PROXY_PASSWORD)
+const BUILD_NFT_PROXY_USE_PUZZLE_AUTH = getEnv(BUILD_TIME_PREFIX & BASE_NAME_NFT_PROXY_USE_PUZZLE_AUTH, "true") == "true"
 
 const
   DEFAULT_TENOR_API_KEY = "DU7DWZ27STB2"
@@ -220,6 +230,31 @@ type StatusDesktopConfig = object
     desc: "Sets custom ETH RPC proxy URL"
     name: $BASE_NAME_ETH_RPC_PROXY_URL
     abbr: "eth-rpc-proxy-url" .}: string
+  nftProxyUrl* {.
+    defaultValue: BUILD_NFT_PROXY_URL
+    desc: "Sets NFT proxy URL override"
+    name: $BASE_NAME_NFT_PROXY_URL
+    abbr: "nft-proxy-url" .}: string
+  nftProxyStageName* {.
+    defaultValue: BUILD_NFT_PROXY_STAGE_NAME
+    desc: "Sets NFT proxy stage name"
+    name: $BASE_NAME_NFT_PROXY_STAGE_NAME
+    abbr: "nft-proxy-stage-name" .}: string
+  nftProxyUser* {.
+    defaultValue: BUILD_NFT_PROXY_USER
+    desc: "Sets NFT proxy username"
+    name: $BASE_NAME_NFT_PROXY_USER
+    abbr: "nft-proxy-user" .}: string
+  nftProxyPassword* {.
+    defaultValue: BUILD_NFT_PROXY_PASSWORD
+    desc: "Sets NFT proxy password"
+    name: $BASE_NAME_NFT_PROXY_PASSWORD
+    abbr: "nft-proxy-password" .}: string
+  nftProxyUsePuzzleAuth* {.
+    defaultValue: BUILD_NFT_PROXY_USE_PUZZLE_AUTH
+    desc: "Enables puzzle authentication for NFT proxy"
+    name: $BASE_NAME_NFT_PROXY_USE_PUZZLE_AUTH
+    abbr: "nft-proxy-use-puzzle-auth" .}: bool
 
   # runtime vars
   dataDir* {.


### PR DESCRIPTION
Since Rarible has dramatically reduced the API limits, we now have to handle requests via Alchemy. 
Here is an integration with the new`test.nft-proxy.status.im` with proof-of-work authentication.

Add NFT proxy configuration support (URL, stage name, user, password, proof of work auth) via environment variables and CLI arguments. Follows the same pattern as existing market-data and ETH RPC proxy configs.

demo:

https://github.com/user-attachments/assets/c4de4956-68df-4861-b8f1-61d97f531e1e


fixes #19740


depends on https://github.com/status-im/status-go/pull/7321 + https://github.com/status-im/status-go/pull/7322