### PR TITLE
perf(wallet): token lookups, Paraswap prefetch, TokenListPopup height 

### DIFF
--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -204,30 +204,28 @@ proc getTokenHistoricalDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
 
 type
   PrefetchParaswapSupportTaskArg = ref object of QObjectTaskArg
-    chainIds: seq[int]
+    chainId: int
 
-proc prefetchParaswapSupportForChain(chainId: int): bool =
+proc prefetchParaswapSupportTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[PrefetchParaswapSupportTaskArg](argEncoded)
+  if arg.chainId <= 0:
+    arg.finish(%*{"chainId": 0, "error": "invalid chainId"})
+    return
   try:
     var response: JsonNode
-    var err = status_go_tokens.isChainSupportedForSwapViaParaswap(response, chainId)
+    var err = status_go_tokens.isChainSupportedForSwapViaParaswap(response, arg.chainId)
     if err.len > 0:
       raise newException(CatchableError, "failed" & err)
     if response.isNil or response.kind != JsonNodeKind.JBool:
       raise newException(CatchableError, "unexpected response")
-    return response.getBool()
+    arg.finish(%*{
+      "chainId": arg.chainId,
+      "supported": response.getBool(),
+      "error": "",
+    })
   except Exception as e:
-    error "prefetch paraswap chain support failed", chainId = chainId, err = e.msg
-    return false
-
-proc prefetchParaswapSupportTask*(argEncoded: string) {.gcsafe, nimcall.} =
-  let arg = decode[PrefetchParaswapSupportTaskArg](argEncoded)
-  var entries = newJArray()
-  for chainId in arg.chainIds:
-    if chainId <= 0:
-      continue
-    entries.add %*{
-      "chainId": chainId,
-      "supported": prefetchParaswapSupportForChain(chainId)
-    }
-  let output = %*{"entries": entries, "error": ""}
-  arg.finish(output)
+    error "prefetch paraswap chain support failed", chainId = arg.chainId, err = e.msg
+    arg.finish(%*{
+      "chainId": arg.chainId,
+      "error": e.msg,
+    })

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -201,3 +201,33 @@ proc getTokenHistoricalDataTask*(argEncoded: string) {.gcsafe, nimcall.} =
   except Exception as e:
     output["error"] = %* "Historical market value not found"
   arg.finish(output)
+
+type
+  PrefetchParaswapSupportTaskArg = ref object of QObjectTaskArg
+    chainIds: seq[int]
+
+proc prefetchParaswapSupportForChain(chainId: int): bool =
+  try:
+    var response: JsonNode
+    var err = status_go_tokens.isChainSupportedForSwapViaParaswap(response, chainId)
+    if err.len > 0:
+      raise newException(CatchableError, "failed" & err)
+    if response.isNil or response.kind != JsonNodeKind.JBool:
+      raise newException(CatchableError, "unexpected response")
+    return response.getBool()
+  except Exception as e:
+    error "prefetch paraswap chain support failed", chainId = chainId, err = e.msg
+    return false
+
+proc prefetchParaswapSupportTask*(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[PrefetchParaswapSupportTaskArg](argEncoded)
+  var entries = newJArray()
+  for chainId in arg.chainIds:
+    if chainId <= 0:
+      continue
+    entries.add %*{
+      "chainId": chainId,
+      "supported": prefetchParaswapSupportForChain(chainId)
+    }
+  let output = %*{"entries": entries, "error": ""}
+  arg.finish(output)

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -45,7 +45,7 @@ QtObject:
     tokensOfInterestByKey: Table[string, TokenItem] # [tokenKey, TokenItem]
     groupsOfInterestByKey: Table[string, TokenGroupItem] # [tokenGroupKey, TokenGroupItem]
     groupsOfInterest: seq[TokenGroupItem] # refers to groups for tokens of interest
-    allTokensByGroupKey: Table[string, seq[TokenItem]] # rebuilt in refreshTokens for getTokenByKeyOrGroupKeyFromAllTokens
+    allTokensByGroupKey: Table[string, seq[TokenItem]] # rebuilt in applyRefreshTokensData for getTokenByKeyOrGroupKeyFromAllTokens
     groupsForChain: seq[TokenGroupItem] # refers to groups for a specific chain
     allTokenGroupsForActiveNetworks: seq[TokenGroupItem] # all token groups, fetched on demand
     allTokenGroupsLoading: bool

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -45,6 +45,7 @@ QtObject:
     tokensOfInterestByKey: Table[string, TokenItem] # [tokenKey, TokenItem]
     groupsOfInterestByKey: Table[string, TokenGroupItem] # [tokenGroupKey, TokenGroupItem]
     groupsOfInterest: seq[TokenGroupItem] # refers to groups for tokens of interest
+    allTokensByGroupKey: Table[string, seq[TokenItem]] # rebuilt in refreshTokens for getTokenByKeyOrGroupKeyFromAllTokens
     groupsForChain: seq[TokenGroupItem] # refers to groups for a specific chain
     allTokenGroupsForActiveNetworks: seq[TokenGroupItem] # all token groups, fetched on demand
     allTokenGroupsLoading: bool
@@ -98,6 +99,7 @@ QtObject:
 
     result.tokensOfInterestByKey = initTable[string, TokenItem]()
     result.groupsOfInterestByKey = initTable[string, TokenGroupItem]()
+    result.allTokensByGroupKey = initTable[string, seq[TokenItem]]()
     result.tokenDetailsTable = initTable[string, TokenDetailsItem]()
     result.tokenMarketValuesTable = initTable[string, TokenMarketValuesItem]()
     result.tokenPriceTable = initTable[string, float64]()

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -78,6 +78,7 @@ QtObject:
   proc onAsyncFetchAllTokenListsDone(self: Service, response: string) {.slot.}
   proc onAsyncBuildGroupsForChainDone(self: Service, response: string) {.slot.}
   proc onAsyncFetchAllTokenGroupsDone(self: Service, response: string) {.slot.}
+  proc prefetchParaswapSupportRetrieved(self: Service, response: string) {.slot.}
 
 
   proc delete*(self: Service)

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -33,17 +33,28 @@ proc applyAllTokenListsData(self: Service, allTokenListsJson: JsonNode) =
     else: Json.decode($allTokenListsJson, seq[TokenListDto], allowUnknownFields = true)
   self.allTokenLists = tokenListsDtos.map(tl => createTokenListItem(tl))
 
+proc rebuildAllTokensByGroupKeyIndex(self: Service) =
+  self.allTokensByGroupKey.clear()
+  let allTokens = getAllTokens()
+  for token in allTokens:
+    self.allTokensByGroupKey.mgetOrPut(token.groupKey, @[]).add(token)
+
 proc prefetchParaswapSupport(self: Service) =
   let chainIds = self.networkService.getEnabledChainIds()
   if chainIds.len == 0:
     return
-  let arg = PrefetchParaswapSupportTaskArg(
-    tptr: prefetchParaswapSupportTask,
-    vptr: cast[uint](self.vptr),
-    slot: "prefetchParaswapSupportRetrieved",
-    chainIds: chainIds,
-  )
-  self.threadpool.start(arg)
+  # One threadpool task per chain so the UI cache fills as each RPC completes; a single batched
+  # task only called finish at the end, so every chain missed the cache until all RPCs finished.
+  for chainId in chainIds:
+    if chainId <= 0:
+      continue
+    let arg = PrefetchParaswapSupportTaskArg(
+      tptr: prefetchParaswapSupportTask,
+      vptr: cast[uint](self.vptr),
+      slot: "prefetchParaswapSupportRetrieved",
+      chainIds: @[chainId],
+    )
+    self.threadpool.start(arg)
 
 proc prefetchParaswapSupportRetrieved(self: Service, response: string) {.slot.} =
   try:
@@ -93,7 +104,9 @@ proc applyRefreshTokensData(self: Service, tokensOfInterestJson: JsonNode, token
         communityId: dto.communityId)
 
   self.rebuildMarketData()
-  self.fetchTokensDetails()
+  self.fetchTokensDetails() # TODO: if the only place where we can see these details is account's details page, we should fetch this on demand, no need to have local cache
+  self.fetchTokenPreferences()
+  self.rebuildAllTokensByGroupKeyIndex()
   # notify modules
   self.events.emit(SIGNAL_TOKENS_LIST_UPDATED, Args())
   self.events.emit(SIGNAL_TOKEN_PREFERENCES_UPDATED, Args())
@@ -332,6 +345,10 @@ proc getTokenByKeyOrGroupKeyFromAllTokens*(self: Service, key: string): TokenIte
   var tokens = self.getTokensByGroupKey(key)
   if tokens.len > 0:
     return tokens[0]
+  if self.allTokensByGroupKey.hasKey(key):
+    let indexed = self.allTokensByGroupKey[key]
+    if indexed.len > 0:
+      return indexed[0]
   tokens = getAllTokens()
   let matchedTokens = tokens.filter(t => t.groupKey == key)
   if matchedTokens.len > 0:

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -33,6 +33,39 @@ proc applyAllTokenListsData(self: Service, allTokenListsJson: JsonNode) =
     else: Json.decode($allTokenListsJson, seq[TokenListDto], allowUnknownFields = true)
   self.allTokenLists = tokenListsDtos.map(tl => createTokenListItem(tl))
 
+proc prefetchParaswapSupport(self: Service) =
+  let chainIds = self.networkService.getEnabledChainIds()
+  if chainIds.len == 0:
+    return
+  let arg = PrefetchParaswapSupportTaskArg(
+    tptr: prefetchParaswapSupportTask,
+    vptr: cast[uint](self.vptr),
+    slot: "prefetchParaswapSupportRetrieved",
+    chainIds: chainIds,
+  )
+  self.threadpool.start(arg)
+
+proc prefetchParaswapSupportRetrieved(self: Service, response: string) {.slot.} =
+  try:
+    let parsedJson = response.parseJson
+    var errorString: string
+    var entries: JsonNode
+    discard parsedJson.getProp("error", errorString)
+    discard parsedJson.getProp("entries", entries)
+    if not errorString.isEmptyOrWhitespace:
+      warn "prefetch paraswap support task error", err = errorString
+      return
+    if entries.isNil or entries.kind != JArray:
+      return
+    for e in entries:
+      if e.kind != JObject:
+        continue
+      let chainId = e["chainId"].getInt()
+      let supported = e["supported"].getBool()
+      self.chainsSupportedForSwapViaParaswap[chainId] = supported
+  except Exception as ex:
+    error "prefetchParaswapSupportRetrieved", err = ex.msg
+
 proc applyRefreshTokensData(self: Service, tokensOfInterestJson: JsonNode, tokenPrefsJson: JsonNode) =
   # Parse tokens of interest
   self.tokensOfInterestByKey.clear()
@@ -134,11 +167,13 @@ proc init*(self: Service) =
 
   self.events.on(SIGNAL_NETWORK_MODE_UPDATED) do(e:Args):
     self.asyncRefreshTokens()
+    self.prefetchParaswapSupport()
 
   self.events.on(SIGNAL_CURRENCY_UPDATED) do(e:Args):
     self.rebuildMarketData()
 
   self.asyncRefreshTokens()
+  self.prefetchParaswapSupport()
 
 proc getMandatoryTokenGroupKeys*(self: Service): seq[string] =
   let tokenKeys = getMandatoryTokenKeys()

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -43,8 +43,7 @@ proc prefetchParaswapSupport(self: Service) =
   let chainIds = self.networkService.getEnabledChainIds()
   if chainIds.len == 0:
     return
-  # One threadpool task per chain so the UI cache fills as each RPC completes; a single batched
-  # task only called finish at the end, so every chain missed the cache until all RPCs finished.
+  # One task per chain so the cache fills incrementally as each RPC completes.
   for chainId in chainIds:
     if chainId <= 0:
       continue
@@ -52,7 +51,7 @@ proc prefetchParaswapSupport(self: Service) =
       tptr: prefetchParaswapSupportTask,
       vptr: cast[uint](self.vptr),
       slot: "prefetchParaswapSupportRetrieved",
-      chainIds: @[chainId],
+      chainId: chainId,
     )
     self.threadpool.start(arg)
 
@@ -60,20 +59,16 @@ proc prefetchParaswapSupportRetrieved(self: Service, response: string) {.slot.} 
   try:
     let parsedJson = response.parseJson
     var errorString: string
-    var entries: JsonNode
     discard parsedJson.getProp("error", errorString)
-    discard parsedJson.getProp("entries", entries)
-    if not errorString.isEmptyOrWhitespace:
-      warn "prefetch paraswap support task error", err = errorString
+    if errorString.len > 0:
       return
-    if entries.isNil or entries.kind != JArray:
+    if not parsedJson.hasKey("chainId") or not parsedJson.hasKey("supported"):
       return
-    for e in entries:
-      if e.kind != JObject:
-        continue
-      let chainId = e["chainId"].getInt()
-      let supported = e["supported"].getBool()
-      self.chainsSupportedForSwapViaParaswap[chainId] = supported
+    let chainId = parsedJson["chainId"].getInt()
+    if chainId <= 0:
+      return
+    let supported = parsedJson["supported"].getBool()
+    self.chainsSupportedForSwapViaParaswap[chainId] = supported
   except Exception as ex:
     error "prefetchParaswapSupportRetrieved", err = ex.msg
 
@@ -105,7 +100,6 @@ proc applyRefreshTokensData(self: Service, tokensOfInterestJson: JsonNode, token
 
   self.rebuildMarketData()
   self.fetchTokensDetails() # TODO: if the only place where we can see these details is account's details page, we should fetch this on demand, no need to have local cache
-  self.fetchTokenPreferences()
   self.rebuildAllTokensByGroupKeyIndex()
   # notify modules
   self.events.emit(SIGNAL_TOKENS_LIST_UPDATED, Args())

--- a/ui/app/AppLayouts/Profile/panels/SupportedTokenListsPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/SupportedTokenListsPanel.qml
@@ -93,6 +93,8 @@ StatusListView {
                 }
 
                 onLinkClicked: (link) => Global.requestOpenLink(link)
+
+                onClosed: popup.close()
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
@@ -32,6 +32,7 @@ StatusDialog {
         readonly property int symbolColumnWidth: 90
         readonly property int addressColumnWidth: 106
         readonly property int externalLinkBtnWidth: 32
+        readonly property int maxTokenListBodyHeight: 420
     }
 
     width: 521 // by design
@@ -44,7 +45,8 @@ StatusDialog {
 
         topMargin: Theme.padding
         bottomMargin: Theme.padding
-        implicitHeight: Math.min(420, contentHeight + topMargin + bottomMargin)
+        // Cap ListView implicit height so delegates recycle instead of laying out the full list
+        implicitHeight: Math.min(d.maxTokenListBodyHeight, contentHeight + topMargin + bottomMargin)
 
         model: root.tokensListModel
 

--- a/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/TokenListPopup.qml
@@ -44,7 +44,7 @@ StatusDialog {
 
         topMargin: Theme.padding
         bottomMargin: Theme.padding
-        implicitHeight: contentHeight
+        implicitHeight: Math.min(420, contentHeight + topMargin + bottomMargin)
 
         model: root.tokensListModel
 

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -159,6 +159,7 @@ StatusDialog {
     property int selectedChainId
     /** property to set and expose currently selected group key **/
     property string selectedGroupKey
+    onSelectedGroupKeyChanged: d.updateResolvedSelectedToken()
     /** property to set and expose the raw amount to send from outside without any localization
     Crypto value in a base unit as a string integer,
     e.g. 1000000000000000000 for 1 ETH **/
@@ -218,13 +219,15 @@ StatusDialog {
         id: d
 
         readonly property bool selectedTokenExistsInAssetsModel: selectedAssetEntry.available
+        onSelectedTokenExistsInAssetsModelChanged: d.updateResolvedSelectedToken()
 
-        readonly property var resolvedSelectedToken: {
-            if (d.selectedTokenExistsInAssetsModel) {
-                return {}
+        property var resolvedSelectedToken: ({})
+        function updateResolvedSelectedToken() {
+            if (d.selectedTokenExistsInAssetsModel || !root.selectedGroupKey) {
+                d.resolvedSelectedToken = {}
+            } else {
+                d.resolvedSelectedToken = root.getTokenByKeyOrGroupKeyFromAllTokens(root.selectedGroupKey)
             }
-
-            return root.getTokenByKeyOrGroupKeyFromAllTokens(root.selectedGroupKey)
         }
 
         readonly property real scrollViewContentY: scrollView.flickable.contentY

--- a/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/simpleSend/SimpleSendModal.qml
@@ -250,6 +250,7 @@ StatusDialog {
             onItemChanged: d.setAssetInTokenSelector()
             onAvailableChanged: d.setAssetInTokenSelector()
             onValueChanged: {
+                d.updateResolvedSelectedToken()
                 // if it's non-interactive mode and the assets model doesn't contain selectedGroupKey set the UI properly
                 if (!root.interactive && !!root.selectedGroupKey) {
                     if (d.selectedTokenExistsInAssetsModel) {
@@ -916,4 +917,6 @@ StatusDialog {
             visible: !!root.routerErrorCode || !!root.routerError
         }
     }
+
+    Component.onCompleted: d.updateResolvedSelectedToken()
 }


### PR DESCRIPTION
Improves wallet token handling: fewer redundant recomputations in Simple Send, faster resolution of tokens by group key, and background prefetch of Paraswap chain support so the swap UI is not cold on first open. Caps TokenListPopup height so an incorrect implicit height does not force a full ListView repaint.


* SimpleSendModal - Replaces the reactive `resolvedSelectedToken` binding with imperative updates on selectedGroupKey and selectedTokenExistsInAssetsModel, so getTokenByKeyOrGroupKeyFromAllTokens is not re-run on unrelated binding invalidations.

* Token service - Builds `allTokensByGroupKey` when token data is refreshed; getTokenByKeyOrGroupKeyFromAllTokens uses this index first instead of repeatedly calling getAllTokens().

* Paraswap(!) - Prefetches `isChainSupportedForSwapViaParaswap` in the background on startup and when the network mode updates (one async task per chain id so the in-memory cache fills as each RPC completes).

* TokenListPopup(!) — Sets implicitHeight to Math.min(420, contentHeight + vertical margins) to avoid triggering a full list render from an oversized implicit height.

SWAP:
* before

<img width="2293" height="1211" alt="image" src="https://github.com/user-attachments/assets/322acc1e-31cf-414f-96e8-92def139768c" />

* after
<img width="1144" height="393" alt="image" src="https://github.com/user-attachments/assets/301b2ee1-5163-4a62-be96-256137c3c147" />


SEND:
* before 
<img width="2303" height="885" alt="image" src="https://github.com/user-attachments/assets/6fc8439e-a3b6-4196-88f0-2d1a53f08244" />

* after
<img width="2305" height="890" alt="image" src="https://github.com/user-attachments/assets/9bcc18ba-34dc-4905-9bca-3e66236fb158" />



Closes #20367