### PR TITLE
fix(Browser): save active tab, tab titles; fix binding loop; simplify.

### DIFF
--- a/storybook/pages/BrowserLayoutPage.qml
+++ b/storybook/pages/BrowserLayoutPage.qml
@@ -11,6 +11,7 @@ import utils
 
 import AppLayouts.Browser
 import AppLayouts.Browser.stores as BrowserStores
+import AppLayouts.Browser.webview
 import AppLayouts.Wallet.stores
 import shared.stores as SharedStores
 import shared.stores.send
@@ -230,17 +231,17 @@ SplitView {
             Layout.fillWidth: true
             Switch {
                 text: "Restore open tabs"
-                checked: browserLayout.uiSettings.restoreOpenTabs
+                checked: BrowserUiSettings.restoreOpenTabs
                 onToggled: {
-                    browserLayout.uiSettings.restoreOpenTabs = checked
-                    browserLayout.uiSettings.sync()
+                    BrowserUiSettings.restoreOpenTabs = checked
+                    BrowserUiSettings.sync()
                 }
             }
             Button {
                 text: "Clear saved tabs"
                 onClicked: {
-                    browserLayout.uiSettings.openTabs = []
-                    browserLayout.uiSettings.sync()
+                    BrowserUiSettings.openTabs = []
+                    BrowserUiSettings.sync()
                 }
             }
         }

--- a/storybook/stubs/nim/sectionmocks/UserProfile.qml
+++ b/storybook/stubs/nim/sectionmocks/UserProfile.qml
@@ -1,0 +1,8 @@
+// Mock of shared/userProfile context property for Storybook
+import QtQuick
+
+QtObject {
+    readonly property string contextPropertyName: "userProfile"
+
+    property string pubKey: "0xdeadbeef"
+}

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -218,7 +218,8 @@ StatusSectionLayout {
             for (let i = 0; i < tabs.count; i++){
                 const webView = webViewContext.getWebView(i)
                 if (!!webView) {
-                    const url = root.browserRootStore.determineRealURL(webView.url.toString())
+                    const raw = webView.url.toString() || (webView.pendingUrl || "")
+                    const url = root.browserRootStore.determineRealURL(raw)
                     if (!!url)
                         tabsModel.push({url: url, title: webView.title || ""})
                 }
@@ -239,31 +240,38 @@ StatusSectionLayout {
             return list.filter(t => t && String(t.url || "").trim() !== "")
         }
 
+        function openDefaultTab() {
+            const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+            // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+            // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+        }
+
         function restoreSession() {
-            if (!uiSettings.restoreOpenTabs) {
-                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+            const tabsToRestore = uiSettings.restoreOpenTabs ? getTabsInfo() : []
+            if (tabsToRestore.length === 0) {
+                openDefaultTab()
                 return
             }
-            const tabsToRestore = getTabsInfo()
-
-            if (tabsToRestore.length > 0) {
-                tabsToRestore.forEach(t => root.openUrlInNewTab(t.url, t.title))
-                const savedIndex = uiSettings.currentTabIndex
-                Qt.callLater(() => {
-                    if (tabs.count === 0) {
-                        webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-                        return
-                    }
-                    if (savedIndex >= 0 && savedIndex < tabs.count)
-                        tabs.activateTab(savedIndex)
-                })
-            } else {
-                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
-            }
+            webViewContext.restoringOpenTabs = true
+            tabsToRestore.forEach((t, i) => {
+                const profileParams = (i === 0)
+                    ? connectorBridge.defaultProfileParams
+                    : webViewContext.getWebView(0).profileParams
+                webViewContext.createEmptyTab(
+                    profileParams, false, false,
+                    root.browserRootStore.determineRealURL(t.url), t.title)
+            })
+            const savedIndex = uiSettings.currentTabIndex
+            Qt.callLater(() => {
+                webViewContext.restoringOpenTabs = false
+                if (tabs.count === 0) {
+                    openDefaultTab()
+                    return
+                }
+                if (savedIndex >= 0 && savedIndex < tabs.count)
+                    tabs.activateTab(savedIndex)
+                webViewContext.commitPendingForCurrent()
+            })
         }
 
         onCurrentWebViewChanged: {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -59,8 +59,8 @@ StatusSectionLayout {
 
     signal sendToRecipientRequested(string address)
 
-    function openUrlInNewTab(url) {
-        Qt.callLater(() => _internal.addNewTab(root.browserRootStore.determineRealURL(url)))
+    function openUrlInNewTab(url, initialTitle) {
+        Qt.callLater(() => _internal.addNewTab(root.browserRootStore.determineRealURL(url), initialTitle))
     }
 
     function reloadCurrentTab() {
@@ -139,8 +139,8 @@ StatusSectionLayout {
             tabs.activateTab(tabs.count - 1)
         }
 
-        function addNewTab(url) {
-            var tab = webViewContext.createEmptyTab(tabs.count !== 0 ? currentWebView.profileParams : connectorBridge.defaultProfileParams, false, true, url);
+        function addNewTab(url, initialTitle) {
+            var tab = webViewContext.createEmptyTab(tabs.count !== 0 ? currentWebView.profileParams : connectorBridge.defaultProfileParams, false, true, url, initialTitle);
             browserToolbarLoader.activateAddressBar()
             return tab;
         }
@@ -220,16 +220,36 @@ StatusSectionLayout {
                 if (!!webView) {
                     const url = root.browserRootStore.determineRealURL(webView.url.toString())
                     if (!!url)
-                        tabsModel.push(url)
+                        tabsModel.push({url: url, title: webView.title || ""})
                 }
             }
             uiSettings.openTabs = tabsModel
             uiSettings.currentTabIndex = tabs.currentIndex
         }
 
+        function getTabsInfo() {
+            var list = []
+            try {
+                list = JSON.parse(JSON.stringify(uiSettings.openTabs || [])) || []
+            } catch (e) {
+                list = []
+            }
+            if (!Array.isArray(list))
+                list = []
+            return list.filter(t => t && String(t.url || "").trim() !== "")
+        }
+
         function restoreSession() {
-            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0) {
-                uiSettings.openTabs.forEach((url) => root.openUrlInNewTab(url))
+            if (!uiSettings.restoreOpenTabs) {
+                const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+                // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+                // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
+                return
+            }
+            const tabsToRestore = getTabsInfo()
+
+            if (tabsToRestore.length > 0) {
+                tabsToRestore.forEach(t => root.openUrlInNewTab(t.url, t.title))
                 const savedIndex = uiSettings.currentTabIndex
                 Qt.callLater(() => {
                     if (tabs.count === 0) {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -55,8 +55,6 @@ StatusSectionLayout {
 
     readonly property string userAgent: connectorBridge.httpUserAgent
 
-    readonly property alias uiSettings: savedSessionContext.uiSettings
-
     signal sendToRecipientRequested(string address)
 
     function openUrlInNewTab(url, initialTitle) {
@@ -276,7 +274,6 @@ StatusSectionLayout {
 
     BrowserSavedSessionContext {
         id: savedSessionContext
-        userUID: root.userUID
         webViewContext: webViewContext
         tabs: tabs
         defaultProfileParams: connectorBridge.defaultProfileParams

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -224,12 +224,22 @@ StatusSectionLayout {
                 }
             }
             uiSettings.openTabs = tabsModel
+            uiSettings.currentTabIndex = tabs.currentIndex
         }
 
         function restoreSession() {
-            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0)
+            if (uiSettings.restoreOpenTabs && !!uiSettings.openTabs && uiSettings.openTabs.length > 0) {
                 uiSettings.openTabs.forEach((url) => root.openUrlInNewTab(url))
-            else {
+                const savedIndex = uiSettings.currentTabIndex
+                Qt.callLater(() => {
+                    if (tabs.count === 0) {
+                        webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
+                        return
+                    }
+                    if (savedIndex >= 0 && savedIndex < tabs.count)
+                        tabs.activateTab(savedIndex)
+                })
+            } else {
                 const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
                 // For Devs: Uncomment the next line if you want to use the simpledapp on first load
                 // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
@@ -253,6 +263,7 @@ StatusSectionLayout {
         category: "BrowserSettings_%1".arg(root.userUID)
         property bool restoreOpenTabs
         property var openTabs: []
+        property int currentTabIndex: 0
     }
 
     BrowserFavoritesContext {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -55,7 +55,7 @@ StatusSectionLayout {
 
     readonly property string userAgent: connectorBridge.httpUserAgent
 
-    readonly property alias uiSettings: uiSettings
+    readonly property alias uiSettings: savedSessionContext.uiSettings
 
     signal sendToRecipientRequested(string address)
 
@@ -68,11 +68,11 @@ StatusSectionLayout {
     }
 
     Component.onCompleted: {
-        _internal.restoreSession()
+        savedSessionContext.restoreSession()
     }
 
     Component.onDestruction: {
-        _internal.saveSession()
+        savedSessionContext.saveSession()
     }
 
     Connections {
@@ -209,71 +209,6 @@ StatusSectionLayout {
             favoriteMenu.createObject(root, {url, name}).popup(parent, pos)
         }
 
-        function saveSession() {
-            if (!uiSettings.restoreOpenTabs)
-                return
-
-            var tabsModel = []
-
-            for (let i = 0; i < tabs.count; i++){
-                const webView = webViewContext.getWebView(i)
-                if (!!webView) {
-                    const raw = webView.url.toString() || (webView.pendingUrl || "")
-                    const url = root.browserRootStore.determineRealURL(raw)
-                    if (!!url)
-                        tabsModel.push({url: url, title: webView.title || ""})
-                }
-            }
-            uiSettings.openTabs = tabsModel
-            uiSettings.currentTabIndex = tabs.currentIndex
-        }
-
-        function getTabsInfo() {
-            var list = []
-            try {
-                list = JSON.parse(JSON.stringify(uiSettings.openTabs || [])) || []
-            } catch (e) {
-                list = []
-            }
-            if (!Array.isArray(list))
-                list = []
-            return list.filter(t => t && String(t.url || "").trim() !== "")
-        }
-
-        function openDefaultTab() {
-            const tab = webViewContext.createEmptyTab(connectorBridge.defaultProfileParams, true)
-            // For Devs: Uncomment the next line if you want to use the simpledapp on first load
-            // tab.url = root.browserRootStore.determineRealURL("https://simpledapp.eth");
-        }
-
-        function restoreSession() {
-            const tabsToRestore = uiSettings.restoreOpenTabs ? getTabsInfo() : []
-            if (tabsToRestore.length === 0) {
-                openDefaultTab()
-                return
-            }
-            webViewContext.restoringOpenTabs = true
-            tabsToRestore.forEach((t, i) => {
-                const profileParams = (i === 0)
-                    ? connectorBridge.defaultProfileParams
-                    : webViewContext.getWebView(0).profileParams
-                webViewContext.createEmptyTab(
-                    profileParams, false, false,
-                    root.browserRootStore.determineRealURL(t.url), t.title)
-            })
-            const savedIndex = uiSettings.currentTabIndex
-            Qt.callLater(() => {
-                webViewContext.restoringOpenTabs = false
-                if (tabs.count === 0) {
-                    openDefaultTab()
-                    return
-                }
-                if (savedIndex >= 0 && savedIndex < tabs.count)
-                    tabs.activateTab(savedIndex)
-                webViewContext.commitPendingForCurrent()
-            })
-        }
-
         onCurrentWebViewChanged: {
             onCurrentTabUrlChanged()
             findBar.reset()
@@ -285,14 +220,6 @@ StatusSectionLayout {
     showFooter: false
     headerPadding: 0
     backgroundColor: Theme.palette.statusAppNavBar.backgroundColor
-
-    Settings {
-        id: uiSettings
-        category: "BrowserSettings_%1".arg(root.userUID)
-        property bool restoreOpenTabs
-        property var openTabs: []
-        property int currentTabIndex: 0
-    }
 
     BrowserFavoritesContext {
         id: favoritesContext
@@ -345,6 +272,15 @@ StatusSectionLayout {
                 findBar.activeMatch = result.activeMatch
             }
         }
+    }
+
+    BrowserSavedSessionContext {
+        id: savedSessionContext
+        userUID: root.userUID
+        webViewContext: webViewContext
+        tabs: tabs
+        defaultProfileParams: connectorBridge.defaultProfileParams
+        determineRealURL: (u) => root.browserRootStore.determineRealURL(u)
     }
 
     headerContent: ColumnLayout {

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -399,7 +399,7 @@ StatusSectionLayout {
                 currentTabLoading: _internal.currentTabLoading
                 currentTabIsDownloads: webStackView.children[tabs.currentIndex]?.isDownloadView ?? false
                 browserDappsModel: browserDappsProvider.model
-                historyModel: _internal.currentWebView && _internal.currentWebView.history.items
+                historyModel: _internal.currentWebView?.history?.items ?? null
             }
         }
 
@@ -416,7 +416,7 @@ StatusSectionLayout {
                 currentTabLoading: _internal.currentTabLoading
                 currentTabIsDownloads: webStackView.children[tabs.currentIndex]?.isDownloadView ?? false
                 browserDappsModel: browserDappsProvider.model
-                historyModel: _internal.currentWebView && _internal.currentWebView.history.items
+                historyModel: _internal.currentWebView?.history?.items ?? null
             }
         }
 

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -19,7 +19,6 @@ Item {
 
     // === State Properties ===
     property url url: ""
-    property url pendingUrl: ""
     readonly property string title: ""
     readonly property bool loading: false
     readonly property bool canGoBack: false

--- a/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
+++ b/ui/app/AppLayouts/Browser/adapters/AbstractWebView.qml
@@ -19,6 +19,7 @@ Item {
 
     // === State Properties ===
     property url url: ""
+    property url pendingUrl: ""
     readonly property string title: ""
     readonly property bool loading: false
     readonly property bool canGoBack: false

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -1,25 +1,23 @@
 import QtQuick
 
+// Thin AbstractWebView that wraps WebViewAdapter in a Loader so WebEngineView is not created for
+// empty tabs. Activation is imperative and one-shot (loader.active flips true once, never back).
+// BrowserWebViewContext calls ensureLoaded() when switching to or loading a tab. Proxied state
+// defaults until the inner item exists. Capability flags are also proxied from loader.item so that
+// the correct per-platform values are reported automatically (e.g. +mobile/WebViewAdapter reports
+// supportsDevTools=false, supportsIncognito=false, dynamic hasNativeFindPanel); no separate
+// +mobile/LazyWebViewAdapter.qml is needed.
+
 AbstractWebView {
     id: root
 
-    // -------------------------------------------------------------------------
-    // AbstractWebView required capability flags – same as WebViewAdapter so that
-    // toolbar/menu bindings (zoom, find, incognito …) work from the moment the
-    // tab is created, even before a WebEngineView is instantiated.
-    // -------------------------------------------------------------------------
-    supportsZoom:       true
-    supportsDevTools:   true
-    supportsFindInPage: true
-    supportsIncognito:  true
-    supportsHistory:    true
-    hasNativeFindPanel: false
+    supportsZoom:       loader.item ? loader.item.supportsZoom       : false
+    supportsDevTools:   loader.item ? loader.item.supportsDevTools   : false
+    supportsFindInPage: loader.item ? loader.item.supportsFindInPage : false
+    supportsIncognito:  loader.item ? loader.item.supportsIncognito  : false
+    supportsHistory:    loader.item ? loader.item.supportsHistory    : false
+    hasNativeFindPanel: loader.item ? loader.item.hasNativeFindPanel : false
 
-    // -------------------------------------------------------------------------
-    // Proxied state – defaults while loader is inactive, live values once loaded.
-    // Must redeclare each inherited readonly property from AbstractWebView as
-    // `readonly property … : …` (simple assignment lines are invalid on readonly).
-    // -------------------------------------------------------------------------
     readonly property string title: loader.item ? loader.item.title : ""
     readonly property bool loading: loader.item ? loader.item.loading : false
     readonly property bool canGoBack: loader.item ? loader.item.canGoBack : false
@@ -31,25 +29,11 @@ AbstractWebView {
     readonly property bool htmlPageLoaded: loader.item ? loader.item.htmlPageLoaded : false
     readonly property var scrollPosition: loader.item ? loader.item.scrollPosition : Qt.point(0, 0)
 
-    // -------------------------------------------------------------------------
-    // One-shot imperative activation: loader.active is flipped to true once and
-    // never back, so the inner WebViewAdapter is never destroyed (e.g. url = ""
-    // after a page loaded won't lose history or scroll state).
-    // When to load is driven by BrowserWebViewContext (ensureLoaded): address bar,
-    // tab switch, createEmptyTab for the foreground tab — not StackLayout attached
-    // properties (avoids races when the stack is hidden behind EmptyWebPage overlay).
-    // Same for download tabs: no WebEngineView until ensureLoaded (non-empty URL / navigation).
-    // -------------------------------------------------------------------------
-    /// Called from BrowserWebViewContext when this tab should materialise WebEngineView.
     function ensureLoaded() {
         if (!loader.active)
             loader.active = true
     }
 
-    // -------------------------------------------------------------------------
-    // Function overrides – forward to inner adapter when alive, else no-op.
-    // loadUrl() also works as the primary activation path.
-    // -------------------------------------------------------------------------
     function loadUrl(u) {
         root.url = u
         if (u && u.toString())
@@ -72,17 +56,11 @@ AbstractWebView {
             loader.item.detachView()
     }
 
-    // Push address-bar / programmatic URL changes into the inner adapter once it
-    // exists. The initial URL is set in the sourceComponent's Component.onCompleted
-    // so it fires after the item is fully constructed.
     onUrlChanged: {
         if (loader.item && loader.item.url !== url)
             loader.item.url = url
     }
 
-    // -------------------------------------------------------------------------
-    // Inner WebViewAdapter, created on demand.
-    // -------------------------------------------------------------------------
     Loader {
         id: loader
         anchors.fill: parent
@@ -97,26 +75,13 @@ AbstractWebView {
             localAccountSensitiveSettings: root.localAccountSensitiveSettings
             isDownloadView:              root.isDownloadView
             freeze:                      root.freeze
-            supportsZoom:                true
-            supportsDevTools:            true
-            supportsFindInPage:          true
-            supportsIncognito:           true
-            supportsHistory:             true
-            hasNativeFindPanel:          false
 
-            // Set initial URL when the component is constructed (not as a binding,
-            // because WebEngine navigation breaks QML bindings on the url property).
             Component.onCompleted: if (root.url.toString()) url = root.url
 
-            // Push browser-driven navigation (link clicks, redirects) back to the
-            // outer wrapper so callers observing root.url stay up to date.
             onUrlChanged: { if (root.url !== url) root.url = url }
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Signal forwarding from inner adapter.
-    // -------------------------------------------------------------------------
     Connections {
         target: loader.item
         function onLinkHovered(hoveredUrl)             { root.linkHovered(hoveredUrl) }

--- a/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/LazyWebViewAdapter.qml
@@ -1,0 +1,132 @@
+import QtQuick
+
+AbstractWebView {
+    id: root
+
+    // -------------------------------------------------------------------------
+    // AbstractWebView required capability flags – same as WebViewAdapter so that
+    // toolbar/menu bindings (zoom, find, incognito …) work from the moment the
+    // tab is created, even before a WebEngineView is instantiated.
+    // -------------------------------------------------------------------------
+    supportsZoom:       true
+    supportsDevTools:   true
+    supportsFindInPage: true
+    supportsIncognito:  true
+    supportsHistory:    true
+    hasNativeFindPanel: false
+
+    // -------------------------------------------------------------------------
+    // Proxied state – defaults while loader is inactive, live values once loaded.
+    // Must redeclare each inherited readonly property from AbstractWebView as
+    // `readonly property … : …` (simple assignment lines are invalid on readonly).
+    // -------------------------------------------------------------------------
+    readonly property string title: loader.item ? loader.item.title : ""
+    readonly property bool loading: loader.item ? loader.item.loading : false
+    readonly property bool canGoBack: loader.item ? loader.item.canGoBack : false
+    readonly property bool canGoForward: loader.item ? loader.item.canGoForward : false
+    readonly property real loadProgress: loader.item ? loader.item.loadProgress : 0
+    readonly property real zoomFactor: loader.item ? loader.item.zoomFactor : 1.0
+    readonly property var history: loader.item ? loader.item.history : null
+    readonly property url icon: loader.item ? loader.item.icon : ""
+    readonly property bool htmlPageLoaded: loader.item ? loader.item.htmlPageLoaded : false
+    readonly property var scrollPosition: loader.item ? loader.item.scrollPosition : Qt.point(0, 0)
+
+    // -------------------------------------------------------------------------
+    // One-shot imperative activation: loader.active is flipped to true once and
+    // never back, so the inner WebViewAdapter is never destroyed (e.g. url = ""
+    // after a page loaded won't lose history or scroll state).
+    // When to load is driven by BrowserWebViewContext (ensureLoaded): address bar,
+    // tab switch, createEmptyTab for the foreground tab — not StackLayout attached
+    // properties (avoids races when the stack is hidden behind EmptyWebPage overlay).
+    // Same for download tabs: no WebEngineView until ensureLoaded (non-empty URL / navigation).
+    // -------------------------------------------------------------------------
+    /// Called from BrowserWebViewContext when this tab should materialise WebEngineView.
+    function ensureLoaded() {
+        if (!loader.active)
+            loader.active = true
+    }
+
+    // -------------------------------------------------------------------------
+    // Function overrides – forward to inner adapter when alive, else no-op.
+    // loadUrl() also works as the primary activation path.
+    // -------------------------------------------------------------------------
+    function loadUrl(u) {
+        root.url = u
+        if (u && u.toString())
+            ensureLoaded()
+    }
+    function goBack()             { if (loader.item) loader.item.goBack() }
+    function goForward()          { if (loader.item) loader.item.goForward() }
+    function goBackOrForward(o)   { if (loader.item) loader.item.goBackOrForward(o) }
+    function reload()             { if (loader.item) loader.item.reload() }
+    function stop()               { if (loader.item) loader.item.stop() }
+    function findText(text, flags){ if (loader.item) loader.item.findText(text, flags) }
+    function showFindPanel()      { if (loader.item) loader.item.showFindPanel() }
+    function hideFindPanel()      { if (loader.item) loader.item.hideFindPanel() }
+    function changeZoomFactor(f)  { if (loader.item) loader.item.changeZoomFactor(f) }
+    function acceptAsNewWindow(req){ if (loader.item) loader.item.acceptAsNewWindow(req) }
+    function triggerWebAction(a)  { if (loader.item) loader.item.triggerWebAction(a) }
+
+    function detachView() {
+        if (loader.item)
+            loader.item.detachView()
+    }
+
+    // Push address-bar / programmatic URL changes into the inner adapter once it
+    // exists. The initial URL is set in the sourceComponent's Component.onCompleted
+    // so it fires after the item is fully constructed.
+    onUrlChanged: {
+        if (loader.item && loader.item.url !== url)
+            loader.item.url = url
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner WebViewAdapter, created on demand.
+    // -------------------------------------------------------------------------
+    Loader {
+        id: loader
+        anchors.fill: parent
+        active: false
+        sourceComponent: WebViewAdapter {
+            profileParams:               root.profileParams
+            bookmarksStore:              root.bookmarksStore
+            downloadsStore:              root.downloadsStore
+            webChannel:                  root.webChannel
+            devToolsEnabled:             root.devToolsEnabled
+            enableJsLogs:                root.enableJsLogs
+            localAccountSensitiveSettings: root.localAccountSensitiveSettings
+            isDownloadView:              root.isDownloadView
+            freeze:                      root.freeze
+            supportsZoom:                true
+            supportsDevTools:            true
+            supportsFindInPage:          true
+            supportsIncognito:           true
+            supportsHistory:             true
+            hasNativeFindPanel:          false
+
+            // Set initial URL when the component is constructed (not as a binding,
+            // because WebEngine navigation breaks QML bindings on the url property).
+            Component.onCompleted: if (root.url.toString()) url = root.url
+
+            // Push browser-driven navigation (link clicks, redirects) back to the
+            // outer wrapper so callers observing root.url stay up to date.
+            onUrlChanged: { if (root.url !== url) root.url = url }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Signal forwarding from inner adapter.
+    // -------------------------------------------------------------------------
+    Connections {
+        target: loader.item
+        function onLinkHovered(hoveredUrl)             { root.linkHovered(hoveredUrl) }
+        function onWindowCloseRequested()              { root.windowCloseRequested() }
+        function onDownloadRequested(download)         { root.downloadRequested(download) }
+        function onNewWindowRequested(makeCurrent, requestedUrl, callback) {
+            root.newWindowRequested(makeCurrent, requestedUrl, callback)
+        }
+        function onCertificateError(error)             { root.certificateError(error) }
+        function onJavaScriptDialogRequested(request)  { root.javaScriptDialogRequested(request) }
+        function onFindTextFinished(result)            { root.findTextFinished(result) }
+    }
+}

--- a/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
+++ b/ui/app/AppLayouts/Browser/adapters/ProfileManager.qml
@@ -41,29 +41,30 @@ QtObject {
         `, root, "ProfilePrototype_" + storageName)
     }
 
-    function getProfile(profileParams) {
-        const key = root._key(profileParams.userId, profileParams.offTheRecord)
+    function getOrCreateStorageProfile(userId, offTheRecord) {
+        const key = root._key(userId, offTheRecord)
         let p = root.profiles[key]
 
         if (!p) {
-            const storageName = profileParams.offTheRecord
-                ? ("IncognitoProfile_" + profileParams.userId)
-                : ("Profile_" + profileParams.userId)
+            const storageName = offTheRecord
+                ? ("IncognitoProfile_" + userId)
+                : ("Profile_" + userId)
 
-            const prototype = root._getProfilePrototype(storageName, profileParams.offTheRecord)
+            const prototype = root._getProfilePrototype(storageName, offTheRecord)
             p = prototype.instance()
             root.profiles[key] = p
         }
 
-        if (profileParams.userAgent && p.httpUserAgent !== profileParams.userAgent) {
-            p.httpUserAgent = profileParams.userAgent
-        }
-
-        if (profileParams.scripts && profileParams.scripts.length > 0) {
-            const scripts = profileParams.scripts.map(path => createScriptFromPath(path))
-            p.userScripts.collection = scripts
-        }
-
         return p
+    }
+
+    function getProfile(profileParams) {
+        return getOrCreateStorageProfile(profileParams.userId, profileParams.offTheRecord)
+    }
+
+    function scriptListForParams(profileParams) {
+        if (!profileParams.scripts || profileParams.scripts.length === 0)
+            return []
+        return profileParams.scripts.map(path => createScriptFromPath(path))
     }
 }

--- a/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
+++ b/ui/app/AppLayouts/Browser/adapters/WebViewAdapter.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQml
 import QtWebEngine
 
 import StatusQ.Core.Theme
@@ -8,7 +9,11 @@ import AppLayouts.Browser.views
 AbstractWebView {
     id: root
 
-    property var profile: ProfileManager.getProfile(root.profileParams)
+    property var profile: root.profileParams
+        ? ProfileManager.getOrCreateStorageProfile(
+              root.profileParams.userId,
+              root.profileParams.offTheRecord)
+        : null
 
     // Expose internal WebEngineView properties
     property alias url: webView.url
@@ -214,20 +219,25 @@ AbstractWebView {
         }
     }
 
+    Binding {
+        when: !!(root.profile && root.profileParams && root.profileParams.userAgent)
+        target: root.profile
+        property: "httpUserAgent"
+        value: root.profileParams.userAgent
+    }
+
+    function applyProfileScripts() {
+        if (!root.profile || !root.profile.userScripts || !root.profileParams)
+            return
+        root.profile.userScripts.collection = ProfileManager.scriptListForParams(root.profileParams)
+    }
+
+    onProfileChanged: applyProfileScripts()
+
     Connections {
-        // This connection is needed because changing profileParams.offTheRecord doesn't trigger the root.profile update
         target: root.profileParams
-        function onOffTheRecordChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
-        }
-        function onUserAgentChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
-        }
         function onScriptsChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
-        }
-        function onUserIdChanged() {
-            root.profile = ProfileManager.getProfile(root.profileParams)
+            root.applyProfileScripts()
         }
     }
 }

--- a/ui/app/AppLayouts/Browser/adapters/qmldir
+++ b/ui/app/AppLayouts/Browser/adapters/qmldir
@@ -1,4 +1,5 @@
 singleton ProfileManager 1.0 ProfileManager.qml
 AbstractWebView 1.0 AbstractWebView.qml
+LazyWebViewAdapter 1.0 LazyWebViewAdapter.qml
 ProfileParams 1.0 ProfileParams.qml
 WebViewAdapter 1.0 WebViewAdapter.qml

--- a/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
@@ -28,7 +28,7 @@ FocusScope {
     signal openNewTabTriggered()
     signal removeView(int index)
 
-    function createEmptyTab(createAsStartPage = false, focusOnNewTab = true, webview = undefined, initialTitle = undefined) {
+    function createEmptyTab(createAsStartPage = false, focusOnNewTab = true, webview = undefined, initialTitle = undefined, initialIcon = undefined) {
         const tabTitle = Qt.binding(function() {
             var tabTitle = ""
             if (webview && webview.title) {
@@ -44,7 +44,7 @@ FocusScope {
             return SQUtils.StringUtils.escapeHtml(tabTitle);
         })
 
-        var newTabButton = tabButtonComponent.createObject(tabBar, {tabTitle})
+        var newTabButton = tabButtonComponent.createObject(tabBar, {tabTitle, tabIcon: initialIcon || ""})
         tabBar.addItem(newTabButton)
 
         if (focusOnNewTab) {
@@ -71,6 +71,10 @@ FocusScope {
 
     function activatePreviousTab() {
         tabBar.decrementCurrentIndex()
+    }
+
+    function determineFaviconURL(iconUrl) {
+        return iconUrl ? iconUrl.toString().replace("image://favicon/", "") : ""
     }
 
     QtObject {
@@ -146,6 +150,7 @@ FocusScope {
         StatusTabButton {
             id: tabButton
             property string tabTitle
+            property string tabIcon
 
             readonly property bool incognito: root.fnGetWebView(tabButton.TabBar.index)?.offTheRecord ?? false
 
@@ -175,7 +180,10 @@ FocusScope {
                 StatusIcon {
                     Layout.preferredWidth: d.iconSize
                     Layout.preferredHeight: d.iconSize
-                    readonly property string favicon: root.fnGetWebView(tabButton.TabBar.index)?.icon.toString().replace("image://favicon/", "") ?? ""
+                    readonly property string favicon: {
+                        const live = determineFaviconURL(root.fnGetWebView(tabButton.TabBar.index)?.icon)
+                        return live || tabButton.tabIcon || ""
+                    }
                     sourceSize: Qt.size(width, height)
                     icon: favicon || "globe"
                     visible: !loadingIndicator.visible

--- a/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
@@ -28,13 +28,14 @@ FocusScope {
     signal openNewTabTriggered()
     signal removeView(int index)
 
-    function createEmptyTab(createAsStartPage = false, focusOnNewTab = true, webview = undefined) {
+    function createEmptyTab(createAsStartPage = false, focusOnNewTab = true, webview = undefined, initialTitle = undefined) {
         const tabTitle = Qt.binding(function() {
             var tabTitle = ""
             if (webview && webview.title) {
                 tabTitle = webview.title
-            }
-            else if (createAsStartPage) {
+            } else if (initialTitle) {
+                tabTitle = initialTitle
+            } else if (createAsStartPage) {
                 tabTitle = qsTr("Start Page")
             } else {
                 tabTitle = qsTr("New Tab")

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -1,27 +1,15 @@
-import QtCore
 import QtQuick
 
 QtObject {
     id: root
 
-    required property string userUID
     required property var webViewContext
     required property var tabs
     required property var defaultProfileParams
     required property var determineRealURL
 
-    readonly property var sessionSettings: Settings {
-        id: _sessionSettings
-        category: "BrowserSettings_%1".arg(root.userUID)
-        property bool restoreOpenTabs
-        property var openTabs: []
-        property int currentTabIndex: 0
-    }
-
-    readonly property alias uiSettings: _sessionSettings
-
     function saveSession() {
-        if (!sessionSettings.restoreOpenTabs)
+        if (!BrowserUiSettings.restoreOpenTabs)
             return
 
         var tabsModel = []
@@ -35,14 +23,15 @@ QtObject {
                     tabsModel.push({url: url, title: webView.title || ""})
             }
         }
-        sessionSettings.openTabs = tabsModel
-        sessionSettings.currentTabIndex = tabs.currentIndex
+        BrowserUiSettings.openTabs = tabsModel
+        BrowserUiSettings.currentTabIndex = tabs.currentIndex
+        BrowserUiSettings.sync()
     }
 
     function getTabsInfo() {
         var list = []
         try {
-            list = JSON.parse(JSON.stringify(sessionSettings.openTabs || [])) || []
+            list = JSON.parse(JSON.stringify(BrowserUiSettings.openTabs || [])) || []
         } catch (e) {
             list = []
         }
@@ -68,7 +57,7 @@ QtObject {
     }
 
     function restoreSession() {
-        const tabsToRestore = sessionSettings.restoreOpenTabs ? getTabsInfo() : []
+        const tabsToRestore = BrowserUiSettings.restoreOpenTabs ? getTabsInfo() : []
         if (tabsToRestore.length === 0) {
             openDefaultTab()
             return
@@ -79,7 +68,7 @@ QtObject {
                 profileParams, false, false,
                 determineRealURL(t.url), t.title)
         })
-        const savedIndex = sessionSettings.currentTabIndex
+        const savedIndex = BrowserUiSettings.currentTabIndex
         Qt.callLater(() => {
             if (tabs.count === 0) {
                 openDefaultTab()

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -17,7 +17,7 @@ QtObject {
         for (let i = 0; i < tabs.count; i++) {
             const webView = webViewContext.getWebView(i)
             if (!!webView && !webView.offTheRecord) {
-                const raw = webView.url.toString() || (webView.pendingUrl || "")
+                const raw = webView.url.toString()
                 const url = determineRealURL(raw)
                 if (!!url)
                     tabsModel.push({url: url, title: webView.title || ""})
@@ -46,16 +46,6 @@ QtObject {
         // tab.url = determineRealURL("https://simpledapp.eth");
     }
 
-    function commitPendingForCurrent() {
-        const w = webViewContext.currentWebView
-        if (!w) return
-        const p = w.pendingUrl
-        if (p && !w.url.toString()) {
-            w.pendingUrl = ""
-            w.url = p
-        }
-    }
-
     function restoreSession() {
         const tabsToRestore = BrowserUiSettings.restoreOpenTabs ? getTabsInfo() : []
         if (tabsToRestore.length === 0) {
@@ -76,14 +66,7 @@ QtObject {
             }
             if (savedIndex >= 0 && savedIndex < tabs.count)
                 tabs.activateTab(savedIndex)
-            commitPendingForCurrent()
+            webViewContext.ensureCurrentWebViewLoaded()
         })
-    }
-
-    readonly property var _currentWebViewConn: Connections {
-        target: webViewContext
-        function onCurrentWebViewChanged() {
-            root.commitPendingForCurrent()
-        }
     }
 }

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -8,6 +8,10 @@ QtObject {
     required property var defaultProfileParams
     required property var determineRealURL
 
+    function determineFaviconURL(iconUrl) {
+        return iconUrl ? iconUrl.toString().replace("image://favicon/", "") : ""
+    }
+
     function saveSession() {
         if (!BrowserUiSettings.restoreOpenTabs)
             return
@@ -19,8 +23,10 @@ QtObject {
             if (!!webView && !webView.offTheRecord) {
                 const raw = webView.url.toString()
                 const url = determineRealURL(raw)
-                if (!!url)
-                    tabsModel.push({url: url, title: webView.title || ""})
+                if (!!url) {
+                    const icon = determineFaviconURL(webView.icon)
+                    tabsModel.push({url: url, title: webView.title || "", icon: icon})
+                }
             }
         }
         BrowserUiSettings.openTabs = tabsModel
@@ -56,7 +62,7 @@ QtObject {
             const profileParams = (i === 0) ? defaultProfileParams : webViewContext.getWebView(0).profileParams
             webViewContext.createEmptyTab(
                 profileParams, false, false,
-                determineRealURL(t.url), t.title)
+                determineRealURL(t.url), t.title, t.icon)
         })
         const savedIndex = BrowserUiSettings.currentTabIndex
         Qt.callLater(() => {

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -16,7 +16,7 @@ QtObject {
 
         for (let i = 0; i < tabs.count; i++) {
             const webView = webViewContext.getWebView(i)
-            if (!!webView) {
+            if (!!webView && !webView.offTheRecord) {
                 const raw = webView.url.toString() || (webView.pendingUrl || "")
                 const url = determineRealURL(raw)
                 if (!!url)

--- a/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserSavedSessionContext.qml
@@ -1,0 +1,100 @@
+import QtCore
+import QtQuick
+
+QtObject {
+    id: root
+
+    required property string userUID
+    required property var webViewContext
+    required property var tabs
+    required property var defaultProfileParams
+    required property var determineRealURL
+
+    readonly property var sessionSettings: Settings {
+        id: _sessionSettings
+        category: "BrowserSettings_%1".arg(root.userUID)
+        property bool restoreOpenTabs
+        property var openTabs: []
+        property int currentTabIndex: 0
+    }
+
+    readonly property alias uiSettings: _sessionSettings
+
+    function saveSession() {
+        if (!sessionSettings.restoreOpenTabs)
+            return
+
+        var tabsModel = []
+
+        for (let i = 0; i < tabs.count; i++) {
+            const webView = webViewContext.getWebView(i)
+            if (!!webView) {
+                const raw = webView.url.toString() || (webView.pendingUrl || "")
+                const url = determineRealURL(raw)
+                if (!!url)
+                    tabsModel.push({url: url, title: webView.title || ""})
+            }
+        }
+        sessionSettings.openTabs = tabsModel
+        sessionSettings.currentTabIndex = tabs.currentIndex
+    }
+
+    function getTabsInfo() {
+        var list = []
+        try {
+            list = JSON.parse(JSON.stringify(sessionSettings.openTabs || [])) || []
+        } catch (e) {
+            list = []
+        }
+        if (!Array.isArray(list))
+            list = []
+        return list.filter(t => t && String(t.url || "").trim() !== "")
+    }
+
+    function openDefaultTab() {
+        const tab = webViewContext.createEmptyTab(defaultProfileParams, true)
+        // For Devs: Uncomment the next line if you want to use the simpledapp on first load
+        // tab.url = determineRealURL("https://simpledapp.eth");
+    }
+
+    function commitPendingForCurrent() {
+        const w = webViewContext.currentWebView
+        if (!w) return
+        const p = w.pendingUrl
+        if (p && !w.url.toString()) {
+            w.pendingUrl = ""
+            w.url = p
+        }
+    }
+
+    function restoreSession() {
+        const tabsToRestore = sessionSettings.restoreOpenTabs ? getTabsInfo() : []
+        if (tabsToRestore.length === 0) {
+            openDefaultTab()
+            return
+        }
+        tabsToRestore.forEach((t, i) => {
+            const profileParams = (i === 0) ? defaultProfileParams : webViewContext.getWebView(0).profileParams
+            webViewContext.createEmptyTab(
+                profileParams, false, false,
+                determineRealURL(t.url), t.title)
+        })
+        const savedIndex = sessionSettings.currentTabIndex
+        Qt.callLater(() => {
+            if (tabs.count === 0) {
+                openDefaultTab()
+                return
+            }
+            if (savedIndex >= 0 && savedIndex < tabs.count)
+                tabs.activateTab(savedIndex)
+            commitPendingForCurrent()
+        })
+    }
+
+    readonly property var _currentWebViewConn: Connections {
+        target: webViewContext
+        function onCurrentWebViewChanged() {
+            root.commitPendingForCurrent()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Browser/webview/BrowserUiSettings.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserUiSettings.qml
@@ -1,0 +1,14 @@
+pragma Singleton
+import QtCore
+
+// Session keys use `userProfile.pubKey` from the engine context so the category
+// is correct before any binding reads properties (no delayed initialize()).
+Settings {
+    id: root
+
+    category: "BrowserSettings_%1".arg(userProfile.pubKey)
+
+    property bool restoreOpenTabs
+    property var openTabs: []
+    property int currentTabIndex: 0
+}

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -83,6 +83,7 @@ QtObject {
             isDownloadView: true
         })
         tabsModel.createDownloadTab()
+        webview.ensureLoaded()
         return webview
     }
 

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -36,7 +36,7 @@ QtObject {
         EmptyContent
     }
 
-    readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? getCurrentWebView() : null
+    readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
             return BrowserWebViewContext.ContentMode.EmptyContent

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -54,7 +54,7 @@ QtObject {
         }
     }
 
-    function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {
+    function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined, initialIcon = undefined) {
         focusOnNewTab = focusOnNewTab && !createAsStartPage
 
         var webview = webViewAdapterComponent.createObject(hostStackLayout, {
@@ -62,7 +62,7 @@ QtObject {
             isDownloadView: false
         })
 
-        tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle)
+        tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle, initialIcon)
 
         if (createAsStartPage && thirdpartyServicesEnabled)
             webview.url = Constants.browserDefaultHomepage

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -36,9 +36,6 @@ QtObject {
         EmptyContent
     }
 
-    // While true, do not commit pending url on tab switch (restore loop is running)
-    property bool restoringOpenTabs: false
-
     readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
@@ -48,19 +45,6 @@ QtObject {
         if (!currentWebView.url?.toString())
             return BrowserWebViewContext.ContentMode.EmptyContent
         return BrowserWebViewContext.ContentMode.WebContent
-    }
-
-    onCurrentWebViewChanged: if (!restoringOpenTabs) commitPendingForCurrent()
-
-    // Apply pendingUrl of the current webview (set when a restored tab is first activated)
-    function commitPendingForCurrent() {
-        const w = currentWebView
-        if (!w) return
-        const p = w.pendingUrl
-        if (p && !w.url.toString()) {
-            w.pendingUrl = ""
-            w.url = p
-        }
     }
 
     function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -47,6 +47,13 @@ QtObject {
         return BrowserWebViewContext.ContentMode.WebContent
     }
 
+    readonly property Connections _currentIndexConnections: Connections {
+        target: tabsModel
+        function onCurrentIndexChanged() {
+            root.ensureCurrentWebViewLoaded()
+        }
+    }
+
     function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {
         focusOnNewTab = focusOnNewTab && !createAsStartPage
 
@@ -57,16 +64,15 @@ QtObject {
 
         tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle)
 
-        const lazy = !focusOnNewTab && url !== undefined
-        if (lazy) {
-            webview.pendingUrl = url
-        } else if (createAsStartPage && thirdpartyServicesEnabled) {
+        if (createAsStartPage && thirdpartyServicesEnabled)
             webview.url = Constants.browserDefaultHomepage
-        } else if (url !== undefined) {
+        else if (url !== undefined)
             webview.url = url
-        } else if (!!browserSettings.browserHomepage) {
+        else if (!!browserSettings.browserHomepage)
             webview.url = determineRealURLFn(browserSettings.browserHomepage)
-        }
+
+        if ((focusOnNewTab || createAsStartPage) && webview.url.toString() && typeof webview.ensureLoaded === "function")
+            webview.ensureLoaded()
 
         return webview
     }
@@ -88,16 +94,24 @@ QtObject {
         return hostStackLayout.children[index]
     }
 
+    function ensureCurrentWebViewLoaded() {
+        const w = getCurrentWebView()
+        if (w && w.url && w.url.toString() && typeof w.ensureLoaded === "function")
+            w.ensureLoaded()
+    }
+
     function setCurrentWebUrl(url) {
-        if (!currentWebView) {
+        var target = currentWebView
+        if (!target) {
             console.error("[Browser] currentWebView is null, cannot set URL")
             return
         }
 
         const newUrl = determineRealURLFn(url)
         Qt.callLater(function() {
-            if (currentWebView)
-                currentWebView.url = newUrl
+            target.url = newUrl
+            if (newUrl && newUrl.toString() && typeof target.ensureLoaded === "function")
+                target.ensureLoaded()
         })
     }
 
@@ -182,7 +196,7 @@ QtObject {
     }
 
     readonly property var webViewAdapterComponent: Component {
-        WebViewAdapter {
+        LazyWebViewAdapter {
             // On mobile, only the active tab must be visible; native WKWebView
             // subviews share the same UIKit window and ignore QML z-order,
             // so StackLayout alone cannot hide inactive tabs reliably.

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -36,6 +36,9 @@ QtObject {
         EmptyContent
     }
 
+    // While true, do not commit pending url on tab switch (restore loop is running)
+    property bool restoringOpenTabs: false
+
     readonly property Item currentWebView: tabsModel.currentIndex < tabsModel.count ? (getCurrentWebView() ?? null) : null
     readonly property int currentContentMode: {
         if (!currentWebView)
@@ -45,6 +48,19 @@ QtObject {
         if (!currentWebView.url?.toString())
             return BrowserWebViewContext.ContentMode.EmptyContent
         return BrowserWebViewContext.ContentMode.WebContent
+    }
+
+    onCurrentWebViewChanged: if (!restoringOpenTabs) commitPendingForCurrent()
+
+    // Apply pendingUrl of the current webview (set when a restored tab is first activated)
+    function commitPendingForCurrent() {
+        const w = currentWebView
+        if (!w) return
+        const p = w.pendingUrl
+        if (p && !w.url.toString()) {
+            w.pendingUrl = ""
+            w.url = p
+        }
     }
 
     function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {
@@ -57,7 +73,10 @@ QtObject {
 
         tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle)
 
-        if (createAsStartPage && thirdpartyServicesEnabled) {
+        const lazy = !focusOnNewTab && url !== undefined
+        if (lazy) {
+            webview.pendingUrl = url
+        } else if (createAsStartPage && thirdpartyServicesEnabled) {
             webview.url = Constants.browserDefaultHomepage
         } else if (url !== undefined) {
             webview.url = url

--- a/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
+++ b/ui/app/AppLayouts/Browser/webview/BrowserWebViewContext.qml
@@ -47,7 +47,7 @@ QtObject {
         return BrowserWebViewContext.ContentMode.WebContent
     }
 
-    function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined) {
+    function createEmptyTab(profileParams, createAsStartPage = false, focusOnNewTab = true, url = undefined, initialTitle = undefined) {
         focusOnNewTab = focusOnNewTab && !createAsStartPage
 
         var webview = webViewAdapterComponent.createObject(hostStackLayout, {
@@ -55,7 +55,7 @@ QtObject {
             isDownloadView: false
         })
 
-        tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview)
+        tabsModel.createEmptyTab(createAsStartPage, focusOnNewTab, webview, initialTitle)
 
         if (createAsStartPage && thirdpartyServicesEnabled) {
             webview.url = Constants.browserDefaultHomepage

--- a/ui/app/AppLayouts/Browser/webview/qmldir
+++ b/ui/app/AppLayouts/Browser/webview/qmldir
@@ -1,3 +1,4 @@
+singleton BrowserUiSettings 1.0 BrowserUiSettings.qml
 BrowserWebViewContext 1.0 BrowserWebViewContext.qml
 BrowserSavedSessionContext 1.0 BrowserSavedSessionContext.qml
 BrowserOverlayContext 1.0 BrowserOverlayContext.qml

--- a/ui/app/AppLayouts/Browser/webview/qmldir
+++ b/ui/app/AppLayouts/Browser/webview/qmldir
@@ -1,4 +1,5 @@
 BrowserWebViewContext 1.0 BrowserWebViewContext.qml
+BrowserSavedSessionContext 1.0 BrowserSavedSessionContext.qml
 BrowserOverlayContext 1.0 BrowserOverlayContext.qml
 BrowserFavoritesContext 1.0 BrowserFavoritesContext.qml
 BrowserDialogsContext 1.0 BrowserDialogsContext.qml

--- a/ui/app/AppLayouts/Profile/views/BrowserView.qml
+++ b/ui/app/AppLayouts/Profile/views/BrowserView.qml
@@ -1,4 +1,3 @@
-import QtCore
 import QtQuick
 
 import StatusQ.Core.Theme
@@ -8,6 +7,7 @@ import StatusQ.Controls
 import utils
 import shared.status
 
+import AppLayouts.Browser.webview
 import AppLayouts.Profile.popups
 import AppLayouts.Profile.views.browser
 
@@ -19,13 +19,6 @@ SettingsContentBase {
 
     property Component searchEngineModal: SearchEngineModal {
         accountSettings: root.accountSettings
-    }
-
-    Settings {
-        id: uiSettings
-        category: "BrowserSettings_%1".arg(root.userUID)
-        property bool restoreOpenTabs
-        property var openTabs: []
     }
 
     Item {
@@ -89,11 +82,12 @@ SettingsContentBase {
                 components: [
                     StatusSwitch {
                         id: restoreTabsSwitch
-                        checked: uiSettings.restoreOpenTabs
+                        checked: BrowserUiSettings.restoreOpenTabs
                         onToggled: {
-                            uiSettings.restoreOpenTabs = checked
+                            BrowserUiSettings.restoreOpenTabs = checked
                             if (!checked) // clear settings
-                                uiSettings.openTabs = []
+                                BrowserUiSettings.openTabs = []
+                            BrowserUiSettings.sync()
                         }
                     }
                 ]


### PR DESCRIPTION
* Persist browser tab title, favicon and which tab is open
* Remove a QML binding loop (profile.userScripts)
* Lazy `Loader` for web view instantiation. This fixes a crash that occurred when the app created multiple web views
* Add saved session context 


fixes #20512 