### PR TITLE
feat: Migrate android binder from files to shared memory

### DIFF
--- a/mobile/android/qt6/aidl/app/status/mobile/ipc/IStatusGoService.aidl
+++ b/mobile/android/qt6/aidl/app/status/mobile/ipc/IStatusGoService.aidl
@@ -1,16 +1,18 @@
 package app.status.mobile.ipc;
 
 import app.status.mobile.ipc.IStatusGoSignalListener;
+import app.status.mobile.ipc.RpcResponse;
 
 interface IStatusGoService {
-    /** Generic call into status-go exports (method name is the C export name). */
-    String call(String method, String argsJson);
-
     /**
-     * Same as call(), but writes the response to a file in the service's cache dir
-     * and returns the absolute file path. This avoids Binder size limits for large JSON.
+     * Hybrid status-go RPC.
+     *
+     * Returns the response inline in the Binder reply Parcel when small enough, otherwise
+     * via an ashmem-backed SharedMemory region carried by the returned RpcResponse. The
+     * server picks the path based on response size; the client must release the
+     * RpcResponse via close() (try-with-resources).
      */
-    String callToFile(String method, String argsJson);
+    RpcResponse rpcCall(String method, String argsJson);
 
     /** Register a signal listener. */
     void registerSignalListener(IStatusGoSignalListener listener);
@@ -26,4 +28,3 @@ interface IStatusGoService {
      */
     void setUiVisible(boolean visible);
 }
-

--- a/mobile/android/qt6/aidl/app/status/mobile/ipc/RpcResponse.aidl
+++ b/mobile/android/qt6/aidl/app/status/mobile/ipc/RpcResponse.aidl
@@ -1,0 +1,5 @@
+package app.status.mobile.ipc;
+
+// Hybrid carrier for status-go RPC responses: inline UTF-8 bytes for small payloads,
+// SharedMemory fd for large ones. Layout and ownership rules in RpcResponse.java.
+parcelable RpcResponse;

--- a/mobile/android/qt6/src/app/status/mobile/ipc/RpcResponse.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/RpcResponse.java
@@ -1,0 +1,122 @@
+package app.status.mobile.ipc;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.os.SharedMemory;
+import android.system.ErrnoException;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Hybrid status-go RPC response carrier.
+ *
+ * Carries exactly one of: an inline UTF-8 byte payload (small responses, returned directly
+ * in the Binder reply Parcel) or a SharedMemory region (large responses, transferred
+ * zero-copy via an ashmem fd). UTF-8 bytes are used for the inline tag so wire-size and
+ * threshold semantics are unit-consistent with the SharedMemory path.
+ *
+ * Server-side ownership: once an RpcResponse holding a SharedMemory is returned to the
+ * Binder framework, writeToParcel is invoked with PARCELABLE_WRITE_RETURN_VALUE; SharedMemory
+ * itself releases its local fd at that point and the Parcel takes ownership for delivery.
+ *
+ * Client-side ownership: callers must use try-with-resources (or otherwise call close())
+ * to release the mapped buffer and the SharedMemory fd. close() is idempotent.
+ */
+public final class RpcResponse implements Parcelable, AutoCloseable {
+    private static final byte TAG_INLINE = 0;
+    private static final byte TAG_SHARED = 1;
+
+    private final byte[] inlineUtf8;
+    private SharedMemory shm;
+    private ByteBuffer mappedBuffer;
+    private String cachedJson;
+
+    private RpcResponse(byte[] inlineUtf8, SharedMemory shm) {
+        this.inlineUtf8 = inlineUtf8;
+        this.shm = shm;
+    }
+
+    public static RpcResponse inline(byte[] utf8) {
+        return new RpcResponse(utf8, null);
+    }
+
+    public static RpcResponse shared(SharedMemory shm) {
+        return new RpcResponse(null, shm);
+    }
+
+    /**
+     * Decodes the JSON payload, mapping the SharedMemory on first call and caching the
+     * resulting String. Subsequent calls return the cache without re-mapping, so callers
+     * may invoke readJson() more than once without leaking ashmem mappings.
+     */
+    public String readJson() throws ErrnoException {
+        if (cachedJson != null) return cachedJson;
+        if (inlineUtf8 != null) {
+            cachedJson = new String(inlineUtf8, StandardCharsets.UTF_8);
+            return cachedJson;
+        }
+        if (shm == null) {
+            cachedJson = "";
+            return cachedJson;
+        }
+        ByteBuffer buf = shm.mapReadOnly();
+        mappedBuffer = buf;
+        cachedJson = StandardCharsets.UTF_8.decode(buf).toString();
+        return cachedJson;
+    }
+
+    @Override
+    public void close() {
+        if (mappedBuffer != null) {
+            try {
+                SharedMemory.unmap(mappedBuffer);
+            } catch (Throwable ignored) {
+                // unmap can throw IllegalArgumentException for foreign buffers; we tolerate.
+            }
+            mappedBuffer = null;
+        }
+        if (shm != null) {
+            shm.close();
+            shm = null;
+        }
+    }
+
+    @Override
+    public int describeContents() {
+        return shm != null ? CONTENTS_FILE_DESCRIPTOR : 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        if (inlineUtf8 != null) {
+            dest.writeByte(TAG_INLINE);
+            dest.writeByteArray(inlineUtf8);
+            return;
+        }
+        dest.writeByte(TAG_SHARED);
+        // SharedMemory.writeToParcel honors PARCELABLE_WRITE_RETURN_VALUE: when set (the
+        // standard case for AIDL return values), it transfers fd ownership to the Parcel
+        // and releases the local SharedMemory's fd, so no explicit close is needed here.
+        // SharedMemory.getSize() is the authoritative payload size on the receiving end.
+        shm.writeToParcel(dest, flags);
+    }
+
+    public static final Parcelable.Creator<RpcResponse> CREATOR =
+            new Parcelable.Creator<RpcResponse>() {
+                @Override
+                public RpcResponse createFromParcel(Parcel in) {
+                    final byte tag = in.readByte();
+                    if (tag == TAG_INLINE) {
+                        return inline(in.createByteArray());
+                    }
+                    final SharedMemory shm = SharedMemory.CREATOR.createFromParcel(in);
+                    return shared(shm);
+                }
+
+                @Override
+                public RpcResponse[] newArray(int size) {
+                    return new RpcResponse[size];
+                }
+            };
+}

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoService.java
@@ -10,12 +10,13 @@ import android.os.Build;
 import android.os.IBinder;
 import android.os.RemoteCallbackList;
 import android.os.RemoteException;
+import android.os.SharedMemory;
+import android.system.OsConstants;
 import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
-import java.io.File;
-import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -39,6 +40,14 @@ import im.status.mobileui.PushNotificationHelper;
  */
 public final class StatusGoService extends Service {
     private static final String TAG = "StatusGoService";
+
+    /**
+     * Responses shorter than this (in UTF-8 bytes) are returned inline in the Binder reply
+     * Parcel; larger responses are transferred via SharedMemory to stay under Android's
+     * per-process Binder transaction budget (~1 MB hard cap). Empirically ~97% of calls fit
+     * at 64 KB.
+     */
+    private static final int INLINE_THRESHOLD_BYTES = 64 * 1024;
 
     public static final String ACTION_START =
             BuildConfig.APPLICATION_ID + ".ipc.StatusGoService.START";
@@ -221,28 +230,36 @@ public final class StatusGoService extends Service {
 
     private final IStatusGoService.Stub binder = new IStatusGoService.Stub() {
         @Override
-        public String call(String method, String argsJson) {
-            enforceCallerIsSameApp();
-            String resp = nativeCall(method, argsJson);
-            maybeStopOnLogoutCall(method, resp);
-            return resp;
-        }
-
-        @Override
-        public String callToFile(String method, String argsJson) {
+        public RpcResponse rpcCall(String method, String argsJson) {
             enforceCallerIsSameApp();
             String resp = nativeCall(method, argsJson);
             if (resp == null) resp = "{\"error\":\"null response\"}";
             maybeStopOnLogoutCall(method, resp);
+
+            final byte[] bytes = resp.getBytes(StandardCharsets.UTF_8);
+            if (bytes.length < INLINE_THRESHOLD_BYTES) {
+                return RpcResponse.inline(bytes);
+            }
+
+            SharedMemory shm = null;
             try {
-                File f = File.createTempFile("statusgo_", ".json", getCacheDir());
-                try (FileOutputStream os = new FileOutputStream(f, false)) {
-                    os.write(resp.getBytes(StandardCharsets.UTF_8));
+                shm = SharedMemory.create("statusgo-rpc", bytes.length);
+                final ByteBuffer buf = shm.mapReadWrite();
+                try {
+                    buf.put(bytes);
+                } finally {
+                    SharedMemory.unmap(buf);
                 }
-                return f.getAbsolutePath();
+                shm.setProtect(OsConstants.PROT_READ);
+
+                final RpcResponse result = RpcResponse.shared(shm);
+                shm = null; // ownership transferred; closure happens in writeToParcel
+                return result;
             } catch (Throwable t) {
-                Log.w(TAG, "callToFile failed", t);
-                return "{\"error\":\"callToFile failed\"}";
+                if (shm != null) shm.close();
+                Log.w(TAG, "rpcCall: SharedMemory path failed; returning error JSON", t);
+                return RpcResponse.inline(
+                        "{\"error\":\"shared memory transfer failed\"}".getBytes(StandardCharsets.UTF_8));
             }
         }
 

--- a/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoServiceClient.java
+++ b/mobile/android/qt6/src/app/status/mobile/ipc/StatusGoServiceClient.java
@@ -8,12 +8,9 @@ import android.os.Build;
 import android.os.IBinder;
 import android.os.Process;
 import android.os.RemoteException;
+import android.system.ErrnoException;
 import android.util.Log;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -200,27 +197,7 @@ public final class StatusGoServiceClient {
             return "{\"error\":\"status-go service not connected\"}";
         }
         try {
-            final String pathOrErr = s.callToFile(method, argsJson);
-            if (pathOrErr == null) {
-                return "{\"error\":\"status-go service returned null\"}";
-            }
-            if (!pathOrErr.startsWith("/")) {
-                // service returned an error JSON (small)
-                return pathOrErr;
-            }
-            final File f = new File(pathOrErr);
-            byte[] data;
-            try {
-                data = Files.readAllBytes(f.toPath());
-            } catch (IOException e) {
-                Log.w(TAG, "Failed to read response file: " + pathOrErr, e);
-                return "{\"error\":\"failed to read response file\"}";
-            } finally {
-                // best-effort cleanup
-                //noinspection ResultOfMethodCallIgnored
-                f.delete();
-            }
-            return new String(data, StandardCharsets.UTF_8);
+            return readRpc(s, method, argsJson);
         } catch (RemoteException e) {
             Log.w(TAG, "call failed", e);
             // After reinstall/update (or service crash), binder can become a dead object.
@@ -243,31 +220,30 @@ public final class StatusGoServiceClient {
                 }
                 if (s != null) {
                     try {
-                        final String pathOrErr2 = s.callToFile(method, argsJson);
-                        if (pathOrErr2 == null) {
-                            return "{\"error\":\"status-go service returned null\"}";
-                        }
-                        if (!pathOrErr2.startsWith("/")) {
-                            return pathOrErr2;
-                        }
-                        final File f2 = new File(pathOrErr2);
-                        byte[] data2;
-                        try {
-                            data2 = Files.readAllBytes(f2.toPath());
-                        } catch (IOException io) {
-                            Log.w(TAG, "Failed to read response file: " + pathOrErr2, io);
-                            return "{\"error\":\"failed to read response file\"}";
-                        } finally {
-                            //noinspection ResultOfMethodCallIgnored
-                            f2.delete();
-                        }
-                        return new String(data2, StandardCharsets.UTF_8);
+                        return readRpc(s, method, argsJson);
                     } catch (RemoteException e2) {
                         Log.w(TAG, "call retry failed", e2);
                     }
                 }
             }
             return "{\"error\":\"status-go service call failed\"}";
+        }
+    }
+
+    /**
+     * Issues an rpcCall and reads the response. The RpcResponse is closed unconditionally
+     * via try-with-resources so the SharedMemory fd (if any) is released on every exit path.
+     */
+    private static String readRpc(IStatusGoService s, String method, String argsJson)
+            throws RemoteException {
+        try (RpcResponse resp = s.rpcCall(method, argsJson)) {
+            if (resp == null) {
+                return "{\"error\":\"status-go service returned null\"}";
+            }
+            return resp.readJson();
+        } catch (ErrnoException e) {
+            Log.w(TAG, "rpcCall: shared memory read failed", e);
+            return "{\"error\":\"shared memory read failed\"}";
         }
     }
 


### PR DESCRIPTION
### What does the PR do

This commit aligns the client-server communication with standard Android solutions - direct binder calls and shared memory. This is done both for perf reasons (has a big impact on high frequency callse) and security concerns (no unencrypted data is touching the disk).

There are two main changes in this commit:
1. Direct communication between client and service when the payload is below 64KB. This is for high frequency and ligh calls (like colorId). The file based communication overhead is just too high for such usage. The reasoning for the 64KB limit is based on max capacity. The android binder transactions are capped at 1MB. But all the threads could run binder calls at the same time. The 64KB max size allows 16 threads to run concurrently with no exception risk. The measurements showed that this is enough for more than 95% of RPC traffic.

2. Shared memory - When the payload is bigger than 64KB we'll use the shared memory

Iterates: https://github.com/status-im/status-app/issues/20228

### Affected areas

statusApp <-> status-go communication

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

The app privacy is preserved even in harsh conditions - nothing touches the disk, even for short periods of time
Improved app speed in flows producing high frequency RPC calls.

### How to test

- login and stress the app

### Risk 

low