### PR TITLE
fix(wallet): fixed incorrectly calculated fiat values in several places

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -553,10 +553,6 @@ QtObject {
         }
     }
 
-    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        return profileSectionModule.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
-    }
-
     function resolveENS(value) {
         mainModuleInst.resolveENS(value, "")
     }

--- a/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SwapInputPanel.qml
@@ -68,6 +68,8 @@ Control {
 
     // output API
     readonly property string selectedHoldingId: d.selectedHoldingId
+    readonly property string selectedHoldingTokenKey: d.selectedHoldingTokenKey
+
     readonly property double value: amountToSendInput.asNumber
     readonly property string rawValue: {
         if (!d.isSelectedHoldingValidAsset) {
@@ -107,7 +109,7 @@ Control {
         id: d
 
         property string selectedHoldingId: root.groupKey
-
+        property string selectedHoldingTokenKey: ""
 
         function reevaluateSelectedId() {
             const entry = SQUtils.ModelUtils.getByKey(d.adaptor.outputAssetsModel, "key", d.selectedHoldingId)
@@ -129,12 +131,26 @@ Control {
         function setHoldingToSelector() {
             // search in currentlly selected output asset model (full(lazy-loaded) or search)
             if (selectedHolding.available && !!selectedHolding.item) {
+                if (!selectedHolding.item.tokens || selectedHolding.item.tokens.ModelCount.count !== 1) {
+                    console.error("token for the selected group cannot be resolved", "group-key", d.selectedHoldingId, "chain", root.selectedNetworkChainId)
+                    return
+                }
+
+                d.selectedHoldingTokenKey = SQUtils.ModelUtils.get(selectedHolding.item.tokens, 0, "key")
+
                 holdingSelector.setSelection(selectedHolding.item.symbol, selectedHolding.item.iconSource, selectedHolding.item.key)
                 return
             }
             // search in full model (lazy-loaded items) if not found in selected model (fir example while searching, but the other token is selected)
             const entry = SQUtils.ModelUtils.getByKey(d.adaptor.fullOutputAssetsModel, "key", d.selectedHoldingId)
             if (!!entry) {
+                if (!entry.tokens || entry.tokens.ModelCount.count !== 1) {
+                    console.error("token for the selected group (full model) cannot be resolved", "group-key", d.selectedHoldingId, "chain", root.selectedNetworkChainId)
+                    return
+                }
+
+                d.selectedHoldingTokenKey = SQUtils.ModelUtils.get(entry.tokens, 0, "key")
+
                 holdingSelector.setSelection(entry.symbol, entry.iconSource, entry.key)
                 return
             }

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModal.qml
@@ -357,7 +357,8 @@ StatusDialog {
                 readonly property string quote: !!lhsAmount && !!rhsAmount ? SQUtils.AmountsArithmetic.div(
                                                     SQUtils.AmountsArithmetic.fromNumber(rhsAmount),
                                                     SQUtils.AmountsArithmetic.fromNumber(lhsAmount)).toFixed(rhsDecimals) : 1
-                readonly property string price: root.swapAdaptor.currencyStore.getFiatValue(1, lhsSymbol)
+
+                readonly property string price: root.swapAdaptor.currencyStore.getFiatValue(1, leftPanel.selectedHoldingTokenKey)
 
                 function formatCurrency(amount, symbol) {
                     return root.swapAdaptor.currencyStore.formatCurrencyAmount(amount, symbol,
@@ -448,9 +449,9 @@ StatusDialog {
                     // value dont update correctly if not done from here
                     d.buyFormData.selectedWalletAddress = root.swapInputParamsForm.selectedAccountAddress
                     d.buyFormData.selectedNetworkChainId = root.swapInputParamsForm.selectedNetworkChainId
-                    d.buyFormData.selectedTokenKey = root.swapAdaptor.isTokenBalanceInsufficient ?
+                    d.buyFormData.selectedTokenGroupKey = root.swapAdaptor.isTokenBalanceInsufficient ?
                                 root.swapInputParamsForm.fromGroupKey :
-                                d.nativeTokenSymbol
+                                Utils.getNativeTokenGroupKey(root.swapInputParamsForm.selectedNetworkChainId)
                     Global.openBuyCryptoModalRequested(d.buyFormData)
                 }
             }
@@ -606,18 +607,8 @@ StatusDialog {
             fromTokenSymbol: root.swapAdaptor.fromToken.symbol
             fromTokenAmount: root.swapInputParamsForm.fromTokenAmount
             fromTokenContractAddress: {
-                let selectedGroup = SQUtils.ModelUtils.getByKey(payPanel.tokenGroupsModel,
-                                                                "key",
-                                                                root.swapAdaptor.swapFormData.fromGroupKey)
-                if (!selectedGroup.tokens) {
-                    return ""
-                }
-
-                let tokenAddress = SQUtils.ModelUtils.getByKey(selectedGroup.tokens,
-                                                               "chainId",
-                                                               root.swapInputParamsForm.selectedNetworkChainId,
-                                                               "address")
-                return tokenAddress
+                let details = Utils.getChainAndAddressFromTokenKey(payPanel.selectedHoldingTokenKey)
+                return details.address
             }
 
             accountName: d.selectedAccount.name
@@ -670,35 +661,15 @@ StatusDialog {
             fromTokenSymbol: root.swapAdaptor.fromToken.symbol
             fromTokenAmount: root.swapInputParamsForm.fromTokenAmount
             fromTokenContractAddress: {
-                let selectedGroup = SQUtils.ModelUtils.getByKey(payPanel.tokenGroupsModel,
-                                                                "key",
-                                                                root.swapAdaptor.swapFormData.fromGroupKey)
-                if (!selectedGroup.tokens) {
-                    return ""
-                }
-
-                let tokenAddress = SQUtils.ModelUtils.getByKey(selectedGroup.tokens,
-                                                               "chainId",
-                                                               root.swapInputParamsForm.selectedNetworkChainId,
-                                                               "address")
-                return tokenAddress
+                let details = Utils.getChainAndAddressFromTokenKey(payPanel.selectedHoldingTokenKey)
+                return details.address
             }
 
             toTokenSymbol: root.swapAdaptor.toToken.symbol
             toTokenAmount: root.swapAdaptor.swapOutputData.toTokenAmount
             toTokenContractAddress: {
-                let selectedGroup = SQUtils.ModelUtils.getByKey(receivePanel.tokenGroupsModel,
-                                                                "key",
-                                                                root.swapAdaptor.swapFormData.toGroupKey)
-                if (!selectedGroup.tokens) {
-                    return ""
-                }
-
-                let tokenAddress = SQUtils.ModelUtils.getByKey(selectedGroup.tokens,
-                                                               "chainId",
-                                                               root.swapInputParamsForm.selectedNetworkChainId,
-                                                               "address")
-                return tokenAddress
+                let details = Utils.getChainAndAddressFromTokenKey(receivePanel.selectedHoldingTokenKey)
+                return details.address
             }
 
             accountName: d.selectedAccount.name

--- a/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
+++ b/ui/app/AppLayouts/Wallet/popups/swap/SwapModalAdaptor.qml
@@ -51,6 +51,7 @@ QObject {
         property string txHash
 
         readonly property string nativeTokenSymbol: Utils.getNativeTokenSymbol(root.swapFormData.selectedNetworkChainId)
+        readonly property string nativeTokenKey: Utils.getNativeTokenKey(root.swapFormData.selectedNetworkChainId)
 
         // Properties to handle error states
         readonly property bool isRouteEthBalanceInsufficient: root.validSwapProposalReceived && root.swapOutputData.errCode === Constants.routerErrorCodes.router.errNotEnoughNativeBalance
@@ -145,16 +146,16 @@ QObject {
                 let totalTokenFeesInFiat = 0
                 if (!!root.fromToken && !!root.fromToken.marketDetails && !!root.fromToken.marketDetails.currencyPrice)
                     totalTokenFeesInFiat = gasTimeEstimate.totalTokenFees * root.fromToken.marketDetails.currencyPrice.amount
-                root.swapOutputData.totalFees = root.currencyStore.getFiatValue(gasTimeEstimate.totalFeesInNativeCrypto, d.nativeTokenSymbol) + totalTokenFeesInFiat
+                root.swapOutputData.totalFees = root.currencyStore.getFiatValue(gasTimeEstimate.totalFeesInNativeCrypto, d.nativeTokenKey) + totalTokenFeesInFiat
                 let bestPath = ModelUtils.get(txRoutes.suggestedRoutes, 0, "route")
 
                 root.swapOutputData.txFeesWei = AmountsArithmetic.sum(AmountsArithmetic.fromString(bestPath.txFeeInWei), AmountsArithmetic.fromString(bestPath.txL1FeeInWei)).toString()
                 const txFeesNative = Utils.nativeTokenRawToDecimal(root.swapFormData.selectedNetworkChainId, root.swapOutputData.txFeesWei)
-                root.swapOutputData.txFeesInFiat = root.currencyStore.getFiatValue(txFeesNative, d.nativeTokenSymbol)
+                root.swapOutputData.txFeesInFiat = root.currencyStore.getFiatValue(txFeesNative, d.nativeTokenKey)
 
                 root.swapOutputData.approvalTxFeesWei = AmountsArithmetic.sum(AmountsArithmetic.fromString(bestPath.approvalFeeInWei), AmountsArithmetic.fromString(bestPath.approvalL1FeeInWei)).toString()
                 const txApprovalFeesNative = Utils.nativeTokenRawToDecimal(root.swapFormData.selectedNetworkChainId, root.swapOutputData.approvalTxFeesWei)
-                root.swapOutputData.approvalTxFeesFiat = root.currencyStore.getFiatValue(txApprovalFeesNative, d.nativeTokenSymbol)
+                root.swapOutputData.approvalTxFeesFiat = root.currencyStore.getFiatValue(txApprovalFeesNative, d.nativeTokenKey)
 
                 const totalMaxFeesInGasUnit = Math.ceil(bestPath.gasFees.maxFeePerGasM) * bestPath.gasAmount
                 root.swapOutputData.maxFeesToReserveRaw = Utils.nativeTokenGasToRaw(root.swapFormData.selectedNetworkChainId, totalMaxFeesInGasUnit).toString()

--- a/ui/app/AppLayouts/Wallet/services/dapps/DAppsModule.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/DAppsModule.qml
@@ -300,8 +300,8 @@ SQUtils.QObject {
         feesBroker: feesBroker
 
         fiatSymbol: root.currenciesStore.currentCurrency
-        getFiatValue: (value, currency) => {
-            return root.currenciesStore.getFiatValue(value, currency)
+        getFiatValue: (value, tokenKey) => {
+            return root.currenciesStore.getFiatValue(value, tokenKey)
         }
 
         onAccepted: (topic, id, userAccepted) => {
@@ -339,8 +339,8 @@ SQUtils.QObject {
         feesBroker: feesBroker
 
         fiatSymbol: root.currenciesStore.currentCurrency
-        getFiatValue: (value, currency) => {
-            return root.currenciesStore.getFiatValue(value, currency)
+        getFiatValue: (value, tokenKey) => {
+            return root.currenciesStore.getFiatValue(value, tokenKey)
         }
 
         onAccepted: (topic, id, userAccepted) => {

--- a/ui/app/AppLayouts/Wallet/services/dapps/plugins/SignRequestPlugin.qml
+++ b/ui/app/AppLayouts/Wallet/services/dapps/plugins/SignRequestPlugin.qml
@@ -47,7 +47,7 @@ SQUtils.QObject {
     // Symbol of the currency used to perform crypto -> fiat conversions
     required property string fiatSymbol
     // Function to transform the eth value to fiat
-    property var getFiatValue: (maxFeesEthStr, token) => console.error("getFiatValue not implemented")
+    property var getFiatValue: (maxFeesEthStr, tokenKey) => console.error("getFiatValue not implemented")
 
     // Signals
     /// Signal emitted when a session request is accepted
@@ -97,7 +97,7 @@ SQUtils.QObject {
             nativeTokenGroupKey: Utils.getNativeTokenGroupKey(request.chainId)
             nativeTokenMaxFees: feesSubscriber.maxEthFee ? SQUtils.AmountsArithmetic.div(feesSubscriber.maxEthFee, SQUtils.AmountsArithmetic.fromNumber(1, 9)) : null
             fiatSymbol: root.fiatSymbol
-            fiatMaxFees: nativeTokenMaxFees ? SQUtils.AmountsArithmetic.fromString(root.getFiatValue(nativeTokenMaxFees.toString(), Utils.getNativeTokenSymbol(request.chainId))) : null
+            fiatMaxFees: nativeTokenMaxFees ? SQUtils.AmountsArithmetic.fromString(root.getFiatValue(nativeTokenMaxFees.toString(), Utils.getNativeTokenKey(request.chainId))) : null
             function signedHandler(topic, id, data) {
                 if (topic != request.topic || id != request.requestId) {
                     return
@@ -143,7 +143,7 @@ SQUtils.QObject {
                 } catch (e) {
                     console.error("Error executing session request", e)
                 }
-                
+
                 if (!executed) {
                     root.rejected(request.topic, request.requestId, true /*hasError*/)
                     root.store.signingResult.disconnect(request.signedHandler)
@@ -298,7 +298,7 @@ SQUtils.QObject {
 
             const token = SQUtils.ModelUtils.getByKey(root.groupedAccountAssetsModel, "key", tokenGroupKey)
             const balance = getBalance(chainId, accountAddress, token)
-            
+
             if (!balance) {
                 console.error("Error fetching balance for account", accountAddress, "on chain", chainId)
                 return true

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -298,7 +298,7 @@ QtObject {
     function cancelPendingRequest(id: string) {
         communitiesModuleInst.cancelRequestToJoinCommunity(id)
     }
-    
+
     function communityHasMember(communityId, pubKey)
     {
         return communitiesModuleInst.isMemberOfCommunity(communityId, pubKey)
@@ -398,10 +398,6 @@ QtObject {
 
 
     property string currentCurrency: walletSection.currentCurrency
-
-    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        return profileSectionStore.ensUsernamesStore.getFiatValue(balance, cryptoSymbol, fiatSymbol)
-    }
 
     signal showToastAccountAdded(string name)
     signal showToastAccountRemoved(string name)

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -60,11 +60,11 @@ StatusListItem {
     readonly property bool isMultiTransaction: isModelDataValid && modelData.isMultiTransaction
     readonly property string currentCurrency: currenciesStore.currentCurrency
     readonly property double cryptoValue: isModelDataValid ? modelData.amount : 0.0
-    readonly property double fiatValue: isModelDataValid ? currenciesStore.getFiatValue(cryptoValue, modelData.symbol) : 0.0
+    readonly property double fiatValue: isModelDataValid ? currenciesStore.getFiatValue(cryptoValue, Utils.composeTokenKey(modelData.chainId, modelData.tokenAddress)) : 0.0
     readonly property double inCryptoValue: isModelDataValid ? modelData.inAmount : 0.0
-    readonly property double inFiatValue: isModelDataValid && isMultiTransaction ? currenciesStore.getFiatValue(inCryptoValue, modelData.inSymbol): 0.0
+    readonly property double inFiatValue: isModelDataValid ? currenciesStore.getFiatValue(inCryptoValue, Utils.composeTokenKey(modelData.chainIdIn, modelData.tokenInAddress)): 0.0
     readonly property double outCryptoValue: isModelDataValid ? modelData.outAmount : 0.0
-    readonly property double outFiatValue: isModelDataValid && isMultiTransaction ? currenciesStore.getFiatValue(outCryptoValue, modelData.outSymbol): 0.0
+    readonly property double outFiatValue: isModelDataValid ? currenciesStore.getFiatValue(outCryptoValue, Utils.composeTokenKey(modelData.chainIdOut, modelData.tokenOutAddress)): 0.0
     readonly property string networkColor: isModelDataValid ? SQUtils.ModelUtils.getByKey(flatNetworks, "chainId", modelData.chainId, "chainColor") : ""
     readonly property string networkName: isModelDataValid ? SQUtils.ModelUtils.getByKey(flatNetworks, "chainId", modelData.chainId, "chainName") : ""
     readonly property string networkNameIn: isMultiTransaction ? SQUtils.ModelUtils.getByKey(flatNetworks, "chainId", modelData.chainIdIn, "chainName") : ""
@@ -136,8 +136,8 @@ StatusListItem {
     }
 
     readonly property string tokenImage: {
-        if (!isModelDataValid || 
-            d.txType === Constants.TransactionType.ContractDeployment || 
+        if (!isModelDataValid ||
+            d.txType === Constants.TransactionType.ContractDeployment ||
             d.txType === Constants.TransactionType.ContractInteraction)
             return ""
         if (root.isNFT) {
@@ -160,7 +160,7 @@ StatusListItem {
                                             isModelDataValid ?
                                                 Utils.compactAddress(modelData.sender, 4) :
                                                 ""
-    
+
     readonly property string interactedContractAddress: isModelDataValid ? Utils.compactAddress(modelData.interactedContractAddress, 4) : ""
     readonly property string approvalSpender: isModelDataValid ? Utils.compactAddress(modelData.approvalSpender, 4) : ""
 

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -943,6 +943,10 @@ QtObject {
         }
     }
 
+    function getNativeTokenKey(chainId) {
+        return composeTokenKey(chainId, Constants.zeroAddress)
+    }
+
     // Get NativeTokenSymbol for ChainID
     function getNativeTokenSymbol(chainID) {
         switch (+chainID) {
@@ -1352,7 +1356,20 @@ QtObject {
         return result
     }
 
-    function buildTokenKey(chainId, address) {
+    function composeTokenKey(chainId, address) {
         return "%1%2%3".arg(chainId).arg(Constants.tokenKeyDelimiter).arg(address.toLowerCase())
+    }
+
+    function getChainAndAddressFromTokenKey(tokenKey) {
+        let result = {
+            address: "",
+            chainId: 0
+        }
+        const parts = tokenKey.split(Constants.tokenKeyDelimiter)
+        if (parts.length === 2) {
+            result.chainId = parseInt(parts[0], 10)
+            result.address = parts[1]
+        }
+        return result
     }
 }


### PR DESCRIPTION
This release PR https://github.com/status-im/status-app/pull/20145 reintroduced over the `master` branch.

- Removed redundant getFiatValue functions from app and chat RootStore.
- fiat value calculation fixed in the following places:
  - swap modal
  - signing popup for both approval and swap tx
  - transaction history
  - signing tx initiate by the dapp

