### PR TITLE
fix(Settings): disallow deleting own device installation

### DIFF
--- a/storybook/pages/SyncingViewPage.qml
+++ b/storybook/pages/SyncingViewPage.qml
@@ -42,6 +42,8 @@ SplitView {
 
         errorDeletingDeviceMessage: ctrlDevicesDeletionError.checked ? "Fake error" : ""
 
+        onDeleteDeviceRequested: installationId => logs.logEvent("onDeleteDeviceRequested", ["installationId"], [installationId])
+
         advancedStore: ProfileStores.AdvancedStore {
             readonly property bool isDebugEnabled: ctrlDebugEnabled.checked
         }
@@ -151,6 +153,7 @@ SplitView {
             Switch {
                 id: ctrlDebugEnabled
                 text: "Debug enabled"
+                checked: true
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/popups/SyncDeviceCustomizationPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/SyncDeviceCustomizationPopup.qml
@@ -82,6 +82,7 @@ StatusDialog {
             StatusButton {
                 text: qsTr("Delete Device")
                 type: StatusBaseButton.Type.Danger
+                visible: !deviceModel.isCurrentDevice
                 onClicked : {
                     root.deleteDeviceRequested(root.deviceModel.installationId)
                     root.close()


### PR DESCRIPTION
### What does the PR do

- hide the Delete button when we're looking at "this" device

Fixes #20219

### Affected areas

Settings/Syncing

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

This device:
<img width="2914" height="1736" alt="Snímek obrazovky z 2026-03-31 14-45-29" src="https://github.com/user-attachments/assets/71f1c40f-1c60-4db4-9462-be7f767e6242" />

A different device:
<img width="2914" height="1736" alt="image" src="https://github.com/user-attachments/assets/9ea2b1bc-7015-43a0-8abc-10d126a16db6" />

### Impact on end user

Prevent deleting our own device

### How to test

- go to Settings/Syncing
- try to delete "This device"

### Risk 

low
