### PR TITLE
fix(invite): fix inviting from the settings fails plus add timer

### DIFF
--- a/src/app/modules/main/profile_section/communities/controller.nim
+++ b/src/app/modules/main/profile_section/communities/controller.nim
@@ -17,9 +17,6 @@ proc newController*(delegate: io_interface.AccessInterface,
 proc delete*(self: Controller) =
   discard
 
-proc shareCommunityToUsers*(self: Controller, communityID: string, pubKeys: string, inviteMessage: string): string =
-  result = self.communityService.shareCommunityToUsers(communityID, pubKeys, inviteMessage)
-
 proc leaveCommunity*(self: Controller, communityID: string) =
   self.communityService.leaveCommunity(communityID)
 

--- a/src/app/modules/main/profile_section/communities/io_interface.nim
+++ b/src/app/modules/main/profile_section/communities/io_interface.nim
@@ -22,9 +22,6 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method shareCommunityToUsers*(self: AccessInterface, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method leaveCommunity*(self: AccessInterface, communityID: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/communities/module.nim
+++ b/src/app/modules/main/profile_section/communities/module.nim
@@ -41,9 +41,6 @@ method viewDidLoad*(self: Module) =
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
-method shareCommunityToUsers*(self: Module, communityID: string, pubKeysJSON: string, inviteMessage: string): string =
-  result = self.controller.shareCommunityToUsers(communityID, pubKeysJSON, inviteMessage)
-
 method leaveCommunity*(self: Module, communityID: string) =
   self.controller.leaveCommunity(communityID)
 

--- a/src/app/modules/main/profile_section/communities/view.nim
+++ b/src/app/modules/main/profile_section/communities/view.nim
@@ -17,9 +17,6 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  proc shareCommunityToUsers*(self: View, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
-    result = self.delegate.shareCommunityToUsers(communityID, pubKeysJSON, inviteMessage)
-
   proc leaveCommunity*(self: View, communityID: string) {.slot.} =
     self.delegate.leaveCommunity(communityID)
 

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -62,12 +62,12 @@ SplitView {
                     name: "community-name"
                 })
 
-                communitySectionModule: QtObject {
-                    function shareCommunityToUsers(keys, message) {
-                        logs.logEvent("communitySectionModule::shareCommunityToUsers",
-                                      ["keys", "message"], arguments)
-                    }
+                shareCommunityToUsers:  function shareCommunityToUsers(keys, message) {
+                    logs.logEvent("communitySectionModule::shareCommunityToUsers",
+                                  ["keys", "message"], arguments)
                 }
+
+                membersModel: []
 
                 contactsModel: ListModel {
                     Component.onCompleted: {
@@ -84,7 +84,7 @@ SplitView {
                                 localNickname: "",
                                 onlineStatus: 1,
                                 pubKey: key,
-                                compressedKey: "zx3sh" + key,
+                                compressedPubKey: "zx3sh" + key,
                             })
                         }
                     }
@@ -106,6 +106,7 @@ SplitView {
 }
 
 // category: Popups
+// status: good
 
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2927%3A343592
 // https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2990%3A353179

--- a/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 
 import StatusQ.Core.Theme
+import StatusQ.Core.Backpressure
 import StatusQ.Controls
 import StatusQ.Components
 import StatusQ.Popups
@@ -18,12 +19,14 @@ StatusStackModal {
 
     property var contactsModel
     property var community
-    property var communitySectionModule
+    required property var membersModel
 
     property var pubKeys: ([])
     property string inviteMessage: ""
     property string validationError: ""
     property string successMessage: ""
+
+    required property var shareCommunityToUsers
 
     QtObject {
         id: d
@@ -33,7 +36,7 @@ StatusStackModal {
         readonly property int popupContentHeight: 551
 
         function shareCommunity(pubKeys, inviteMessage) {
-            const error = root.communitySectionModule.shareCommunityToUsers(JSON.stringify(pubKeys), inviteMessage);
+            const error = root.shareCommunityToUsers(JSON.stringify(pubKeys), inviteMessage);
             d.processInviteResult(error);
         }
 
@@ -44,6 +47,9 @@ StatusStackModal {
             } else {
                 root.validationError = "";
                 root.successMessage = qsTr("Invite successfully sent");
+                Backpressure.debounce(root, 500, () => {
+                    root.close()
+                })()
             }
         }
     }
@@ -78,7 +84,6 @@ StatusStackModal {
         text: qsTr("Send %n invite(s)", "", root.pubKeys.length)
         onClicked: {
             d.shareCommunity(root.pubKeys, root.inviteMessage);
-            root.close();
         }
     }
 
@@ -95,7 +100,7 @@ StatusStackModal {
         ProfilePopupInviteFriendsPanel {
 
             contactsModel: root.contactsModel
-            membersModel: root.communitySectionModule.membersModel
+            membersModel: root.membersModel
             communityId: root.community.id
 
             onPubKeysChanged: root.pubKeys = pubKeys

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -524,13 +524,13 @@ StatusSectionLayout {
                                                    return false
                                                }
 
-                onLeaveCommunityRequest: root.leaveCommunityRequest(communityId)
-                onSetCommunityMutedRequest: root.setCommunityMutedRequest(communityId, mutedType)
-                onInviteFriends: root.inviteFriends(communityData)
+                onLeaveCommunityRequest: communityId => root.leaveCommunityRequest(communityId)
+                onSetCommunityMutedRequest: (communityId, mutedType) => root.setCommunityMutedRequest(communityId, mutedType)
+                onInviteFriends: communityData => root.inviteFriends(communityData)
                 onCancelPendingRequestRequested: (communityId) => {
                                                      const communityAccessStore = getSpecificCommunityAccessStore(communityId)
                                                      if(communityAccessStore) {
-                                                         communityAccessStore.cancelPendignRequest(communityId)
+                                                         communityAccessStore.cancelPendingRequest(communityId)
                                                      }
                                                  }
             }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -198,29 +198,28 @@ SettingsContentBase {
             filters: panel.filters
         }
 
-        onCloseCommunityClicked: {
+        onCloseCommunityClicked: communityId => {
             root.leaveCommunityRequest(communityId)
         }
 
-        onLeaveCommunityClicked: {
+        onLeaveCommunityClicked: communityId => {
             Global.leaveCommunityRequested(community, communityId, outroMessage)
         }
 
-        onSetCommunityMutedClicked: {
+        onSetCommunityMutedClicked: communityId => {
             root.setCommunityMutedRequest(communityId, mutedType)
         }
 
-        onSetActiveCommunityClicked: {
+        onSetActiveCommunityClicked: communityId => {
             rootStore.setActiveCommunity(communityId)
         }
 
-        onInviteFriends: {
-            root.inviteFriends(communityData)
-        }
-        onShowCommunityMembershipSetupDialog: {
+        onInviteFriends: communityData => root.inviteFriends(communityData)
+
+        onShowCommunityMembershipSetupDialog: (communityId, name, introMessage, imageSrc, accessType) =>{
             Global.communityIntroPopupRequested(communityId, name, introMessage, imageSrc, root.fnIsMyCommunityRequestPending(communityId))
         }
-        onCancelMembershipRequest: {
+        onCancelMembershipRequest: communityId => {
             root.cancelPendingRequestRequested(communityId)
         }
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1942,11 +1942,9 @@ Item {
                                 ThemeUtils.setPaddingFactor(appMain.Window.window, paddingFactor)
                             }
                             // Communities related settings view:
-                            onLeaveCommunityRequest: appMain.communitiesStore.leaveCommunity(communityId)
-                            onSetCommunityMutedRequest: appMain.communitiesStore.setCommunityMuted(communityId, mutedType)
-                            onInviteFriends: Global.openInviteFriendsToCommunityPopup(communityData,
-                                                                                      appMain.communitiesStore.communitiesProfileModule,
-                                                                                      null)
+                            onLeaveCommunityRequest: communityId => appMain.communitiesStore.leaveCommunity(communityId)
+                            onSetCommunityMutedRequest: (communityId, mutedType) => appMain.communitiesStore.setCommunityMuted(communityId, mutedType)
+                            onInviteFriends: communityData => Global.openInviteFriendsToCommunityByIdPopup(communityData.id, null)
                             onOpenThirdpartyServicesInfoPopupRequested: popupRequestsHandler.thirdpartyServicesPopupHandler.openPopup()
                             onOpenDiscussPageRequested: Global.requestOpenLink(Constants.statusDiscussPageUrl)
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -260,14 +260,26 @@ QtObject {
     }
 
     function openInviteFriendsToCommunityPopup(community, communitySectionModule, cb) {
-        openPopup(inviteFriendsToCommunityPopup, { community: community, communitySectionModule: communitySectionModule }, cb)
+        openPopup(inviteFriendsToCommunityPopup, {
+            community: community,
+            membersModel: communitySectionModule.membersModel,
+            shareCommunityToUsers: (pubkeysStr, inviteMessage) => {
+                communitySectionModule.shareCommunityToUsers(pubkeysStr, inviteMessage)
+            }
+        }, cb)
     }
 
     function openInviteFriendsToCommunityByIdPopup(communityId, cb) {
         const communitySectionModuleData = root.chatStore.getCommunitySectionModule(communityId)
         const communityData = root.communitiesStore.getCommunityDetails(communityId)
 
-        openPopup(inviteFriendsToCommunityPopup, { community: communityData, communitySectionModule: communitySectionModuleData }, cb)
+        openPopup(inviteFriendsToCommunityPopup, {
+            community: communityData,
+            membersModel: communitySectionModuleData.membersModel,
+            shareCommunityToUsers: (pubkeysStr, inviteMessage) => {
+                communitySectionModuleData.shareCommunityToUsers(pubkeysStr, inviteMessage)
+            }
+        }, cb)
     }
 
     function openContactRequestPopup(publicKey, cb) {

--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -115,7 +115,7 @@ CalloutCard {
                 Layout.bottomMargin: 6
                 objectName: "linkPreviewEmojiHash"
                 visible: root.type === Constants.LinkPreviewType.StatusContact
-                emojiHash: JSON.parse(root.userData.emojiHash)
+                emojiHash: visible ? JSON.parse(root.userData.emojiHash) : []
                 oneRow: true
             }
             StatusBaseText {

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -105,6 +105,7 @@ Item {
                 objectName: "contactCheckbox-%1".arg(model.displayName)
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.right: parent.right
+                anchors.rightMargin: Theme.halfPadding
                 checked: root.pubKeys.indexOf(model.pubKey) > -1
                 onClicked: {
                     root.contactClicked(model);


### PR DESCRIPTION
### What does the PR do

Fixes #20008

The problem was that we were using the same call for both opening in the community view and the settings view, however, they do not use the same module in the background. I fixed that by removing the direct access to the module + standardized to only use the chat section module.

Finally, I added a timer when it succeeds, so users can see that it worked.

### Affected areas

- Popups.qml
- InviteFriendsToCommunityPopup.qml
- A couple other files for clean ups

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[fix-invite.webm](https://github.com/user-attachments/assets/95ccedbf-9e5e-453e-9bec-18b4cb2619cd)

### Impact on end user

Fixes the issue

### How to test

Test the different ways to invite users

### Risk 

Low-medium. I did modify the way we call the opening of the popup and did clean ups. If I forgot a way to invite users, it might be broken
