### PR TITLE
feat(StatusTextField): provide a standard edit context menu

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -6,6 +6,7 @@ import StatusQ.Components
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Core.Utils
+import StatusQ.Popups
 
 TextField {
     id: root
@@ -35,4 +36,34 @@ TextField {
         if (noSelection && activeFocus)
             deselect()
     }
+
+    StatusMenu {
+        id: contextMenu
+
+        hideDisabledItems: false
+
+        StatusAction {
+            text: qsTr("Cut")
+            enabled: !noSelection
+            onTriggered: root.cut()
+        }
+        StatusAction {
+            text: qsTr("Copy")
+            enabled: !noSelection
+            onTriggered: root.copy()
+        }
+        StatusAction {
+            text: qsTr("Paste")
+            enabled: root.canPaste
+            onTriggered: root.paste()
+        }
+        StatusMenuSeparator {}
+        StatusAction {
+            text: qsTr("Select All")
+            enabled: !noSelection
+            onTriggered: root.selectAll()
+        }
+    }
+
+    ContextMenu.menu: Utils.isMobile ? null : contextMenu
 }


### PR DESCRIPTION
### What does the PR do

- allows to be styled properly using our Theme
- disabled on mobile (iOS/Android provide their own)

Fixes #20632
Iterates #20544

### Affected areas

StatusTextField

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2944" height="1800" alt="Snímek obrazovky z 2026-05-04 17-54-38" src="https://github.com/user-attachments/assets/4b8071aa-19c4-49f5-b726-971d9c4bd3fc" />

### Impact on end user

Smoother editing UX

### How to test

- invoke context menu on desktop/mobile (single line inputs deriving from TextField)

### Risk 

- low
