### PR TITLE
fix(ModuleWarning): adjust the action button height

### DIFF
--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -223,9 +223,7 @@ Item {
             Button {
                 id: button
                 objectName: "actionButton"
-                topPadding: Theme.halfPadding
-                bottomPadding: Theme.halfPadding
-                implicitHeight: 2 * contentItem.implicitHeight
+                Layout.fillHeight: true
                 visible: !!text
                 focusPolicy: Qt.NoFocus
                 onClicked: {
@@ -235,7 +233,6 @@ Item {
                     text: button.text
                     font.pixelSize: Theme.additionalTextSize
                     font.weight: Font.Medium
-                    font.family: Fonts.baseFont.family
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     color: Theme.palette.indirectColor1
@@ -244,7 +241,7 @@ Item {
                     radius: 4
                     border.width: 1
                     border.color: Theme.palette.indirectColor3
-                    color: StatusColors.getColor("white", button.hovered ? 0.4 : 0.1)
+                    color: StatusColors.alphaColor(StatusColors.white, button.hovered ? 0.4 : 0.1)
                 }
                 HoverHandler {
                     cursorShape: Qt.PointingHandCursor


### PR DESCRIPTION
### What does the PR do

Fixes #20069

### Affected areas

Banners

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Desktop:
<img width="2522" height="1846" alt="Snímek obrazovky z 2026-02-24 16-56-07" src="https://github.com/user-attachments/assets/668b3e37-b9d0-4978-90e3-b287483373e2" />

Mobile:
<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/e08dd8b0-f497-4aba-8b01-83b98d07d885" />


### Impact on end user

Easier banner button UX, esp. on mobile

### How to test

- check the banner's button dimensions/margins

### Risk 

- low
