### PR TITLE
fix: Issues with alignment of some UI elements

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -233,6 +233,7 @@ SettingsContentBase {
             }
 
             footer: StatusDialogFooter {
+                bottomPadding: Theme.padding + syncingOnMobileNetworkPopup.parent.SafeArea.margins.bottom
                 leftButtons: ObjectModel {
                     StatusButton {
                         text: qsTr("Mobile data and Wi-Fi")

--- a/ui/imports/shared/popups/RenameGroupPopup.qml
+++ b/ui/imports/shared/popups/RenameGroupPopup.qml
@@ -59,7 +59,7 @@ StatusDialog {
             StatusInput {
                 id: groupName
                 input.edit.objectName: "groupChatEdit_name"
-                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: true
                 label: qsTr("Name the group")
                 charLimit: d.nameCharLimit
 
@@ -100,7 +100,7 @@ StatusDialog {
             StatusColorSelectorGrid {
                 id: colorSelectionGrid
                 objectName: "groupChatEdit_color"
-                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: true
                 Layout.topMargin: -(parent.spacing / 3)
                 diameter: 40
                 selectorDiameter: 16


### PR DESCRIPTION
Closes #20426

### What does the PR do

1. Fix content overflow and misalignment in portrait mode
3.  Fix bottom padding in Settings / Messaging / Message syncing footer dialog

### Affected areas
 - Messenger >> Create a group >> Edit group name and image
 - Settings >> Messaging >> Message syncing

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality
Fix point 1:

https://github.com/user-attachments/assets/604c4fde-23b2-4bfc-8537-3ff7b90ea90d

Fix point 3: 

<img width="429" height="917" alt="Screenshot 2026-04-15 at 12 13 51" src="https://github.com/user-attachments/assets/8d7d92b6-0ad1-4770-873c-817a61afbd26" />

### Impact on end user

Better UX

### How to test

Follow the steps described in task, points 1 and 3

### Risk 

Low
