### PR TITLE
feat(ActivityCenter): Mark notifications as read + context menu

### DIFF
--- a/storybook/pages/ActivityCenterPanelPage.qml
+++ b/storybook/pages/ActivityCenterPanelPage.qml
@@ -147,6 +147,29 @@ SplitView {
         ]
     }
 
+    property int unreadCount: 0
+
+    function recomputeUnreadCount() {
+        const src = allNotificationsModelMock.sourceModel
+        let count = 0
+        for (let i = 0; i < src.count; i++)
+            if (src.get(i).unread) count++
+        unreadCount = count
+    }
+
+    Component.onCompleted: recomputeUnreadCount()
+
+    function setNotificationUnread(notificationId, unreadValue) {
+        const src = allNotificationsModelMock.sourceModel
+        for (let i = 0; i < src.count; i++) {
+            if (src.get(i).notificationId === notificationId) {
+                src.setProperty(i, "unread", unreadValue)
+                recomputeUnreadCount()
+                return
+            }
+        }
+    }
+
     function getNotificationsModelMock() {
         switch (root.currentActiveGroup) {
         case ActivityCenterTypes.ActivityCenterGroup.Admin:
@@ -182,7 +205,7 @@ SplitView {
             color: Theme.palette.baseColor4
 
             Rectangle {
-                color: Theme.palette.baseColor2
+                color: Theme.palette.statusAppLayout.backgroundColor
                 radius: 12
                 anchors.centerIn: parent
                 width: slider.value
@@ -211,7 +234,10 @@ SplitView {
                     onCloseRequested: logs.logEvent("ActivityCenterPanel::onCloseRequested")
                     onMarkAllAsReadRequested: {
                         logs.logEvent("ActivityCenterPanel::onMarkAllAsReadRequested")
-                        unreadNotifications.checked = false
+                        const src = allNotificationsModelMock.sourceModel
+                        for (let i = 0; i < src.count; i++)
+                            src.setProperty(i, "unread", false)
+                        root.recomputeUnreadCount()
                     }
                     onHideShowReadNotificationsRequested: {
                         logs.logEvent("ActivityCenterPanel::onHideShowReadNotificationsRequested: " + hideReadNotifications)
@@ -241,6 +267,15 @@ SplitView {
                                          }
                     onRedirectToSection: (sectionId) => { logs.logEvent("ActivityCenterPanel::onRedirectToSection: " + sectionId) }
                     onRedirectToPopup: (notification) => { logs.logEvent("ActivityCenterPanel::onRedirectToPopup: " + notification)}
+                    onMarkNotificationRead: (notificationId) => {
+                        logs.logEvent("ActivityCenterPanel::onMarkNotificationRead: " + notificationId)
+                        root.setNotificationUnread(notificationId, false)
+                    }
+
+                    onMarkNotificationUnread: (notificationId) => {
+                        logs.logEvent("ActivityCenterPanel::onMarkNotificationUnread: " + notificationId)
+                        root.setNotificationUnread(notificationId, true)
+                    }
                 }
             }
         }
@@ -327,8 +362,8 @@ SplitView {
             CheckBox {
                 id: unreadNotifications
                 Layout.fillWidth: true
-                text: "Has unread nontificaitons?"
-                checked: true
+                text: "Has unread notifications?"
+                checked: root.unreadCount > 0
             }
         }
     }

--- a/storybook/pages/NotificationCardPage.qml
+++ b/storybook/pages/NotificationCardPage.qml
@@ -40,9 +40,10 @@ SplitView {
         orientation: Qt.Vertical
         SplitView.fillWidth: true
 
-        Item {
+        Rectangle {
             SplitView.fillHeight: true
             SplitView.fillWidth: true
+            color: Theme.palette.baseColor5
 
             NotificationCard {
                 Tracer {
@@ -86,16 +87,31 @@ SplitView {
                                                                                             contentEditor.sevenAttachments ? d.sevenAttachments : []
                 actionId: contentEditor.actionId
 
+                // Colors
+                backgroundColor: cardBgSwitch.checked ? Theme.palette.primaryColor2 : Theme.palette.statusAppLayout.backgroundColor
+                contextMenuColor: contextMenuSwitch.checked ? Theme.palette.baseColor3 : Theme.palette.baseColor4
+
                 // Timestamp related
                 timestamp: dateText.text
 
                 // Interactions
                 onAvatarClicked: logs.logEvent("NotificationCard::onAvatarClicked --> Avatar clicked")
-                onClicked: logs.logEvent("NotificationCard::onClicked --> Card clicked")
+                onClicked: {
+                    logs.logEvent("NotificationCard::onClicked --> Card clicked")
+                    undreadCheck.checked = false
+                }
                 onDeclineRequested: logs.logEvent("NotificationCard::onDeclineRequested --> Decline button clicked")
                 onAcceptRequested: logs.logEvent("NotificationCard::onAcceptRequested --> Accept button clicked")
+                onMarkAsReadRequested: {
+                    logs.logEvent("NotificationCard::onMarkAsReadRequested --> Mark as read clicked")
+                    undreadCheck.checked = false
+                }
+                onMarkAsUnreadRequested: {
+                    logs.logEvent("NotificationCard::onMarkAsUnreadRequested --> Mark as unread clicked")
+                    undreadCheck.checked = true
+                }
             }
-        }
+        }  // end Rectangle
 
         LogsAndControlsPanel {
             SplitView.minimumHeight: 100
@@ -133,6 +149,23 @@ SplitView {
                     id: selectedCheck
                     text: "Selected?"
                     checked: true
+                }
+
+                Label {
+                    Layout.topMargin: Theme.padding
+                    Layout.bottomMargin: Theme.padding
+                    text: "COLORS"
+                    font.weight: Font.Bold
+                }
+
+                Switch {
+                    id: cardBgSwitch
+                    text: checked ? "Card background: primaryColor2" : "Card background: default"
+                }
+
+                Switch {
+                    id: contextMenuSwitch
+                    text: checked ? "Context menu: baseColor3" : "Context menu: default"
                 }
 
                 Label {

--- a/storybook/qmlTests/tests/tst_ActivityCenterPanel.qml
+++ b/storybook/qmlTests/tests/tst_ActivityCenterPanel.qml
@@ -111,12 +111,15 @@ Item {
         }
 
         function test_markAllReadButton() {
-            controlUnderTest = createTemporaryObject(componentUnderTest, root)
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {
+                hasUnreadNotifications: true
+            })
             verify(!!controlUnderTest)
             waitForRendering(controlUnderTest)
 
             const markAllBtn = findChild(controlUnderTest, "markAllReadButton")
             verify(!!markAllBtn)
+            verify(markAllBtn.enabled)
             mouseClick(markAllBtn)
             compare(markAllAsReadSpy.count, 1)
         }

--- a/storybook/qmlTests/tests/tst_NotificationCard.qml
+++ b/storybook/qmlTests/tests/tst_NotificationCard.qml
@@ -43,6 +43,18 @@ Item {
         signalName: "acceptRequested"
     }
 
+    SignalSpy {
+        id: markAsReadRequestedSpy
+        target: controlUnderTest
+        signalName: "markAsReadRequested"
+    }
+
+    SignalSpy {
+        id: markAsUnreadRequestedSpy
+        target: controlUnderTest
+        signalName: "markAsUnreadRequested"
+    }
+
     property NotificationCard controlUnderTest: null
 
     TestCase {
@@ -56,6 +68,8 @@ Item {
             avatarClickedSpy.clear()
             declineRequestedSpy.clear()
             acceptRequestedSpy.clear()
+            markAsReadRequestedSpy.clear()
+            markAsUnreadRequestedSpy.clear()
         }
 
         function test_defaults() {
@@ -341,6 +355,91 @@ Item {
             compare(acceptRequestedSpy.count, 0)
             mouseClick(acceptBtn)
             compare(acceptRequestedSpy.count, 1)
+        }
+
+        function rightClickCenter(item) {
+            mouseClick(item, item.width / 2, item.height / 2, Qt.RightButton)
+        }
+
+        function waitForContextMenuOpen(card) {
+            const panel = findChild(card, "notificationContextPanel")
+            verify(!!panel)
+            tryVerify(() => panel.height >= panel.expandedHeight - 1)
+        }
+
+        function waitForContextMenuClosed(card) {
+            const panel = findChild(card, "notificationContextPanel")
+            verify(!!panel)
+            tryVerify(() => panel.height === 0)
+        }
+
+        function test_markAsUnreadContextMenu() {
+            // Card is read (unread: false) → button says "Mark as unread"
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {
+                title: "Test",
+                unread: false
+            })
+            verify(!!controlUnderTest)
+            waitForRendering(controlUnderTest)
+
+            const btn = findChild(controlUnderTest, "notificationMarkUnreadBtn")
+            verify(!!btn)
+            verify(!btn.visible)
+
+            rightClickCenter(controlUnderTest)
+            waitForContextMenuOpen(controlUnderTest)
+            compare(btn.text, qsTr("Mark as unread"))
+
+            compare(markAsUnreadRequestedSpy.count, 0)
+            mouseClick(btn)
+            compare(markAsUnreadRequestedSpy.count, 1)
+            compare(markAsReadRequestedSpy.count, 0)
+            waitForContextMenuClosed(controlUnderTest)
+        }
+
+        function test_markAsReadContextMenu() {
+            // Card is unread (unread: true) → button says "Mark as read"
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {
+                title: "Test",
+                unread: true
+            })
+            verify(!!controlUnderTest)
+            waitForRendering(controlUnderTest)
+
+            const btn = findChild(controlUnderTest, "notificationMarkUnreadBtn")
+            verify(!!btn)
+
+            rightClickCenter(controlUnderTest)
+            waitForContextMenuOpen(controlUnderTest)
+            compare(btn.text, qsTr("Mark as read"))
+
+            compare(markAsReadRequestedSpy.count, 0)
+            mouseClick(btn)
+            compare(markAsReadRequestedSpy.count, 1)
+            compare(markAsUnreadRequestedSpy.count, 0)
+            waitForContextMenuClosed(controlUnderTest)
+        }
+
+        function test_contextMenuClosesOnLeftClick() {
+            controlUnderTest = createTemporaryObject(componentUnderTest, root, {
+                title: "Test"
+            })
+            verify(!!controlUnderTest)
+            waitForRendering(controlUnderTest)
+
+            const btn = findChild(controlUnderTest, "notificationMarkUnreadBtn")
+            verify(!!btn)
+
+            // Open context menu via right-click
+            rightClickCenter(controlUnderTest)
+            waitForContextMenuOpen(controlUnderTest)
+
+            // Left-click on the card closes the menu without emitting clicked()
+            const cardBg = findChild(controlUnderTest, "notificationCardBg")
+            verify(!!cardBg)
+            mouseClick(cardBg)
+            waitForContextMenuClosed(controlUnderTest)
+            compare(clickedSpy.count, 0)
         }
     }
 }

--- a/storybook/src/Models/NotificationsModel.qml
+++ b/storybook/src/Models/NotificationsModel.qml
@@ -14,7 +14,7 @@ import AppLayouts.ActivityCenter.helpers
 // Here is an example of the complete set of properties that a `Notification model` can contain:
 //{
 //    // Card states related
-//    notificationsType: ActivityCenterTypes.NotificationType.Mention,
+//    notificationType: ActivityCenterTypes.NotificationType.Mention,
 //    unread: false,
 //    selected: false,
 //

--- a/storybook/src/Models/NotificationsModel.qml
+++ b/storybook/src/Models/NotificationsModel.qml
@@ -857,7 +857,9 @@ ObjectProxyModel {
             }
         ]
 
-        Component.onCompleted: append(data)
+        Component.onCompleted: {
+            append(data.map((item, index) => Object.assign({}, item, {notificationId: "notif-" + index})))
+        }
     }
 
     delegate: QtObject {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusSecondaryActionHandler.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSecondaryActionHandler.qml
@@ -1,0 +1,29 @@
+import QtQuick
+
+import MobileUI
+
+// StatusSecondaryActionHandler.qml
+// Detects platform-appropriate secondary action gestures:
+// right-click / stylus tap on desktop, long-press on touch screens.
+// Emits triggered() — the parent decides what to do.
+Item {
+    anchors.fill: parent
+
+    signal triggered()
+
+    // Right-click / stylus: desktop and tablet with mouse.
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+        onTapped: triggered()
+    }
+
+    // Long-press: touch screens only.
+    TapHandler {
+        acceptedDevices: PointerDevice.TouchScreen
+        onLongPressed: {
+            MobileUI.vibrate() // no-op on non-mobile platforms (e.g. laptop touch screens)
+            triggered()
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Controls/qmldir
+++ b/ui/StatusQ/src/StatusQ/Controls/qmldir
@@ -46,6 +46,7 @@ StatusProgressBar 0.1 StatusProgressBar.qml
 StatusRadioButton 0.1 StatusRadioButton.qml
 StatusRoundButton 0.1 StatusRoundButton.qml
 StatusScrollBar 0.1 StatusScrollBar.qml
+StatusSecondaryActionHandler 0.1 StatusSecondaryActionHandler.qml
 StatusSeedPhraseField 0.1 StatusSeedPhraseField.qml
 StatusSeedPhraseInput 0.1 StatusSeedPhraseInput.qml
 StatusSeedPhraseTabBar 0.1 StatusSeedPhraseTabBar.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -122,6 +122,7 @@
         <file>StatusQ/Controls/StatusItemPicker.qml</file>
         <file>StatusQ/Controls/StatusLabeledSlider.qml</file>
         <file>StatusQ/Controls/StatusLinkText.qml</file>
+        <file>StatusQ/Controls/StatusSecondaryActionHandler.qml</file>
         <file>StatusQ/Controls/NativeSwipeHandler.qml</file>
         <file>StatusQ/Controls/NativeSwipeHandlerImpl.qml</file>
         <file>StatusQ/Controls/NativeIndicator.qml</file>

--- a/ui/app/AppLayouts/ActivityCenter/adaptors/ActivityCenterAdaptor.qml
+++ b/ui/app/AppLayouts/ActivityCenter/adaptors/ActivityCenterAdaptor.qml
@@ -138,7 +138,8 @@ QtObject {
 
         Model structure (output):
 
-        notificationsType    [int]     - notification type
+        id                   [string]  - notificaiton identifier
+        notificationType     [int]     - notification type
         unread               [bool]    - whether the notification is unread
         selected             [bool]    - selection state (UI-managed)
 
@@ -229,7 +230,7 @@ QtObject {
 
             expectedRoles: [
                 // Notification status / management
-                "notificationType", "timestamp", "read", "dismissed", "accepted",
+                "id", "notificationType", "timestamp", "read", "dismissed", "accepted",
 
                 // Notification context
                 "chatId", "communityId", "sectionId",
@@ -246,7 +247,7 @@ QtObject {
 
             exposedRoles: [
                 // Card states related
-                "notificationsType", "unread",
+                "notificationId", "notificationType", "unread",
 
                 // Avatar related
                 "avatarSource", "badgeIconName", "isCircularAvatar", "isAvatarClickable", "avatarId",
@@ -395,7 +396,8 @@ QtObject {
                 // -------------------------
                 // Card state
                 // -------------------------
-                readonly property int notificationsType: notification.notificationType
+                readonly property string notificationId: notification.notificationId
+                readonly property int notificationType: notification.notificationType
                 readonly property bool unread: !(notification.read ?? false)
 
                 // -------------------------

--- a/ui/app/AppLayouts/ActivityCenter/controls/NotificationAvatar.qml
+++ b/ui/app/AppLayouts/ActivityCenter/controls/NotificationAvatar.qml
@@ -87,6 +87,12 @@ Control {
     // badge to be clickable or highlight on hover.
     property bool isBadgeClickable: true
 
+    // Cursor shape shown when hovering over the avatar area. Defaults to a pointing
+    // hand when clickable, arrow otherwise. Override to force a specific cursor
+    // regardless of isAvatarClickable (e.g. Qt.PointingHandCursor when the parent
+    // card is always clickable).
+    property int avatarCursorShape: root.isAvatarClickable ? Qt.PointingHandCursor : Qt.ArrowCursor
+
     // Properties used to show up avatar letters whenever no image source is provided
     property color avatarLetterColor: Theme.palette.miscColor5
     property string avatarLetterText: ""
@@ -130,7 +136,7 @@ Control {
         MouseArea {
             anchors.fill: avatarComponent
             enabled: root.isAvatarClickable
-            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+            cursorShape: root.avatarCursorShape
             onClicked: root.avatarClicked()
         }
 

--- a/ui/app/AppLayouts/ActivityCenter/controls/NotificationCard.qml
+++ b/ui/app/AppLayouts/ActivityCenter/controls/NotificationCard.qml
@@ -45,6 +45,7 @@ import StatusQ.Core.Theme
 import StatusQ.Components
 import StatusQ.Controls
 import StatusQ.Core
+import StatusQ.Core.Utils as SQUtils
 
 import utils
 
@@ -169,11 +170,18 @@ Control {
     // Style / layout
     // ──────────────────────────────────────────────────────────────────────────
 
+    // Background color of the card. Should match the page/panel background so
+    // the card blends in and the context panel overlap is properly hidden.
+    property color backgroundColor: Theme.palette.statusAppLayout.backgroundColor
+
+    // Background color of the context menu panel shown below the card.
+    property color contextMenuColor: Theme.palette.baseColor4
+
     // Horizontal spacing between avatar and content column.
     spacing: Math.max(Theme.halfPadding, 8)
 
-    // Vertical padding inside the card background.
-    verticalPadding: Math.max(Theme.halfPadding, 8)
+    // No padding — managed explicitly inside contentItem via cardVPad.
+    padding: 0
 
     // ──────────────────────────────────────────────────────────────────────────
     // Interactions
@@ -186,6 +194,10 @@ Control {
     // Emitted when quick actions are shown and user interacts with the corresponding buttons
     signal declineRequested()
     signal acceptRequested()
+
+    // Emitted when the user requests to mark the notification as read/unread via the context menu.
+    signal markAsReadRequested()
+    signal markAsUnreadRequested()
 
     QtObject {
         id: d
@@ -208,14 +220,23 @@ Control {
         readonly property int readUnreadBadgeSize: 8
 
         // Color of the unread indicator dot.
-        readonly property color unreadDotColor: Theme.palette.primaryColor1
+        readonly property color unreadDotColor: root.Theme.palette.primaryColor1
 
         // Fixed diameter (or the small unread dot (read-only convenience).
         readonly property int unreadBadgeSize: 18
 
+        // Vertical padding inside the card background.
+        readonly property int cardVPad: Math.max(Theme.halfPadding, 8)
+
+        // How many pixels the context panel overlaps the card bottom edge.
+        readonly property int contextPanelOverlap: root.Theme.radius * 2
+
         // True when the pointer is over an interactive child (e.g. avatar),
         // used to temporarily block the card tap handler in favor of the child one.
         property bool hasInteractiveChildHovered: false
+
+        // True when the context menu (right-click / long-press) is expanded.
+        property bool contextMenuOpen: false
 
         // Returns the avatar scaling factor for a given font size enum value.
         function avatarFactorForFontSize(fs) {
@@ -233,168 +254,273 @@ Control {
 
     objectName: "notificationCard"
 
-    // Card background and unread indicator.
-    background: Rectangle {
-        radius: Theme.radius
-        color: StatusColors.transparent
-        border.width: 2
-        border.color: root.selected || (root.hovered && root.enabled) ? Theme.palette.primaryColor1 : StatusColors.transparent
+    // The card background is drawn inside contentItem so its height is fixed
+    // to the card content area only — the context panel appears below as a
+    // separate element and must not cause the card background to expand.
+    background: null
 
-         // Unread indicator dot (top-right).
+    // ──────────────────────────────────────────────────────────────────────────
+    // Content
+    // ──────────────────────────────────────────────────────────────────────────
+    contentItem: Item {
+        id: contentRoot
+
+        implicitWidth: cardLayout.implicitWidth
+        implicitHeight: cardBg.height + Math.max(0, contextPanel.height - d.contextPanelOverlap)
+
+        // ── Card visual background ────────────────────────────────────────────
+        // Sized to the card content only. The context panel sits below this.
+        // z: 1 ensures the card's rounded bottom corners render on top of the
+        // context panel, which overlaps the card bottom by Theme.radius pixels.
         Rectangle {
-            objectName: "notificationReadIndicator"
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.margins: Math.max(Theme.halfPadding, 8)
-            width: Math.max(Theme.halfPadding, 8)
-            height: width
-            radius: width / 2
-            color: d.unreadDotColor
-            visible: root.unread
-        }
+            id: cardBg
+            objectName: "notificationCardBg"
+            z: 1
+            anchors { left: parent.left; right: parent.right; top: parent.top }
+            height: cardLayout.implicitHeight + 2 * d.cardVPad
+            radius: Theme.radius
+            color: d.contextMenuOpen ? root.contextMenuColor : root.backgroundColor
+            border.width: 2
+            border.color: root.selected || (root.hovered && root.enabled) ? Theme.palette.primaryColor1 : StatusColors.transparent
 
-        // Full-card click target
-        TapHandler {
-            enabled: !d.hasInteractiveChildHovered
-            onTapped: root.clicked()
-        }
-
-        HoverHandler {
-            enabled: !d.hasInteractiveChildHovered
-            cursorShape: Qt.PointingHandCursor
-        }
-    }
-
-    // ──────────────────────────────────────────────────────────────────────────
-    // Content - Main layout: avatar + content column.
-    // ──────────────────────────────────────────────────────────────────────────
-    contentItem: RowLayout {
-        spacing: root.spacing
-
-        // Avatar block (non-clickable here; card handles clicks).
-        NotificationAvatar {
-            Layout.alignment: Qt.AlignTop
-            Layout.leftMargin: Math.max(Theme.halfPadding, 8)
-
-            objectName: "notificationAvatar"
-
-            // Scale avatar with current font size factor
-            density: d.avatarFactorForFontSize(Theme.currentFontSize)
-
-            avatarSource: root.avatarSource
-            badgeIconName: root.badgeIconName
-            circular: root.isCircularAvatar
-            isAvatarClickable: root.isAvatarClickable
-            isBadgeClickable: root.isBadgeClickable
-            avatarLetterColor: root.avatarLetterColor
-            avatarLetterText: root.avatarLetterText
-            isAvatarLetterAcronym: root.isAvatarLetterAcronym
-            avatarMaxTextLen: root.avatarMaxTextLen
-
-            onAvatarClicked: root.avatarClicked()
-
-            HoverHandler {
-                cursorShape: Qt.PointingHandCursor
-                onHoveredChanged: d.hasInteractiveChildHovered = hovered
+            // Unread indicator dot (top-right).
+            Rectangle {
+                objectName: "notificationReadIndicator"
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: Math.max(Theme.halfPadding, 8)
+                width: Math.max(Theme.halfPadding, 8)
+                height: width
+                radius: width / 2
+                color: d.unreadDotColor
+                visible: root.unread
             }
-        }
 
-        // Main content area
-        ColumnLayout {
-            spacing: Theme.smallPadding / 2
-            Layout.fillWidth: true
-            Layout.rightMargin: Math.max(Theme.halfPadding, 8)
+            // Full-card left-click: close context menu if open, otherwise navigate.
+            TapHandler {
+                enabled: !d.hasInteractiveChildHovered
+                onTapped: {
+                    if (d.contextMenuOpen) {
+                        d.contextMenuOpen = false
+                    } else {
+                        root.clicked()
+                    }
+                }
+            }
+
+            StatusSecondaryActionHandler {
+                onTriggered: d.contextMenuOpen = !d.contextMenuOpen
+            }
 
             HoverHandler {
                 enabled: !d.hasInteractiveChildHovered
                 cursorShape: Qt.PointingHandCursor
             }
+        }
 
-            // Header row: title + chat key + contact/trust badges.
-            NotificationHeaderRow {
-                Layout.fillWidth: true
-                Layout.rightMargin: d.unreadBadgeSize / 2
-                objectName: "notificationHeader"
-                visible: root.title != ""
-                title: root.title
-                chatKey: root.chatKey
-                isContact: root.isContact
-                trustIndicator: root.trustIndicator
-                isBlocked: root.isBlocked
+        // ── Main card content ─────────────────────────────────────────────────
+        // Avatar + text + quick actions + timestamp.
+        // Anchored at top with cardVPad margin so the card background has equal
+        // padding on all sides. z: 1 keeps content above the context panel.
+        ColumnLayout {
+            id: cardLayout
+            z: 1
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: parent.top
+                topMargin: d.cardVPad
             }
-
-            // Context row: community + channel + optional icons.
-            NotificationContextRow {
-                Layout.fillWidth: true
-                Layout.rightMargin: d.unreadBadgeSize / 2
-                objectName: "notificationContext"
-                visible: root.primaryText != ""
-                primaryText: root.primaryText
-                contextAvatar: root.contextAvatar
-                secondaryText: root.secondaryText
-                iconName: root.iconName
-                separatorIconName: root.separatorIconName
-            }
-
-            // Optional action hint/body line under context row.
-            StatusBaseText {
-                Layout.fillWidth: true
-                objectName: "notificationActionText"
-                visible: root.actionText
-                text: root.actionText
-                font.pixelSize: Theme.fontSize(13)
-                color: Theme.palette.directColor5
-                elide: Text.ElideRight
-            }
-
-            // Rich content block: HTML, banner, attachments.
-            NotificationContentBlock {
-                Layout.fillWidth: true
-                objectName: "notificationContent"
-                contentText: root.content
-                preImageSource: root.preImageSource
-                preImageRadius: root.preImageRadius
-                attachments: root.attachments
-                thumbSpacing: 6
-            }
+            spacing: Theme.halfPadding / 2
 
             RowLayout {
-                id: quickActions
-                objectName: "quickActions"
-
-                visible: root.actionId !== ""
                 Layout.fillWidth: true
-                spacing: Theme.halfPadding
+                spacing: root.spacing
 
-                StatusButton {
-                    Layout.fillWidth: true
+            // Avatar block (non-clickable here; card handles clicks).
+            NotificationAvatar {
+                Layout.alignment: Qt.AlignTop
+                Layout.leftMargin: Math.max(Theme.halfPadding, 8)
 
-                    objectName: "notificationDeclineBtn"
-                    text: qsTr("Decline")
-                    size: StatusBaseButton.Size.Small
-                    type: StatusBaseButton.Type.Danger
-                    onClicked: root.declineRequested()
+                objectName: "notificationAvatar"
+
+                // Scale avatar with current font size factor
+                density: d.avatarFactorForFontSize(Theme.currentFontSize)
+
+                avatarSource: root.avatarSource
+                badgeIconName: root.badgeIconName
+                circular: root.isCircularAvatar
+                isAvatarClickable: root.isAvatarClickable
+                isBadgeClickable: root.isBadgeClickable
+                avatarLetterColor: root.avatarLetterColor
+                avatarLetterText: root.avatarLetterText
+                isAvatarLetterAcronym: root.isAvatarLetterAcronym
+                avatarMaxTextLen: root.avatarMaxTextLen
+
+                onAvatarClicked: root.avatarClicked()
+
+                HoverHandler {
+                    cursorShape: Qt.PointingHandCursor
+                    onHoveredChanged: d.hasInteractiveChildHovered = hovered
                 }
+            }
+
+            // Main content area
+            ColumnLayout {
+                spacing: Theme.smallPadding / 2
+                Layout.fillWidth: true
+                Layout.rightMargin: Math.max(Theme.halfPadding, 8)
+
+                HoverHandler {
+                    enabled: !d.hasInteractiveChildHovered
+                    cursorShape: Qt.PointingHandCursor
+                }
+
+                // Header row: title + chat key + contact/trust badges.
+                NotificationHeaderRow {
+                    Layout.fillWidth: true
+                    Layout.rightMargin: d.unreadBadgeSize / 2
+                    objectName: "notificationHeader"
+                    visible: root.title != ""
+                    title: root.title
+                    chatKey: root.chatKey
+                    isContact: root.isContact
+                    trustIndicator: root.trustIndicator
+                    isBlocked: root.isBlocked
+                }
+
+                // Context row: community + channel + optional icons.
+                NotificationContextRow {
+                    Layout.fillWidth: true
+                    Layout.rightMargin: d.unreadBadgeSize / 2
+                    objectName: "notificationContext"
+                    visible: root.primaryText != ""
+                    primaryText: root.primaryText
+                    contextAvatar: root.contextAvatar
+                    secondaryText: root.secondaryText
+                    iconName: root.iconName
+                    separatorIconName: root.separatorIconName
+                }
+
+                // Optional action hint/body line under context row.
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    objectName: "notificationActionText"
+                    visible: root.actionText
+                    text: root.actionText
+                    font.pixelSize: Theme.fontSize(13)
+                    color: Theme.palette.directColor5
+                    elide: Text.ElideRight
+                }
+
+                // Rich content block: HTML, banner, attachments.
+                NotificationContentBlock {
+                    Layout.fillWidth: true
+                    objectName: "notificationContent"
+                    contentText: root.content
+                    preImageSource: root.preImageSource
+                    preImageRadius: root.preImageRadius
+                    attachments: root.attachments
+                    thumbSpacing: 6
+                }
+
+                RowLayout {
+                    id: quickActions
+                    objectName: "quickActions"
+
+                    visible: root.actionId !== ""
+                    Layout.fillWidth: true
+                    spacing: Theme.halfPadding
+
+                    StatusButton {
+                        Layout.fillWidth: true
+
+                        objectName: "notificationDeclineBtn"
+                        text: qsTr("Decline")
+                        size: StatusBaseButton.Size.Small
+                        type: StatusBaseButton.Type.Danger
+                        onClicked: root.declineRequested()
+                    }
+                    StatusButton {
+                        Layout.fillWidth: true
+
+                        objectName: "notificationAcceptBtn"
+                        text: qsTr("Accept")
+                        size: StatusBaseButton.Size.Small
+                        type: StatusBaseButton.Type.Normal
+                        onClicked: root.acceptRequested()
+                    }
+                }
+
+                // Timestamp row (falls back to "Just now").
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    objectName: "notificationTimestamp"
+                    text: LocaleUtils.formatRelativeTimestamp(root.timestamp)
+                    font.pixelSize: Theme.fontSize(11)
+                    color: Theme.palette.directColor5
+                    elide: Text.ElideRight
+                }
+            }
+            } // end inner RowLayout
+        } // end cardLayout
+
+        // ── Context menu panel ────────────────────────────────────────────────
+        // Appears anchored below the card background as a separate rounded
+        // rectangle. The card's own visual is unchanged when this is shown.
+        Rectangle {
+            id: contextPanel
+            objectName: "notificationContextPanel"
+
+            readonly property real expandedHeight: contextActionsRow.implicitHeight + Theme.padding * 2 + d.contextPanelOverlap
+
+            clip: true
+            visible: height > 0
+            anchors {
+                top: cardBg.bottom
+                topMargin: -d.contextPanelOverlap
+                left: parent.left
+                right: parent.right
+            }
+            height: d.contextMenuOpen ? expandedHeight : 0
+            radius: Theme.radius
+            color: root.contextMenuColor
+
+            RowLayout {
+                id: contextActionsRow
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    top: parent.top
+                    bottom: parent.bottom
+                    topMargin: Theme.padding + d.contextPanelOverlap
+                    bottomMargin: Theme.padding
+                    leftMargin: Theme.padding
+                    rightMargin: Theme.padding
+                }
+
                 StatusButton {
                     Layout.fillWidth: true
-
-                    objectName: "notificationAcceptBtn"
-                    text: qsTr("Accept")
+                    objectName: "notificationMarkUnreadBtn"
+                    text: root.unread ? qsTr("Mark as read") : qsTr("Mark as unread")
                     size: StatusBaseButton.Size.Small
                     type: StatusBaseButton.Type.Normal
-                    onClicked: root.acceptRequested()
+                    onClicked: {
+                        d.contextMenuOpen = false
+                        if (root.unread)
+                            root.markAsReadRequested()
+                        else
+                            root.markAsUnreadRequested()
+                    }
                 }
             }
 
-            // Timestamp row (falls back to "Just now").
-            StatusBaseText {
-                Layout.fillWidth: true
-                objectName: "notificationTimestamp"
-                text: LocaleUtils.formatRelativeTimestamp(root.timestamp)
-                font.pixelSize: Theme.fontSize(11)
-                color: Theme.palette.directColor5
-                elide: Text.ElideRight
+            Behavior on height {
+                NumberAnimation {
+                    duration: ThemeUtils.AnimationDuration.Slow
+                    easing.type: Easing.OutCubic
+                }
             }
         }
-    }
+    } // end contentItem
 }

--- a/ui/app/AppLayouts/ActivityCenter/controls/NotificationCard.qml
+++ b/ui/app/AppLayouts/ActivityCenter/controls/NotificationCard.qml
@@ -352,12 +352,22 @@ Control {
                 circular: root.isCircularAvatar
                 isAvatarClickable: root.isAvatarClickable
                 isBadgeClickable: root.isBadgeClickable
+                avatarCursorShape: Qt.PointingHandCursor
                 avatarLetterColor: root.avatarLetterColor
                 avatarLetterText: root.avatarLetterText
                 isAvatarLetterAcronym: root.isAvatarLetterAcronym
                 avatarMaxTextLen: root.avatarMaxTextLen
 
-                onAvatarClicked: root.avatarClicked()
+                onAvatarClicked: {
+                    root.avatarClicked()
+                    if (root.unread)
+                        root.markAsReadRequested()
+                }
+
+                TapHandler {
+                    enabled: !root.isAvatarClickable
+                    onTapped: root.clicked()
+                }
 
                 HoverHandler {
                     cursorShape: Qt.PointingHandCursor
@@ -520,6 +530,24 @@ Control {
                     duration: ThemeUtils.AnimationDuration.Slow
                     easing.type: Easing.OutCubic
                 }
+            }
+        }
+
+        // When the context menu expands, scroll the ListView so the panel
+        // is fully visible — avoids having to manually scroll to see the button.
+        Connections {
+            target: d
+            function onContextMenuOpenChanged() {
+                if (!d.contextMenuOpen) return
+                const lv = root.ListView.view
+                if (!lv) return
+                const panelBottom = contentRoot.mapToItem(lv.contentItem, 0, 0).y
+                                    + cardBg.height
+                                    + contextPanel.expandedHeight
+                                    - d.contextPanelOverlap
+                const visibleBottom = lv.contentY + lv.height
+                if (panelBottom > visibleBottom)
+                    lv.contentY = lv.contentY + (panelBottom - visibleBottom)
             }
         }
     } // end contentItem

--- a/ui/app/AppLayouts/ActivityCenter/controls/NotificationCard.qml
+++ b/ui/app/AppLayouts/ActivityCenter/controls/NotificationCard.qml
@@ -254,10 +254,37 @@ Control {
 
     objectName: "notificationCard"
 
-    // The card background is drawn inside contentItem so its height is fixed
-    // to the card content area only — the context panel appears below as a
-    // separate element and must not cause the card background to expand.
-    background: null
+    // ──────────────────────────────────────────────────────────────────────────
+    // Background
+    // ──────────────────────────────────────────────────────────────────────────
+    // Single rectangle that fills the full control (card + context panel area).
+    // Changes colour immediately when the context menu opens or closes.
+    background: Rectangle {
+        objectName: "notificationCardBg"
+        radius: Theme.radius
+        color: d.contextMenuOpen ? root.contextMenuColor : root.backgroundColor
+
+        // Full-card left-click: close context menu if open, otherwise navigate.
+        TapHandler {
+            enabled: !d.hasInteractiveChildHovered
+            onTapped: {
+                if (d.contextMenuOpen) {
+                    d.contextMenuOpen = false
+                } else {
+                    root.clicked()
+                }
+            }
+        }
+
+        StatusSecondaryActionHandler {
+            onTriggered: d.contextMenuOpen = !d.contextMenuOpen
+        }
+
+        HoverHandler {
+            enabled: !d.hasInteractiveChildHovered
+            cursorShape: Qt.PointingHandCursor
+        }
+    }
 
     // ──────────────────────────────────────────────────────────────────────────
     // Content
@@ -265,66 +292,44 @@ Control {
     contentItem: Item {
         id: contentRoot
 
-        implicitWidth: cardLayout.implicitWidth
-        implicitHeight: cardBg.height + Math.max(0, contextPanel.height - d.contextPanelOverlap)
+        readonly property int cardHeight: cardLayout.implicitHeight + 2 * d.cardVPad
 
-        // ── Card visual background ────────────────────────────────────────────
-        // Sized to the card content only. The context panel sits below this.
-        // z: 1 ensures the card's rounded bottom corners render on top of the
-        // context panel, which overlaps the card bottom by Theme.radius pixels.
+        implicitWidth: cardLayout.implicitWidth
+        implicitHeight: cardHeight + Math.max(0, contextPanel.height - d.contextPanelOverlap)
+
+        // ── Selection / hover border ─────────────────────────────────────────────────
+        // Explicitly sized to the card area only — never extends over the
+        // context panel below.
         Rectangle {
-            id: cardBg
-            objectName: "notificationCardBg"
-            z: 1
-            anchors { left: parent.left; right: parent.right; top: parent.top }
-            height: cardLayout.implicitHeight + 2 * d.cardVPad
+            anchors {
+                left: parent.left
+                right: parent.right
+                top: parent.top
+            }
+            height: contentRoot.cardHeight
+            color: StatusColors.transparent
             radius: Theme.radius
-            color: d.contextMenuOpen ? root.contextMenuColor : root.backgroundColor
             border.width: 2
             border.color: root.selected || (root.hovered && root.enabled) ? Theme.palette.primaryColor1 : StatusColors.transparent
+        }
 
-            // Unread indicator dot (top-right).
-            Rectangle {
-                objectName: "notificationReadIndicator"
-                anchors.right: parent.right
-                anchors.top: parent.top
-                anchors.margins: Math.max(Theme.halfPadding, 8)
-                width: Math.max(Theme.halfPadding, 8)
-                height: width
-                radius: width / 2
-                color: d.unreadDotColor
-                visible: root.unread
-            }
-
-            // Full-card left-click: close context menu if open, otherwise navigate.
-            TapHandler {
-                enabled: !d.hasInteractiveChildHovered
-                onTapped: {
-                    if (d.contextMenuOpen) {
-                        d.contextMenuOpen = false
-                    } else {
-                        root.clicked()
-                    }
-                }
-            }
-
-            StatusSecondaryActionHandler {
-                onTriggered: d.contextMenuOpen = !d.contextMenuOpen
-            }
-
-            HoverHandler {
-                enabled: !d.hasInteractiveChildHovered
-                cursorShape: Qt.PointingHandCursor
-            }
+        // Unread indicator dot (top-right).
+        Rectangle {
+            objectName: "notificationReadIndicator"
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: Math.max(Theme.halfPadding, 8)
+            width: Math.max(Theme.halfPadding, 8)
+            height: width
+            radius: width / 2
+            color: d.unreadDotColor
+            visible: root.unread
         }
 
         // ── Main card content ─────────────────────────────────────────────────
         // Avatar + text + quick actions + timestamp.
-        // Anchored at top with cardVPad margin so the card background has equal
-        // padding on all sides. z: 1 keeps content above the context panel.
         ColumnLayout {
             id: cardLayout
-            z: 1
             anchors {
                 left: parent.left
                 right: parent.right
@@ -337,164 +342,159 @@ Control {
                 Layout.fillWidth: true
                 spacing: root.spacing
 
-            // Avatar block (non-clickable here; card handles clicks).
-            NotificationAvatar {
-                Layout.alignment: Qt.AlignTop
-                Layout.leftMargin: Math.max(Theme.halfPadding, 8)
+                // Avatar block
+                NotificationAvatar {
+                    Layout.alignment: Qt.AlignTop
+                    Layout.leftMargin: Math.max(Theme.halfPadding, 8)
 
-                objectName: "notificationAvatar"
+                    objectName: "notificationAvatar"
 
-                // Scale avatar with current font size factor
-                density: d.avatarFactorForFontSize(Theme.currentFontSize)
+                    density: d.avatarFactorForFontSize(Theme.currentFontSize)
 
-                avatarSource: root.avatarSource
-                badgeIconName: root.badgeIconName
-                circular: root.isCircularAvatar
-                isAvatarClickable: root.isAvatarClickable
-                isBadgeClickable: root.isBadgeClickable
-                avatarCursorShape: Qt.PointingHandCursor
-                avatarLetterColor: root.avatarLetterColor
-                avatarLetterText: root.avatarLetterText
-                isAvatarLetterAcronym: root.isAvatarLetterAcronym
-                avatarMaxTextLen: root.avatarMaxTextLen
+                    avatarSource: root.avatarSource
+                    badgeIconName: root.badgeIconName
+                    circular: root.isCircularAvatar
+                    isAvatarClickable: root.isAvatarClickable
+                    isBadgeClickable: root.isBadgeClickable
+                    avatarCursorShape: Qt.PointingHandCursor
+                    avatarLetterColor: root.avatarLetterColor
+                    avatarLetterText: root.avatarLetterText
+                    isAvatarLetterAcronym: root.isAvatarLetterAcronym
+                    avatarMaxTextLen: root.avatarMaxTextLen
 
-                onAvatarClicked: {
-                    root.avatarClicked()
-                    if (root.unread)
-                        root.markAsReadRequested()
-                }
-
-                TapHandler {
-                    enabled: !root.isAvatarClickable
-                    onTapped: root.clicked()
-                }
-
-                HoverHandler {
-                    cursorShape: Qt.PointingHandCursor
-                    onHoveredChanged: d.hasInteractiveChildHovered = hovered
-                }
-            }
-
-            // Main content area
-            ColumnLayout {
-                spacing: Theme.smallPadding / 2
-                Layout.fillWidth: true
-                Layout.rightMargin: Math.max(Theme.halfPadding, 8)
-
-                HoverHandler {
-                    enabled: !d.hasInteractiveChildHovered
-                    cursorShape: Qt.PointingHandCursor
-                }
-
-                // Header row: title + chat key + contact/trust badges.
-                NotificationHeaderRow {
-                    Layout.fillWidth: true
-                    Layout.rightMargin: d.unreadBadgeSize / 2
-                    objectName: "notificationHeader"
-                    visible: root.title != ""
-                    title: root.title
-                    chatKey: root.chatKey
-                    isContact: root.isContact
-                    trustIndicator: root.trustIndicator
-                    isBlocked: root.isBlocked
-                }
-
-                // Context row: community + channel + optional icons.
-                NotificationContextRow {
-                    Layout.fillWidth: true
-                    Layout.rightMargin: d.unreadBadgeSize / 2
-                    objectName: "notificationContext"
-                    visible: root.primaryText != ""
-                    primaryText: root.primaryText
-                    contextAvatar: root.contextAvatar
-                    secondaryText: root.secondaryText
-                    iconName: root.iconName
-                    separatorIconName: root.separatorIconName
-                }
-
-                // Optional action hint/body line under context row.
-                StatusBaseText {
-                    Layout.fillWidth: true
-                    objectName: "notificationActionText"
-                    visible: root.actionText
-                    text: root.actionText
-                    font.pixelSize: Theme.fontSize(13)
-                    color: Theme.palette.directColor5
-                    elide: Text.ElideRight
-                }
-
-                // Rich content block: HTML, banner, attachments.
-                NotificationContentBlock {
-                    Layout.fillWidth: true
-                    objectName: "notificationContent"
-                    contentText: root.content
-                    preImageSource: root.preImageSource
-                    preImageRadius: root.preImageRadius
-                    attachments: root.attachments
-                    thumbSpacing: 6
-                }
-
-                RowLayout {
-                    id: quickActions
-                    objectName: "quickActions"
-
-                    visible: root.actionId !== ""
-                    Layout.fillWidth: true
-                    spacing: Theme.halfPadding
-
-                    StatusButton {
-                        Layout.fillWidth: true
-
-                        objectName: "notificationDeclineBtn"
-                        text: qsTr("Decline")
-                        size: StatusBaseButton.Size.Small
-                        type: StatusBaseButton.Type.Danger
-                        onClicked: root.declineRequested()
+                    onAvatarClicked: {
+                        root.avatarClicked()
+                        if (root.unread)
+                            root.markAsReadRequested()
                     }
-                    StatusButton {
-                        Layout.fillWidth: true
 
-                        objectName: "notificationAcceptBtn"
-                        text: qsTr("Accept")
-                        size: StatusBaseButton.Size.Small
-                        type: StatusBaseButton.Type.Normal
-                        onClicked: root.acceptRequested()
+                    TapHandler {
+                        enabled: !root.isAvatarClickable
+                        onTapped: root.clicked()
+                    }
+
+                    HoverHandler {
+                        cursorShape: Qt.PointingHandCursor
+                        onHoveredChanged: d.hasInteractiveChildHovered = hovered
                     }
                 }
 
-                // Timestamp row (falls back to "Just now").
-                StatusBaseText {
+                // Main content area
+                ColumnLayout {
+                    spacing: Theme.smallPadding / 2
                     Layout.fillWidth: true
-                    objectName: "notificationTimestamp"
-                    text: LocaleUtils.formatRelativeTimestamp(root.timestamp)
-                    font.pixelSize: Theme.fontSize(11)
-                    color: Theme.palette.directColor5
-                    elide: Text.ElideRight
+                    Layout.rightMargin: Math.max(Theme.halfPadding, 8)
+
+                    HoverHandler {
+                        enabled: !d.hasInteractiveChildHovered
+                        cursorShape: Qt.PointingHandCursor
+                    }
+
+                    // Header row: title + chat key + contact/trust badges.
+                    NotificationHeaderRow {
+                        Layout.fillWidth: true
+                        Layout.rightMargin: d.unreadBadgeSize / 2
+                        objectName: "notificationHeader"
+                        visible: root.title != ""
+                        title: root.title
+                        chatKey: root.chatKey
+                        isContact: root.isContact
+                        trustIndicator: root.trustIndicator
+                        isBlocked: root.isBlocked
+                    }
+
+                    // Context row: community + channel + optional icons.
+                    NotificationContextRow {
+                        Layout.fillWidth: true
+                        Layout.rightMargin: d.unreadBadgeSize / 2
+                        objectName: "notificationContext"
+                        visible: root.primaryText != ""
+                        primaryText: root.primaryText
+                        contextAvatar: root.contextAvatar
+                        secondaryText: root.secondaryText
+                        iconName: root.iconName
+                        separatorIconName: root.separatorIconName
+                    }
+
+                    // Optional action hint/body line under context row.
+                    StatusBaseText {
+                        Layout.fillWidth: true
+                        objectName: "notificationActionText"
+                        visible: root.actionText
+                        text: root.actionText
+                        font.pixelSize: Theme.fontSize(13)
+                        color: Theme.palette.directColor5
+                        elide: Text.ElideRight
+                    }
+
+                    // Rich content block: HTML, banner, attachments.
+                    NotificationContentBlock {
+                        Layout.fillWidth: true
+                        objectName: "notificationContent"
+                        contentText: root.content
+                        preImageSource: root.preImageSource
+                        preImageRadius: root.preImageRadius
+                        attachments: root.attachments
+                        thumbSpacing: 6
+                    }
+
+                    RowLayout {
+                        id: quickActions
+                        objectName: "quickActions"
+
+                        visible: root.actionId !== ""
+                        Layout.fillWidth: true
+                        spacing: Theme.halfPadding
+
+                        StatusButton {
+                            Layout.fillWidth: true
+                            objectName: "notificationDeclineBtn"
+                            text: qsTr("Decline")
+                            size: StatusBaseButton.Size.Small
+                            type: StatusBaseButton.Type.Danger
+                            onClicked: root.declineRequested()
+                        }
+                        StatusButton {
+                            Layout.fillWidth: true
+                            objectName: "notificationAcceptBtn"
+                            text: qsTr("Accept")
+                            size: StatusBaseButton.Size.Small
+                            type: StatusBaseButton.Type.Normal
+                            onClicked: root.acceptRequested()
+                        }
+                    }
+
+                    // Timestamp row (falls back to "Just now").
+                    StatusBaseText {
+                        Layout.fillWidth: true
+                        objectName: "notificationTimestamp"
+                        text: LocaleUtils.formatRelativeTimestamp(root.timestamp)
+                        font.pixelSize: Theme.fontSize(11)
+                        color: Theme.palette.directColor5
+                        elide: Text.ElideRight
+                    }
                 }
-            }
             } // end inner RowLayout
         } // end cardLayout
 
         // ── Context menu panel ────────────────────────────────────────────────
-        // Appears anchored below the card background as a separate rounded
-        // rectangle. The card's own visual is unchanged when this is shown.
-        Rectangle {
+        // Expands below the card content. Its height drives contentItem's
+        // implicitHeight so the ListView allocates space for it automatically.
+        Item {
             id: contextPanel
-            objectName: "notificationContextPanel"
 
             readonly property real expandedHeight: contextActionsRow.implicitHeight + Theme.padding * 2 + d.contextPanelOverlap
 
+            objectName: "notificationContextPanel"
             clip: true
             visible: height > 0
             anchors {
-                top: cardBg.bottom
-                topMargin: -d.contextPanelOverlap
+                top: parent.top
+                topMargin: contentRoot.cardHeight - d.contextPanelOverlap
                 left: parent.left
                 right: parent.right
             }
             height: d.contextMenuOpen ? expandedHeight : 0
-            radius: Theme.radius
-            color: root.contextMenuColor
 
             RowLayout {
                 id: contextActionsRow
@@ -542,9 +542,9 @@ Control {
                 const lv = root.ListView.view
                 if (!lv) return
                 const panelBottom = contentRoot.mapToItem(lv.contentItem, 0, 0).y
-                                    + cardBg.height
-                                    + contextPanel.expandedHeight
-                                    - d.contextPanelOverlap
+                                  + contentRoot.cardHeight
+                                  + contextPanel.expandedHeight
+                                  - d.contextPanelOverlap
                 const visibleBottom = lv.contentY + lv.height
                 if (panelBottom > visibleBottom)
                     lv.contentY = lv.contentY + (panelBottom - visibleBottom)

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
@@ -98,6 +98,7 @@ Control {
 
     // Card interactions
     signal markNotificationRead(string notificationId)
+    signal markNotificationUnread(string notificationId)
     signal avatarClicked(string avatarId)
     signal redirectToDetails(string sectionId, string subsectionId, string itemId)
     signal redirectToSection(string sectionId)
@@ -139,7 +140,7 @@ Control {
             Layout.leftMargin: Theme.padding
             Layout.topMargin: Theme.halfPadding
             Layout.bottomMargin: Theme.halfPadding
-            Layout.rightMargin: 0
+            Layout.rightMargin: Theme.halfPadding
 
             spacing: 0
 
@@ -159,6 +160,7 @@ Control {
             StatusFlatRoundButton {
                 id: markAllReadBtn
                 objectName: "markAllReadButton"
+                enabled: root.hasUnreadNotifications
                 icon.name: "double-checkmark"
                 onClicked: root.markAllAsReadRequested()
             }
@@ -211,6 +213,8 @@ Control {
                 anchors.left: listView.contentItem.left
                 anchors.right: listView.contentItem.right
                 anchors.margins: Math.max(Theme.halfPadding, 8)
+
+                backgroundColor: root.backgroundColor
 
                 // Card states related
                 unread: model.unread
@@ -283,6 +287,8 @@ Control {
                 onAvatarClicked: root.avatarClicked(model.avatarId)
                 onAcceptRequested: root.acceptRequested(model.avatarId ?? "", model.actionId ?? "")
                 onDeclineRequested: root.declineRequested(model.avatarId ?? "", model.actionId ?? "")
+                onMarkAsReadRequested: root.markNotificationRead(model.notificationId)
+                onMarkAsUnreadRequested: root.markNotificationUnread(model.notificationId)
             }
 
             onContentYChanged: d.fetchMoreNotifications()

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
@@ -97,6 +97,7 @@ Control {
     signal enableNewsRequested()
 
     // Card interactions
+    signal markNotificationRead(string notificationId)
     signal avatarClicked(string avatarId)
     signal redirectToDetails(string sectionId, string subsectionId, string itemId)
     signal redirectToSection(string sectionId)
@@ -255,6 +256,11 @@ Control {
 
                 // Interactions
                 onClicked: {
+
+                    // 1. When a notification is clicked, it is immediately marked as read
+                    root.markNotificationRead(model.notificationId)
+
+                    // 2. Once marked as read, the corresponding navigation logic is executed.
                     if(model.redirectToDetails)
                         return root.redirectToDetails(model.sectionId, model.subsectionId, model.subsectionItemId)
 
@@ -272,7 +278,7 @@ Control {
                     if(model.avatarId)
                         return root.avatarClicked(model.avatarId)
 
-                    // No actions when clicked
+                    // No navigation actions when clicked
                 }
                 onAvatarClicked: root.avatarClicked(model.avatarId)
                 onAcceptRequested: root.acceptRequested(model.avatarId ?? "", model.actionId ?? "")

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1666,6 +1666,7 @@ Item {
                 onEnableNewsRequested: appMain.notificationsStore.notificationsSettings.notifSettingStatusNews = Constants.settingsSection.notifications.sendAlertsValue
 
                 // Card Interactions
+                onMarkNotificationRead: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationRead(notificationId) }
                 onAvatarClicked: (avatarId) => { Global.openProfilePopup(avatarId) }
                 onRedirectToDetails: (sectionId, subsectionId, subsectionItemId) => {
                                          appMain.rootStore.setNavToMsgDetailsFlag(true) // It covers in-app link navigation in portrait mode

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1667,6 +1667,7 @@ Item {
 
                 // Card Interactions
                 onMarkNotificationRead: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationRead(notificationId) }
+                onMarkNotificationUnread: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationUnread(notificationId) }
                 onAvatarClicked: (avatarId) => { Global.openProfilePopup(avatarId) }
                 onRedirectToDetails: (sectionId, subsectionId, subsectionItemId) => {
                                          appMain.rootStore.setNavToMsgDetailsFlag(true) // It covers in-app link navigation in portrait mode

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1666,7 +1666,11 @@ Item {
                 onEnableNewsRequested: appMain.notificationsStore.notificationsSettings.notifSettingStatusNews = Constants.settingsSection.notifications.sendAlertsValue
 
                 // Card Interactions
-                onMarkNotificationRead: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationRead(notificationId) }
+                onMarkNotificationRead: (notificationId) => {
+                    appMain.activityCenterStore.markActivityCenterNotificationRead(notificationId)
+                    if (hideReadNotifications)
+                        appMain.activityCenterStore.setActivityCenterReadType(ActivityCenterTypes.ActivityCenterReadType.Unread)
+                }
                 onMarkNotificationUnread: (notificationId) => { appMain.activityCenterStore.markActivityCenterNotificationUnread(notificationId) }
                 onAvatarClicked: (avatarId) => { Global.openProfilePopup(avatarId) }
                 onRedirectToDetails: (sectionId, subsectionId, subsectionItemId) => {


### PR DESCRIPTION
Part of #20252

### What does the PR do

 - **Mark as read on click**: clicking a notification card now emits a signal that marks it as read before
    navigating to the content
 - **Context menu below card**: right-click or long-press reveals a panel anchored below the card
   (overlapping its bottom edge with the card's rounded corners on top) with a "Mark as read / Mark as
   unread" toggle button
 - **UI polish**: close button right margin, mark-all-as-read button disabled when no unread notifications
    exist, storybook wiring with live badge toggle and color customisation switches for both card and
   context menu backgrounds

**NOTE**: Tested on _macos_, _android_ and _ios_ devices.

### Affected areas

Activity Center

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/6bf1b5a2-a789-4dcd-b2f5-b56f1921e826

### Impact on end user

Better UX - Fixes issues with mark as read  / unread

### How to test

   - [ ] Right-click / long-press a notification card → context menu panel appears below the card
   - [ ] "Mark as read" button marks the notification and closes the menu
   - [ ] Right-click again → "Mark as unread" is shown
   - [ ] "Mark all as read" button in the header disables when all notifications are read
   - [ ] Clicking a notification marks it as read and navigates correctly
   - [ ] Storybook `NotificationCardPage` — color switches for card bg and context menu bg work
   - [ ] Storybook `ActivityCenterPanelPage` — mark all as read updates unread badge reactively

### Risk 

Low
