### PR TITLE
ci: fix android release builds

### DIFF
--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -73,7 +73,8 @@ if [[ "${OS}" == "android" ]]; then
   AAB_OUT="build/outputs/bundle/${BUILD_TYPE}/android-build-${BUILD_TYPE}.aab"
 
   # Build with specified gradle targets
-  ./gradlew "${GRADLE_TARGETS}" --no-daemon
+  # shellcheck disable=SC2086 # intentional word splitting for multiple gradle tasks
+  ./gradlew ${GRADLE_TARGETS} --no-daemon
 
   # Copy whichever artifacts were built
   BUILT=""


### PR DESCRIPTION
Otherwise they would fail like this :
```
[2026-02-17T01:17:53.201Z] * What went wrong:
[2026-02-17T01:17:53.201Z] Task 'assembleRelease bundleRelease' not
found in root project 'android-build'.
```
