### PR TITLE
fix(Browser): move the FindBar to be always on top

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -434,28 +434,6 @@ StatusSectionLayout {
                 onFavMenuRequested: (parent, pos, url, name) => _internal.openFavoriteMenu(parent, pos, url, name)
             }
         }
-
-        FindBar {
-            id: findBar
-            visible: false
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: tabs.tabHeight
-
-            onFindNext: {
-                if (text)
-                    webViewContext.findTextCurrent(text)
-                else if (!visible)
-                    _internal.showFindBar()
-            }
-            onFindPrevious: {
-                if (text)
-                    webViewContext.findTextCurrent(text, true)
-                else if (!visible)
-                    _internal.showFindBar()
-            }
-            onVisibleChanged: if (!visible) webViewContext.findTextCurrent("") // reset the highlight
-        }
     }
 
     footer: Loader {
@@ -488,6 +466,28 @@ StatusSectionLayout {
             onRequestOpenDapp: url => _internal.onRequestOpenDapp(url)
             onRequestDisconnectDapp: dappUrl => connectorBridge.disconnect(dappUrl)
             onRequestWalletMenu: dialogsContext.openWalletMenu(browserWalletMenu)
+        }
+
+        FindBar {
+            id: findBar
+            visible: false
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: tabs.tabHeight
+
+            onFindNext: {
+                if (text)
+                    webViewContext.findTextCurrent(text)
+                else if (!visible)
+                    _internal.showFindBar()
+            }
+            onFindPrevious: {
+                if (text)
+                    webViewContext.findTextCurrent(text, true)
+                else if (!visible)
+                    _internal.showFindBar()
+            }
+            onVisibleChanged: if (!visible) webViewContext.findTextCurrent("") // reset the highlight
         }
 
         StackLayout {


### PR DESCRIPTION
### What does the PR do

- instead of switching between header/footer

Fixes #20442

### Affected areas

Browser

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Landscape:
<img width="3298" height="2224" alt="Snímek obrazovky z 2026-04-29 11-42-30" src="https://github.com/user-attachments/assets/e34fc291-8fb3-4d67-9449-0dcfc64e36a7" />

Portrait:
<img width="1602" height="2224" alt="Snímek obrazovky z 2026-04-29 11-42-50" src="https://github.com/user-attachments/assets/942af0a1-dfa7-4174-ad64-cad3711337a2" />

### Impact on end user

Better "Find in page" UX

### How to test

- invoke "Find in page"

### Risk 

low
