### PR TITLE
fix(Stickers): sticker pack preview image is not respecting aspect ratio

### DIFF
--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -8311,13 +8311,6 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
-    <name>HistoryBetaTag</name>
-    <message>
-        <source>Activity is in beta. For any issues, go to Settings → Advanced → Refetch transaction history.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>HistoryView</name>
     <message>
         <source>Status Desktop is connected to a non-archival node. Transaction history may be incomplete.</source>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -10154,14 +10154,6 @@
     </message>
   </context>
   <context>
-    <name>HistoryBetaTag</name>
-    <message>
-      <source>Activity is in beta. For any issues, go to Settings → Advanced → Refetch transaction history.</source>
-      <comment>HistoryBetaTag</comment>
-      <translation>Activity is in beta. For any issues, go to Settings → Advanced → Refetch transaction history.</translation>
-    </message>
-  </context>
-  <context>
     <name>HistoryView</name>
     <message>
       <source>Status Desktop is connected to a non-archival node. Transaction history may be incomplete.</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -8355,13 +8355,6 @@ Opravdu to chcete udělat?</translation>
     </message>
 </context>
 <context>
-    <name>HistoryBetaTag</name>
-    <message>
-        <source>Activity is in beta. For any issues, go to Settings → Advanced → Refetch transaction history.</source>
-        <translation></translation>
-    </message>
-</context>
-<context>
     <name>HistoryView</name>
     <message>
         <source>Status Desktop is connected to a non-archival node. Transaction history may be incomplete.</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -8325,13 +8325,6 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
-    <name>HistoryBetaTag</name>
-    <message>
-        <source>Activity is in beta. For any issues, go to Settings → Advanced → Refetch transaction history.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>HistoryView</name>
     <message>
         <source>Status Desktop is connected to a non-archival node. Transaction history may be incomplete.</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -8296,13 +8296,6 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
-    <name>HistoryBetaTag</name>
-    <message>
-        <source>Activity is in beta. For any issues, go to Settings → Advanced → Refetch transaction history.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>HistoryView</name>
     <message>
         <source>Status Desktop is connected to a non-archival node. Transaction history may be incomplete.</source>

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -110,6 +110,7 @@ Item {
                     width: parent.width
                     radius: 12
                     source: model.preview
+                    fillMode: Image.PreserveAspectFit
                     onClicked: {
                         stickerPackDetailsPopup.open()
                         root.closeRequested()


### PR DESCRIPTION
### What does the PR do

Fixes sticker pack preview image
(separate commit to update TS files)

Fixes #20546

### Affected areas

Stickers popup

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1126" height="2086" alt="Snímek obrazovky z 2026-04-22 14-45-17" src="https://github.com/user-attachments/assets/ee0d8cde-53a2-4cdf-a508-831077a7cd7d" />

### Impact on end user

Better mobile UX

### How to test

- open Sticker market

### Risk 

low
