### PR TITLE
chore(ci): add fdroid builds to release job

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -169,6 +169,12 @@ pipeline {
             }
           }
         }
+        stage('Fdroid/arm64') {
+          steps { script {
+            fdroid_arm64 = getArtifacts(
+              'Fdroid/arm64', jenkins.Build('status-app/systems/fdroid/arm64/package')
+            )
+        } } }
         stage('Linux/x86_64 nwaku') { steps { script {
           linux_x86_64_nwaku = getArtifacts(
             'Linux/nwaku', build(


### PR DESCRIPTION
### Summary

Adds `fdroid` builds to release job.

Tested by configuring nightly to point to this branch : https://ci.status.im/blue/organizations/jenkins/status-app%2Fnightly/detail/nightly/1224/pipeline