### PR TITLE
Chat Input: proper hover highlight handling, send button enable only if there is content to send

### DIFF
--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -793,6 +793,10 @@ Control {
                 imageDialog.open()
             }
 
+            sendButton.enabled: messageInputField.length > 0 || messageInputField.preeditText
+                               || root.fileUrlsAndSources.length > 0
+                               || (!!root.paymentRequestModel && root.paymentRequestModel.ModelCount.count > 0)
+
             sendButton.limitText: messageInputField.length >= root.messageLimit - root.messageLimitSoft
                                   ? (root.messageLimit - messageInputField.length).toString()
                                   : ""

--- a/ui/imports/shared/status/StatusChatInputToolBar.qml
+++ b/ui/imports/shared/status/StatusChatInputToolBar.qml
@@ -6,6 +6,7 @@ import QtQuick.Layouts
 import StatusQ.Core
 import StatusQ.Controls
 import StatusQ.Core.Theme
+import StatusQ.Core.Utils as SQUtils
 
 import utils
 
@@ -60,13 +61,16 @@ Control {
                 width: 24 + Math.max(0, Theme.fontSizeOffset * 2)
                 height: width
 
-                color: chatIconRoot.checked || chatIconRoot.hovered
+                color: chatIconRoot.checked || hoverHandler.hovered
                        ? Theme.palette.primaryColor1
                        : Theme.palette.directColor4
             }
         }
 
         HoverHandler {
+            id: hoverHandler
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+            enabled: root.hoverEnabled
             cursorShape: Qt.PointingHandCursor
         }
     }


### PR DESCRIPTION
### What does the PR do

- Tiny fix preventing from using hover highlight on mobile.
- Chat input: send button enabled only if there is sth to send 

Closes: #20415

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusChatInputToolBar`
