### PR TITLE
fix: android deadlock when spawning app foreground/background cycles

### DIFF
--- a/mobile/scripts/buildApp.sh
+++ b/mobile/scripts/buildApp.sh
@@ -64,6 +64,18 @@ if [[ "${OS}" == "android" ]]; then
     --android-platform android-35 \
     --verbose --aux-mode
 
+  # Package service-only libs into the APK without adding them to Qt's
+  # bundled_libs auto-load list. Qt has no qmake variable for "package only",
+  # so we drop the libs into android-build/libs/<abi>/ directly after
+  # androiddeployqt (gradle's jniLibs.srcDirs=['libs'] picks them up).
+  # These are loaded by the :statusgo service via System.loadLibrary("status_service")
+  # and must NOT be dlopen'd in the UI process (see mobile/wrapperApp/Status.pro).
+  # cp -f overwrites any stale copy androiddeployqt may have left from a prior
+  # build when these libs were still in ANDROID_EXTRA_LIBS.
+  for lib in libstatus.so libstatus_service.so libsds.so; do
+    cp -f "$CWD/../lib/android/qt${QT_MAJOR}/$lib" "$BUILD_DIR/android-build/libs/arm64-v8a/$lib"
+  done
+
   # Copy custom Android files, preserve Qt-generated libs.xml
   cp "$CWD/../android/qt${QT_MAJOR}"/{AndroidManifest.xml,build.gradle,settings.gradle,gradle.properties} "$BUILD_DIR/android-build/"
   rsync -a --exclude='libs.xml' "$CWD/../android/qt${QT_MAJOR}/res/" "$BUILD_DIR/android-build/res/" 2>/dev/null || true

--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -50,10 +50,7 @@ android {
                         $$PWD/../lib/$$LIB_PREFIX/libcrypto_3.so \
                         $$PWD/../lib/$$LIB_PREFIX/libnim_status_client.so \
                         $$PWD/../lib/$$LIB_PREFIX/libDOtherSide$$(LIB_SUFFIX)$$(LIB_EXT) \
-                        $$PWD/../lib/$$LIB_PREFIX/libstatus.so \
                         $$PWD/../lib/$$LIB_PREFIX/libstatus_stub.so \
-                        $$PWD/../lib/$$LIB_PREFIX/libstatus_service.so \
-                        $$PWD/../lib/$$LIB_PREFIX/libsds.so \
                         $$PWD/../lib/$$LIB_PREFIX/libStatusQ$$(LIB_SUFFIX)$$(LIB_EXT) \
                         $$PWD/../lib/$$LIB_PREFIX/libMobileWebView$$(LIB_SUFFIX)$$(LIB_EXT)
     contains(DEFINES, FLAG_KEYCARD_ENABLED) {

--- a/src/app/core/main.nim
+++ b/src/app/core/main.nim
@@ -21,7 +21,6 @@ proc newStatusFoundation*(): StatusFoundation =
   result.signalsManager = newSignalsManager(result.events)
 
 proc delete*(self: StatusFoundation) =
-  self.threadpool.teardown()
   self.signalsManager.delete()
   self.urlsManager.delete()
 

--- a/ui/StatusQ/src/keychain_android.cpp
+++ b/ui/StatusQ/src/keychain_android.cpp
@@ -247,7 +247,7 @@ void Keychain::cancelActiveRequest()
     const QJniObject auth = ensureJavaAuth();
     if (!auth.isValid()) return;
 
-    auth.callMethod<void>("cancel", "()I");
+    auth.callMethod<void>("cancel", "()V");
 }
 
 // Credential saved result (async)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -65,7 +65,7 @@ Window {
 
     // Store the native SafeArea bottom margin (e.g., iOS home indicator)
     // Must be set in Component.onCompleted before any additionalMargins are applied
-    property real nativeSafeAreaBottom: 0
+    property real nativeSafeAreaBottom: applicationWindow.contentItem.SafeArea.margins.bottom
 
     // Use native Android keyboard tracking via WindowInsets API
     // This bypasses Qt's unreliable inputMethod and works with any windowSoftInputMode
@@ -396,26 +396,6 @@ Window {
         }
     }
 
-    // Clear additional SafeArea's margins when regular margins are initialized. Doing cleanup
-    // this way prevents binding loop between margins and additional margins.
-    Connections {
-        id: safeMarginsCleanupConnections
-
-        enabled: false
-        target: applicationWindow.contentItem.SafeArea
-
-        function onMarginsChanged() {
-            const safeArea = applicationWindow.contentItem.SafeArea
-
-            safeArea.additionalMargins.top = 0
-            safeArea.additionalMargins.bottom = Qt.binding(() => applicationWindow.additionalBottomMargin)
-            safeArea.additionalMargins.left = 0
-            safeArea.additionalMargins.right = 0
-
-            safeMarginsCleanupConnections.enabled = false
-        }
-    }
-
     Component.onCompleted: {
 
         console.info(">>> %1 %2 started, using Qt version %3, QPA: %4".arg(Application.name).arg(Application.version).arg(SystemUtils.qtRuntimeVersion()).arg(Qt.platform.pluginName))
@@ -439,29 +419,6 @@ Window {
         restoreAppState()
 
         Global.openShakeToSharePopupRequested.connect(openShakeToSharePopup)
-
-        nativeSafeAreaBottom = MobileUI.safeAreaBottom + MobileUI.navbarHeight
-
-        // SafeArea margins works well out of the box when app uses regular qml Window as a top level
-        // window. When custom window derived from QQuickWindow is used, SafeArea's margins are all 0
-        // till first screen rotation or virtual keyboard usage (Android 15, 16, not and issue on Android 14).
-        // This workaround initializes margins by adding addtionalMargins using values read directly from
-        // via native API. When the margins are initialized, binding is cleared.
-        const safeArea = applicationWindow.contentItem.SafeArea
-
-        if (safeArea.margins.bottom === 0 && MobileUI.safeAreaBottom + MobileUI.navbarHeight > 0)
-            safeArea.additionalMargins.bottom = Qt.binding(() => MobileUI.safeAreaBottom + MobileUI.navbarHeight + applicationWindow.additionalBottomMargin)
-
-        if (safeArea.margins.top === 0 && MobileUI.safeAreaTop > 0)
-            safeArea.additionalMargins.top = Qt.binding(() => MobileUI.safeAreaTop)
-
-        if (safeArea.margins.right === 0 && MobileUI.safeAreaRight > 0)
-            safeArea.additionalMargins.right = Qt.binding(() => MobileUI.safeAreaRight)
-
-        if (safeArea.margins.left === 0 && MobileUI.safeAreaLeft > 0)
-            safeArea.additionalMargins.left = Qt.binding(() => MobileUI.safeAreaLeft)
-
-        safeMarginsCleanupConnections.enabled = true
 
         if (applicationWindow.skipOnboarding) {
             moveToAppMain()


### PR DESCRIPTION
### What does the PR do

closes https://github.com/status-im/status-app/issues/20460

I've identified 4 different issues leading to similar behavior where the app hangs either in splash screen, loading screen or immediately after app start.

- go-waku deadlock: When stress testing with app background -> app kill -> warm start cycles it will eventually freeze. `qml` and peer updates in go will spam go-waku with connection checks and eventually it will go into a deadlock if it happens while go-waku has ongoing work. PR https://github.com/logos-messaging/logos-delivery-go/pull/1301

- start-up crash due to status-go link dependencies: Sometimes the app will just fail to start with unresolved external symbols for `__gxx_personality_v0`. This happened because we've been (wrongly) linking status-go in the main android lib. Status-go needs to be on its own now since it's not part of the UI process. To fix this I've removed the status-go dependency from `Status.pro`

- app hangs at startup: For some reason qt would just freeze on this `nativeSafeAreaBottom = MobileUI.safeAreaBottom + MobileUI.navbarHeight`. Happens on both qt 6.9.2 and 6.11.0. Maybe a similar issue we see on desktop sometimes with a corrupted qmlcache. Anyways, didn't go deeper into it now. Removed it as it seems it's no longer needed for qt 6.11.0

- app fails to close: We're using `threadpool.syncAll()` in the destructor, with no way to time box it and it will sometimes block for a very long time under bad internet conditions - especially when the task does a very intensive work, like downloading sticker packs. I've removed it from the close sequence.

- app crashes on startup: it only happens with qt 6.9.2, under some specific android config. I could only reproduce on BrowserStack devices (all of them). But not on my devices with the same android version and HW. There's probably an underlying issue here, but since we're moving to qt 6.11.0 and it's not reproducible on this version, I've let it go.

### Affected areas

app startup (both cold and warm start-up)

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

Open the app, login.
Go through start/stop cycles multiple times (at least 5 times).
Leave the app in the background for 10 minutes and then bring it back.
Leave the app in the background for 10 minutes, kill it and reopen it.

### Risk 

medium
