### PR TITLE
fix(PrimaryNavSidebar): Prevent click-through when tapping outside sidebar

### DIFF
--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -134,7 +134,8 @@ Control {
         }
     }
 
-    // Tap outside the sidebar to close it
+    // Overlay area outside the sidebar that captures the first tap
+    // to close it and prevents click-through to underlying content.
     Item {
         parent: Window.window?.contentItem
         readonly property point sidebarTopLeft: parent?.mapFromItem(root, 0, 0) ?? Qt.point(0, 0)
@@ -142,9 +143,19 @@ Control {
         height: parent?.height ?? 0
         x: Math.max(0, sidebarBottomRight.x)
         width: Math.max(0, (parent?.width ?? 0) - x)
+        visible: !root.alwaysVisible && root.position > 0.5
+        enabled: visible
+
         TapHandler {
-            enabled: !root.alwaysVisible && root.position > 0.5
-            onPressedChanged: root.close()
+            // Ensure this handler captures the gesture even if other handlers
+            // started processing it.
+            grabPermissions: PointerHandler.CanTakeOverFromAnything
+
+            // Only treat the interaction as a valid tap if the pointer is
+            // pressed and released within this overlay area.
+            gesturePolicy: TapHandler.ReleaseWithinBounds
+
+            onTapped: root.close()
         }
     }
 


### PR DESCRIPTION
Fixes #19913

### What does the PR do

Improve the overlay area outside the sidebar that captures the first tap and closes the drawer without propagating the event to underlying UI.

The `TapHandler` is configured to take over the gesture and only trigger on a valid tap, ensuring popup-like behavior and preventing accidental navigation when dismissing the sidebar.

**Note**: Tested on _Android 15_ (_Motorola Razr 60_) using _gesture-based system navigation_.

### Affected areas

Navigation bar interaction on mobile layouts (tap outside behavior when sidebar is open).

### Architecture compliance

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)

### Impact on end user

Prevents accidental navigation when dismissing the sidebar. Tapping outside now behaves like a proper modal overlay, improving interaction predictability and overall UX.

### How to test

- Open the sidebar in mobile device.
- Tap outside the sidebar.
- Verify the sidebar closes.
- Confirm that no UI elements are triggered by that tap.

### Risk 

Low