### PR TITLE
StatusChatInput: italics fixed (regression of #19812)

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -679,7 +679,7 @@ Rectangle {
                     icon.name: "italic"
                     checked: {
                         const text = d.getSelectedTextWithFormationChars(messageInputField)
-                        return (surroundedBy(text, "*") && !surroundedBy(text, "**")) || surroundedBy(text, "***")
+                        return (d.surroundedBy(text, "*") && !d.surroundedBy(text, "**")) || d.surroundedBy(text, "***")
                     }
                     shortcut: StandardKey.Italic
                 }


### PR DESCRIPTION
### What does the PR do

Fixes regression - method `surroundedBy` were refrenced incorrectly.

### Affected areas
`StatusChatInput`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)