### PR TITLE
scripts: version.sh should be referred in case of mobile

### DIFF
--- a/mobile/scripts/buildNimStatusClient.sh
+++ b/mobile/scripts/buildNimStatusClient.sh
@@ -20,8 +20,8 @@ FLAG_SWAP_ENABLED=${FLAG_SWAP_ENABLED:-1}
 FLAG_BRIDGE_ENABLED=${FLAG_BRIDGE_ENABLED:-1}
 
 BUNDLE_IDENTIFIER=${BUNDLE_IDENTIFIER:-"app.status.mobile"}
-DESKTOP_VERSION=$(eval cd "$STATUS_DESKTOP" && git describe --tags --dirty="-dirty" --always)
-STATUSGO_VERSION=$(eval cd "$STATUS_DESKTOP/vendor/status-go" && git describe --tags --dirty="-dirty" --always)
+DESKTOP_VERSION=$(cd "$STATUS_DESKTOP" && ./scripts/version.sh)
+STATUSGO_VERSION=$(cd "$STATUS_DESKTOP/vendor/status-go" && ./scripts/version.sh)
 
 if [[ "$ARCH" == "x86_64" ]]; then
     CARCH="amd64"


### PR DESCRIPTION
## Summary

Otherwise mobile app can end up with "-dirty" in version on about screen which currently adds no value.
