### PR TITLE
fix: Warn users before migrating to keycard

### DIFF
--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -15155,6 +15155,10 @@ to load</source>
         <source>Other key pairs</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectKeypair</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -18455,6 +18455,11 @@
       <comment>SelectKeyPair</comment>
       <translation>Other key pairs</translation>
     </message>
+    <message>
+      <source>If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.</source>
+      <comment>SelectKeyPair</comment>
+      <translation>If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.</translation>
+    </message>
   </context>
   <context>
     <name>SelectKeypair</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -15264,6 +15264,10 @@ selhalo</translation>
         <source>Other key pairs</source>
         <translation>Ostatní páry klíčů</translation>
     </message>
+    <message>
+        <source>If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectKeypair</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -15178,6 +15178,10 @@ al cargar</translation>
         <source>Other key pairs</source>
         <translation>Otros pares de claves</translation>
     </message>
+    <message>
+        <source>If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectKeypair</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -15133,6 +15133,10 @@ to load</source>
         <source>Other key pairs</source>
         <translation>다른 키 페어</translation>
     </message>
+    <message>
+        <source>If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectKeypair</name>

--- a/ui/imports/shared/popups/keycard/states/SelectKeyPair.qml
+++ b/ui/imports/shared/popups/keycard/states/SelectKeyPair.qml
@@ -115,6 +115,25 @@ Control {
                 root.keyPairSelected()
             }
         }
+
+        Control {
+            Layout.fillWidth: true
+            Layout.topMargin: Theme.padding
+            padding: Theme.padding
+            background: Rectangle {
+                radius: Theme.radius
+                color: Theme.palette.warningColor3
+                border.width: 1
+                border.color: Theme.palette.warningColor2
+            }
+            contentItem: StatusBaseText {
+                id: noKeyPairsText
+                text: qsTr("If a paired device (like a tablet without NFC) can’t use a Keycard, unpair it before migrating your Status profile. Otherwise, Status will stop working on that device.")
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                color: Theme.palette.warningColor1
+            }
+        }
         Item {
             Layout.fillHeight: true
         }


### PR DESCRIPTION
### What does the PR do

Iterates: #19846 

Add a warning based on comment https://github.com/status-im/status-app/issues/19846#issuecomment-3843054857


### Affected areas

Keycard migration

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality


<img width="1208" height="763" alt="Screenshot 2026-02-23 at 14 27 21" src="https://github.com/user-attachments/assets/420b0432-b800-46ce-a7fc-3f27999cd4c7" />


### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

Go to settings and initiate profile migration to keycard.

### Risk 

low