### PR TITLE
fix(Chat): Download image broken on `Android` due to incorrect path handling

### DIFF
--- a/mobile/android/qt6/src/app/status/mobile/MediaStoreHelper.java
+++ b/mobile/android/qt6/src/app/status/mobile/MediaStoreHelper.java
@@ -1,0 +1,73 @@
+package app.status.mobile;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.MediaStore;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Helper for inserting images into the shared MediaStore gallery (Pictures).
+ * Requires Android 10+ (API 29); no storage permission is needed on Q+.
+ */
+public final class MediaStoreHelper {
+    private MediaStoreHelper() {}
+
+    public static boolean insertImageFromPath(Context context,
+                                              String srcPath,
+                                              String mimeType,
+                                              String displayName) {
+        if (context == null || srcPath == null || srcPath.isEmpty()) return false;
+        if (mimeType == null || mimeType.isEmpty()) mimeType = "image/jpeg";
+        if (displayName == null || displayName.isEmpty()) displayName = "image.jpg";
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return false;
+        }
+
+        ContentValues values = new ContentValues();
+        values.put(MediaStore.Images.Media.DISPLAY_NAME, displayName);
+        values.put(MediaStore.Images.Media.MIME_TYPE, mimeType);
+        values.put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES);
+        values.put(MediaStore.Images.Media.IS_PENDING, 1);
+        final Uri contentUri =
+                MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
+
+        Uri itemUri = null;
+        try {
+            itemUri = context.getContentResolver().insert(contentUri, values);
+            if (itemUri == null) return false;
+
+            try (InputStream is = new FileInputStream(new File(srcPath));
+                 OutputStream os = context.getContentResolver().openOutputStream(itemUri, "w")) {
+                if (os == null) {
+                    context.getContentResolver().delete(itemUri, null, null);
+                    return false;
+                }
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = is.read(buf)) != -1) {
+                    os.write(buf, 0, n);
+                }
+                os.flush();
+            }
+
+            ContentValues update = new ContentValues();
+            update.put(MediaStore.Images.Media.IS_PENDING, 0);
+            context.getContentResolver().update(itemUri, update, null, null);
+            return true;
+        } catch (IOException | SecurityException e) {
+            if (itemUri != null) {
+                context.getContentResolver().delete(itemUri, null, null);
+            }
+            return false;
+        }
+    }
+}

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -3,8 +3,10 @@
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QMimeDatabase>
+#include <QDir>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QSslError>
 #include <QProcess>
 #include <QSaveFile>
 #include <QStandardPaths>
@@ -14,6 +16,7 @@
 #include <mutex>
 
 #ifdef Q_OS_ANDROID
+#include <QFile>
 #include <QJniObject>
 #include <QJniEnvironment>
 #include <QtCore/qnativeinterface.h>
@@ -140,7 +143,7 @@ void save(const QByteArray& imageData, const QString& targetDir)
 {
     // Get current Date/Time information to use in naming of the image file
     const auto dateTimeString = QDateTime::currentDateTime().toString(
-                QStringLiteral("dd-MM-yyyy_hh-mm-ss"));
+                QStringLiteral("yyyy-MM-dd_HH-mm-ss"));
 
     // Get the preferred extension
     QMimeDatabase mimeDb;
@@ -151,6 +154,13 @@ void save(const QByteArray& imageData, const QString& targetDir)
     // Construct the target path
     const auto targetFile = QStringLiteral("%1/image_%2.%3").arg(
                 targetDir, dateTimeString, ext);
+
+    if (!QDir().mkpath(targetDir)) {
+        qWarning() << "SystemUtilsInternal::downloadImageByUrl: "
+                      "Failed to create target directory:"
+                   << targetDir;
+        return;
+    }
 
     // Save the image in a safe way
     QSaveFile image(targetFile);
@@ -169,6 +179,55 @@ void save(const QByteArray& imageData, const QString& targetDir)
                     << targetFile;
 }
 
+#ifdef Q_OS_ANDROID
+static void saveToAndroidGallery(const QByteArray& imageData)
+{
+    QMimeDatabase mimeDb;
+    const auto mimeType = mimeDb.mimeTypeForData(imageData);
+    auto ext = mimeType.preferredSuffix();
+    if (ext.isEmpty())
+        ext = QStringLiteral("jpg");
+    auto mime = mimeType.name();
+    if (mime.isEmpty())
+        mime = QStringLiteral("image/jpeg");
+
+    const auto dateTimeString = QDateTime::currentDateTime().toString(
+                QStringLiteral("yyyy-MM-dd_HH-mm-ss"));
+    const auto displayName = QStringLiteral("image_%1.%2").arg(dateTimeString, ext);
+
+    const auto tempPath = QStandardPaths::writableLocation(QStandardPaths::TempLocation)
+                          + QChar('/') + displayName;
+    {
+        QFile tempFile(tempPath);
+        if (!tempFile.open(QIODevice::WriteOnly)) {
+            qWarning() << "saveToAndroidGallery: failed to open temp file:" << tempPath;
+            return;
+        }
+        if (tempFile.write(imageData) == -1) {
+            qWarning() << "saveToAndroidGallery: failed to write temp file:" << tempPath;
+            QFile::remove(tempPath);
+            return;
+        }
+    } // tempFile flushed and closed here before JNI reads it
+
+    QJniObject ctx = QNativeInterface::QAndroidApplication::context();
+    const bool ok = QJniObject::callStaticMethod<jboolean>(
+        "app/status/mobile/MediaStoreHelper",
+        "insertImageFromPath",
+        "(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z",
+        ctx.object(),
+        QJniObject::fromString(tempPath).object<jstring>(),
+        QJniObject::fromString(mime).object<jstring>(),
+        QJniObject::fromString(displayName).object<jstring>()
+    );
+    QFile::remove(tempPath);
+
+    if (!ok)
+        qWarning() << "saveToAndroidGallery: MediaStore insertion failed for" << displayName;
+}
+
+#endif
+
 void SystemUtilsInternal::downloadImageByUrl(
         const QUrl& url, const QString& path) const
 {
@@ -177,13 +236,18 @@ void SystemUtilsInternal::downloadImageByUrl(
 
     QNetworkReply *reply = manager.get(QNetworkRequest(url));
 
+    // The image may be served from the local Status Go node (https://localhost:…)
+    // which uses a self-signed certificate. Accept SSL errors only for localhost
+    // so we match the behaviour of the engine's QML network access manager.
+    if (url.host() == QLatin1String("localhost") || url.host() == QLatin1String("127.0.0.1")) {
+        QObject::connect(reply, &QNetworkReply::sslErrors, reply,
+                         [reply](const QList<QSslError>&) { reply->ignoreSslErrors(); });
+    }
+
     // accept both "file:/foo/bar" and "/foo/bar"
-    auto targetDir = QUrl::fromUserInput(path)
-#ifndef Q_OS_ANDROID
-                         .toLocalFile();
-#else
-                         .toString(); // don't touch the "content://" URI
-#endif
+    const auto parsedPath = QUrl::fromUserInput(path);
+
+    auto targetDir = parsedPath.toLocalFile();
 
     if (targetDir.isEmpty())
         targetDir = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
@@ -191,7 +255,7 @@ void SystemUtilsInternal::downloadImageByUrl(
     QObject::connect(reply, &QNetworkReply::finished, this, [reply, targetDir] {
         if(reply->error() != QNetworkReply::NoError) {
             qWarning() << "SystemUtilsInternal::downloadImageByUrl: Downloading image"
-                       << reply->request().url() << "failed!";
+                       << reply->request().url() << "failed:" << reply->errorString();
             return;
         }
 
@@ -200,6 +264,8 @@ void SystemUtilsInternal::downloadImageByUrl(
         Q_ASSERT(!btArray.isEmpty());
 #ifdef Q_OS_IOS
         saveImageToPhotosAlbum(btArray);
+#elif defined(Q_OS_ANDROID)
+        saveToAndroidGallery(btArray);
 #else
         save(btArray, targetDir);
 #endif

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -421,9 +421,12 @@ QtObject {
     }
 
     function openDownloadImageDialog(imageSource) {
-        // On IOS the app is sandboxed and the FileDialog has limited access to the system.
-        // We'll save the image to the default location - currenty the Photos album.
-        if (SQUtils.Utils.isIOS) {
+        // iOS: the app is sandboxed so FileDialog has limited system access.
+        // Android: opening the folder picker sends the app to background, which
+        // causes the Status Go image server to become unreachable — the download
+        // fails with a connection error by the time the picker returns.
+        // In both cases, save directly to the system gallery instead.
+        if (SQUtils.Utils.isIOS || SQUtils.Utils.isAndroid) {
             SystemUtils.downloadImageByUrl(imageSource, "")
             return
         }


### PR DESCRIPTION
Part of #20537

### What does the PR do

- Skip the folder picker on Android (opening it backgrounds the app, making the image URL unreachable) and save directly to the system gallery via the `MediaStore` API instead.

- Also fix SSL errors for the localhost self-signed certificate and ensure the target directory exists before saving.

### Affected areas

Android / download chat images

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX

### How to test

Try downloading image from chat on Android

### Risk 

Low
