### PR TITLE
fix(StatusSearchPopup): Use `implicitHeight` so landscape binding computes correct size

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml
@@ -13,7 +13,7 @@ import StatusQ.Core.Utils
 StatusModal {
     id: root
     width: 700
-    height: !!searchResults && searchResults.count >= 0 && searchText !== "" ? 560 : 200
+    implicitHeight: !!searchResults && searchResults.count >= 0 && searchText !== "" ? 560 : 200
     showHeader: false
     showFooter: false
 


### PR DESCRIPTION
Fixes #20414

### What does the PR do

`height` was silently overridden by `StatusDialog`'s landscape Binding on height, which reads `implicitHeight`. Since `implicitHeight` was never set, the popup collapsed to ~0 in landscape.


### Affected areas

Search in chat

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/7467dab0-909e-49db-91a4-95f12dcf4ebc


### Impact on end user

Better UX

### How to test

Do a search on landscape mode and see the popup size is different than 0 so that you can see the elements in the list

### Risk 

Low
