### PR TITLE
fix(Wallet): chart YTD data is displayed instead of Monthly

### DIFF
--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -67,6 +67,19 @@ type
     currency: string
     range: int
 
+proc daysInCurrentMonthCycle(): int =
+  let today = now()
+
+  # Subtract 1 month to get the "same day" in the previous month
+  # Nim handles the year rollover and month lengths automatically
+  let sameDayLastMonth = today - months(1)
+
+  # Calculate the duration between the two points in time
+  let diff = today - sameDayLastMonth
+
+  # Return the total number of full days as an integer
+  return diff.inDays.int
+
 proc getTokenHistoricalDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetTokenHistoricalDataTaskArg](argEncoded)
   var
@@ -82,7 +95,7 @@ proc getTokenHistoricalDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
       of WEEKLY_TIME_RANGE:
         response = backend.getHourlyMarketValues(arg.tokenKey, arg.currency, DAYS_IN_WEEK*HOURS_IN_DAY, 1).result
       of MONTHLY_TIME_RANGE:
-        response = backend.getHourlyMarketValues(arg.tokenKey, arg.currency, getDaysInMonth(td.month, td.year)*HOURS_IN_DAY, 2).result
+        response = backend.getDailyMarketValues(arg.tokenKey, arg.currency, daysInCurrentMonthCycle(), false, 1).result
       of HALF_YEARLY_TIME_RANGE:
         response = backend.getDailyMarketValues(arg.tokenKey, arg.currency, int(getDaysInYear(td.year)/2), false, 1).result
       of YEARLY_TIME_RANGE:

--- a/ui/StatusQ/src/StatusQ/Components/private/chart/ChartCanvas.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/chart/ChartCanvas.qml
@@ -1,6 +1,7 @@
 import QtQuick
 
 import StatusQ.Core
+import StatusQ.Core.Backpressure
 
 import "./Library/Library.js" as Lib
 
@@ -110,8 +111,8 @@ Canvas {
     onPluginsChanged: refresh()
     onLabelsChanged: refresh()
     onDatasetsChanged: rebuild()
-    onHeightChanged: resized()
-    onWidthChanged: resized()
+    onHeightChanged: d.resizeDebouncer()
+    onWidthChanged: d.resizeDebouncer()
     onAvailableChanged: {
         if (!d.instance) {
             rebuild()
@@ -150,6 +151,10 @@ Canvas {
             }
             instance = new Chart(ctx, config)
         }
+
+        readonly property var resizeDebouncer: Backpressure.oneInTimeQueued(canvas, 100, function() {
+            canvas.resized()
+        })
     }
 
     Component.onDestruction: {

--- a/ui/app/AppLayouts/Wallet/helpers/ChartDataBase.qml
+++ b/ui/app/AppLayouts/Wallet/helpers/ChartDataBase.qml
@@ -5,7 +5,7 @@ import utils
 QtObject {
     id: root
 
-    // @see src/app_service/service/token/async_tasks.nim BalanceHistoryTimeInterval
+    // @see src/app_service/service/token/dto/market_data.nim
     enum TimeRange {
         Weekly = 0,
         Monthly,
@@ -33,7 +33,7 @@ QtObject {
     property var yearlyTimeRange: []
     property var allTimeRange: []
 
-    property int monthlyMaxTicks: monthlyTimeRange.length/d.hoursInADay
+    property int monthlyMaxTicks: monthlyTimeRange.length/d.avgLengthOfMonth
     property int weeklyMaxTicks: weeklyTimeRange.length/d.hoursInADay
     property int halfYearlyMaxTicks: halfYearlyTimeRange.length/d.avgLengthOfMonth
     property int yearlyMaxTicks: yearlyTimeRange.length/d.avgLengthOfMonth


### PR DESCRIPTION
### What does the PR do

- fetch daily data for the last 30 days, instead of fetching hourly (!) data since beginning of the year; much faster and since we don't support zooming, also useless to have that much granularity
- massively speedup resizing the window by debouncing the redraw/update operation

Fixes #20130
Fixes #18439

### Affected areas

Wallet/Asset/Chart

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="4473" height="2516" alt="Snímek obrazovky z 2026-03-26 18-12-52" src="https://github.com/user-attachments/assets/b1ffa362-19ff-48cf-8ee1-49c90056f72c" />


### Impact on end user

Faster and accurate Asset chart

### How to test

- click an asset
- compare the Asset chart with a 3rd party service
- try to resize window

### Risk 

low
