### PR TITLE
fix(ActivityCenter): Community membership request improvements

### DIFF
--- a/ui/app/AppLayouts/ActivityCenter/adaptors/ActivityCenterAdaptor.qml
+++ b/ui/app/AppLayouts/ActivityCenter/adaptors/ActivityCenterAdaptor.qml
@@ -612,8 +612,8 @@ QtObject {
 
                         // Required data
                         readonly property NotificationSenderResolver senderResolver: NotificationSenderResolver {
-                            isOutgoingMessage: root.notification?.message?.amISender ?? false
-                            contactId: root.notification ? (isOutgoingMessage ? root.notification.chatId : root.notification.author) : ""
+                            isOutgoingMessage: row.notification?.message?.amISender ?? false
+                            contactId: row.notification ? (isOutgoingMessage ? row.notification.chatId : row.notification.author) : ""
                             contactsModel: root.contactsModel
 
                             onPopulateContactDetailsRequested: (contactId) => root.populateContactDetailsRequested(contactId)
@@ -641,9 +641,14 @@ QtObject {
                     NotificationAdaptorCommunity {
 
                         // Required data
+                        readonly property int membershipStatus: notification && notification.membershipStatus ?
+                                                                    notification.membershipStatus :
+                                                                    ActivityCenterTypes.ActivityCenterMembershipStatus.None
+                        readonly property bool pending: membershipStatus === ActivityCenterTypes.ActivityCenterMembershipStatus.Pending
+
                         readonly property NotificationSenderResolver senderResolver: NotificationSenderResolver {
-                            isOutgoingMessage: root.notification?.message?.amISender ?? false
-                            contactId: root.notification ? (isOutgoingMessage ? root.notification.chatId : root.notification.author) : ""
+                            isOutgoingMessage: row.notification?.message?.amISender ?? false
+                            contactId: row.notification ? (isOutgoingMessage ? row.notification.chatId : row.notification.author) : ""
                             contactsModel: root.contactsModel
 
                             onPopulateContactDetailsRequested: (contactId) => root.populateContactDetailsRequested(contactId)
@@ -658,7 +663,14 @@ QtObject {
                         actionText: qsTr("Community membership request")
 
                         // Content related
-                        content: senderResolver.sender?.displayName ?? ""
+                        content: senderResolver.sender?.displayName
+                                 ? "<font color='%1'>@%2</font>".arg(Theme.palette.primaryColor1)
+                                                                .arg(senderResolver.sender.displayName)
+                                 : ""
+
+                        // Quick actions — only when genuinely pending (excludes AcceptedPending=4, DeclinedPending=5)
+                        showQuickActions: pending
+                        actionId: pending ? notification.notificationId : ""
                     }
                 }
 
@@ -688,8 +700,8 @@ QtObject {
                             if(accepted)
                                 return "<font color='%1'>".arg(Theme.palette.successColor1) + qsTr("Accepted") + "</font>"
 
-                            if(dismissed)
-                                return "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Decline") + "</font>"
+                            if(declined)
+                                return "<font color='%1'>".arg(Theme.palette.dangerColor1) + qsTr("Declined") + "</font>"
 
                             if(pending)
                                 return qsTr("In progress")

--- a/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
+++ b/ui/app/AppLayouts/ActivityCenter/panels/ActivityCenterPanel.qml
@@ -107,9 +107,9 @@ Control {
     signal redirectToPopup(var notification)
     signal redirectToWallet(string address, string txHash)
 
-    // Emitted when quick actions are shown and user iteracts with the corresponding buttons
-    signal declineRequested(string avatarId, string actionId)
-    signal acceptRequested(string avatarId, string actionId)
+    // Emitted when quick actions are shown and user interacts with the corresponding buttons
+    signal declineRequested(string requestId, string actionId, int notificationType)
+    signal acceptRequested(string requestId, string actionId, int notificationType)
 
     QtObject {
         id: d
@@ -290,8 +290,18 @@ Control {
                     // No navigation actions when clicked
                 }
                 onAvatarClicked: root.avatarClicked(model.avatarId)
-                onAcceptRequested: root.acceptRequested(model.avatarId ?? "", model.actionId ?? "")
-                onDeclineRequested: root.declineRequested(model.avatarId ?? "", model.actionId ?? "")
+                onAcceptRequested: {
+                    if (model.notificationType === ActivityCenterTypes.NotificationType.CommunityMembershipRequest)
+                        root.acceptRequested(model.communityId ?? "", model.actionId ?? "", model.notificationType)
+                    else
+                        root.acceptRequested(model.avatarId ?? "", model.actionId ?? "", model.notificationType)
+                }
+                onDeclineRequested: {
+                    if (model.notificationType === ActivityCenterTypes.NotificationType.CommunityMembershipRequest)
+                        root.declineRequested(model.communityId ?? "", model.actionId ?? "", model.notificationType)
+                    else
+                        root.declineRequested(model.avatarId ?? "", model.actionId ?? "", model.notificationType)
+                }
                 onMarkAsReadRequested: root.markNotificationRead(model.notificationId)
                 onMarkAsUnreadRequested: root.markNotificationUnread(model.notificationId)
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1759,26 +1759,36 @@ Item {
                                     }
 
                 // Quick actions
-                // NOTE: There are now just quick actions specific for `Contact Requests`, OR generally to accept / decline notification.
-                // If more quick actions are introduced, this will need some generalization rule / implementation
-                onAcceptRequested: (avatarId, actionId) => {
+                onAcceptRequested: (requestId, actionId, notificationType) => {
                                        // This means, Contact Requests
-                                       if(avatarId) {
-                                           appMain.contactsStore.acceptContactRequest(avatarId, actionId)
+                                       if (notificationType === ActivityCenterTypes.NotificationType.ContactRequest) {
+                                           appMain.contactsStore.acceptContactRequest(requestId, actionId)
+                                       }
+                                       // This means, Community Membership Requests
+                                       else if (notificationType === ActivityCenterTypes.NotificationType.CommunityMembershipRequest) {
+                                           const store = appMain.messagingRootStore.createCommunityRootStore(appMain, requestId)
+                                           store.communityAccessStore.acceptRequestToJoinCommunityRequested(actionId, requestId)
+                                           store.destroy()
                                        }
                                        // This means, generic accept notification by id
                                        else {
-                                            appMain.activityCenterStore.acceptActivityCenterNotification(actionId)
+                                           appMain.activityCenterStore.acceptActivityCenterNotification(actionId)
                                        }
                                    }
-                onDeclineRequested: (avatarId, actionId) => {
+                onDeclineRequested: (requestId, actionId, notificationType) => {
                                         // This means, Contact Requests
-                                        if(avatarId) {
-                                            appMain.contactsStore.dismissContactRequest(avatarId, actionId)
+                                        if (notificationType === ActivityCenterTypes.NotificationType.ContactRequest) {
+                                            appMain.contactsStore.dismissContactRequest(requestId, actionId)
+                                        }
+                                        // This means, Community Membership Requests
+                                        else if (notificationType === ActivityCenterTypes.NotificationType.CommunityMembershipRequest) {
+                                            const store = appMain.messagingRootStore.createCommunityRootStore(appMain, requestId)
+                                            store.communityAccessStore.declineRequestToJoinCommunityRequested(actionId, requestId)
+                                            store.destroy()
                                         }
                                         // This means, generic dismiss notification by id
                                         else {
-                                             appMain.activityCenterStore.dismissActivityCenterNotification(actionId)
+                                            appMain.activityCenterStore.dismissActivityCenterNotification(actionId)
                                         }
                                     }
             }


### PR DESCRIPTION
Part of #20463

### What does the PR do

 Description:
  - Fix scope bug: `root.notification` → `row.notification` in community adaptors
  - Fix communityRequestAdaptor: show "Declined" state using membershipStatus instead of dismissed flag
  - Style communityMembershipRequest sender as @mention
  - Add accept/decline quick actions for pending community membership requests
  - Route accept/decline by notificationType (community vs contact vs generic)

### Affected areas

Activity center

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="427" height="290" alt="Screenshot 2026-04-23 at 13 21 12" src="https://github.com/user-attachments/assets/dd4dbc76-76d1-4ece-9042-67c6482c883b" />

### Impact on end user

Better UX

### How to test

Interact with `Join / Request access to community`

### Risk 

Low
