### PR TITLE
fix(Browser): open URLs in a new tab from Downloads view

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -98,6 +98,7 @@ StatusSectionLayout {
         readonly property Item currentWebView: webViewContext.currentWebView
         readonly property bool currentTabIncognito: currentWebView?.offTheRecord ?? false
         readonly property bool currentTabLoading: currentWebView?.loading ?? false
+        readonly property bool currentTabIsDownloads: webStackView.children[tabs.currentIndex]?.isDownloadView ?? false
 
         property real lastScrollPos: 0
         property bool scrolledUp: true
@@ -356,7 +357,10 @@ StatusSectionLayout {
                     root.bookmarksStore.deleteBookmark(url)
                 }
                 function onRequestLaunchInBrowser(url) {
-                    _internal.onRequestLaunchInBrowser(url)
+                    if (_internal.currentTabIsDownloads)
+                        root.openUrlInNewTab(url)
+                    else
+                        _internal.onRequestLaunchInBrowser(url)
                 }
                 function onRequestWalletMenu() {
                     dialogsContext.openWalletMenu(browserWalletMenu)
@@ -397,7 +401,7 @@ StatusSectionLayout {
                 currentTabIncognito: _internal.currentTabIncognito
                 currentTabIsBookmark: favoritesContext.currentTabIsBookmark
                 currentTabLoading: _internal.currentTabLoading
-                currentTabIsDownloads: webStackView.children[tabs.currentIndex]?.isDownloadView ?? false
+                currentTabIsDownloads: _internal.currentTabIsDownloads
                 browserDappsModel: browserDappsProvider.model
                 historyModel: _internal.currentWebView?.history?.items ?? null
             }
@@ -414,7 +418,7 @@ StatusSectionLayout {
                 currentTabIncognito: _internal.currentTabIncognito
                 currentTabIsBookmark: favoritesContext.currentTabIsBookmark
                 currentTabLoading: _internal.currentTabLoading
-                currentTabIsDownloads: webStackView.children[tabs.currentIndex]?.isDownloadView ?? false
+                currentTabIsDownloads: _internal.currentTabIsDownloads
                 browserDappsModel: browserDappsProvider.model
                 historyModel: _internal.currentWebView?.history?.items ?? null
             }
@@ -428,7 +432,7 @@ StatusSectionLayout {
             sourceComponent: FavoritesBar {
                 currentTabIncognito: _internal.currentTabIncognito
                 bookmarkModel: root.bookmarksStore.bookmarksModel
-                onSetAsCurrentWebUrl: url => webViewContext.setCurrentWebUrl(url)
+                onSetAsCurrentWebUrl: url => _internal.currentTabIsDownloads ? root.openUrlInNewTab(url) : webViewContext.setCurrentWebUrl(url)
                 onOpenInNewTab: url => root.openUrlInNewTab(url)
                 onAddBookmarkRequested: _internal.openFavoriteModal()
                 onFavMenuRequested: (parent, pos, url, name) => _internal.openFavoriteMenu(parent, pos, url, name)
@@ -460,7 +464,10 @@ StatusSectionLayout {
             onRequestReloadPage: webViewContext.reloadCurrent()
             onRequestStopLoadingPage: webViewContext.stopCurrent()
             onRequestLaunchInBrowser: url => {
-                                          _internal.onRequestLaunchInBrowser(url)
+                                          if (_internal.currentTabIsDownloads)
+                                              root.openUrlInNewTab(url)
+                                          else
+                                              _internal.onRequestLaunchInBrowser(url)
                                           deactivateAddressBar()
                                       }
             onRequestOpenDapp: url => _internal.onRequestOpenDapp(url)


### PR DESCRIPTION
### What does the PR do

- when activating a bookmark or entering URL while having the Downloads view active

Fixes #20685

### Affected areas

Browser

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="2698" height="1950" alt="image" src="https://github.com/user-attachments/assets/e7e48aae-6db8-44ea-a40a-6875b42a9b71" />

### Impact on end user

Fix opening favorites

### How to test

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
