### PR TITLE
ChatColumnView: ChatPermissionQualificationPanel positioning fixed

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -510,10 +510,9 @@ Item {
 
                 ChatPermissionQualificationPanel {
                     id: channelPostRestrictions
-                    width: chatInput.textInput.width
-                    height: chatInput.textInput.height
-                    anchors.left: parent.left
-                    anchors.leftMargin: (2*Theme.bigPadding)
+
+                    parent: chatInput.textInput
+                    anchors.fill: parent
                     visible: (!!root.viewAndPostHoldingsModel && (root.viewAndPostHoldingsModel.count > 0)
                               && !root.amISectionAdmin && !root.canPost)
                     assetsModel: root.rootStore.assetsModel


### PR DESCRIPTION
### What does the PR do

- fixes positioning of `ChatPermissionQualificationPanel` by aligning to text input area.

Closes: #19977

### Screencapture of the functionality

<img width="460" height="196" alt="image" src="https://github.com/user-attachments/assets/7c115b3c-be7a-465d-a3a1-4a8be3e09b26" />
