### PR TITLE
feat(NavigationEducationDialog): Show navigation education popup on first login and / or first time when navbar collapses

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -150,18 +150,7 @@ Item {
 
     required property bool systemTrayIconAvailable
 
-
     readonly property bool isPortraitMode: appMain.width < ThemeUtils.portraitBreakpoint.width
-
-    // Indicates whether the user has already seen the education popup
-    // for the new navigation menu.
-    readonly property bool newMenuEducationPopupSeenSetting: appMainLocalSettings.newMenuEducationPopupSeen
-
-    // Marks the navigation education popup as seen (or unseen).
-    // Persists the value in local settings.
-    function setNewMenuEducationPopupSeenSetting(value) {
-        appMainLocalSettings.newMenuEducationPopupSeen = value
-    }
 
     function showEnableBiometricsFlow() {
         popupRequestsHandler.enableBiometricsPopupHandler.openPopup()
@@ -920,6 +909,12 @@ Item {
             changeAppSectionBySectionId(Constants.appSection.browser)
             Qt.callLater(() => browserLayoutContainer.item.openUrlInNewTab(link))
         }
+
+        function tryOpenNavigationEducationPopup() {
+            if(!appMainLocalSettings.newMenuEducationPopupSeen && !sidebar.alwaysVisible) {
+                Global.openNavigationEducationPopupRequested()
+            }
+        }
     }
 
     Settings {
@@ -949,6 +944,10 @@ Item {
             ThemeUtils.setTheme(appMain.Window.window, appMainLocalSettings.theme)
             ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
             ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
+
+            // Show the navigation education dialog the first time the app
+            // is opened after the new menu is introduce, if the nav bar is in collapsed mode
+            d.tryOpenNavigationEducationPopup()
         }
     }
 
@@ -993,6 +992,7 @@ Item {
         }
         onTransferOwnershipRequested: (tokenId, senderAddress) => popupRequestsHandler.sendModalHandler.transferOwnership(tokenId, senderAddress)
         onWcUriScanned: uri => d.pairWalletConnectUri(uri)
+        onNavigationEducationDialogSeenRequested: appMainLocalSettings.newMenuEducationPopupSeen = true
     }
 
     HandlersManager {
@@ -2306,6 +2306,14 @@ Item {
                         Global.openQRScannerRequested()
                     } else {
                         changeAppSectionBySectionId(sectionId)
+                    }
+                }
+
+                onAlwaysVisibleChanged: {
+                    if(!alwaysVisible) {
+                        // Show the navigation education dialog, the first time the new collapsed menu bar
+                        // is shown after it's been introduced
+                        d.tryOpenNavigationEducationPopup()
                     }
                 }
             }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -25,6 +25,7 @@ import AppLayouts.Wallet.popups
 import AppLayouts.Communities.stores
 import AppLayouts.Profile.helpers
 import AppLayouts.Wallet.services.dapps
+import mainui.popups
 
 import AppLayouts.Wallet.stores as WalletStores
 import AppLayouts.Chat.stores as ChatStores
@@ -77,6 +78,7 @@ QtObject {
     signal ownershipDeclined(string communityId, string communityName)
     signal transferOwnershipRequested(string tokenId, string senderAddress)
     signal wcUriScanned(string uri)
+    signal navigationEducationDialogSeenRequested()
 
     property var activePopupComponents: []
 
@@ -150,6 +152,7 @@ QtObject {
         Global.openQRScannerRequested.connect(() => openPopup(qrCodeScannerDialogComponent))
         Global.openInfoPopup.connect(openInfoPopup)
         Global.shareProfileDialogRequested.connect(openShareProfilePopup)
+        Global.openNavigationEducationPopupRequested.connect(openNavigationEducationPopup)
     }
 
     property var currentPopup
@@ -479,6 +482,10 @@ QtObject {
 
         openPopup(shareProfileCmp, {isCurrentUser: contactDetails.isCurrentUser, publicKey, emojiHash, colorId: contactDetails.colorId,
                       linkToProfile, displayName: contactDetails.displayName, usesDefaultName: contactDetails.usesDefaultName, largeImage: contactDetails.largeImage})
+    }
+
+    function openNavigationEducationPopup() {
+        openPopup(openNavigationEducationComponent)
     }
 
     readonly property list<Component> _components: [
@@ -1503,6 +1510,15 @@ QtObject {
             ShareProfileDialog {
                 destroyOnClose: true
                 qrCode: root.profileStore.getQrCodeSource(linkToProfile)
+            }
+        },
+
+        Component {
+            id: openNavigationEducationComponent
+            NavigationEducationDialog {
+
+                destroyOnClose: true
+                onClosed: root.navigationEducationDialogSeenRequested()
             }
         }
     ]

--- a/ui/app/mainui/popups/NavigationEducationDialog.qml
+++ b/ui/app/mainui/popups/NavigationEducationDialog.qml
@@ -7,7 +7,7 @@ import shared.panels
 
 StatusDialog {
     width: 600
-    title: qsTr("Open app menu")
+    title: qsTr("To open app menu")
     implicitHeight: 420 + 2 * Theme.padding
     contentItem: SVGImage {
         height: parent.height

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -12078,7 +12078,7 @@ to load</source>
 <context>
     <name>NavigationEducationDialog</name>
     <message>
-        <source>Open app menu</source>
+        <source>To open app menu</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -14707,9 +14707,9 @@
   <context>
     <name>NavigationEducationDialog</name>
     <message>
-      <source>Open app menu</source>
+      <source>To open app menu</source>
       <comment>NavigationEducationDialog</comment>
-      <translation>Open app menu</translation>
+      <translation>To open app menu</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -12175,7 +12175,7 @@ selhalo</translation>
 <context>
     <name>NavigationEducationDialog</name>
     <message>
-        <source>Open app menu</source>
+        <source>To open app menu</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -12099,8 +12099,8 @@ al cargar</translation>
 <context>
     <name>NavigationEducationDialog</name>
     <message>
-        <source>Open app menu</source>
-        <translation>Abrir menú</translation>
+        <source>To open app menu</source>
+        <translation>Para abrir el menú de la app</translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -12064,7 +12064,7 @@ to load</source>
 <context>
     <name>NavigationEducationDialog</name>
     <message>
-        <source>Open app menu</source>
+        <source>To open app menu</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -78,6 +78,7 @@ QtObject {
     signal openEditSharedAddressesFlow(string communityId)
 
     signal shareProfileDialogRequested(string publicKey)
+    signal openNavigationEducationPopupRequested()
 
     signal playSendMessageSound()
     signal playNotificationSound()

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -8,7 +8,6 @@ import shared.popups
 import shared.stores
 
 import mainui
-import mainui.popups
 import AppLayouts.stores as AppStores
 import AppLayouts.Profile.stores
 
@@ -561,8 +560,6 @@ Window {
     Component {
         id: app
         AppMain {
-            id:appItem
-
             objectName: "appMain"
 
             utilsStore: applicationWindow.utilsStore
@@ -577,18 +574,6 @@ Window {
             keychain: appKeychain
             Component.onCompleted: {
                 applicationWindow.contentLoaded()
-
-                // Show the navigation education dialog the first time the app
-                // is opened after the new menu is introduced
-                if(!appItem.newMenuEducationPopupSeenSetting) {
-                    showNavigationEducation.open()
-                }
-            }
-
-            NavigationEducationDialog {
-                id: showNavigationEducation
-                destroyOnClose: true
-                onClosed: appItem.setNewMenuEducationPopupSeenSetting(true)
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

The Navigation Education popup is now shown on first login when the app starts in a collapsed navbar mode.

Additionally, if the app is already running and the window is resized causing the navbar to collapse, the education popup will be displayed at that moment.

This ensures users are properly introduced to the new navigation behavior both on initial login and on layout changes that affect navbar state.

### Affected areas

New Navigation Education popup

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/87345474-eceb-44ff-b10c-58021c8c4e45

https://github.com/user-attachments/assets/e4564c0b-7339-4778-b668-17477d7b3595

### Impact on end user

Better UX

### How to test

1. First time running the version (setting already not set), after login, if in nav bar collapsed mode (portrait), ensure the popup appears. And ensure that after this, it doesn't show up again

2. First time running the version (setting already not set), resize the app forcing the nav bar is collapsed (portrait), ensure the popup appears. And ensure that after this, it doesn't show up again

### Risk 

Low
