### PR TITLE
fix(SendContactRequestToChatKeyModal): don't overflow the width in portrait mode

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestToChatKeyModal.qml
@@ -127,7 +127,7 @@ StatusModal {
         StatusInput {
             id: chatKeyInput
             input.edit.objectName: "SendContactRequestModal_ChatKey_Input"
-
+            width: parent.width
             placeholderText: qsTr("Enter chat key here")
             input.text: input.edit.focus? d.realChatKey : d.elidedChatKey
             input.rightComponent: {
@@ -150,7 +150,7 @@ StatusModal {
             id: messageInput
             input.edit.objectName: "SendContactRequestModal_SayWhoYouAre_Input"
             charLimit: d.maxMsgLength
-
+            width: parent.width
             placeholderText: qsTr("Say who you are / why you want to become a contact...")
             input.multiline: true
             minimumHeight: d.msgHeight


### PR DESCRIPTION
### What does the PR do

- properly set the width to the parent Column

Fixes #20011

### Affected areas

Settings / Messaging / Contacts

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="792" height="1800" alt="image" src="https://github.com/user-attachments/assets/3f87ef45-baa2-4dfd-b395-9e69fd2f75ec" />

### Impact on end user

Better UX on mobile

### How to test

- open Settings / Messaging / Contacts on Mobile
- click Send Contact Request...

### Risk 

low
