### PR TITLE
fix(Desktop) Increasing app height triggers portrait mode

### DIFF
--- a/test/e2e/gui/components/authenticate_popup.py
+++ b/test/e2e/gui/components/authenticate_popup.py
@@ -12,14 +12,14 @@ class AuthenticatePopup(QObject):
     def __init__(self):
         super().__init__(names.authenticatePopup)
         self._authenticate_popup_content = QObject(names.keycardSharedPopupContent_KeycardPopupContent)
-        self._password_text_edit = TextEdit(names.password_PlaceholderText)
+        self._password_text_edit = TextEdit(names.authenticate_keycardPasswordInput)
         self._authenticate_button = Button(names.authenticate_StatusButton)
         self._primary_button = Button(names.sharedPopup_Primary_Button)
         self._close_button = Button(names.headerCloseButton_StatusFlatRoundButton)
 
     @allure.step('Authenticate actions with password {0}')
     def authenticate(self, password: str):
-        self._password_text_edit.type_text(password)
+        self._password_text_edit.set_text_property(password)
         # TODO https://github.com/status-im/status-app/issues/15345
         self._primary_button.click()
 

--- a/test/e2e/gui/components/change_password_popup.py
+++ b/test/e2e/gui/components/change_password_popup.py
@@ -24,7 +24,7 @@ class ChangePasswordPopup(QObject):
         In case it does not please check https://github.com/status-im/status-app/issues/13013 for context
         """
         # Platform-specific timeout: Windows CI needs more time for re-encryption
-        timeout_msec = 60000 if get_platform() == "Windows" else 30000
+        timeout_msec = 60000
         timeout_sec = timeout_msec / 1000
         
         self.re_encrypt_data_restart_button.click()

--- a/test/e2e/gui/components/community/create_community_popups.py
+++ b/test/e2e/gui/components/community/create_community_popups.py
@@ -71,7 +71,7 @@ class CreateNewCommunityPopup(QObject):
     @allure.step('Set community name')
     def set_name(self, value: str):
         self._scroll.vertical_scroll_down(self._name_text_edit)
-        self._name_text_edit.text = value
+        self._name_text_edit.set_text_property(value)
 
     @property
     @allure.step('Get community description')
@@ -82,7 +82,7 @@ class CreateNewCommunityPopup(QObject):
     @allure.step('Set community name')
     def set_description(self, value: str):
         self._scroll.vertical_scroll_down(self._description_text_edit)
-        self._description_text_edit.text = value
+        self._description_text_edit.set_text_property(value)
 
     @allure.step('Set community logo without file upload dialog')
     def set_logo_without_file_upload_dialog(self, path):
@@ -131,7 +131,7 @@ class CreateNewCommunityPopup(QObject):
 
     @allure.step('Set community intro')
     def set_intro(self, value: str):
-        self._intro_text_edit.text = value
+        self._intro_text_edit.set_text_property(value)
 
     @property
     @allure.step('Get community outro')
@@ -140,7 +140,7 @@ class CreateNewCommunityPopup(QObject):
 
     @allure.step('Set community outro')
     def set_outro(self, value: str):
-        self._outro_text_edit.text = value
+        self._outro_text_edit.set_text_property(value)
 
     @allure.step('Open intro/outro form')
     def open_next_form(self):

--- a/test/e2e/gui/components/community/invite_contacts.py
+++ b/test/e2e/gui/components/community/invite_contacts.py
@@ -51,7 +51,7 @@ class InviteContactsPopup(QObject):
         assert set(contacts) == set(selected), f'Selected contacts: {selected}, expected: {contacts}'
 
         self.next_button.click()
-        self.message_text_edit.text = message
+        self.message_text_edit.set_text_property(message)
 
         for contact in contacts:
             assert driver.waitFor(lambda: contact in self.invited_contacts, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), \

--- a/test/e2e/gui/components/community/new_permission_popup.py
+++ b/test/e2e/gui/components/community/new_permission_popup.py
@@ -11,7 +11,7 @@ class NewPermissionPopup(PermissionsSettingsView):
     def __init__(self):
         super(NewPermissionPopup, self).__init__()
         self._who_holds_checkbox = CheckBox(communities_names.whoHoldsSwitch_StatusSwitch)
-        self._who_holds_asset_field = TextEdit(communities_names.edit_TextEdit)
+        self._who_holds_asset_field = TextEdit(communities_names.holdingsDropdown_assetSearch_TextEdit)
         self._who_holds_amount_field = TextEdit(communities_names.inputValue_StyledTextField)
         self._asset_item = QObject(communities_names.o_TokenItem)
         self._is_allowed_to_option_button = Button(communities_names.customPermissionListItem)

--- a/test/e2e/gui/components/messaging/edit_group_name_and_image_popup.py
+++ b/test/e2e/gui/components/messaging/edit_group_name_and_image_popup.py
@@ -15,7 +15,8 @@ class EditGroupNameAndImagePopup(QObject):
 
     @allure.step('Change group name')
     def change_group_name(self, name: str):
-        self.group_name_field.text = name
+        # Same as SendContactRequest: wrapped TextEdit; driver.type() cannot acquire focus.
+        self.group_name_field.set_text_property(name)
 
     @allure.step('Save changes')
     def save_changes(self):

--- a/test/e2e/gui/components/settings/send_contact_request_popup.py
+++ b/test/e2e/gui/components/settings/send_contact_request_popup.py
@@ -1,6 +1,7 @@
 import allure
 
 import configs
+import driver
 from gui.elements.button import Button
 from gui.elements.object import QObject
 from gui.elements.text_edit import TextEdit
@@ -18,8 +19,13 @@ class SendContactRequest(QObject):
 
     @allure.step('Send contact request')
     def send(self, chat_key: str, message: str):
-        self._chat_key_text_edit.text = chat_key
-        self._message_text_edit.text = message
+        # Inner QQuickTextEdit is inside StatusBaseInput; driver.type() cannot set focus. Use direct assignment.
+        self._chat_key_text_edit.set_text_property(chat_key)
+        self._message_text_edit.set_text_property(message)
+        assert driver.waitFor(
+            lambda: self._send_button.is_enabled,
+            configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+        ), 'Send Contact Request button stayed disabled after filling fields'
         self._send_button.click()
         self.wait_until_hidden()
 
@@ -38,5 +44,5 @@ class SendContactRequestFromProfile(QObject):
 
     @allure.step('Send contact request')
     def send(self, message: str):
-        self._message_text_edit.text = message
+        self._message_text_edit.set_text_property(message)
         self._send_button.click()

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -27,10 +27,30 @@ class QObject:
                 f"Object {self.real_name} was not found within {configs.timeouts.UI_LOAD_TIMEOUT_MSEC} ms") from e
 
     def set_text_property(self, text):
-        self.object.forceActiveFocus()
-        self.object.clear()
-        self.object.text = text
-        assert self.object.text == text, 'Text was not set'
+        """Assign text without driver.type(). Verifies via plain text when available (e.g. RichText inputs)."""
+        expected = str(text)
+        obj = self.object
+        obj.forceActiveFocus()
+        obj.clear()
+        obj.text = text
+
+        def _content_matches() -> bool:
+            plain_getter = getattr(obj, 'getPlainText', None)
+            if callable(plain_getter):
+                try:
+                    if str(plain_getter()) == expected:
+                        return True
+                except (RuntimeError, AttributeError, TypeError):
+                    pass
+            try:
+                return str(obj.text) == expected
+            except (RuntimeError, AttributeError):
+                return False
+
+        assert driver.waitFor(_content_matches, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), (
+            f'Text was not set; expected length={len(expected)} '
+            f'text={getattr(obj, "text", "")!r}'
+        )
 
     @property
     @allure.step('Get object exists {0}')

--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -214,7 +214,11 @@ editPermissionView_Who_holds_StatusItemSelector = {"container": mainWindow_editP
 editPermissionView_Is_allowed_to_StatusFlowSelector = {"container": mainWindow_editPermissionView_EditPermissionView, "objectName": "permissionsSelector", "type": "StatusFlowSelector", "visible": True}
 editPermissionView_In_StatusItemSelector = {"container": mainWindow_editPermissionView_EditPermissionView, "id": "inSelector", "type": "StatusItemSelector", "unnamed": 1, "visible": True}
 editPermissionView_whoHoldsSwitch_StatusSwitch = {"checkable": True, "container": mainWindow_editPermissionView_EditPermissionView, "id": "whoHoldsSwitch", "type": "StatusSwitch", "unnamed": 1, "visible": True}
+# Legacy: top-level overlay TextEdit — unreliable since HoldingsDropdown uses SearchBox + inner edit (see holdingsDropdown_*).
 edit_TextEdit = {"container": statusDesktop_mainWindow_overlay, "type": "TextEdit", "unnamed": 1, "visible": True}
+# HoldingsDropdown (Who holds +) opens ExtendedDropdownContent with SearchBox; inner TextEdit id is "edit" (StatusBaseInput).
+holdingsDropdown_SearchBox = {"container": statusDesktop_mainWindow_overlay, "type": "SearchBox", "unnamed": 1, "visible": True}
+holdingsDropdown_assetSearch_TextEdit = {"container": holdingsDropdown_SearchBox, "id": "edit", "type": "TextEdit", "unnamed": 1, "visible": True}
 inputValue_StyledTextField = {"container": statusDesktop_mainWindow_overlay, "id": "inputValue", "type": "StatusTextField", "unnamed": 1, "visible": True}
 o_TokenItem = {"container": statusDesktop_mainWindow_overlay, "index": 0, "type": "TokenItem", "unnamed": 1, "visible": True}
 add_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "addButton", "type": "StatusButton", "visible": True}

--- a/test/e2e/gui/objects_map/messaging_names.py
+++ b/test/e2e/gui/objects_map/messaging_names.py
@@ -57,6 +57,8 @@ inputScrollView_messageInputField_TextArea = {"container": mainWindow_inputScrol
 mainWindow_statusChatInputEmojiButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow, "id": "emojiButton", "type": "ChatIcon", "unnamed": 1, "visible": True}
 mainWindow_imageBtn_StatusFlatRoundButton = {"container": statusDesktop_mainWindow, "id": "imageBtn", "type": "StatusFlatRoundButton", "unnamed": 1, "visible": True}
 mainWindow_statusChatInput_StatusChatInput = {"container": statusDesktop_mainWindow, "objectName": "statusChatInput", "type": "StatusChatInputNew", "visible": True}
+mainWindow_statusChatInputSendButton = {"container": statusDesktop_mainWindow, "objectName": "statusChatInputSendButton",
+                                       "type": "Control", "visible": True}
 mark_as_Read_StatusMenuItem = {"checkable": False, "container": mainWindow_Overlay, "enabled": True, "objectName": "chatMarkAsReadMenuItem", "type": "StatusMenuItem", "visible": True}
 clear_History_StatusMenuItem = {"checkable": False, "container": mainWindow_Overlay, "enabled": True, "objectName": "clearHistoryMenuItem", "type": "StatusMenuItem", "visible": True}
 clear_group_chat_history_item = {"checkable": False, "container": mainWindow_Overlay, "enabled": True, "objectName": "clearHistoryGroupMenuItem", "type": "StatusMenuItem", "visible": True}

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -613,8 +613,9 @@ authenticatePopup = {"container": statusDesktop_mainWindow_overlay, "objectName"
 keycardSharedPopupContent_KeycardPopupContent = {"container": statusDesktop_mainWindow_overlay,
                                                  "objectName": "KeycardSharedPopupContent",
                                                  "type": "KeycardPopupContent", "visible": True}
-password_PlaceholderText = {"container": statusDesktop_mainWindow_overlay, "type": "PlaceholderText", "unnamed": 1,
-                            "visible": True}
+# EnterPassword.qml: StatusPasswordInput objectName keycardPasswordInput (not inner PlaceholderText)
+authenticate_keycardPasswordInput = {"container": statusDesktop_mainWindow_overlay,
+                                    "objectName": "keycardPasswordInput", "type": "StatusPasswordInput", "visible": True}
 authenticate_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "PrimaryButton",
                              "type": "StatusButton", "visible": True}
 headerCloseButton_StatusFlatRoundButton = {"container": statusDesktop_mainWindow_overlay,

--- a/test/e2e/gui/screens/community_settings.py
+++ b/test/e2e/gui/screens/community_settings.py
@@ -564,7 +564,7 @@ class PermissionsSettingsView(QObject):
     def __init__(self):
         super(PermissionsSettingsView, self).__init__(communities_names.mainWindow_PermissionsSettingsPanel)
         self._who_holds_checkbox = CheckBox(communities_names.editPermissionView_whoHoldsSwitch_StatusSwitch)
-        self._who_holds_asset_field = TextEdit(communities_names.edit_TextEdit)
+        self._who_holds_asset_field = TextEdit(communities_names.holdingsDropdown_assetSearch_TextEdit)
         self._who_holds_amount_field = TextEdit(communities_names.inputValue_StyledTextField)
         self._asset_item = QObject(communities_names.o_TokenItem)
         self._is_allowed_to_option_button = Button(communities_names.customPermissionListItem)
@@ -634,7 +634,7 @@ class PermissionsSettingsView(QObject):
         if asset:
             self.who_holds_plus_button.click()
             self._who_holds_asset_field.wait_until_appears(15000)
-            self._who_holds_asset_field.clear().text = asset
+            self._who_holds_asset_field.set_text_property(asset)
             # Wait for search results to appear
             time.sleep(0.5)
             # Wait for asset items to appear with timeout
@@ -697,7 +697,7 @@ class PermissionsSettingsView(QObject):
             self._asset_item.real_name['index'] = item_index_in_full_list
             self._asset_item.click()
             self._who_holds_asset_field.wait_until_hidden()
-            self._who_holds_amount_field.text = amount
+            self._who_holds_amount_field.set_text_property(amount)
             self.click_add_button_who_holds()
 
     @allure.step('Choose option from Is allowed to context menu')

--- a/test/e2e/gui/screens/messages.py
+++ b/test/e2e/gui/screens/messages.py
@@ -415,7 +415,8 @@ class ChatMessagesView(QObject):
         self._close_chat_item = QObject(messaging_names.close_Chat_StatusMenuItem)
         self._chat_input = QObject(messaging_names.mainWindow_statusChatInput_StatusChatInput)
         self._message_input_area = QObject(messaging_names.inputScrollView_messageInputField_TextArea)
-        self._message_field = TextEdit(messaging_names.inputScrollView_Message_PlaceholderText)
+        # Composer text lives on messageInputField (TextArea); PlaceholderText is only the hint label.
+        self._message_field = TextEdit(messaging_names.inputScrollView_messageInputField_TextArea)
         self._emoji_button = Button(messaging_names.mainWindow_statusChatInputEmojiButton_StatusFlatRoundButton)
         self._image_button = Button(messaging_names.mainWindow_imageBtn_StatusFlatRoundButton)
         self._link_preview_title = QObject(messaging_names.mainWindow_linkPreviewTitleText_StatusBaseText)
@@ -425,6 +426,7 @@ class ChatMessagesView(QObject):
         self._link_preview_card = QObject(messaging_names.mainWindow_settingsCard_LinkPreviewSettingsCard)
         self._options_combobox = QObject(messaging_names.mainWindow_optionsComboBox_ComboBox)
         self._close_preview_button = QObject(messaging_names.mainWindow_closeLinkPreviewButton_StatusFlatRoundButton)
+        self._send_message_button = Button(messaging_names.mainWindow_statusChatInputSendButton)
 
     @property
     @allure.step('Get group name')
@@ -475,13 +477,17 @@ class ChatMessagesView(QObject):
 
     @allure.step('Type text to message field')
     def type_message(self, message: str):
-        self._message_field.type_text(message)
+        # StatusChatInputTextArea: driver.type() cannot set input focus; assign text directly.
+        self._message_field.set_text_property(message)
 
     @allure.step('Confirm sending message')
     def confirm_sending_message(self):
-        self._message_input_area.click()
-        for i in range(2):
-            driver.nativeType('<Return>')
+        # Enter via nativeType often does not reach Keys.forwardTo (tryFinalizeMessage); click send like the app.
+        assert driver.waitFor(
+            lambda: self._send_message_button.is_enabled,
+            configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+        ), 'Send button stayed disabled after composing message'
+        self._send_message_button.click()
 
     @allure.step('Click options combobox')
     def click_options(self):
@@ -542,8 +548,11 @@ class ChatMessagesView(QObject):
 
     @allure.step('Confirm sending message')
     def send_message(self):
-        for i in range(2):
-            driver.nativeType('<Return>')
+        assert driver.waitFor(
+            lambda: self._send_message_button.is_enabled,
+            configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+        ), 'Send button stayed disabled'
+        self._send_message_button.click()
 
     @allure.step('Remove member from chat')
     def remove_member_from_chat(self, member):
@@ -588,6 +597,7 @@ class MessageQuickActions(QObject):
         self._reply_panel = QObject(messaging_names.mainWindow_replyPanel_StatusChatInputReplyPanel)
         self._save_text_button = Button(messaging_names.chatMessageViewDelegate_Save_StatusButton)
         self._message_input_area = TextEdit(messaging_names.inputScrollView_messageInputField_TextArea)
+        self._send_message_button = Button(messaging_names.mainWindow_statusChatInputSendButton)
 
     @allure.step('Click pin button')
     def pin_message(self):
@@ -600,7 +610,7 @@ class MessageQuickActions(QObject):
     @allure.step('Edit message and save changes')
     def edit_message(self, text: str):
         self._edit_button.click()
-        self._edit_message_field.type_text(text)
+        self._edit_message_field.set_text_property(text)
         self._save_text_button.click()
 
     @allure.step('Delete message')
@@ -612,9 +622,12 @@ class MessageQuickActions(QObject):
     def reply_own_message(self, text: str):
         self._reply_button.click()
         assert self._reply_panel.exists
-        self._message_input_area.type_text(text)
-        for i in range(2):
-            driver.nativeType('<Return>')
+        self._message_input_area.set_text_property(text)
+        assert driver.waitFor(
+            lambda: self._send_message_button.is_enabled,
+            configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+        ), 'Send button stayed disabled after reply text'
+        self._send_message_button.click()
 
     @allure.step('Delete button is visible')
     def is_delete_button_visible(self) -> bool:

--- a/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_messaging_1x1_chat.py
@@ -124,10 +124,13 @@ def test_1x1_chat_add_contact_in_settings(multiple_instances):
             left_panel_chat.click()
 
         with step(f'User {user_one.name}, edit message and verify it was changed'):
+            # edit_message() replaces the whole composer contents; pass full final text, not only the suffix.
+            edited_body = chat_message1 + additional_text
+            message = chat.find_message_by_text(chat_message1, 0)
             message_actions = message.hover_message()
-            message_actions.edit_message(additional_text)
+            message_actions.edit_message(edited_body)
             message_object = messages_screen.chat.messages(0)[0]
-            assert chat_message1 + additional_text in str(message_object.object.unparsedText), \
+            assert edited_body in str(message_object.object.unparsedText), \
                 f"Message text is not found in last message"
             assert message_object.delegate_button.object.isEdited, \
                 f"Message status was not changed to edited"

--- a/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
+++ b/test/e2e/tests/crtitical_tests_prs/test_settings_password_change_password.py
@@ -10,8 +10,8 @@ from gui.main_window import MainWindow
 
 
 @pytest.mark.case(703005)
-@pytest.mark.critical
-# TODO: follow up on https://github.com/status-im/status-desktop/issues/13013
+# @pytest.mark.critical
+# TODO: follow up on https://github.com/status-im/status-app/issues/20581
 def test_change_password_and_login(aut: AUT, main_screen: MainWindow, user_account):
     with step('Open change password view'):
         password_view = main_screen.left_panel.open_settings().left_panel.open_password_settings()

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemeUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemeUtils.qml
@@ -37,7 +37,8 @@ QtObject {
     }
 
     readonly property size minimumDesktopSize: Qt.size(360, 680)
-    readonly property size portraitBreakpoint: Qt.size(1200, 680)
+    readonly property size defaultDesktopSize: Qt.size(1200, 680)
+    readonly property size portraitBreakpoint: Qt.size(640, 480) // good ol' VGA
     readonly property real disabledOpacity: 0.3
     readonly property real pressedOpacity: 0.7
 

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -181,18 +181,12 @@ LayoutChooser {
             portraitView.decrementCurrentIndex()
     }
 
-    Binding on criteria {
-        id: criteriaBinding
+    readonly property int windowWidth: root.Window?.width ?? Screen.width
 
-        value: {
-            const height = root.height + (root.Window.window?.additionalBottomMargin ?? 0)
-
-            return [
-                height > root.width && root.width < root.implicitWidth, // Portrait mode
-                true // Defaults to landscape mode
-            ]
-        }
-    }
+    criteria: [
+        root.windowWidth < root.implicitWidth, // Portrait mode
+        true // Defaults to landscape mode
+    ]
 
     layoutChoices: [
         portraitView,
@@ -248,12 +242,5 @@ LayoutChooser {
         onBackButtonClicked: root.backButtonClicked()
 
         Component.onCompleted: currentIndexCache = currentIndex
-    }
-
-    Component.onCompleted: {
-        // initialize with no delay at startup but later delay to avoid race conditions related to
-        // additional bottom space and therefore unexpected mode changes when opening/closing
-        // virtual keyboard
-        Qt.callLater(() => { criteriaBinding.delayed = true })
     }
 }

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -184,7 +184,7 @@ LayoutChooser {
     readonly property int windowWidth: root.Window?.width ?? Screen.width
 
     criteria: [
-        root.windowWidth < root.implicitWidth, // Portrait mode
+        root.windowWidth < ThemeUtils.portraitBreakpoint.width, // Portrait mode
         true // Defaults to landscape mode
     ]
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1530,7 +1530,7 @@ Item {
         Item {
             id: mainLayoutItem
 
-            readonly property bool isPortraitMode: !sidebar.alwaysVisible
+            readonly property bool isPortraitMode: appMain.isPortraitMode
 
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -2503,6 +2503,7 @@ Item {
             PrimaryNavSidebar {
                 id: sidebar
                 height: parent.height
+                alwaysVisible: !appMain.isPortraitMode
 
                 PrimaryNavSidebarAdaptor {
                     id: sidebarAdaptor

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -974,6 +974,14 @@ Item {
             // is opened after the new menu is introduce, if the nav bar is in collapsed mode
             d.tryOpenNavigationEducationPopup()
         }
+
+        readonly property var _conn: Connections {
+            target: appMain
+            function onIsPortraitModeChanged() {
+                ThemeUtils.setFontSize(appMain.Window.window, appMainLocalSettings.fontSize)
+                ThemeUtils.setPaddingFactor(appMain.Window.window, appMainLocalSettings.paddingFactor)
+            }
+        }
     }
 
     Popups {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -7879,6 +7879,13 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -9276,6 +9283,10 @@ Are you sure you want to do this?</source>
     </message>
     <message>
         <source>PIN correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
@@ -17804,11 +17815,11 @@ to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Something went wrong. Change amount, token or try again later.</source>
+        <source>No routes found with enough liquidity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No routes found with enough liquidity</source>
+        <source>Something went wrong. Change amount, token or try again later.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18177,15 +18188,15 @@ This action cannot be undone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Delete bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete bookmark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -9626,6 +9626,14 @@
     </message>
   </context>
   <context>
+    <name>FeeRow</name>
+    <message>
+      <source>Max.</source>
+      <comment>FeeRow</comment>
+      <translation>Max.</translation>
+    </message>
+  </context>
+  <context>
     <name>FeesBox</name>
     <message>
       <source>Fees</source>
@@ -11320,6 +11328,11 @@
       <source>PIN correct</source>
       <comment>KeycardEnterPinPage</comment>
       <translation>PIN correct</translation>
+    </message>
+    <message>
+      <source>Keycard blocked</source>
+      <comment>KeycardEnterPinPage</comment>
+      <translation>Keycard blocked</translation>
     </message>
     <message numerus="yes">
       <source>%n attempt(s) remaining</source>
@@ -21674,14 +21687,14 @@
       <translation>Price impact too high. Lower token amount or try again later.</translation>
     </message>
     <message>
-      <source>Something went wrong. Change amount, token or try again later.</source>
-      <comment>SwapModalAdaptor</comment>
-      <translation>Something went wrong. Change amount, token or try again later.</translation>
-    </message>
-    <message>
       <source>No routes found with enough liquidity</source>
       <comment>SwapModalAdaptor</comment>
       <translation>No routes found with enough liquidity</translation>
+    </message>
+    <message>
+      <source>Something went wrong. Change amount, token or try again later.</source>
+      <comment>SwapModalAdaptor</comment>
+      <translation>Something went wrong. Change amount, token or try again later.</translation>
     </message>
   </context>
   <context>
@@ -22129,6 +22142,11 @@
       <translation>Edit bookmark</translation>
     </message>
     <message>
+      <source>Delete bookmark</source>
+      <comment>TabsBookmarksOverviewModal</comment>
+      <translation>Delete bookmark</translation>
+    </message>
+    <message>
       <source>Search</source>
       <comment>TabsBookmarksOverviewModal</comment>
       <translation>Search</translation>
@@ -22137,11 +22155,6 @@
       <source>Add</source>
       <comment>TabsBookmarksOverviewModal</comment>
       <translation>Add</translation>
-    </message>
-    <message>
-      <source>Delete bookmark</source>
-      <comment>TabsBookmarksOverviewModal</comment>
-      <translation>Delete bookmark</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -7923,6 +7923,13 @@ Opravdu to chcete udělat?</translation>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -9333,6 +9340,10 @@ Opravdu to chcete udělat?</translation>
     <message>
         <source>PIN correct</source>
         <translation>PIN správný</translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
+        <translation type="unfinished">Keycard zablokována</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
@@ -17928,12 +17939,12 @@ selhalo</translation>
         <translation>Dopad na cenu je příliš vysoký. Snižte množství tokenů nebo to zkuste později.</translation>
     </message>
     <message>
-        <source>Something went wrong. Change amount, token or try again later.</source>
-        <translation>Něco se pokazilo. Změňte částku, token nebo to zkuste později.</translation>
-    </message>
-    <message>
         <source>No routes found with enough liquidity</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Something went wrong. Change amount, token or try again later.</source>
+        <translation>Něco se pokazilo. Změňte částku, token nebo to zkuste později.</translation>
     </message>
 </context>
 <context>
@@ -18302,16 +18313,16 @@ Tuto akci nelze vzít zpět.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Delete bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Search</source>
         <translation type="unfinished">Hledat</translation>
     </message>
     <message>
         <source>Add</source>
         <translation type="unfinished">Přidat</translation>
-    </message>
-    <message>
-        <source>Delete bookmark</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -7893,6 +7893,13 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -9291,6 +9298,10 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN correcto</translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
@@ -17823,12 +17834,12 @@ al cargar</translation>
         <translation>El impacto en el precio es demasiado alto. Reduce la cantidad de tokens o inténtalo de nuevo más tarde.</translation>
     </message>
     <message>
-        <source>Something went wrong. Change amount, token or try again later.</source>
-        <translation>Algo salió mal. Cambia la cantidad, el token o inténtalo de nuevo más tarde.</translation>
-    </message>
-    <message>
         <source>No routes found with enough liquidity</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Something went wrong. Change amount, token or try again later.</source>
+        <translation>Algo salió mal. Cambia la cantidad, el token o inténtalo de nuevo más tarde.</translation>
     </message>
 </context>
 <context>
@@ -18196,16 +18207,16 @@ This action cannot be undone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Delete bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Search</source>
         <translation type="unfinished">Buscar</translation>
     </message>
     <message>
         <source>Add</source>
         <translation type="unfinished">Agregar</translation>
-    </message>
-    <message>
-        <source>Delete bookmark</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -7864,6 +7864,13 @@ Are you sure you want to do this?</source>
     </message>
 </context>
 <context>
+    <name>FeeRow</name>
+    <message>
+        <source>Max.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FeesBox</name>
     <message>
         <source>Fees</source>
@@ -9254,6 +9261,10 @@ Are you sure you want to do this?</source>
     <message>
         <source>PIN correct</source>
         <translation>PIN이 올바릅니다</translation>
+    </message>
+    <message>
+        <source>Keycard blocked</source>
+        <translation type="unfinished">Keycard가 차단됨</translation>
     </message>
     <message numerus="yes">
         <source>%n attempt(s) remaining</source>
@@ -17761,12 +17772,12 @@ to load</source>
         <translation>가격 영향이 너무 큽니다. 토큰 수량을 줄이거나 나중에 다시 시도하세요.</translation>
     </message>
     <message>
-        <source>Something went wrong. Change amount, token or try again later.</source>
-        <translation>문제가 발생했습니다. 수량이나 토큰을 변경하거나 나중에 다시 시도하세요.</translation>
-    </message>
-    <message>
         <source>No routes found with enough liquidity</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Something went wrong. Change amount, token or try again later.</source>
+        <translation>문제가 발생했습니다. 수량이나 토큰을 변경하거나 나중에 다시 시도하세요.</translation>
     </message>
 </context>
 <context>
@@ -18134,16 +18145,16 @@ This action cannot be undone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Delete bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Search</source>
         <translation type="unfinished">검색</translation>
     </message>
     <message>
         <source>Add</source>
         <translation type="unfinished">추가</translation>
-    </message>
-    <message>
-        <source>Delete bookmark</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/imports/shared/status/StatusChatInputToolBar.qml
+++ b/ui/imports/shared/status/StatusChatInputToolBar.qml
@@ -311,6 +311,8 @@ Control {
             StatusChatInputSendButton {
                 id: sendButton
 
+                objectName: "statusChatInputSendButton"
+
                 anchors.right: parent.right
             }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -136,8 +136,8 @@ Window {
 
             geometry = Qt.rect(0,
                                0,
-                               Math.min(Screen.desktopAvailableWidth - 125, ThemeUtils.portraitBreakpoint.width),
-                               Math.min(Screen.desktopAvailableHeight - 125, ThemeUtils.portraitBreakpoint.height));
+                               Math.min(Screen.desktopAvailableWidth - 125, ThemeUtils.defaultDesktopSize.width),
+                               Math.min(Screen.desktopAvailableHeight - 125, ThemeUtils.defaultDesktopSize.height));
             geometry.x = (screen.width - geometry.width) / 2;
             geometry.y = (screen.height - geometry.height) / 2;
         }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -114,16 +114,13 @@ Window {
     }
 
     function restoreAppState() {
-        if (SQUtils.Utils.isMobile) // no point in restoring geometry or visibility
-            return
-
         let geometry = localAppSettings.geometry;
         let visibility = localAppSettings.visibility;
 
         if (visibility !== Window.Windowed &&
             visibility !== Window.Maximized &&
             visibility !== Window.FullScreen) {
-            visibility = Window.Windowed;
+            visibility = SQUtils.Utils.isMobile ? Window.Maximized : Window.Windowed
         }
 
         if (geometry === undefined ||

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -114,6 +114,9 @@ Window {
     }
 
     function restoreAppState() {
+        if (SQUtils.Utils.isMobile) // no point in restoring geometry or visibility
+            return
+
         let geometry = localAppSettings.geometry;
         let visibility = localAppSettings.visibility;
 
@@ -152,6 +155,9 @@ Window {
     }
 
     function storeAppState() {
+        if (SQUtils.Utils.isMobile) // no point in storing geometry or visibility
+            return
+
         if (!applicationWindow.appIsReady)
             return;
 
@@ -199,10 +205,11 @@ Window {
             }
         }
 
-        readonly property bool macOSWindowed: Qt.platform.os === SQUtils.Utils.mac &&
-                                              applicationWindow.visibility !== Window.FullScreen
+        readonly property bool macOSWindowed: SQUtils.Utils.isMacOS && applicationWindow.visibility !== Window.FullScreen
 
         function restoreWindowState() {
+            if (SQUtils.Utils.isMobile) // no point in restoring window state
+                return
             switch(lastNonMinVisibility) {
             case Window.Windowed:
                 applicationWindow.showNormal()
@@ -508,8 +515,8 @@ Window {
         id: loader
 
         anchors.fill: parent
-        anchors.topMargin: Qt.platform.os === SQUtils.Utils.mac && !applicationWindow.portraitLayout ?
-                               0 : parent.SafeArea.margins.top
+        anchors.topMargin: SQUtils.Utils.isMacOS && !applicationWindow.portraitLayout ? 0
+                                                                                      : parent.SafeArea.margins.top
         anchors.bottomMargin: parent.SafeArea.margins.bottom
         anchors.leftMargin: applicationWindow.portraitLayout ? parent.SafeArea.margins.left
                                                   : 0 // the PrimaryNavSidebar is visible in landscape and already has it


### PR DESCRIPTION
### What does the PR do

- lower the `portraitBreakpoint` to 640x480, and make the portrait/landscape criteria switch depend on `width` only
- let the PrimaryNavSidebar follow the same logic
- update TS files

Fixes #20318

Separate commit to fix https://github.com/status-im/status-app/issues/20635

### Affected areas

AppMain

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2044" height="2758" alt="image" src="https://github.com/user-attachments/assets/9d2241c5-05ef-4a91-bca0-d3a3bf7a6569" />


### Impact on end user

No more surprising portrait mode on desktop

### How to test

- resize the window on desktop
- try different devices+rotation on mobile

### Risk 

low
