### PR TITLE
ChatInput: new line on enter via virtual keyboard

### DIFF
--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -133,10 +133,13 @@ Control {
     QtObject {
         id: d
 
-        // whether to send message using Ctrl+Return or just Enter; based on
+        // Whether to send message using Ctrl+Return or just Enter; based on
         // OSK (virtual keyboard presence)
+        // Qt.inputMethod.visible is not reliable in some cases, as a workaround android and ios keyboards
+        // are checked directly as well.
         readonly property int kbdModifierToSendMessage:
-            Qt.inputMethod.visible ? Qt.ControlModifier : Qt.NoModifier
+            (SystemUtils.androidKeyboardVisible || SystemUtils.iosKeyboardVisible || Qt.inputMethod.visible)
+                ? Qt.ControlModifier : Qt.NoModifier
 
         property bool emojiPopupOpened: false
         property bool stickersPopupOpened: false


### PR DESCRIPTION
### What does the PR do

Qt.inputMethod.visible is not working properly in all configurations. Direct checkes for android and ios added as a workaround for that.

Closes: #20409

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Chat input

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/bfcec6d8-0175-4bad-85ee-eea8b6b4d9d1


<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user
Low

### How to test

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
