### PR TITLE
fix(Wallet): unbreak Buy/Add assets button

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoParamsForm.qml
+++ b/ui/app/AppLayouts/Wallet/popups/buy/BuyCryptoParamsForm.qml
@@ -11,7 +11,7 @@ QtObject {
 
     readonly property bool filledCorrectly: !!selectedWalletAddress && !!selectedTokenGroupKey && selectedNetworkChainId !== -1
 
-    property string defaultTokenGroupKey: Utils.getNativeTokenGroupKey(root.selectedNetworkChainId)
+    readonly property string defaultTokenGroupKey: Utils.getNativeTokenGroupKey(root.selectedNetworkChainId)
 
     function resetFormData() {
         selectedWalletAddress = ""

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -149,10 +149,10 @@ QtObject {
             return root.walletRootStore.getOpenSeaUrl(networkShortName)
         }
 
-        onLaunchBuyFlowRequested: {
+        onLaunchBuyFlowRequested: function (accountAddress, chainId, groupKey) {
             buyFormData.selectedWalletAddress = accountAddress
             buyFormData.selectedNetworkChainId = chainId
-            buyFormData.selectedTokenKey = tokenKey
+            buyFormData.selectedTokenGroupKey = groupKey
             Global.openBuyCryptoModalRequested(buyFormData)
         }
 


### PR DESCRIPTION
### What does the PR do

- set the correct BuyParams, and also adjust to the signal signature change

Fixes #20010

### Affected areas

Wallet/Send & Swap

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2644" height="1658" alt="Snímek obrazovky z 2026-02-18 20-31-44" src="https://github.com/user-attachments/assets/d8b39825-98e8-4c44-9abf-a3c97bf05417" />

### Impact on end user

Can add/buy assets

### How to test

- try to Send an unavailable amount
- hit "Add assets"
- Buy modal opens correctly

### Risk 

low
