### PR TITLE
fix: Unbreak qt 6.9.2 mobile builds

### DIFF
--- a/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
@@ -4,9 +4,7 @@ import StatusQ.CustomWebView 1.0
 
 import AppLayouts.Browser.stores as BrowserStores
 
-import "../" as Base
-
-Base.AbstractWebView {
+AbstractWebView {
     id: root
 
     required property BrowserStores.BookmarksStore bookmarksStore

--- a/ui/app/AppLayouts/Browser/adapters/+mobile/qmldir
+++ b/ui/app/AppLayouts/Browser/adapters/+mobile/qmldir
@@ -1,0 +1,4 @@
+singleton ProfileManager 1.0 ProfileManager.qml
+AbstractWebView 1.0 ../AbstractWebView.qml
+ProfileParams 1.0 ../ProfileParams.qml
+WebViewAdapter 1.0 WebViewAdapter.qml


### PR DESCRIPTION

### What does the PR do

+mobile/WebViewAdapter has difficulties in finding the AbstractWebView.qml and the behavior is different in 6.9.2 vs 6.11.0. The only common solution I've found was to create a qmldir file in the + mobile as well.

