### PR TITLE
fix: set correct proxy stage for iOS release

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -89,6 +89,8 @@ pipeline {
     FLAG_BUY_ENABLED = "${utils.isReleaseBuild() ? 0 : 1}"
     FLAG_SWAP_ENABLED = "${utils.isReleaseBuild() ? 0 : 1}"
     FLAG_BRIDGE_ENABLED = "${utils.isReleaseBuild() ? 0 : 1}"
+    /* fix for proxy stage defaulting to test */
+    STATUS_BUILD_PROXY_STAGE_NAME = "${utils.isReleaseBuild() ? 'prod' : 'test'}"
   }
 
   stages {


### PR DESCRIPTION
Other wise market data is empty due to mismatch in stage and credentials

