### PR TITLE
fix(StatusQ): prevent use-after-free in macOS gesture recognizer teardown

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/NativeIndicatorItem_macos.mm
+++ b/ui/StatusQ/src/StatusQ/Controls/NativeIndicatorItem_macos.mm
@@ -5,6 +5,7 @@
 #import <AppKit/AppKit.h>
 
 #include <QBuffer>
+#include <QGuiApplication>
 #include <QImage>
 #include <QPainter>
 #include <QPointer>
@@ -67,7 +68,15 @@ NSView *NativeIndicatorItem_macOS::getNSView() const
 {
     if (!window())
         return nullptr;
-    return reinterpret_cast<NSView *>(window()->winId());
+    if (QGuiApplication::platformName() == QStringLiteral("offscreen"))
+        return nullptr;
+    WId winId = window()->winId();
+    if (!winId)
+        return nullptr;
+    id viewId = reinterpret_cast<id>(winId);
+    if (![viewId isKindOfClass:[NSView class]])
+        return nullptr;
+    return reinterpret_cast<NSView *>(viewId);
 }
 
 void NativeIndicatorItem_macOS::ensureViews()

--- a/ui/StatusQ/src/StatusQ/Controls/NativeSwipeHandlerItem_macos.mm
+++ b/ui/StatusQ/src/StatusQ/Controls/NativeSwipeHandlerItem_macos.mm
@@ -133,12 +133,11 @@ void NativeSwipeHandlerItem_macOS::detachGestureRecognizer()
     if (!m_attached)
         return;
 
-    NSView *view = getNSView();
-    if (view && m_delegate && m_delegate.panGesture) {
-        [view removeGestureRecognizer:m_delegate.panGesture];
-        m_delegate.panGesture = nil;
-    }
     if (m_delegate) {
+        if (m_delegate.panGesture) {
+            [m_delegate.panGesture.view removeGestureRecognizer:m_delegate.panGesture];
+            m_delegate.panGesture = nil;
+        }
         m_delegate.handler = nullptr;
         [m_delegate release];
         m_delegate = nullptr;


### PR DESCRIPTION
## Summary

Fixes a use-after-free crash in `NativeSwipeHandlerItem_macos.mm` that causes `EXC_BAD_ACCESS` (SIGSEGV) with infinite metaclass recursion, leading to `ReportCrash` pegging the CPU at ~99%.

- **Fix 1 — `NativeSwipeHandlerItem_macos.mm`:** In `detachGestureRecognizer()`, use `m_delegate.panGesture.view` (the view the recognizer is actually attached to) instead of `getNSView()` (which returns `nullptr` when the Qt window is already destroyed). This ensures the gesture recognizer is always properly removed before the delegate is freed.
- **Fix 2 — `NativeIndicatorItem_macos.mm`:** Harden `getNSView()` with the same safety checks (offscreen platform guard, null `winId` check, `NSView` class validation) already used in the swipe handler's version.

## Platform Context

This crash was originally observed on an **Apple Silicon Mac running the iOS build** of Status v2.36.1 via macOS's native iOS app compatibility (bundle ID: `app.status.mobile`). The crash was initially reported as a desktop issue (#19869), but the bundle ID revealed it was the mobile build running on macOS.

However, the affected files (`NativeSwipeHandlerItem_macos.mm` and `NativeIndicatorItem_macos.mm`) are in the shared `ui/StatusQ/` library and are compiled into **both** mobile and desktop macOS builds. The underlying bug — freeing the delegate while its gesture recognizer is still attached to a view — is a genuine code defect that could manifest in any macOS build where the window is destroyed before `detachGestureRecognizer()` runs. The fix is defensive and correct regardless of which build triggers it.

## Root Cause

When `detachGestureRecognizer()` is called after the Qt window is destroyed:
1. `getNSView()` returns `nullptr` (window is gone)
2. The gesture recognizer removal is skipped (guarded by `if (view && ...)`)
3. The delegate is freed immediately after
4. The next gesture event dispatches to freed memory
5. The ObjC runtime chases a corrupt `isa` pointer → infinite `metaclass` recursion
6. `ReportCrash` gets stuck symbolizing the deep stack trace → CPU spike

Offset `0x28` from null is consistent with the ObjC runtime walking `isa→superclass→cache` on a dangling pointer.

## Test Plan

- [ ] Verify desktop macOS build compiles cleanly
- [ ] Verify mobile iOS build compiles cleanly
- [ ] Test window close / app quit with active swipe gestures on macOS
- [ ] Confirm `ReportCrash` no longer spikes CPU after app termination

Closes #19869

🤖 Generated with [Claude Code](https://claude.com/claude-code)