### PR TITLE
Onboarding: welcome page overflow on mobile fix

### DIFF
--- a/ui/app/AppLayouts/Onboarding/components/NewsCarousel.qml
+++ b/ui/app/AppLayouts/Onboarding/components/NewsCarousel.qml
@@ -18,15 +18,13 @@ Control {
         radius: 20
     }
 
-    verticalPadding: Theme.xlPadding
+    verticalPadding: Theme.padding
     horizontalPadding: Theme.xlPadding * 2
 
     contentItem: ColumnLayout {
         id: newsPage
         readonly property string primaryText: root.newsModel.get(pageIndicator.currentIndex).primary
         readonly property string secondaryText: root.newsModel.get(pageIndicator.currentIndex).secondary
-
-        spacing: Theme.halfPadding
 
         Image {
             Layout.fillWidth: true
@@ -35,7 +33,7 @@ Control {
             Layout.maximumHeight: 582
             Layout.alignment: Qt.AlignHCenter
             fillMode: Image.PreserveAspectFit
-            asynchronous: true
+            asynchronous: false
             source: Assets.png(root.newsModel.get(pageIndicator.currentIndex).image)
         }
 

--- a/ui/app/AppLayouts/Onboarding/controls/ListItemButton.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/ListItemButton.qml
@@ -46,6 +46,7 @@ AbstractButton {
                 font.weight: Font.Medium
                 lineHeightMode: Text.FixedHeight
                 lineHeight: 18
+                wrapMode: Text.Wrap
             }
             StatusBaseText {
                 Layout.fillWidth: true
@@ -54,6 +55,7 @@ AbstractButton {
                 visible: !!text
                 lineHeightMode: Text.FixedHeight
                 lineHeight: 18
+                wrapMode: Text.Wrap
             }
         }
 

--- a/ui/app/AppLayouts/Onboarding/pages/WelcomePage.qml
+++ b/ui/app/AppLayouts/Onboarding/pages/WelcomePage.qml
@@ -51,6 +51,8 @@ OnboardingPage {
                 image: "onboarding/carousel/keycard"
             }
         }
+
+        readonly property int maximumWidth: 400
     }
 
     title: qsTr("Welcome to Status")
@@ -58,156 +60,157 @@ OnboardingPage {
     contentItem: GridLayout {
         rows: root.isPortrait ? 2 : 1
         columns: root.isPortrait ? 1 : 2
-        uniformCellHeights: true
         uniformCellWidths: true
         layoutDirection: Qt.RightToLeft
+
+        rowSpacing: 0
 
         NewsCarousel {
             Layout.fillWidth: true
             Layout.fillHeight: true
             newsModel: d.newsModel
         }
+
         // left part (welcome + buttons)
-        Item {
+        ColumnLayout {
             Layout.fillWidth: true
-            Layout.fillHeight: true
 
-            ColumnLayout {
-                anchors.top: parent.top
-                anchors.bottom: parent.bottom
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: Math.min(400, parent.width)
-                spacing: root.isPortrait ? 6 : 28
+            spacing: root.isPortrait ? 6 : 28
 
-                Item { Layout.fillHeight: true } // Spacer
+            Item {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
 
-                ColumnLayout {
-                    id: logoAndTextLayout
-                    Layout.fillWidth: true
-                    spacing: root.isPortrait ? 6 : 28
-                    StatusImage {
-                        Layout.preferredWidth: 90
-                        Layout.preferredHeight: 90
-                        Layout.alignment: Qt.AlignHCenter
-                        source: Assets.png("status")
-                        mipmap: true
-                        layer.enabled: true
-                        layer.effect: DropShadow {
-                            horizontalOffset: 0
-                            verticalOffset: 4
-                            radius: 12
-                            samples: 25
-                            spread: 0.2
-                            color: Theme.palette.dropShadow
-                        }
-                    }
-
-                    StatusBaseText {
-                        id: headerText
-                        Layout.fillWidth: true
-                        text: root.title
-                        font.pixelSize: Theme.fontSize(40)
-                        font.bold: true
-                        wrapMode: Text.WordWrap
-                        horizontalAlignment: Text.AlignHCenter
-                    }
-
-                    StatusBaseText {
-                        Layout.fillWidth: true
-                        text: qsTr("The open-source, decentralised wallet and messenger")
-                        wrapMode: Text.WordWrap
-                        horizontalAlignment: Text.AlignHCenter
-                    }
-                }
-
-                Item { Layout.fillHeight: true } // Spacer
-
-                ColumnLayout {
-                    id: buttonsLayout
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignBottom
-                    Layout.bottomMargin: Theme.xlPadding
-                    spacing: root.padding
-                    StatusButton {
-                        objectName: "btnCreateProfile"
-                        id: btnCreateProfile
-                        Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignBottom
-                        text: qsTr("Create profile")
-                        onClicked: root.createProfileRequested()
-                    }
-                    StatusButton {
-                        objectName: "btnLogin"
-                        Layout.fillWidth: true
-                        text: qsTr("Log in")
-                        isOutline: true
-                        onClicked: root.loginRequested()
-                    }
-
-                    StatusBaseText {
-                        objectName: "thirdPartyServices"
-                        Layout.fillWidth: true
-                        Layout.topMargin: Theme.halfPadding
-                        Layout.bottomMargin: Theme.halfPadding
-                        text: qsTr("Third-party services %1").arg(
-                                  Utils.getStyledLink(root.thirdpartyServicesEnabled ? qsTr("enabled"): qsTr("disabled"),
-                                                      "#",
-                                                      hoveredLink,
-                                                      Theme.palette.primaryColor1,
-                                                      Theme.palette.primaryColor1,
-                                                      false))
-                        textFormat: Text.RichText
-                        font.pixelSize: Theme.tertiaryTextFontSize
-                        lineHeightMode: Text.FixedHeight
-                        lineHeight: 16
-                        wrapMode: Text.WordWrap
-                        color: Theme.palette.baseColor1
-                        horizontalAlignment: Text.AlignHCenter
-                        onLinkActivated: root.openThirdpartyServicesInfoPopupRequested()
-
-                        HoverHandler {
-                            // Qt CSS doesn't support custom cursor shape
-                            cursorShape: !!parent.hoveredLink ? Qt.PointingHandCursor : undefined
-                        }
-
-                        visible: root.privacyModeFeatureEnabled
-                    }
-                    StatusBaseText {
-                        objectName: "approvalLinks"
-                        Layout.fillWidth: true
-                        text: qsTr("By proceeding you accept Status<br>%1 and %2")
-                            .arg(Utils.getStyledLink(qsTr("Terms of Use"), "#terms", hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
-                            .arg(Utils.getStyledLink(qsTr("Privacy Policy"), "#privacy", hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
-                        textFormat: Text.RichText
-                        font.pixelSize: Theme.tertiaryTextFontSize
-                        lineHeightMode: Text.FixedHeight
-                        lineHeight: 16
-                        wrapMode: Text.WordWrap
-                        color: Theme.palette.baseColor1
-                        horizontalAlignment: Text.AlignHCenter
-                        onLinkActivated: (link) => {
-                            if (link === "#terms")
-                                root.termsOfUseRequested()
-                            else if (link === "#privacy")
-                                root.privacyPolicyRequested()
-                        }
-
-                        HoverHandler {
-                            // Qt CSS doesn't support custom cursor shape
-                            cursorShape: !!parent.hoveredLink ? Qt.PointingHandCursor : undefined
-                        }
-                    }
+                StatusLanguageSelector {
+                    anchors.right: parent.right
+                    anchors.rightMargin: root.isPortrait ? 0 : Theme.padding
+                    anchors.top: parent.top
+                    anchors.topMargin: root.isPortrait ? Theme.halfPadding : 0
+                    currentLanguage: root.currentLanguage
+                    languageCodes: root.availableLanguages
+                    onLanguageSelected: (languageCode) => root.changeLanguageRequested(languageCode)
                 }
             }
 
-            StatusLanguageSelector {
-                anchors.right: parent.right
-                anchors.rightMargin: root.isPortrait ? 0 : Theme.padding
-                anchors.top: parent.top
-                anchors.topMargin: root.isPortrait ? Theme.halfPadding : 0
-                currentLanguage: root.currentLanguage
-                languageCodes: root.availableLanguages
-                onLanguageSelected: (languageCode) => root.changeLanguageRequested(languageCode)
+            ColumnLayout {
+                id: logoAndTextLayout
+                Layout.fillWidth: true
+                spacing: root.isPortrait ? 6 : 28
+
+                Layout.maximumWidth: d.maximumWidth
+                Layout.alignment: Qt.AlignHCenter
+
+                StatusImage {
+                    Layout.preferredWidth: 90
+                    Layout.preferredHeight: 90
+                    Layout.alignment: Qt.AlignHCenter
+                    source: Assets.png("status")
+                    mipmap: true
+                    layer.enabled: true
+                    layer.effect: DropShadow {
+                        horizontalOffset: 0
+                        verticalOffset: 4
+                        radius: 12
+                        samples: 25
+                        spread: 0.2
+                        color: Theme.palette.dropShadow
+                    }
+                }
+
+                StatusBaseText {
+                    id: headerText
+                    Layout.fillWidth: true
+                    text: root.title
+                    font.pixelSize: Theme.fontSize(35)
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    text: qsTr("The open-source, decentralised wallet and messenger")
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+
+            Item { Layout.fillHeight: true } // Spacer
+
+            ColumnLayout {
+                id: buttonsLayout
+                Layout.fillWidth: true
+                Layout.maximumWidth: d.maximumWidth
+                Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
+                spacing: Theme.smallPadding
+                StatusButton {
+                    objectName: "btnCreateProfile"
+                    id: btnCreateProfile
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignBottom
+                    text: qsTr("Create profile")
+                    onClicked: root.createProfileRequested()
+                }
+                StatusButton {
+                    objectName: "btnLogin"
+                    Layout.fillWidth: true
+                    text: qsTr("Log in")
+                    isOutline: true
+                    onClicked: root.loginRequested()
+                }
+
+                StatusBaseText {
+                    objectName: "thirdPartyServices"
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.halfPadding
+                    text: qsTr("Third-party services %1").arg(
+                              Utils.getStyledLink(root.thirdpartyServicesEnabled ? qsTr("enabled"): qsTr("disabled"),
+                                                  "#",
+                                                  hoveredLink,
+                                                  Theme.palette.primaryColor1,
+                                                  Theme.palette.primaryColor1,
+                                                  false))
+                    textFormat: Text.RichText
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    lineHeightMode: Text.FixedHeight
+                    lineHeight: 16
+                    wrapMode: Text.WordWrap
+                    color: Theme.palette.baseColor1
+                    horizontalAlignment: Text.AlignHCenter
+                    onLinkActivated: root.openThirdpartyServicesInfoPopupRequested()
+
+                    HoverHandler {
+                        // Qt CSS doesn't support custom cursor shape
+                        cursorShape: !!parent.hoveredLink ? Qt.PointingHandCursor : undefined
+                    }
+
+                    visible: root.privacyModeFeatureEnabled
+                }
+                StatusBaseText {
+                    objectName: "approvalLinks"
+                    Layout.fillWidth: true
+                    text: qsTr("By proceeding you accept Status<br>%1 and %2")
+                        .arg(Utils.getStyledLink(qsTr("Terms of Use"), "#terms", hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
+                        .arg(Utils.getStyledLink(qsTr("Privacy Policy"), "#privacy", hoveredLink, Theme.palette.primaryColor1, Theme.palette.primaryColor1, false))
+                    textFormat: Text.RichText
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    lineHeightMode: Text.FixedHeight
+                    lineHeight: 16
+                    wrapMode: Text.WordWrap
+                    color: Theme.palette.baseColor1
+                    horizontalAlignment: Text.AlignHCenter
+                    onLinkActivated: (link) => {
+                        if (link === "#terms")
+                            root.termsOfUseRequested()
+                        else if (link === "#privacy")
+                            root.privacyPolicyRequested()
+                    }
+
+                    HoverHandler {
+                        // Qt CSS doesn't support custom cursor shape
+                        cursorShape: !!parent.hoveredLink ? Qt.PointingHandCursor : undefined
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

Makes the welcome page of onboarding more compact and responding better to smaller available space.

CC @Rsttskyy : This area may require further design improvements, the news carousel may become really small, to small to enjoy our fancy images.

Closes: #20503


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`WelcomePage`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/7f0f5574-305b-4203-a4fc-7935f399ae83" />


### How to test

Run the fresh app (without any account) on mobile with small screen.

### Risk 
Low
