### PR TITLE
fix(@e2e): use fixed compose project name and move fleet cleanup inside lock

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -189,47 +189,51 @@ pipeline {
 
     stage('Test') {
       steps {
-        /* Lock the agent so we run only one e2e build at a time */
         lock(resource: "e2e-linux-${env.NODE_NAME}", quantity: 1) {
-          timeout(2) {
-            /* Clean up any leftover containers from a previous aborted run */
-            sh 'docker compose -f docker-compose.waku.yml down --remove-orphans || true'
-            sh 'docker compose -f docker-compose.waku.yml up -d'
-            sh 'sleep 15'
-          }
-          timeout(time: getTestStageTimeout()) {
-            dir('test/e2e') {
-              script {
-                def flags = []
-                if (params.TEST_NAME)  { flags.add("-k=${params.TEST_NAME}") }
-                if (params.TEST_SCOPE_FLAG) { flags.add(params.TEST_SCOPE_FLAG) }
-                if (params.LOG_LEVEL)  { flags.addAll(["--log-level=${params.LOG_LEVEL}", "--log-cli-level=${params.LOG_LEVEL}"]) }
-                dir ('configs') { sh 'ln -s _local.ci.py _local.py' }
-                wrap([
-                  $class:            'Xvfb',
-                  autoDisplayName:   true,
-                  parallelBuild:     true,
-                  screen:            '2560x1440x24',
-                  additionalOptions: '-dpi 1'
-                ]) {
-                  sh 'fluxbox &'
-                  withCredentials([
-                    usernamePassword(
-                      credentialsId: 'test-rail-api-devops',
-                      usernameVariable: 'TESTRAIL_USR',
-                      passwordVariable: 'TESTRAIL_PSW'
-                    ),
-                    string(credentialsId: 'wallet-test-user-seed', variable: 'WALLET_TEST_USER_SEED')
+          script {
+            try {
+              timeout(2) {
+                /* Clean up any leftover containers from a previous aborted run */
+                sh 'docker compose -p e2e-fleet -f docker-compose.waku.yml down --remove-orphans || true'
+                sh 'docker compose -p e2e-fleet -f docker-compose.waku.yml up -d'
+                sh 'sleep 15'
+              }
+              timeout(time: getTestStageTimeout()) {
+                dir('test/e2e') {
+                  def flags = []
+                  if (params.TEST_NAME)  { flags.add("-k=${params.TEST_NAME}") }
+                  if (params.TEST_SCOPE_FLAG) { flags.add(params.TEST_SCOPE_FLAG) }
+                  if (params.LOG_LEVEL)  { flags.addAll(["--log-level=${params.LOG_LEVEL}", "--log-cli-level=${params.LOG_LEVEL}"]) }
+                  dir ('configs') { sh 'ln -s _local.ci.py _local.py' }
+                  wrap([
+                    $class:            'Xvfb',
+                    autoDisplayName:   true,
+                    parallelBuild:     true,
+                    screen:            '2560x1440x24',
+                    additionalOptions: '-dpi 1'
                   ]) {
-                    sh """
-                      python3 -m pytest -m "not keycard" -v --reruns=1 --timeout=300 ${flags.join(" ")} \
-                        --disable-warnings \
-                        --alluredir=./allure-results \
-                        -o timeout_func_only=true
-                    """
+                    sh 'fluxbox &'
+                    withCredentials([
+                      usernamePassword(
+                        credentialsId: 'test-rail-api-devops',
+                        usernameVariable: 'TESTRAIL_USR',
+                        passwordVariable: 'TESTRAIL_PSW'
+                      ),
+                      string(credentialsId: 'wallet-test-user-seed', variable: 'WALLET_TEST_USER_SEED')
+                    ]) {
+                      sh """
+                        python3 -m pytest -m "not keycard" -v --reruns=1 --timeout=300 ${flags.join(" ")} \
+                          --disable-warnings \
+                          --alluredir=./allure-results \
+                          -o timeout_func_only=true
+                      """
+                    }
                   }
                 }
               }
+            } finally {
+              /* Stop local waku fleet */
+              sh 'docker compose -p e2e-fleet -f docker-compose.waku.yml down --remove-orphans || true'
             }
           }
         }
@@ -239,9 +243,6 @@ pipeline {
 
   post {
     always { script {
-      /* Stop local waku fleet */
-      sh 'docker compose -f docker-compose.waku.yml down --remove-orphans || true'
-
       dir('test/e2e') {
         archiveArtifacts('aut/*.*')
 


### PR DESCRIPTION
### What does the PR do
Fixes port collisions between concurrent E2E builds on the same agent. Jenkins creates separate workspaces (prs, prs@2) for concurrent builds, each generating a different docker compose project name. This caused nwaku nodes to fail with "Address in use" errors.

Two changes:
- Uses `-p e2e-fleet` to force a fixed compose project name across all workspaces
- Moves fleet teardown into try/finally inside the lock block, removing it from post.always to prevent race conditions

### Affected areas
CI/CD - Linux E2E Jenkinsfile

### How to test
Trigger multiple PR E2E builds on the same Linux agent simultaneously. All should queue properly and run without port conflicts.

### Risk
Low - fleet lifecycle is now fully contained within the lock.