### PR TITLE
chore: fix compiling and running against Qt 6.11

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -49,7 +49,7 @@ FetchContent_Declare(
   QmlStorybook
 
   GIT_REPOSITORY https://github.com/status-im/QmlStorybook.git
-  GIT_TAG eb3481c9e210c7631a65540ee2551c528a3f8522
+  GIT_TAG fc13fc5fdba86da17e71e5985178d2a8fdb5cb3e
 )
 FetchContent_MakeAvailable(QmlStorybook)
 

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -320,7 +320,7 @@ FetchContent_Declare(
   QtModelsToolkit
 
   GIT_REPOSITORY https://github.com/status-im/QtModelsToolkit.git
-  GIT_TAG af59b81bc10bc37359c2839ae202c160c8321f1a
+  GIT_TAG b249dc22be1e1e728acce90065f943d7db3636e5
 )
 
 FetchContent_MakeAvailable(QtModelsToolkit)


### PR DESCRIPTION
### What does the PR do

- unblocks building against Qt 6.11
- needed updates for the QmlStorybook and QtModelsToolkit modules

### Affected areas

App

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="5040" height="4740" alt="Snímek obrazovky z 2026-03-23 23-43-06" src="https://github.com/user-attachments/assets/a325cd54-5c5d-4738-8980-d2391fed5888" />

### Impact on end user

New Qt goodies

### How to test

- install Qt 6.11
- build & run

### Risk 

low
