### PR TITLE
fix(e2e_appium): update gate tests (push notification, messaging, wallet)

### DIFF
--- a/test/e2e_appium/core/device_context.py
+++ b/test/e2e_appium/core/device_context.py
@@ -159,8 +159,10 @@ class DeviceContext:
         self.logger.info("Using Invite contacts path for profile link")
         profile_link = self._capture_via_settings(main_app)
 
-        # Re-activate app after overlay dismissal
-        main_app.app_lifecycle.activate_app()
+        # Re-activate app and verify the main UI is usable.
+        # The overlay cleanup uses driver.back() which can over-navigate
+        # and send the app to the background on Android.
+        self._restore_main_ui(main_app)
 
         if not profile_link:
             self.logger.error("All profile-link capture paths failed")
@@ -234,11 +236,56 @@ class DeviceContext:
 
             return link
         finally:
-            for i in range(overlays_to_dismiss):
-                try:
-                    self.driver.back()
-                except Exception:
+            # Dismiss overlays cautiously — verify each one is still
+            # present before pressing back, to avoid navigating out of
+            # the app entirely.
+            dialog_locator = ("xpath", "//*[contains(@resource-id,'ShareProfileDialog')]")
+            popup_locator = ("xpath", "//*[contains(@resource-id,'userStatusShareProfileAction') "
+                             "or contains(@resource-id,'ProfileMenu')]")
+
+            for i, check_locator in enumerate(
+                [dialog_locator, popup_locator][:overlays_to_dismiss]
+            ):
+                if app.is_element_visible(check_locator, timeout=1):
+                    try:
+                        self.driver.back()
+                        self.logger.debug("driver.back() #%d dismissed overlay", i + 1)
+                    except Exception:
+                        self.logger.debug(
+                            "driver.back() #%d suppressed during overlay cleanup", i + 1
+                        )
+                else:
                     self.logger.debug(
-                        "driver.back() #%d suppressed during overlay cleanup", i + 1
+                        "Overlay #%d already gone, skipping back()", i + 1
                     )
+
+    def _restore_main_ui(self, app) -> None:
+        """Ensure the Status app is in the foreground with the main nav visible.
+
+        After overlay cleanup the app may have been sent to the background
+        by an extra ``driver.back()``.  This method re-activates the app
+        and waits for the left navigation bar to become visible.
+        """
+        from locators.app_locators import AppLocators
+
+        locators = AppLocators()
+
+        app.app_lifecycle.activate_app()
+
+        # Quick check — if the nav bar is already there, we're done.
+        if app.is_element_visible(locators.LEFT_NAV_WALLET, timeout=3):
+            self.logger.debug("Main UI already visible after activate_app()")
+            return
+
+        # The app may need a moment to fully resume.  Try activating once
+        # more, then give it a longer wait.
+        self.logger.info("Main nav not visible after activate_app(), retrying")
+        app.app_lifecycle.activate_app()
+
+        if not app.is_element_visible(locators.LEFT_NAV_WALLET, timeout=10):
+            self.logger.warning(
+                "Main nav still not visible after second activate_app() — "
+                "subsequent steps may fail"
+            )
+            app.dump_page_source("restore_main_ui_failure")
 

--- a/test/e2e_appium/fixtures/onboarding_fixture.py
+++ b/test/e2e_appium/fixtures/onboarding_fixture.py
@@ -23,6 +23,7 @@ from pages.onboarding import (
     BiometricsPage,
     CreateProfilePage,
     PasswordPage,
+    PushNotificationsPage,
     SeedPhraseInputPage,
     SplashScreen,
     WelcomePage,
@@ -86,6 +87,7 @@ class OnboardingFlow:
         self.seed_phrase_page = SeedPhraseInputPage(self.driver)
         self.password_page = PasswordPage(self.driver)
         self.biometrics_page = BiometricsPage(self.driver)
+        self.push_notifications_page = PushNotificationsPage(self.driver)
         self.loading_page = SplashScreen(self.driver)
         self.app = App(self.driver)
 
@@ -157,6 +159,8 @@ class OnboardingFlow:
 
             if self.config.verify_main_app:
                 self._execute_main_app_verification()
+
+            self._dismiss_push_notifications()
 
             execution_result = self._build_success_result()
             self.logger.info(
@@ -401,6 +405,43 @@ class OnboardingFlow:
 
         if self.config.take_screenshots:
             self._take_screenshot("onboarding_completed")
+
+    def _dismiss_push_notifications(self):
+        """Dismiss the 'Enable push notifications' dialog if it appears.
+
+        This dialog can appear after the wallet landing screen loads and
+        blocks all interaction with the underlying UI.  We dismiss it
+        with 'Maybe later' so subsequent test steps can proceed.
+        """
+        self.current_step = "push_notifications"
+        self.logger.info("Step 7: Push Notifications Dialog (dismiss if present)")
+        step_start = datetime.now()
+
+        if self.push_notifications_page.is_screen_displayed(timeout=5):
+            self.logger.info(
+                "Push notifications dialog detected, selecting 'Maybe later'"
+            )
+            dismissed = self.push_notifications_page.select_maybe_later()
+            if not dismissed:
+                self.logger.error("Failed to dismiss push notifications dialog")
+            self.step_results["push_notifications"] = {
+                "success": dismissed,
+                "action": "dismissed" if dismissed else "dismiss_failed",
+                "timestamp": datetime.now(),
+            }
+        else:
+            self.logger.info("Push notifications dialog not displayed, skipping")
+            self.step_results["push_notifications"] = {
+                "success": True,
+                "action": "not_displayed",
+                "timestamp": datetime.now(),
+            }
+
+        elapsed = (datetime.now() - step_start).total_seconds()
+        self.logger.info("Step 7 completed in %.1fs", elapsed)
+
+        if self.config.take_screenshots:
+            self._take_screenshot("push_notifications_handled")
 
     def _take_screenshot(self, name: str):
         """Take screenshot during flow execution"""

--- a/test/e2e_appium/locators/onboarding/push_notifications_locators.py
+++ b/test/e2e_appium/locators/onboarding/push_notifications_locators.py
@@ -1,0 +1,21 @@
+from ..base_locators import BaseLocators
+
+
+class PushNotificationsLocators(BaseLocators):
+    """Locators for the 'Enable push notifications' dialog shown post-onboarding."""
+
+    DIALOG = BaseLocators.xpath(
+        "//*[contains(@resource-id,'EnablePushNotificationsPopup')]"
+    )
+    MAYBE_LATER_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'tid:btnPushNotificationsLater') "
+        "or contains(@name, 'btnPushNotificationsLater')]"
+    )
+    CONTINUE_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'tid:btnPushNotificationsPrimary') "
+        "or contains(@name, 'btnPushNotificationsPrimary')]"
+    )
+    CLOSE_BUTTON = BaseLocators.xpath(
+        "//*[contains(@content-desc, 'tid:headerActionsCloseButton') "
+        "or contains(@name, 'headerActionsCloseButton')]"
+    )

--- a/test/e2e_appium/pages/messaging/chat_page.py
+++ b/test/e2e_appium/pages/messaging/chat_page.py
@@ -213,10 +213,6 @@ class ChatPage(BasePage):
         timeout: int = 60,
     ) -> bool:
         self.dismiss_introduce_prompt(timeout=2)
-
-        if self.is_element_visible(self.locators.MESSAGE_INPUT, timeout=2):
-            return True
-
         self._ensure_chat_list_visible()
         locators = self._resolve_chat_locators(chat_identifier, display_name)
         return self.wait_for_condition(

--- a/test/e2e_appium/pages/onboarding/__init__.py
+++ b/test/e2e_appium/pages/onboarding/__init__.py
@@ -8,6 +8,7 @@ from .home_page import HomePage
 from .seed_phrase_input_page import SeedPhraseInputPage
 from .welcome_back_page import WelcomeBackPage
 from .biometrics_page import BiometricsPage
+from .push_notifications_page import PushNotificationsPage
 
 __all__ = [
     "WelcomePage",
@@ -18,4 +19,5 @@ __all__ = [
     "SeedPhraseInputPage",
     "WelcomeBackPage",
     "BiometricsPage",
+    "PushNotificationsPage",
 ]

--- a/test/e2e_appium/pages/onboarding/push_notifications_page.py
+++ b/test/e2e_appium/pages/onboarding/push_notifications_page.py
@@ -1,0 +1,41 @@
+from ..base_page import BasePage
+from locators.onboarding.push_notifications_locators import PushNotificationsLocators
+from utils.exceptions import ElementInteractionError
+
+
+class PushNotificationsPage(BasePage):
+    """Page object for the 'Enable push notifications' dialog.
+
+    This dialog may appear after onboarding completes and the wallet
+    landing screen loads.  It blocks interaction with all underlying
+    UI until dismissed.
+    """
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.locators = PushNotificationsLocators()
+        self.IDENTITY_LOCATOR = self.locators.MAYBE_LATER_BUTTON
+
+    def select_maybe_later(self) -> bool:
+        """Dismiss the dialog by tapping 'Maybe later'."""
+        try:
+            self.safe_click(self.locators.MAYBE_LATER_BUTTON)
+        except ElementInteractionError:
+            self.logger.error(
+                "Failed to tap 'Maybe later' on push notifications dialog",
+                exc_info=True,
+            )
+            return False
+
+        return self.wait_for_invisibility(self.IDENTITY_LOCATOR)
+
+    def dismiss_if_present(self, timeout: int = 3) -> bool:
+        """Dismiss the push notifications dialog if it is visible.
+
+        Safe to call at any point (e.g. after an app restart) — returns
+        True if the dialog was not present or was successfully dismissed.
+        """
+        if not self.is_element_visible(self.locators.MAYBE_LATER_BUTTON, timeout=timeout):
+            return True
+        self.logger.info("Push notifications dialog detected post-restart, dismissing")
+        return self.select_maybe_later()

--- a/test/e2e_appium/pages/settings/change_password_modal.py
+++ b/test/e2e_appium/pages/settings/change_password_modal.py
@@ -74,9 +74,17 @@ class ChangePasswordModal(BasePage):
             self.logger.error("Change password modal remained visible after restart attempts")
             return False
 
-        if not self.app_lifecycle.wait_for_app_not_running(timeout=30):
-            self.logger.error("App never reached NOT_RUNNING state after tapping restart")
-            return False
+        # SystemUtils.restartApplication() on Android may leave the app in
+        # RUNNING_IN_BACKGROUND rather than NOT_RUNNING.  Give it a short
+        # window to terminate on its own, then force-terminate if needed.
+        if not self.app_lifecycle.wait_for_app_not_running(timeout=10):
+            self.logger.info(
+                "App still running after restart button; force-terminating"
+            )
+            self.app_lifecycle.terminate_app()
+            if not self.app_lifecycle.wait_for_app_not_running(timeout=10):
+                self.logger.error("App never reached NOT_RUNNING after force-terminate")
+                return False
 
         if not self.app_lifecycle.activate_app_with_ui_ready():
             self.logger.error("App activation with UI ready failed after password change")

--- a/test/e2e_appium/pages/wallet/wallet_left_panel.py
+++ b/test/e2e_appium/pages/wallet/wallet_left_panel.py
@@ -134,9 +134,18 @@ class WalletLeftPanel(BasePage):
         return None
 
     def open_add_account_popup(self) -> AddEditAccountModal | None:
-        self.safe_click(self.locators.ADD_ACCOUNT_BUTTON, timeout=5)
+        try:
+            self.safe_click(self.locators.ADD_ACCOUNT_BUTTON, timeout=5)
+        except Exception as e:
+            self.logger.error("Add account button not clickable: %s", e)
+            self.take_screenshot("add_account_button_not_clickable")
+            return None
         modal = AddEditAccountModal(self.driver)
-        return modal if modal.is_displayed(timeout=10) else None
+        if not modal.is_displayed(timeout=10):
+            self.logger.error("Add account modal did not appear after clicking button")
+            self.take_screenshot("add_account_modal_not_displayed")
+            return None
+        return modal
 
     def add_account(self, name: str, auth_password: str | None = None) -> bool:
         modal = self.open_add_account_popup()

--- a/test/e2e_appium/tests/messaging/conftest.py
+++ b/test/e2e_appium/tests/messaging/conftest.py
@@ -178,7 +178,7 @@ async def _setup_established_chat(
     secondary = contexts[device_names[1]]
 
     primary_suffix, secondary_suffix = await _establish_contact(
-        primary, secondary, timeout=180
+        primary, secondary, timeout=240
     )
 
     return EstablishedChatContext(
@@ -214,13 +214,13 @@ async def established_chat(request, test_environment) -> EstablishedChatContext:
                 ...
     """
     global _module_pools
-    
+
     logger.info("Setting up module-scoped established_chat fixture")
-    
+
     pool = None
     ctx = None
     setup_failed = False
-    max_attempts = 2
+    max_attempts = 1
     last_error: BaseException | None = None
     
     for attempt in range(1, max_attempts + 1):

--- a/test/e2e_appium/tests/messaging/test_messaging_1x1_chat.py
+++ b/test/e2e_appium/tests/messaging/test_messaging_1x1_chat.py
@@ -190,19 +190,31 @@ class TestMessaging1x1Chat(StepMixin):
         secondary_chat_page = ChatPage(secondary_device.driver)
         primary_chat_page = ChatPage(primary_device.driver)
 
-        async with self.step(secondary_device, "Dismiss backup prompt if visible"):
+        async with self.step(secondary_device, "Navigate to messages from secondary"):
+            # After accepting a contact request the app may auto-navigate
+            # to the chat, but message history isn't always loaded.
+            # Navigate explicitly to the Messages section for a clean state.
+            secondary_app = App(secondary_device.driver)
             secondary_chat_page.dismiss_backup_prompt(timeout=4)
+            assert secondary_app.click_messages_button(), (
+                "Failed to navigate to messages on secondary"
+            )
 
-        async with self.step(secondary_device, "Verify contact request message received"):
+        async with self.step(secondary_device, "Open chat and verify contact request message"):
             assert secondary_chat_page.wait_for_new_chat_to_arrive(
                 primary_suffix,
                 display_name=primary_display_name,
+                timeout=self.DM_TIMEOUT,
             ), (
                 "Secondary did not show DM row for the primary contact"
             )
+            assert secondary_chat_page.open_chat_by_suffix(
+                primary_suffix,
+                display_name=primary_display_name,
+            ), "Failed to open chat with primary on secondary device"
             assert secondary_chat_page.message_exists(
                 contact_request_message,
-                timeout=self.UI_TIMEOUT,
+                timeout=self.DM_TIMEOUT,
             ), "Contact request message not visible on secondary"
 
         async with self.step(secondary_device, "Send greeting to primary"):

--- a/test/e2e_appium/tests/test_onboarding_import_seed.py
+++ b/test/e2e_appium/tests/test_onboarding_import_seed.py
@@ -11,6 +11,8 @@ from pages.onboarding import (
 )
 from pages.base_page import BasePage
 from pages.app import App
+from pages.onboarding.push_notifications_page import PushNotificationsPage
+from pages.wallet.wallet_left_panel import WalletLeftPanel
 from locators.app_locators import AppLocators
 from locators.onboarding.wallet.wallet_locators import WalletLocators
 from locators.onboarding.returning_login_locators import ReturningLoginLocators
@@ -67,30 +69,29 @@ class TestOnboardingImportSeed(StepMixin):
                 "App did not finish loading"
             )
 
+        async with self.step(self.device, "Dismiss push notifications if present"):
+            PushNotificationsPage(driver).dismiss_if_present(timeout=5)
+
         async with self.step(self.device, "Verify wallet address"):
-            wallet_locators = WalletLocators()
-            base = BasePage(driver)
             app = App(driver)
             app_locators = AppLocators()
+            base = BasePage(driver)
 
             base.safe_click(app_locators.LEFT_NAV_WALLET, timeout=5)
 
-            try:
-                base.safe_click(wallet_locators.ACCOUNT_LIST_ITEM_ANY)
-            except Exception:
-                base.safe_click(wallet_locators.ACCOUNT_1_BY_TEXT)
+            # The QML account row has clickable=false in the Android a11y
+            # tree, so selecting an individual account is unreliable.
+            # Instead, copy the address via context menu (proven reliable)
+            # and compare against the expected address from the seed phrase.
+            panel = WalletLeftPanel(driver)
+            assert panel.is_loaded(timeout=10), "Wallet panel not loaded"
 
-            header_el = base.find_element_safe(
-                wallet_locators.WALLET_HEADER_ADDRESS, timeout=10
-            )
-            assert header_el is not None, "Wallet header address button not found"
-            header_desc = header_el.get_attribute("content-desc") or ""
-            assert header_desc, "Header content-desc is empty"
+            copied_addr = panel.copy_account_address_via_context_menu(index=0)
+            assert copied_addr is not None, "Failed to copy wallet address via context menu"
 
             full_addr = get_wallet_address_from_mnemonic(seed_phrase)
-            expected_display = f"0×{full_addr[2:6]}…{full_addr[-4:]}"
-            assert header_desc.startswith(expected_display), (
-                f"Header address display mismatch. Expected prefix '{expected_display}', got '{header_desc}'"
+            assert copied_addr.lower() == full_addr.lower(), (
+                f"Wallet address mismatch. Expected '{full_addr}', got '{copied_addr}'"
             )
 
         async with self.step(self.device, "Restart app"):

--- a/test/e2e_appium/tests/test_wallet_accounts_basic.py
+++ b/test/e2e_appium/tests/test_wallet_accounts_basic.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pages.app import App
+from pages.onboarding.push_notifications_page import PushNotificationsPage
 from pages.onboarding.welcome_back_page import WelcomeBackPage
 from pages.wallet.wallet_left_panel import WalletLeftPanel
 from utils.generators import generate_account_name
@@ -96,6 +97,8 @@ class TestWalletAccountsBasic(StepMixin):
             panel = WalletLeftPanel(self.device.driver)
             app = App(self.device.driver)
             assert panel.is_loaded(timeout=20), "Wallet panel not visible after restart"
+            # Push notification dialog may re-appear after restart + login
+            PushNotificationsPage(self.device.driver).dismiss_if_present(timeout=5)
 
         async with self.step(self.device, "Verify renamed account persists after restart"):
             assert panel.wait_for_account_name(renamed_name, timeout=10), (

--- a/test/e2e_appium/utils/app_lifecycle_manager.py
+++ b/test/e2e_appium/utils/app_lifecycle_manager.py
@@ -67,6 +67,14 @@ class AppLifecycleManager:
             self.logger.error("UI activation failed after restart: %s", err)
             return False
 
+        # Dismiss overlays that may re-appear after restart
+        try:
+            from pages.onboarding.push_notifications_page import PushNotificationsPage
+
+            PushNotificationsPage(self.driver).dismiss_if_present(timeout=3)
+        except Exception as err:
+            self.logger.debug("Push notification dismiss check skipped: %s", err)
+
         return True
 
     def restart_app_with_data_cleared(self, app_package: Optional[str] = None) -> bool:

--- a/test/e2e_appium/utils/contact_helpers.py
+++ b/test/e2e_appium/utils/contact_helpers.py
@@ -32,7 +32,7 @@ async def establish_contact(
     sender: DeviceContext,
     receiver: DeviceContext,
     *,
-    timeout: int = 180,
+    timeout: int = 240,
 ) -> tuple[str, str, str, str]:
     """Establish a 1:1 contact between *sender* and *receiver*.
 


### PR DESCRIPTION
Handle push notification dialog blocking onboarding and profile link capture. Fix wait_for_new_chat_to_arrive false positive that caused "Receiver failed to open chat" failures. Fix app backgrounding during password change test. Use context menu for wallet address verification (clickable=false in a11y tree). Drop contact establishment retries to 1 and increase network timeout to 240s.