### PR TITLE
fix(StatusSectionLayout): potential fix for wrong right panel bg color

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutLandscape.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayoutLandscape.qml
@@ -72,7 +72,7 @@ Control {
         \qmlproperty Item StatusSectionLayout::rightPanel
         This property holds the right panel of the component.
     */
-    property alias rightPanel: rightPanelProxy.target
+    property Item rightPanel
     /*!
         \qmlproperty Item StatusSectionLayout::footer
         This property holds the footer of the component.
@@ -209,7 +209,7 @@ Control {
             SplitView.preferredWidth: !!d.effectiveLeftPanel ? d.leftPanelWidth : 0
             SplitView.fillHeight: !!d.effectiveLeftPanel
             background: Rectangle {
-                color: Theme.palette.baseColor4
+                color: root.Theme.palette.baseColor4
             }
             contentItem: LayoutItemProxy {
                 target: d.effectiveLeftPanel
@@ -226,7 +226,6 @@ Control {
 
             contentItem: Item {
                 LayoutItemProxy {
-                    id: headerBackgroundSlot
                     anchors.top: parent.top
                     width: parent.width
                     target: root.headerBackground
@@ -241,7 +240,6 @@ Control {
                     padding: root.headerPadding
                     backButtonName: root.backButtonName
                     headerContent: LayoutItemProxy {
-                        id: headerContentProxy
                         target: root.headerContent
                     }
                     onBackButtonClicked: root.backButtonClicked()
@@ -273,10 +271,9 @@ Control {
             opacity: root.showRightPanel ? 1.0 : 0.0
             visible: (opacity > 0.1)
             background: Rectangle {
-                color: Theme.palette.baseColor4
+                color: root.Theme.palette.baseColor4
             }
             contentItem: LayoutItemProxy {
-                id: rightPanelProxy
                 target: root.rightPanel
             }
         }


### PR DESCRIPTION
### What does the PR do

- do not use a circular dependency (both an `alias` and a `target`)
- set the `background` color using the `root` reference, just to be sure

Fixes #19980

### Affected areas

StatusSectionLayout/Chat

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2444" height="1858" alt="image" src="https://github.com/user-attachments/assets/9772e51e-d3f0-421f-9ce1-54ab6df8bb15" />

### Impact on end user

correct light/dark UI mode/colors

### How to test

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

low
