### PR TITLE
fix(ci): use correct commit sha for fdroid checkouts

### DIFF
--- a/ci/Jenkinsfile.fdroid
+++ b/ci/Jenkinsfile.fdroid
@@ -72,8 +72,8 @@ pipeline {
       steps {
         sh './fdroid/cleanup-fdroiddata.sh'
         sh "git clone --branch '${params.FDROIDDATA_BRANCH}' '${params.FDROIDDATA_REPO}' ${env.FDROIDDATA_PATH}"
-        /* Update metadata commit to current HEAD so we always build the checked-out revision */
-        sh "sed -i 's/commit: .*/commit: '`git rev-parse HEAD`'/' ${env.FDROIDDATA_PATH}/metadata/app.status.mobile.yml"
+        /* Update metadata commit to current GIT_COMMIT so we always build the checked-out revision. */
+        sh "sed -i 's/commit: .*/commit: '${env.GIT_COMMIT}'/' ${env.FDROIDDATA_PATH}/metadata/app.status.mobile.yml"
       }
     }
 


### PR DESCRIPTION
Otherwise they fail like this :
```
[2026-03-23T13:34:47.879Z] fdroidserver.exception.VCSException: Git
checkout of 'f8f4730617f65f3e495aca0241fad2eb8f20a31f' failed
[2026-03-23T13:34:47.879Z] ==== detail begin ====
[2026-03-23T13:34:47.879Z] fatal: unable to read tree
(f8f4730617f65f3e495aca0241fad2eb8f20a31f)
[2026-03-23T13:34:47.879Z] ==== detail end ====
```