### PR TITLE
fix(ci): make macos build compatible with nix-darwin

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -98,6 +98,9 @@ pipeline {
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
     /* Ensure nimcache is not shared between builds. */
     NIMFLAGS = "${params.NIMFLAGS} --colors:off --nimcache:${env.WORKSPACE_TMP}/nimcache"
+    // Workaround for cmake 4.x dropping compatibility with cmake_minimum_required < 3.5
+    // Required by vendor/QR-Code-generator (scodes) until upstream bumps their CMakeLists.txt
+    CMAKE_POLICY_VERSION_MINIMUM = 3.5
   }
 
   stages {


### PR DESCRIPTION
Referenced issue:
* https://github.com/status-im/infra-role-bootstrap-macos/issues/12

### What does the PR do

Fixes macos build for the new changes we introduced by using nix-darwin on macos hosts.

### Affected areas

MacOS CI.
