### PR TITLE
fix(ChatInput): Restore native paste menu on iOS

### DIFF
--- a/ui/imports/shared/status/StatusChatInputTextArea.qml
+++ b/ui/imports/shared/status/StatusChatInputTextArea.qml
@@ -73,7 +73,7 @@ StatusQ.StatusTextArea {
     textFormat: Text.RichText
     color: Theme.palette.textColor
     background: null
-    inputMethodHints: Qt.ImhMultiLine | Qt.ImhNoEditMenu
+    inputMethodHints: Qt.ImhMultiLine | (StatusQUtils.Utils.isMobile ? 0 : Qt.ImhNoEditMenu)
 
     EnterKey.type: Qt.EnterKeyReturn // insert newlines hint for OSK
 


### PR DESCRIPTION
Closes #20588

### What does the PR do

`Qt.ImhNoEditMenu` was suppressing the native iOS edit menu (long-press paste popup) globally. Since the custom context menu is already disabled on mobile, iOS had no way topast e. The flag is now only applied on desktop, where it's needed to avoid conflicting with the custom `StatusMenu`.

### Affected areas

`ios` native paste context menu

### Quality checklist

- [X] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [X] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Broken paste flow on chat solved

### How to test

Follow same instructions than in task description

### Risk 

Low
