### PR TITLE
 chore(roadmap): update 2026-H1 progress

### DIFF
--- a/docs/roadmap/2026-H1.md
+++ b/docs/roadmap/2026-H1.md
@@ -70,7 +70,7 @@ Estimated release: End of April
   - [Keycard Shell integration](https://github.com/status-im/status-app/issues/20293)
     - In Progress ⏳ 🟩⬜⬜⬜⬜ 25% 
 - [Support Hoodi network](https://github.com/status-im/eth-rpc-proxy/pull/115):
-  - Done ✅ 🟩🟩🟩🟩🟩 100%
+  - In Progress ⏳ 🟩⬜⬜⬜⬜ 25%
 - Introduce new L2s
 - Status L2 mainnet
 - [SDS phase 2](https://github.com/status-im/status-go/issues/7363)


### PR DESCRIPTION

### What does the PR do

Update epic progress for 2.38 milestone based on current GitHub Project status.
