### PR TITLE
fix(NavBar): Slightly increase navigation bar width for better usability on protected mobile screens

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -19,7 +19,7 @@ QtObject {
     readonly property bool isAndroid: Qt.platform.os === android
     readonly property bool isMacOS: Qt.platform.os === mac
 
-    readonly property int swipeIndicatorWidth: 6
+    readonly property int swipeIndicatorWidth: 8
 
     function getAbsolutePosition(node) {
         var returnPos = {};


### PR DESCRIPTION
### What does the PR do

Increase the navigation bar width slightly to improve usability on mobile devices, especially for users with screen protectors or protective cases.

This makes edge gestures and interactions more comfortable without affecting the overall layout or desktop behavior.

### Affected areas

Navigation Bar in portrait mode.

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better usability

### How to test

In portrait mode, use the navigation bar when it's collapsed.

### Risk 

Low