### PR TITLE
StatusGifPoup: close sub-popup on close to prevent crash

### DIFF
--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -91,9 +91,8 @@ StatusDropdown {
         root.currentCategory = GifPopupDefinitions.Category.Trending
         root.previousCategory = GifPopupDefinitions.Category.Trending
 
-        if (confirmationPopupLoader.active) {
-            confirmationPopupLoader.active = false
-        }
+        if (confirmationPopupLoader.item)
+            confirmationPopupLoader.item.close()
     }
 
     padding: 0


### PR DESCRIPTION
### What does the PR do

Instead directly destroying popup, closing it via close() to prevent crash in bottom sheet mode on gif popup close. The most probable the reason of the crash was the fact that in bottom-sheet mode the top-level popup is reparented, which means ConfirmationPopup's overlay cleanup runs against an already-modified overlay stack.

Closes: #20197


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusGifPopup`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

[Screencast from 16.03.2026 11:00:27.webm](https://github.com/user-attachments/assets/61a4ec29-52c3-447a-9e18-112bf35f4609)
