### PR TITLE
fix: Sign flow using garbaged strings

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -429,13 +429,10 @@ proc connectKeycardReponseSignal(self: Controller) =
     let currentFlow = self.keycardService.getCurrentFlow()
     if currentFlow != KCSFlowType.Sign:
       return
-    let keyUid = self.silentSigningKeyUid
-    let path = self.silentSigningPath
-    let pin = self.silentSigningPin
+    self.delegate.onDataSigned(self.silentSigningKeyUid, self.silentSigningPath, args.flowEvent.txSignature.r, args.flowEvent.txSignature.s, args.flowEvent.txSignature.v, self.silentSigningPin)
     self.silentSigningKeyUid = ""
     self.silentSigningPath = ""
     self.silentSigningPin = ""
-    self.delegate.onDataSigned(keyUid, path, args.flowEvent.txSignature.r, args.flowEvent.txSignature.s, args.flowEvent.txSignature.v, pin)
 
 proc cancelCurrentFlow*(self: Controller) =
   self.keycardService.cancelCurrentFlow()


### PR DESCRIPTION
### What does the PR do

closes #20036

This piece of code was getting keyUid into an undefined state. The flow was failing afterwards.

```
let keyUid = self.silentSigningKeyUid
self.silentSigningKeyUid = ""
```

### Affected areas

Join community

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/4733e720-6e1c-4c9b-82ed-799bdc52bf6a


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

User can join communities

### How to test

Login with keycard
Open community
Join community

### Risk 

0