### PR TITLE
perf: seed contacts with community members data

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -92,11 +92,19 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_CHAT_MEMBERS_ADDED) do(e: Args):
       let args = ChatMembersAddedArgs(e)
       if (args.chatId == self.chatId):
+        # The signal carries only IDs (no enriched ChatMembers). Touch the
+        # cache for each just-added member so the placeholder gets
+        # constructed
+        for memberId in args.ids:
+          discard self.contactService.getContactDetails(memberId)
         self.delegate.onChatMembersAdded(args.ids)
 
     self.events.on(SIGNAL_CHAT_MEMBERS_CHANGED) do(e: Args):
       var args = ChatMembersChangedArgs(e)
       if (args.chatId == self.chatId):
+        # Args carry status-go-enriched members — seed before delegating
+        # so `processChatMember` reads enriched data from the cache.
+        self.contactService.seedFromChatMembers(args.members)
         self.delegate.onMembersChanged(args.members)
 
     self.events.on(SIGNAL_CHAT_MEMBER_REMOVED) do(e: Args):

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -92,9 +92,10 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_CHAT_MEMBERS_ADDED) do(e: Args):
       let args = ChatMembersAddedArgs(e)
       if (args.chatId == self.chatId):
-        # The signal carries only IDs (no enriched ChatMembers). Touch the
-        # cache for each just-added member so the placeholder gets
-        # constructed
+        # TODO(status-go): enrich the addMembers response with alias/colorId/
+        # compressedKey/emojiHash like community/contacts payloads do, then
+        # drop this loop. Until then, falling back to per-id getContactDetails
+        # synthesizes the visual identity via 4 RPCs per new member.
         for memberId in args.ids:
           discard self.contactService.getContactDetails(memberId)
         self.delegate.onChatMembersAdded(args.ids)
@@ -104,7 +105,7 @@ proc init*(self: Controller) =
       if (args.chatId == self.chatId):
         # Args carry status-go-enriched members — seed before delegating
         # so `processChatMember` reads enriched data from the cache.
-        self.contactService.seedFromChatMembers(args.members)
+        self.contactService.seedFromChatMembers(args.members.toMemberSeeds())
         self.delegate.onMembersChanged(args.members)
 
     self.events.on(SIGNAL_CHAT_MEMBER_REMOVED) do(e: Args):

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -210,48 +210,53 @@ method addGroupMembers*(self: Module, pubKeys: seq[string]) =
 method removeGroupMembers*(self: Module, pubKeys: seq[string]) =
   self.controller.removeGroupMembers(pubKeys)
 
-method updateMembersList*(self: Module, membersToReset: seq[ChatMember] = @[]) =
-  let reset = membersToReset.len > 0
-  var members: seq[ChatMember]
-  if reset:
-    members = membersToReset
-  else:
-    if self.controller.belongsToCommunity():
-      let myCommunity = self.controller.getMyCommunity()
+proc resolveMembersForUpdate(self: Module, membersToReset: seq[ChatMember]):
+    tuple[members: seq[ChatMember], reset: bool, returnEarly: bool] =
+  result.reset = membersToReset.len > 0
+  if result.reset:
+    result.members = membersToReset
+    return
+  if self.controller.belongsToCommunity():
+    let myCommunity = self.controller.getMyCommunity()
 
-      if self.isSectionMemberList:
-        members = myCommunity.members
+    if self.isSectionMemberList:
+      result.members = myCommunity.members
+    else:
+      # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
+      # see log here: https://github.com/status-im/status-app/issues/14442#issuecomment-2120756598
+      # should be resolved in https://github.com/status-im/status-app/issues/11694
+      let myChatId = self.controller.getMyChatId()
+      let chat = myCommunity.getCommunityChat(myChatId)
+      if not chat.tokenGated:
+        # No need to get the members, this channel is not encrypted and can use the section member list
+        self.isPublicCommunityChannel = true
+        result.returnEarly = true
+        return
+      self.isPublicCommunityChannel = false
+      if chat.members.len > 0:
+        result.members = chat.members
       else:
-        # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
-        # see log here: https://github.com/status-im/status-app/issues/14442#issuecomment-2120756598
-        # should be resolved in https://github.com/status-im/status-app/issues/11694
-        let myChatId = self.controller.getMyChatId()
-        let chat = myCommunity.getCommunityChat(myChatId)
-        if not chat.tokenGated:
-          # No need to get the members, this channel is not encrypted and can use the section member list
-          self.isPublicCommunityChannel = true
+        if chat.missingEncryptionKey:
+          # We don't have the encryption keys, so we can't show the members
+          result.returnEarly = true
           return
-        self.isPublicCommunityChannel = false
-        if chat.members.len > 0:
-          members = chat.members
-        else:
-          if chat.missingEncryptionKey:
-            # We don't have the enryption keys, so we can't show the members
-            return
-          # The channel now has a permisison, but the re-eval wasn't performed yet. Show all members for now
-          members = myCommunity.members
+        # The channel now has a permission, but the re-eval wasn't performed yet. Show all members for now
+        result.members = myCommunity.members
+  if result.members.len == 0:
+    result.members = self.controller.getMyChat().members
 
-    if members.len == 0:
-      members = self.controller.getMyChat().members
+method updateMembersList*(self: Module, membersToReset: seq[ChatMember] = @[]) =
+  let resolved = self.resolveMembersForUpdate(membersToReset)
+  if resolved.returnEarly:
+    return
 
   var memberItems: seq[MemberItem] = @[]
-
-  for member in members:
-    let (doAdd, item) = self.processChatMember(member, reset)
+  for member in resolved.members:
+    let (doAdd, item) = self.processChatMember(member, resolved.reset)
     if doAdd:
       memberItems.add(item)
 
-  if reset:
+  if resolved.reset:
     self.view.model().setItems(memberItems)
   else:
     self.view.model().addItems(memberItems)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -539,7 +539,7 @@ proc getContactDetails*(self: Controller, id: string): ContactDetails =
   return self.contactService.getContactDetails(id)
 
 proc seedContactsFromChatMembers*(self: Controller, members: seq[ChatMember]) =
-  self.contactService.seedFromChatMembers(members)
+  self.contactService.seedFromChatMembers(members.toMemberSeeds())
 
 proc getStatusForContactWithId*(self: Controller, publicKey: string): StatusUpdateDto =
   return self.contactService.getStatusForContactWithId(publicKey)
@@ -703,7 +703,7 @@ proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communit
   return self.messageService.getMessagesParsedPlainText(message, communityChats)
 
 proc getColorId*(self: Controller, pubkey: string): int =
-  procs_from_visual_identity_service.colorIdOf(pubkey)
+  self.contactService.getContactColorId(pubkey)
 
 proc getTokenByKey*(self: Controller, tokenKey: string): TokenItem =
   return self.tokenService.getTokenByKey(tokenKey)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -538,6 +538,9 @@ proc getContactById*(self: Controller, id: string): ContactsDto =
 proc getContactDetails*(self: Controller, id: string): ContactDetails =
   return self.contactService.getContactDetails(id)
 
+proc seedContactsFromChatMembers*(self: Controller, members: seq[ChatMember]) =
+  self.contactService.seedFromChatMembers(members)
+
 proc getStatusForContactWithId*(self: Controller, publicKey: string): StatusUpdateDto =
   return self.contactService.getStatusForContactWithId(publicKey)
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -374,7 +374,7 @@ method onChatsLoaded*(
   self.chatsLoaded = true
 
   # Pre-populate the contacts cache with community members
-  contactService.seedFromChatMembers(community.members)
+  contactService.seedFromChatMembers(community.members.toMemberSeeds())
 
   self.buildChatSectionUI(community, chats, events, settingsService, nodeConfigurationService,
     contactService, chatService, communityService, messageService, mailserversService, sharedUrlsService)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -373,6 +373,9 @@ method onChatsLoaded*(
   ) =
   self.chatsLoaded = true
 
+  # Pre-populate the contacts cache with community members
+  contactService.seedFromChatMembers(community.members)
+
   self.buildChatSectionUI(community, chats, events, settingsService, nodeConfigurationService,
     contactService, chatService, communityService, messageService, mailserversService, sharedUrlsService)
 
@@ -423,6 +426,8 @@ method getSectionMemberList*(self: Module): QVariant =
   return self.membersListModule.getUsersListVariant()
 
 method updateCommunityMemberList*(self: Module, members: seq[ChatMember]) =
+  # Re-seed the contacts cache for late joiners.
+  self.controller.seedContactsFromChatMembers(members)
   self.membersListModule.updateMembersList(members)
 
 method viewDidLoad*(self: Module) =

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -579,7 +579,7 @@ proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
   return self.contactsService.getContactDetails(contactId)
 
 proc seedContactsFromChatMembers*(self: Controller, members: seq[ChatMember]) =
-  self.contactsService.seedFromChatMembers(members)
+  self.contactsService.seedFromChatMembers(members.toMemberSeeds())
 
 proc resolveENS*(self: Controller, ensName: string, uuid: string = "", reason: string = "") =
   self.contactsService.resolveENS(ensName, uuid, reason)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -578,6 +578,9 @@ proc getContactNameAndImage*(self: Controller, contactId: string):
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
   return self.contactsService.getContactDetails(contactId)
 
+proc seedContactsFromChatMembers*(self: Controller, members: seq[ChatMember]) =
+  self.contactsService.seedFromChatMembers(members)
+
 proc resolveENS*(self: Controller, ensName: string, uuid: string = "", reason: string = "") =
   self.contactsService.resolveENS(ensName, uuid, reason)
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2263,7 +2263,10 @@ method contactUpdated*[T](self: Module[T], contactId: string) =
   )
 
 proc getAllCommunityMemberItems[T](self: Module[T], community: CommunityDto): seq[MemberItem] =
-  # Add members who were kicked from the community after the ownership change for auto-rejoin after they share addresses
+  # Pre-populate the contacts cache with the community members
+  self.controller.seedContactsFromChatMembers(community.members)
+
+  # Add members who were kicked from the community after the ownership change for auto-rejoin after they share addresses.
   var members = community.members
   for requestForAutoRejoin in community.waitingForSharedAddressesRequestsToJoin:
     var chatMember = ChatMember()
@@ -2271,6 +2274,8 @@ proc getAllCommunityMemberItems[T](self: Module[T], community: CommunityDto): se
     chatMember.joined = false
     chatMember.role = MemberRole.None
     members.add(chatMember)
+    # Resolve contact
+    discard self.controller.getContactDetails(requestForAutoRejoin.publicKey)
 
   var bannedMembers = newSeq[MemberItem]()
   for memberId, memberState in community.pendingAndBannedMembers.pairs:

--- a/src/app/modules/shared_models/member_item.nim
+++ b/src/app/modules/shared_models/member_item.nim
@@ -37,6 +37,8 @@ proc initMemberItem*(
   requestToJoinLoading: bool = false,
   airdropAddress: string = "",
   membershipRequestState: MembershipRequestState = MembershipRequestState.None,
+  compressedPubKey: string = "",
+  emojiHash: string = "[]",
 ): MemberItem =
   result = MemberItem()
   result.memberRole = memberRole
@@ -61,6 +63,8 @@ proc initMemberItem*(
     isBlocked = isBlocked,
     contactRequest = contactRequest,
     trustStatus = trustStatus,
+    compressedPubKey = compressedPubKey,
+    emojiHash = emojiHash,
   )
 
 proc `$`*(self: MemberItem): string =

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -1,7 +1,6 @@
 import nimqml, tables, std/strformat, sequtils, sugar
 # TODO: use generics to remove duplication between user_model and member_model
 
-import app/global/global_singleton
 import ../../../app_service/common/types
 import ../../../app_service/service/contacts/dto/[contacts, contact_details]
 import member_item
@@ -41,6 +40,9 @@ QtObject:
   type
     Model* = ref object of QAbstractListModel
       items: seq[MemberItem]
+      # O(1) pubkey -> row index lookup for hasMember and the various per-pubkey
+      # update procs. Maintained by every mutation below.
+      pubKeyIndex: Table[string, int]
 
   proc delete(self: Model)
   proc setup(self: Model)
@@ -50,9 +52,15 @@ QtObject:
 
   proc countChanged(self: Model) {.signal.}
 
+  proc rebuildPubKeyIndex(self: Model) =
+    self.pubKeyIndex.clear()
+    for i, it in self.items:
+      self.pubKeyIndex[it.pubKey] = i
+
   proc setItems*(self: Model, items: seq[MemberItem]) =
     self.beginResetModel()
     self.items = items
+    self.rebuildPubKeyIndex()
     self.endResetModel()
     self.countChanged()
 
@@ -119,7 +127,7 @@ QtObject:
     of ModelRole.PubKey:
       result = newQVariant(item.pubKey)
     of ModelRole.CompressedPubKey:
-      result = newQVariant(compressPk(item.pubKey))
+      result = newQVariant(item.compressedPubKey)
     of ModelRole.IsCurrentUser:
       result = newQVariant(item.isCurrentUser)
     of ModelRole.DisplayName:
@@ -136,14 +144,10 @@ QtObject:
     of ModelRole.LocalNickname:
       result = newQVariant(item.localNickname)
     of ModelRole.Alias:
-      if item.alias == "":
-        item.alias = singletonInstance.utils.generateAlias(item.pubKey)
       result = newQVariant(item.alias)
     of ModelRole.Icon:
       result = newQVariant(item.icon)
     of ModelRole.ColorId:
-      if item.colorId == 0:
-        item.colorId = singletonInstance.utils.getColorId(item.pubKey)
       result = newQVariant(item.colorId)
     of ModelRole.OnlineStatus:
       result = newQVariant(item.onlineStatus.int)
@@ -178,16 +182,13 @@ QtObject:
     let modelIndex = newQModelIndex()
     defer: modelIndex.delete
     self.beginInsertRows(modelIndex, self.items.len, self.items.len)
+    self.pubKeyIndex[item.pubKey] = self.items.len
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
 
   proc findIndexForMember*(self: Model, pubKey: string): int =
-    for i in 0 ..< self.items.len:
-      if self.items[i].pubKey == pubKey:
-        return i
-
-    return -1
+    return self.pubKeyIndex.getOrDefault(pubKey, -1)
 
   proc getMemberItemByIndex*(self: Model, ind: int): MemberItem =
     if ind >= 0 and ind < self.items.len:
@@ -199,15 +200,21 @@ QtObject:
       return self.items[ind]
 
   proc hasMember*(self: Model, pubKey: string): bool {.slot.} =
-    let ind = self.findIndexForMember(pubKey)
-    return ind != -1
+    return self.pubKeyIndex.hasKey(pubKey)
+
 
   proc removeItemWithIndex(self: Model, index: int) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
+    let removedPubKey = self.items[index].pubKey
     self.beginRemoveRows(parentModelIndex, index, index)
     self.items.delete(index)
+    self.pubKeyIndex.del(removedPubKey)
+    # seq.delete shifts every later entry left by one — reflect that in the index.
+    for v in self.pubKeyIndex.mvalues:
+      if v > index:
+        dec v
     self.endRemoveRows()
     self.countChanged()
 
@@ -217,6 +224,7 @@ QtObject:
 
     self.beginResetModel()
     self.items = @[]
+    self.pubKeyIndex.clear()
     self.endResetModel()
     self.countChanged()
 
@@ -239,6 +247,8 @@ QtObject:
     let last = first + items.len - 1
 
     self.beginInsertRows(modelIndex, first, last)
+    for i, it in items:
+      self.pubKeyIndex[it.pubKey] = first + i
     self.items.add(items)
     self.endInsertRows()
     self.countChanged()
@@ -324,7 +334,10 @@ QtObject:
     updateRole(ensName, EnsName)
     updateRole(localNickname, LocalNickname)
     updateRole(isEnsVerified, IsEnsVerified)
-    updateRole(alias, Alias)
+    # `alias` is deterministic from the pubkey — preserve any previously
+    # resolved value when the incoming alias is empty (typical for
+    # `getContactDetails` placeholders that haven't been enriched yet).
+    updateRolePreserveOnEmpty(alias, Alias)
     updateRole(icon, Icon)
     updateRole(isContact, IsContact)
     updateRole(memberRole, MemberRole)
@@ -541,14 +554,9 @@ QtObject:
       ModelRole.MembershipRequestState.int
     ])
 
-  proc getNewMembers*(self: Model, pubkeys: seq[string]): seq[string] = 
+  proc getNewMembers*(self: Model, pubkeys: seq[string]): seq[string] =
     for pubkey in pubkeys:
-      var found = false
-      for item in self.items:
-        if item.pubKey == pubkey:
-          found = true
-          break
-      if not found:
+      if not self.pubKeyIndex.hasKey(pubkey):
         result.add(pubkey)
 
   proc createMemberItemFromDtos*(
@@ -585,6 +593,8 @@ QtObject:
       requestToJoinId = requestId,
       airdropAddress = airdropAddress,
       joined = joined,
+      compressedPubKey = contactDetails.dto.compressedPubKey,
+      emojiHash = contactDetails.dto.emojiHash,
     )
 
   proc delete(self: Model) =

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -240,16 +240,24 @@ QtObject:
     if items.len == 0:
       return
 
+    var newItems: seq[MemberItem] = @[]
+    let first = self.items.len
+    for it in items:
+      if self.pubKeyIndex.hasKey(it.pubKey):
+        continue
+      self.pubKeyIndex[it.pubKey] = first + newItems.len
+      newItems.add(it)
+
+    if newItems.len == 0:
+      return
+
     let modelIndex = newQModelIndex()
     defer: modelIndex.delete
 
-    let first = self.items.len
-    let last = first + items.len - 1
+    let last = first + newItems.len - 1
 
     self.beginInsertRows(modelIndex, first, last)
-    for i, it in items:
-      self.pubKeyIndex[it.pubKey] = first + i
-    self.items.add(items)
+    self.items.add(newItems)
     self.endInsertRows()
     self.countChanged()
 

--- a/src/app/modules/shared_models/model_utils.nim
+++ b/src/app/modules/shared_models/model_utils.nim
@@ -18,3 +18,12 @@ macro updateRoleWithValue*(propertyName: untyped, roleName: untyped, value: unty
     if self.items[ind].`propertyName` != `value`:
       self.items[ind].`propertyName` = `value`
       roles.add(ModelRole.`roleName`.int)
+
+# Like updateRole but skip the assignment when the incoming string value is
+# empty AND the existing value is non-empty. Use for fields that are
+# deterministic and cannot change once set
+macro updateRolePreserveOnEmpty*(propertyName: untyped, roleName: untyped): untyped =
+  quote do:
+    if `propertyName`.len > 0 and self.items[ind].`propertyName` != `propertyName`:
+      self.items[ind].`propertyName` = `propertyName`
+      roles.add(ModelRole.`roleName`.int)

--- a/src/app/modules/shared_models/user_item.nim
+++ b/src/app/modules/shared_models/user_item.nim
@@ -24,6 +24,7 @@ proc toContactStatus*(value: ContactRequestState): ContactRequest =
 type
   UserItem* = ref object of RootObj
     pubKey: string
+    compressedPubKey: string
     emojiHash: string
     displayName: string
     usesDefaultName: bool
@@ -64,6 +65,8 @@ proc setup*(self: UserItem,
   isBlocked: bool,
   contactRequest: ContactRequest,
   #TODO: #14964 - remove defaults
+  compressedPubKey: string = "",
+  emojiHash: string = "[]",
   isCurrentUser: bool = false,
   lastUpdated: int64 = 0,
   lastUpdatedLocally: int64 = 0,
@@ -98,12 +101,8 @@ proc setup*(self: UserItem,
   self.isContactRequestSent = isContactRequestSent
   self.isRemoved = isRemoved
   self.trustStatus = trustStatus
-
-  # Setup emojiHash:
-  if pubKey == "" or not singletonInstance.utils.isChatKey(pubKey):
-    self.emojiHash = ""
-  else:
-    self.emojiHash = singletonInstance.utils.getEmojiHashAsJson(pubKey)
+  self.compressedPubKey = compressedPubKey
+  self.emojiHash = emojiHash
 
 # FIXME: remove defaults
 # TODO: #14964
@@ -121,6 +120,8 @@ proc initUserItem*(
     isContact: bool,
     isBlocked: bool,
     contactRequest: ContactRequest = ContactRequest.None,
+    compressedPubKey: string = "",
+    emojiHash: string = "[]",
     isCurrentUser: bool = false,
     lastUpdated: int64 = 0,
     lastUpdatedLocally: int64 = 0,
@@ -147,6 +148,8 @@ proc initUserItem*(
     isContact = isContact,
     isBlocked = isBlocked,
     contactRequest = contactRequest,
+    compressedPubKey = compressedPubKey,
+    emojiHash = emojiHash,
     isCurrentUser = isCurrentUser,
     lastUpdated = lastUpdated,
     lastUpdatedLocally = lastUpdatedLocally,
@@ -195,6 +198,12 @@ proc emojiHash*(self: UserItem): string {.inline.} =
 
 proc `emojiHash=`*(self: UserItem, value: string) {.inline.} =
   self.emojiHash = value
+
+proc compressedPubKey*(self: UserItem): string {.inline.} =
+  self.compressedPubKey
+
+proc `compressedPubKey=`*(self: UserItem, value: string) {.inline.} =
+  self.compressedPubKey = value
 
 proc displayName*(self: UserItem): string {.inline.} =
   self.displayName

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -2,7 +2,6 @@ import nimqml, tables, std/strformat, sequtils, sugar
 import user_item
 
 import ../../../app_service/common/types
-import ../../../app_service/service/accounts/utils
 import ../../../app_service/service/contacts/dto/[contacts, contact_details]
 import contacts_utils
 import model_utils
@@ -42,6 +41,10 @@ QtObject:
   type
     Model* = ref object of QAbstractListModel
       items: seq[UserItem]
+      # O(1) pubkey -> row index lookup. Maintained by every mutation
+      # (setItems / addItem / addItems / removeItemWithIndex / clear).
+      # Mirrors `member_model.nim`'s pubKeyIndex.
+      pubKeyIndex: Table[string, int]
 
   # Forward declarations for ORC
   proc delete(self: Model)
@@ -59,9 +62,15 @@ QtObject:
 
   proc countChanged(self: Model) {.signal.}
 
+  proc rebuildPubKeyIndex(self: Model) =
+    self.pubKeyIndex.clear()
+    for i, it in self.items:
+      self.pubKeyIndex[it.pubKey] = i
+
   proc setItems*(self: Model, items: seq[UserItem]) =
     self.beginResetModel()
     self.items = items
+    self.rebuildPubKeyIndex()
     self.endResetModel()
     self.countChanged()
 
@@ -126,7 +135,7 @@ QtObject:
     of ModelRole.PubKey:
       result = newQVariant(item.pubKey)
     of ModelRole.CompressedPubKey:
-      result = newQVariant(utils.compressPk(item.pubKey))
+      result = newQVariant(item.compressedPubKey)
     of ModelRole.DisplayName:
       result = newQVariant(item.displayName)
     of ModelRole.PreferredDisplayName:
@@ -194,27 +203,21 @@ QtObject:
     let first = self.items.len
     let last = first + items.len - 1
     self.beginInsertRows(parentModelIndex, first, last)
+    for i, it in items:
+      self.pubKeyIndex[it.pubKey] = first + i
     self.items.add(items)
     self.endInsertRows()
     self.countChanged()
 
   proc findIndexByPubKey*(self: Model, pubKey: string): int =
-    for i in 0 ..< self.items.len:
-      if self.items[i].pubKey == pubKey:
-        return i
-
-    return -1
+    return self.pubKeyIndex.getOrDefault(pubKey, -1)
 
   proc hasUser*(self: Model, pubKey: string): bool {.slot.} =
-    for i in 0 ..< self.items.len:
-      if self.items[i].pubKey == pubKey:
-        return true
+    return self.pubKeyIndex.hasKey(pubKey)
 
-    return false
 
   proc addItem*(self: Model, item: UserItem) =
-    let ind = self.findIndexByPubKey(item.pubKey)
-    if ind != -1:
+    if self.pubKeyIndex.hasKey(item.pubKey):
       return
 
     let position = self.items.len
@@ -223,6 +226,7 @@ QtObject:
     defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, position, position)
+    self.pubKeyIndex[item.pubKey] = position
     self.items.insert(item, position)
     self.endInsertRows()
     self.countChanged()
@@ -230,20 +234,25 @@ QtObject:
   proc clear*(self: Model) =
      self.beginResetModel()
      self.items = @[]
+     self.pubKeyIndex.clear()
      self.endResetModel()
 
   proc getItemByPubKey*(self: Model, pubKey: string): UserItem =
-    for item in self.items:
-      if item.pubKey == pubKey:
-        return item
+    let ind = self.pubKeyIndex.getOrDefault(pubKey, -1)
+    if ind != -1:
+      return self.items[ind]
 
   proc removeItemWithIndex(self: Model, index: int) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
+    let removedPubKey = self.items[index].pubKey
     self.beginRemoveRows(parentModelIndex, index, index)
-    let pubKey = self.items[index].pubKey
     self.items.delete(index)
+    self.pubKeyIndex.del(removedPubKey)
+    for v in self.pubKeyIndex.mvalues:
+      if v > index:
+        dec v
     self.endRemoveRows()
     self.countChanged()
 
@@ -326,7 +335,8 @@ QtObject:
     updateRole(displayName, DisplayName)
     updateRole(ensName, EnsName)
     updateRole(localNickname, LocalNickname)
-    updateRole(alias, Alias)
+    # `alias` is deterministic from the pubkey — preserve if set
+    updateRolePreserveOnEmpty(alias, Alias)
     updateRole(icon, Icon)
     updateRole(trustStatus, TrustStatus)
     updateRole(onlineStatus, OnlineStatus)
@@ -459,6 +469,8 @@ QtObject:
       isBlocked = contactDetails.dto.isBlocked(),
       isCurrentUser = contactDetails.isCurrentUser,
       contactRequest = toContactStatus(contactRequest),
+      compressedPubKey = contactDetails.dto.compressedPubKey,
+      emojiHash = contactDetails.dto.emojiHash,
       lastUpdated = contactDetails.dto.lastUpdated,
       lastUpdatedLocally = contactDetails.dto.lastUpdatedLocally,
       bio = contactDetails.dto.bio,

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -197,15 +197,23 @@ QtObject:
     if(items.len == 0):
       return
 
+    var newItems: seq[UserItem] = @[]
+    let first = self.items.len
+    for it in items:
+      if self.pubKeyIndex.hasKey(it.pubKey):
+        continue
+      self.pubKeyIndex[it.pubKey] = first + newItems.len
+      newItems.add(it)
+
+    if newItems.len == 0:
+      return
+
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
-    let first = self.items.len
-    let last = first + items.len - 1
+    let last = first + newItems.len - 1
     self.beginInsertRows(parentModelIndex, first, last)
-    for i, it in items:
-      self.pubKeyIndex[it.pubKey] = first + i
-    self.items.add(items)
+    self.items.add(newItems)
     self.endInsertRows()
     self.countChanged()
 

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -116,3 +116,13 @@ type
 
   MessengerStartedArgs* = ref object of Args
     error*: string
+
+  # Minimal projection of a ChatMember used to seed the contacts cache with
+  # status-go-enriched visual identity. Lives here so the contacts service does
+  # not have to import chat/dto.
+  MemberSeed* = object
+    id*: string
+    alias*: string
+    colorId*: int
+    compressedPubKey*: string
+    emojiHash*: string

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, std/strformat, strutils, tables, marshal
+import json, std/strformat, strutils, tables
 import ../../shared_urls/dto/url_data
 import app_service/service/message/dto/message
 
@@ -240,10 +240,7 @@ proc toChannelMember*(jsonObj: JsonNode, memberId: string): ChatMember =
   result.emojiHash = "[]"
   var emojiHashNode: JsonNode
   if jsonObj.getProp("emojiHash", emojiHashNode) and emojiHashNode.kind == JArray:
-    var parts: seq[string] = @[]
-    for e in emojiHashNode:
-      parts.add(e.getStr)
-    result.emojiHash = $$ parts
+    result.emojiHash = $emojiHashNode
 
   result.role = MemberRole.None
   if roles.contains(MemberRole.Owner.int):
@@ -256,6 +253,20 @@ proc toChannelMember*(jsonObj: JsonNode, memberId: string): ChatMember =
     result.role = MemberRole.ModerateContent
   elif roles.contains(MemberRole.TokenMaster.int):
     result.role = MemberRole.TokenMaster
+
+proc toMemberSeed*(m: ChatMember): MemberSeed =
+  MemberSeed(
+    id: m.id,
+    alias: m.alias,
+    colorId: m.colorId,
+    compressedPubKey: m.compressedPubKey,
+    emojiHash: m.emojiHash,
+  )
+
+proc toMemberSeeds*(members: seq[ChatMember]): seq[MemberSeed] =
+  result = newSeqOfCap[MemberSeed](members.len)
+  for m in members:
+    result.add(m.toMemberSeed)
 
 proc toChatDto*(jsonObj: JsonNode): ChatDto =
   result = ChatDto()

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, std/strformat, strutils, tables
+import json, std/strformat, strutils, tables, marshal
 import ../../shared_urls/dto/url_data
 import app_service/service/message/dto/message
 
@@ -41,6 +41,14 @@ type ChatMember* = object
   id*: string
   joined*: bool
   role*: MemberRole
+  # Visual identity baked into the member entry by status-go's
+  # Community.MarshalJSON enrichment (see `EnrichedCommunityMember`). The
+  # desktop side reads these directly onto MemberItem/UserItem at
+  # construction time — no separate cache, no per-pubkey RPC fan-out.
+  alias*: string
+  colorId*: int
+  compressedPubKey*: string
+  emojiHash*: string
 
 type CheckPermissionsResultDto* = object
   criteria*: seq[bool]
@@ -225,6 +233,17 @@ proc toChannelMember*(jsonObj: JsonNode, memberId: string): ChatMember =
 
   # People in the community members' list are joined by default
   result.joined = true
+
+  discard jsonObj.getProp("alias", result.alias)
+  discard jsonObj.getProp("colorId", result.colorId)
+  discard jsonObj.getProp("compressedKey", result.compressedPubKey)
+  result.emojiHash = "[]"
+  var emojiHashNode: JsonNode
+  if jsonObj.getProp("emojiHash", emojiHashNode) and emojiHashNode.kind == JArray:
+    var parts: seq[string] = @[]
+    for e in emojiHashNode:
+      parts.add(e.getStr)
+    result.emojiHash = $$ parts
 
   result.role = MemberRole.None
   if roles.contains(MemberRole.Owner.int):

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, std/strformat, strutils, marshal
+import json, std/strformat, strutils
 
 include ../../../common/json_utils
 include ../../../common/utils
@@ -140,10 +140,7 @@ proc toContactsDto*(jsonObj: JsonNode): ContactsDto =
   result.emojiHash = "[]"
   var emojiHashNode: JsonNode
   if jsonObj.getProp("emojiHash", emojiHashNode) and emojiHashNode.kind == JArray:
-    var parts: seq[string] = @[]
-    for e in emojiHashNode:
-      parts.add(e.getStr)
-    result.emojiHash = $$ parts
+    result.emojiHash = $emojiHashNode
 
 proc userExtractedName(contact: ContactsDto): string =
   if(contact.name.len > 0 and contact.ensVerified):

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import json, std/strformat, strutils
+import json, std/strformat, strutils, marshal
 
 include ../../../common/json_utils
 include ../../../common/utils
@@ -34,6 +34,9 @@ type ContactsDto* = object
   removed*: bool
   trustStatus*: TrustStatus
   contactRequestState*: ContactRequestState
+  colorId*: int
+  compressedPubKey*: string
+  emojiHash*: string
 
 proc `$`(self: Images): string =
   result = fmt"""Images(
@@ -60,6 +63,9 @@ proc `$`*(self: ContactsDto): string =
     removed:{self.removed},
     trustStatus:{self.trustStatus},
     contactRequestState:{self.contactRequestState},
+    colorId:{self.colorId},
+    compressedPubKey:{self.compressedPubKey},
+    emojiHash:{self.emojiHash}
     )"""
 
 proc toImages*(jsonObj: JsonNode): Images =
@@ -127,6 +133,17 @@ proc toContactsDto*(jsonObj: JsonNode): ContactsDto =
   discard jsonObj.getProp("blocked", result.blocked)
   discard jsonObj.getProp("hasAddedUs", result.hasAddedUs)
   discard jsonObj.getProp("Removed", result.removed)
+
+  discard jsonObj.getProp("colorId", result.colorId)
+  discard jsonObj.getProp("compressedKey", result.compressedPubKey)
+
+  result.emojiHash = "[]"
+  var emojiHashNode: JsonNode
+  if jsonObj.getProp("emojiHash", emojiHashNode) and emojiHashNode.kind == JArray:
+    var parts: seq[string] = @[]
+    for e in emojiHashNode:
+      parts.add(e.getStr)
+    result.emojiHash = $$ parts
 
 proc userExtractedName(contact: ContactsDto): string =
   if(contact.name.len > 0 and contact.ensVerified):

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -13,6 +13,7 @@ import ../settings/service as settings_service
 import ../network/service as network_service
 import ../message/dto/message as message_dto
 import ../visual_identity/service as procs_from_visual_identity_service
+from ../chat/dto/chat import ChatMember
 
 import ./dto/contacts as contacts_dto
 import ./dto/status_update as status_update_dto
@@ -136,6 +137,49 @@ QtObject:
     # Private proc, used for adding contacts only.
     self.contacts[contact.dto.id] = contact
     self.contactsStatus[contact.dto.id] = StatusUpdateDto(publicKey: contact.dto.id, statusType: StatusType.Unknown)
+
+  proc seedFromChatMembers*(self: Service, members: seq[ChatMember]) =
+    for member in members:
+      if member.id.len == 0:
+        continue
+      if self.contacts.hasKey(member.id):
+        var dto = self.contacts[member.id].dto
+        let isCurrentUser = self.contacts[member.id].isCurrentUser
+        var changed = false
+        if dto.alias.len == 0 and member.alias.len > 0:
+          dto.alias = member.alias
+          changed = true
+        if dto.colorId == 0 and member.colorId != 0:
+          dto.colorId = member.colorId
+          changed = true
+        if dto.compressedPubKey.len == 0 and member.compressedPubKey.len > 0:
+          dto.compressedPubKey = member.compressedPubKey
+          changed = true
+        if (dto.emojiHash.len == 0 or dto.emojiHash == "[]") and
+           member.emojiHash.len > 0 and member.emojiHash != "[]":
+          dto.emojiHash = member.emojiHash
+          changed = true
+        if changed:
+          # Rebuild ContactDetails so derived fields (defaultDisplayName,
+          # optionalName, colorId) reflect the fresh data
+          self.contacts[member.id] = self.constructContactDetails(dto, isCurrentUser)
+      elif member.id != singletonInstance.userProfile.getPubKey():
+        let placeholder = self.constructContactDetails(
+          ContactsDto(
+            id: member.id,
+            alias: member.alias,
+            ensVerified: false,
+            added: false,
+            blocked: false,
+            hasAddedUs: false,
+            trustStatus: TrustStatus.Unknown,
+            compressedPubKey: member.compressedPubKey,
+            colorId: member.colorId,
+            emojiHash: if member.emojiHash.len > 0: member.emojiHash else: "[]",
+          ),
+          isCurrentUser = false,
+        )
+        self.addContact(placeholder)
 
   proc fetchContacts*(self: Service) =
     let arg = AsyncFetchContactsTaskArg(
@@ -296,7 +340,7 @@ QtObject:
     result.defaultDisplayName = name
     result.optionalName = optionalName
     result.icon = icon
-    result.colorId = procs_from_visual_identity_service.colorIdOf(contactDto.id)
+    result.colorId = contactDto.colorId
     result.isCurrentUser = isCurrentUser
     result.dto = contactDto
 
@@ -309,16 +353,15 @@ QtObject:
     if len(pubkey) == 0:
       return
 
-    ## Returns contact details based on passed id (public key)
-    ## If we don't have stored contact localy or in the db then we create it based on public key.
     if self.contacts.hasKey(pubkey):
       return self.contacts[pubkey]
 
     if pubkey == singletonInstance.userProfile.getPubKey():
-      # If we try to get the contact details of ourselves, just return our own info
+      # If we try to get the contact details of ourselves, just return our own info.
+      let myPubKey = singletonInstance.userProfile.getPubKey()
       return self.constructContactDetails(
         ContactsDto(
-          id: singletonInstance.userProfile.getPubKey(),
+          id: myPubKey,
           displayName: singletonInstance.userProfile.getDisplayName(),
           name: singletonInstance.userProfile.getPreferredName(),
           alias: singletonInstance.userProfile.getUsername(),
@@ -330,6 +373,9 @@ QtObject:
           ),
           trustStatus: TrustStatus.Trusted,
           bio: self.settingsService.getBio(),
+          colorId: procs_from_visual_identity_service.colorIdOf(myPubKey),
+          compressedPubKey: status_accounts.compressPk(myPubKey).result,
+          emojiHash: procs_from_visual_identity_service.getEmojiHashAsJson(myPubKey),
         ),
         isCurrentUser = true,
       )
@@ -353,6 +399,9 @@ QtObject:
         blocked: false,
         hasAddedUs: false,
         trustStatus: TrustStatus.Unknown,
+        compressedPubKey: status_accounts.compressPk(pubkey).result,
+        colorId: procs_from_visual_identity_service.colorIdOf(pubkey),
+        emojiHash: procs_from_visual_identity_service.getEmojiHashAsJson(pubkey),
       ),
       isCurrentUser = false,
     )
@@ -384,11 +433,29 @@ QtObject:
     let tempRes = self.getContactNameAndImageInternal(contactDto)
     return (tempRes.name, tempRes.image, tempRes.largeImage)
 
+  proc preserveCachedEnrichment(self: Service, contact: ContactsDto): ContactsDto =
+    ## Defense-in-depth: an incoming wire ContactsDto can in principle have
+    ## empty visual-identity fields. Merge only empty fields
+    result = contact
+    if not self.contacts.hasKey(contact.id):
+      return
+    let cached = self.contacts[contact.id].dto
+    if result.alias.len == 0:
+      result.alias = cached.alias
+    if result.colorId == 0:
+      result.colorId = cached.colorId
+    if result.compressedPubKey.len == 0:
+      result.compressedPubKey = cached.compressedPubKey
+    if result.emojiHash.len == 0 or result.emojiHash == "[]":
+      if cached.emojiHash.len > 0 and cached.emojiHash != "[]":
+        result.emojiHash = cached.emojiHash
+
   proc saveContact(self: Service, contact: ContactsDto) =
     # we must keep local contacts updated
-    self.contacts[contact.id] = self.constructContactDetails(
-      contact,
-      isCurrentUser = contact.id == singletonInstance.userProfile.getPubKey()
+    let merged = self.preserveCachedEnrichment(contact)
+    self.contacts[merged.id] = self.constructContactDetails(
+      merged,
+      isCurrentUser = merged.id == singletonInstance.userProfile.getPubKey()
     )
 
   # fromBackup is used to indicate that the contact was loaded from a backup
@@ -401,9 +468,10 @@ QtObject:
       if contact.removed and not self.contacts[publicKey].dto.removed:
         singletonInstance.globalEvents.showContactRemoved("Contact removed", fmt "You removed {contact.displayName} as a contact", contact.id)
         signal = SIGNAL_CONTACT_REMOVED
+    let merged = self.preserveCachedEnrichment(contact)
     self.contacts[publicKey] = self.constructContactDetails(
-      contact,
-      isCurrentUser = contact.id == singletonInstance.userProfile.getPubKey()
+      merged,
+      isCurrentUser = merged.id == singletonInstance.userProfile.getPubKey()
     )
     self.events.emit(signal, ContactArgs(contactId: publicKey, fromBackup: fromBackup))
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -13,7 +13,6 @@ import ../settings/service as settings_service
 import ../network/service as network_service
 import ../message/dto/message as message_dto
 import ../visual_identity/service as procs_from_visual_identity_service
-from ../chat/dto/chat import ChatMember
 
 import ./dto/contacts as contacts_dto
 import ./dto/status_update as status_update_dto
@@ -138,7 +137,7 @@ QtObject:
     self.contacts[contact.dto.id] = contact
     self.contactsStatus[contact.dto.id] = StatusUpdateDto(publicKey: contact.dto.id, statusType: StatusType.Unknown)
 
-  proc seedFromChatMembers*(self: Service, members: seq[ChatMember]) =
+  proc seedFromChatMembers*(self: Service, members: seq[MemberSeed]) =
     for member in members:
       if member.id.len == 0:
         continue
@@ -164,18 +163,28 @@ QtObject:
           # optionalName, colorId) reflect the fresh data
           self.contacts[member.id] = self.constructContactDetails(dto, isCurrentUser)
       elif member.id != singletonInstance.userProfile.getPubKey():
+        let alias =
+          if member.alias.len > 0: member.alias
+          else: status_accounts.generateAlias(member.id).result.getStr
+        let colorId = member.colorId
+        let compressedPubKey =
+          if member.compressedPubKey.len > 0: member.compressedPubKey
+          else: status_accounts.compressPk(member.id).result
+        let emojiHash =
+          if member.emojiHash.len > 0 and member.emojiHash != "[]": member.emojiHash
+          else: procs_from_visual_identity_service.getEmojiHashAsJson(member.id)
         let placeholder = self.constructContactDetails(
           ContactsDto(
             id: member.id,
-            alias: member.alias,
+            alias: alias,
             ensVerified: false,
             added: false,
             blocked: false,
             hasAddedUs: false,
             trustStatus: TrustStatus.Unknown,
-            compressedPubKey: member.compressedPubKey,
-            colorId: member.colorId,
-            emojiHash: if member.emojiHash.len > 0: member.emojiHash else: "[]",
+            compressedPubKey: compressedPubKey,
+            colorId: colorId,
+            emojiHash: emojiHash,
           ),
           isCurrentUser = false,
         )
@@ -410,6 +419,20 @@ QtObject:
 
   proc getContactById*(self: Service, id: string): ContactsDto =
     return self.getContactDetails(id).dto
+
+  proc getContactColorId*(self: Service, id: string): int =
+    var pubkey = id
+
+    if service_conversion.isCompressedPubKey(id):
+      pubkey = status_accounts.decompressPk(id).result
+
+    if len(pubkey) == 0:
+      return 0
+
+    if self.contacts.hasKey(pubkey):
+      return self.contacts[pubkey].colorId
+
+    return procs_from_visual_identity_service.colorIdOf(pubkey)
 
   proc getStatusForContactWithId*(self: Service, publicKey: string): StatusUpdateDto =
     if publicKey == singletonInstance.userProfile.getPubKey():

--- a/src/app_service/service/visual_identity/service.nim
+++ b/src/app_service/service/visual_identity/service.nim
@@ -8,28 +8,20 @@ export dto
 proc emojiHashOf*(pubkey: string): EmojiHashDto =
   try:
     let response = status_visual_identity.emojiHashOf(pubkey)
-
-    if(not response.error.isNil):
+    if not response.error.isNil:
       error "error emojiHashOf: ", errDescription = response.error.message
-
     result = toEmojiHashDto(response.result)
-
   except Exception as e:
-    error "error: ", procName = "emojiHashOf", errName = e.name,
-        errDesription = e.msg
+    error "error: ", procName = "emojiHashOf", errName = e.name, errDesription = e.msg
 
 proc colorIdOf*(pubkey: string): int =
   try:
     let response = status_visual_identity.colorIdOf(pubkey)
-
-    if(not response.error.isNil):
+    if not response.error.isNil:
       error "error colorIdOf: ", errDescription = response.error.message
-
     result = toColorId(response.result)
-
   except Exception as e:
-    error "error: ", procName = "colorIdOf", errName = e.name,
-        errDesription = e.msg
+    error "error: ", procName = "colorIdOf", errName = e.name, errDesription = e.msg
 
 proc getEmojiHashAsJson*(publicKey: string): string =
-  return $$emojiHashOf(publicKey)
+  return $$ emojiHashOf(publicKey)

--- a/test/nim/member_model_test.nim
+++ b/test/nim/member_model_test.nim
@@ -129,3 +129,45 @@ suite "updating member items":
     check(itemD.displayName == "amanda")
     let itemE = model.getMemberItem("0xe")
     check(itemE.displayName == "gina")
+
+suite "pubKeyIndex invariants":
+  test "addItems drops duplicates against existing rows":
+    let model = newModel()
+    model.addItems(@[memberA, memberB])
+    # memberA is already in the model; memberC is new
+    model.addItems(@[memberA, memberC])
+    check(model.rowCount == 3)
+    check(model.findIndexForMember("0xa") == 0)
+    check(model.findIndexForMember("0xb") == 1)
+    check(model.findIndexForMember("0xc") == 2)
+
+  test "addItems drops duplicates within the same batch":
+    let model = newModel()
+    model.addItems(@[memberA, memberA, memberB])
+    check(model.rowCount == 2)
+    check(model.findIndexForMember("0xa") == 0)
+    check(model.findIndexForMember("0xb") == 1)
+
+  test "removeItemById shifts pubKeyIndex of later rows":
+    let model = newModel()
+    model.addItems(@[memberA, memberB, memberC, memberD])
+    model.removeItemById("0xb")
+    check(model.rowCount == 3)
+    check(model.findIndexForMember("0xa") == 0)
+    check(model.findIndexForMember("0xb") == -1)
+    check(model.findIndexForMember("0xc") == 1)
+    check(model.findIndexForMember("0xd") == 2)
+    # The shifted index must point at the right item
+    check(model.getMemberItemByIndex(1).pubKey == "0xc")
+    check(model.getMemberItemByIndex(2).pubKey == "0xd")
+
+  test "updateToTheseItems with empty seq clears pubKeyIndex":
+    let model = newModel()
+    model.addItems(@[memberA, memberB])
+    model.updateToTheseItems(@[])
+    check(model.rowCount == 0)
+    check(model.findIndexForMember("0xa") == -1)
+    check(model.findIndexForMember("0xb") == -1)
+    # New inserts after a clear must start at row 0
+    model.addItems(@[memberC])
+    check(model.findIndexForMember("0xc") == 0)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -622,7 +622,7 @@ QtObject {
                 publicKey: d.activeChatId
                 contactsModel: root.contactsModel
                 onPopulateContactDetailsRequested: {
-                    root.populateContactDetails(d.activeChatId)
+                    root.populateContactDetailsRequested(d.activeChatId)
                 }
             }
         }


### PR DESCRIPTION
### What does the PR do

Iterates: https://github.com/status-im/status-app/issues/20228

Resolving community members creates a high frequency RPC flood at start-up when the app tries to eagerly resolve every community members. On Android, Status community adds around 2 sec in CPU time on warm start-up.

The solution implements an enriched community member type and contact type returned from status-go. The app will receive this extra data and seed the contacts cache (instead of creating the contacts cache using 4 separate RPCs for each member/contact).

### Affected areas

community members
mentions
members list
contact profile
add contact
app start-up

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Before
<img width="607" height="451" alt="Screenshot 2026-05-04 at 10 12 16" src="https://github.com/user-attachments/assets/00f77eb0-077c-4ab0-b935-89ca67888d04" />

After

<img width="446" height="266" alt="Screenshot 2026-05-04 at 16 26 36" src="https://github.com/user-attachments/assets/71c36c34-1cc3-40a0-b191-270111f2c05e" />

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

**Android**
Login, close the app and try a warm start-up. Make sure the Status community is loaded

**All platforms**
Message history shows contact info (alias, ens or names) - especially communities
Mentions are resolved
Members list has complete data (alias, ens or names) - especially communities
Contact have alias, ens or names
User profile view -> make sure the user data is complete for contacts and community members
Send contact request

### Risk 

Medium