### PR TITLE
fix(wc): freezes when connecting to dapp

### DIFF
--- a/src/app/modules/shared_modules/connector/controller.nim
+++ b/src/app/modules/shared_modules/connector/controller.nim
@@ -1,5 +1,5 @@
 import nimqml
-import json, strutils
+import json, strutils, tables
 import chronicles, json_serialization
 import app/core/eventemitter
 
@@ -24,6 +24,9 @@ QtObject:
     Controller* = ref object of QObject
       service: connector_service.Service
       events: EventEmitter
+      wcRequestCounter: uint64
+      latestGetActiveSessionsRequestId: string
+      pendingDisconnectUrls: Table[string, string]
 
   proc delete*(self: Controller)
   proc emitConnectRequested*(self: Controller, requestId: string, payload: string)
@@ -37,12 +40,14 @@ QtObject:
   proc wcSessionProposal*(self: Controller, requestId: string, uri: string, proposal: string)
   proc wcSessionRequest*(self: Controller, topic: string, requestId: string, requestJson: string)
   proc wcSessionDelete*(self: Controller, topic: string, dappUrl: string)
+  proc setupWcEvents*(self: Controller)
 
   proc newController*(service: connector_service.Service, events: EventEmitter): Controller =
     new(result, delete)
 
     result.events = events
     result.service = service
+    result.pendingDisconnectUrls = initTable[string, string]()
 
     let controller = result  # Capture result in a local variable
 
@@ -138,26 +143,7 @@ QtObject:
       except Exception as ex:
         error "error processing SIGNAL_CONNECTOR_ACCOUNT_CHANGED", error=ex.msg, exceptionName=ex.name
 
-    result.events.on(connector_service.SIGNAL_WC_SESSION_PROPOSAL) do(e: Args):
-      try:
-        let params = WCSessionProposalSignal(e)
-        controller.wcSessionProposal(params.requestId, params.uri, params.proposal)
-      except Exception as ex:
-        error "error processing SIGNAL_WC_SESSION_PROPOSAL", error=ex.msg, exceptionName=ex.name
-
-    result.events.on(connector_service.SIGNAL_WC_SESSION_REQUEST) do(e: Args):
-      try:
-        let params = WCSessionRequestSignal(e)
-        controller.wcSessionRequest(params.topic, $params.requestId, params.requestJson)
-      except Exception as ex:
-        error "error processing SIGNAL_WC_SESSION_REQUEST", error=ex.msg, exceptionName=ex.name
-
-    result.events.on(connector_service.SIGNAL_WC_SESSION_DELETE) do(e: Args):
-      try:
-        let params = WCSessionDeleteSignal(e)
-        controller.wcSessionDelete(params.topic, params.dappUrl)
-      except Exception as ex:
-        error "error processing SIGNAL_WC_SESSION_DELETE", error=ex.msg, exceptionName=ex.name
+    controller.setupWcEvents()
 
     result.QObject.setup
 
@@ -180,7 +166,15 @@ QtObject:
   proc wcSessionProposal*(self: Controller, requestId: string, uri: string, proposal: string) {.signal.}
   proc wcSessionRequest*(self: Controller, topic: string, requestId: string, requestJson: string) {.signal.}
   proc wcSessionDelete*(self: Controller, topic: string, dappUrl: string) {.signal.}
+  proc wcPairWalletConnectDone*(self: Controller, success: bool, error: string) {.signal.}
+  proc wcApproveSessionDone*(self: Controller, proposalId: string, sessionJson: string, error: string) {.signal.}
+  proc wcRejectSessionDone*(self: Controller, proposalId: string, error: string) {.signal.}
+  proc wcSessionRequestAnswerDone*(self: Controller, topic: string, requestId: string, accept: bool, error: string) {.signal.}
+  proc wcEmitSessionEventDone*(self: Controller, topic: string, name: string, error: string) {.signal.}
+  proc wcGetActiveSessionsDone*(self: Controller, sessionsJson: string, error: string) {.signal.}
+  proc wcDisconnectSessionDone*(self: Controller, topic: string, dappUrl: string, error: string) {.signal.}
 
+  include controller_wc_events
   proc emitConnectRequested*(self: Controller, requestId: string, payload: string) =
     self.connectRequested(requestId, payload)
 
@@ -240,31 +234,43 @@ QtObject:
   proc disconnect*(self: Controller, dAppUrl: string, clientId: string = ""): bool {.slot.} =
     result = self.service.recallDAppPermission(dAppUrl, clientId)
 
-  # WalletConnect (via connector)
-  proc pairWalletConnect*(self: Controller, uri: string): bool {.slot.} =
-    return self.service.pairWalletConnect(uri)
+  proc nextWcRequestId(self: Controller, prefix: string): string =
+    self.wcRequestCounter += 1
+    return prefix & "-" & $self.wcRequestCounter
 
-  proc approveWCSession*(self: Controller, proposalId: string, accountAddr: string, dappUrl: string, dappName: string, dappIcon: string, supportedChainsJson: string): string {.slot.} =
-    let chains = Json.decode(supportedChainsJson, seq[uint64])
-    return self.service.approveWCSession(proposalId, accountAddr, dappUrl, dappName, dappIcon, chains)
+  proc pairWalletConnect*(self: Controller, uri: string) {.slot.} =
+    let requestId = self.nextWcRequestId("pair")
+    self.service.pairWalletConnectAsync(requestId, uri)
 
-  proc rejectWCSession*(self: Controller, proposalId: string): bool {.slot.} =
-    return self.service.rejectWCSession(proposalId)
+  proc approveWCSession*(self: Controller, proposalId: string, accountAddr: string, dappUrl: string, dappName: string, dappIcon: string, supportedChainsJson: string) {.slot.} =
+    let requestId = self.nextWcRequestId("approve-session")
+    self.service.approveWCSessionAsync(requestId, proposalId, accountAddr, dappUrl, dappName, dappIcon, supportedChainsJson)
 
-  proc approveWCSessionRequest*(self: Controller, topic: string, requestId: string, signature: string): bool {.slot.} =
-    return self.service.approveWCSessionRequest(topic, requestId, signature)
+  proc rejectWCSession*(self: Controller, proposalId: string) {.slot.} =
+    let requestId = self.nextWcRequestId("reject-session")
+    self.service.rejectWCSessionAsync(requestId, proposalId)
 
-  proc rejectWCSessionRequest*(self: Controller, topic: string, requestId: string): bool {.slot.} =
-    return self.service.rejectWCSessionRequest(topic, requestId)
+  proc approveWCSessionRequest*(self: Controller, topic: string, requestId: string, signature: string) {.slot.} =
+    let internalRequestId = self.nextWcRequestId("approve-request")
+    self.service.approveWCSessionRequestAsync(internalRequestId, topic, requestId, signature)
 
-  proc disconnectWCSession*(self: Controller, topic: string): bool {.slot.} =
-    return self.service.disconnectWCSession(topic)
+  proc rejectWCSessionRequest*(self: Controller, topic: string, requestId: string) {.slot.} =
+    let internalRequestId = self.nextWcRequestId("reject-request")
+    self.service.rejectWCSessionRequestAsync(internalRequestId, topic, requestId)
 
-  proc getWCActiveSessions*(self: Controller, validAtTimestamp: int): string {.slot.} =
-    return self.service.getWCActiveSessions(int64(validAtTimestamp))
+  proc disconnectWCSession*(self: Controller, topic: string, dappUrl: string) {.slot.} =
+    let requestId = self.nextWcRequestId("disconnect")
+    self.pendingDisconnectUrls[requestId] = dappUrl
+    self.service.disconnectWCSessionAsync(requestId, topic)
 
-  proc emitWCSessionEvent*(self: Controller, topic: string, name: string, dataJson: string, chainId: string): bool {.slot.} =
-    return self.service.emitWCSessionEvent(topic, name, dataJson, chainId)
+  proc getWCActiveSessions*(self: Controller, validAtTimestamp: int) {.slot.} =
+    let requestId = self.nextWcRequestId("get-sessions")
+    self.latestGetActiveSessionsRequestId = requestId
+    self.service.getWCActiveSessionsAsync(requestId, int64(validAtTimestamp))
+
+  proc emitWCSessionEvent*(self: Controller, topic: string, name: string, dataJson: string, chainId: string) {.slot.} =
+    let requestId = self.nextWcRequestId("emit-event")
+    self.service.emitWCSessionEventAsync(requestId, topic, name, dataJson, chainId)
 
   proc getDApps*(self: Controller): string {.slot.} =
     return self.service.getDApps()

--- a/src/app/modules/shared_modules/connector/controller_wc_events.nim
+++ b/src/app/modules/shared_modules/connector/controller_wc_events.nim
@@ -1,0 +1,107 @@
+proc setupWcEvents*(self: Controller) =
+  self.events.on(connector_service.SIGNAL_WC_SESSION_PROPOSAL) do(e: Args):
+    try:
+      let params = WCSessionProposalSignal(e)
+      self.wcSessionProposal(params.requestId, params.uri, params.proposal)
+    except Exception as ex:
+      error "error processing SIGNAL_WC_SESSION_PROPOSAL", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_SESSION_REQUEST) do(e: Args):
+    try:
+      let params = WCSessionRequestSignal(e)
+      self.wcSessionRequest(params.topic, $params.requestId, params.requestJson)
+    except Exception as ex:
+      error "error processing SIGNAL_WC_SESSION_REQUEST", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_SESSION_DELETE) do(e: Args):
+    try:
+      let params = WCSessionDeleteSignal(e)
+      self.wcSessionDelete(params.topic, params.dappUrl)
+    except Exception as ex:
+      error "error processing SIGNAL_WC_SESSION_DELETE", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_PAIR_RESULT) do(e: Args):
+    try:
+      let params = connector_service.WCAsyncResultArgs(e)
+      let payload = params.payload.parseJson
+      self.wcPairWalletConnectDone(
+        payload{"ok"}.getBool(false),
+        payload{"error"}.getStr("")
+      )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_PAIR_RESULT", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_APPROVE_SESSION_RESULT) do(e: Args):
+    try:
+      let payload = connector_service.WCAsyncResultArgs(e).payload.parseJson
+      self.wcApproveSessionDone(
+        payload{"proposalId"}.getStr(""),
+        payload{"sessionJson"}.getStr(""),
+        payload{"error"}.getStr("")
+      )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_APPROVE_SESSION_RESULT", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_REJECT_SESSION_RESULT) do(e: Args):
+    try:
+      let payload = connector_service.WCAsyncResultArgs(e).payload.parseJson
+      self.wcRejectSessionDone(
+        payload{"proposalId"}.getStr(""),
+        payload{"error"}.getStr("")
+      )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_REJECT_SESSION_RESULT", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT) do(e: Args):
+    try:
+      let params = connector_service.WCAsyncResultArgs(e)
+      let payload = params.payload.parseJson
+      let sessionRequestId = payload{"sessionRequestId"}.getStr("")
+      self.wcSessionRequestAnswerDone(
+        payload{"topic"}.getStr(""),
+        sessionRequestId,
+        payload{"accept"}.getBool(false),
+        payload{"error"}.getStr("")
+      )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_EMIT_EVENT_RESULT) do(e: Args):
+    try:
+      let payload = connector_service.WCAsyncResultArgs(e).payload.parseJson
+      self.wcEmitSessionEventDone(
+        payload{"topic"}.getStr(""),
+        payload{"name"}.getStr(""),
+        payload{"error"}.getStr("")
+      )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_EMIT_EVENT_RESULT", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_GET_ACTIVE_SESSIONS_RESULT) do(e: Args):
+    try:
+      let params = connector_service.WCAsyncResultArgs(e)
+      let payload = params.payload.parseJson
+      if params.requestId == self.latestGetActiveSessionsRequestId:
+        self.wcGetActiveSessionsDone(
+          payload{"sessionsJson"}.getStr("[]"),
+          payload{"error"}.getStr("")
+        )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_GET_ACTIVE_SESSIONS_RESULT", error=ex.msg, exceptionName=ex.name
+
+  self.events.on(connector_service.SIGNAL_WC_DISCONNECT_SESSION_RESULT) do(e: Args):
+    try:
+      let params = connector_service.WCAsyncResultArgs(e)
+      let requestId = params.requestId
+      defer: self.pendingDisconnectUrls.del(requestId)
+      let payload = params.payload.parseJson
+      let topic = payload{"topic"}.getStr("")
+      let errorText = payload{"error"}.getStr("")
+      let dappUrl = self.pendingDisconnectUrls.getOrDefault(requestId, "")
+      self.wcDisconnectSessionDone(
+        topic,
+        dappUrl,
+        errorText
+      )
+    except Exception as ex:
+      error "error processing SIGNAL_WC_DISCONNECT_SESSION_RESULT", error=ex.msg, exceptionName=ex.name

--- a/src/app_service/service/connector/async_tasks.nim
+++ b/src/app_service/service/connector/async_tasks.nim
@@ -1,9 +1,5 @@
 import json, json_serialization, chronicles
 import backend/connector as status_go
-import app/core/tasks/qt
-
-logScope:
-  topics = "connector-async-tasks"
 
 type
   ConnectorCallRPCTaskArg* = ref object of QObjectTaskArg
@@ -27,4 +23,5 @@ proc connectorCallRPCTask*(argEncoded: string) {.gcsafe, nimcall.} =
       "requestId": arg.requestId,
       "error": e.msg
     })
+include async_tasks_wc
 

--- a/src/app_service/service/connector/async_tasks_wc.nim
+++ b/src/app_service/service/connector/async_tasks_wc.nim
@@ -1,0 +1,212 @@
+import json, json_serialization
+import chronicles
+import backend/connector as status_go
+
+const
+  WC_REJECT_SESSION_REQUEST_CODE = 5000
+  WC_REJECT_SESSION_REQUEST_MESSAGE = "User rejected"
+
+type
+  PairWalletConnectTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    uri*: string
+  ApproveWCSessionTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    proposalId*: string
+    account*: string
+    dappUrl*: string
+    dappName*: string
+    dappIcon*: string
+    supportedChainsJson*: string
+  RejectWCSessionTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    proposalId*: string
+  ApproveWCSessionRequestTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    topic*: string
+    sessionRequestId*: string
+    signature*: string
+  RejectWCSessionRequestTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    topic*: string
+    sessionRequestId*: string
+  EmitWCSessionEventTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    topic*: string
+    name*: string
+    dataJson*: string
+    chainId*: string
+  GetWCActiveSessionsTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    validAtTimestamp*: int64
+  DisconnectWCSessionTaskArg* = ref object of QObjectTaskArg
+    requestId*: string
+    topic*: string
+
+proc pairWalletConnectTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[PairWalletConnectTaskArg](argEncoded)
+  try:
+    let rpcResponse = status_go.pairWalletConnectRpc(arg.uri)
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "ok": rpcResponse.error.isNil,
+      "error": if rpcResponse.error.isNil: "" else: rpcResponse.error.message
+    })
+  except Exception as e:
+    error "pairWalletConnectTask failed", error=e.msg
+    arg.finish(%* {"requestId": arg.requestId, "ok": false, "error": e.msg})
+
+proc approveWCSessionTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[ApproveWCSessionTaskArg](argEncoded)
+  try:
+    let supportedChains = Json.decode(arg.supportedChainsJson, seq[uint64])
+    let rpcResponse = status_go.approveWCSessionRpc(
+      arg.proposalId,
+      arg.account,
+      arg.dappUrl,
+      arg.dappName,
+      arg.dappIcon,
+      supportedChains
+    )
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "proposalId": arg.proposalId,
+      "sessionJson": if rpcResponse.error.isNil: rpcResponse.result.getStr("") else: "",
+      "ok": rpcResponse.error.isNil,
+      "error": if rpcResponse.error.isNil: "" else: rpcResponse.error.message
+    })
+  except Exception as e:
+    error "approveWCSessionTask failed", error=e.msg
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "proposalId": arg.proposalId,
+      "sessionJson": "",
+      "ok": false,
+      "error": e.msg
+    })
+
+proc rejectWCSessionTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[RejectWCSessionTaskArg](argEncoded)
+  try:
+    let ok = status_go.rejectWCSessionRpc(arg.proposalId)
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "proposalId": arg.proposalId,
+      "ok": ok,
+      "error": if ok: "" else: "Failed to reject session"
+    })
+  except Exception as e:
+    error "rejectWCSessionTask failed", error=e.msg
+    arg.finish(%* {"requestId": arg.requestId, "proposalId": arg.proposalId, "ok": false, "error": e.msg})
+
+proc approveWCSessionRequestTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[ApproveWCSessionRequestTaskArg](argEncoded)
+  try:
+    let ok = status_go.approveWCSessionRequestRpc(arg.topic, arg.sessionRequestId, arg.signature)
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "sessionRequestId": arg.sessionRequestId,
+      "accept": true,
+      "ok": ok,
+      "error": if ok: "" else: "Failed to send signature"
+    })
+  except Exception as e:
+    error "approveWCSessionRequestTask failed", error=e.msg
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "sessionRequestId": arg.sessionRequestId,
+      "accept": true,
+      "ok": false,
+      "error": e.msg
+    })
+
+proc rejectWCSessionRequestTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[RejectWCSessionRequestTaskArg](argEncoded)
+  try:
+    let ok = status_go.rejectWCSessionRequestRpc(
+      arg.topic,
+      arg.sessionRequestId,
+      WC_REJECT_SESSION_REQUEST_CODE,
+      WC_REJECT_SESSION_REQUEST_MESSAGE
+    )
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "sessionRequestId": arg.sessionRequestId,
+      "accept": false,
+      "ok": ok,
+      "error": if ok: "" else: "Failed to reject"
+    })
+  except Exception as e:
+    error "rejectWCSessionRequestTask failed", error=e.msg
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "sessionRequestId": arg.sessionRequestId,
+      "accept": false,
+      "ok": false,
+      "error": e.msg
+    })
+
+proc emitWCSessionEventTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[EmitWCSessionEventTaskArg](argEncoded)
+  try:
+    let ok = status_go.emitWCSessionEventRpc(arg.topic, arg.name, arg.dataJson, arg.chainId)
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "name": arg.name,
+      "ok": ok,
+      "error": if ok: "" else: "Failed to emit session event"
+    })
+  except Exception as e:
+    error "emitWCSessionEventTask failed", error=e.msg
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "name": arg.name,
+      "ok": false,
+      "error": e.msg
+    })
+
+proc getWCActiveSessionsTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[GetWCActiveSessionsTaskArg](argEncoded)
+  try:
+    let rpcResponse = status_go.getWCActiveSessionsRpc(arg.validAtTimestamp)
+    let sessionsJson = if rpcResponse.error.isNil:
+      let jsonArray = $rpcResponse.result
+      if jsonArray != "null": jsonArray else: "[]"
+    else:
+      "[]"
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "validAtTimestamp": arg.validAtTimestamp,
+      "sessionsJson": sessionsJson,
+      "ok": rpcResponse.error.isNil,
+      "error": if rpcResponse.error.isNil: "" else: rpcResponse.error.message
+    })
+  except Exception as e:
+    error "getWCActiveSessionsTask failed", error=e.msg
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "validAtTimestamp": arg.validAtTimestamp,
+      "sessionsJson": "[]",
+      "ok": false,
+      "error": e.msg
+    })
+
+proc disconnectWCSessionTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[DisconnectWCSessionTaskArg](argEncoded)
+  try:
+    let ok = status_go.disconnectWCSessionRpc(arg.topic)
+    arg.finish(%* {
+      "requestId": arg.requestId,
+      "topic": arg.topic,
+      "ok": ok,
+      "error": if ok: "" else: "Failed to disconnect session"
+    })
+  except Exception as e:
+    error "disconnectWCSessionTask failed", error=e.msg
+    arg.finish(%* {"requestId": arg.requestId, "topic": arg.topic, "ok": false, "error": e.msg})

--- a/src/app_service/service/connector/service.nim
+++ b/src/app_service/service/connector/service.nim
@@ -26,6 +26,13 @@ const SIGNAL_CONNECTOR_ACCOUNT_CHANGED* = "ConnectorAccountChanged"
 const SIGNAL_WC_SESSION_PROPOSAL* = "WCSessionProposal"
 const SIGNAL_WC_SESSION_REQUEST* = "WCSessionRequest"
 const SIGNAL_WC_SESSION_DELETE* = "WCSessionDelete"
+const SIGNAL_WC_PAIR_RESULT* = "WCPairResult"
+const SIGNAL_WC_APPROVE_SESSION_RESULT* = "WCApproveSessionResult"
+const SIGNAL_WC_REJECT_SESSION_RESULT* = "WCRejectSessionResult"
+const SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT* = "WCSessionRequestAnswerResult"
+const SIGNAL_WC_EMIT_EVENT_RESULT* = "WCEmitEventResult"
+const SIGNAL_WC_GET_ACTIVE_SESSIONS_RESULT* = "WCGetActiveSessionsResult"
+const SIGNAL_WC_DISCONNECT_SESSION_RESULT* = "WCDisconnectSessionResult"
 
 # Enum with events
 type Event* = enum
@@ -33,6 +40,10 @@ type Event* = enum
 
 type ConnectorCallRPCResultArgs* = ref object of Args
   requestId*: int
+  payload*: string
+
+type WCAsyncResultArgs* = ref object of Args
+  requestId*: string
   payload*: string
 
 # Event handler function
@@ -298,6 +309,183 @@ QtObject:
     except Exception as e:
       error "connectorCallRPC: starting async background task failed", requestId=requestId, error=e.msg
 
+  proc emitWCAsyncResult*(self: Service, signalName: string, responseObj: JsonNode) =
+    var data = WCAsyncResultArgs()
+    data.requestId = responseObj{"requestId"}.getStr("")
+    data.payload = $responseObj
+    self.events.emit(signalName, data)
+
+  proc onPairWalletConnectResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_PAIR_RESULT, response.parseJson)
+    except Exception as e:
+      error "onPairWalletConnectResolved failed", error=e.msg
+
+  proc onApproveWCSessionResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_APPROVE_SESSION_RESULT, response.parseJson)
+    except Exception as e:
+      error "onApproveWCSessionResolved failed", error=e.msg
+
+  proc onRejectWCSessionResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_REJECT_SESSION_RESULT, response.parseJson)
+    except Exception as e:
+      error "onRejectWCSessionResolved failed", error=e.msg
+
+  proc onApproveWCSessionRequestResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT, response.parseJson)
+    except Exception as e:
+      error "onApproveWCSessionRequestResolved failed", error=e.msg
+
+  proc onRejectWCSessionRequestResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT, response.parseJson)
+    except Exception as e:
+      error "onRejectWCSessionRequestResolved failed", error=e.msg
+
+  proc onEmitWCSessionEventResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_EMIT_EVENT_RESULT, response.parseJson)
+    except Exception as e:
+      error "onEmitWCSessionEventResolved failed", error=e.msg
+
+  proc onGetWCActiveSessionsResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_GET_ACTIVE_SESSIONS_RESULT, response.parseJson)
+    except Exception as e:
+      error "onGetWCActiveSessionsResolved failed", error=e.msg
+
+  proc onDisconnectWCSessionResolved*(self: Service, response: string) {.slot.} =
+    try:
+      self.emitWCAsyncResult(SIGNAL_WC_DISCONNECT_SESSION_RESULT, response.parseJson)
+    except Exception as e:
+      error "onDisconnectWCSessionResolved failed", error=e.msg
+
+  proc pairWalletConnectAsync*(self: Service, requestId: string, uri: string) =
+    try:
+      let arg = PairWalletConnectTaskArg(
+        tptr: pairWalletConnectTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onPairWalletConnectResolved",
+        requestId: requestId,
+        uri: uri
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "pairWalletConnectAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_PAIR_RESULT, %* {"requestId": requestId, "ok": false, "error": e.msg})
+
+  proc disconnectWCSessionAsync*(self: Service, requestId: string, topic: string) =
+    try:
+      let arg = DisconnectWCSessionTaskArg(
+        tptr: disconnectWCSessionTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onDisconnectWCSessionResolved",
+        requestId: requestId,
+        topic: topic
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "disconnectWCSessionAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_DISCONNECT_SESSION_RESULT, %* {"requestId": requestId, "topic": topic, "ok": false, "error": e.msg})
+
+  proc getWCActiveSessionsAsync*(self: Service, requestId: string, validAtTimestamp: int64) =
+    try:
+      let arg = GetWCActiveSessionsTaskArg(
+        tptr: getWCActiveSessionsTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onGetWCActiveSessionsResolved",
+        requestId: requestId,
+        validAtTimestamp: validAtTimestamp
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "getWCActiveSessionsAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_GET_ACTIVE_SESSIONS_RESULT, %* {"requestId": requestId, "validAtTimestamp": validAtTimestamp, "sessionsJson": "[]", "ok": false, "error": e.msg})
+
+  proc approveWCSessionRequestAsync*(self: Service, requestId: string, topic, sessionRequestId, signature: string) =
+    try:
+      let arg = ApproveWCSessionRequestTaskArg(
+        tptr: approveWCSessionRequestTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onApproveWCSessionRequestResolved",
+        requestId: requestId,
+        topic: topic,
+        sessionRequestId: sessionRequestId,
+        signature: signature
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "approveWCSessionRequestAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT, %* {"requestId": requestId, "topic": topic, "sessionRequestId": sessionRequestId, "accept": true, "ok": false, "error": e.msg})
+
+  proc rejectWCSessionRequestAsync*(self: Service, requestId: string, topic, sessionRequestId: string) =
+    try:
+      let arg = RejectWCSessionRequestTaskArg(
+        tptr: rejectWCSessionRequestTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onRejectWCSessionRequestResolved",
+        requestId: requestId,
+        topic: topic,
+        sessionRequestId: sessionRequestId
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "rejectWCSessionRequestAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_SESSION_REQUEST_ANSWER_RESULT, %* {"requestId": requestId, "topic": topic, "sessionRequestId": sessionRequestId, "accept": false, "ok": false, "error": e.msg})
+
+  proc approveWCSessionAsync*(self: Service, requestId: string, proposalId, account: string, dappUrl, dappName, dappIcon: string, supportedChainsJson: string) =
+    try:
+      let arg = ApproveWCSessionTaskArg(
+        tptr: approveWCSessionTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onApproveWCSessionResolved",
+        requestId: requestId,
+        proposalId: proposalId,
+        account: account,
+        dappUrl: dappUrl,
+        dappName: dappName,
+        dappIcon: dappIcon,
+        supportedChainsJson: supportedChainsJson
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "approveWCSessionAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_APPROVE_SESSION_RESULT, %* {"requestId": requestId, "proposalId": proposalId, "sessionJson": "", "ok": false, "error": e.msg})
+
+  proc rejectWCSessionAsync*(self: Service, requestId: string, proposalId: string) =
+    try:
+      let arg = RejectWCSessionTaskArg(
+        tptr: rejectWCSessionTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onRejectWCSessionResolved",
+        requestId: requestId,
+        proposalId: proposalId
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "rejectWCSessionAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_REJECT_SESSION_RESULT, %* {"requestId": requestId, "proposalId": proposalId, "ok": false, "error": e.msg})
+
+  proc emitWCSessionEventAsync*(self: Service, requestId: string, topic, name, dataJson, chainId: string) =
+    try:
+      let arg = EmitWCSessionEventTaskArg(
+        tptr: emitWCSessionEventTask,
+        vptr: cast[uint](self.vptr),
+        slot: "onEmitWCSessionEventResolved",
+        requestId: requestId,
+        topic: topic,
+        name: name,
+        dataJson: dataJson,
+        chainId: chainId
+      )
+      self.threadpool.start(arg)
+    except Exception as e:
+      error "emitWCSessionEventAsync failed to enqueue", requestId=requestId, error=e.msg
+      self.emitWCAsyncResult(SIGNAL_WC_EMIT_EVENT_RESULT, %* {"requestId": requestId, "topic": topic, "name": name, "ok": false, "error": e.msg})
+
   proc changeAccount*(self: Service, url: string, clientId: string, newAccount: string): bool =
     try:
       var args = ChangeAccountArgs(
@@ -310,71 +498,6 @@ QtObject:
 
     except Exception as e:
       error "changeAccount failed", error=e.msg
-      return false
-
-  # WalletConnect (via connector)
-  proc pairWalletConnect*(self: Service, uri: string): bool =
-    try:
-      let response = status_go.pairWalletConnectRpc(uri)
-      return response.error.isNil
-    except Exception as e:
-      error "pairWalletConnect failed", error=e.msg
-      return false
-
-  proc disconnectWCSession*(self: Service, topic: string): bool =
-    try:
-      return status_go.disconnectWCSessionRpc(topic)
-    except Exception as e:
-      error "disconnectWCSession failed", error=e.msg
-      return false
-
-  proc getWCActiveSessions*(self: Service, validAtTimestamp: int64): string =
-    try:
-      let response = status_go.getWCActiveSessionsRpc(validAtTimestamp)
-      if not response.error.isNil:
-        return "[]"
-      let jsonArray = $response.result
-      return if jsonArray != "null": jsonArray else: "[]"
-    except Exception as e:
-      error "getWCActiveSessions failed", error=e.msg
-      return "[]"
-
-  proc approveWCSessionRequest*(self: Service, topic, requestId, signature: string): bool =
-    try:
-      return status_go.approveWCSessionRequestRpc(topic, requestId, signature)
-    except Exception as e:
-      error "approveWCSessionRequest failed", error=e.msg
-      return false
-
-  proc rejectWCSessionRequest*(self: Service, topic, requestId: string, code: int = 5000, message: string = "User rejected"): bool =
-    try:
-      return status_go.rejectWCSessionRequestRpc(topic, requestId, code, message)
-    except Exception as e:
-      error "rejectWCSessionRequest failed", error=e.msg
-      return false
-
-  proc approveWCSession*(self: Service, proposalId, account: string, dappUrl, dappName, dappIcon: string, supportedChains: seq[uint64]): string =
-    try:
-      let response = status_go.approveWCSessionRpc(proposalId, account, dappUrl, dappName, dappIcon, supportedChains)
-      if not response.error.isNil:
-        return ""
-      return response.result.getStr("")
-    except Exception as e:
-      error "approveWCSession failed", error=e.msg
-      return ""
-
-  proc rejectWCSession*(self: Service, proposalId: string): bool =
-    try:
-      return status_go.rejectWCSessionRpc(proposalId)
-    except Exception as e:
-      error "rejectWCSession failed", error=e.msg
-      return false
-
-  proc emitWCSessionEvent*(self: Service, topic, name, dataJson, chainId: string): bool =
-    try:
-      return status_go.emitWCSessionEventRpc(topic, name, dataJson, chainId)
-    except Exception as e:
-      error "emitWCSessionEvent failed", error=e.msg
       return false
 
   proc delete*(self: Service) =

--- a/ui/app/AppLayouts/Wallet/services/dapps/ConnectorWCSDK.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/ConnectorWCSDK.qml
@@ -25,6 +25,7 @@ WalletConnectSDKBase {
     QtObject {
         id: d
         readonly property var sessionRequests: new Map()
+        property var pendingGetActiveSessionsCallback: null
 
         function buildSessionFromWCSession(wcSession) {
             try {
@@ -69,6 +70,23 @@ WalletConnectSDKBase {
                 topic: url
             }
         }
+
+        function parseSessionsJson(sessionsJson) {
+            const activeSessions = {}
+            try {
+                const sessions = JSON.parse(sessionsJson || "[]")
+                for (let i = 0; i < sessions.length; i++) {
+                    const s = sessions[i]
+                    const session = d.buildSessionFromWCSession(s.sessionJson || s)
+                    if (session && session.topic) {
+                        activeSessions[session.topic] = session
+                    }
+                }
+            } catch (e) {
+                console.error("Failed to parse WC sessions", e)
+            }
+            return activeSessions
+        }
     }
 
     Connections {
@@ -109,6 +127,63 @@ WalletConnectSDKBase {
                 }
             }
         }
+
+        function onWcPairWalletConnectDone(success, error) {
+            root.pairResponse(success, success ? "" : (error || "Pair failed"))
+        }
+
+        function onWcGetActiveSessionsDone(sessionsJson, error) {
+            const callback = d.pendingGetActiveSessionsCallback
+            d.pendingGetActiveSessionsCallback = null
+            if (!callback) {
+                return
+            }
+
+            if (error) {
+                callback({})
+                return
+            }
+            callback(d.parseSessionsJson(sessionsJson))
+        }
+
+        function onWcApproveSessionDone(proposalId, sessionJson, error) {
+            d.sessionRequests.delete(proposalId)
+            if (error || !sessionJson) {
+                root.approveSessionResult(proposalId, {}, error || "Approval failed")
+                return
+            }
+
+            try {
+                const session = JSON.parse(sessionJson)
+                root.approveSessionResult(proposalId, session, "")
+            } catch (e) {
+                console.error("Failed to parse approve session result", e)
+                root.approveSessionResult(proposalId, {}, "Approval failed")
+            }
+        }
+
+        function onWcRejectSessionDone(proposalId, error) {
+            d.sessionRequests.delete(proposalId)
+            root.rejectSessionResult(proposalId, error || "")
+        }
+
+        function onWcSessionRequestAnswerDone(topic, requestId, accept, error) {
+            const reqId = String(requestId)
+            if (d.sessionRequests.has(reqId)) {
+                d.sessionRequests.delete(reqId)
+            }
+            root.sessionRequestUserAnswerResult(topic, requestId, accept, error || "")
+        }
+
+        function onWcEmitSessionEventDone(topic, name, error) {
+            if (error) {
+                console.warn("[WC QML] emit session event failed", topic, name, error)
+            }
+        }
+
+        function onWcDisconnectSessionDone(topic, dappUrl, error) {
+            root.disconnected(dappUrl, error || "")
+        }
     }
 
     pair: function(uri) {
@@ -117,8 +192,7 @@ WalletConnectSDKBase {
             root.pairResponse(false, "Connector not available")
             return
         }
-        const success = connectorController.pairWalletConnect(uri)
-        root.pairResponse(success, success ? "" : "Pair failed")
+        connectorController.pairWalletConnect(uri)
     }
 
     getActiveSessions: function(callback) {
@@ -126,22 +200,13 @@ WalletConnectSDKBase {
             callback({})
             return
         }
-        const validAt = Math.floor(Date.now() / 1000)
-        const sessionsJson = connectorController.getWCActiveSessions(validAt)
-        let activeSessions = {}
-        try {
-            const sessions = JSON.parse(sessionsJson || "[]")
-            for (let i = 0; i < sessions.length; i++) {
-                const s = sessions[i]
-                const session = d.buildSessionFromWCSession(s.sessionJson || s)
-                if (session && session.topic) {
-                    activeSessions[session.topic] = session
-                }
-            }
-        } catch (e) {
-            console.error("Failed to parse WC sessions", e)
+        const previousCallback = d.pendingGetActiveSessionsCallback
+        if (previousCallback) {
+            previousCallback({})
         }
-        callback(activeSessions)
+        const validAt = Math.floor(Date.now() / 1000)
+        d.pendingGetActiveSessionsCallback = callback
+        connectorController.getWCActiveSessions(validAt)
     }
 
     disconnect: function(url, clientId) {
@@ -153,12 +218,15 @@ WalletConnectSDKBase {
 
     disconnectByTopic: function(topic, url) {
         if (connectorController) {
-            const success = connectorController.disconnectWCSession(topic)
-            root.disconnected(url, success ? "" : "Failed to disconnect")
+            connectorController.disconnectWCSession(topic, url)
         }
     }
 
     approveSession: function(requestId, account, selectedChains) {
+        if (!connectorController) {
+            console.error("[WC QML] ConnectorWCSDK: connectorController not available")
+            return
+        }
         const pending = d.sessionRequests.get(requestId)
         if (!pending) {
             console.error("Session request not found for approval", requestId)
@@ -166,29 +234,17 @@ WalletConnectSDKBase {
         }
         const meta = pending.proposal?.params?.proposer?.metadata || {}
         const chains = (selectedChains && selectedChains.length > 0) ? selectedChains : [1]
-        const sessionJson = connectorController.approveWCSession(
+        connectorController.approveWCSession(
             requestId, account,
             meta.url || "", meta.name || "", (meta.icons && meta.icons[0]) || "", JSON.stringify(chains))
-        if (sessionJson) {
-            try {
-                const session = JSON.parse(sessionJson)
-                root.approveSessionResult(requestId, session, "")
-            } catch (e) {
-                console.error("Failed to parse approve session result", e)
-                root.approveSessionResult(requestId, {}, "Approval failed")
-            }
-        } else {
-            root.approveSessionResult(requestId, {}, "Approval failed")
-        }
-        d.sessionRequests.delete(requestId)
     }
 
     rejectSession: function(requestId) {
-        if (connectorController) {
-            connectorController.rejectWCSession(requestId)
+        if (!connectorController) {
+            root.rejectSessionResult(requestId, "Connector not available")
+            return
         }
-        d.sessionRequests.delete(requestId)
-        root.rejectSessionResult(requestId, "")
+        connectorController.rejectWCSession(requestId)
     }
 
     acceptSessionRequest: function(topic, id, signature) {
@@ -196,9 +252,8 @@ WalletConnectSDKBase {
             root.sessionRequestUserAnswerResult(topic, id, false, "Connector not available")
             return
         }
-        const ok = connectorController.approveWCSessionRequest(topic, (typeof id === "string" ? id : String(id)), signature)
-        root.sessionRequestUserAnswerResult(topic, id, ok, ok ? "" : "Failed to send signature")
-        d.sessionRequests.delete(String(id))
+        const reqId = (typeof id === "string" ? id : String(id))
+        connectorController.approveWCSessionRequest(topic, reqId, signature)
     }
 
     rejectSessionRequest: function(topic, id, error) {
@@ -206,9 +261,8 @@ WalletConnectSDKBase {
             root.sessionRequestUserAnswerResult(topic, id, false, "Connector not available")
             return
         }
-        const ok = connectorController.rejectWCSessionRequest(topic, (typeof id === "string" ? id : String(id)))
-        root.sessionRequestUserAnswerResult(topic, id, false, ok ? (error || "") : "Failed to reject")
-        d.sessionRequests.delete(String(id))
+        const reqId = (typeof id === "string" ? id : String(id))
+        connectorController.rejectWCSessionRequest(topic, reqId)
     }
 
     getPairings: function(callback) { callback([]) }


### PR DESCRIPTION
fixes #20110 
fixes #20107 

WalletConnect RPC calls were blocking the main thread.

- WC API now uses threadpool async tasks
- Controller slots are now `void` (fire-and-forget); results come back via Qt signals
- QML updated to handle results in `Connections` handlers instead of synchronous return values

In future, we would need a proper UI for pending WC connections and errors