### PR TITLE
fix(ci): add nix system path to macos and ios jenkinsfiles

### DIFF
--- a/ci/Jenkinsfile.ios
+++ b/ci/Jenkinsfile.ios
@@ -63,7 +63,7 @@ pipeline {
     QTDIR = sh(script:"${env.QMAKE} -query QT_INSTALL_PREFIX", returnStdout: true).trim()
     /* Enforce Go version installed infra-role-golang. */
     /* to fix missing rcc, since QT6 rcc is located at ${QTDIR}/libexec/rcc */
-    PATH = "${env.QTDIR}/bin:${env.QTDIR}/libexec:${env.HOME}/go/bin:/usr/local/go/bin:${env.PATH}"
+    PATH = "${env.QTDIR}/bin:${env.QTDIR}/libexec:${env.HOME}/go/bin:/usr/local/go/bin:${env.PATH}:/run/current-system/sw/bin"
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -73,7 +73,7 @@ pipeline {
     QTDIR = sh(script:"${env.QMAKE} -query QT_INSTALL_PREFIX", returnStdout: true).trim()
     /* Enforce Go version installed infra-role-golang. */
     /* to fix missing rcc, since QT6 rcc is located at ${QTDIR}/libexec/rcc and nix */
-    PATH = "/nix/var/nix/profiles/default/bin:${env.QTDIR}/bin:${env.QTDIR}/libexec:${env.HOME}/go/bin:/usr/local/go/bin:${env.PATH}"
+    PATH = "/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:${env.QTDIR}/bin:${env.QTDIR}/libexec:${env.HOME}/go/bin:/usr/local/go/bin:${env.PATH}"
     /* Avoid weird bugs caused by stale cache. */
     QML_DISABLE_DISK_CACHE = "true"
     /* nim-sds source directory */


### PR DESCRIPTION
Fixes the release pipeline for ios and macos when building status-go:
```
running "protoc --go_out=. ./protocol_message.proto": exec: "protoc": executable file not found in $PATH
```