### PR TITLE
fix(StatusDialog): fix wrong custom bg color

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -24,7 +24,7 @@ Dialog {
        \qmlproperty color backgroundColor
         This property decides the modal background color
     */
-    property color backgroundColor: Theme.palette.statusModal.backgroundColor
+    property alias backgroundColor: background.color
 
     /*!
        \qmlproperty var closeHandler
@@ -172,7 +172,9 @@ Dialog {
         color: Theme.palette.backdropColor
     }
 
-    background: StatusDialogBackground {}
+    background: StatusDialogBackground {
+        id: background
+    }
 
     header: StatusDialogHeader {
         id: dialogHeader

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -526,6 +526,7 @@ StatusDialog {
     horizontalPadding: Theme.xlPadding
     topMargin: margins + accountSelector.height + Theme.padding
     fillHeightOnBottomSheet: true
+    backgroundColor: Theme.palette.baseColor3
 
     Behavior on height {
         id: modalHeightBehavior
@@ -534,10 +535,6 @@ StatusDialog {
     }
 
     onOpened: d.enableAnimationTimer.start()
-
-    background: StatusDialogBackground {
-        color: Theme.palette.baseColor3
-    }
 
     // Bindings needed for exposing and setting raw values from AmountToSend
     onSelectedRawAmountChanged: d.setRawValue()


### PR DESCRIPTION
### What does the PR do

- propagate the color using an alias; the default value isn't resolved properly because `Popup` isn't a graphical `Item`

Fixes #19968

### Affected areas

StatusDialog

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Light mode:
<img width="2706" height="2062" alt="Snímek obrazovky z 2026-02-17 19-53-11" src="https://github.com/user-attachments/assets/581052b8-6a9d-4c1b-a472-ba5f1cefc378" />

Dark mode:
<img width="2706" height="2062" alt="Snímek obrazovky z 2026-02-17 19-53-19" src="https://github.com/user-attachments/assets/e39acc24-f6a0-4929-8cbc-7342dad24212" />


### Impact on end user

Proper color palettes and background color in StatusDialog derived popups

### How to test

- launch Swap modal
- correct bg color, also observing the user configured light/dark mode

### Risk 
- low

