### PR TITLE
fix(community): fix community join called twice with keycard

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -679,7 +679,10 @@ proc signRevealedAddressesForNonKeycardKeypairs(self: Module): bool =
   return true
 
 proc signRevealedAddressesForNonKeycardKeypairsAndEmitSignal(self: Module) =
-  if self.signRevealedAddressesForNonKeycardKeypairs() and self.joiningCommunityDetails.allSigned():
+  let wereAllSigned = self.joiningCommunityDetails.allSigned()
+  if not self.signRevealedAddressesForNonKeycardKeypairs():
+    return
+  if not wereAllSigned and self.joiningCommunityDetails.allSigned():
     self.view.sendAllSharedAddressesSignedSignal()
 
 proc anyProfileKeyPairAddressSelectedToBeRevealed(self: Module): bool =


### PR DESCRIPTION
Part of #20036

### What does the PR do

There was a double call to join community when using a keycard, which threw an error, though the join did also work. So I think some changes by @alexjba already fixed most of it, but this commit also makes sure to not show an error for no reason.

### Affected areas

communities module

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/b96f04a7-8f02-448a-9c37-b768c73fcb42

### Impact on end user

Fixes the UX of joining a community with a keycard

### How to test

on desktop and mobile, have a keycard profile and try to join a community

### Risk 

Low. I tested both normal and keycard accounts and both still work and there are no errors
