### PR TITLE
fix(keycard): Fix flows requiring metadata sync

### DIFF
--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -298,9 +298,6 @@ method loginRequested*[T](self: Module[T], keyUid: string, loginFlow: int, dataJ
     self.view.accountLoginError(e.msg, wrongPassword = false)
 
 proc syncAppAndKeycardState[T](self: Module[T]) =
-  # don't sync on mobile devices (requires one keycard tap more)
-  if main_constants.IS_MOBILE:
-    return
   let kcEvent = self.view.getKeycardEvent()
   if kcEvent.keycardInfo.keyUID == "":
     return
@@ -322,7 +319,6 @@ proc syncAppAndKeycardState[T](self: Module[T]) =
     kcName = singletonInstance.userProfile.getName()
   if kcName.len == 0:
     kcName = "Status Keycard"
-  self.controller.storeMetadata(kcName, pathsToStore)
 
   var kcDto = KeycardDto(keycardUid: kcEvent.keycardInfo.instanceUID,
     keycardName: kcName,
@@ -330,6 +326,9 @@ proc syncAppAndKeycardState[T](self: Module[T]) =
     accountsAddresses: addressesToStore,
     keyUid: kcEvent.keycardInfo.keyUID)
   self.controller.addKeycardOrAccounts(kcDto, password = "")
+  if main_constants.IS_MOBILE:
+    return
+  self.controller.storeMetadata(kcName, pathsToStore)
 
 proc finishAppLoading2[T](self: Module[T]) =
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
@@ -271,7 +271,7 @@ proc ensureReaderAndCardPresenceAndResolveNextState*(state: State, keycardFlowTy
           controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.UseGeneralMessageForLockedState, add = true))
           return createState(StateType.MaxPukRetriesReached, state.flowType, nil)
     if keycardFlowType == ResponseTypeValueEnterPIN:
-      if keycardEvent.keyUid == controller.getKeyUidWhichIsBeingAuthenticating():
+      if keycardEvent.keyUid == controller.getKeyUidWhichIsBeingAuthenticating() or keycardEvent.keyUid.len == 0:
         if singletonInstance.userProfile.getUsingBiometricLogin():
           if keycardEvent.error.len > 0 and
             keycardEvent.error == ErrorPIN:
@@ -310,7 +310,7 @@ proc ensureReaderAndCardPresenceAndResolveNextState*(state: State, keycardFlowTy
           controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.UseGeneralMessageForLockedState, add = true))
           return createState(StateType.MaxPukRetriesReached, state.flowType, nil)
     if keycardFlowType == ResponseTypeValueEnterPIN:
-      if keycardEvent.keyUid == controller.getKeyUidWhichIsBeingSigning():
+      if keycardEvent.keyUid == controller.getKeyUidWhichIsBeingSigning() or keycardEvent.keyUid.len == 0:
         if singletonInstance.userProfile.getUsingBiometricLogin():
           if keycardEvent.error.len > 0 and
             keycardEvent.error == ErrorPIN:


### PR DESCRIPTION
### What does the PR do

Closes #20034

On mobile there's no metadata sync post login. But we were skipping the entire sync logic, including the status-go update where we notify status-go that we're using a keycard.

+ Align some flows not to require keyUID (keycard tap) before authenticating the keycard. The keycard authentication is usually the first step on mobile and it will be the first keycard tap. Before this we won't have the keycard keyUID

### Affected areas

Keycard on mobile

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality
https://github.com/user-attachments/assets/f7a8dec6-d4e8-42d3-befc-03422f5fc0ad


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

Create a keycard account
Make sure the wallet accounts are recognized as keycard accounts
Create a new account or try any other keycard action (send, swap, etc)

### Risk 

low