### PR TITLE
feat(Wallet): Long press to reveal close button on banner cards (touch screens)

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/BannerCard.qml
+++ b/ui/app/AppLayouts/Wallet/controls/BannerCard.qml
@@ -17,8 +17,17 @@ Control {
     property alias subTitle: subTitle.text
     property bool closeEnabled: true
 
+    // Dismisses the long-press state, e.g. when tapping outside the card.
+    function reset() { d.closeVisible = false }
+
     signal clicked()
     signal close()
+
+    QtObject {
+        id: d
+        // Touch screens: long-press pins the close button visible.
+        property bool closeVisible: false
+    }
 
     implicitHeight: 70
     implicitWidth: 400
@@ -27,11 +36,24 @@ Control {
 
     TapHandler {
         acceptedButtons: Qt.LeftButton
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad | PointerDevice.Stylus
+        enabled: !closeHandler.pressed
+        onTapped: root.clicked()
+    }
+
+    // Long press (touch screens): pins the close button visible.
+    // exclusiveSignals ensures tapped and longPressed are mutually exclusive.
+    TapHandler {
+        acceptedDevices: PointerDevice.TouchScreen
+        exclusiveSignals: TapHandler.SingleTap | TapHandler.LongPress
         enabled: !closeHandler.pressed
         onTapped: {
+            d.closeVisible = false
             root.clicked()
         }
+        onLongPressed: d.closeVisible = true
     }
+
     HoverHandler {
         cursorShape: Qt.PointingHandCursor
     }
@@ -83,15 +105,16 @@ Control {
             Layout.topMargin: 4
             Layout.rightMargin: 4
             Layout.alignment: Qt.AlignTop
-            Layout.preferredWidth: 16
-            Layout.preferredHeight: 16
+            Layout.preferredWidth: 24
+            Layout.preferredHeight: 24
             icon: "close"
             color: closeHoverHandler.hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
-            visible: root.closeEnabled && root.hovered
+            visible: root.closeEnabled && (d.closeVisible || root.hovered)
             TapHandler {
                 id: closeHandler
                 acceptedButtons: Qt.LeftButton
                 onTapped: {
+                    d.closeVisible = false
                     root.close()
                 }
             }

--- a/ui/app/AppLayouts/Wallet/panels/BuyReceiveBanner.qml
+++ b/ui/app/AppLayouts/Wallet/panels/BuyReceiveBanner.qml
@@ -20,6 +20,21 @@ Control {
     signal closeBuy()
     signal closeReceive()
 
+    // Full-screen overlay (touch screens): resets any card on tap outside.
+    // TakeOverForbidden observes taps without consuming them.
+    Item {
+        parent: root.Window.contentItem
+        anchors.fill: parent
+
+        TapHandler {
+            grabPermissions: PointerHandler.TakeOverForbidden
+            onTapped: {
+                buyCard.reset()
+                receiveCard.reset()
+            }
+        }
+    }
+
     contentItem: RowLayout {
         id: layout
         spacing: Theme.padding

--- a/ui/app/AppLayouts/Wallet/panels/BuyReceiveBanner.qml
+++ b/ui/app/AppLayouts/Wallet/panels/BuyReceiveBanner.qml
@@ -20,17 +20,17 @@ Control {
     signal closeBuy()
     signal closeReceive()
 
-    // Full-screen overlay (touch screens): resets any card on tap outside.
-    // TakeOverForbidden observes taps without consuming them.
+    // Full-screen overlay resets any card on tap outside.
     Item {
         parent: root.Window.contentItem
         anchors.fill: parent
 
-        TapHandler {
-            grabPermissions: PointerHandler.TakeOverForbidden
-            onTapped: {
-                buyCard.reset()
-                receiveCard.reset()
+        PointHandler {
+            onActiveChanged: {
+                if (active) {
+                    buyCard.reset()
+                    receiveCard.reset()
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #20404

### What does the PR do

On touch screens, long pressing a `Ways to buy` or `Receive` card reveals the close button.

Tapping outside dismisses it. `Desktop` behavior unchanged.

### Affected areas

Wallet / `Ways to buy` or `Receive` card on touch screens

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX

### How to test

- Navigate to main Wallet page
- Long press `Ways to buy` or `Receive` cards and see the X button is bigger and it keeps visible until there is another click outside the card

### Risk 

Low
