### PR TITLE
chore(roadmap): update 2026-H1 progress

### DIFF
--- a/docs/roadmap/2026-H1.md
+++ b/docs/roadmap/2026-H1.md
@@ -55,22 +55,23 @@ Estimated release: End of April
 #### Features
 
 - ⭐ [Mobile Dapp Browser](https://github.com/status-im/status-app/issues/19535)
-  - In Progress ⏳ 🟩🟩🟩🟨⬜ 74%
+  - In Progress ⏳ 🟩🟩🟩🟨⬜ 73%
 - ⭐ [Push Notifications](https://github.com/status-im/status-app/issues/19532): In Progress ⏳ 🟩🟨⬜⬜⬜ 33% 
   - Local and server notifications for Android
   - Basic server Push notifications for iOS
 - [Chat Input Field UX Improvements](https://github.com/status-im/status-app/issues/19524)
-  - In Progress ⏳🟩🟩🟨⬜⬜ 50% 
+  - In Progress ⏳ 🟩🟨⬜⬜⬜ 33% 
 - [Activity Center revamp](https://github.com/status-im/status-app/issues/18516)
   - In Progress ⏳ 🟩🟩🟩🟩🟨 94% 
-- Improve handling of online/offline and wallet error banners 
+- [Improve handling of online/offline and wallet error banners](https://github.com/status-im/status-app/issues/20325)
+  - In Progress ⏳ 🟩⬜⬜⬜⬜ 25% 
 - Keycard library/service alignement
   - [Keycard new approach](https://github.com/status-im/status-app/issues/20289)
-    - In Progress ⏳ 🟩⬜⬜⬜⬜ 22%   
+    - In Progress ⏳ 🟩🟩⬜⬜⬜ 42%   
   - [Keycard Shell integration](https://github.com/status-im/status-app/issues/20293)
     - In Progress ⏳ 🟩⬜⬜⬜⬜ 25% 
 - [Support Hoodi network](https://github.com/status-im/eth-rpc-proxy/pull/115):
-  - In Progress ⏳ 🟩⬜⬜⬜⬜ 25%
+  - Done ✅ 🟩🟩🟩🟩🟩 100%
 - Introduce new L2s
 - Status L2 mainnet
 - [SDS phase 2](https://github.com/status-im/status-go/issues/7363)


### PR DESCRIPTION
### What does the PR do

Update epic progress for 2.38 milestone based on current GitHub Project status.