### PR TITLE
fix(ci): set nimcache later to avoid null value

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -40,7 +40,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+      defaultValue: ''
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
@@ -96,7 +96,6 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
     /* Hack fix for params not being set in job on first run */
-    NIMFLAGS =               "${params.NIMFLAGS}"
     ENTITLEMENTS =           "${params.ENTITLEMENTS}"
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
@@ -104,6 +103,8 @@ pipeline {
     USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}"
+    /* Ensure nimcache is not shared between builds. */
+    NIMFLAGS = "${params.NIMFLAGS} --colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
   }
 
   stages {

--- a/ci/Jenkinsfile.linux-nix
+++ b/ci/Jenkinsfile.linux-nix
@@ -28,7 +28,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+      defaultValue: ''
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
@@ -70,7 +70,6 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
     /* Hack fix for params not being set in job on first run */
-    NIMFLAGS =               "${params.NIMFLAGS}"
     ENTITLEMENTS =           "${params.ENTITLEMENTS}"
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
@@ -78,6 +77,8 @@ pipeline {
     USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
+    /* Ensure nimcache is not shared between builds. */
+    NIMFLAGS = "${params.NIMFLAGS} --colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
   }
 
   stages {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -44,7 +44,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+      defaultValue: ''
     )
   }
 
@@ -98,7 +98,6 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
     /* Hack fix for params not being set in job on first run */
-    NIMFLAGS =               "${params.NIMFLAGS}"
     ENTITLEMENTS =           "${params.ENTITLEMENTS}"
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
@@ -106,6 +105,8 @@ pipeline {
     USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
+    /* Ensure nimcache is not shared between builds. */
+    NIMFLAGS = "${params.NIMFLAGS} --colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
   }
 
   stages {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -26,7 +26,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: "--colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+      defaultValue: ''
     )
     booleanParam(
       name: 'USE_MOCKED_KEYCARD_LIB',
@@ -90,7 +90,6 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     SENTRY_PRODUCTION = "${utils.isReleaseBuild() ? 'true' : 'false'}"
     /* Hack fix for params not being set in job on first run */
-    NIMFLAGS =               "${params.NIMFLAGS}"
     ENTITLEMENTS =           "${params.ENTITLEMENTS}"
     RELEASE =                "${params.RELEASE}"
     INCLUDE_DEBUG_SYMBOLS =  "${params.INCLUDE_DEBUG_SYMBOLS}"
@@ -98,6 +97,10 @@ pipeline {
     USE_MOCKED_KEYCARD_LIB = "${params.USE_MOCKED_KEYCARD_LIB}"
     /* FIXME: figure out why NIMFLAGS are not respected */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
+    /* Nim build on Windows puts nimcache in user HOME. */
+    USERPROFILE = "${env.WORKSPACE_TMP}"
+    /* Ensure nimcache is not shared between builds. */
+    NIMFLAGS = "${params.NIMFLAGS} --colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
     NIM_SDS_SOURCE_DIR = "${env.WORKSPACE_TMP}/nim-sds".replace('\\', '/')
   }
 
@@ -105,7 +108,7 @@ pipeline {
     stage('Cleanup Workspace') {
       steps {
         sh './scripts/clean-git.sh'
-        sh 'mkdir -p "${WORKSPACE_TMP}/gotmp"'
+        sh "mkdir -p '${env.GOTMPDIR}'"
       }
     }
     stage('Fetch submodules') {


### PR DESCRIPTION
Accessing `env.WORKSPACE_TMP` in parameters section gives `null` value. To avoid issue we need to set it in the environment section. We also set `USERPROFILE` for windows builds to fix shared location of nimcache under user home directory.

This might be the fix we need for Windows build failures on release CI caused by shared `C:\Users\jenkins\nimcache` folder.
```
x86_64-w64-mingw32/bin/ld.exe:
  C:\Users\jenkins\nimcache\koch_d\@mlib@sstd@sprivate@swin_setenv.nim.c.o:@mlib@sstd@sprivate@swin_setenv.nim.c:
  (.rdata$.refptr.__imp__environ[.refptr.__imp__environ]+0x0): undefined reference to `__imp__environ'
collect2.exe: error: ld returned 1 exit status
```