### PR TITLE
perf: Async start messenger

### DIFF
--- a/src/app/modules/onboarding/controller.nim
+++ b/src/app/modules/onboarding/controller.nim
@@ -12,6 +12,7 @@ import app_service/service/wallet_account/service as wallet_account_service
 import app_service/service/devices/service as devices_service
 import app_service/service/keycardV2/service as keycard_serviceV2
 import app_service/common/utils
+import app_service/common/types
 from app_service/service/keycardV2/dto import KeycardExportedKeysDto
 from app_service/service/chat/service import SIGNAL_CHATS_LOADING_FAILED
 
@@ -154,6 +155,11 @@ proc init*(self: Controller) =
 
   handlerId = self.events.onWithUUID(SIGNAL_CHATS_LOADING_FAILED) do(e: Args):
     self.delegate.onMainFailedToLoad()
+  self.connectionIds.add(handlerId)
+
+  handlerId = self.events.onWithUUID(SIGNAL_MESSENGER_STARTED) do(e: Args):
+    let args = MessengerStartedArgs(e)
+    self.delegate.onMessengerStarted(args.error)
   self.connectionIds.add(handlerId)
 
 proc initialize*(self: Controller, pin: string) =

--- a/src/app/modules/onboarding/io_interface.nim
+++ b/src/app/modules/onboarding/io_interface.nim
@@ -97,6 +97,9 @@ method onKeycardExportLoginKeysSuccess*(self: AccessInterface, exportedKeys: Key
 method onAccountLoginError*(self: AccessInterface, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onMessengerStarted*(self: AccessInterface, err: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method exportRecoverKeys*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -371,11 +371,7 @@ method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settin
 
   self.controller.setLoggedInAccount(account)
 
-  let err2 = self.delegate.userLoggedIn()
-  if err2.len != 0:
-    error "error from userLoggedIn", err2
-    self.onAccountLoginError(err2)
-    return
+  self.delegate.userLoggedIn()
 
 
 method onMessengerStarted*[T](self: Module[T], err: string) =

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -377,6 +377,13 @@ method onNodeLogin*[T](self: Module[T], err: string, account: AccountDto, settin
     self.onAccountLoginError(err2)
     return
 
+
+method onMessengerStarted*[T](self: Module[T], err: string) =
+  if err.len != 0:
+    error "error starting messenger", err
+    self.onAccountLoginError(err)
+    return
+
   if self.localPairingStatus != nil and self.localPairingStatus.installation != nil and
       self.localPairingStatus.installation.id != "" and self.localPairingStatus.state == LocalPairingState.Error:
     # We tried to login by pairing, so finalize the process

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -107,7 +107,12 @@ type TrustStatus* {.pure.}= enum
 
 const SIGNAL_LOCAL_BACKUP_IMPORT_COMPLETED* = "localBackupImportCompletedSignal"
 
+const SIGNAL_MESSENGER_STARTED* = "messengerStartedSignal"
+
 type
   LocalBackupImportArg* = ref object of Args
     error*: string
     response*: JsonNode
+
+  MessengerStartedArgs* = ref object of Args
+    error*: string

--- a/src/app_service/service/general/async_tasks.nim
+++ b/src/app_service/service/general/async_tasks.nim
@@ -24,9 +24,12 @@ proc asyncStartMessengerTask(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncStartMessengerTaskArg](argEncoded)
   try:
     let response = status_general.startMessenger()
-    let resultJson = if response.result.isNil: newJObject() else: response.result
+    var trimmed = newJObject()
+    if not response.result.isNil and response.result.kind == JObject and
+        response.result.hasKey("activityCenterNotifications"):
+      trimmed["activityCenterNotifications"] = response.result["activityCenterNotifications"]
     arg.finish(%* {
-      "response": resultJson,
+      "response": trimmed,
       "error": "",
     })
   except Exception as e:

--- a/src/app_service/service/general/async_tasks.nim
+++ b/src/app_service/service/general/async_tasks.nim
@@ -15,3 +15,21 @@ proc asyncImportLocalBackupFileTask(argEncoded: string) {.gcsafe, nimcall.} =
     arg.finish(%* {
       "error": e.msg,
     })
+
+type
+  AsyncStartMessengerTaskArg = ref object of QObjectTaskArg
+    discard
+
+proc asyncStartMessengerTask(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncStartMessengerTaskArg](argEncoded)
+  try:
+    let response = status_general.startMessenger()
+    let resultJson = if response.result.isNil: newJObject() else: response.result
+    arg.finish(%* {
+      "response": resultJson,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+    })

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -39,12 +39,32 @@ QtObject:
       createDir(app_constants.ROOTKEYSTOREDIR)
 
   proc startMessenger*(self: Service) =
-    let response = status_general.startMessenger()
-    if response.result.contains("activityCenterNotifications"):
-      let notifications = JsonNode(%{"notifications": response.result["activityCenterNotifications"]})
-      let activityCenterNotificationsTuple = parseActivityCenterNotifications(notifications)
-      self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED,
-        ActivityCenterNotificationsArgs(activityCenterNotifications: activityCenterNotificationsTuple[1]))
+    let arg = AsyncStartMessengerTaskArg(
+      tptr: asyncStartMessengerTask,
+      vptr: cast[uint](self.vptr),
+      slot: "onAsyncStartMessengerDone",
+    )
+    self.threadpool.start(arg)
+
+  proc onAsyncStartMessengerDone(self: Service, response: string) {.slot.} =
+    var startError = ""
+    try:
+      let rpcResponseObj = response.parseJson
+
+      if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
+        raise newException(CatchableError, rpcResponseObj{"error"}.getStr)
+
+      let responseResult = rpcResponseObj{"response"}
+      if not responseResult.isNil and responseResult.kind == JObject and
+          responseResult.contains("activityCenterNotifications"):
+        let notifications = JsonNode(%{"notifications": responseResult["activityCenterNotifications"]})
+        let activityCenterNotificationsTuple = parseActivityCenterNotifications(notifications)
+        self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_RECEIVED,
+          ActivityCenterNotificationsArgs(activityCenterNotifications: activityCenterNotificationsTuple[1]))
+    except Exception as e:
+      startError = e.msg
+      error "error:", procName="startMessenger", errName = e.name, errDesription = startError
+    self.events.emit(SIGNAL_MESSENGER_STARTED, MessengerStartedArgs(error: startError))
 
   proc logout*(self: Service) =
     discard status_general.logout()


### PR DESCRIPTION
### What does the PR do

Iterates: https://github.com/status-im/status-app/issues/20228

The startMessenger backend call is a lengthy process, blocking the main thread for a few seconds. Moving it to async tasks gives the main thread the chance advance on the login work until the messenger starts successfully.

Perf improvement on my heavy account:

Before: 17 sec warm start-up
After: 14 sec warm start-up

- Added `onMessengerStarted` method to `AccessInterface` to handle messenger start errors.
- Implemented `onMessengerStarted` method in `Module` to emit error notifications.
- Introduced `SIGNAL_MESSENGER_STARTED` constant for signaling messenger start events.
- Created `asyncStartMessengerTask` to manage asynchronous messenger start operations.
- Updated `startMessenger` method in `Service` to utilize the new async task and handle responses.


### Affected areas


Messenger start-up
