### PR TITLE
fix(community): fix chat loading forever on first switch

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -243,10 +243,12 @@ proc checkIfMessageLoadedAndScroll(self: Module) =
   if index == -1:
     self.controller.increaseLoadingMessagesPerPageFactor()
     if self.controller.loadMoreMessages():
-      warn "failed to start loading more messages"
+      # Wait for more messages to be fetched before checking for the searched message again
       return
-    # If failed to `loadMoreMessages`, then the most recent message is already loaded.
-    # Then message is not found.
+    else:
+      warn "failed to start loading more messages"
+      # If it failed to `loadMoreMessages`, then the most recent messages are already loaded.
+      # It means the message is not found or was already loaded. We can clear the search
 
   self.controller.clearSearchedMessageId()
   self.controller.resetLoadingMessagesPerPageFactor()
@@ -294,6 +296,7 @@ method messagesAdded*(self: Module, messages: seq[MessageDto]) =
   let items = self.createMessageItemsFromMessageDtos(messages)
 
   self.view.model().insertItemsBasedOnClock(items)
+  self.checkIfMessageLoadedAndScroll()
 
 method removeNewMessagesMarker*(self: Module)
 
@@ -535,7 +538,6 @@ method onGetMessageById*(self: Module, requestId: UUID, messageId: string, messa
     return
 
   self.checkIfMessageLoadedAndScroll()
-  self.reevaluateViewLoadingState()
 
 method fillGaps*(self: Module, messageId: string) =
   self.controller.fillGaps(messageId)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -290,7 +290,7 @@ Loader {
 
 
     function startMessageFoundAnimation() {
-        if (root.active && root.item.startMessageFoundAnimation) {
+        if (root.active && root.item && root.item.startMessageFoundAnimation) {
             root.item.startMessageFoundAnimation()
         }
     }


### PR DESCRIPTION
### What does the PR do

Fixes #20165

When we get the ID for the first message of a chat, we then try to fetch that message in batches. However, there is a slight chance that the message will be fetched from the normal store fetches instead of the DB fetch, which did not check for the searched message. This caused the loading to never end.

### Affected areas

messages module

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[fixed-chat-loading.webm](https://github.com/user-attachments/assets/361dd57c-32e2-4402-8f59-cc216fedc589)

### Impact on end user

Fixes the infinite loading

### How to test

Spectate a community, wait for some messages to load and click the chat

### Risk 

Low. The risk is that the bug is not fully fixed
