### PR TITLE
KeycardPopup: adjust content positioning on mobile

### DIFF
--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -96,6 +96,9 @@ StatusDialog {
         contentWidth: availableWidth
         padding: 0
 
+        // keep content visible on mobile when keyboard activated
+        onHeightChanged: scrollView.scrollEnd()
+
         KeycardPopupContent {
             id: content
             width: scrollView.availableWidth


### PR DESCRIPTION
### What does the PR do

Provides a fix to keep the scroll view at the end after invoking virtual keybaord

Closes: #19964

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`KeycardPopup`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/a68b0f96-3c45-40c5-94bb-b22b4d5e3a3f


