### PR TITLE
fix(Banners): suspend updating when offline

### DIFF
--- a/storybook/pages/ConnectionWarningsPage.qml
+++ b/storybook/pages/ConnectionWarningsPage.qml
@@ -117,20 +117,22 @@ SplitView {
                 Label { text: "Connection state:" }
                 ComboBox {
                     id: ctrlConnectionState
-                    enabled: ctrlIsOnline.checked
                     textRole: "text"
                     valueRole: "value"
                     model: [
                         { value: Constants.ConnectionStatus.Success, text: "Success" },
                         { value: Constants.ConnectionStatus.Failure, text: "Failure" },
-                        { value: Constants.ConnectionStatus.Retrying, text: "Retrying" }
+                        { value: Constants.ConnectionStatus.Retrying, text: "Retrying" },
+                        { value: Constants.ConnectionStatus.Unknown, text: "Unknown" }
                     ]
-                    currentIndex: Constants.ConnectionStatus.Retrying
+                    currentIndex: Constants.ConnectionStatus.Unknown
                     onActivated: {
                         const isSuccess = currentValue === Constants.ConnectionStatus.Success
-                        banner.completelyDown = isSuccess ? false : Math.round(Math.random())
-                        banner.withCache = isSuccess ? false : Math.round(Math.random())
-                        banner.updateBanner()
+                        const completelyDown = isSuccess ? false : Math.round(Math.random())
+                        const chainIdsDown = isSuccess ? [] : [1, 10, 8453]
+                        // SIMULATE THE CHANGE WITH EMITTING THE BACKEND SIGNAL; IGNORED WHEN OFFLINE
+                        banner.networkConnectionStore.networkConnectionModuleInst.networkConnectionStatusUpdate(ctrlWebsiteDown.currentValue, completelyDown, ctrlConnectionState.currentValue,
+                                                                                                                chainIdsDown, new Date()/1000)
                     }
                 }
             }
@@ -139,7 +141,6 @@ SplitView {
                 Label { text: "Website down:" }
                 ComboBox {
                     id: ctrlWebsiteDown
-                    enabled: ctrlIsOnline.checked
                     model: [Constants.walletConnections.collectibles, Constants.walletConnections.blockchains, Constants.walletConnections.market]
                 }
             }

--- a/ui/StatusQ/src/networkchecker.cpp
+++ b/ui/StatusQ/src/networkchecker.cpp
@@ -28,7 +28,6 @@ NetworkChecker::NetworkChecker(QObject *parent)
 
 void NetworkChecker::onReachabilityChanged(QNetworkInformation::Reachability reachability)
 {
-    qInfo() << "!!! REACHABILITY CHANGED:" << reachability;
     if (m_active) {
         setOnline(reachability == QNetworkInformation::Reachability::Online);
     }

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -27,7 +27,10 @@ Loader {
     onRelevantForCurrentSectionChanged: updateBanner(false)
 
     required property bool isOnline // strict online/offline check, doesn't care about the wallet services
-    onIsOnlineChanged: updateBanner()
+    onIsOnlineChanged: {
+        connectionState = Constants.ConnectionStatus.Unknown // reset the state; wait for real status change from backend
+        updateBanner()
+    }
 
     function updateBanner(showOnlineBanners = true) {
         // if offline or irrelevant, hide the item
@@ -73,6 +76,7 @@ Loader {
     }
 
     Connections {
+        enabled: root.isOnline // suspend the updates while offline; https://github.com/status-im/status-app/issues/20124
         target: root.networkConnectionStore.networkConnectionModuleInst
         function onNetworkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAtUnix: double) {
             if (website === websiteDown) {


### PR DESCRIPTION
### What does the PR do

- do not process the service status changes when offline; we are hidden anyway and it would only result in those error banners resurfacing when coming back online

Fixes #20124

### Affected areas

AppMain/Wallet banners

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

TBD

### Impact on end user

Less annoying banner UX

### How to test

- flight mode
- watch the red banners after coming back online

### Risk 

- low
