### PR TITLE
ci(e2e-mobile): add nightly Android E2E stage to combined pipeline

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -134,11 +134,34 @@ pipeline {
             'iOS/aarch64', jenkins.Build('status-app/systems/ios/aarch64/package')
           )
         } } }
-        stage('Android/arm64') { steps { script {
-          ios_aarch64 = getArtifacts(
-            'Android/arm64', jenkins.Build('status-app/systems/android/arm64/package')
-          )
-        } } }
+        stage('Android/arm64 and E2E') {
+          stages {
+            stage('Android/arm64') {
+              steps { script {
+                android_arm64 = getArtifacts(
+                  'Android/arm64', jenkins.Build('status-app/systems/android/arm64/package')
+                )
+              } }
+            }
+            stage('Android E2E') {
+              when {
+                expression {
+                  env.JOB_NAME.toLowerCase().contains('nightly')
+                }
+              }
+              steps { script {
+                android_e2e = build(
+                  job: 'status-app/systems/android/arm64/tests-e2e',
+                  parameters: jenkins.mapToParams([
+                    GIT_REF:      env.BRANCH_NAME,
+                    BUILD_SOURCE: urls['Android/arm64'],
+                    PYTEST_ARGS:  '-n=5 -m smoke tests',
+                  ]),
+                )
+              } }
+            }
+          }
+        }
         stage('Linux/x86_64 nwaku') { steps { script {
           linux_x86_64_nwaku = getArtifacts(
             'Linux/nwaku', build(


### PR DESCRIPTION
## Summary

- Add a nightly Android E2E test stage to `Jenkinsfile.combined`, triggered after the Android build completes
- Nightly runs use `-m smoke` (full test set); PR builds continue to trigger E2E separately from `Jenkinsfile.android`
- Fix copy-paste bug: rename `ios_aarch64` to `android_arm64` for the Android build variable

## Prerequisites

- A new Jenkins job `status-app/systems/android/arm64/tests-e2e` must be created, pointing to `ci/Jenkinsfile.test-e2e.android`