### PR TITLE
MessageView: prevent unnecessary vkbd opening on menu close

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -243,6 +243,7 @@ Loader {
             hasLocalNickname: !!contactDetails.localNickname
         }
 
+        d.preventVirtualKeyboardOpening()
         profileContextMenuComponent.createObject(root, params).popup(x, y)
     }
 
@@ -268,6 +269,7 @@ Loader {
             editRestricted: root.editRestricted,
         }
 
+        d.preventVirtualKeyboardOpening()
         messageContextMenuComponent.createObject(root, params).popup(point)
     }
 
@@ -494,9 +496,11 @@ Loader {
         function onImageClicked(image, mouse, imageSource, url = "") {
             switch (mouse.button) {
             case Qt.LeftButton:
+                d.preventVirtualKeyboardOpening()
                 Global.openImagePopup(image, url, false)
                 break;
             case Qt.RightButton:
+                d.preventVirtualKeyboardOpening()
                 Global.openMenu(imageContextMenuComponent, image, { imageSource, url })
                 break;
             }
@@ -504,6 +508,17 @@ Loader {
 
         function correctBridgeNameCapitalization(bridgeName) {
             return (bridgeName === "discord") ? "Discord" : bridgeName
+        }
+
+        // Qt's Popup/Menu stashes the activeFocusItem on open and restores it on close via
+        // an internal forceActiveFocus call. It causes that text edit gains focus and opens
+        // virtual keyboard even if it was closed before opening popup/menu. To prevent that
+        // behavior, if virtual keyboard is not visible focus is changed to message itself.
+        // On close focus is restored to message component, without invoking vkbd.
+        function preventVirtualKeyboardOpening() {
+            if (!SystemUtils.androidKeyboardVisible && !SystemUtils.iosKeyboardVisible && !Qt.inputMethod.visible) {
+                root.forceActiveFocus()
+            }
         }
     }
 
@@ -1339,6 +1354,7 @@ Loader {
             onOpened: {
                 root.setMessageActive(model.id, true)
             }
+
             onClosed: {
                 root.setMessageActive(model.id, false)
                 destroy()


### PR DESCRIPTION
### What does the PR do

If input field has focus but virtual keyboard is closed, opening and closing menu should not trigger virtual keyboard. This PR fixes that issue in chat view.

Iterates: https://github.com/status-im/status-app/issues/20362

### Affected areas
`MessageView`

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

https://github.com/user-attachments/assets/e7104342-4089-4db6-be47-6d27477ed21b


### Impact on end user
Low

### How to test

1. go to chat
2. open and close virtual keyboard to have chat input field focused
3. long press on message to trigger context menu
4. close context menu - virtual keyboard should stay closed


### Risk 
Low
