### PR TITLE
chore(android): Compile 16kb page size against qt 6.11

### DIFF
--- a/mobile/scripts/EnvVariables.mk
+++ b/mobile/scripts/EnvVariables.mk
@@ -98,6 +98,10 @@ else
         export ANDROID_ABI=x86_64
     endif
     export LIB_EXT := .so
+
+    export LDFLAGS := -Wl,-z,max-page-size=16384
+    export NIMFLAGS := --passL:"$(LDFLAGS)"
+    export CGO_LDFLAGS := $(LDFLAGS)
 endif
 
 

--- a/mobile/scripts/android/clangWrap.sh
+++ b/mobile/scripts/android/clangWrap.sh
@@ -27,4 +27,6 @@ fi
 TARGET="$CARCH-linux-android${TARGET_SUFFIX}${ANDROID_API}"
 EXTRA_ARGS="-fembed-bitcode"
 
-exec "$CLANG" --target="$TARGET" "$EXTRA_ARGS" --sysroot="$SYSROOT" -v "$@"
+LINK_PAGE_SIZE_ARGS="-Wl,-z,max-page-size=16384"
+
+exec "$CLANG" --target="$TARGET" "$EXTRA_ARGS" --sysroot="$SYSROOT" "${LINK_PAGE_SIZE_ARGS}" -v "$@"

--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -97,7 +97,7 @@ if [[ "${OS}" == "android" ]]; then
 
   # Build with specified gradle targets
   # shellcheck disable=SC2086 # intentional word splitting for multiple gradle tasks
-  ./gradlew ${GRADLE_TARGETS} --no-daemon --console=plain
+  $("$QMAKE_BIN" -query QT_INSTALL_PREFIX)/src/3rdparty/gradle/gradlew ${GRADLE_TARGETS} --no-daemon --console=plain
 
   echo "APK outputs:"
   find build/outputs/apk -name '*.apk' 2>/dev/null || echo "No APKs found"

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -37,6 +37,9 @@ LIB_PREFIX = $$(APP_VARIANT)
 android {
     message("Configuring for android $${QT_ARCH}, $$(ANDROID_ABI)")
 
+    QMAKE_LFLAGS += -Wl,-z,max-page-size=16384
+    QMAKE_LFLAGS_SHLIB += -Wl,-z,max-page-size=16384
+
     ANDROID_VERSION_NAME = $$VERSION
 
     ANDROID_PACKAGE_SOURCE_DIR = $$PWD/../android/qt$$QT_MAJOR_VERSION

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS
-        Core Qml Gui Quick QuickControls2 WebChannel Svg REQUIRED)
+        Core CorePrivate Qml Gui Quick QuickControls2 WebChannel Svg REQUIRED)
 
 # --- QML test hooks flag and TestConfig generation ---
 option(STATUSQ_TESTMODE "Enable QML test hooks (TestConfig.testMode)" OFF)

--- a/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
@@ -4,7 +4,9 @@ import StatusQ.CustomWebView 1.0
 
 import AppLayouts.Browser.stores as BrowserStores
 
-AbstractWebView {
+import "../" as Base
+
+Base.AbstractWebView {
     id: root
 
     required property BrowserStores.BookmarksStore bookmarksStore


### PR DESCRIPTION
### What does the PR do

Prepare the app for qt 6.11 and 16kb page size on Android


- update linker flags
- update imports for mobile WebViewAdapter
- explicit cmake find for qt code private

### Affected areas

build system
mobile webview

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality
<img width="1114" height="198" alt="Screenshot 2026-03-25 at 12 02 02" src="https://github.com/user-attachments/assets/fbf5f411-6247-486e-9bf0-220e4d49f13c" />

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/3b4524e3-1ba2-480e-bc0d-a6ab5b67e132" />

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

Users with 16kb page size android will be able to install the app.

### How to test

compile and run the app with qt 6.11

### Risk 

low