### PR TITLE
feat(Browser): refactor the address field into its own component

### DIFF
--- a/storybook/stubs/AppLayouts/Browser/stores/BookmarksStore.qml
+++ b/storybook/stubs/AppLayouts/Browser/stores/BookmarksStore.qml
@@ -10,6 +10,10 @@ QtObject {
             url: "https://hub.status.network/" // Constants.browserDefaultHomepage
         }
         ListElement {
+            name: "Status App"
+            url: "https://status.app/"
+        }
+        ListElement {
             name: "Seznam"
             url: "https://www.seznam.cz/"
         }

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -434,7 +434,7 @@ StatusSectionLayout {
             currentTabLoading: _internal.currentTabLoading
             incognitoMode: _internal.currentTabIncognito
             browserDappsModel: browserDappsProvider.model
-            faviconImage: _internal.currentWebView?.icon?.toString().replace("image://favicon/", "") ?? ""
+            faviconUrl: _internal.currentWebView?.icon ?? ""
 
             onRequestReloadPage: webViewContext.reloadCurrent()
             onRequestStopLoadingPage: webViewContext.stopCurrent()
@@ -622,7 +622,7 @@ StatusSectionLayout {
                 if (!webView)
                     return Assets.svg("globe")
 
-                return root.browserRootStore.determineRealURL(webView.icon.toString().replace("image://favicon/", "") || Assets.svg("globe"))
+                return root.browserRootStore.determineRealURL(webView.icon?.toString() || Assets.svg("globe"))
             }
             getWebViewScreenshot: function (tabIndex, targetImage, targetSize) {
                 const webView = webViewContext.getWebView(tabIndex)

--- a/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
+++ b/ui/app/AppLayouts/Browser/controls/BrowserAddressField.qml
@@ -1,0 +1,87 @@
+import QtQuick
+
+import StatusQ.Core.Theme
+import StatusQ.Controls
+import StatusQ.Components
+
+import utils
+
+StatusTextField {
+    id: root
+
+    required property url url
+    required property bool incognitoMode
+    required property color bgColor
+
+    property url faviconUrl
+    property bool showFavicon
+    property bool loading
+
+    readonly property url searchEngineIcon: Assets.svg(SearchEnginesConfig.getEngineIcon(localAccountSensitiveSettings.selectedBrowserSearchEngineId))
+
+    implicitHeight: 36
+
+    background: Rectangle {
+        color: root.bgColor
+        radius: 40
+    }
+    verticalAlignment: TextInput.AlignVCenter
+    leftPadding: showFavicon ? Theme.halfPadding + favicon.width + favicon.anchors.leftMargin
+                             : Theme.padding
+    rightPadding: Theme.halfPadding + clearButton.width
+    placeholderText: qsTr("Search or enter address")
+    font.pixelSize: Theme.additionalTextSize
+    color: root.incognitoMode ? Theme.palette.privacyColors.tertiary : Theme.palette.textColor
+
+    inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase
+    EnterKey.type: Qt.EnterKeyGo
+
+    text: root.url
+    onActiveFocusChanged: {
+        if (activeFocus) {
+            selectAll()
+        } else {
+            if (text === "") // restore the old URL
+                text = Qt.binding(() => root.url)
+        }
+    }
+
+    StatusRoundedImage {
+        id: favicon
+        visible: root.showFavicon
+        height: parent.height/2
+        width: height
+        anchors.left: parent.left
+        anchors.leftMargin: Theme.halfPadding
+        anchors.verticalCenter: parent.verticalCenter
+        image.sourceSize: Qt.size(width, height)
+        image.source: {
+            if (root.url.toString() !== root.text || root.text === "") {
+                return root.searchEngineIcon
+            }
+
+            if (root.showFavicon) {
+                if (root.faviconUrl.toString() !== "" )
+                    return root.faviconUrl
+                return Assets.svg("globe")
+            }
+
+            return root.searchEngineIcon
+        }
+    }
+
+    StatusClearButton {
+        id: clearButton
+        anchors.right: parent.right
+        anchors.rightMargin: Theme.halfPadding
+        anchors.verticalCenter: parent.verticalCenter
+        visible: parent.cursorVisible && !!parent.text
+        icon.width: 18
+        icon.height: 18
+        tooltip.orientation: StatusToolTip.Orientation.Bottom
+        onClicked: {
+            parent.forceActiveFocus()
+            parent.clear()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Browser/controls/qmldir
+++ b/ui/app/AppLayouts/Browser/controls/qmldir
@@ -1,3 +1,4 @@
+BrowserAddressField 1.0 BrowserAddressField.qml
 DownloadElement 1.0 DownloadElement.qml
 BrowserHeaderButton 1.0 BrowserHeaderButton.qml
 StatusBubble 1.0 StatusBubble.qml

--- a/ui/app/AppLayouts/Browser/panels/BrowserLandscapeToolbar.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserLandscapeToolbar.qml
@@ -47,6 +47,7 @@ BrowserToolbarBase {
         LandscapeToolbarButton {
             incognitoMode: root.currentTabIncognito
             icon.name: root.currentTabLoading ? "close-circle" : "refresh"
+            interactive: root.url.toString() !== ""
             tooltip.text: root.currentTabLoading ? qsTr("Stop") : qsTr("Reload")
             onClicked: root.currentTabLoading ? root.requestStopLoadingPage(): root.requestReloadPage()
         }
@@ -69,51 +70,18 @@ BrowserToolbarBase {
             onToggled: root.goIncognito(checked)
         }
 
-        // TODO: should be reworked as a separate component as per deisgn for mobile here
-        // https://github.com/status-im/status-app/issues/19564
-        StatusTextField {
+        BrowserAddressField {
             id: addressBar
-
-            Layout.preferredHeight: 36
             Layout.fillWidth: true
 
-            background: Rectangle {
-                color: {
-                    if (!addressBar.cursorVisible)
-                        return StatusColors.transparent
-                    return root.currentTabIncognito ? Theme.palette.privacyColors.secondary : Theme.palette.baseColor2
-                }
-                radius: 40
-            }
-            leftPadding: Theme.padding
-            rightPadding: Theme.padding
-            placeholderText: qsTr("Search or enter address")
-            font.pixelSize: Theme.additionalTextSize
-            color: root.currentTabIncognito ? Theme.palette.privacyColors.tertiary : Theme.palette.textColor
-            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData
-            EnterKey.type: Qt.EnterKeyGo
-            onActiveFocusChanged: {
-                if (activeFocus) {
-                    selectAll()
-                } else {
-                    if (text === "") // restore the old URL
-                        text = Qt.binding(() => root.url)
-                }
+            url: root.url
+            incognitoMode: root.currentTabIncognito
+            bgColor: {
+                if (!addressBar.cursorVisible)
+                    return StatusColors.transparent
+                return incognitoMode ? Theme.palette.privacyColors.secondary : Theme.palette.baseColor2
             }
             onAccepted: root.requestLaunchInBrowser(text)
-            text: root.url
-
-            StatusClearButton {
-                id: clearButton
-                anchors.right: parent.right
-                anchors.rightMargin: Theme.halfPadding
-                anchors.verticalCenter: parent.verticalCenter
-                visible: parent.cursorVisible && !!parent.text
-                onClicked: {
-                    parent.forceActiveFocus()
-                    parent.clear()
-                }
-            }
         }
 
         LandscapeToolbarButton {

--- a/ui/app/AppLayouts/Browser/panels/FavoritesList.qml
+++ b/ui/app/AppLayouts/Browser/panels/FavoritesList.qml
@@ -23,7 +23,7 @@ StatusGridView {
         readonly property bool isAddBookmarkButton: model.url === Constants.newBookmark
 
         text: model.name
-        source: model.imageUrl
+        source: model.imageUrl || ""
         webUrl: root.determineRealURLFn(model.url)
         onClicked: function(mouse) {
             if (isAddBookmarkButton) {

--- a/ui/app/AppLayouts/Browser/panels/MobileAddressBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/MobileAddressBar.qml
@@ -19,7 +19,7 @@ Control {
     required property bool incognitoMode
     required property var browserDappsModel
     required property url url
-    property string faviconImage
+    property url faviconUrl
 
     signal requestStopLoadingPage()
     signal requestReloadPage()
@@ -50,62 +50,21 @@ Control {
     contentItem: RowLayout {
         spacing: 4
 
-        StatusTextField {
+        BrowserAddressField {
             id: addressBar
-
-            Layout.preferredHeight: 36
             Layout.fillWidth: true
 
-            background: Rectangle {
-                color: {
-                    if (root.incognitoMode)
-                        return addressBar.cursorVisible ? Theme.palette.privacyColors.primary : Theme.palette.privacyColors.secondary
-                    return addressBar.cursorVisible ? Theme.palette.baseColor2 : Theme.palette.background
-                }
-                radius: 40
+            url: root.url
+            incognitoMode: root.incognitoMode
+            faviconUrl: root.faviconUrl
+            showFavicon: true
+            loading: root.currentTabLoading
+            bgColor: {
+                if (incognitoMode)
+                    return addressBar.cursorVisible ? Theme.palette.privacyColors.primary : Theme.palette.privacyColors.secondary
+                return addressBar.cursorVisible ? Theme.palette.baseColor2 : Theme.palette.background
             }
-            leftPadding: Theme.halfPadding + favicon.width + favicon.anchors.leftMargin
-            rightPadding: Theme.halfPadding + clearButton.width
-            placeholderText: qsTr("Search or enter address")
-            font.pixelSize: Theme.additionalTextSize
-            color: root.incognitoMode ? Theme.palette.privacyColors.tertiary : Theme.palette.textColor
-            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData
-            EnterKey.type: Qt.EnterKeyGo
-            onActiveFocusChanged: {
-                if (activeFocus) {
-                    selectAll()
-                } else {
-                    if (text === "") // restore the old URL
-                        text = Qt.binding(() => root.url)
-                }
-            }
-
             onAccepted: root.requestLaunchInBrowser(text)
-            text: root.url
-
-            StatusRoundedImage {
-                id: favicon
-                height: parent.height/2
-                width: height
-                anchors.left: parent.left
-                anchors.leftMargin: Theme.halfPadding
-                anchors.verticalCenter: parent.verticalCenter
-                image.sourceSize: Qt.size(width, height)
-                image.source: root.url.toString() === "" || root.faviconImage === "" ? Assets.svg("globe")
-                                                                                     : root.faviconImage // FIXME include the search engine icon
-            }
-
-            StatusClearButton {
-                id: clearButton
-                anchors.right: parent.right
-                anchors.rightMargin: Theme.halfPadding
-                anchors.verticalCenter: parent.verticalCenter
-                visible: parent.cursorVisible && !!parent.text
-                onClicked: {
-                    parent.forceActiveFocus()
-                    parent.clear()
-                }
-            }
         }
 
         BrowserHeaderButton {
@@ -114,6 +73,7 @@ Control {
 
             incognitoMode: root.incognitoMode
             icon.name: root.currentTabLoading ? "close-circle" : "refresh"
+            interactive: root.url.toString() !== ""
             tooltip.text: root.currentTabLoading ? qsTr("Stop") : qsTr("Reload")
             tooltip.orientation: StatusToolTip.Orientation.Bottom
             onClicked: root.currentTabLoading ? root.requestStopLoadingPage(): root.requestReloadPage()

--- a/ui/app/AppLayouts/Browser/popups/TabsBookmarksOverviewModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/TabsBookmarksOverviewModal.qml
@@ -118,7 +118,7 @@ StatusDialog {
             placeholderText: mainTabBar.currentIndex === TabsBookmarksOverviewModal.Mode.OpenTabs ? qsTr("Search in open tabs")
                                                                                                   : qsTr("Search in bookmarks")
             font.pixelSize: Theme.fontSize(13)
-            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData
+            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase
             EnterKey.type: Qt.EnterKeySearch
 
             StatusIcon {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2388,6 +2388,13 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
     </message>
 </context>
 <context>
+    <name>BrowserAddressField</name>
+    <message>
+        <source>Search or enter address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserConnectionModal</name>
     <message>
         <source>&apos;%1&apos; would like to connect to</source>
@@ -2416,10 +2423,6 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
 </context>
 <context>
     <name>BrowserLandscapeToolbar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Back</source>
         <translation type="unfinished"></translation>
@@ -11542,10 +11545,6 @@ to load</source>
 </context>
 <context>
     <name>MobileAddressBar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Stop</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -2931,6 +2931,14 @@
     </message>
   </context>
   <context>
+    <name>BrowserAddressField</name>
+    <message>
+      <source>Search or enter address</source>
+      <comment>BrowserAddressField</comment>
+      <translation>Search or enter address</translation>
+    </message>
+  </context>
+  <context>
     <name>BrowserConnectionModal</name>
     <message>
       <source>&#39;%1&#39; would like to connect to</source>
@@ -2965,11 +2973,6 @@
   </context>
   <context>
     <name>BrowserLandscapeToolbar</name>
-    <message>
-      <source>Search or enter address</source>
-      <comment>BrowserLandscapeToolbar</comment>
-      <translation>Search or enter address</translation>
-    </message>
     <message>
       <source>Back</source>
       <comment>BrowserLandscapeToolbar</comment>
@@ -14060,11 +14063,6 @@
   </context>
   <context>
     <name>MobileAddressBar</name>
-    <message>
-      <source>Search or enter address</source>
-      <comment>MobileAddressBar</comment>
-      <translation>Search or enter address</translation>
-    </message>
     <message>
       <source>Stop</source>
       <comment>MobileAddressBar</comment>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2398,6 +2398,13 @@ Pro zálohování obnovovací fráze si ji zapište a bezpečně uložte na bezp
     </message>
 </context>
 <context>
+    <name>BrowserAddressField</name>
+    <message>
+        <source>Search or enter address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserConnectionModal</name>
     <message>
         <source>&apos;%1&apos; would like to connect to</source>
@@ -2426,10 +2433,6 @@ Pro zálohování obnovovací fráze si ji zapište a bezpečně uložte na bezp
 </context>
 <context>
     <name>BrowserLandscapeToolbar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Back</source>
         <translation type="unfinished">Zpět</translation>
@@ -11635,10 +11638,6 @@ selhalo</translation>
 </context>
 <context>
     <name>MobileAddressBar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Stop</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2391,6 +2391,13 @@ Para respaldar tu frase de recuperación, escríbela y guárdala de forma segura
     </message>
 </context>
 <context>
+    <name>BrowserAddressField</name>
+    <message>
+        <source>Search or enter address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserConnectionModal</name>
     <message>
         <source>&apos;%1&apos; would like to connect to</source>
@@ -2419,10 +2426,6 @@ Para respaldar tu frase de recuperación, escríbela y guárdala de forma segura
 </context>
 <context>
     <name>BrowserLandscapeToolbar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Back</source>
         <translation type="unfinished">Atrás</translation>
@@ -11559,10 +11562,6 @@ al cargar</translation>
 </context>
 <context>
     <name>MobileAddressBar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Stop</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2383,6 +2383,13 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
     </message>
 </context>
 <context>
+    <name>BrowserAddressField</name>
+    <message>
+        <source>Search or enter address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BrowserConnectionModal</name>
     <message>
         <source>&apos;%1&apos; would like to connect to</source>
@@ -2411,10 +2418,6 @@ To backup you recovery phrase, write it down and store it securely in a safe pla
 </context>
 <context>
     <name>BrowserLandscapeToolbar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Back</source>
         <translation type="unfinished">뒤로</translation>
@@ -11524,10 +11527,6 @@ to load</source>
 </context>
 <context>
     <name>MobileAddressBar</name>
-    <message>
-        <source>Search or enter address</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Stop</source>
         <translation type="unfinished"></translation>

--- a/ui/imports/shared/controls/AccountSelector.qml
+++ b/ui/imports/shared/controls/AccountSelector.qml
@@ -127,7 +127,7 @@ StatusComboBox {
                    !!currentAccount && currentAccount.name === model.name ? Theme.palette.statusListItem.highlightColor : "transparent"
         onClicked: {
             d.currentAccountSelection = model.address
-            control.popup.close()
+            root.control.popup.close()
         }
     }
 

--- a/ui/imports/utils/SearchEnginesConfig.qml
+++ b/ui/imports/utils/SearchEnginesConfig.qml
@@ -113,6 +113,11 @@ QtObject {
         return engine ? engine.description : ""
     }
 
+    function getEngineIcon(engineId = "") {
+        const engine = getEngineByIdOrDefault(engineId)
+        return engine ? engine.iconUrl : ""
+    }
+
     function formatSearchUrl(engineId, query, customUrl) {
         const engine = getEngineByIdOrDefault(engineId)
         if (!engine) {


### PR DESCRIPTION
### What does the PR do

- shared between the mobile address bar and the toolbar
- simplify the favicon access; QML Image understands the `image://favicon/` protocol directly
- add support for showing the search engine icon

Fixes #19564

### Affected areas

Browser

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Typing a search query:
<img width="1798" height="2398" alt="image" src="https://github.com/user-attachments/assets/759c5382-d5d3-424a-859a-6c4cc88048f1" />

Getting search results:
<img width="1818" height="2398" alt="image" src="https://github.com/user-attachments/assets/9a5b084c-93c3-4c58-aff0-969df1d22218" />


### Impact on end user

More streamlined browser address entry

### How to test

- play around the address field, both in portrait and landscape modes
- test both desktop and mobile

### Risk 

low
