### PR TITLE
ChatColumnView: proper clearing of reply id

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -465,8 +465,13 @@ Item {
                     }
 
                     onIsReplyChanged: {
-                        if (!isReply)
-                            replyMessageId = ""
+                        if (isReply)
+                            return
+
+                        replyMessageId = ""
+
+                        if (!!d.activeChatContentModule)
+                            d.activeChatContentModule.inputAreaModule.preservedProperties.replyMessageId = ""
                     }
 
                     onSendMessageRequested: {


### PR DESCRIPTION
### What does the PR do

Proper clearing of reply id when the reply message is sent. Prevents re-opening reply mode when switching chats.

Closes: #20419

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)


