### PR TITLE
fix(ios): Fixing some theme releated crashes

### DIFF
--- a/ui/StatusQ/src/theme.cpp
+++ b/ui/StatusQ/src/theme.cpp
@@ -1,7 +1,10 @@
 #include "StatusQ/theme.h"
 
+#include <QMetaObject>
+#include <QPointer>
 #include <QQmlApplicationEngine>
 #include <QQmlEngine>
+#include <QQuickItem>
 
 namespace {
 
@@ -279,9 +282,17 @@ void Theme::inheritPadding(qreal padding)
 
 void Theme::propagatePadding()
 {
-    const auto themes = attachedChildren();
-    for (QQuickAttachedPropertyPropagator *child : themes) {
-        auto theme = qobject_cast<Theme*>(child);
+    const auto children = attachedChildren();
+    QList<QPointer<QQuickAttachedPropertyPropagator>> childrenSnapshot;
+    childrenSnapshot.reserve(children.size());
+    for (QQuickAttachedPropertyPropagator *child : children)
+        childrenSnapshot.push_back(QPointer<QQuickAttachedPropertyPropagator>(child));
+
+    for (const QPointer<QQuickAttachedPropertyPropagator> &childGuard : childrenSnapshot) {
+        if (!childGuard)
+            continue;
+
+        auto theme = qobject_cast<Theme*>(childGuard.data());
         if (theme)
             theme->inheritPadding(m_padding);
     }
@@ -299,9 +310,17 @@ void Theme::inheritStyle(Style style)
 
 void Theme::propagateStyle()
 {
-    const auto themes = attachedChildren();
-    for (QQuickAttachedPropertyPropagator *child : themes) {
-        auto theme = qobject_cast<Theme*>(child);
+    const auto children = attachedChildren();
+    QList<QPointer<QQuickAttachedPropertyPropagator>> childrenSnapshot;
+    childrenSnapshot.reserve(children.size());
+    for (QQuickAttachedPropertyPropagator *child : children)
+        childrenSnapshot.push_back(QPointer<QQuickAttachedPropertyPropagator>(child));
+
+    for (const QPointer<QQuickAttachedPropertyPropagator> &childGuard : childrenSnapshot) {
+        if (!childGuard)
+            continue;
+
+        auto theme = qobject_cast<Theme*>(childGuard.data());
         if (theme)
             theme->inheritStyle(m_style);
     }
@@ -320,9 +339,17 @@ void Theme::inheritFontSizeOffset(int fontSizeOffset)
 
 void Theme::propagateFontSizeOffset()
 {
-    const auto themes = attachedChildren();
-    for (QQuickAttachedPropertyPropagator *child : themes) {
-        auto theme = qobject_cast<Theme*>(child);
+    const auto children = attachedChildren();
+    QList<QPointer<QQuickAttachedPropertyPropagator>> childrenSnapshot;
+    childrenSnapshot.reserve(children.size());
+    for (QQuickAttachedPropertyPropagator *child : children)
+        childrenSnapshot.push_back(QPointer<QQuickAttachedPropertyPropagator>(child));
+
+    for (const QPointer<QQuickAttachedPropertyPropagator> &childGuard : childrenSnapshot) {
+        if (!childGuard)
+            continue;
+
+        auto theme = qobject_cast<Theme*>(childGuard.data());
         if (theme)
             theme->inheritFontSizeOffset(m_fontSizeOffset);
     }
@@ -334,8 +361,25 @@ void Theme::attachedParentChange(QQuickAttachedPropertyPropagator* newParent,
     Q_UNUSED(oldParent);
     auto attachedParentTheme = qobject_cast<Theme*>(newParent);
     if (attachedParentTheme) {
-        inheritPadding(attachedParentTheme->padding());
-        inheritStyle(attachedParentTheme->style());
-        inheritFontSizeOffset(attachedParentTheme->fontSizeOffset());
+        const QPointer<Theme> expectedParent = attachedParentTheme;
+
+        // Defer inherited theme propagation to avoid re-entrant geometry/binding
+        // updates while the item is being reparented. Read inherited values from
+        // the current attached parent when the callback runs to avoid stale state
+        // if another reparent happens before the queued callback executes.
+        QMetaObject::invokeMethod(this,
+                                  [this, expectedParent]() {
+            auto currentParentTheme = qobject_cast<Theme*>(attachedParent());
+            if (!currentParentTheme || currentParentTheme != expectedParent.data())
+                return;
+
+            auto itemParent = qobject_cast<QQuickItem*>(parent());
+            if (itemParent && !itemParent->window())
+                return;
+
+            inheritPadding(currentParentTheme->padding());
+            inheritStyle(currentParentTheme->style());
+            inheritFontSizeOffset(currentParentTheme->fontSizeOffset());
+        }, Qt::QueuedConnection);
     }
 }


### PR DESCRIPTION
### What does the PR do

Fixing 3 crashes found in the app (all relate to Theme.cpp):
1. Go to backup seed, confirm seed and rotate the IOS device
2. Go to keycard -> migrate to keycard -> input new seed -> enter the first word
3. Go to wallet -> chat -> wallet again

Closes: #19925 #19752
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->


Changes:

1 - qobject cast on destroyed object. The `propagate*` methods needs to be available for re-entry. On layout change (portrait/landscape) the items can be re-parented or deleted in the middle of the child iteration
2 - `attachedParentChange`. Queue the theme propagation to avoid to avoid re-entrant geometry or binding updates. Reject stale queued work - if the current parent changed by the end of the queue the callback doesn't apply. Skip QQuickItems without a window.

