### PR TITLE
fix: send community assets

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -213,10 +213,7 @@ StatusDialog {
     QtObject {
         id: d
 
-        readonly property bool selectedTokenExistsInAssetsModel: {
-            const tokenGroup = SQUtils.ModelUtils.getByKey(root.assetsModel, "key", root.selectedGroupKey)
-            return !!tokenGroup
-        }
+        readonly property bool selectedTokenExistsInAssetsModel: selectedAssetEntry.available
 
         readonly property var resolvedSelectedToken: {
             if (d.selectedTokenExistsInAssetsModel) {


### PR DESCRIPTION
### What does the PR do

Closes: #19975

The property `selectedTokenExistsInAssetsModel` was wrongfully assigned at startup when the model was incomplete. Further model updates were not connected