### PR TITLE
fix(windows): big buttons in format menu

### DIFF
--- a/ui/imports/shared/status/StatusTextFormatMenu.qml
+++ b/ui/imports/shared/status/StatusTextFormatMenu.qml
@@ -9,6 +9,10 @@ Menu {
     id: root
 
     padding: 4
+    topInset: 0
+    bottomInset: 0
+    leftInset: 0
+    rightInset: 0
 
     background: Rectangle {
        color: Theme.palette.statusMenu.backgroundColor


### PR DESCRIPTION
### What does the PR do

Fixes #20052

> The issue was that Qt's Menu component adds default insets on Windows that are larger than on other platforms. By explicitly setting topInset, bottomInset, leftInset, and rightInset to 0, the menu will now have consistent sizing across all platforms, using only your specified padding: 4.

### Affected areas

StatusTextFormatMenu

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="393" height="197" alt="image" src="https://github.com/user-attachments/assets/b792cbf4-715d-4cfb-81aa-29d7f35803aa" />


### Impact on end user

Fixes the issue

### How to test

Be on windows and select text in the input

### Risk 

Low
