### PR TITLE
StatusChatInput: Context menu for copy/cut/paste on desktop

### DIFF
--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -16726,6 +16726,21 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>StatusChatInputTextArea</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>StatusChatListCategoryItem</name>
     <message>
         <source>Add channel inside category</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -20370,6 +20370,24 @@
     </message>
   </context>
   <context>
+    <name>StatusChatInputTextArea</name>
+    <message>
+      <source>Cut</source>
+      <comment>StatusChatInputTextArea</comment>
+      <translation>Cut</translation>
+    </message>
+    <message>
+      <source>Copy</source>
+      <comment>StatusChatInputTextArea</comment>
+      <translation>Copy</translation>
+    </message>
+    <message>
+      <source>Paste</source>
+      <comment>StatusChatInputTextArea</comment>
+      <translation>Paste</translation>
+    </message>
+  </context>
+  <context>
     <name>StatusChatListCategoryItem</name>
     <message>
       <source>Add channel inside category</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -16845,6 +16845,21 @@ selhalo</translation>
     </message>
 </context>
 <context>
+    <name>StatusChatInputTextArea</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Kopírovat</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Vložit</translation>
+    </message>
+</context>
+<context>
     <name>StatusChatListCategoryItem</name>
     <message>
         <source>Add channel inside category</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -16744,6 +16744,21 @@ al cargar</translation>
     </message>
 </context>
 <context>
+    <name>StatusChatInputTextArea</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Pegar</translation>
+    </message>
+</context>
+<context>
     <name>StatusChatListCategoryItem</name>
     <message>
         <source>Add channel inside category</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -16686,6 +16686,21 @@ to load</source>
     </message>
 </context>
 <context>
+    <name>StatusChatInputTextArea</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">클립보드로 복사</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">붙여넣기</translation>
+    </message>
+</context>
+<context>
     <name>StatusChatListCategoryItem</name>
     <message>
         <source>Add channel inside category</source>

--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -1,10 +1,12 @@
 import QtQuick
+import QtQuick.Controls
 
 import StatusQ
+import StatusQ.Controls as StatusQ
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Core.Utils as StatusQUtils
-import StatusQ.Controls as StatusQ
+import StatusQ.Popups
 
 import AppLayouts.Chat.adaptors
 import utils
@@ -142,78 +144,10 @@ StatusQ.StatusTextArea {
             }
         }
 
-        if (event.matches(StandardKey.Copy) || event.matches(StandardKey.Cut)) {
-            if (root.selectedText !== "") {
-                d.copiedTextPlain = root.getText(
-                            root.selectionStart, root.selectionEnd)
-                d.copiedTextFormatted = root.getFormattedText(
-                            root.selectionStart, root.selectionEnd)
-                d.copyMentions(root.selectionStart, root.selectionEnd)
-            }
-        } else if (event.matches(StandardKey.Paste)) {
-            if (!ClipboardUtils.hasText)
-                return
-
-            const clipboardText = StatusQUtils.StringUtils.plainText(ClipboardUtils.text)
-            // prevent repetitive & huge clipboard paste, where huge is total char count > than messageLimitHard
-            const selectionLength = root.selectionEnd - root.selectionStart
-            if ((length + clipboardText.length - selectionLength) > root.messageLimitHard)
-            {
-                attemptToExceedHardLimit()
-                event.accepted = true
-                return
-            }
-
-            root.remove(root.selectionStart, root.selectionEnd)
-
-            // cursor position must be stored in a helper property because setting readonly to true causes change
-            // of the cursor position to the end of the input
-            d.copyTextStart = root.cursorPosition
-            root.readOnly = true
-
-            const copiedText = StatusQUtils.StringUtils.plainText(d.copiedTextPlain)
-
-            if (copiedText === clipboardText) {
-                if (d.copiedTextPlain.includes("@")) {
-                    d.copiedTextFormatted = d.copiedTextFormatted.replace(
-                                        /span style="/g, "span style=\" text-decoration:none;")
-
-                    let lastFoundIndex = -1
-                    for (let j = 0; j < d.copiedMentionsPos.length; j++) {
-                        const name = d.copiedMentionsPos[j].name
-                        const indexOfName = d.copiedTextPlain.indexOf(name, lastFoundIndex)
-                        lastFoundIndex += name.length
-
-                        if (indexOfName === d.copiedMentionsPos[j].leftIndex + 1) {
-                            const mention = {
-                                name: name,
-                                pubKey: d.copiedMentionsPos[j].pubKey,
-                                leftIndex: (d.copiedMentionsPos[j].leftIndex + d.copyTextStart - 1),
-                                rightIndex: (d.copiedMentionsPos[j].leftIndex + d.copyTextStart + name.length)
-                            }
-                            d.mentionsPos.push(mention)
-                            d.sortMentions()
-                        }
-                    }
-                }
-                insertInTextInput(d.copyTextStart, d.copiedTextFormatted)
-            } else {
-                d.copiedTextPlain = ""
-                d.copiedTextFormatted = ""
-                d.copiedMentionsPos = []
-                root.insert(d.copyTextStart, ((d.nbEmojisInClipboard === 0) ?
-                ("<div style='white-space: pre-wrap'>" + StatusQUtils.StringUtils.escapeHtml(ClipboardUtils.text) + "</div>")
-                : StatusQUtils.Emoji.deparse(ClipboardUtils.html)))
-            }
-
-            // Reset readOnly immediately after paste completes
-            // Don't wait for onReleased which might not fire on mobile
-            if (StatusQUtils.Utils.isMobile) {
-                root.readOnly = false
-                root.cursorPosition = (d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard)
-            }
-            event.accepted = true
-        }
+        if (event.matches(StandardKey.Copy) || event.matches(StandardKey.Cut))
+            d.prepareCopyOrCut()
+        else if (event.matches(StandardKey.Paste))
+            event.accepted = d.paste()
     }
 
     // gives up-to-date cursorPosition
@@ -721,6 +655,82 @@ StatusQ.StatusTextArea {
                 }
             }
         }
+
+        function prepareCopyOrCut() {
+            if (root.selectedText === "")
+                return
+
+            d.copiedTextPlain = root.getText(
+                        root.selectionStart, root.selectionEnd)
+            d.copiedTextFormatted = root.getFormattedText(
+                        root.selectionStart, root.selectionEnd)
+            d.copyMentions(root.selectionStart, root.selectionEnd)
+        }
+
+        function paste(immediateCleanup = false) {
+            if (!ClipboardUtils.hasText)
+                return false
+
+            const clipboardText = StatusQUtils.StringUtils.plainText(ClipboardUtils.text)
+            // prevent repetitive & huge clipboard paste, where huge is total char count > than messageLimitHard
+            const selectionLength = root.selectionEnd - root.selectionStart
+            if ((length + clipboardText.length - selectionLength) > root.messageLimitHard)
+            {
+                root.attemptToExceedHardLimit()
+                return true
+            }
+
+            root.remove(root.selectionStart, root.selectionEnd)
+
+            // cursor position must be stored in a helper property because setting readonly to true causes change
+            // of the cursor position to the end of the input
+            d.copyTextStart = root.cursorPosition
+            root.readOnly = true
+
+            const copiedText = StatusQUtils.StringUtils.plainText(d.copiedTextPlain)
+
+            if (copiedText === clipboardText) {
+                if (d.copiedTextPlain.includes("@")) {
+                    d.copiedTextFormatted = d.copiedTextFormatted.replace(
+                                        /span style="/g, "span style=\" text-decoration:none;")
+
+                    let lastFoundIndex = -1
+                    for (let j = 0; j < d.copiedMentionsPos.length; j++) {
+                        const name = d.copiedMentionsPos[j].name
+                        const indexOfName = d.copiedTextPlain.indexOf(name, lastFoundIndex)
+                        lastFoundIndex += name.length
+
+                        if (indexOfName === d.copiedMentionsPos[j].leftIndex + 1) {
+                            const mention = {
+                                name: name,
+                                pubKey: d.copiedMentionsPos[j].pubKey,
+                                leftIndex: (d.copiedMentionsPos[j].leftIndex + d.copyTextStart - 1),
+                                rightIndex: (d.copiedMentionsPos[j].leftIndex + d.copyTextStart + name.length)
+                            }
+                            d.mentionsPos.push(mention)
+                            d.sortMentions()
+                        }
+                    }
+                }
+                root.insertInTextInput(d.copyTextStart, d.copiedTextFormatted)
+            } else {
+                d.copiedTextPlain = ""
+                d.copiedTextFormatted = ""
+                d.copiedMentionsPos = []
+                root.insert(d.copyTextStart, ((d.nbEmojisInClipboard === 0) ?
+                ("<div style='white-space: pre-wrap'>" + StatusQUtils.StringUtils.escapeHtml(ClipboardUtils.text) + "</div>")
+                : StatusQUtils.Emoji.deparse(ClipboardUtils.html)))
+            }
+
+            // Reset readOnly immediately after paste completes
+            // Don't wait for onReleased which might not fire on mobile
+            if (StatusQUtils.Utils.isMobile || immediateCleanup) {
+                root.readOnly = false
+                root.cursorPosition = (d.copyTextStart + ClipboardUtils.text.length + d.nbEmojisInClipboard)
+            }
+
+            return true
+        }
     }
 
     SuggestionsFilterAdaptor {
@@ -764,4 +774,34 @@ StatusQ.StatusTextArea {
         enabled: parent.hoveredLink
         cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
     }
+
+    StatusMenu {
+        id: contextMenu
+
+        hideDisabledItems: false
+
+        StatusAction {
+            text: qsTr("Cut")
+            enabled: root.selectionStart !== root.selectionEnd
+            onTriggered: {
+                d.prepareCopyOrCut()
+                root.cut()
+            }
+        }
+        StatusAction {
+            text: qsTr("Copy")
+            enabled: root.selectionStart !== root.selectionEnd
+            onTriggered: {
+                d.prepareCopyOrCut()
+                root.copy()
+            }
+        }
+        StatusAction {
+            text: qsTr("Paste")
+            enabled: root.canPaste
+            onTriggered: d.paste(true)
+        }
+    }
+
+    ContextMenu.menu: StatusQUtils.Utils.isMobile ? null : contextMenu
 }


### PR DESCRIPTION
### What does the PR do

Adds simple context menu to copy/cut/paste

Closes: #20536

### Affected areas
`StatusChatInputTextArea`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

[Screencast from 22.04.2026 13:02:02.webm](https://github.com/user-attachments/assets/cc9f756f-93b6-4d07-92fd-16fcacdf7eb7)

[Screencast from 22.04.2026 12:19:06.webm](https://github.com/user-attachments/assets/7116a98d-17e1-478a-b011-a85260147eef)

### Impact on end user
Ability to copy/cut/paste using mouse

### How to test
Go to chat input on desktop, right click in text area to copy/cut/paste

### Risk 
Low
