### PR TITLE
chore: update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ export QT_ANDROID_DIR := $(QT_INSTALL_PREFIX)/src/android/java
 # separate DOS build dir, per Qt version
 DOTHERSIDE_BUILD_PATH := vendor/DOtherSide/build/Qt$(QT_VERSION)
 # separate StatusQ/storybook/... build dirs, per Qt version
-COMMON_CMAKE_CONFIG_PARAMS := -DCMAKE_PREFIX_PATH=$(QT_INSTALL_PREFIX)
+COMMON_CMAKE_CONFIG_PARAMS := -DCMAKE_PREFIX_PATH=$(QT_INSTALL_PREFIX) -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 # Qt dirs (we can't indent with tabs here)
  QT_MAJOR_VERSION := $(shell $(QMAKE) -query QT_VERSION | head -c 1 2>/dev/null)


### PR DESCRIPTION
### What does the PR do

Without this change local build on windows fails to me with this:

```
make[2]: Leaving directory 'C:/Users/anast/AppData/Local/Temp/nim-sds'
Building                                                                       g shared library...
Tags: gowaku_no_rln
mode=c-shared \
        -o build/bin/libstatus.dll \
        ./build/bin/statusgo-lib
build                                                                          m
CMake Error at build/Qt6.9.2/_deps/scodes-src/src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
make: *** [Makefile:315: ui/StatusQ/build/Qt6.9.2/CMakeCache.txt] Error 1
.
..
                                                                              oShared library built:
-rwxr-xr-x 1 anast 197609 193410469 Feb 18 13:19 build/bin/libstatus.dll
-rw-r--r-- 1 anast 197609      9390 Feb 18 13:19 build/bin/libstatus.h
make[1]: Leaving directory 'C:/Users/anast/status-app/vendor/status-go'
```
