### PR TITLE
chore(android): Remove workarounds for keyboard and safe area

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -637,12 +637,4 @@ Window {
             }
         }
     }
-
-    //Workaround for QTBUG-140897
-    onKeyboardHeightChanged: {
-        if (applicationWindow.keyboardHeight > 0) {
-            SystemUtils.requestAndroidKeyboardShow()
-        }
-    }
-
 }


### PR DESCRIPTION
### What does the PR do

Removing workaround for keyboard (https://qt-project.atlassian.net/browse/QTBUG-140897) and safe area (https://github.com/status-im/status-app/issues/19074)


### Affected areas

android keyboard
safe area

