### PR TITLE
text input: ensure cursor visibility on Android

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -455,6 +455,17 @@ Item {
                             cursorVisible: edit.cursorVisible
                         }
 
+                        // selectedText is not notified correctly when selection is cleared on Android.
+                        // Similarly cursorVisible is not updated properly to be visible when text is
+                        // deselected. As a workaround selection is tracked via selectionStart
+                        // and selectionEnd and deselect is called manually to update cursor visibility.
+                        readonly property bool noSelection: selectionStart === selectionEnd
+
+                        onNoSelectionChanged: {
+                            if (noSelection && activeFocus)
+                                deselect()
+                        }
+
                         StatusBaseText {
                             id: placeholder
                             visible: (edit.length === 0)

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -58,6 +58,8 @@ TextArea {
 
     // Workaround to make selection working on Android. Otherwise
     // selection is dropped right after selection.
+    //
+    // Related QT issue: QTBUG-145720
     onPressAndHold: ;
 
     leftPadding: Theme.padding
@@ -100,5 +102,16 @@ TextArea {
 
     cursorDelegate: StatusCursorDelegate {
         cursorVisible: root.cursorVisible
+    }
+
+    // selectedText is not notified correctly when selection is cleared on Android.
+    // Similarly cursorVisible is not updated properly to be visible when text is
+    // deselected. As a workaround selection is tracked via selectionStart
+    // and selectionEnd and deselect is called manually to update cursor visibility.
+    readonly property bool noSelection: selectionStart === selectionEnd
+
+    onNoSelectionChanged: {
+        if (noSelection && activeFocus)
+            deselect()
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -24,4 +24,15 @@ TextField {
     cursorDelegate: StatusCursorDelegate {
         cursorVisible: root.cursorVisible
     }
+
+    // selectedText is not notified correctly when selection is cleared on Android.
+    // Similarly cursorVisible is not updated properly to be visible when text is
+    // deselected. As a workaround selection is tracked via selectionStart
+    // and selectionEnd and deselect is called manually to update cursor visibility.
+    readonly property bool noSelection: selectionStart === selectionEnd
+
+    onNoSelectionChanged: {
+        if (noSelection && activeFocus)
+            deselect()
+    }
 }

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -274,6 +274,17 @@ ColumnLayout {
                             cursorVisible: edit.cursorVisible
                         }
 
+                        // selectedText is not notified correctly when selection is cleared on Android.
+                        // Similarly cursorVisible is not updated properly to be visible when text is
+                        // deselected. As a workaround selection is tracked via selectionStart
+                        // and selectionEnd and deselect is called manually to update cursor visibility.
+                        readonly property bool noSelection: selectionStart === selectionEnd
+
+                        onNoSelectionChanged: {
+                            if (noSelection && activeFocus)
+                                deselect()
+                        }
+
                         onTextEdited: {
                             if (suggestionsDialog.forceHide && !pasteOperation)
                                 suggestionsDialog.forceHide = false


### PR DESCRIPTION
### What does the PR do

Workaround for Qt bug on Android causing that custom cursor is not set visible when text is deselected.

Closes: #20496

### Affected areas
Editable text fields with custom cursor.

### Screencapture of the functionality

https://github.com/user-attachments/assets/cad34c74-9a82-49ba-ac7f-b42c4e1a9811

### Impact on end user
Low

### How to test
1. Select text on Androd
2. Tap text to deselect

### Risk 
Low
