### PR TITLE
fix(ActivityCenter): Notification group fixes, interaction & layout improvements

### DIFF
--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -206,6 +206,13 @@ QtObject:
     read = getSystemCount
     notify = groupCountersChanged
 
+  proc getNewsCount*(self: View): int {.slot.} =
+    return self.groupCounters.getOrDefault(ActivityCenterGroup.News, 0)
+
+  QtProperty[int] newsCount:
+    read = getNewsCount
+    notify = groupCountersChanged
+
   proc setActivityGroupCounters*(self: View, counters: Table[ActivityCenterGroup, int]) =
     self.groupCounters = counters
     self.groupCountersChanged()

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -199,6 +199,13 @@ QtObject:
     read = getMembershipCount
     notify = groupCountersChanged
 
+  proc getSystemCount*(self: View): int {.slot.} =
+    return self.groupCounters.getOrDefault(ActivityCenterGroup.System, 0)
+
+  QtProperty[int] systemCount:
+    read = getSystemCount
+    notify = groupCountersChanged
+
   proc setActivityGroupCounters*(self: View, counters: Table[ActivityCenterGroup, int]) =
     self.groupCounters = counters
     self.groupCountersChanged()

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -230,5 +230,10 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
       return @[ActivityCenterNotificationType.ContactVerification.int]
     of ActivityCenterGroup.News:
       return @[ActivityCenterNotificationType.ActivityCenterNotificationTypeNews.int]
+    of ActivityCenterGroup.System:
+      return @[
+        ActivityCenterNotificationType.NewInstallationReceived.int,
+        ActivityCenterNotificationType.NewInstallationCreated.int,
+      ]
     else:
       return @[]

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -56,7 +56,8 @@ const ACTIVITY_GROUPS = @[
   ActivityCenterGroup.Membership,
   ActivityCenterGroup.Admin,
   ActivityCenterGroup.ContactRequests,
-  ActivityCenterGroup.IdentityVerification
+  ActivityCenterGroup.IdentityVerification,
+  ActivityCenterGroup.System
 ]
 
 QtObject:

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -57,7 +57,8 @@ const ACTIVITY_GROUPS = @[
   ActivityCenterGroup.Admin,
   ActivityCenterGroup.ContactRequests,
   ActivityCenterGroup.IdentityVerification,
-  ActivityCenterGroup.System
+  ActivityCenterGroup.System,
+  ActivityCenterGroup.News
 ]
 
 QtObject:

--- a/storybook/pages/ActivityCenterPanelPage.qml
+++ b/storybook/pages/ActivityCenterPanelPage.qml
@@ -147,6 +147,23 @@ SplitView {
         ]
     }
 
+    SortFilterProxyModel {
+        id: systemMock
+        sourceModel: allNotificationsModelMock
+        filters: [
+            AnyOf {
+                ValueFilter {
+                    roleName: "notificationType"
+                    value: ActivityCenterTypes.NotificationType.NewInstallationReceived
+                }
+                ValueFilter {
+                    roleName: "notificationType"
+                    value: ActivityCenterTypes.NotificationType.NewInstallationCreated
+                }
+            }
+        ]
+    }
+
     property int unreadCount: 0
 
     function recomputeUnreadCount() {
@@ -189,6 +206,9 @@ SplitView {
 
         case ActivityCenterTypes.ActivityCenterGroup.NewsMessage:
             return newsMock
+
+        case ActivityCenterTypes.ActivityCenterGroup.System:
+            return systemMock
         }
         return allNotificationsModelMock
     }
@@ -221,6 +241,7 @@ SplitView {
                     hasReplies: repliesMock.count > 0
                     hasContactRequests: contactRequestsMock.count > 0
                     hasMembership: membershipMock.count > 0
+                    hasSystem: systemMock.count > 0
                     activeGroup: root.currentActiveGroup
 
                     hasUnreadNotifications: unreadNotifications.checked

--- a/storybook/pages/ActivityCenterPanelPage.qml
+++ b/storybook/pages/ActivityCenterPanelPage.qml
@@ -242,6 +242,7 @@ SplitView {
                     hasContactRequests: contactRequestsMock.count > 0
                     hasMembership: membershipMock.count > 0
                     hasSystem: systemMock.count > 0
+                    hasNews: newsMock.count > 0
                     activeGroup: root.currentActiveGroup
 
                     hasUnreadNotifications: unreadNotifications.checked

--- a/storybook/qmlTests/tests/tst_ActivityCenterPanel.qml
+++ b/storybook/qmlTests/tests/tst_ActivityCenterPanel.qml
@@ -23,6 +23,7 @@ Item {
             hasContactRequests: false
             hasMembership: false
             hasSystem: false
+            hasNews: false
             activeGroup: ActivityCenterTypes.ActivityCenterGroup.All
 
             readNotificationsStatus: ActivityCenterTypes.ActivityCenterReadType.All

--- a/storybook/qmlTests/tests/tst_ActivityCenterPanel.qml
+++ b/storybook/qmlTests/tests/tst_ActivityCenterPanel.qml
@@ -22,6 +22,7 @@ Item {
             hasReplies: false
             hasContactRequests: false
             hasMembership: false
+            hasSystem: false
             activeGroup: ActivityCenterTypes.ActivityCenterGroup.All
 
             readNotificationsStatus: ActivityCenterTypes.ActivityCenterReadType.All

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseButton.qml
@@ -142,6 +142,14 @@ AbstractButton {
     icon.height: d.iconSize
     icon.color: asset.color
 
+    // Only activate hover for mouse/touchpad/stylus, not touchscreen, so that
+    // tapped buttons don't stay visually highlighted after the finger is lifted.
+    HoverHandler {
+        id: pointerHoverHandler
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+        enabled: root.hoverEnabled
+    }
+
     background: Rectangle {
         radius: root.radius
         border.color: root.borderColor
@@ -149,7 +157,7 @@ AbstractButton {
         color: {
             if ((!root.enabled || !root.interactive) && !root.checked)
                 return disabledColor
-            return !root.loading && !root.loadingWithText && (root.hovered || root.highlighted || root.checked) ? hoverColor : normalColor
+            return !root.loading && !root.loadingWithText && (pointerHoverHandler.hovered || root.highlighted || root.checked) ? hoverColor : normalColor
         }
     }
 

--- a/ui/app/AppLayouts/ActivityCenter/adaptors/NotificationAdaptorBase.qml
+++ b/ui/app/AppLayouts/ActivityCenter/adaptors/NotificationAdaptorBase.qml
@@ -38,7 +38,7 @@ SQUtils.QObject {
     readonly property string primaryText: context.primaryText
     readonly property url    contextAvatar: context.contextAvatar
     readonly property string iconName: context.iconName
-    readonly property string secondaryText: context.secondaryName ?? ""
+    readonly property string secondaryText: context.secondaryText ?? ""
     readonly property string separatorIconName: context.separatorIconName
 
     // Action text

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
@@ -31,6 +31,7 @@ Control {
     required property bool hasReplies
     required property bool hasContactRequests
     required property bool hasMembership
+    required property bool hasSystem
     required property int activeGroup
 
     // Properties related to notifications states:
@@ -188,6 +189,7 @@ Control {
             hasMentions: root.hasMentions
             hasContactRequests: root.hasContactRequests
             hasMembership: root.hasMembership
+            hasSystem: root.hasSystem
             activeGroup: root.activeGroup
 
             gradientColor: root.backgroundColor

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
@@ -32,6 +32,7 @@ Control {
     required property bool hasContactRequests
     required property bool hasMembership
     required property bool hasSystem
+    required property bool hasNews
     required property int activeGroup
 
     // Properties related to notifications states:
@@ -190,6 +191,8 @@ Control {
             hasContactRequests: root.hasContactRequests
             hasMembership: root.hasMembership
             hasSystem: root.hasSystem
+            hasNews: root.hasNews
+            newsDisabledBySettings: d.newsDisabledBySettings
             activeGroup: root.activeGroup
 
             gradientColor: root.backgroundColor

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPopupTopBarPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPopupTopBarPanel.qml
@@ -22,6 +22,8 @@ StatusRollArea {
     required property bool hasContactRequests
     required property bool hasMembership
     required property bool hasSystem
+    required property bool hasNews
+    required property bool newsDisabledBySettings
     required property int activeGroup
 
     signal setActiveGroupRequested(int group)
@@ -39,7 +41,7 @@ StatusRollArea {
         Repeater {
             // NOTE: some entries are hidden until implementation
             model: [ { text: qsTr("All"), group: ActivityCenterTypes.ActivityCenterGroup.All, visible: true, enabled: true },
-                { text: qsTr("News"), group: ActivityCenterTypes.ActivityCenterGroup.NewsMessage, visible: true, enabled: true },
+                { text: qsTr("News"), group: ActivityCenterTypes.ActivityCenterGroup.NewsMessage, visible: true, enabled: root.hasNews || root.newsDisabledBySettings },
                 { text: qsTr("Admin"), group: ActivityCenterTypes.ActivityCenterGroup.Admin, visible: root.hasAdmin, enabled: root.hasAdmin },
                 { text: qsTr("Mentions"), group: ActivityCenterTypes.ActivityCenterGroup.Mentions, visible: true, enabled: root.hasMentions },
                 { text: qsTr("Replies"), group: ActivityCenterTypes.ActivityCenterGroup.Replies, visible: true, enabled: root.hasReplies },

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPopupTopBarPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPopupTopBarPanel.qml
@@ -21,6 +21,7 @@ StatusRollArea {
     required property bool hasReplies
     required property bool hasContactRequests
     required property bool hasMembership
+    required property bool hasSystem
     required property int activeGroup
 
     signal setActiveGroupRequested(int group)
@@ -45,7 +46,7 @@ StatusRollArea {
                 { text: qsTr("Contact requests"), group: ActivityCenterTypes.ActivityCenterGroup.ContactRequests, visible: true, enabled: root.hasContactRequests },
                 { text: qsTr("Transactions"), group: ActivityCenterTypes.ActivityCenterGroup.Transactions, visible: false, enabled: true },
                 { text: qsTr("Membership"), group: ActivityCenterTypes.ActivityCenterGroup.Membership, visible: true, enabled: root.hasMembership },
-                { text: qsTr("System"), group: ActivityCenterTypes.ActivityCenterGroup.System, visible: false, enabled: true } ]
+                { text: qsTr("System"), group: ActivityCenterTypes.ActivityCenterGroup.System, visible: root.hasSystem, enabled: root.hasSystem } ]
 
             StatusFlatButton {
                 objectName: "activityCenterGroupButton"

--- a/ui/app/AppLayouts/stores/ActivityCenterStore.qml
+++ b/ui/app/AppLayouts/stores/ActivityCenterStore.qml
@@ -19,6 +19,7 @@ QtObject {
     readonly property int contactRequestsCount: activityCenterModuleInst.contactRequestsCount
     readonly property int membershipCount: activityCenterModuleInst.membershipCount
     readonly property int systemCount: activityCenterModuleInst.systemCount
+    readonly property int newsCount: activityCenterModuleInst.newsCount
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()

--- a/ui/app/AppLayouts/stores/ActivityCenterStore.qml
+++ b/ui/app/AppLayouts/stores/ActivityCenterStore.qml
@@ -18,6 +18,7 @@ QtObject {
     readonly property int repliesCount: activityCenterModuleInst.repliesCount
     readonly property int contactRequestsCount: activityCenterModuleInst.contactRequestsCount
     readonly property int membershipCount: activityCenterModuleInst.membershipCount
+    readonly property int systemCount: activityCenterModuleInst.systemCount
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1529,9 +1529,12 @@ Item {
                 // Keep alive while closing animation
                 property bool _shown: openPanel
 
+                // Turns true only after the open animation completes
+                property bool _fullyOpen: false
+
                 // Layout
                 z: sectionLayout.z + 1
-                color: Theme.palette.transparent
+                color: _fullyOpen ? Theme.palette.baseColor4 : Theme.palette.transparent
                 height: parent.height
                 width: parent.extendedLeftPanelWidth
                 clip: true
@@ -1548,16 +1551,18 @@ Item {
                         easing.type: Easing.OutCubic
                     }
                 }
-                // When close finishe, finally hide, no more inputs to capture
+                // When close finished, finally hide, no more inputs to capture.
+                // Also drives _fullyOpen to ensure when the panel is fully open.
                 onYChanged: {
-                    if (!openPanel && y >= height) {
-                        // Ensure the slide to bottom has been finished
+                    if (openPanel && y === 0)
+                        _fullyOpen = true
+                    if (!openPanel && y >= height)
                         _shown = false
-                    }
                 }
                 // Drives animation
                 onOpenPanelChanged: {
                     if (openPanel) _shown = true
+                    _fullyOpen = false
                 }
 
                 LayoutItemProxy {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1099,6 +1099,11 @@ Item {
         function onOpenSavedAddressActivityPopup(params) {
             savedAddressActivity.open(params)
         }
+
+        function onCloseActivityCenterRequested() {
+            if (mainLayoutItem.isPortraitMode)
+                mainLayoutItem.openACCenterPanel = false
+        }
     }
 
     Connections {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1651,6 +1651,7 @@ Item {
                 hasContactRequests: appMain.activityCenterStore.contactRequestsCount > 0
                 hasMembership: appMain.activityCenterStore.membershipCount > 0
                 hasSystem: appMain.activityCenterStore.systemCount > 0
+                hasNews: appMain.activityCenterStore.newsCount > 0
                 activeGroup: appMain.activityCenterStore.activeNotificationGroup
 
                 hasUnreadNotifications: appMain.activityCenterStore.unreadNotificationsCount > 0

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1645,6 +1645,7 @@ Item {
                 hasMentions: appMain.activityCenterStore.mentionsCount > 0
                 hasContactRequests: appMain.activityCenterStore.contactRequestsCount > 0
                 hasMembership: appMain.activityCenterStore.membershipCount > 0
+                hasSystem: appMain.activityCenterStore.systemCount > 0
                 activeGroup: appMain.activityCenterStore.activeNotificationGroup
 
                 hasUnreadNotifications: appMain.activityCenterStore.unreadNotificationsCount > 0

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1623,6 +1623,8 @@ Item {
                     color: Theme.palette.backdropColor
                 }
 
+                background: null
+
                 contentItem: LayoutItemProxy {
                     target: acPanelItem
                     anchors.fill: parent

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -746,6 +746,8 @@ QtObject {
                     }
                     destroy()
                 }
+
+                onNavigationRequested: Global.closeActivityCenterRequested()
             }
         },
 

--- a/ui/imports/shared/popups/ProfileDialog.qml
+++ b/ui/imports/shared/popups/ProfileDialog.qml
@@ -30,6 +30,12 @@ StatusDialog {
     property alias assetsModel: profileView.assetsModel
     property alias collectiblesModel: profileView.collectiblesModel
 
+    // Triggered whenever an action inside this component causes a navigation away from it.
+    // The following actions are considered::
+    // ** Sending a message
+    // ** Editing profile
+    signal navigationRequested()
+
     implicitHeight: implicitContentHeight + (header.visible ? header.height : 0)
     width: 640
     padding: 0
@@ -58,5 +64,6 @@ StatusDialog {
         id: profileView
 
         onCloseRequested: root.close()
+        onNavigationRequested: root.navigationRequested()
     }
 }

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -58,6 +58,12 @@ Pane {
 
     signal closeRequested()
 
+    // Triggered whenever an action inside this component causes a navigation away from it.
+    // The following actions are considered::
+    // ** Sending a message
+    // ** Editing profile
+    signal navigationRequested()
+
     padding: 0
     topPadding: 32
 
@@ -98,6 +104,7 @@ Pane {
             tooltip.text: interactive ? "" : qsTr("Not available in preview mode")
             onClicked: {
                 Global.changeAppSectionBySectionType(Constants.appSection.profile)
+                root.navigationRequested()
                 root.closeRequested()
             }
         }
@@ -111,6 +118,7 @@ Pane {
             objectName: "sendMessageButton"
             onClicked: {
                 root.contactsStore.joinPrivateChat(root.publicKey)
+                root.navigationRequested()
                 root.closeRequested()
             }
         }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -95,6 +95,8 @@ QtObject {
 
     signal openNewsMessagePopupRequested(var notification)
 
+    signal closeActivityCenterRequested()
+
     signal openInfoPopup(string title, string message)
     signal openShakeToSharePopupRequested()
 


### PR DESCRIPTION
Closes #20252 

### What does the PR do

These are the fixes covered on this PR in relation of the issues posted on task #20252 numbered in the same way:
 
4. **News tab** is now _disabled_ only when there are no items and all settings are enabled. If RSS or notification settings are off, the tab stays enabled to show the placeholder allowing the user to turn them on. 
5. Fix portrait popup rounded corners     
6. Close _ActivityCenter_ when a navigation action is triggered from `ProfileDialog` (portrait mode only) -> _Send Message_
7.  Fix channel name missing in mention notifications (typo: `context.secondaryName` → `context.secondaryText`)   
8. Fix hover state sticking on category buttons on touchscreen (use `HoverHandler` with `acceptedDevices` to exclude touch)

**Additionally:**
 - Fixed left section panel scrollbar visible behind AC landscape panel
  - Add **System notification group** support (`NewInstallationReceived`, `NewInstallationCreated`) with `systemCount` `QtProperty` wired through the full stack (Nim → Store → QML) 
  ⚠️ Tryed the path supposed to trigger the notifications and it didn't work. There is something on the backend that will be revisit on [this task](https://github.com/status-im/status-app/issues/20253)      

### Affected areas

Activity Center

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX

### How to test

Review the issues posted on the task and try the same flows in different platforms (mobile and desktop)

### Risk 

Low
