### PR TITLE
feat: "Stop using Keycard for profile key pair" flow added to keycard management

### DIFF
--- a/src/app/modules/shared_modules/keycard_management/controller.nim
+++ b/src/app/modules/shared_modules/keycard_management/controller.nim
@@ -135,6 +135,9 @@ proc createAccountFromMnemonic*(self: Controller, mnemonic: string, includeEncry
 proc convertRegularProfileKeypairToKeycard*(self: Controller, keycardUid, currentPassword, newPassword: string) =
   self.accountsService.convertRegularProfileKeypairToKeycard(keycardUid, currentPassword, newPassword)
 
+proc convertKeycardProfileKeypairToRegular*(self: Controller, mnemonic, currentPassword, newPassword: string) =
+  self.accountsService.convertKeycardProfileKeypairToRegular(mnemonic, currentPassword, newPassword)
+
 proc setStoreToKeychainValueNotNow*(self: Controller) =
   singletonInstance.localAccountSettings.setStoreToKeychainValue(LS_VALUE_NOT_NOW)
 

--- a/src/app/modules/shared_modules/keycard_management/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_management/io_interface.nim
@@ -88,6 +88,9 @@ method startStopUsingKeycardForKeyPair*(self: AccessInterface, keyUid, seedPhras
 method onStopUsingKeycardForKeyPairFinished*(self: AccessInterface, keyUid: string, success: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method startStopUsingKeycardForProfileKeyPair*(self: AccessInterface, seedPhrase, newPassword: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getKeyPairItemForKeyUid*(self: AccessInterface, keyUid: string): KeyPairItem {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/keycard_management/module.nim
+++ b/src/app/modules/shared_modules/keycard_management/module.nim
@@ -32,6 +32,7 @@ type FlowType {.pure.} = enum
   MigratingProfileKeypairToKeycard = "MigratingProfileKeypairToKeycard" # migrates a profile keypair to the keycard (only if the keypair is not already migrated)
   AddingKeyPairFromKeycard = "AddingKeyPairFromKeycard" # adds a new key pair from the keycard to the app (only if the key pair is not already added)
   StoppingKeycardForKeyPair = "StoppingKeycardForKeyPair" # stops using a Keycard for a non-profile key pair by moving it back into the app
+  StoppingKeycardForProfileKeyPair = "StoppingKeycardForProfileKeyPair" # stops using a Keycard for the profile key pair by moving it back into the app
 
 type
   Module*[T: io_interface.DelegateInterface] = ref object of io_interface.AccessInterface
@@ -183,6 +184,8 @@ proc emitError[T](self: Module[T], err: string) =
     self.view.keycardAddKeyPairError(err)
   elif self.tmpFlowType == FlowType.StoppingKeycardForKeyPair:
     self.view.stopUsingKeycardForKeyPairError(err)
+  elif self.tmpFlowType == FlowType.StoppingKeycardForProfileKeyPair:
+    self.view.stopUsingKeycardForProfileKeyPairError(err)
   else:
     error "invalid flow type", flowType=($self.tmpFlowType)
 
@@ -235,10 +238,18 @@ method startMigratingProfileKeypairToKeycard*[T](self: Module[T], password: stri
   self.startLoadSeedPhrase(pin, seedPhrase, metadataName, metadataAccounts)
 
 method onConvertingProfileKeypairFinished*[T](self: Module[T], success: bool) =
-  if not success:
-    self.emitError("failed to convert profile keypair to keycard")
-    return
-  self.view.keycardMoveProfileKeyPairSuccess()
+  if self.tmpFlowType == FlowType.MigratingProfileKeypairToKeycard:
+    if not success:
+      self.emitError("failed to convert profile keypair to keycard")
+      return
+    self.view.keycardMoveProfileKeyPairSuccess()
+  elif self.tmpFlowType == FlowType.StoppingKeycardForProfileKeyPair:
+    if not success:
+      self.emitError("failed to convert profile keypair to the app")
+      return
+    self.view.stopUsingKeycardForProfileKeyPairSuccess()
+  else:
+    error "unexpected flow type on converting profile keypair finished", flowType=($self.tmpFlowType)
 
 proc addNewKeycardKeypair*[T](self: Module[T]): string =
   var walletAccounts: seq[wallet_account_service.WalletAccountDto]
@@ -304,6 +315,18 @@ method onStopUsingKeycardForKeyPairFinished*[T](self: Module[T], keyUid: string,
     self.emitError("failed to stop using Keycard for key pair")
     return
   self.view.stopUsingKeycardForKeyPairSuccess()
+
+method startStopUsingKeycardForProfileKeyPair*[T](self: Module[T], seedPhrase, newPassword: string) =
+  self.tmpFlowType = FlowType.StoppingKeycardForProfileKeyPair
+  self.tmpSeedPhrase = seedPhrase
+  self.tmpPassword = newPassword # don't hash it here, cause it's hashed in the service
+  let acc = self.controller.createAccountFromMnemonic(seedPhrase, includeEncryption = true)
+  let currentPassword = acc.derivedAccounts.encryption.publicKey
+  if currentPassword.len == 0:
+    self.emitError("failed to derive encryption public key from seed phrase")
+    return
+  self.controller.setStoreToKeychainValueNotNow()
+  self.controller.convertKeycardProfileKeypairToRegular(seedPhrase, currentPassword, newPassword)
 
 method startAddingKeyPairToStatusFromKeycard*[T](self: Module[T], pin: string, keyUid: string,
     metadataName: string, metadataAccounts: string) =

--- a/src/app/modules/shared_modules/keycard_management/view.nim
+++ b/src/app/modules/shared_modules/keycard_management/view.nim
@@ -69,6 +69,9 @@ QtObject:
   proc stopUsingKeycardForKeyPairSuccess*(self: View) {.signal.}
   proc stopUsingKeycardForKeyPairError*(self: View, error: string) {.signal.}
 
+  proc stopUsingKeycardForProfileKeyPairSuccess*(self: View) {.signal.}
+  proc stopUsingKeycardForProfileKeyPairError*(self: View, error: string) {.signal.}
+
   proc keyPairModelChanged(self: View) {.signal.}
   proc getKeyPairModel(self: View): QVariant {.slot.} =
     if self.keyPairModelVariant.isNil:
@@ -129,6 +132,9 @@ QtObject:
 
   proc startStopUsingKeycardForKeyPair*(self: View, keyUid: string, seedPhrase: string, newPassword: string) {.slot.} =
     self.delegate.startStopUsingKeycardForKeyPair(keyUid, seedPhrase, newPassword)
+
+  proc startStopUsingKeycardForProfileKeyPair*(self: View, seedPhrase: string, newPassword: string) {.slot.} =
+    self.delegate.startStopUsingKeycardForProfileKeyPair(seedPhrase, newPassword)
 
   proc remainingKeypairCapacity*(self: View): int {.slot.} =
     return self.delegate.remainingKeypairCapacity()

--- a/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
@@ -55,12 +55,19 @@ Rectangle {
             asset {
                 width: !!root.keyPair && keyPair.icon? root.Theme.bigPadding : 40
                 height: !!root.keyPair && keyPair.icon? root.Theme.bigPadding : 40
-                name: !!root.keyPair? !!root.keyPair.image? root.keyPair.image : root.keyPair.icon : ""
+                name: !root.keyPair? ""
+                                   : !!root.keyPair.image? root.keyPair.image
+                                                         : !!root.keyPair.icon? root.keyPair.icon
+                                                                              : d.isProfileKeypair? "contact"
+                                                                                                  : ""
                 isImage: !!root.keyPair && !!keyPair.image
-                color: d.isProfileKeypair ? Utils.colorForPubkey(Theme.palette, root.userProfilePublicKey) : root.Theme.palette.primaryColor1
+                color: d.isProfileKeypair ? Theme.palette.indirectColor2
+                                          : Theme.palette.primaryColor1
                 letterSize: Math.max(4, asset.width / 2.4)
                 charactersLen: 2
                 isLetterIdenticon: !!root.keyPair && !keyPair.icon && !asset.name.toString()
+                bgColor: d.isProfileKeypair? Utils.colorForPubkey(Theme.palette, root.userProfilePublicKey)
+                                           : Theme.palette.primaryColor3
             }
             components: [
                 StatusFlatRoundButton {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -272,12 +272,47 @@ QtObject {
     }
 
     function openKeycardManagementPopup(flow, keyUid, keycardUid, cardMetadataName, cardMetadataWalletAccountsJson) {
+        let finalFlow = flow
+        let finalKeyUid = keyUid
+
+        // if no keyUid is set, follow the flow, otherwise, validate and adjust params
+        if (!!finalKeyUid) {
+            switch(flow) {
+            case Constants.keycard.flow.moveKeyPair:
+                if (finalKeyUid === root.keycardManagementStore.userProfileKeyUid) {
+                    finalFlow = Constants.keycard.flow.moveProfileKeyPair
+                }
+                break
+            case Constants.keycard.flow.stopUsingKeycard:
+                if (finalKeyUid === root.keycardManagementStore.userProfileKeyUid) {
+                    finalFlow = Constants.keycard.flow.stopUsingKeycardForProfile
+                }
+                break
+            case Constants.keycard.flow.moveProfileKeyPair:
+                if (finalKeyUid !== root.keycardManagementStore.userProfileKeyUid) {
+                    finalFlow = Constants.keycard.flow.stopUsingKeycard
+                }
+                break
+            case Constants.keycard.flow.stopUsingKeycardForProfile:
+                if (finalKeyUid !== root.keycardManagementStore.userProfileKeyUid) {
+                    finalFlow = Constants.keycard.flow.stopUsingKeycard
+                }
+                break
+            }
+        }
+
+        if (finalFlow !== flow) {
+            console.info("wrong flow for the provided keyUid: ", keyUid, " flow changed from ", flow, " to ", finalFlow)
+        }
+
+        console.info("openning keycard popup for flow: ", finalFlow, " keyUid: ", finalKeyUid, " keycardUid: ", keycardUid, " cardMetadataName: ", cardMetadataName, " cardMetadataWalletAccountsJson: ", cardMetadataWalletAccountsJson)
+
         openPopup(keycardManagementPopupComponent, {
-            flow: flow,
-            keyUid: keyUid,
+            flow: finalFlow,
+            keyUid: finalKeyUid,
             keycardUid: keycardUid,
-            cardMetadataName: cardMetadataName ?? "",
-            cardMetadataWalletAccountsJson: cardMetadataWalletAccountsJson ?? "[]"
+            cardMetadataName: cardMetadataName,
+            cardMetadataWalletAccountsJson: cardMetadataWalletAccountsJson
         })
     }
 

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -10074,6 +10074,22 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <source>Status password is now required to sign.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Stop using Keycard for profile key pair</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moving profile key pair to Status...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile key pair has been moved to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status password is now required to log in and sign.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeycardNotEmptyPage</name>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -12283,6 +12283,26 @@
       <comment>KeycardManagementPopup</comment>
       <translation>Status password is now required to sign.</translation>
     </message>
+    <message>
+      <source>Stop using Keycard for profile key pair</source>
+      <comment>KeycardManagementPopup</comment>
+      <translation>Stop using Keycard for profile key pair</translation>
+    </message>
+    <message>
+      <source>Moving profile key pair to Status...</source>
+      <comment>KeycardManagementPopup</comment>
+      <translation>Moving profile key pair to Status...</translation>
+    </message>
+    <message>
+      <source>Profile key pair has been moved to Status</source>
+      <comment>KeycardManagementPopup</comment>
+      <translation>Profile key pair has been moved to Status</translation>
+    </message>
+    <message>
+      <source>Status password is now required to log in and sign.</source>
+      <comment>KeycardManagementPopup</comment>
+      <translation>Status password is now required to log in and sign.</translation>
+    </message>
   </context>
   <context>
     <name>KeycardNotEmptyPage</name>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -10152,6 +10152,22 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <source>Status password is now required to sign.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Stop using Keycard for profile key pair</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moving profile key pair to Status...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile key pair has been moved to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status password is now required to log in and sign.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeycardNotEmptyPage</name>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -10088,6 +10088,22 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <source>Status password is now required to sign.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Stop using Keycard for profile key pair</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moving profile key pair to Status...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile key pair has been moved to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status password is now required to log in and sign.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeycardNotEmptyPage</name>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -10067,6 +10067,22 @@ corruption, loss of your Status profile and the inability to restart Status.</so
         <source>Status password is now required to sign.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Stop using Keycard for profile key pair</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Moving profile key pair to Status...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Profile key pair has been moved to Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Status password is now required to log in and sign.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>KeycardNotEmptyPage</name>

--- a/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
+++ b/ui/imports/shared/popups/keycard_new/KeycardManagementPopup.qml
@@ -57,6 +57,8 @@ StatusDialog {
             return qsTr("Add key pair to Status")
         case Constants.keycard.flow.stopUsingKeycard:
             return qsTr("Stop using Keycard for key pair")
+        case Constants.keycard.flow.stopUsingKeycardForProfile:
+            return qsTr("Stop using Keycard for profile key pair")
         default:
             return qsTr("Keycard Flow")
         }
@@ -93,16 +95,24 @@ StatusDialog {
 
         property bool factoryResetConfirmationChecked: false
 
-        property int currentStep: (root.flow === Constants.keycard.flow.moveKeyPair
-                                      || root.flow === Constants.keycard.flow.moveProfileKeyPair)
-                                     ? KeycardManagementPopup.FlowStep.SelectKeyPair
-                                     : (root.flow === Constants.keycard.flow.stopUsingKeycard)
-                                         ? KeycardManagementPopup.FlowStep.ConfirmKeyPair
-                                         : (root.flow === Constants.keycard.flow.addKeyPairToStatus)
-                                             ? KeycardManagementPopup.FlowStep.EnterPin
-                                             : d.keycardHasOnlyPinSet
-                                                 ? KeycardManagementPopup.FlowStep.EnterPin
-                                                 : KeycardManagementPopup.FlowStep.EnterNewPin
+        property int currentStep: {
+            switch(root.flow) {
+            case Constants.keycard.flow.moveKeyPair:
+                return KeycardManagementPopup.FlowStep.SelectKeyPair
+            case Constants.keycard.flow.moveProfileKeyPair:
+                return KeycardManagementPopup.FlowStep.SelectKeyPair
+            case Constants.keycard.flow.stopUsingKeycard:
+                return KeycardManagementPopup.FlowStep.ConfirmKeyPair
+            case Constants.keycard.flow.stopUsingKeycardForProfile:
+                return KeycardManagementPopup.FlowStep.ConfirmKeyPair
+            case Constants.keycard.flow.addKeyPairToStatus:
+                return KeycardManagementPopup.FlowStep.EnterPin
+            default:
+                return d.keycardHasOnlyPinSet
+                    ? KeycardManagementPopup.FlowStep.EnterPin
+                    : KeycardManagementPopup.FlowStep.EnterNewPin
+            }
+        }
 
         property string newPin: ""
         property bool pinMismatch: false
@@ -137,6 +147,8 @@ StatusDialog {
                     return moveProfileKeyPairEnterSeedPhraseComponent
                 if (root.flow === Constants.keycard.flow.stopUsingKeycard)
                     return stopUsingEnterSeedPhraseComponent
+                if (root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+                    return stopUsingForProfileEnterSeedPhraseComponent
                 return enterSeedPhraseComponent
             case KeycardManagementPopup.FlowStep.EnterKeyPairName:
                 return enterKeyPairNameComponent
@@ -227,6 +239,16 @@ StatusDialog {
                                     })()
         }
 
+        function startStopUsingKeycardForProfileKeyPair() {
+            d.currentStep = KeycardManagementPopup.FlowStep.Stopping
+            d.keycardInteractionCompleted = true
+            d.processing = true
+            Backpressure.setTimeout(this, 500, () => {
+                                        root.store.startStopUsingKeycardForProfileKeyPair(d.seedPhrase,
+                                                                                          d.newStatusPassword)
+                                    })()
+        }
+
         function nextStep() {
             if (d.currentStep === KeycardManagementPopup.FlowStep.SelectKeyPair) {
                 d.currentStep = d.keycardHasOnlyPinSet
@@ -243,7 +265,11 @@ StatusDialog {
                 return
             }
             if (d.currentStep === KeycardManagementPopup.FlowStep.ConfirmPassword) {
-                d.startStopUsingKeycardForKeyPair()
+                if (root.flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
+                    d.startStopUsingKeycardForProfileKeyPair()
+                } else {
+                    d.startStopUsingKeycardForKeyPair()
+                }
                 return
             }
             if (d.currentStep === KeycardManagementPopup.FlowStep.EnterPin) {
@@ -293,7 +319,8 @@ StatusDialog {
                     Global.openAuthenticationPopup(Constants.keycard.flow.moveProfileKeyPair, root.store.userProfileKeyUid)
                     return
                 }
-                if (root.flow === Constants.keycard.flow.stopUsingKeycard) {
+                if (root.flow === Constants.keycard.flow.stopUsingKeycard
+                        || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
                     d.currentStep = KeycardManagementPopup.FlowStep.CreatePassword
                     return
                 }
@@ -354,7 +381,8 @@ StatusDialog {
                 return
             }
             if (d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase) {
-                if (root.flow === Constants.keycard.flow.stopUsingKeycard) {
+                if (root.flow === Constants.keycard.flow.stopUsingKeycard
+                        || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
                     d.currentStep = KeycardManagementPopup.FlowStep.ConfirmKeyPair
                     return
                 }
@@ -542,6 +570,17 @@ StatusDialog {
             d.processing = false
             d.error = error
         }
+
+        function onStopUsingKeycardForProfileKeyPairSuccess() {
+            d.processing = false
+            d.success = true
+        }
+
+        function onStopUsingKeycardForProfileKeyPairError(error) {
+            console.error("Stop using Keycard for profile key pair error:", error)
+            d.processing = false
+            d.error = error
+        }
     }
 
     Connections {
@@ -638,6 +677,10 @@ StatusDialog {
                              && (d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase
                                  || d.currentStep === KeycardManagementPopup.FlowStep.CreatePassword
                                  || d.currentStep === KeycardManagementPopup.FlowStep.ConfirmPassword))
+                         || (root.flow === Constants.keycard.flow.stopUsingKeycardForProfile
+                             && (d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase
+                                 || d.currentStep === KeycardManagementPopup.FlowStep.CreatePassword
+                                 || d.currentStep === KeycardManagementPopup.FlowStep.ConfirmPassword))
 
                 onClicked: {
                     d.previousStep()
@@ -664,7 +707,8 @@ StatusDialog {
                                || root.flow === Constants.keycard.flow.moveKeyPair
                                || root.flow === Constants.keycard.flow.moveProfileKeyPair
                                || root.flow === Constants.keycard.flow.addKeyPairToStatus
-                               || root.flow === Constants.keycard.flow.stopUsingKeycard) {
+                               || root.flow === Constants.keycard.flow.stopUsingKeycard
+                               || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
                         if (!d.processing && !d.success && !d.error) {
                             return qsTr("Cancel")
                         }
@@ -673,7 +717,8 @@ StatusDialog {
                     if (!!d.error) {
                         return qsTr("Done")
                     } else if (d.success) {
-                        if (root.flow === Constants.keycard.flow.moveProfileKeyPair) {
+                        if (root.flow === Constants.keycard.flow.moveProfileKeyPair
+                                || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile) {
                             return qsTr("Quit and restart Status")
                         }
                         return qsTr("Done")
@@ -682,8 +727,9 @@ StatusDialog {
                 }
 
                 onClicked: {
-                    if (d.success && root.flow === Constants.keycard.flow.moveProfileKeyPair) {
-                        console.info("the app is closing due to successfully migrated profile key pair to a keycard")
+                    if (d.success && (root.flow === Constants.keycard.flow.moveProfileKeyPair
+                                      || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)) {
+                        console.info("the app is closing due to successfully converted profile key pair - flow: ", root.flow)
                         root.store.signOutAndQuit()
                     }
 
@@ -755,6 +801,11 @@ StatusDialog {
                                  && (d.currentStep === KeycardManagementPopup.FlowStep.EnterKeyPairName
                                      || d.currentStep === KeycardManagementPopup.FlowStep.ManageAccounts))
                              || (root.flow === Constants.keycard.flow.stopUsingKeycard
+                                 && (d.currentStep === KeycardManagementPopup.FlowStep.ConfirmKeyPair
+                                     || d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase
+                                     || d.currentStep === KeycardManagementPopup.FlowStep.CreatePassword
+                                     || d.currentStep === KeycardManagementPopup.FlowStep.ConfirmPassword))
+                             || (root.flow === Constants.keycard.flow.stopUsingKeycardForProfile
                                  && (d.currentStep === KeycardManagementPopup.FlowStep.ConfirmKeyPair
                                      || d.currentStep === KeycardManagementPopup.FlowStep.EnterSeedPhrase
                                      || d.currentStep === KeycardManagementPopup.FlowStep.CreatePassword
@@ -863,6 +914,8 @@ StatusDialog {
             root.store.prepareKeyPairModel()
         if (root.flow === Constants.keycard.flow.stopUsingKeycard)
             root.store.resolveKeyPairItemForKeyUid(root.keyUid)
+        if (root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+            root.store.resolveKeyPairItemForKeyUid(root.store.userProfileKeyUid)
     }
 
     onClosed: {
@@ -890,6 +943,10 @@ StatusDialog {
             break
         case Constants.keycard.flow.stopUsingKeycard:
             keyUid = root.keyUid
+            keycardUid = root.keycardUid
+            break
+        case Constants.keycard.flow.stopUsingKeycardForProfile:
+            keyUid = root.store.userProfileKeyUid
             keycardUid = root.keycardUid
             break
         }
@@ -931,14 +988,20 @@ StatusDialog {
                     return qsTr("Adding key pair to Status...")
                 case Constants.keycard.flow.stopUsingKeycard:
                     return qsTr("Moving key pair to Status...")
+                case Constants.keycard.flow.stopUsingKeycardForProfile:
+                    return qsTr("Moving profile key pair to Status...")
                 default:
                     return qsTr("Reading...")
                 }
             }
-            processingSpecialWarning1: root.flow === Constants.keycard.flow.moveProfileKeyPair? qsTr("Re-encrypting data may take some time")
-                                                                                              : ""
-            processingSpecialWarning2: root.flow === Constants.keycard.flow.moveProfileKeyPair? qsTr("Do not quit the application or turn off your device. Doing so will lead to data\ncorruption, loss of your Status profile and the inability to restart Status.")
-                                                                                              : ""
+            processingSpecialWarning1: (root.flow === Constants.keycard.flow.moveProfileKeyPair
+                                        || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+                                       ? qsTr("Re-encrypting data may take some time")
+                                       : ""
+            processingSpecialWarning2: (root.flow === Constants.keycard.flow.moveProfileKeyPair
+                                        || root.flow === Constants.keycard.flow.stopUsingKeycardForProfile)
+                                       ? qsTr("Do not quit the application or turn off your device. Doing so will lead to data\ncorruption, loss of your Status profile and the inability to restart Status.")
+                                       : ""
 
             success: {
                 if (root.flow === Constants.keycard.flow.readKeycard)
@@ -955,6 +1018,7 @@ StatusDialog {
                 case Constants.keycard.flow.moveProfileKeyPair:
                 case Constants.keycard.flow.addKeyPairToStatus:
                 case Constants.keycard.flow.stopUsingKeycard:
+                case Constants.keycard.flow.stopUsingKeycardForProfile:
                     return Assets.png("keycard/card_insert/insert")
                 default:
                     return ""
@@ -975,6 +1039,8 @@ StatusDialog {
                     return qsTr("Key pair has been added to Status")
                 case Constants.keycard.flow.stopUsingKeycard:
                     return qsTr("Key pair has been moved to Status")
+                case Constants.keycard.flow.stopUsingKeycardForProfile:
+                    return qsTr("Profile key pair has been moved to Status")
                 default:
                     return qsTr("Success")
                 }
@@ -993,6 +1059,8 @@ StatusDialog {
                     return qsTr("Now you can sign with this key pair using Keycard.")
                 case Constants.keycard.flow.stopUsingKeycard:
                     return qsTr("Status password is now required to sign.")
+                case Constants.keycard.flow.stopUsingKeycardForProfile:
+                    return qsTr("Status password is now required to log in and sign.")
                 default:
                     return ""
                 }
@@ -1013,6 +1081,7 @@ StatusDialog {
                 case Constants.keycard.flow.moveProfileKeyPair:
                 case Constants.keycard.flow.addKeyPairToStatus:
                 case Constants.keycard.flow.stopUsingKeycard:
+                case Constants.keycard.flow.stopUsingKeycardForProfile:
                     return Assets.png("keycard/wrong_card/something-went-wrong")
                 default:
                     return ""
@@ -1257,6 +1326,26 @@ StatusDialog {
                 if (keyUid === root.keyUid)
                     return keyUid
                 console.error("provided seed phrase doesn't match the key pair being tried to stop using a keycard for")
+                return ""
+            }
+
+            onSeedPhraseValidated: function(phrase, keyUid) {
+                d.seedPhrase = phrase
+                d.seedPhraseKeyUid = keyUid
+            }
+        }
+    }
+
+    Component {
+        id: stopUsingForProfileEnterSeedPhraseComponent
+        EnterSeedPhraseState {
+            initialSeedPhrase: d.seedPhrase
+
+            validateSeedPhrase: function(phrase) {
+                const keyUid = root.store.getKeyUidForSeedPhrase(phrase)
+                if (keyUid === root.store.userProfileKeyUid)
+                    return keyUid
+                console.error("provided seed phrase doesn't match the profile key pair being tried to stop using a keycard for")
                 return ""
             }
 

--- a/ui/imports/shared/popups/keycard_new/helpers/KeyPairItem.qml
+++ b/ui/imports/shared/popups/keycard_new/helpers/KeyPairItem.qml
@@ -32,11 +32,14 @@ Rectangle {
     required property var keyPairAccounts // [ { "path", "address", "publicKey?" } ] from card metadata JSON
     property bool isKnownKeyPair: false
 
+    property real accountsListMaxHeight: 0
+
     readonly property bool isProfileKeyPair: root.keyPairKeyUid !== ""
                                              && root.keyPairKeyUid === root.userProfileKeyUid
 
     color: Theme.palette.baseColor2
     radius: Theme.halfPadding
+    clip: true
     implicitWidth: 448
     implicitHeight: columnLayout.implicitHeight
 
@@ -90,7 +93,8 @@ Rectangle {
         StatusListView {
             id: accountsList
             Layout.fillWidth: true
-            Layout.preferredHeight: contentHeight
+            Layout.preferredHeight: root.accountsListMaxHeight > 0? Math.min(contentHeight, root.accountsListMaxHeight)
+                                                                  : contentHeight
             Layout.preferredWidth: parent.width
             Layout.bottomMargin: Theme.padding
             Layout.leftMargin: Theme.padding

--- a/ui/imports/shared/popups/keycard_new/states/ConfirmKeyPairForStopUsingState.qml
+++ b/ui/imports/shared/popups/keycard_new/states/ConfirmKeyPairForStopUsingState.qml
@@ -55,6 +55,8 @@ Control {
             keyPairAccounts: root.keyPairItem ? root.keyPairItem.accounts : null
             keyPairLocation: root.keyPairItem ? Utils.getKeypairLocation(root.keyPairItem, false) : ""
             keyPairLocationColor: root.keyPairItem ? Utils.getKeypairLocationColor(Theme.palette, root.keyPairItem) : ""
+
+            accountsListMaxHeight: Math.max(120, Constants.keycard.general.popupHeight - 280)
         }
 
         Item {

--- a/ui/imports/shared/popups/keycard_new/stores/KeycardManagementStore.qml
+++ b/ui/imports/shared/popups/keycard_new/stores/KeycardManagementStore.qml
@@ -26,6 +26,9 @@ QtObject {
     signal stopUsingKeycardForKeyPairSuccess()
     signal stopUsingKeycardForKeyPairError(string error)
 
+    signal stopUsingKeycardForProfileKeyPairSuccess()
+    signal stopUsingKeycardForProfileKeyPairError(string error)
+
     readonly property bool ready: d.ready
 
     readonly property string userProfileKeyUid: userProfile.keyUid
@@ -105,6 +108,14 @@ QtObject {
 
         function onStopUsingKeycardForKeyPairError(error) {
             root.stopUsingKeycardForKeyPairError(error)
+        }
+
+        function onStopUsingKeycardForProfileKeyPairSuccess() {
+            root.stopUsingKeycardForProfileKeyPairSuccess()
+        }
+
+        function onStopUsingKeycardForProfileKeyPairError(error) {
+            root.stopUsingKeycardForProfileKeyPairError(error)
         }
     }
 
@@ -313,6 +324,14 @@ QtObject {
             return
         }
         d.mainModuleInst.keycardManagementModule.startStopUsingKeycardForKeyPair(keyUid, seedPhrase, newPassword)
+    }
+
+    function startStopUsingKeycardForProfileKeyPair(seedPhrase, newPassword) {
+        if (!d.mainModuleInst.keycardManagementModule) {
+            console.error("keycard management module was not created")
+            return
+        }
+        d.mainModuleInst.keycardManagementModule.startStopUsingKeycardForProfileKeyPair(seedPhrase, newPassword)
     }
 
     function remainingKeypairCapacity() {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -522,6 +522,7 @@ QtObject {
             readonly property string moveProfileKeyPair: "move-profile-key-pair"
             readonly property string addKeyPairToStatus: "add-key-pair-to-status"
             readonly property string stopUsingKeycard: "stop-using-keycard"
+            readonly property string stopUsingKeycardForProfile: "stop-using-keycard-for-profile"
         }
     }
 


### PR DESCRIPTION
This PR adds a new "Stop using Keycard for profile key pair" flow to keycard management.

Closes: https://github.com/status-im/status-app/issues/20301

The recording below shows the process of moving the profile key pair to the keycard and the flow for stop using a keycard for the profile key pair:

https://github.com/user-attachments/assets/d851392b-6c3b-47d0-b673-1ddc2c5edc39



