### PR TITLE
fix(ci): try to fix ios build issue

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -89,6 +89,9 @@ pipeline {
     FLAG_BRIDGE_ENABLED = "${utils.isReleaseBuild() ? 0 : 1}"
     /* fix for proxy stage defaulting to test */
     STATUS_BUILD_PROXY_STAGE_NAME = "${utils.isReleaseBuild() ? 'prod' : 'test'}"
+    // Workaround for cmake 4.x dropping compatibility with cmake_minimum_required < 3.5
+    // Required by vendor/QR-Code-generator (scodes) until upstream bumps their CMakeLists.txt
+    CMAKE_POLICY_VERSION_MINIMUM = 3.5
   }
 
   stages {


### PR DESCRIPTION
Fixes error introduced due to replacing homebrew with nix-darwin on the CI hosts.
```
11:02:28  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar failed: fork/exec arm64-apple-ios16 -fembed-bitcode -miphoneos-version-min=16 /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.2.sdk
11:02:28  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar: no such file or directory
11:02:28  
11:02:28  make[2]: *** [statusgo-ios-library] Error 1
11:02:28  make[1]: *** [/Users/jenkins/workspace/prs_ios_aarch64_package_PR-20401/mobile/lib/ios/qt6/libstatus.a] Error 2
11:02:28  make[1]: *** Waiting for unfinished jobs....
11:02:58  Status Desktop Lib built /Users/jenkins/workspace/prs_ios_aarch64_package_PR-20401/mobile/lib/ios/qt6/libnim_status_client.a
11:02:58  make: *** [mobile-build] Error 2
```