### PR TITLE
StatusSectionLayout: skip vkbd height when determining portrait/landscape mode

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -3,7 +3,6 @@ import QtQuick.Layouts
 import QtQuick.Controls
 
 import StatusQ.Core.Theme
-import StatusQ.Core.Utils
 
 /*!
      \qmltype StatusSectionLayout
@@ -183,13 +182,10 @@ LayoutChooser {
     }
 
     criteria: {
-        // On mobile it's necessary to use window height because virtual keyboard may make
-        // the content shorter, triggering the opposite mode. Ideally InputMethod could be
-        // used to compensate keyboard height but it's not providing reliable value in
-        // the current configuration.
-        const safeArea = root.Window.window.contentItem.SafeArea
-        const height = Utils.isMobile ? root.Window.height - safeArea.margins.bottom - safeArea.margins.top
-                                      : root.height
+        // Workaround to compensate keyboard height when determining mode. Relying on SafeArea's
+        // additionalMargings doesn't work as expected, therefore additionalBottomMargin is used
+        // directly.
+        const height = root.height + Window.window.additionalBottomMargin
 
         return [
             height > root.width && root.width < root.implicitWidth, // Portrait mode


### PR DESCRIPTION
### What does the PR do

Virtual keyboard height is affecting safe areas when opened, triggering mode change. It was causing mode switching on vkbd activation and immediate vkbd hiding. Now, only the fixed height values of statusbar and navbar are used to avoid unnecessary mode switching.

Closes: #20437

### Affected areas
`StatusSectionLayout`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)


### Impact on end user
High in specific cases (screens with specific aspect ratio), where due to that bug it was impossible to use virtual keyboard.

### How to test

On foldable Android phone open chat and invoke virtual keyboard. The keyboard should open and stay in place, without re-layouting to landscape mode.
