### PR TITLE
feat(mobile-browser): use freeze instead of hiding webview when popups are shown

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -160,7 +160,7 @@ compile-translations:
 ifeq ($(HOST_OS),linux)
 	@make -C $(STATUS_DESKTOP) compile-translations $(HANDLE_OUTPUT)
 else
-	@CC= CXX= make -C $(STATUS_DESKTOP) compile-translations $(HANDLE_OUTPUT)
+	@CC= CXX= LDFLAGS= CGO_LDFLAGS= NIMFLAGS= make -C $(STATUS_DESKTOP) compile-translations $(HANDLE_OUTPUT)
 endif
 
 .PHONY: apk

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -296,7 +296,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG a997e4d7f4b482a0f32e56f8442e0fcfbc6566a3
+      GIT_TAG 9b39e091f71402eb83319794367f867bf0908ff7
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -296,7 +296,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG bf007ec813203a685540bd51f5af6b3f3a134fc3
+      GIT_TAG a997e4d7f4b482a0f32e56f8442e0fcfbc6566a3
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)

--- a/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
@@ -122,6 +122,27 @@ AbstractWebView {
         backend.zoomFactor = factor
     }
 
+    // targetSize is the logical on-screen size
+    function grabToImage(callback, targetSize) {
+        function onReady(imageUrl, ok) {
+            backend.snapshotReady.disconnect(onReady)
+            if (callback)
+                callback({ url: ok ? imageUrl : "" })
+        }
+        backend.snapshotReady.connect(onReady)
+
+        const scale = 2;
+        if (targetSize !== undefined && targetSize !== null) {
+            backend.requestSnapshot(
+                Qt.size(
+                    targetSize.width * scale,
+                    targetSize.height * scale
+                )
+            )
+        } else
+            backend.requestSnapshot()
+    }
+
     function acceptAsNewWindow(request) {
         console.warn("WebViewAdapter: acceptAsNewWindow not supported")
     }

--- a/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/+mobile/WebViewAdapter.qml
@@ -34,6 +34,7 @@ AbstractWebView {
         id: backend
         anchors.fill: parent
         visible: root.visible
+        freeze: root.freeze
         userScripts: root.profileParams.scripts
         webChannel: root.webChannel
     }

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -38,6 +38,9 @@ Item {
     required property bool supportsHistory
     required property bool hasNativeFindPanel
 
+    // Mobile-only: pauses native webview updates (no-op on desktop)
+    property bool freeze: false
+
     readonly property int devToolsHeight: 400
 
     readonly property int findBackward: 1

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -183,9 +183,10 @@ QtObject {
             // On mobile, only the active tab must be visible; native WKWebView
             // subviews share the same UIKit window and ignore QML z-order,
             // so StackLayout alone cannot hide inactive tabs reliably.
-            visible: root.isMobile ? StackLayout.isCurrentItem && !root.hasPopups
-                                   : true
+            visible: root.isMobile ? StackLayout.isCurrentItem : true
             enabled: visible
+            // Freeze native webview while QML popup is shown
+            freeze: root.isMobile && root.hasPopups
 
             bookmarksStore: root.bookmarksStore
             downloadsStore: root.downloadsStore


### PR DESCRIPTION
* Adds a freeze property on AbstractWebView (default false; no effect on desktop / Qt WebEngine)
* When hasPopups is set on mobile, freeze is set instead of toggling visible
* integrate status-im/mobilewebview#3

fixes #20445
fixes #20547
fixes #20453
fixes #20075
