### PR TITLE
fix(ios): limit keychain list to avoid stale keychains

### DIFF
--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -77,6 +77,13 @@ platform :ios do
         timeout: 3600,
         lock_when_sleeps: false
       )
+
+      # Remove stale keychains (e.g. fastlane.keychain-db) from the search list
+      # to prevent "ambiguous" codesign errors when the same certificate exists
+      # in multiple keychains.
+      kc_path = File.expand_path("~/Library/Keychains/#{keychain_name}-db")
+      login_kc = File.expand_path("~/Library/Keychains/login.keychain-db")
+      sh("security", "list-keychains", "-d", "user", "-s", kc_path, login_kc)
     end
   end
 


### PR DESCRIPTION
## Summary

Otherwise `fastlane` in CI sometimes fails like this : 

```

[2026-03-26T23:16:04.905Z] Apple Distribution: Status Research & Development GmbH 
(8B5X2M6H2Y): ambiguous (matches "Apple Distribution: Status Research & Development GmbH (8B5X2M6H2Y)"
 in /Users/jenkins/Library/Keychains/fastlane.keychain-db and 
 "Apple Distribution: Status Research & Development GmbH (8B5X2M6H2Y)" in
  /Users/jenkins/Library/Keychains/status_ci_222.keychain-db)

[2026-03-26T23:16:04.905Z] Encountered an error, aborting!
```

