### PR TITLE
fix: Theme is not properly propagated

### DIFF
--- a/ui/StatusQ/include/StatusQ/theme.h
+++ b/ui/StatusQ/include/StatusQ/theme.h
@@ -3,8 +3,11 @@
 #include "StatusQ/themepalette.h"
 
 #include <QJSValue>
+#include <QMetaObject>
 #include <QQmlEngine>
 #include <QQuickAttachedPropertyPropagator>
+
+class QQuickItem;
 
 class Theme : public QQuickAttachedPropertyPropagator
 {
@@ -140,6 +143,8 @@ protected:
         QQuickAttachedPropertyPropagator *oldParent) override;
 
 private:
+    void attachWindowReadySync(QQuickItem *itemParent);
+
     bool m_explicitPadding = false;
     qreal m_padding = 0.0;
 
@@ -149,6 +154,8 @@ private:
     bool m_explicitFontSizeOffset = false;
     int m_fontSizeOffset = 0;
     mutable QJSValue m_fontSizeFn;
+
+    QMetaObject::Connection m_windowChangedConnection;
 };
 
 QML_DECLARE_TYPEINFO(Theme, QML_HAS_ATTACHED_PROPERTIES)

--- a/ui/StatusQ/src/theme.cpp
+++ b/ui/StatusQ/src/theme.cpp
@@ -1,10 +1,9 @@
 #include "StatusQ/theme.h"
 
-#include <QMetaObject>
-#include <QPointer>
 #include <QQmlApplicationEngine>
 #include <QQmlEngine>
 #include <QQuickItem>
+#include <QQuickWindow>
 
 namespace {
 
@@ -341,18 +340,49 @@ void Theme::propagateFontSizeOffset()
     });
 }
 
+void Theme::attachWindowReadySync(QQuickItem *itemParent)
+{
+    if (m_windowChangedConnection) {
+        QObject::disconnect(m_windowChangedConnection);
+        m_windowChangedConnection = {};
+    }
+
+    m_windowChangedConnection = connect(itemParent, &QQuickItem::windowChanged, this,
+                                        [this](QQuickWindow *window) {
+        if (!window)
+            return;
+        //just wait for a valid window before giving up the connection                                
+        QObject::disconnect(m_windowChangedConnection);
+        m_windowChangedConnection = {};
+        attachedParentChange(attachedParent(), nullptr);
+    });
+}
+
 void Theme::attachedParentChange(QQuickAttachedPropertyPropagator* newParent,
                                  QQuickAttachedPropertyPropagator* oldParent)
 {
     Q_UNUSED(oldParent);
+
     auto attachedParentTheme = qobject_cast<Theme*>(newParent);
+    auto selfItem = qobject_cast<QQuickItem*>(parent());
+
     if (attachedParentTheme) {
-        auto itemParent = qobject_cast<QQuickItem*>(parent());
-        if (itemParent && !itemParent->window())
+        // apply style immediately to avoid a light->dark visual flash.
+        // the style is usually safe (as this is already implemented and tested by qt default themes)
+        // the geometry change seems to pose problems 
+        inheritStyle(attachedParentTheme->style());
+
+        if (selfItem && !selfItem->window()) {
+            attachWindowReadySync(selfItem);
             return;
+        }
+
+        if (m_windowChangedConnection) {
+            QObject::disconnect(m_windowChangedConnection);
+            m_windowChangedConnection = {};
+        }
 
         inheritPadding(attachedParentTheme->padding());
-        inheritStyle(attachedParentTheme->style());
         inheritFontSizeOffset(attachedParentTheme->fontSizeOffset());
     }
 }


### PR DESCRIPTION
### What does the PR do

closes #19980 #20001


We've had a filter that's skipping the items without a valid window from theme propagation because it would cause some crashes in the app. But in some cases the items can have a transient state and the window is not available when the attachedParentChange is called. For these items we'll apply the theme style and delay the paddings/size updates until the items will be attached to a window.

### Affected areas

App theme

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/435c1b62-ca1e-48c6-8da7-11f4b8ba672e

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

The main risk would be to have some crashes in the app. It looks safe so far