### PR TITLE
fix: crash on quick app restart on Android

### DIFF
--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -55,6 +55,10 @@ public:
     // Debug helper (used from QML to verify signal handlers fire on device)
     Q_INVOKABLE void debugLog(const QString& message) const;
 
+    // Start mobile shake detection
+    // emits shakeDetected signal when shake is detected
+    Q_INVOKABLE void startShakeDetection();
+
 signals:
     // Emitted when event of type QEvent::Quit is detected by event filter on
     // QGuiApplication. It's helpful to handle close requests on mac coming from

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -96,47 +96,11 @@ SystemUtilsInternal::SystemUtilsInternal(QObject *parent)
         }
     });
     keyboardTimer->start();
-
-    // Set up Android shake detection and event-driven native callback
-    QJniObject activity = QNativeInterface::QAndroidApplication::context();
-    if (activity.isValid()) {
-        QJniObject::callStaticMethod<void>(
-            "app/status/mobile/ShakeDetector",
-            "start",
-            "(Landroid/app/Activity;)V",
-            activity.object<jobject>()
-        );
-    }
-
-    static std::once_flag regOnce;
-    std::call_once(regOnce, []{
-        QJniEnvironment env;
-        jclass clazz = env->FindClass("app/status/mobile/ShakeDetector");
-        if (!clazz) return;
-
-        const JNINativeMethod methods[] = {
-            { const_cast<char*>("nativeShakeDetected"),
-              const_cast<char*>("()V"),
-              reinterpret_cast<void*>(jni_nativeShakeDetected) },
-        };
-
-        jint rc = env->RegisterNatives(clazz, methods, jint(std::size(methods)));
-        env->DeleteLocalRef(clazz);
-
-        if (rc != 0) {
-            qWarning() << "[Android Shake] RegisterNatives failed:" << rc;
-        }
-    });
 #endif
 
 #ifdef Q_OS_IOS
     // Set up iOS keyboard tracking
     ::setupIOSKeyboardTracking();
-
-    ::setIOSShakeCallback(&iosShakeDetected);
-    ::setIOSShakeToEditEnabled(false);
-    // Set up iOS shake detection
-    ::setupIOSShakeDetection();
     
     // Poll iOS keyboard state and emit property change signals
     m_iosKeyboardPollTimer = new QTimer(this);
@@ -481,6 +445,48 @@ void SystemUtilsInternal::sharePaths(const QStringList& filePaths) const
 void SystemUtilsInternal::debugLog(const QString& message) const
 {
     qInfo() << "[QML]" << message;
+}
+
+void SystemUtilsInternal::startShakeDetection()
+{
+#ifdef Q_OS_ANDROID
+    static std::once_flag regOnce;
+    std::call_once(regOnce, []{
+        // Set up Android shake detection and event-driven native callback
+        QJniObject activity = QNativeInterface::QAndroidApplication::context();
+        if (activity.isValid()) {
+            QJniObject::callStaticMethod<void>(
+                "app/status/mobile/ShakeDetector",
+                "start",
+                "(Landroid/app/Activity;)V",
+                activity.object<jobject>()
+            );
+        }
+        QJniEnvironment env;
+        jclass clazz = env->FindClass("app/status/mobile/ShakeDetector");
+        if (!clazz) return;
+
+        const JNINativeMethod methods[] = {
+            { const_cast<char*>("nativeShakeDetected"),
+              const_cast<char*>("()V"),
+              reinterpret_cast<void*>(jni_nativeShakeDetected) },
+        };
+
+        jint rc = env->RegisterNatives(clazz, methods, jint(std::size(methods)));
+        env->DeleteLocalRef(clazz);
+
+        if (rc != 0) {
+            qWarning() << "[Android Shake] RegisterNatives failed:" << rc;
+        }
+    });
+#endif
+
+#ifdef Q_OS_IOS
+    ::setIOSShakeCallback(&iosShakeDetected);
+    ::setIOSShakeToEditEnabled(false);
+    // Set up iOS shake detection
+    ::setupIOSShakeDetection();
+#endif
 }
 
 #include "systemutilsinternal.moc"

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -319,6 +319,12 @@ Window {
             }
             d.lastShakeShareMs = nowMs
         }
+
+        Component.onCompleted: {
+            if (SQUtils.Utils.isMobile) {
+                SystemUtils.startShakeDetection()
+            }
+        }
     }
 
     Connections {


### PR DESCRIPTION
### What does the PR do

I have a blocking issue for dev workflows where the app would crash when restarting it.

When restarting the app on Android it will sometimes fail with unresolved link error on `ShakeDetector` due to the android lifecycle. The C++ constructor will sometimes run before the `ShakeDetector` is exported.

This fix will update how the shake detector starts. It will be started on demand. The section is now instrumented by qml since qml is the consumer.

### Affected areas

Shake detector

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/0eee2c69-293c-474c-8a66-c4ec9410c3ae


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Quick app restart will work reliably 

### How to test

open/close the app in a quickly a few times in a row

### Risk 

low
