### PR TITLE
feat(wc): support WC deep links

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2030,6 +2030,9 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   if not self.chatsLoaded:
     self.statusDeepLinkToActivate = statusDeepLink
     return
+  if statusDeepLink.contains("/wc?"):
+    self.view.wcLinkActivated(statusDeepLink)
+    return
   let urlData = self.sharedUrlsModule.parseSharedUrl(statusDeepLink)
   if urlData.notASupportedStatusLink:
     # Just open it in the browser

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -403,6 +403,8 @@ QtObject:
   proc emitOpenUrlSignal*(self: View, url: string) =
     self.openUrl(url)
 
+  proc wcLinkActivated*(self: View, url: string) {.signal.}
+
   proc loadMembersForSectionId*(self: View, communityId: string) {.slot.} =
     self.delegate.loadMembersForSectionId(communityId)
 

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -184,6 +184,10 @@ QtObject {
                 root.openUrl(url)
             }
 
+            function onWcLinkActivated(url) {
+                root.wcLinkActivated(url)
+            }
+
             function onDisplayUserProfile(publicKey: string) {
                 root.displayUserProfile(publicKey)
             }
@@ -206,6 +210,7 @@ QtObject {
 
     signal ensNameResolved(string resolvedPubKey, string resolvedAddress, string uuid)
     signal openUrl(string link)
+    signal wcLinkActivated(string link)
     signal displayUserProfile(string publicKey)
     signal showToastPairingFallbackCompleted()
     // End of Settings related stuff

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -71,6 +71,12 @@ Item {
         thirdpartyServicesEnabled: appMain.featureFlagsStore.privacyModeFeatureEnabled ?
                                    appMain.privacyStore.thirdpartyServicesEnabled: true
         onOpenUrl: (link) => Global.requestOpenLink(link)
+        onWcLinkActivated: (link) => {
+            const wcUri = Utils.walletConnectUriFromStatusLink(link)
+            if (!!wcUri) {
+                d.pairWalletConnectUri(wcUri)
+            }
+        }
         keychain: appMain.keychain
         palette: appMain.Theme.palette
     }
@@ -883,6 +889,18 @@ Item {
             return username
         }
 
+        function pairWalletConnectUri(uri: string) {
+            if (!dAppsServiceLoader.active || !dAppsServiceLoader.item || !uri) {
+                return
+            }
+            function pairingHandler() {
+                dAppsServiceLoader.item.dappsModule.pair(uri)
+                dAppsServiceLoader.item.pairingValidated.disconnect(pairingHandler)
+            }
+            dAppsServiceLoader.item.pairingValidated.connect(pairingHandler)
+            dAppsServiceLoader.item.validatePairingUri(uri)
+        }
+
         function openLinkInBrowser(link: string) {
             if (!appMain.rootStore.openLinksInStatus ||
                     !d.isBrowserEnabled ||
@@ -966,17 +984,7 @@ Item {
             }
         }
         onTransferOwnershipRequested: (tokenId, senderAddress) => popupRequestsHandler.sendModalHandler.transferOwnership(tokenId, senderAddress)
-        onWcUriScanned: uri => {
-            if (!dAppsServiceLoader.active || !dAppsServiceLoader.item) {
-                return
-            }
-            function pairingHandler() {
-                dAppsServiceLoader.item.dappsModule.pair(uri)
-                dAppsServiceLoader.item.pairingValidated.disconnect(pairingHandler)
-            }
-            dAppsServiceLoader.item.pairingValidated.connect(pairingHandler)
-            dAppsServiceLoader.item.validatePairingUri(uri)
-        }
+        onWcUriScanned: uri => d.pairWalletConnectUri(uri)
     }
 
     HandlersManager {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -1069,6 +1069,43 @@ QtObject {
         }
     }
 
+    function walletConnectUriFromStatusLink(link: string): string {
+        if (!link || !link.includes("/wc?")) {
+            return ""
+        }
+
+        const queryStart = link.indexOf("?")
+        if (queryStart < 0 || queryStart >= link.length - 1) {
+            return ""
+        }
+
+        const query = link.slice(queryStart + 1)
+        const params = query.split("&")
+        for (let i = 0; i < params.length; i++) {
+            const keyValue = params[i].split("=")
+            if (keyValue.length < 2) {
+                continue
+            }
+
+            if (keyValue[0] !== "uri") {
+                continue
+            }
+
+            const encodedUri = keyValue.slice(1).join("=")
+            if (!encodedUri) {
+                return ""
+            }
+
+            try {
+                return decodeURIComponent(encodedUri)
+            } catch (e) {
+                return encodedUri
+            }
+        }
+
+        return ""
+    }
+
     // TODO: remove when getElidedCompressedPk moved to utilsStore
     function _getCompressedPk(publicKey) {
         if (publicKey === "") {


### PR DESCRIPTION
### What does the PR do

Fixes #20086

We already supported WalletConnect Codes using the QR code scanner and the Wallet connection popup.

Now, we also support deep links by catching when they contain `/wc?`, then we parse them to get the actual code and pass them to the Dapps Module as we do for the QR scanner.

### Affected areas

- AppMain
- main module

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

The double popup is a known issue that Andrey has fixed in another PR

https://github.com/user-attachments/assets/59a632e3-d09f-474e-9bef-661502d9e9e5

### Impact on end user

Supports WC deep links, making it work with ThirdWeb, which is what Lizy uses

### How to test

1. Go to the ThirdWeb playground: https://playground.thirdweb.com/wallets/sign-in/button
2. Tap Connect a Wallet Button
3. Tap to All Wallets
4. Search for Status
5. Tap Status
6. See the status app(s)
7. Click the unified Status app (StatusPR if you downloaded it from this PR)
-> Should launch the app and show the connection popup

### Risk 

Low
