### PR TITLE
Settings: keycard - responsive layout

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -199,14 +199,18 @@ Rectangle {
 
             StatusTextWithLoadingState {
                 id: statusListItemTitle
+
                 text: root.title
                 font.pixelSize: Theme.primaryTextFontSize
+                width: Math.min(implicitWidth, parent.width)
                 height: visible ? contentHeight : 0
-                elide: Text.ElideRight
+
+                wrapMode: Text.Wrap
+
                 anchors.left: parent.left
                 anchors.top: bottomModel.length === 0 ? undefined:  parent.top
                 anchors.topMargin: bottomModel.length === 0 ? undefined : 20
-                width: Math.min(implicitWidth, parent.width)
+
                 customColor: {
                     if (!root.enabled) {
                         return Theme.palette.baseColor1

--- a/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
@@ -37,6 +37,7 @@ ColumnLayout {
         Layout.alignment: Qt.AlignCenter
         Layout.preferredHeight: 240
         Layout.preferredWidth: 350
+        Layout.fillWidth: true
         fillMode: Image.PreserveAspectFit
         antialiasing: true
         source: Assets.png("keycard/card_insert/insert")
@@ -52,10 +53,12 @@ ColumnLayout {
 
     StyledText {
         visible: d.noKeycardsSet
-        Layout.alignment: Qt.AlignCenter
+        Layout.fillWidth: true
+        horizontalAlignment: Text.AlignHCenter
         font.pixelSize: Theme.fontSize(18)
         color: Theme.palette.directColor1
         text: qsTr("Secure your funds. Keep your profile safe.")
+        wrapMode: Text.Wrap
     }
 
     Item {
@@ -116,6 +119,7 @@ ColumnLayout {
         Layout.leftMargin: Theme.padding
         Layout.rightMargin: Theme.padding
         text: qsTr("Create, import or restore a Keycard account")
+        wrapMode: Text.Wrap
     }
 
     StatusListItem {


### PR DESCRIPTION
### What does the PR do

Layout adjusted to narrow mobile screens.

Closes: #20500

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screencapture of the functionality

<img width="372" height="899" alt="Screenshot from 2026-04-21 01-44-15" src="https://github.com/user-attachments/assets/1007985b-457a-4ab5-ab69-1f6562fbe313" />
