### PR TITLE
test(e2e-mobile): add iOS support for Appium test framework

### DIFF
--- a/test/e2e_appium/config/environments/browserstack.yaml
+++ b/test/e2e_appium/config/environments/browserstack.yaml
@@ -78,6 +78,31 @@ devices:
         platformName: "android"
         platformVersion: "13"
         deviceName: "Samsung Galaxy S23"
+    # --- iOS devices ---
+    - id: "ipad_10th_gen_ios_16"
+      display_name: "iPad 10th Gen – iOS 16"
+      tags: ["ios", "tablet", "cloud"]
+      capabilities:
+        platformName: "iOS"
+        automationName: "XCUITest"
+        platformVersion: "16"
+        deviceName: "iPad 10th"
+    - id: "ipad_air_6th_gen_ios_18"
+      display_name: "iPad Air 6th Gen – iOS 18"
+      tags: ["ios", "tablet", "cloud"]
+      capabilities:
+        platformName: "iOS"
+        automationName: "XCUITest"
+        platformVersion: "18"
+        deviceName: "iPad Air (6th generation)"
+    - id: "iphone_15_ios_17"
+      display_name: "iPhone 15 – iOS 17"
+      tags: ["ios", "phone", "cloud"]
+      capabilities:
+        platformName: "iOS"
+        automationName: "XCUITest"
+        platformVersion: "17"
+        deviceName: "iPhone 15"
 
 execution:
   concurrency:

--- a/test/e2e_appium/core/providers/browserstack.py
+++ b/test/e2e_appium/core/providers/browserstack.py
@@ -63,6 +63,11 @@ class BrowserStackProvider(Provider):
         if app_id:
             capabilities["app"] = app_id
 
+        # Strip Android-only capabilities when targeting iOS
+        platform = (capabilities.get("platformName") or "").lower()
+        if platform == "ios":
+            self._strip_android_capabilities(capabilities)
+
         bstack_options = capabilities.setdefault("bstack:options", {})
         self._populate_metadata(bstack_options, metadata, device)
 
@@ -203,6 +208,27 @@ class BrowserStackProvider(Provider):
         merged_caps = device.merged_capabilities(defaults)
         bstack_options.setdefault("osVersion", merged_caps.get("platformVersion"))
         bstack_options.setdefault("deviceName", merged_caps.get("deviceName"))
+
+    # Capabilities that are valid only for Android / UiAutomator2 sessions.
+    _ANDROID_ONLY_CAPS = frozenset({
+        "appium:unicodeKeyboard",
+        "appium:resetKeyboard",
+        "appium:systemPort",
+        "appPackage",
+        "appActivity",
+        "appium:appPackage",
+        "appium:appActivity",
+        # Legacy short-form keys that may leak from device_defaults
+        "unicodeKeyboard",
+        "resetKeyboard",
+    })
+
+    def _strip_android_capabilities(self, capabilities: Dict[str, str]) -> None:
+        """Remove capabilities that are invalid for iOS / XCUITest sessions."""
+        for key in list(capabilities):
+            if key in self._ANDROID_ONLY_CAPS:
+                logger.debug("Stripped Android-only capability for iOS session: %s", key)
+                del capabilities[key]
 
     def _resolve_with_overrides(self, template: str, overrides: Dict[str, str]) -> str:
         original: Dict[str, Optional[str]] = {}

--- a/test/e2e_appium/core/providers/local.py
+++ b/test/e2e_appium/core/providers/local.py
@@ -29,7 +29,7 @@ class LocalProvider(Provider):
 
         if not capabilities.get("app") and not capabilities.get("noReset", False):
             raise ConfigurationError(
-                "Local provider requires either an APK path (set LOCAL_APP_PATH or "
+                "Local provider requires either an app path (set LOCAL_APP_PATH or "
                 "update path_template) or noReset=true for preinstalled apps."
             )
 

--- a/test/e2e_appium/fixtures/multi_device_fixtures.py
+++ b/test/e2e_appium/fixtures/multi_device_fixtures.py
@@ -85,7 +85,12 @@ def _local_env_overrides(device_count: int) -> Optional[List[Dict[str, Any]]]:
 
 def _parse_device_markers(request, test_environment) -> tuple:
     """
-    Extract device configuration from pytest markers.
+    Extract device configuration from pytest markers and environment.
+
+    Also respects the ``TEST_DEVICE_ID`` environment variable.  When set,
+    the named device's capabilities are loaded from the YAML config and
+    used as the device override — this allows selecting iOS or specific
+    Android devices without modifying test markers.
 
     Returns:
         Tuple of (device_count, device_overrides, device_tags)
@@ -102,6 +107,22 @@ def _parse_device_markers(request, test_environment) -> tuple:
         device_overrides = list(device_overrides)[:device_count]
     elif test_environment == "local":
         device_overrides = _local_env_overrides(device_count)
+
+    # Honour TEST_DEVICE_ID env var: resolve the named device from YAML
+    # and inject its capabilities as an override so SessionManager picks
+    # the correct platform (e.g. iOS instead of the default Android).
+    env_device_id = os.getenv("TEST_DEVICE_ID")
+    if env_device_id and not device_overrides:
+        try:
+            cfg_mgr = ConfigurationManager()
+            env_cfg = cfg_mgr.load_environment(test_environment)
+            device_cfg = env_cfg.get_device(env_device_id)
+            defaults = env_cfg.device_defaults.get("capabilities", {})
+            merged = device_cfg.merged_capabilities(defaults)
+            device_overrides = [{"capabilities": merged}] * device_count
+        except Exception:
+            # Fall through to tag-based or default selection
+            pass
 
     if device_tags and not device_overrides:
         cfg_mgr = ConfigurationManager()

--- a/test/e2e_appium/fixtures/onboarding_fixture.py
+++ b/test/e2e_appium/fixtures/onboarding_fixture.py
@@ -207,7 +207,8 @@ class OnboardingFlow:
                 time.sleep(1)
         
         try:
-            self.app.driver.tap([(500, 300)])  
+            from utils.gestures import Gestures
+            Gestures(self.app.driver).tap(500, 300)
             time.sleep(1)
         except Exception:
             self.logger.debug("Initial tap attempt skipped", exc_info=True)

--- a/test/e2e_appium/locators/base_locators.py
+++ b/test/e2e_appium/locators/base_locators.py
@@ -109,3 +109,43 @@ class BaseLocators:
     @staticmethod
     def any_element_with_text(text: str) -> tuple:
         return (BaseLocators.BY_XPATH, f"//*[@text='{text}' or @content-desc='{text}']")
+
+    # ------------------------------------------------------------------
+    # Cross-platform locators (Android + iOS)
+    #
+    # Qt/QML maps Accessible.name → content-desc (Android) / label (iOS)
+    # Qt/QML maps objectName      → resource-id (Android) / name  (iOS)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def label_contains(value: str) -> tuple:
+        """Cross-platform: find by Accessible.name substring.
+
+        Searches ``content-desc`` on Android and ``label`` on iOS.
+        """
+        return (
+            BaseLocators.BY_XPATH,
+            f"//*[contains(@content-desc, '{value}') or contains(@label, '{value}')]",
+        )
+
+    @staticmethod
+    def label_exact(value: str) -> tuple:
+        """Cross-platform: find by exact Accessible.name.
+
+        Searches ``content-desc`` on Android and ``label`` on iOS.
+        """
+        return (
+            BaseLocators.BY_XPATH,
+            f"//*[@content-desc='{value}' or @label='{value}']",
+        )
+
+    @staticmethod
+    def object_name_contains(value: str) -> tuple:
+        """Cross-platform: find by QML objectName substring.
+
+        Searches ``resource-id`` on Android and ``name`` on iOS.
+        """
+        return (
+            BaseLocators.BY_XPATH,
+            f"//*[contains(@resource-id, '{value}') or contains(@name, '{value}')]",
+        )

--- a/test/e2e_appium/locators/onboarding/analytics_screen_locators.py
+++ b/test/e2e_appium/locators/onboarding/analytics_screen_locators.py
@@ -2,12 +2,17 @@ from ..base_locators import BaseLocators
 
 class AnalyticsScreenLocators(BaseLocators):
 
-    ANALYTICS_PAGE_BY_CONTENT_DESC = BaseLocators.accessibility_id(
+    ANALYTICS_PAGE_BY_CONTENT_DESC = BaseLocators.label_contains(
         "Help us improve Status"
     )
-    SHARE_USAGE_DATA_BUTTON = BaseLocators.accessibility_id("Share usage data")
-    NOT_NOW_BUTTON = BaseLocators.content_desc_contains("[tid:btnDontShare]")
+    SHARE_USAGE_DATA_BUTTON = BaseLocators.label_exact("Share usage data")
+    # On Android content-desc contains "[tid:btnDontShare]";
+    # on iOS label is "Skip sharing" and name contains "btnDontShare".
+    NOT_NOW_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, '[tid:btnDontShare]') "
+        "or contains(@name, 'btnDontShare')]"
+    )
 
-    ONBOARDING_CONTAINER = BaseLocators.id(
-        "QGuiApplication.mainWindow.startupOnboardingLayout"
+    ONBOARDING_CONTAINER = BaseLocators.object_name_contains(
+        "startupOnboardingLayout"
     )

--- a/test/e2e_appium/locators/onboarding/biometrics_locators.py
+++ b/test/e2e_appium/locators/onboarding/biometrics_locators.py
@@ -4,7 +4,14 @@ from ..base_locators import BaseLocators
 class BiometricsLocators(BaseLocators):
     """Locators for the biometrics prompt displayed during onboarding."""
 
-    BIOMETRICS_DIALOG_TITLE = BaseLocators.text_contains("Enable biometrics")
-    MAYBE_LATER_BUTTON = BaseLocators.content_desc_contains("tid:btnDontEnableBiometrics")
-    ENABLE_BUTTON = BaseLocators.content_desc_contains("tid:btnEnableBiometrics")
-
+    BIOMETRICS_DIALOG_TITLE = BaseLocators.label_contains("Enable biometrics")
+    # On Android content-desc contains "tid:btnDontEnableBiometrics";
+    # on iOS name contains "btnDontEnableBiometrics".
+    MAYBE_LATER_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'tid:btnDontEnableBiometrics') "
+        "or contains(@name, 'btnDontEnableBiometrics')]"
+    )
+    ENABLE_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'tid:btnEnableBiometrics') "
+        "or contains(@name, 'btnEnableBiometrics')]"
+    )

--- a/test/e2e_appium/locators/onboarding/create_profile_screen_locators.py
+++ b/test/e2e_appium/locators/onboarding/create_profile_screen_locators.py
@@ -3,18 +3,14 @@ from ..base_locators import BaseLocators
 
 class CreateProfileScreenLocators(BaseLocators):
 
-    CREATE_PROFILE_SCREEN = BaseLocators.accessibility_id("Create profile")
-    LETS_GO_BUTTON = BaseLocators.accessibility_id("Let's go!")
-    USE_RECOVERY_PHRASE_BUTTON = BaseLocators.accessibility_id("Use a recovery phrase")
-    USE_KEYCARD_BUTTON = BaseLocators.accessibility_id("Use an empty Keycard")
+    CREATE_PROFILE_SCREEN = BaseLocators.label_contains("Create profile")
+    LETS_GO_BUTTON = BaseLocators.label_exact("Let's go!")
+    USE_RECOVERY_PHRASE_BUTTON = BaseLocators.label_exact("Use a recovery phrase")
+    USE_KEYCARD_BUTTON = BaseLocators.label_exact("Use an empty Keycard")
 
-    ONBOARDING_CONTAINER = BaseLocators.id(
-        "QGuiApplication.mainWindow.startupOnboardingLayout"
+    ONBOARDING_CONTAINER = BaseLocators.object_name_contains(
+        "startupOnboardingLayout"
     )
 
-    LETS_GO_BUTTON_BY_ID = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'btnCreateWithPassword')]"
-    )
-    CREATE_PROFILE_PARTIAL = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'CreateProfilePage')]"
-    )
+    LETS_GO_BUTTON_BY_ID = BaseLocators.object_name_contains("btnCreateWithPassword")
+    CREATE_PROFILE_PARTIAL = BaseLocators.object_name_contains("CreateProfilePage")

--- a/test/e2e_appium/locators/onboarding/loading_screen_locators.py
+++ b/test/e2e_appium/locators/onboarding/loading_screen_locators.py
@@ -3,20 +3,16 @@ from ..base_locators import BaseLocators
 
 class LoadingScreenLocators(BaseLocators):
 
-    # Loading screen container
+    # Loading screen container (full ID — Android only, kept for reference)
     SPLASH_SCREEN = BaseLocators.id(
         "QGuiApplication.mainWindow.startupOnboardingLayout.ProfileCreationFlow_QMLTYPE_206.splashScreenV2"
     )
 
-    # (avoiding dynamic QMLTYPE)
-    SPLASH_SCREEN_PARTIAL = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'splashScreenV2')]"
-    )
+    # Cross-platform partial match
+    SPLASH_SCREEN_PARTIAL = BaseLocators.object_name_contains("splashScreenV2")
 
-    PROGRESS_BAR = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'StatusProgressBar')]"
-    )
+    PROGRESS_BAR = BaseLocators.object_name_contains("StatusProgressBar")
 
-    ONBOARDING_CONTAINER = BaseLocators.id(
-        "QGuiApplication.mainWindow.startupOnboardingLayout"
+    ONBOARDING_CONTAINER = BaseLocators.object_name_contains(
+        "startupOnboardingLayout"
     )

--- a/test/e2e_appium/locators/onboarding/password_screen_locators.py
+++ b/test/e2e_appium/locators/onboarding/password_screen_locators.py
@@ -3,23 +3,26 @@ from ..base_locators import BaseLocators
 
 class PasswordScreenLocators(BaseLocators):
 
-    # Screen identification - stable content-desc
-    PASSWORD_SCREEN = BaseLocators.accessibility_id("Create profile password")
+    # Screen identification
+    PASSWORD_SCREEN = BaseLocators.label_contains("Create profile password")
 
-    # TODO: Replace fallbacks with accessibility_id/tid
-    
     PASSWORD_INPUT = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'passwordViewNewPassword') and not(contains(@resource-id, 'Confirm'))]"
+        "//*[(contains(@resource-id, 'passwordViewNewPassword') "
+        "or contains(@name, 'passwordViewNewPassword')) "
+        "and not(contains(@resource-id, 'Confirm') or contains(@name, 'Confirm'))]"
     )
     PASSWORD_CONFIRM_INPUT = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'passwordViewNewPasswordConfirm')]"
+        "//*[contains(@resource-id, 'passwordViewNewPasswordConfirm') "
+        "or contains(@name, 'passwordViewNewPasswordConfirm')]"
     )
 
-    # Password creation button - tid-aware content-desc
-    CONFIRM_PASSWORD_BUTTON = BaseLocators.content_desc_contains(
-        "[tid:btnConfirmPassword]"
+    # On Android content-desc contains "[tid:btnConfirmPassword]";
+    # on iOS name contains "btnConfirmPassword".
+    CONFIRM_PASSWORD_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, '[tid:btnConfirmPassword]') "
+        "or contains(@name, 'btnConfirmPassword')]"
     )
 
-    ONBOARDING_CONTAINER = BaseLocators.id(
-        "QGuiApplication.mainWindow.startupOnboardingLayout"
+    ONBOARDING_CONTAINER = BaseLocators.object_name_contains(
+        "startupOnboardingLayout"
     )

--- a/test/e2e_appium/locators/onboarding/welcome_screen_locators.py
+++ b/test/e2e_appium/locators/onboarding/welcome_screen_locators.py
@@ -3,11 +3,14 @@ from ..base_locators import BaseLocators
 class WelcomeScreenLocators(BaseLocators):
 
     # Screen identification
-    WELCOME_PAGE = BaseLocators.content_desc_contains("Welcome to Status")
+    WELCOME_PAGE = BaseLocators.label_contains("Welcome to Status")
 
-    CREATE_PROFILE_BUTTON = BaseLocators.content_desc_contains("[tid:btnCreateProfile]")
-    LOGIN_BUTTON = BaseLocators.accessibility_id("Log in")
-
-    ONBOARDING_LAYOUT = BaseLocators.xpath(
-        "//*[contains(@resource-id, 'startupOnboardingLayout')]"
+    # On Android content-desc is "Create profile [tid:btnCreateProfile]";
+    # on iOS label is "Create profile" and name contains "btnCreateProfile".
+    CREATE_PROFILE_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, '[tid:btnCreateProfile]') "
+        "or contains(@name, 'btnCreateProfile')]"
     )
+    LOGIN_BUTTON = BaseLocators.label_exact("Log in")
+
+    ONBOARDING_LAYOUT = BaseLocators.object_name_contains("startupOnboardingLayout")

--- a/test/e2e_appium/locators/wallet/accounts_locators.py
+++ b/test/e2e_appium/locators/wallet/accounts_locators.py
@@ -2,7 +2,7 @@ from ..base_locators import BaseLocators
 
 
 class WalletAccountsLocators(BaseLocators):
-    ADD_ACCOUNT_BUTTON = BaseLocators.resource_id_contains("addAccountButton")
+    ADD_ACCOUNT_BUTTON = BaseLocators.object_name_contains("addAccountButton")
     ALL_ACCOUNTS_BUTTON = BaseLocators.xpath(
         "//*[contains(@resource-id,'allAccountsBtn')]"
     )

--- a/test/e2e_appium/pages/base_page.py
+++ b/test/e2e_appium/pages/base_page.py
@@ -19,6 +19,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from config import get_config, log_element_action
 from utils.exceptions import ElementInteractionError
 from utils.gestures import Gestures
+from utils.platform import is_ios as _is_ios_driver
 from utils.screenshot import save_screenshot, save_page_source
 from utils.app_lifecycle_manager import AppLifecycleManager
 from utils.keyboard_manager import KeyboardManager
@@ -51,6 +52,7 @@ class BasePage:
             self._screenshots_dir = "screenshots"
 
         self.wait = WebDriverWait(driver, element_wait_timeout)
+        self._is_ios = _is_ios_driver(driver)
 
         self.logger = logging.getLogger(
             self.__class__.__module__ + "." + self.__class__.__name__
@@ -253,10 +255,12 @@ class BasePage:
 
                 element.clear()
 
-                self.driver.update_settings({
-                    "sendKeyStrategy": "oneByOne",
-                    "interKeyDelay": inter_key_delay,
-                })
+                # sendKeyStrategy / interKeyDelay are UiAutomator2-only settings
+                if not self._is_ios:
+                    self.driver.update_settings({
+                        "sendKeyStrategy": "oneByOne",
+                        "interKeyDelay": inter_key_delay,
+                    })
                 actions = ActionChains(self.driver)
                 actions.send_keys(text).perform()
 
@@ -317,8 +321,9 @@ class BasePage:
 
     def _verify_input_success(self, element, expected_text: str) -> bool:
         try:
-            # Android UIAutomator2 exposes entered value via 'text'
-            actual_text = element.get_attribute("text")
+            # Android exposes entered value via 'text'; iOS uses 'value'
+            attr = "value" if self._is_ios else "text"
+            actual_text = element.get_attribute(attr)
             if actual_text is None:
                 return True
             return len(actual_text) > 0
@@ -328,8 +333,9 @@ class BasePage:
     def _clear_input_field(self, locator: tuple, timeout: int = 5) -> bool:
         """Clear text from an input field using select-all + delete.
 
-        Uses Ctrl+A to select all text, then Backspace to delete.
-        More reliable than element.clear() for Qt/QML fields.
+        Uses Ctrl+A (Android) or Cmd+A (iOS) to select all text, then
+        Backspace to delete.  More reliable than ``element.clear()`` for
+        Qt/QML fields.
 
         Args:
             locator: Element locator tuple.
@@ -347,18 +353,47 @@ class BasePage:
         try:
             element.click()
 
-            # Select all with Ctrl+A, then delete (Ctrl is correct for Android)
+            # iOS uses Command (META); Android uses Ctrl
+            modifier = Keys.META if self._is_ios else Keys.CONTROL
             actions = ActionChains(self.driver)
-            actions.key_down(Keys.CONTROL).send_keys("a").key_up(Keys.CONTROL)
+            actions.key_down(modifier).send_keys("a").key_up(modifier)
             actions.send_keys(Keys.BACKSPACE)
             actions.perform()
 
-            self.logger.debug("Cleared input field via Ctrl+A + Backspace")
+            self.logger.debug("Cleared input field via select-all + Backspace")
             return True
         except Exception as exc:
             self.logger.debug(f"Select-all clear failed: {exc}")
             return False
 
+    def _read_element_text(self, locator: tuple, timeout: int = 4) -> str | None:
+        """Read the visible text from an element, trying multiple attributes.
+
+        Android: checks ``text``, ``content-desc``, ``value``.
+        iOS:     checks ``value``, ``label``, ``name``.
+
+        Returns the first non-empty string found, or ``None`` if the
+        element is missing or has no readable text.
+        """
+        element = self.find_element_safe(locator, timeout=timeout)
+        if not element:
+            return None
+
+        attrs = ("value", "label", "name") if self._is_ios else ("text", "content-desc", "value")
+        for attr in attrs:
+            try:
+                raw = element.get_attribute(attr)
+                if not raw or raw == "null":
+                    continue
+                value = raw.strip()
+                # Strip [tid:...] suffix from Accessible.name values
+                if " [tid:" in value:
+                    value = value.split(" [tid:")[0].strip()
+                if value:
+                    return value
+            except Exception:
+                continue
+        return None
     def long_press_element(self, element, duration: int = 800) -> bool:
         """Perform long-press gesture on element to trigger context menu.
 
@@ -436,6 +471,44 @@ class BasePage:
             time.sleep(poll_interval)
         return False
 
+    def _collect_element_text(self, root_element) -> str:
+        """Collect all visible text from an element and its descendants.
+
+        Harvests both 'text' and 'content-desc' attributes, deduplicating values.
+        """
+        values: list[str] = []
+        self._append_element_text(root_element, values)
+
+        try:
+            descendants = root_element.find_elements("xpath", ".//*")
+        except Exception:
+            descendants = []
+
+        for element in descendants:
+            self._append_element_text(element, values)
+
+        return " ".join(values).strip()
+
+    def _append_element_text(self, element, target: list[str]) -> None:
+        """Append non-empty text values from element to target list.
+
+        Uses platform-appropriate attributes (Android: ``text``,
+        ``content-desc``; iOS: ``value``, ``label``).
+        """
+        attrs = ("value", "label") if self._is_ios else ("text", "content-desc")
+        for attr in attrs:
+            try:
+                raw = element.get_attribute(attr)
+                if not raw or raw == "null":
+                    continue
+                value = raw.strip()
+                # Strip [tid:...] suffix from Accessible.name values
+                if " [tid:" in value:
+                    value = value.split(" [tid:")[0].strip()
+            except Exception:
+                continue
+            if value and value not in target:
+                target.append(value)
     def _wait_between_attempts(self, base_delay: float = 0.5) -> None:
         env_name = os.getenv("CURRENT_TEST_ENVIRONMENT", "browserstack").lower()
         if env_name in ("browserstack",):

--- a/test/e2e_appium/pages/onboarding/password_page.py
+++ b/test/e2e_appium/pages/onboarding/password_page.py
@@ -36,7 +36,16 @@ class PasswordPage(BasePage):
 
         button = self.find_element_safe(self.locators.CONFIRM_PASSWORD_BUTTON, timeout=10)
         if not button:
+            # On iOS the app may auto-advance past the password screen if
+            # both fields were filled and validated before we reach this
+            # point.  Check whether we've already moved forward.
+            if not self.is_element_visible(self.IDENTITY_LOCATOR, timeout=2):
+                self.logger.info(
+                    "Password screen no longer visible — app appears to have advanced"
+                )
+                return True
             self.logger.error("Confirm password button not found")
+            self.dump_page_source("password_confirm_button_not_found")
             return False
 
         return self.gestures.element_center_tap(button)

--- a/test/e2e_appium/pytest.ini
+++ b/test/e2e_appium/pytest.ini
@@ -22,3 +22,4 @@ markers =
     single_device: Tests that only require a single device (use device_count(1) marker)
     device_count(count): Override number of devices provisioned by multi-device fixtures
     asyncio: Async test marker (managed by pytest-asyncio)
+    ios: iOS platform tests (requires iOS IPA on BrowserStack)

--- a/test/e2e_appium/tests/test_ios_poc.py
+++ b/test/e2e_appium/tests/test_ios_poc.py
@@ -1,0 +1,76 @@
+"""iOS onboarding integration test.
+
+Runs the full onboarding fixture on iOS and verifies that the wallet
+landing screen appears.  This exercises cross-platform locators, text
+input, gestures, and page navigation end-to-end.
+
+Prerequisites
+-------------
+An iOS ``.ipa`` build must be uploaded to BrowserStack.  Set
+``BROWSERSTACK_APP_ID`` to the IPA's ``bs://`` URL or ``shareable_id``.
+
+Running
+-------
+::
+
+    # Upload an iOS .ipa to BrowserStack, then:
+    export BROWSERSTACK_APP_ID="bs://<ios_ipa_hash>"
+
+    TEST_DEVICE_ID=ipad_10th_gen_ios_16 \\
+    python -m pytest tests/test_ios_poc.py::TestIOSOnboarding -v --env=browserstack -n 0 \\
+      -o "addopts=-v --tb=short --strict-markers --timeout=600 --reruns 0 --dist=loadscope"
+"""
+
+import pytest
+
+from pages.base_page import BasePage
+from utils.multi_device_helpers import StepMixin
+from utils.platform import get_platform
+
+
+@pytest.mark.ios
+@pytest.mark.smoke
+@pytest.mark.device_count(1)
+class TestIOSOnboarding(StepMixin):
+    """Run the full onboarding fixture on iOS and verify wallet landing.
+
+    This test does **not** use ``raw_devices`` — it exercises the
+    ``OnboardingFlow`` fixture end-to-end, which covers:
+
+    1. Welcome screen → Create Profile
+    2. Analytics screen → Skip
+    3. Create Profile → Let's go
+    4. Password screen → enter + confirm password
+    5. Biometrics → dismiss
+    6. Loading / splash screen → wait for completion
+    7. Wallet landing → verify ADD_ACCOUNT_BUTTON visible
+    """
+
+    async def test_ios_onboarding_flow(self):
+        """Verify onboarding completes and wallet landing is reached on iOS."""
+        base = BasePage(self.device.driver)
+
+        async with self.step(self.device, "Report platform and user info"):
+            platform = get_platform(self.device.driver)
+            user = self.device.user
+            self.logger.info(
+                "Platform: %s | User: %s | Onboarded: %s",
+                platform,
+                user.display_name if user else "N/A",
+                user is not None,
+            )
+            assert user is not None, (
+                "Onboarding fixture should have created a user"
+            )
+
+        async with self.step(self.device, "Dump wallet landing page source"):
+            base.dump_page_source("ios_onboarding_wallet_landing")
+
+        async with self.step(self.device, "Verify wallet landing screen"):
+            from locators.wallet.accounts_locators import WalletAccountsLocators
+            visible = base.is_element_visible(
+                WalletAccountsLocators.ADD_ACCOUNT_BUTTON, timeout=15
+            )
+            assert visible, (
+                "Wallet ADD_ACCOUNT_BUTTON should be visible after onboarding"
+            )

--- a/test/e2e_appium/utils/app_lifecycle_manager.py
+++ b/test/e2e_appium/utils/app_lifecycle_manager.py
@@ -11,6 +11,7 @@ import time
 from typing import Optional, Tuple
 
 from config.logging_config import get_logger
+from utils.platform import is_ios as _is_ios_driver
 
 
 class AppLifecycleManager:
@@ -25,6 +26,7 @@ class AppLifecycleManager:
     def __init__(self, driver):
         self.driver = driver
         self.logger = get_logger("app_lifecycle")
+        self._is_ios = _is_ios_driver(driver)
         self._default_package, self._default_activity = self._resolve_app_identifiers()
 
     @property
@@ -156,6 +158,10 @@ class AppLifecycleManager:
             self._activate_app(package)
             return True
         except Exception as e:
+            # start_activity is Android-only; skip on iOS
+            if self._is_ios:
+                self.logger.error("activate_app failed on iOS for %s: %s", package, e)
+                return False
             self.logger.debug(
                 "activate_app failed for %s: %s; attempting start_activity", package, e
             )
@@ -241,7 +247,12 @@ class AppLifecycleManager:
         return False
 
     def _restart_via_mobile_commands(self, app_package: str) -> bool:
-        """Restart the app using Appium mobile: terminateApp / launchApp commands."""
+        """Restart the app using Appium mobile: terminateApp / activateApp.
+
+        On Android, falls back to ``start_activity`` if ``activate_app``
+        fails.  ``start_activity`` does not exist on iOS so the fallback
+        is skipped there.
+        """
         try:
             self.logger.debug("Attempting mobile restart for %s", app_package)
             try:
@@ -259,6 +270,13 @@ class AppLifecycleManager:
                 self.logger.info("App restart completed via activate_app")
                 return True
             except Exception as activate_err:
+                if self._is_ios:
+                    self.logger.error(
+                        "activate_app failed on iOS for %s: %s",
+                        app_package,
+                        activate_err,
+                    )
+                    return False
                 self.logger.debug(
                     "activate_app failed for %s: %s; attempting start_activity",
                     app_package,
@@ -274,7 +292,7 @@ class AppLifecycleManager:
                 return False
         except Exception:
             self.logger.exception(
-                "App restart via activate_app/start_activity failed for %s",
+                "App restart failed for %s",
                 app_package,
             )
             return False
@@ -283,17 +301,21 @@ class AppLifecycleManager:
         package = override or self._default_package
         if package:
             return package
+        cap_hint = "bundleId" if self._is_ios else "appPackage"
         self.logger.error(
-            "Unable to determine app package. Ensure appPackage capability is set."
+            "Unable to determine app identifier. Ensure %s capability is set.",
+            cap_hint,
         )
         return None
 
     def _resolve_app_identifiers(self) -> Tuple[Optional[str], Optional[str]]:
-        """
-        Extract the application package and activity from driver capabilities.
+        """Extract the application package/bundleId and activity from capabilities.
+
+        On iOS the relevant identifier is ``bundleId`` (no activity concept).
+        On Android the identifiers are ``appPackage`` and ``appActivity``.
 
         Returns:
-            tuple(package, activity)
+            ``(package_or_bundle_id, activity_or_none)``
         """
         capability_sources = [
             getattr(self.driver, "capabilities", None),
@@ -306,23 +328,43 @@ class AppLifecycleManager:
         for caps in capability_sources:
             if not caps:
                 continue
-            package = caps.get("appium:appPackage") or caps.get("appPackage") or package
-            activity = (
-                caps.get("appium:appActivity") or caps.get("appActivity") or activity
-            )
-            if package and activity:
+
+            if self._is_ios:
+                # iOS: read bundleId
+                package = (
+                    caps.get("appium:bundleId")
+                    or caps.get("bundleId")
+                    or caps.get("CFBundleIdentifier")
+                    or package
+                )
+            else:
+                # Android: read appPackage / appActivity
+                package = (
+                    caps.get("appium:appPackage")
+                    or caps.get("appPackage")
+                    or package
+                )
+                activity = (
+                    caps.get("appium:appActivity")
+                    or caps.get("appActivity")
+                    or activity
+                )
+
+            if package and (self._is_ios or activity):
                 break
 
         if package:
-            self.logger.debug(f"Detected AUT package from capabilities: {package}")
+            id_type = "bundleId" if self._is_ios else "appPackage"
+            self.logger.debug("Detected AUT %s from capabilities: %s", id_type, package)
         else:
+            default = "app.status.mobile"
             self.logger.warning(
-                "AUT package not found in capabilities; falling back to legacy default"
+                "AUT identifier not found in capabilities; falling back to %s", default
             )
-            package = "app.status.mobile"
+            package = default
 
         if activity:
-            self.logger.debug(f"Detected AUT launch activity: {activity}")
+            self.logger.debug("Detected AUT launch activity: %s", activity)
 
         return package, activity
 

--- a/test/e2e_appium/utils/element_state_checker.py
+++ b/test/e2e_appium/utils/element_state_checker.py
@@ -1,8 +1,25 @@
+from utils.platform import is_ios as _is_ios_driver
 
+
+def _element_is_ios(element) -> bool:
+    """Detect whether an element belongs to an iOS session.
+
+    Appium ``WebElement`` objects expose a ``parent`` attribute that
+    references the driver, which lets us read ``platformName`` without
+    requiring callers to pass extra context.
+    """
+    driver = getattr(element, "parent", None)
+    if driver is None:
+        return False
+    return _is_ios_driver(driver)
 
 
 class ElementStateChecker:
-    """Static utility methods for element state checks."""
+    """Static utility methods for element state checks.
+
+    Methods are platform-aware: they detect iOS vs Android via the
+    element's parent driver and read the appropriate attributes.
+    """
 
     @staticmethod
     def is_enabled(element) -> bool:
@@ -21,6 +38,13 @@ class ElementStateChecker:
 
     @staticmethod
     def is_focused(element) -> bool:
+        """Check whether the element has input focus.
+
+        On iOS the ``focused`` attribute does not exist; we return
+        ``False`` as a safe default so callers can proceed.
+        """
+        if _element_is_ios(element):
+            return False
         try:
             return str(element.get_attribute("focused")).lower() == "true"
         except Exception:
@@ -35,9 +59,18 @@ class ElementStateChecker:
 
     @staticmethod
     def get_text_content(element) -> str:
+        """Return the visible text from an element.
+
+        Android: tries ``text``, ``content-desc``, ``name``.
+        iOS:     tries ``value``, ``label``, ``name``.
+        """
         try:
-            # Try different attributes in order of preference
-            for attr in ("text", "content-desc", "name"):
+            if _element_is_ios(element):
+                attrs = ("value", "label", "name")
+            else:
+                attrs = ("text", "content-desc", "name")
+
+            for attr in attrs:
                 value = element.get_attribute(attr)
                 if value and value.strip():
                     return value.strip()
@@ -47,10 +80,28 @@ class ElementStateChecker:
 
     @staticmethod
     def is_password_field(element) -> bool:
+        """Detect password input fields.
+
+        Android: checks ``resource-id`` and ``content-desc`` for
+        "password" hints.
+        iOS: checks the element ``type`` for
+        ``XCUIElementTypeSecureTextField``, and falls back to
+        ``name`` / ``label`` attribute inspection.
+        """
         try:
+            if _element_is_ios(element):
+                element_type = element.get_attribute("type") or ""
+                if "SecureTextField" in element_type:
+                    return True
+                name = element.get_attribute("name") or ""
+                label = element.get_attribute("label") or ""
+                return (
+                    "password" in name.lower()
+                    or "password" in label.lower()
+                )
+
             resource_id = element.get_attribute("resource-id") or ""
             content_desc = element.get_attribute("content-desc") or ""
-
             return (
                 "password" in resource_id.lower()
                 or content_desc.lower() == "type password"
@@ -60,8 +111,17 @@ class ElementStateChecker:
 
     @staticmethod
     def is_field_empty(element) -> bool:
+        """Return ``True`` when the element contains no visible text.
+
+        Checks platform-appropriate attributes.
+        """
         try:
-            for attr in ("text", "content-desc", "name", "hint"):
+            if _element_is_ios(element):
+                attrs = ("value", "label", "name")
+            else:
+                attrs = ("text", "content-desc", "name", "hint")
+
+            for attr in attrs:
                 val = element.get_attribute(attr)
                 if val and len(val.strip()) > 0:
                     return False

--- a/test/e2e_appium/utils/gestures.py
+++ b/test/e2e_appium/utils/gestures.py
@@ -1,29 +1,50 @@
 from config.logging_config import get_logger
+from utils.platform import is_ios
 
 
 class Gestures:
-    """Touch gesture operations for mobile UI automation."""
+    """Touch gesture operations for mobile UI automation.
+
+    All gesture methods detect the platform at runtime via
+    ``utils.platform.is_ios`` and dispatch the correct Appium
+    ``mobile:`` command for Android (UiAutomator2) or iOS (XCUITest).
+    """
 
     def __init__(self, driver, logger=None):
         self._driver = driver
         self._logger = logger or get_logger("gestures")
+        self._ios = is_ios(driver)
 
     def tap(self, x: int, y: int) -> bool:
         """Tap at screen coordinates."""
         try:
-            self._driver.execute_script("mobile: clickGesture", {"x": x, "y": y})
+            if self._ios:
+                self._driver.execute_script("mobile: tap", {"x": x, "y": y})
+            else:
+                self._driver.execute_script("mobile: clickGesture", {"x": x, "y": y})
             return True
         except Exception as e:
             self._logger.debug("tap(%d, %d) failed: %s", x, y, e)
             return False
 
     def long_press(self, element_id: str, duration_ms: int = 800) -> bool:
-        """Long press on element by ID."""
+        """Long press on element by ID.
+
+        On iOS the XCUITest ``mobile: touchAndHold`` command expects
+        *seconds* rather than milliseconds, so we convert accordingly.
+        The element key is ``element`` (not ``elementId``).
+        """
         try:
-            self._driver.execute_script(
-                "mobile: longClickGesture",
-                {"elementId": element_id, "duration": duration_ms},
-            )
+            if self._ios:
+                self._driver.execute_script(
+                    "mobile: touchAndHold",
+                    {"element": element_id, "duration": duration_ms / 1000},
+                )
+            else:
+                self._driver.execute_script(
+                    "mobile: longClickGesture",
+                    {"elementId": element_id, "duration": duration_ms},
+                )
             return True
         except Exception as e:
             self._logger.debug("long_press failed: %s", e)
@@ -33,50 +54,65 @@ class Gestures:
         self, left: int, top: int, width: int, height: int, percent: float = 0.8
     ) -> bool:
         """Swipe down within bounds."""
-        try:
-            self._driver.execute_script(
-                "mobile: swipeGesture",
-                {
-                    "left": left,
-                    "top": top,
-                    "width": width,
-                    "height": height,
-                    "direction": "down",
-                    "percent": percent,
-                },
-            )
-            return True
-        except Exception as e:
-            self._logger.debug("swipe_down failed: %s", e)
-            return False
+        return self._swipe("down", left, top, width, height, percent)
 
     def swipe_up(
         self, left: int, top: int, width: int, height: int, percent: float = 0.8
     ) -> bool:
         """Swipe up within bounds."""
+        return self._swipe("up", left, top, width, height, percent)
+
+    def _swipe(
+        self,
+        direction: str,
+        left: int,
+        top: int,
+        width: int,
+        height: int,
+        percent: float,
+    ) -> bool:
+        """Platform-aware swipe implementation.
+
+        Android uses ``mobile: swipeGesture`` with bounding-box params.
+        iOS uses ``mobile: swipe`` with a ``direction`` and optional
+        ``velocity`` (pixels-per-second).
+        """
         try:
-            self._driver.execute_script(
-                "mobile: swipeGesture",
-                {
-                    "left": left,
-                    "top": top,
-                    "width": width,
-                    "height": height,
-                    "direction": "up",
-                    "percent": percent,
-                },
-            )
+            if self._ios:
+                # iOS swipe needs a rough velocity; percent maps loosely
+                velocity = int(percent * 1500)
+                self._driver.execute_script(
+                    "mobile: swipe",
+                    {"direction": direction, "velocity": velocity},
+                )
+            else:
+                self._driver.execute_script(
+                    "mobile: swipeGesture",
+                    {
+                        "left": left,
+                        "top": top,
+                        "width": width,
+                        "height": height,
+                        "direction": direction,
+                        "percent": percent,
+                    },
+                )
             return True
         except Exception as e:
-            self._logger.debug("swipe_up failed: %s", e)
+            self._logger.debug("swipe_%s failed: %s", direction, e)
             return False
 
     def element_tap(self, element) -> bool:
         """Tap element using its element ID."""
         try:
-            self._driver.execute_script(
-                "mobile: clickGesture", {"elementId": element.id}
-            )
+            if self._ios:
+                self._driver.execute_script(
+                    "mobile: tap", {"element": element.id}
+                )
+            else:
+                self._driver.execute_script(
+                    "mobile: clickGesture", {"elementId": element.id}
+                )
             return True
         except Exception as e:
             self._logger.debug("element_tap failed: %s", e)
@@ -96,14 +132,19 @@ class Gestures:
     def double_tap(self, x: int, y: int) -> bool:
         """Double-tap at coordinates; fallback to two single taps."""
         try:
-            self._driver.execute_script(
-                "mobile: clickGesture", {"x": x, "y": y, "count": 2}
-            )
+            if self._ios:
+                self._driver.execute_script(
+                    "mobile: doubleTap", {"x": x, "y": y}
+                )
+            else:
+                self._driver.execute_script(
+                    "mobile: clickGesture", {"x": x, "y": y, "count": 2}
+                )
             return True
         except Exception:
             try:
-                self._driver.execute_script("mobile: clickGesture", {"x": x, "y": y})
-                self._driver.execute_script("mobile: clickGesture", {"x": x, "y": y})
+                self.tap(x, y)
+                self.tap(x, y)
                 return True
             except Exception as e:
                 self._logger.debug("double_tap(%d, %d) failed: %s", x, y, e)
@@ -112,18 +153,19 @@ class Gestures:
     def element_double_tap(self, element) -> bool:
         """Double-tap on element; fallback to two element taps."""
         try:
-            self._driver.execute_script(
-                "mobile: clickGesture", {"elementId": element.id, "count": 2}
-            )
+            if self._ios:
+                self._driver.execute_script(
+                    "mobile: doubleTap", {"element": element.id}
+                )
+            else:
+                self._driver.execute_script(
+                    "mobile: clickGesture", {"elementId": element.id, "count": 2}
+                )
             return True
         except Exception:
             try:
-                self._driver.execute_script(
-                    "mobile: clickGesture", {"elementId": element.id}
-                )
-                self._driver.execute_script(
-                    "mobile: clickGesture", {"elementId": element.id}
-                )
+                self.element_tap(element)
+                self.element_tap(element)
                 return True
             except Exception as e:
                 self._logger.debug("element_double_tap failed: %s", e)

--- a/test/e2e_appium/utils/platform.py
+++ b/test/e2e_appium/utils/platform.py
@@ -1,0 +1,27 @@
+"""Platform detection utilities for cross-platform test support.
+
+Provides lightweight helpers that read ``platformName`` from the Appium
+driver's capabilities at runtime so that framework code can branch on
+Android vs iOS without hard-coding assumptions.
+"""
+
+
+def get_platform(driver) -> str:
+    """Return the normalised platform name from driver capabilities.
+
+    Returns ``"android"`` or ``"ios"`` (lowercase).  Falls back to
+    ``"android"`` when the capability is missing or empty — this keeps
+    existing behaviour unchanged for tests that predate iOS support.
+    """
+    caps = getattr(driver, "capabilities", None) or {}
+    return (caps.get("platformName") or "android").lower()
+
+
+def is_ios(driver) -> bool:
+    """Return ``True`` when the driver session targets an iOS device."""
+    return get_platform(driver) == "ios"
+
+
+def is_android(driver) -> bool:
+    """Return ``True`` when the driver session targets an Android device."""
+    return get_platform(driver) in ("android", "")


### PR DESCRIPTION
Make the e2e mobile test framework platform-aware so tests can run on both Android and iOS devices via BrowserStack.

- Add platform detection utility and iOS device config entries
- Make Gestures, ElementStateChecker, BasePage, and AppLifecycleManager platform-aware for iOS attribute mapping and XCUITest commands
- Strip Android-only capabilities for iOS sessions in BrowserStack provider
- Add cross-platform locator helpers (label_contains, label_exact, object_name_contains) and migrate onboarding locators to use them
- Guard Android-only Appium settings for iOS compatibility
- Handle iOS-specific onboarding behavior (auto-advance, objectName locators)
- Add iOS onboarding integration test exercising the full fixture flow

Now working using updated helpers based on OS attributes:
|      QML Property |                       Android Attribute |                                                                       iOS Attribute |
|:------------------|:----------------------------------------|:------------------------------------------------------------------------------------|
|      `objectName` | `resource-id` (contains package prefix) | `name` (full QML object path, e.g. `QGuiApplication.mainWindow...btnCreateProfile`) |
| `Accessible.name` |                          `content-desc` |                                                                             `label` |
|      Element type |  `class` (e.g. `android.widget.Button`) |                                               `type` (e.g. `XCUIElementTypeButton`) |
|      Text content |                                  `text` |                                                                             `value` |


https://github.com/user-attachments/assets/1ba5eede-e1c6-4b8d-8fea-7e57456d1e8c

