### PR TITLE
fix(ci): limit android e2e tests to one at the time

### DIFF
--- a/ci/Jenkinsfile.test-e2e.android
+++ b/ci/Jenkinsfile.test-e2e.android
@@ -141,19 +141,21 @@ pipeline {
     }
 
     stage('Run pytest suite') {
-      steps {
-        script {
-          env.E2E_RUN_ID = env.BUILD_TAG
-          def appId = env.UPLOADED_BROWSERSTACK_APP_ID ?: params.BROWSERSTACK_APP_ID
-          dir('test/e2e_appium') {
-            withCredentials([
-              usernamePassword(
-                credentialsId: 'browserstack-status-mobile-android',
-                usernameVariable: 'BROWSERSTACK_USERNAME',
-                passwordVariable: 'BROWSERSTACK_ACCESS_KEY'
-              )
-            ]) {
-              sh "BROWSERSTACK_APP_ID=${appId} ${VIRTUAL_ENV}/bin/python -m pytest --env browserstack ${params.PYTEST_ARGS?.trim() ?: ''}"
+      steps{
+        lock(resource: 'e2e-android') {
+          script {
+            env.E2E_RUN_ID = env.BUILD_TAG
+            def appId = env.UPLOADED_BROWSERSTACK_APP_ID ?: params.BROWSERSTACK_APP_ID
+            dir('test/e2e_appium') {
+              withCredentials([
+                usernamePassword(
+                  credentialsId: 'browserstack-status-mobile-android',
+                  usernameVariable: 'BROWSERSTACK_USERNAME',
+                  passwordVariable: 'BROWSERSTACK_ACCESS_KEY'
+                )
+              ]) {
+                sh "BROWSERSTACK_APP_ID=${appId} ${VIRTUAL_ENV}/bin/python -m pytest --env browserstack ${params.PYTEST_ARGS?.trim() ?: ''}"
+              }
             }
           }
         }


### PR DESCRIPTION
This restriction comes from the fact we have only 5 devices on Browserstack. Each test can use multiple devices and we limit number of tests in parallel to 2(n=2). A single test can use 3 devices and another with 2 - maxing out 5 available.

### What does the PR do

Use lockable resource in the android E2E builds so only one build at the time can be executed.

### Affected areas

CI

### Impact on end user

None

### How to test
Run the Android E2E CI build from multiple PRs


