### PR TITLE
fix(chat): set chat as active if it's the only one

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -752,7 +752,8 @@ proc addNewChat(
 
   if insertIntoModel:
     self.view.chatsModel().appendItem(chatItem)
-  if setChatAsActive:
+  # Set active if it's the only chat or if specified
+  if setChatAsActive or self.chatContentModules.len == 1:
     self.setActiveItem(chatItem.id)
 
 method switchToChannel*(self: Module, channelName: string) =


### PR DESCRIPTION
### What does the PR do

Fixes #19965

Makes it that the user sees the chat straight away if it's the only one he has, without having to click on the chat

### Affected areas

- chat section module

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[open-chat.webm](https://github.com/user-attachments/assets/77c809cf-3037-4a66-8148-bf865dbe7684)

### Impact on end user

Better UX

### How to test

1. Create a new account
2. send a CR to another
3. accept on that other installation
4. See the chat become active
5. Do it again with another chat
6. new chat should **not** become active

### Risk 

Low
