### PR TITLE
fix(browser): lazy-restore for browser tabs

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -218,7 +218,8 @@ StatusSectionLayout {
             for (let i = 0; i < tabs.count; i++){
                 const webView = webViewContext.getWebView(i)
                 if (!!webView) {
-                    const url = root.browserRootStore.determineRealURL(webView.url.toString())
+                    const raw = webView.url.toString() || (webView.pendingUrl || "")
+                    const url = root.browserRootStore.determineRealURL(raw)
                     if (!!url)
                         tabsModel.push({url: url, title: webView.title || ""})
                 }
@@ -239,31 +240,38 @@ StatusSectionLayout {
             return list.filter(t => t && String(t.url || "").trim() !== "")
         }
 
+        function openDefaultTab() {
+            const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+            // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+            // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+        }
+
         function restoreSession() {
-            if (!uiSettings.restoreOpenTabs) {
-                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+            const tabsToRestore = uiSettings.restoreOpenTabs ? getTabsInfo() : []
+            if (tabsToRestore.length === 0) {
+                openDefaultTab()
                 return
             }
-            const tabsToRestore = getTabsInfo()
-
-            if (tabsToRestore.length > 0) {
-                tabsToRestore.forEach(t => root.openUrlInNewTab(t.url, t.title))
-                const savedIndex = uiSettings.currentTabIndex
-                Qt.callLater(() => {
-                    if (tabs.count === 0) {
-                        webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-                        return
-                    }
-                    if (savedIndex >= 0 && savedIndex < tabs.count)
-                        tabs.activateTab(savedIndex)
-                })
-            } else {
-                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
-            }
+            webViewContext.restoringOpenTabs = true
+            tabsToRestore.forEach((t, i) => {
+                const profileParams = (i === 0)
+                    ? connectorBridge.defaultProfileParams
+                    : webViewContext.getWebView(0).profileParams
+                webViewContext.createEmptyTab(
+                    profileParams, false, false,
+                    root.browserRootStore.determineRealURL(t.url), t.title)
+            })
+            const savedIndex = uiSettings.currentTabIndex
+            Qt.callLater(() => {
+                webViewContext.restoringOpenTabs = false
+                if (tabs.count === 0) {
+                    openDefaultTab()
+                    return
+                }
+                if (savedIndex >= 0 && savedIndex < tabs.count)
+                    tabs.activateTab(savedIndex)
+                webViewContext.commitPendingForCurrent()
+            })
         }
 
         onCurrentWebViewChanged: {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -59,8 +59,8 @@ StatusSectionLayout {
 
     signal sendToRecipientRequested(string address)
 
-    function openUrlInNewTab(url) {
-        Qt.callLater(() => _internal.addNewTab(root.browserRootStore.determineRealURL(url)))
+    function openUrlInNewTab(url, initialTitle) {
+        Qt.callLater(() => _internal.addNewTab(root.browserRootStore.determineRealURL(url), initialTitle))
     }
 
     function reloadCurrentTab() {
@@ -139,8 +139,8 @@ StatusSectionLayout {
             tabs.activateTab(tabs.count - 1)
         }
 
-        function addNewTab(url) {
-            var tab = webViewContext.createEmptyTab(tabs.count !== 0 ? currentWebView.profileParams : connectorBridge.defaultProfileParams, false, true, url);
+        function addNewTab(url, initialTitle) {
+            var tab = webViewContext.createEmptyTab(tabs.count !== 0 ? currentWebView.profileParams : connectorBridge.defaultProfileParams, false, true, url, initialTitle);
             browserToolbarLoader.activateAddressBar()
             return tab;
         }
@@ -220,16 +220,36 @@ StatusSectionLayout {
                 if (!!webView) {
                     const url = root.browserRootStore.determineRealURL(webView.url.toString())
                     if (!!url)
-                        tabsModel.push(url)
+                        tabsModel.push({url: url, title: webView.title || ""})
                 }
             }
             uiSettings.openTabs = tabsModel
             uiSettings.currentTabIndex = tabs.currentIndex
         }
 
+        function getTabsInfo() {
+            var list = []
+            try {
+                list = JSON.parse(JSON.stringify(uiSettings.openTabs || [])) || []
+            } catch (e) {
+                list = []
+            }
+            if (!Array.isArray(list))
+                list = []
+            return list.filter(t => t && String(t.url || "").trim() !== "")
+        }
+
         function restoreSession() {
-            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0) {
-                uiSettings.openTabs.forEach((url) => root.openUrlInNewTab(url))
+            if (!uiSettings.restoreOpenTabs) {
+                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+                return
+            }
+            const tabsToRestore = getTabsInfo()
+
+            if (tabsToRestore.length > 0) {
+                tabsToRestore.forEach(t => root.openUrlInNewTab(t.url, t.title))
                 const savedIndex = uiSettings.currentTabIndex
                 Qt.callLater(() => {
                     if (tabs.count === 0) {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -224,12 +224,22 @@ StatusSectionLayout {
                 }
             }
             uiSettings.openTabs = tabsModel
+            uiSettings.currentTabIndex = tabs.currentIndex
         }
 
         function restoreSession() {
-            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0)
+            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0) {
                 uiSettings.openTabs.forEach((url) => root.openUrlInNewTab(url))
-            else {
+                const savedIndex = uiSettings.currentTabIndex
+                Qt.callLater(() => {
+                    if (tabs.count === 0) {
+                        webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+                        return
+                    }
+                    if (savedIndex >= 0 && savedIndex < tabs.count)
+                        tabs.activateTab(savedIndex)
+                })
+            } else {
                 const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
                 // For Devs: Uncomment the next line if you want to use the simpledapp on first load
                 // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
@@ -253,6 +263,7 @@ StatusSectionLayout {
         category: "BrowserSettings_%1".arg(root.userUID)
         property bool restoreOpenTabs
         property var openTabs: []
+        property int currentTabIndex: 0
     }
 
     BrowserFavoritesContext {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -55,7 +55,7 @@ StatusSectionLayout {
 
     readonly property string userAgent: connectorBridge.httpUserAgent
 
-    readonly property alias uiSettings: uiSettings
+    readonly property alias uiSettings: savedSessionContext.uiSettings
 
     signal sendToRecipientRequested(string address)
 
@@ -68,11 +68,11 @@ StatusSectionLayout {
     }
 
     Component.onCompleted: {
-        _internal.restoreSession()
+        savedSessionContext.restoreSession()
     }
 
     Component.onDestruction: {
-        _internal.saveSession()
+        savedSessionContext.saveSession()
     }
 
     Connections {
@@ -209,71 +209,6 @@ StatusSectionLayout {
             favoriteMenu.createObject(root, {url, name}).popup(parent, pos)
         }
 
-        function saveSession() {
-            if (!uiSettings.restoreOpenTabs)
-                return
-
-            var tabsModel = []
-
-            for (let i = 0; i < tabs.count; i++){
-                const webView = webViewContext.getWebView(i)
-                if (!!webView) {
-                    const raw = webView.url.toString() || (webView.pendingUrl || "")
-                    const url = root.browserRootStore.determineRealURL(raw)
-                    if (!!url)
-                        tabsModel.push({url: url, title: webView.title || ""})
-                }
-            }
-            uiSettings.openTabs = tabsModel
-            uiSettings.currentTabIndex = tabs.currentIndex
-        }
-
-        function getTabsInfo() {
-            var list = []
-            try {
-                list = JSON.parse(JSON.stringify(uiSettings.openTabs || [])) || []
-            } catch (e) {
-                list = []
-            }
-            if (!Array.isArray(list))
-                list = []
-            return list.filter(t => t && String(t.url || "").trim() !== "")
-        }
-
-        function openDefaultTab() {
-            const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-            // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-            // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
-        }
-
-        function restoreSession() {
-            const tabsToRestore = uiSettings.restoreOpenTabs ? getTabsInfo() : []
-            if (tabsToRestore.length === 0) {
-                openDefaultTab()
-                return
-            }
-            webViewContext.restoringOpenTabs = true
-            tabsToRestore.forEach((t, i) => {
-                const profileParams = (i === 0)
-                    ? connectorBridge.defaultProfileParams
-                    : webViewContext.getWebView(0).profileParams
-                webViewContext.createEmptyTab(
-                    profileParams, false, false,
-                    root.browserRootStore.determineRealURL(t.url), t.title)
-            })
-            const savedIndex = uiSettings.currentTabIndex
-            Qt.callLater(() => {
-                webViewContext.restoringOpenTabs = false
-                if (tabs.count === 0) {
-                    openDefaultTab()
-                    return
-                }
-                if (savedIndex >= 0 && savedIndex < tabs.count)
-                    tabs.activateTab(savedIndex)
-                webViewContext.commitPendingForCurrent()
-            })
-        }
-
         onCurrentWebViewChanged: {
             onCurrentTabUrlChanged()
             findBar.reset()
@@ -285,14 +220,6 @@ StatusSectionLayout {
     showFooter: false
     headerPadding: 0
     backgroundColor: Theme.palette.statusAppNavBar.backgroundColor
-
-    Settings {
-        id: uiSettings
-        category: "BrowserSettings_%1".arg(root.userUID)
-        property bool restoreOpenTabs
-        property var openTabs: []
-        property int currentTabIndex: 0
-    }
 
     BrowserFavoritesContext {
         id: favoritesContext
@@ -345,6 +272,15 @@ StatusSectionLayout {
                 findBar.activeMatch = result.activeMatch
             }
         }
+    }
+
+    BrowserSavedSessionContext {
+        id: savedSessionContext
+        userUID: root.userUID
+        webViewContext: webViewContext
+        tabs: tabs
+        defaultProfileParams: connectorBridge.defaultProfileParams
+        determineRealURL: (u) => root.browserRootStore.determineRealURL(u)
     }
 
     headerContent: ColumnLayout {

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -19,6 +19,7 @@ Item {
 
     // === State Properties ===
     property url url: ""
+    property url pendingUrl: ""
     readonly property string title: ""
     readonly property bool loading: false
     readonly property bool canGoBack: false

--- a/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
@@ -41,29 +41,30 @@ QtObject {
         `, root, "ProfilePrototype_" + storageName)
     }
 
-    function getProfile(profileParams) {
-        const key = root._key(profileParams.userId, profileParams.offTheRecord)
+    function getOrCreateStorageProfile(userId, offTheRecord) {
+        const key = root._key(userId, offTheRecord)
         let p = root.profiles[key]
 
         if (!p) {
-            const storageName = profileParams.offTheRecord
-                ? ("IncognitoProfile_" + profileParams.userId)
-                : ("Profile_" + profileParams.userId)
+            const storageName = offTheRecord
+                ? ("IncognitoProfile_" + userId)
+                : ("Profile_" + userId)
 
-            const prototype = root._getProfilePrototype(storageName, profileParams.offTheRecord)
+            const prototype = root._getProfilePrototype(storageName, offTheRecord)
             p = prototype.instance()
             root.profiles[key] = p
         }
 
-        if (profileParams.userAgent && p.httpUserAgent !== profileParams.userAgent) {
-            p.httpUserAgent = profileParams.userAgent
-        }
-
-        if (profileParams.scripts && profileParams.scripts.length > 0) {
-            const scripts = profileParams.scripts.map(path => createScriptFromPath(path))
-            p.userScripts.collection = scripts
-        }
-
         return p
+    }
+
+    function getProfile(profileParams) {
+        return getOrCreateStorageProfile(profileParams.userId, profileParams.offTheRecord)
+    }
+
+    function scriptListForParams(profileParams) {
+        if (!profileParams.scripts || profileParams.scripts.length === 0)
+            return []
+        return profileParams.scripts.map(path => createScriptFromPath(path))
     }
 }

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQml
 import QtWebEngine
 
 import StatusQ.Core.Theme
@@ -8,7 +9,11 @@ import AppLayouts.Browser.views
 AbstractWebView {
     id: root
 
-    property var profile: ProfileManager.getProfile(root.profileParams)
+    property var profile: root.profileParams
+        ? ProfileManager.getOrCreateStorageProfile(
+              root.profileParams.userId,
+              root.profileParams.offTheRecord)
+        : null
 
     // Expose internal WebEngineView properties
     property alias url: webView.url
@@ -214,20 +219,25 @@ AbstractWebView {
         }
     }
 
+    Binding {
+        when: !!(root.profile && root.profileParams && root.profileParams.userAgent)
+        target: root.profile
+        property: "httpUserAgent"
+        value: root.profileParams.userAgent
+    }
+
+    function applyProfileScripts() {
+        if (!root.profile || !root.profile.userScripts || !root.profileParams)
+            return
+        root.profile.userScripts.collection = ProfileManager.scriptListForParams(root.profileParams)
+    }
+
+    onProfileChanged: applyProfileScripts()
+
     Connections {
-        // This connection is needed because changing profileParams.offTheRecord doesn't trigger the root.profile update
         target: root.profileParams
-        function onOffTheRecordChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
-        }
-        function onUserAgentChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
-        }
         function onScriptsChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
-        }
-        function onUserIdChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
+            root.applyProfileScripts()
         }
     }
 }

--- a/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
@@ -28,13 +28,14 @@ FocusScope {
     signal openNewTabTriggered()
     signal removeView(int index)
 
-    function createEmptyTab(createAsStartPage = false, focusOnNewTab = true, webview = undefined) {
+    function createEmptyTab(createAsStartPage = false, focusOnNewTab = true, webview = undefined, initialTitle = undefined) {
         const tabTitle = Qt.binding(function() {
             var tabTitle = ""
             if (webview && webview.title) {
                 tabTitle = webview.title
-            }
-            else if (createAsStartPage) {
+            } else if (initialTitle) {
+                tabTitle = initialTitle
+            } else if (createAsStartPage) {
                 tabTitle = qsTr("Start Page")
             } else {
                 tabTitle = qsTr("New Tab")

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -1,0 +1,100 @@
+import QtCore
+import QtQuick
+
+QtObject {
+    id: root
+
+    required property string userUID
+    required property var webViewContext
+    required property var tabs
+    required property var defaultProfileParams
+    required property var determineRealURL
+
+    readonly property alias uiSettings: sessionSettings
+
+    Settings {
+        id: sessionSettings
+        category: "BrowserSettings_%1".arg(root.userUID)
+        property bool restoreOpenTabs
+        property var openTabs: []
+        property int currentTabIndex: 0
+    }
+
+    function saveSession() {
+        if (!sessionSettings.restoreOpenTabs)
+            return
+
+        var tabsModel = []
+
+        for (let i = 0; i < tabs.count; i++) {
+            const webView = webViewContext.getWebView(i)
+            if (!!webView) {
+                const raw = webView.url.toString() || (webView.pendingUrl || "")
+                const url = determineRealURL(raw)
+                if (!!url)
+                    tabsModel.push({url: url, title: webView.title || ""})
+            }
+        }
+        sessionSettings.openTabs = tabsModel
+        sessionSettings.currentTabIndex = tabs.currentIndex
+    }
+
+    function getTabsInfo() {
+        var list = []
+        try {
+            list = JSON.parse(JSON.stringify(sessionSettings.openTabs || [])) || []
+        } catch (e) {
+            list = []
+        }
+        if (!Array.isArray(list))
+            list = []
+        return list.filter(t => t && String(t.url || "").trim() !== "")
+    }
+
+    function openDefaultTab() {
+        const tab = webViewContext.createEmptyTab(defaultProfileParams, true)
+        // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+        // tab.url = determineRealURL("https://simpledapp.eth");
+    }
+
+    function commitPendingForCurrent() {
+        const w = webViewContext.currentWebView
+        if (!w) return
+        const p = w.pendingUrl
+        if (p && !w.url.toString()) {
+            w.pendingUrl = ""
+            w.url = p
+        }
+    }
+
+    function restoreSession() {
+        const tabsToRestore = sessionSettings.restoreOpenTabs ? getTabsInfo() : []
+        if (tabsToRestore.length === 0) {
+            openDefaultTab()
+            return
+        }
+        tabsToRestore.forEach((t, i) => {
+            const profileParams = (i === 0) ? defaultProfileParams : webViewContext.getWebView(0).profileParams
+            webViewContext.createEmptyTab(
+                profileParams, false, false,
+                determineRealURL(t.url), t.title)
+        })
+        const savedIndex = sessionSettings.currentTabIndex
+        Qt.callLater(() => {
+            if (tabs.count === 0) {
+                openDefaultTab()
+                return
+            }
+            if (savedIndex >= 0 && savedIndex < tabs.count)
+                tabs.activateTab(savedIndex)
+            commitPendingForCurrent()
+        })
+    }
+
+    Connections {
+        target: webViewContext
+        function onCurrentWebViewChanged() {
+            root.commitPendingForCurrent()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -36,7 +36,7 @@ QtObject {
         EmptyContent
     }
 
-    readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? getCurrentWebView() : null
+    readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
             return BrowserWebViewContext.ContentMode.EmptyContent

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -36,9 +36,6 @@ QtObject {
         EmptyContent
     }
 
-    // While true, do not commit pending url on tab switch (restore loop is running)
-    property bool restoringOpenTabs: false
-
     readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
@@ -48,19 +45,6 @@ QtObject {
         if (!currentWebView.url?.toString())
             return BrowserWebViewContext.ContentMode.EmptyContent
         return BrowserWebViewContext.ContentMode.WebContent
-    }
-
-    onCurrentWebViewChanged: if (!restoringOpenTabs) commitPendingForCurrent()
-
-    // Apply pendingUrl of the current webview (set when a restored tab is first activated)
-    function commitPendingForCurrent() {
-        const w = currentWebView
-        if (!w) return
-        const p = w.pendingUrl
-        if (p && !w.url.toString()) {
-            w.pendingUrl = ""
-            w.url = p
-        }
     }
 
     function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -36,6 +36,9 @@ QtObject {
         EmptyContent
     }
 
+    // While true, do not commit pending url on tab switch (restore loop is running)
+    property bool restoringOpenTabs: false
+
     readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
@@ -45,6 +48,19 @@ QtObject {
         if (!currentWebView.url?.toString())
             return BrowserWebViewContext.ContentMode.EmptyContent
         return BrowserWebViewContext.ContentMode.WebContent
+    }
+
+    onCurrentWebViewChanged: if (!restoringOpenTabs) commitPendingForCurrent()
+
+    // Apply pendingUrl of the current webview (set when a restored tab is first activated)
+    function commitPendingForCurrent() {
+        const w = currentWebView
+        if (!w) return
+        const p = w.pendingUrl
+        if (p && !w.url.toString()) {
+            w.pendingUrl = ""
+            w.url = p
+        }
     }
 
     function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {
@@ -57,7 +73,10 @@ QtObject {
 
         tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle)
 
-        if (createAsStartPage && thirdpartyServicesEnabled) {
+        const lazy = !focusOnNewTab && url !== undefined
+        if (lazy) {
+            webview.pendingUrl = url
+        } else if (createAsStartPage && thirdpartyServicesEnabled) {
             webview.url = Constants.browserDefaultHomepage
         } else if (url !== undefined) {
             webview.url = url

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -47,7 +47,7 @@ QtObject {
         return BrowserWebViewContext.ContentMode.WebContent
     }
 
-    function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined) {
+    function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {
         focusOnNewTab = focusOnNewTab && !createAsStartPage
 
         var webview = webViewAdapterComponent.createObject(hostStackLayout, {
@@ -55,7 +55,7 @@ QtObject {
             isDownloadView: false
         })
 
-        tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview)
+        tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle)
 
         if (createAsStartPage && thirdpartyServicesEnabled) {
             webview.url = Constants.browserDefaultHomepage

--- a/ui/app/AppLayouts/Browser/webview/qmldir
+++ b/ui/app/AppLayouts/Browser/webview/qmldir
@@ -1,4 +1,5 @@
 BrowserWebViewContext 1.0 BrowserWebViewContext.qml
+BrowserSavedSessionContext 1.0 BrowserSavedSessionContext.qml
 BrowserOverlayContext 1.0 BrowserOverlayContext.qml
 BrowserFavoritesContext 1.0 BrowserFavoritesContext.qml
 BrowserDialogsContext 1.0 BrowserDialogsContext.qml


### PR DESCRIPTION
* creating multiple chromium webviews at once causes crash
* lazy restore: on startup we create only TabRecords + empty StackLayout pages. The actual `WebEngineView` is materialized by BrowserWebViewContext.materializeTab(index) only when the user activates a tab
* BrowserTabView now consumes a plain UI tabsModel + currentIndex from SessionContext instead of reaching into the webview stack.
* save active tab index and incognito flag to persistence

```mermaid
flowchart TD
    Settings[(Qt Settings<br/>openTabs, selectedIndex,<br/>restoreOpenTabs)]
    SC[BrowserSessionContext<br/>tabs, currentIndex<br/>save/restoreSession]
    TR[TabRecord<br/>pendingUrl/title/favicon<br/>lastKnownUrl, webView, page]
    WVC[BrowserWebViewContext<br/>createPendingTab<br/>materializeTab]
    Stack[StackLayout webViewHost<br/>one page per tab]
    WV[WebEngineView<br/>created lazily]
    TabsUI[BrowserTabView<br/>tabsModel + currentIndex]

    Settings <-->|persist/restore| SC
    SC -->|owns N| TR
    SC -->|tabsUiModel| TabsUI
    TabsUI -->|activateTab| SC
    SC -->|onCurrentIndexChanged| WVC
    WVC -->|materializeTab i| TR
    TR -->|page| Stack
    WVC -->|create on demand| WV
    WV -->|attach| TR
    WV -->|title/icon/url/loading| SC

```
fixes #20512
