### PR TITLE
StatusTextArea: workaround to make selection working on Android

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -56,6 +56,10 @@ TextArea {
     */
     property bool valid: true
 
+    // Workaround to make selection working on Android. Otherwise
+    // selection is dropped right after selection.
+    onPressAndHold: ;
+
     leftPadding: Theme.padding
     rightPadding: Theme.padding
     topPadding: Theme.smallPadding

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -784,7 +784,7 @@ Control {
             Theme.fontSizeOffset: ThemeUtils.fontSizeOffsetM
 
             styleButtonVisible: false
-            showFormatting: !!messageInputField.selectedText
+            showFormatting: messageInputField.selectionStart !== messageInputField.selectionEnd
 
             cameraButton.visible: false
 


### PR DESCRIPTION
### What does the PR do

- consumes pressAndHold handler, what makes selection working in TextArea.
- changed condition to display formatting buttons, previous ones was giving false positives in some cases

Closes: #20496

### Affected areas
`StatusTextArea`


### Screencapture of the functionality

https://github.com/user-attachments/assets/5c1420ec-dfec-4ceb-98c6-22744ae94888


### Impact on end user
It's possible to select and format text via buttons on Android 

### How to test
Go to chat input, select word or sentence, use formatting buttons.

### Risk 
Low
