### PR TITLE
fix(NetworkChecker): process updates only when app is active

### DIFF
--- a/storybook/pages/ConnectionWarningsPage.qml
+++ b/storybook/pages/ConnectionWarningsPage.qml
@@ -50,8 +50,8 @@ SplitView {
                 Tracer { border.color: "blue" }
                 Layout.fillWidth: true
 
-                isOnline: ctrlIsOnline.checked
                 networkConnectionStore: NetworkConnectionStore {
+                    isOnline: ctrlIsOnline.checked
                     function getChainIdsJointString(chainIdsDown) {
                         return chainIdsDown.join(" & ")
                     }

--- a/storybook/stubs/shared/stores/NetworkConnectionStore.qml
+++ b/storybook/stubs/shared/stores/NetworkConnectionStore.qml
@@ -1,6 +1,7 @@
 import QtQuick
 
 QtObject {
+    property bool isOnline: true
     property var blockchainNetworksDown: []
     property bool walletReadyForTransactionsEnabled: true
 }

--- a/ui/StatusQ/include/StatusQ/networkchecker.h
+++ b/ui/StatusQ/include/StatusQ/networkchecker.h
@@ -32,6 +32,8 @@ private slots:
 private:
     QNetworkInformation* m_netinfo{nullptr};
 
+    void init();
+
     bool m_online{true};
     bool isOnline() const;
     void setOnline(bool online);

--- a/ui/StatusQ/src/networkchecker.cpp
+++ b/ui/StatusQ/src/networkchecker.cpp
@@ -1,6 +1,8 @@
 #include "StatusQ/networkchecker.h"
 
 #include <QDebug>
+#include <QGuiApplication>
+#include <QTimer>
 
 namespace {
 // Must match the connection types defined in status-go (see internal/connection/state.go)
@@ -17,6 +19,9 @@ QString connectionTypeFromTransport(QNetworkInformation::TransportMedium transpo
         return QStringLiteral("unknown");
     }
 }
+
+using namespace std::chrono_literals;
+constexpr auto kCheckDelay = 10s;
 }
 
 NetworkChecker::NetworkChecker(QObject *parent)
@@ -29,22 +34,40 @@ NetworkChecker::NetworkChecker(QObject *parent)
 
     m_netinfo = QNetworkInformation::instance();
 
+    // initial update (optionally delayed)
+    QDeadlineTimer deadline(kCheckDelay);
+    while (!deadline.hasExpired() || (QGuiApplication::applicationState() & Qt::ApplicationActive)) {
+        init();
+        break;
+    }
+}
+
+void NetworkChecker::init()
+{
     // subscribe for updates
     connect(m_netinfo, &QNetworkInformation::reachabilityChanged, this, &NetworkChecker::onReachabilityChanged);
     connect(m_netinfo, &QNetworkInformation::transportMediumChanged, this, &NetworkChecker::onTransportMediumChanged);
     connect(m_netinfo, &QNetworkInformation::isMeteredChanged, this, &NetworkChecker::onMeteredChanged);
 
-    // initial update
+    connect(qApp, &QGuiApplication::applicationStateChanged, this, [&](Qt::ApplicationState state) {
+        QTimer::singleShot(kCheckDelay, this, [&]() { onReachabilityChanged(m_netinfo->reachability()); });
+    });
+
     onReachabilityChanged(m_netinfo->reachability());
     updateConnectionDetails();
 }
 
 void NetworkChecker::onReachabilityChanged(QNetworkInformation::Reachability reachability)
 {
-    if (m_active) {
-        setOnline(reachability == QNetworkInformation::Reachability::Online);
-        updateConnectionDetails();
-    }
+    if (!m_active)
+        return;
+
+    const auto appStateFlags = QGuiApplication::applicationState();
+    if (!(appStateFlags & Qt::ApplicationActive))
+        return;
+
+    setOnline(reachability == QNetworkInformation::Reachability::Online);
+    updateConnectionDetails();
 }
 
 void NetworkChecker::onTransportMediumChanged()
@@ -88,6 +111,8 @@ QString NetworkChecker::connectionType() const
 
 bool NetworkChecker::isExpensive() const
 {
+    if (!m_netinfo)
+        return false;
     return m_netinfo->isMetered() || m_netinfo->transportMedium() == QNetworkInformation::TransportMedium::Cellular;
 }
 
@@ -98,6 +123,7 @@ void NetworkChecker::updateConnectionDetails()
 
 void NetworkChecker::checkNetwork()
 {
+    setActive(false);
     setChecking(true);
     setActive(true);
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -122,6 +122,7 @@ Item {
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore: ChatStores.CreateChatPropertiesStore {}
     property SharedStores.NetworkConnectionStore networkConnectionStore: SharedStores.NetworkConnectionStore {
         networksStore: appMain.networksStore
+        isOnline: d.networkChecker.isOnline
     }
     property SharedStores.CommunityTokensStore communityTokensStore: SharedStores.CommunityTokensStore {
         currencyStore: appMain.currencyStore
@@ -831,15 +832,12 @@ Item {
             active: {
                 if (!appMain.rootStore.thirdpartyServicesEnabled) // the connectivity checks might leak our IP
                     return false
-                if (SQUtils.Utils.isMobile) // on mobile, suspend the checks when in background
-                    return appMain.Window.window.active
                 return true
             }
 
             Component.onCompleted: d.connectionChange()
             onIsOnlineChanged: d.connectionChange()
             onConnectionTypeChanged: d.connectionChange()
-            onIsExpensiveChanged: d.connectionChange()
         }
 
         readonly property int activeSectionType: appMain.rootStore.activeSectionType
@@ -1403,7 +1401,6 @@ Item {
                         return ""
                     }
                 }
-                isOnline: d.networkChecker.isOnline
             }
 
             ConnectionWarnings {
@@ -1455,7 +1452,6 @@ Item {
                         return ""
                     }
                 }
-                isOnline: d.networkChecker.isOnline
             }
 
             ConnectionWarnings {
@@ -1482,7 +1478,6 @@ Item {
                         return ""
                     }
                 }
-                isOnline: d.networkChecker.isOnline
             }
         }
 
@@ -2640,7 +2635,7 @@ Item {
         }
     }
     Shortcut {
-        sequence: StandardKey.Find
+        sequences: [StandardKey.Find]
         context: Qt.ApplicationShortcut
         enabled: d.activeSectionType !== Constants.appSection.browser // has its own "Search"
         onActivated: {

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -26,7 +26,7 @@ Loader {
     property bool relevantForCurrentSection: true
     onRelevantForCurrentSectionChanged: updateBanner(false)
 
-    required property bool isOnline // strict online/offline check, doesn't care about the wallet services
+    readonly property bool isOnline: networkConnectionStore.isOnline // strict online/offline check, doesn't care about the wallet services
     onIsOnlineChanged: {
         connectionState = Constants.ConnectionStatus.Unknown // reset the state; wait for real status change from backend
         updateBanner()

--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -19,7 +19,7 @@ QtObject {
 
     readonly property var networkConnectionModuleInst: networkConnectionModule
 
-    readonly property bool isOnline: mainModule.isOnline
+    property bool isOnline: true
 
     readonly property bool balanceCache: walletSectionAssets.hasBalanceCache
     readonly property bool marketValuesCache: walletSectionAssets.hasMarketValuesCache


### PR DESCRIPTION
### What does the PR do

- additonally delay the initial check by 10 seconds for when the app is fully app and running

Fixes #20326

### Affected areas

AppMain/Offline banner

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

After startup:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/a4d29860-0f37-4db6-8d12-652d0c8606d9" />

Flight mode on:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/17f74f0a-4835-4009-8f15-23eb85dd69d4" />

Back online (flight mode turned off):
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/b3b43566-9165-4bcc-a744-bdc079ea8f3e" />

### Impact on end user

Smoother UX

### How to test

- flip airplane mode

### Risk 

low
