### PR TITLE
feat(Browser): save/restore open tabs between sessions

### DIFF
--- a/storybook/pages/BrowserLayoutPage.qml
+++ b/storybook/pages/BrowserLayoutPage.qml
@@ -74,6 +74,10 @@ SplitView {
             function disconnect(hostname) {
                 console.info("connectorController.disconnect", hostname)
             }
+
+            function connectorCallRPC(requestId, rpcRequestJSON) {
+                console.info("connectorController.connectorCallRPC", requestId, rpcRequestJSON)
+            }
         }
 
         platformOS: ctrlPlatformOS.currentValue
@@ -222,12 +226,22 @@ SplitView {
             checked: true
         }
 
-        Button {
-            text: "Open some tabs"
-            onClicked: {
-                browserLayout.openUrlInNewTab("https://www.kde.org")
-                browserLayout.openUrlInNewTab("https://status.app")
-                browserLayout.openUrlInNewTab("https://www.google.com")
+        RowLayout {
+            Layout.fillWidth: true
+            Switch {
+                text: "Restore open tabs"
+                checked: browserLayout.uiSettings.restoreOpenTabs
+                onToggled: {
+                    browserLayout.uiSettings.restoreOpenTabs = checked
+                    browserLayout.uiSettings.sync()
+                }
+            }
+            Button {
+                text: "Clear saved tabs"
+                onClicked: {
+                    browserLayout.uiSettings.openTabs = []
+                    browserLayout.uiSettings.sync()
+                }
             }
         }
     }

--- a/storybook/pages/BrowserSettingsPage.qml
+++ b/storybook/pages/BrowserSettingsPage.qml
@@ -19,6 +19,7 @@ SplitView {
             property string customSearchEngineUrl: "https://example.com/search?q="
             property bool shouldShowFavoritesBar: true
             property int useBrowserEthereumExplorer: 1
+            property bool openLinksInStatus
         }
     }
     SplitView {
@@ -31,6 +32,7 @@ SplitView {
             contentWidth: parent.width
             sectionTitle: "Browser"
             
+            userUID: "0xdeadbeef"
             accountSettings: mockData.accountSettings
         }
 

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -54,10 +55,12 @@ StatusSectionLayout {
 
     readonly property string userAgent: connectorBridge.httpUserAgent
 
+    readonly property alias uiSettings: uiSettings
+
     signal sendToRecipientRequested(string address)
 
     function openUrlInNewTab(url) {
-        _internal.addNewTab(root.browserRootStore.determineRealURL(url))
+        Qt.callLater(() => _internal.addNewTab(root.browserRootStore.determineRealURL(url)))
     }
 
     function reloadCurrentTab() {
@@ -65,9 +68,11 @@ StatusSectionLayout {
     }
 
     Component.onCompleted: {
-        var tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true);
-        // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-        // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+        _internal.restoreSession()
+    }
+
+    Component.onDestruction: {
+        _internal.saveSession()
     }
 
     Connections {
@@ -204,6 +209,33 @@ StatusSectionLayout {
             favoriteMenu.createObject(root, {url, name}).popup(parent, pos)
         }
 
+        function saveSession() {
+            if (!uiSettings.restoreOpenTabs)
+                return
+
+            var tabsModel = []
+
+            for (let i = 0; i < tabs.count; i++){
+                const webView = webViewContext.getWebView(i)
+                if (!!webView) {
+                    const url = root.browserRootStore.determineRealURL(webView.url.toString())
+                    if (!!url)
+                        tabsModel.push(url)
+                }
+            }
+            uiSettings.openTabs = tabsModel
+        }
+
+        function restoreSession() {
+            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0)
+                uiSettings.openTabs.forEach((url) => root.openUrlInNewTab(url))
+            else {
+                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+            }
+        }
+
         onCurrentWebViewChanged: {
             onCurrentTabUrlChanged()
             findBar.reset()
@@ -215,6 +247,13 @@ StatusSectionLayout {
     showFooter: false
     headerPadding: 0
     backgroundColor: Theme.palette.statusAppNavBar.backgroundColor
+
+    Settings {
+        id: uiSettings
+        category: "BrowserSettings_%1".arg(root.userUID)
+        property bool restoreOpenTabs
+        property var openTabs: []
+    }
 
     BrowserFavoritesContext {
         id: favoritesContext

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -37,6 +37,7 @@ StatusSectionLayout {
     id: root
 
     required property bool isProduction
+    required property string userUID
 
     property alias settingsSubsection: leftPanel.settingsSubsection
     property int settingsSubSubsection
@@ -457,6 +458,7 @@ StatusSectionLayout {
                 implicitWidth: parent.width
                 implicitHeight: parent.height
 
+                userUID: root.userUID
                 accountSettings: localAccountSensitiveSettings
                 sectionTitle: settingsEntriesModel.getNameForSubsection(Constants.settingsSubsection.browserSettings)
                 contentWidth: d.contentWidth

--- a/ui/app/AppLayouts/Profile/views/BrowserView.qml
+++ b/ui/app/AppLayouts/Profile/views/BrowserView.qml
@@ -1,3 +1,4 @@
+import QtCore
 import QtQuick
 
 import StatusQ.Core.Theme
@@ -13,10 +14,18 @@ import AppLayouts.Profile.views.browser
 SettingsContentBase {
     id: root
 
+    required property string userUID
     property var accountSettings
 
     property Component searchEngineModal: SearchEngineModal {
         accountSettings: root.accountSettings
+    }
+
+    Settings {
+        id: uiSettings
+        category: "BrowserSettings_%1".arg(root.userUID)
+        property bool restoreOpenTabs
+        property var openTabs: []
     }
 
     Item {
@@ -33,7 +42,6 @@ SettingsContentBase {
             padding: Theme.halfPadding
 
             HomePageView {
-                id: homePageView
                 width: parent.width
                 accountSettings: root.accountSettings
             }
@@ -48,7 +56,6 @@ SettingsContentBase {
             }
 
             DefaultDAppExplorerView {
-                id: dAppExplorerView
                 width: parent.width
                 accountSettings: root.accountSettings
             }
@@ -59,19 +66,38 @@ SettingsContentBase {
             }
 
             StatusListItem {
-                id: showFavouritesItem
                 width: parent.width
                 leftPadding: 0
                 bgColor: StatusColors.transparent
                 title: qsTr("Show bookmarks bar")
                 components: [
                     StatusSwitch {
-                        id: favSwitch
                         checked: accountSettings.shouldShowFavoritesBar
                         onToggled: { accountSettings.shouldShowFavoritesBar = checked }
                     }
                 ]
                 onClicked: accountSettings.shouldShowFavoritesBar = !accountSettings.shouldShowFavoritesBar
+            }
+
+            StatusListItem {
+                width: parent.width
+                leftPadding: 0
+                bgColor: StatusColors.transparent
+                title: qsTr("Restore open tabs")
+                subTitle: qsTr("Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.")
+                statusListItemSubTitle.font.pixelSize: Theme.fontSize(13)
+                components: [
+                    StatusSwitch {
+                        id: restoreTabsSwitch
+                        checked: uiSettings.restoreOpenTabs
+                        onToggled: {
+                            uiSettings.restoreOpenTabs = checked
+                            if (!checked) // clear settings
+                                uiSettings.openTabs = []
+                        }
+                    }
+                ]
+                onClicked: restoreTabsSwitch.click()
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -172,7 +172,7 @@ FocusScope {
                 Behavior on implicitHeight {
                     enabled: root.autoscrollWhenDirty
                     NumberAnimation {
-                        duration: 150
+                        duration: ThemeUtils.AnimationDuration.Fast
                         easing.type: Easing.InOutQuad
                     }
                 }
@@ -187,6 +187,7 @@ FocusScope {
         anchors.bottomMargin: d.bottomDirtyToastMargin
         anchors.horizontalCenter: parent.horizontalCenter
 
+        visible: active
         active: root.dirty
         flickable: root.autoscrollWhenDirty ? scrollView.flickable : null
         saveChangesButtonEnabled: root.saveChangesButtonEnabled

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -2093,7 +2093,13 @@ Item {
                     Loader {
                         id: browserLayoutContainer
 
-                        active: d.isBrowserEnabled && appView.currentIndex === Constants.appViewStackIndex.browser
+                        // Do not unload section data from the memory once activated
+                        active: false
+                        Binding on active {
+                            when: d.isBrowserEnabled && appView.currentIndex === Constants.appViewStackIndex.browser
+                            value: true
+                            restoreMode: Binding.RestoreNone
+                        }
 
                         sourceComponent: appMain.rootStore.thirdpartyServicesEnabled ? browserLayoutComp: browserPrivacyWall
 
@@ -2154,6 +2160,7 @@ Item {
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
                         sourceComponent: ProfileLayout {
                             isProduction: appMain.rootStore.isProduction
+                            userUID: appMain.profileStore.pubKey
 
                             sharedRootStore: appMain.sharedRootStore
                             utilsStore: appMain.utilsStore

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -2648,6 +2648,14 @@ Do you wish to override the security check and continue?</source>
         <source>Show bookmarks bar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Restore open tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BurnTokensPopup</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -3246,6 +3246,16 @@
       <comment>BrowserView</comment>
       <translation>Show bookmarks bar</translation>
     </message>
+    <message>
+      <source>Restore open tabs</source>
+      <comment>BrowserView</comment>
+      <translation>Restore open tabs</translation>
+    </message>
+    <message>
+      <source>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</source>
+      <comment>BrowserView</comment>
+      <translation>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</translation>
+    </message>
   </context>
   <context>
     <name>BurnTokensPopup</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -2659,6 +2659,14 @@ Přejete si obejít bezpečnostní kontrolu a pokračovat?</translation>
         <source>Show bookmarks bar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Restore open tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BurnTokensPopup</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -2652,6 +2652,14 @@ Do you wish to override the security check and continue?</source>
         <source>Show bookmarks bar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Restore open tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BurnTokensPopup</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -2644,6 +2644,14 @@ Do you wish to override the security check and continue?</source>
         <source>Show bookmarks bar</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Restore open tabs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Turn on to save your tabs only on this device and restore them next time. Turning off deletes all saved session data.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BurnTokensPopup</name>


### PR DESCRIPTION
### What does the PR do

- when the user closes and reopens the app, all previously open tabs are restored
- session is restored after a full app restart (cold start)
- a toggle "Restore open tabs" is present in Browser Settings, OFF by default; clearing the toggle clears the saved session

Fixes #20343
Fixes #20456

### Affected areas

Browser/Settings

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Restored session:
<img width="2646" height="1862" alt="image" src="https://github.com/user-attachments/assets/761e5c9b-0b43-4e4f-91f9-75aacd6e44d3" />

Settings:
<img width="2646" height="1862" alt="image" src="https://github.com/user-attachments/assets/205a81eb-5f6d-496d-87df-745022d3d843" />

### Impact on end user

Better Browser UX across sessions

### How to test

- open some tabs
- switch sections/restart app
- open tabs should be restored (if enabled in Settings)

### Risk 

low
