### PR TITLE
fix(StatusMessage): fix context menus

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -404,14 +404,13 @@ Control {
             }
         }
 
-        // TODO remove me completely? literally the same as MessageContextMenuView, and overlaps the message text
         Loader {
             active: root.hovered && root.quickActions.length > 0
                     && !Utils.isMobile // hover menu disabled on mobile; we use the MessageContextMenuView
             visible: active
             anchors.right: parent.right
             anchors.rightMargin: Theme.padding
-            anchors.top: parent.top
+            anchors.verticalCenter: parent.top
             sourceComponent: StatusMessageQuickActions {
                 items: root.quickActions
             }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -88,7 +88,6 @@ Control {
     signal senderNameClicked(var sender)
     signal replyProfileClicked(var sender, var mouse)
     signal replyMessageClicked(var mouse)
-    signal pressAndHold(var mouse)
 
     signal addReactionClicked(var sender, var mouse)
     signal toggleReactionClicked(string hexcode)
@@ -288,7 +287,6 @@ Control {
                             textField.onHoveredLinkChanged: {
                                 root.hoveredLink = hoveredLink;
                             }
-                            onPressAndHold: mouse => root.pressAndHold(mouse)
                         }
                     }
                     Loader {
@@ -311,7 +309,12 @@ Control {
                                     allowShowMore: !root.isInPinnedPopup
                                     textField.anchors.rightMargin: root.isInPinnedPopup ? Theme.xlPadding : 0 // margin for the "Unpin" floating button
                                     highlightedLink: root.highlightedLink
+                                    linkAddressAndEnsName: root.linkAddressAndEnsName
+                                    disabledTooltipText: root.disabledTooltipText
                                     onLinkActivated: link => root.linkActivated(link)
+                                    textField.onHoveredLinkChanged: {
+                                        root.hoveredLink = hoveredLink
+                                    }
                                 }
                             }
 

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -87,7 +87,7 @@ Item {
                             acceptedButtons: Qt.LeftButton | Qt.RightButton
                             anchors.fill: parent
                             enabled: root.profileClickable
-                            onClicked: root.replyProfileClicked(this, mouse)
+                            onClicked: mouse => root.replyProfileClicked(this, mouse)
                         }
                     }
                     StatusBaseText {
@@ -105,9 +105,7 @@ Item {
                             acceptedButtons: Qt.LeftButton | Qt.RightButton
                             enabled: root.profileClickable
                             hoverEnabled: true
-                            onClicked: {
-                                root.replyProfileClicked(this, mouse)
-                            }
+                            onClicked: mouse => root.replyProfileClicked(this, mouse)
                         }
                     }
                 }
@@ -166,9 +164,7 @@ Item {
                         enabled: !root.replyDetails.messageDeleted && root.replyDetails.sender.id
                         hoverEnabled: true
                         cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                        onClicked: {
-                            root.messageClicked(mouse)
-                        }
+                        onClicked: mouse => root.messageClicked(mouse)
                     }
                 }
             }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -31,8 +31,6 @@ Item {
     implicitWidth: chatText.implicitWidth
     implicitHeight: chatText.height + d.showMoreHeight / 2
 
-    signal pressAndHold(var mouseEvent)
-
     QtObject {
         id: d
         property string hoveredLink: chatText.hoveredLink || root.highlightedLink
@@ -90,7 +88,7 @@ Item {
         color: Theme.palette.baseColor1
     }
 
-    StatusTextArea {
+    TextEdit {
         id: chatText
         objectName: "StatusTextMessage_chatText"
 
@@ -103,18 +101,21 @@ Item {
         anchors.leftMargin: d.isQuote ? Theme.halfPadding : 0
         anchors.right: parent.right
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
-        background: null
-        leftPadding: 0
-        rightPadding: 0
-        topPadding: 0
-        bottomPadding: 0
         text: d.text
         selectedTextColor: Theme.palette.directColor1
+        selectionColor: Theme.palette.primaryColor3
         color: d.isQuote ? Theme.palette.baseColor1 : Theme.palette.directColor1
+        font.family: Fonts.baseFont.family
+        font.pixelSize: Theme.primaryTextFontSize
         textFormat: Text.RichText
         wrapMode: root.convertToSingleLine ? Text.NoWrap : Text.Wrap
         readOnly: true
-        selectByMouse: !Utils.isMobile // applies to mouse only, not touch
+        selectByMouse: true  // applies to mouse only, not touch
+        enabled: !Utils.isMobile // eats the internal touch events to enable the external context menu on long press
+
+        // disable native (edit) context menu; we're really not an edit control
+        inputMethodHints: Qt.ImhNoEditMenu
+
         onLinkActivated: function(link) {
             if(d.showDisabledTooltipForAddressEnsName(link)) {
                 return
@@ -132,7 +133,6 @@ Item {
             x: hoverHandler.point.position.x - 60
             y: -disabledLinkTooltip.height + hoverHandler.point.position.y - 10
         }
-        onPressAndHold: mouseEvent => root.pressAndHold(mouseEvent)
     }
 
     StatusSyntaxHighlighter {

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -405,9 +405,7 @@ Item {
 
             onTokenPaymentRequested: root.tokenPaymentRequested(recipientAddress, tokenKey, rawAmount)
 
-            onShowReplyArea: {
-                root.showReplyArea(messageId, author)
-            }
+            onShowReplyArea: (messageId, author) => root.showReplyArea(messageId, author)
 
             stickersLoaded: root.stickersLoaded
 

--- a/ui/imports/shared/status/StatusChatInputReplyArea.qml
+++ b/ui/imports/shared/status/StatusChatInputReplyArea.qml
@@ -146,7 +146,7 @@ Rectangle {
         StatusMouseArea {
             cursorShape: Qt.PointingHandCursor
             anchors.fill: parent
-            onPressed: mouse.accepted = false
+            onPressed: mouse => mouse.accepted = false
         }
     }
 

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -104,7 +104,7 @@ Flow {
             link: modelData
             isOnline: root.isOnline
             playAnimation: root.playAnimations
-            onClicked: root.imageClicked(imageAlias, mouse, link, link)
+            onClicked: mouse => root.imageClicked(imageAlias, mouse, link, link)
         }
     }
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -244,7 +244,7 @@ Loader {
         profileContextMenuComponent.createObject(root, params).popup(x, y)
     }
 
-    function openMessageContextMenu(x, y) {
+    function openMessageContextMenu(point) {
         if (isViewMemberMessagesePopup || placeholderMessage || !root.joined)
             return
 
@@ -266,7 +266,7 @@ Loader {
             editRestricted: root.editRestricted,
         }
 
-        messageContextMenuComponent.createObject(root, params).popup(x, y)
+        messageContextMenuComponent.createObject(root, params).popup(point)
     }
 
     function setMessageActive(messageId, active) {
@@ -898,10 +898,16 @@ Loader {
                     root.messageStore.resendMessage(root.messageId)
                 }
 
-                ContextMenu.onRequested: pos => root.openMessageContextMenu(pos.x, pos.y)
-                onPressAndHold: function (mouse) {
-                    if (mouse.wasHeld && (root.chatLogView && !root.chatLogView.moving))
-                        root.openMessageContextMenu(mouse.x, mouse.y)
+                TapHandler {
+                    gesturePolicy: TapHandler.ReleaseWithinBounds // exclusive grab on press
+                    acceptedDevices: PointerDevice.TouchScreen
+                    onLongPressed: root.openMessageContextMenu(point.position)
+                }
+
+                TapHandler {
+                    acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+                    acceptedButtons: Qt.RightButton
+                    onTapped: (point, button) => root.openMessageContextMenu(point.position)
                 }
 
                 messageDetails: StatusMessageDetails {
@@ -921,7 +927,6 @@ Loader {
                         case StatusMessage.ContentType.Sticker:
                             return root.sticker;
                         case StatusMessage.ContentType.Image:
-
                             return root.messageImage;
                         }
                         if (root.isDiscordMessage && root.messageImage != "") {


### PR DESCRIPTION
### What does the PR do

Separate commits fixing:
- [fix(StatusMessage): menu in chats overlaps with the typed content](https://github.com/status-im/status-app/commit/cc51be315ca2c47b138ec6dc93ec540967ebceb3)
- [fix(MessageView): fix context menu appearing on scroll](https://github.com/status-im/status-app/commit/790c825ac38a9350bad296b0a363e888840c2a19)

Fixes #20378
Fixes #20360

### Affected areas

StatusMessage/MessageView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="3214" height="2270" alt="Snímek obrazovky z 2026-04-09 13-51-18" src="https://github.com/user-attachments/assets/7417fd4a-2f8e-46ec-a8f1-cd5467cc0bf9" />

### Impact on end user

Smoother UI/UX when viewing/scrolling messages

### How to test

- try the message context menu(s), using mouse/touchpad/touchscreen

### Risk 

low
