### PR TITLE
feat(android): call logout before quit to stop status-go service

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -653,3 +653,6 @@ proc stopTokenHoldersManagement*(self: Controller) =
 
 proc connectionChange*(self: Controller, connectionType: string, isExpensive: bool) =
   self.generalService.connectionChange(connectionType, isExpensive)
+
+proc logout*(self: Controller) =
+  self.generalService.logout()

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -488,6 +488,9 @@ method requestGetCredentialFromKeychainResult*(self: AccessInterface, success: b
 method credentialStoredToKeychainResult*(self: AccessInterface, success: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method signOutAndQuit*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2005,6 +2005,11 @@ proc runStartUsingKeycardForProfilePopup[T](self: Module[T]) =
     singletonInstance.userProfile.getKeyUid(), bip44Paths = @[], txHash = "", forceFlow = true)
 ################################################################################
 
+method signOutAndQuit*[T](self: Module[T]) =
+  info "signOutAndQuit: logging out and quitting"
+  self.controller.logout()
+  quit()
+
 method checkAndPerformProfileMigrationIfNeeded*[T](self: Module[T]) =
   let keyUid = singletonInstance.userProfile.getKeyUid()
   let migrationNeeded = self.settingsService.getProfileMigrationNeeded()

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -456,3 +456,6 @@ QtObject:
 
   proc credentialStoredToKeychainResult*(self: View, success: bool) {.slot.} =
     self.delegate.credentialStoredToKeychainResult(success)
+
+  proc signOutAndQuit*(self: View) {.slot.} =
+    self.delegate.signOutAndQuit()

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1508,7 +1508,7 @@ QtObject {
                 headerSettings.title: qsTr("Sign out")
                 confirmationText: qsTr("Make sure you have your account password and recovery phrase stored. Without them you can lock yourself out of your account and lose funds.")
                 confirmButtonLabel: qsTr("Sign out & Quit")
-                onConfirmButtonClicked: Qt.exit(0)
+                onConfirmButtonClicked: mainModule.signOutAndQuit()
             }
         },
 


### PR DESCRIPTION
Closes https://github.com/status-im/status-app/issues/20229

When the user clicks "Sign out & Quit", the app now calls logout() before quitting so the Android StatusGoService receives the Logout RPC and stops itself, instead of remaining alive in the background.