### PR TITLE
fix: Navbar regression where the indicator is always visible

### DIFF
--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -106,7 +106,7 @@ Control {
                                                                                  : root.Theme.palette.privacyColors.primary
         readonly property int containerBgRadius: root.Theme.defaultPadding
 
-        readonly property bool hasPopups: root.Overlay.overlay.children.filter(item => item.toString().includes("QQuickPopupItem") && item.toString().includes("StatusTooltip")).length
+        readonly property bool hasPopups: root.Overlay.overlay.children.filter(item => item.toString().includes("QQuickPopupItem") || item.toString().includes("StatusTooltip")).length
 
         onHasPopupsChanged: {
             if (d.hasPopups) {


### PR DESCRIPTION
### What does the PR do

I've missed this when solving conflicts for the native nav indicator. As a result the indicator is always visible.