### PR TITLE
fix(NewsMessagePopup): Fix header layout after `StatusDialogHeader` refactor

### DIFF
--- a/ui/imports/shared/popups/NewsMessagePopup.qml
+++ b/ui/imports/shared/popups/NewsMessagePopup.qml
@@ -23,6 +23,16 @@ StatusDialog {
     property var activityCenterNotifications
     signal linkClicked(string link)
 
+    QtObject {
+        id: d
+
+        readonly property StatusDateGroupLabel dateGroupLabel : StatusDateGroupLabel {
+            messageTimestamp: notification ? notification.timestamp : 0
+            // Hidden label to get the string
+            visible: false
+        }
+    }
+
     Component.onCompleted: {
         if (!root.notification && root.notificationId) {
             notificationModelEntryLoader.active = true
@@ -34,15 +44,8 @@ StatusDialog {
     padding: Theme.bigPadding
 
     header: StatusDialogHeader {
-        StatusDateGroupLabel {
-            id: dateGroupLabel
-            messageTimestamp: notification ? notification.timestamp : 0
-            // Hidden label to get the string
-            visible: false
-        }
-
         headline.title: notification.newsTitle
-        headline.subtitle: dateGroupLabel.text
+        headline.subtitle: d.dateGroupLabel.text
         actions.closeButton.onClicked: root.close()
         leftComponent: Item {
             width: 40


### PR DESCRIPTION
Fixes #20024

### What does the PR do

After `StatusDialogHeader` changed from _Rectangle_ to _ToolBar_, the hidden _StatusDateGroupLabel_ inside the header was interfering with its layout/implicit height, causing the header to render incorrectly.

Moving the label outside the header fixes the layout and restores the subtitle display.

### Affected areas
NewsMessagePopup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="577" height="370" alt="Screenshot 2026-02-24 at 00 16 12" src="https://github.com/user-attachments/assets/620de35b-694f-4cea-ab99-7dfbcf098b76" />

### Impact on end user

Better UX

### How to test
Open a `News` popup

### Risk 

Low
