### PR TITLE
feat(NetworkChecker): port to QNetworkInformation backend

### DIFF
--- a/storybook/pages/GlobalBannerPage.qml
+++ b/storybook/pages/GlobalBannerPage.qml
@@ -2,6 +2,8 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ
+
 import Storybook
 
 import utils
@@ -17,6 +19,10 @@ SplitView {
         id: d
         property bool userDeclinedBackupBanner
         property bool testnetEnabled
+
+        readonly property var networkChecker: NetworkChecker {
+            active: ctrlUseOnlineChecker.checked
+        }
     }
 
     Item {
@@ -66,9 +72,21 @@ SplitView {
 
         RowLayout {
             Switch {
+                id: ctrlUseOnlineChecker
+                text: "Use real online checker"
+                checked: false
+            }
+
+            Switch {
                 id: ctrlIsOnline
                 text: "Online"
                 checked: true
+                enabled: !ctrlUseOnlineChecker.checked
+
+                Binding on checked {
+                    when: ctrlUseOnlineChecker.checked
+                    value: d.networkChecker.isOnline
+                }
             }
 
             Switch {

--- a/ui/StatusQ/include/StatusQ/networkchecker.h
+++ b/ui/StatusQ/include/StatusQ/networkchecker.h
@@ -1,18 +1,11 @@
 #pragma once
 
-#include <QNetworkReply>
-#include <QObject>
-#include <QQmlParserStatus>
-#include <QTimer>
+#include <QNetworkInformation>
 
-class QNetworkAccessManager;
-
-/// Checks if the internet connection is available, when active.
-/// It checks the connection every 30 seconds as long as the \c active property is \c true (by default it is)
-class NetworkChecker : public QObject, public QQmlParserStatus
+/// Automatically checks if the internet connection is available as long as the \c active property is \c true (by default it is)
+class NetworkChecker : public QObject
 {
     Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
 
     Q_PROPERTY(bool isOnline READ isOnline NOTIFY isOnlineChanged FINAL)
     Q_PROPERTY(bool active READ isActive WRITE setActive NOTIFY activeChanged FINAL)
@@ -20,30 +13,27 @@ class NetworkChecker : public QObject, public QQmlParserStatus
 
 public:
     explicit NetworkChecker(QObject *parent = nullptr);
-    bool isOnline() const;
-
-    bool isActive() const;
-    void setActive(bool active);
 
     Q_INVOKABLE void checkNetwork();
-
-protected:
-    void classBegin() override;
-    void componentComplete() override;
 
 signals:
     void isOnlineChanged(bool online);
     void activeChanged(bool active);
-    void checkingChanged();
+    void checkingChanged(bool checking);
+
+private slots:
+    void onReachabilityChanged(QNetworkInformation::Reachability reachability);
 
 private:
-    QNetworkAccessManager manager;
-    QTimer timer;
-    bool online = false;
-    bool active = true;
+    QNetworkInformation* m_netinfo;
 
-    void onFinished(QNetworkReply *reply);
-    void updateRegularCheck(bool active);
+    bool m_online{true};
+    bool isOnline() const;
+    void setOnline(bool online);
+
+    bool m_active{true};
+    bool isActive() const;
+    void setActive(bool active);
 
     bool m_checking{false};
     bool checking() const;

--- a/ui/StatusQ/src/networkchecker.cpp
+++ b/ui/StatusQ/src/networkchecker.cpp
@@ -1,75 +1,76 @@
 #include "StatusQ/networkchecker.h"
 
-namespace {
-using namespace std::chrono_literals;
-
-constexpr static auto checkInterval = 30s;
-}
+#include <QDebug>
 
 NetworkChecker::NetworkChecker(QObject *parent)
     : QObject(parent)
 {
-    manager.setTransferTimeout();
-    connect(&manager, &QNetworkAccessManager::finished, this, &NetworkChecker::onFinished);
-    connect(&timer, &QTimer::timeout, this, &NetworkChecker::checkNetwork);
+    qInfo() << "!!! QNetworkInformation backends:" << QNetworkInformation::availableBackends();
+
+    if (!QNetworkInformation::loadDefaultBackend()) {
+        qWarning() << "QNetworkInformation is not supported on this platform or backend.";
+        return;
+    }
+
+    m_netinfo = QNetworkInformation::instance();
+    qInfo() << "!!! Using QNetworkInformation backend:" << m_netinfo->backendName();
+
+    // subscribe for updates
+    connect(m_netinfo, &QNetworkInformation::reachabilityChanged, this, &NetworkChecker::onReachabilityChanged);
+
+    // initial update
+    onReachabilityChanged(m_netinfo->reachability());
+
+    connect(this, &NetworkChecker::isOnlineChanged, this, [](bool online) {
+        qInfo() << "!!! ONLINE CHANGED:" << online;
+    });
+}
+
+void NetworkChecker::onReachabilityChanged(QNetworkInformation::Reachability reachability)
+{
+    qInfo() << "!!! REACHABILITY CHANGED:" << reachability;
+    if (m_active) {
+        setOnline(reachability == QNetworkInformation::Reachability::Online);
+    }
 }
 
 bool NetworkChecker::isOnline() const
 {
-    return online;
+    return m_online;
+}
+
+void NetworkChecker::setOnline(bool online)
+{
+    if (m_online == online)
+        return;
+    m_online = online;
+    emit isOnlineChanged(m_online);
 }
 
 void NetworkChecker::checkNetwork()
 {
-    QNetworkRequest request(QUrl(QStringLiteral("http://fedoraproject.org/static/hotspot.txt")));
-    manager.get(request);
     setChecking(true);
-}
-
-void NetworkChecker::classBegin()
-{
-    // empty on purpose
-}
-
-void NetworkChecker::componentComplete() {
-    updateRegularCheck(active);
-}
-
-void NetworkChecker::onFinished(QNetworkReply *reply)
-{
-    setChecking(false);
-    const auto wasOnline = online;
-    online = (reply->error() == QNetworkReply::NoError);
-    reply->deleteLater();
-
-    if (wasOnline != online) {
-        emit isOnlineChanged(online);
-    }
+    setActive(true);
 }
 
 bool NetworkChecker::isActive() const
 {
-    return active;
+    return m_active;
 }
 
 void NetworkChecker::setActive(bool active)
 {
-    if (active == this->active)
+    setChecking(false);
+
+    if (active == m_active)
         return;
 
-    this->active = active;
+    m_active = active;
     emit activeChanged(active);
 
-    updateRegularCheck(active);
-}
-
-void NetworkChecker::updateRegularCheck(bool active)
-{
-    if (active) {
-        checkNetwork();
-        timer.start(checkInterval);
-    } else {
-        timer.stop();
+    // check immediately, when re-activating, or when called from checkNetwork()
+    if (m_active) {
+        setOnline(m_netinfo && m_netinfo->reachability() == QNetworkInformation::Reachability::Online);
     }
 }
 
@@ -84,5 +85,5 @@ void NetworkChecker::setChecking(bool checking)
         return;
 
     m_checking = checking;
-    emit checkingChanged();
+    emit checkingChanged(m_checking);
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -853,7 +853,15 @@ Item {
         id: d
 
         // strict online/offline checker, doesn't care about the wallet services
-        readonly property var networkChecker: NetworkChecker {}
+        readonly property var networkChecker: NetworkChecker {
+            active: {
+                if (!appMain.rootStore.thirdpartyServicesEnabled) // the connectivity checks might leak our IP
+                    return false
+                if (SQUtils.Utils.isMobile) // on mobile, suspend the checks when in background
+                    return appMain.Window.window.active
+                return true
+            }
+        }
 
         readonly property int activeSectionType: appMain.rootStore.activeSectionType
         readonly property bool isWalletRelatedSectionType: activeSectionType === Constants.appSection.wallet ||
@@ -1285,7 +1293,7 @@ Item {
             GlobalBanner {
                 Layout.fillWidth: true
 
-                isOnline: appMain.rootStore.isOnline
+                isOnline: d.networkChecker.isOnline
                 testnetEnabled: appMain.networksStore.areTestNetworksEnabled
                 seedphraseBackedUp: appMain.privacyStore.mnemonicBackedUp || appMain.profileStore.userDeclinedBackupBanner
 


### PR DESCRIPTION
### What does the PR do

- no need to set a timer and do periodical checks
- no delay when reporting state changes (online/offline)
- native backends for all the supported OSs (Linux, Windows, Android, mac/iOS)
- the Global offline banner now properly suppresses all the other banners
- make the net checker active on mobile only when in foreground

Fixes #20091

### Affected areas

NetworkChecker, Banners

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Offline (flight mode on), no other banners shown:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/dda69f7b-2e42-4a3b-9dd7-c0fdef9d1691" />

Back online:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/493e411d-ceae-4d15-b1ce-48eab1227687" />

Desktop:
<img width="2522" height="1846" alt="Snímek obrazovky z 2026-02-25 00-43-01" src="https://github.com/user-attachments/assets/39fce7ff-dbd2-4f38-926f-1f8418ce483d" />

Storybook simulation:
<img width="3007" height="1686" alt="image" src="https://github.com/user-attachments/assets/8b742b2b-786d-440a-9226-491ee224c52b" />

### Impact on end user

More precise online/offline checks, more accurate banner reporting

### How to test

- switch the airplane mode on/off
- watch the banners react

### Risk 

- low
