### PR TITLE
MessageView: context menu with bigger emojis

### DIFF
--- a/storybook/pages/MessageContextMenuViewPage.qml
+++ b/storybook/pages/MessageContextMenuViewPage.qml
@@ -26,12 +26,6 @@ SplitView {
             SplitView.fillHeight: true
             color: Theme.palette.background
 
-            Button {
-                anchors.centerIn: parent
-                text: "Reopen"
-                onClicked: messageContextMenuView.popup()
-            }
-
             MessageContextMenuView {
                 id: messageContextMenuView
                 anchors.centerIn: parent
@@ -61,6 +55,8 @@ SplitView {
                 onShowReplyArea: (senderId) => logs.logEvent("onShowReplyArea", ["senderId"], [senderId])
                 onCopyToClipboard: (text) => logs.logEvent("onCopyToClipboard", ["text"], [text])
                 onOpenEmojiPopup: logs.logEvent("onOpenEmojiPopup")
+
+                Component.onCompleted: popup()
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -168,7 +168,7 @@ MenuItem {
 
     background: Rectangle {
         color: {
-            if (!root.hovered && !d.subMenuOpened)
+            if (!hoverHandler.hovered && !d.subMenuOpened)
                 return "transparent"
             if (d.isStatusDangerAction)
                 return Theme.palette.dangerColor3;
@@ -179,6 +179,8 @@ MenuItem {
     }
 
     HoverHandler {
+        id: hoverHandler
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
         cursorShape: hovered ? Qt.PointingHandCursor : undefined
         enabled: root.enabled
     }

--- a/ui/imports/shared/controls/chat/EmojiReaction.qml
+++ b/ui/imports/shared/controls/chat/EmojiReaction.qml
@@ -9,12 +9,15 @@ import shared
 import shared.panels
 
 Rectangle {
+    id: root
+
     required property string emojiId
+
+    property int emojiSize: 23
     property bool reactedByUser: false
     property bool isHovered: false
     signal toggleReaction()
 
-    id: root
     width: statusEmoji.width + Theme.halfPadding
     height: width
     color: reactedByUser ? Theme.palette.secondaryBackground :
@@ -29,8 +32,8 @@ Rectangle {
     StatusEmoji {
         id: statusEmoji
         anchors.centerIn: parent
-        width: Theme.fontSize(23)
-        height: Theme.fontSize(23)
+        width: root.emojiSize
+        height: root.emojiSize
         emojiId: root.emojiId
     }
 

--- a/ui/imports/shared/controls/chat/MessageReactionsRow.qml
+++ b/ui/imports/shared/controls/chat/MessageReactionsRow.qml
@@ -1,14 +1,14 @@
 import QtQuick
+import QtQuick.Layouts
 
-import StatusQ
 import StatusQ.Core.Theme
 import StatusQ.Controls
 
-import shared.controls.chat
-
 import SortFilterProxyModel
 
-Row {
+import utils
+
+RowLayout {
     id: root
 
     enum Size {
@@ -24,52 +24,48 @@ Row {
 
     property int countLimit: 5
 
-    spacing: Theme.halfPadding
-    leftPadding: Theme.halfPadding
-    rightPadding: Theme.halfPadding
+    spacing: Theme.smallPadding
 
-    Loader {
-        active: root.visible
+    QtObject {
+        id: d
 
-        sourceComponent: Row {
-            spacing: Theme.halfPadding
+        readonly property int emojiSize:
+            root.Theme.fontSize(
+                root.size === MessageReactionsRow.Size.Regular ? 23 : 33)
+    }
 
-            Repeater {
-                id: recentEmojisRepeater
-                model: SortFilterProxyModel {
-                    sourceModel: root.emojiModel
-                    filters: IndexFilter {
-                        maximumIndex: root.countLimit - 1
-                    }
-                }
-                delegate: EmojiReaction {
-                    required property string unicode
+    Repeater {
+        id: recentEmojisRepeater
+        model: SortFilterProxyModel {
+            sourceModel: root.emojiModel
+            filters: IndexFilter {
+                maximumIndex: root.countLimit - 1
+            }
+        }
+        delegate: EmojiReaction {
+            required property string unicode
 
-                    emojiId: unicode
-                    emojiSize: Theme.fontSize(
-                                   root.size === MessageReactionsRow.Size.Regular ? 23 : 33)
+            Layout.alignment: Qt.AlignVCenter
 
-                    anchors.verticalCenter: parent.verticalCenter
-                    // TODO not implemented yet. We'll need to pass this info
-                    // reactedByUser: model.didIReactWithThisEmoji
-                    onToggleReaction: {
-                        root.toggleReaction(unicode)
-                    }
-                }
+            emojiId: unicode
+            emojiSize: d.emojiSize
+
+            // TODO not implemented yet. We'll need to pass this info
+            // reactedByUser: model.didIReactWithThisEmoji
+            onToggleReaction: {
+                root.toggleReaction(unicode)
             }
         }
     }
 
     StatusFlatRoundButton {
-        height: parent.height
-        width: height
+        Layout.alignment: Qt.AlignVCenter
 
-        Binding on icon.width {
-            when: root.size === MessageReactionsRow.Size.Big
-            value: height * 0.75
-        }
+        Layout.preferredHeight: d.emojiSize + Theme.halfPadding
+        Layout.preferredWidth: Layout.preferredHeight
 
-        icon.height: icon.width
+        icon.width: d.emojiSize
+        icon.height: d.emojiSize
         icon.name: "reaction-b"
         type: StatusFlatRoundButton.Type.Tertiary
         onClicked: mouse => root.openEmojiPopup(this, mouse)

--- a/ui/imports/shared/controls/chat/MessageReactionsRow.qml
+++ b/ui/imports/shared/controls/chat/MessageReactionsRow.qml
@@ -11,13 +11,19 @@ import SortFilterProxyModel
 Row {
     id: root
 
+    enum Size {
+        Regular,
+        Big
+    }
+
     required property var emojiModel
-    property int buttonSize
+    property int size: MessageReactionsRow.Size.Regular
 
     signal toggleReaction(string hexcode)
     signal openEmojiPopup(var parent, var mouse)
 
-    height: buttonSize
+    property int countLimit: 5
+
     spacing: Theme.halfPadding
     leftPadding: Theme.halfPadding
     rightPadding: Theme.halfPadding
@@ -33,13 +39,16 @@ Row {
                 model: SortFilterProxyModel {
                     sourceModel: root.emojiModel
                     filters: IndexFilter {
-                        maximumIndex: 4
+                        maximumIndex: root.countLimit - 1
                     }
                 }
                 delegate: EmojiReaction {
                     required property string unicode
 
                     emojiId: unicode
+                    emojiSize: Theme.fontSize(
+                                   root.size === MessageReactionsRow.Size.Regular ? 23 : 33)
+
                     anchors.verticalCenter: parent.verticalCenter
                     // TODO not implemented yet. We'll need to pass this info
                     // reactedByUser: model.didIReactWithThisEmoji
@@ -52,8 +61,15 @@ Row {
     }
 
     StatusFlatRoundButton {
-        height: root.buttonSize ? buttonSize : parent.height
+        height: parent.height
         width: height
+
+        Binding on icon.width {
+            when: root.size === MessageReactionsRow.Size.Big
+            value: height * 0.75
+        }
+
+        icon.height: icon.width
         icon.name: "reaction-b"
         type: StatusFlatRoundButton.Type.Tertiary
         onClicked: mouse => root.openEmojiPopup(this, mouse)

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Layouts
 import QtQuick.Controls
 
 import StatusQ
@@ -53,6 +54,9 @@ StatusMenu {
 
         size: MessageReactionsRow.Size.Big
         countLimit: 4
+
+        Layout.leftMargin: Theme.smallPadding
+        Layout.rightMargin: Theme.smallPadding
 
         visible: !root.emojiReactionLimitReached && (!root.disabledForChat || root.forceEnableEmojiReactions)
         emojiModel: root.emojiModel

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -50,6 +50,10 @@ StatusMenu {
     MessageReactionsRow {
         id: emojiRow
         objectName: "messageContextMenu_reactionsRow"
+
+        size: MessageReactionsRow.Size.Big
+        countLimit: 4
+
         visible: !root.emojiReactionLimitReached && (!root.disabledForChat || root.forceEnableEmojiReactions)
         emojiModel: root.emojiModel
         onToggleReaction: hexcode => {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1114,7 +1114,7 @@ Loader {
                             root.emojiReactionLimitReached
                             return !root.emojiReactionLimitReached && !root.isViewMemberMessagesePopup
                         }
-                        buttonSize: d.chatButtonSize
+                        height: d.chatButtonSize
                         leftPadding: 0
                         rightPadding: 0
                         emojiModel: emojiPopup.fullModel

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1114,9 +1114,7 @@ Loader {
                             root.emojiReactionLimitReached
                             return !root.emojiReactionLimitReached && !root.isViewMemberMessagesePopup
                         }
-                        height: d.chatButtonSize
-                        leftPadding: 0
-                        rightPadding: 0
+                        anchors.verticalCenter: parent.verticalCenter
                         emojiModel: emojiPopup.fullModel
                         onToggleReaction: hexcode => root.emojiReactionToggled(root.messageId, hexcode)
                         onOpenEmojiPopup: (parent, mouse) => {


### PR DESCRIPTION
### What does the PR do

Hot-fix to make message context menu more convenient on mobile

- changes hover behavior of StatusMenu - no hover state remaining persistent on the items
- number of emojis in MessageContextMenuView reduced to 4, made bigger
- minor Storybook page changes

### Affected areas
`MessageReactionsRow`, `EmojiReaction`, `MessageContextMenuView`

### Screencapture of the functionality

desktop:
<img width="719" height="589" alt="Screenshot from 2026-04-28 19-27-05" src="https://github.com/user-attachments/assets/45d4a344-3969-481b-bb68-9a305b4be61a" />

mobile:
<img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/f2d54316-fb6b-4bf8-80b0-869800685bb1" />


### Impact on end user
Low

### How to test
Long press on message on mobile to open context menu

### Risk 
Low
