### PR TITLE
fix(portal): remove badge on Create Community btn and Portal btn

### DIFF
--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -71,8 +71,6 @@ const LSS_KEY_USER_DECLINED_BACKUP_BANNER* = "userDeclinedBackupBanner"
 const DEFAULT_USER_DECLINED_BACKUP_BANNER = false
 const LSS_KEY_GIF_UNFURLING_ENABLED* = "gifUnfurlingEnabled"
 const DEFAULT_GIF_UNFURLING_ENABLED* = false
-const LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN = "createCommunityPopupSeen"
-const DEFAULT_LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN = false
 const LS_KEY_LOCAL_BACKUP_CHOSEN_PATH* = "localBackupChosenPath"
 
 logScope:
@@ -554,20 +552,6 @@ QtObject:
     write = setGifUnfurlingEnabled
     notify = gifUnfurlingEnabledChanged
 
-  proc createCommunityPopupSeenChanged(self: LocalAccountSensitiveSettings) {.signal.}
-  proc getCreateCommunityPopupSeen(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    self.settings.value(LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN, newQVariant(DEFAULT_LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN)).boolVal
-  proc setCreateCommunityPopupSeen(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
-    if value == self.getCreateCommunityPopupSeen:
-      return
-    self.settings.setValue(LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN, newQVariant(value))
-    self.createCommunityPopupSeenChanged()
-
-  QtProperty[bool] createCommunityPopupSeen:
-    read = getCreateCommunityPopupSeen
-    write = setCreateCommunityPopupSeen
-    notify = createCommunityPopupSeenChanged
-
   proc localBackupChosenPathChanged*(self: LocalAccountSensitiveSettings) {.signal.}
 
   proc getLocalBackupChosenPathSetting*(self: LocalAccountSensitiveSettings): string =
@@ -637,7 +621,6 @@ QtObject:
       of LSS_KEY_STICKERS_ENS_ROPSTEN: self.stickersEnsRopstenChanged()
       of LSS_KEY_USER_DECLINED_BACKUP_BANNER: self.userDeclinedBackupBannerChanged()
       of LSS_KEY_GIF_UNFURLING_ENABLED: self.gifUnfurlingEnabledChanged()
-      of LSS_KEY_CREATE_COMMUNITY_POPUP_SEEN: self.createCommunityPopupSeenChanged()
 
   proc setup(self: LocalAccountSensitiveSettings) =
     self.QObject.setup

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -36,18 +36,11 @@ SplitView {
             SplitView.fillHeight: true
 
             createCommunityEnabled: ctrlCommunityCreationEnabled.checked
-            createCommunityBadgeVisible: !communitiesStore.createCommunityPopupSeen
 
             assetsModel: AssetsModel {}
             collectiblesModel: CollectiblesModel {}
             communitiesStore: CommunitiesStore {
                 readonly property string communityTags: ModelsData.communityTags
-
-                property bool createCommunityPopupSeen
-                function setCreateCommunityPopupSeen() {
-                    createCommunityPopupSeen = true
-                    logs.logEvent("CommunitiesStore::setCreateCommunityPopupSeen")
-                }
 
                 readonly property var curatedCommunitiesModel: SortFilterProxyModel {
                     sourceModel: CommunitiesPortalDummyModel { id: mockedModel }

--- a/storybook/pages/PrimaryNavSidebarPage.qml
+++ b/storybook/pages/PrimaryNavSidebarPage.qml
@@ -248,7 +248,6 @@ SplitView {
             }
 
             thirdpartyServicesEnabled: ctrlThirdPartyServices.checked
-            showCreateCommunityBadge: ctrlShowCreateCommunityBadge.checked
             profileSectionHasNotification: ctrlSettingsHasNotification.checked
 
             onItemActivated: function (sectionType, sectionId) {
@@ -309,10 +308,6 @@ SplitView {
                 Switch {
                     id: ctrlSettingsHasNotification
                     text: "Settings has notification"
-                }
-                Switch {
-                    id: ctrlShowCreateCommunityBadge
-                    text: "Show create community badge"
                 }
             }
 

--- a/storybook/qmlTests/tests/tst_PrimaryNavSidebar.qml
+++ b/storybook/qmlTests/tests/tst_PrimaryNavSidebar.qml
@@ -56,7 +56,6 @@ Item {
             }
 
             profileSectionHasNotification: false
-            showCreateCommunityBadge: false
             thirdpartyServicesEnabled: true
 
             acVisible: false
@@ -283,18 +282,6 @@ Item {
             // Settings button should show notification when profileSectionHasNotification is true
             tryCompare(settingsBtn, "showBadge", true)
             tryCompare(settingsBtn, "badgeVisible", true)
-        }
-
-        function test_create_community_badge() {
-            controlUnderTest.showCreateCommunityBadge = true
-
-            const communitiesBtn = findChild(controlUnderTest, "Communities-navbar")
-            verify(!!communitiesBtn)
-
-            // Communities button should show badge gradient
-            tryCompare(communitiesBtn, "showBadgeGradient", true)
-            tryCompare(communitiesBtn, "showBadge", true)
-            tryCompare(communitiesBtn, "badgeVisible", true)
         }
 
         function test_community_buttons_have_object_name() {

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -34,7 +34,6 @@ StatusSectionLayout {
     property var collectiblesModel
 
     property bool createCommunityEnabled: true
-    property bool createCommunityBadgeVisible
 
     objectName: "communitiesPortalLayout"
 
@@ -211,12 +210,7 @@ StatusSectionLayout {
             type: StatusBaseButton.Type.Primary
             onClicked: {
                 // Global.openPopup(chooseCommunityCreationTypePopupComponent) // hidden as part of https://github.com/status-im/status-app/issues/17726
-                root.communitiesStore.setCreateCommunityPopupSeen()
                 Global.createCommunityPopupRequested(false /*isDiscordImport*/)
-            }
-
-            StatusNewBadge {
-                visible: root.createCommunityBadgeVisible
             }
         }
     }

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -37,11 +37,6 @@ QtObject {
 
     readonly property bool testEnvironment: localAppSettings.testEnvironment ?? false
 
-    readonly property bool createCommunityPopupSeen: localAccountSensitiveSettings.createCommunityPopupSeen ?? false
-    function setCreateCommunityPopupSeen() {
-        localAccountSensitiveSettings.createCommunityPopupSeen = true
-    }
-
     property string communityTags: communitiesModuleInst.tags
 
     readonly property QtObject _d: QtObject {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1748,7 +1748,6 @@ Item {
                             communitiesStore: appMain.communitiesStore
                             assetsModel: appMain.rootStore.globalAssetsModel
                             collectiblesModel: appMain.rootStore.globalCollectiblesModel
-                            createCommunityBadgeVisible: !appMain.communitiesStore.createCommunityPopupSeen
 
                             // Floating panel
                             leftFloatingPanelItem: appMain.activityCenterPanel
@@ -2240,7 +2239,6 @@ Item {
 
                 communityPopupMenu: communityContextMenuComponent
 
-                showCreateCommunityBadge: !appMain.communitiesStore.createCommunityPopupSeen
                 profileSectionHasNotification: {
                     if (contactsModelAdaptor.pendingReceivedRequestContacts.ModelCount.count > 0) // pending contact request
                         return true

--- a/ui/app/mainui/panels/PrimaryNavSidebar.qml
+++ b/ui/app/mainui/panels/PrimaryNavSidebar.qml
@@ -53,7 +53,6 @@ Control {
     property Component communityPopupMenu // required property var model
 
     required property bool profileSectionHasNotification
-    required property bool showCreateCommunityBadge
     required property bool thirdpartyServicesEnabled
 
     required property bool acVisible // FIXME AC should not be a section
@@ -402,13 +401,10 @@ Control {
     }
 
     component BottomSectionButton: RegularSectionButton {
-        readonly property bool displayCreateCommunityBadge: model.sectionType === Constants.appSection.communitiesPortal && root.showCreateCommunityBadge
-        showBadgeGradient: displayCreateCommunityBadge
+        showBadgeGradient: false
         showBadge: {
             if (model.sectionType === Constants.appSection.profile)
                 return root.profileSectionHasNotification
-            if (displayCreateCommunityBadge)
-                return true
             return model.hasNotification
         }
     }


### PR DESCRIPTION
### What does the PR do

Fixes #20044

This feature is no longer new, so we can remove the dot.

### Affected areas

- settings
- Nav bar
- portal

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[no-more-dot.webm](https://github.com/user-attachments/assets/3acd8fab-4c00-432a-b716-5ba2928d31f2)

### Impact on end user

No more annoying dot on mobile that cannot be removed

### How to test

Create a new account or test an old mobile account

### Risk 

Low
