### PR TITLE
Chat input: prevent vkbd hiding on pressing toolbar buttons

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -187,7 +187,7 @@ LayoutChooser {
         delayed: true
 
         value: {
-            const height = root.height + root.Window.window.additionalBottomMargin
+            const height = root.height + (root.Window.window?.additionalBottomMargin ?? 0)
 
             return [
                 height > root.width && root.width < root.implicitWidth, // Portrait mode

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -181,16 +181,19 @@ LayoutChooser {
             portraitView.decrementCurrentIndex()
     }
 
-    criteria: {
-        // Workaround to compensate keyboard height when determining mode. Relying on SafeArea's
-        // additionalMargings doesn't work as expected, therefore additionalBottomMargin is used
-        // directly.
-        const height = root.height + Window.window.additionalBottomMargin
+    Binding on criteria {
+        // delay to avoid race conditions related to additional bottom space and therefore
+        // unexpected mode changes when opening/closing virtual keyboard
+        delayed: true
 
-        return [
-            height > root.width && root.width < root.implicitWidth, // Portrait mode
-            true // Defaults to landscape mode
-        ]
+        value: {
+            const height = root.height + root.Window.window.additionalBottomMargin
+
+            return [
+                height > root.width && root.width < root.implicitWidth, // Portrait mode
+                true // Defaults to landscape mode
+            ]
+        }
     }
 
     layoutChoices: [

--- a/ui/imports/shared/status/StatusChatInputToolBar.qml
+++ b/ui/imports/shared/status/StatusChatInputToolBar.qml
@@ -37,6 +37,8 @@ Control {
     component ChatIcon: AbstractButton {
         id: chatIconRoot
 
+        focusPolicy: Qt.NoFocus
+
         checkable: true
         padding: Math.round(Theme.halfPadding / 2)
 


### PR DESCRIPTION
### What does the PR do

- no focus policy for chat input toolbar buttons
- moreover: delayed criteria calculation in StatusSectionLayout to avoid unintended mode switching

Closes: #20498

### Affected areas
Chat Input, Status Section Layout

### Screencapture of the functionality


https://github.com/user-attachments/assets/1e858661-113e-4278-b183-769b923ea8d7


### How to test
Go to chat, use toolbar buttons with virtual keyboard opened.

