### PR TITLE
chore(Syncing): Temporarily hide mobile network sync setting for `v2.38`

### DIFF
--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -305,7 +305,10 @@ QtObject:
     return false
 
   proc getSyncingOnMobileNetwork*(self: Service): bool =
-    self.settings.syncingOnMobileNetwork
+    # Hardcoded to true (Mobile data + Wi-Fi) for v2.38 while the feature is under review.
+    # Re-enable the line below in v2.39 once the WiFi-only behaviour is validated.
+    # self.settings.syncingOnMobileNetwork
+    true
 
   proc saveMnemonic*(self: Service, value: string): bool =
     if(self.saveSetting(KEY_MNEMONIC, value)):

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -75,6 +75,7 @@ SettingsContentBase {
 
         StatusListItem {
             id: allowSyncingOnMobileNetwork
+            visible: false
 
             Layout.fillWidth: true
             implicitHeight: 64


### PR DESCRIPTION
Closes #20459

### What does the PR do

Hides the "Message syncing" UI option (Wi-Fi only / Mobile data + Wi-Fi) and hardcodes the behaviour to always allow syncing on any network type.

The Wi-Fi only option was found to have unexpected behaviour (issue #20458). All feature code is preserved and can be re-enabled in `v2.39` once the expected behaviour is validated.

### Affected areas

Mobile Data Syncing

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Data will be synced by default. No option to just sync on wifi mode

### How to test

Review the mobile data sync happens when in wifi mode but also without wifi.

### Risk 

Low