### PR TITLE
feat(@e2e): unify local waku fleet compose for Linux and Windows

### DIFF
--- a/ci/Jenkinsfile.tests-e2e.windows
+++ b/ci/Jenkinsfile.tests-e2e.windows
@@ -98,6 +98,11 @@ pipeline {
     /* Set to a non-zero value to make Qt print out diagnostic information about the each (C++) plugin it tries to load. */
     /* QT_DEBUG_PLUGINS = 0 */
 
+    /* Use local waku fleet */
+    E2E_LOCAL_WAKU_FLEET = '1'
+    STATUS_FLEET = 'status-app.test'
+    STATUS_FLEET_CONFIG_FILE = "${WORKSPACE}\\assets\\local-waku-fleets-config.json"
+
     /* Hack fix for params not being set in job on first run */
     BUILD_SOURCE =      "${params.BUILD_SOURCE}"
     TEST_NAME =         "${params.TEST_NAME}"
@@ -172,32 +177,39 @@ pipeline {
 
     stage('Test') {
       steps {
-        timeout(time: getTestStageTimeout()) {
-          dir('test/e2e') {
-            /* Lock the agent so we run only one e2e build at a time */
-            lock(resource: "e2e-windows-${env.NODE_NAME}", quantity: 1) {
-              script {
-                def flags = []
-                if (params.TEST_NAME)       { flags.add("-k=${params.TEST_NAME}") }
-                if (params.TEST_SCOPE_FLAG) { flags.add(params.TEST_SCOPE_FLAG) }
-                if (params.LOG_LEVEL)       { flags.addAll(["--log-level=${params.LOG_LEVEL}", "--log-cli-level=${params.LOG_LEVEL}"]) }
-                def flagStr = flags.join(' ')
+        lock(resource: "e2e-windows-${env.NODE_NAME}", quantity: 1) {
+          script {
+            try {
+              timeout(2) {
+                sh 'docker compose -p e2e-fleet -f docker-compose.waku.yml down --remove-orphans || true'
+                sh 'docker compose -p e2e-fleet -f docker-compose.waku.yml up -d'
+                sh 'sleep 15'
+              }
+              timeout(time: getTestStageTimeout()) {
+                dir('test/e2e') {
+                  def flags = []
+                  if (params.TEST_NAME)       { flags.add("-k=${params.TEST_NAME}") }
+                  if (params.TEST_SCOPE_FLAG) { flags.add(params.TEST_SCOPE_FLAG) }
+                  if (params.LOG_LEVEL)       { flags.addAll(["--log-level=${params.LOG_LEVEL}", "--log-cli-level=${params.LOG_LEVEL}"]) }
+                  def flagStr = flags.join(' ')
 
-                withCredentials([
-                  usernamePassword(credentialsId: 'test-rail-api-devops', usernameVariable: 'TESTRAIL_USR', passwordVariable: 'TESTRAIL_PSW'),
-                  string(credentialsId: 'wallet-test-user-seed', variable: 'WALLET_TEST_USER_SEED')
-                ]) {
-                  sh"""
-                    pushd configs
-                    ln -sf _local.ci.py _local.py || cp _local.ci.py _local.py
-                    popd
-
-                  """
-                  bat"""
-                    ${VIRTUAL_ENV}\\Scripts\\python.exe -m pytest -m "not keycard and not benchmark" -v --reruns=1 --timeout=300 ${flagStr} --disable-warnings --alluredir=./allure-results -o timeout_func_only=true
-                  """
+                  withCredentials([
+                    usernamePassword(credentialsId: 'test-rail-api-devops', usernameVariable: 'TESTRAIL_USR', passwordVariable: 'TESTRAIL_PSW'),
+                    string(credentialsId: 'wallet-test-user-seed', variable: 'WALLET_TEST_USER_SEED')
+                  ]) {
+                    sh """
+                      pushd configs
+                      ln -sf _local.ci.py _local.py || cp _local.ci.py _local.py
+                      popd
+                    """
+                    bat """
+                      ${VIRTUAL_ENV}\\Scripts\\python.exe -m pytest -m "not keycard and not benchmark" -v --reruns=1 --timeout=300 ${flagStr} --disable-warnings --alluredir=./allure-results -o timeout_func_only=true
+                    """
+                  }
                 }
               }
+            } finally {
+              sh 'docker compose -p e2e-fleet -f docker-compose.waku.yml down --remove-orphans || true'
             }
           }
         }

--- a/ci/Jenkinsfile.tests-e2e.windows-benchmark
+++ b/ci/Jenkinsfile.tests-e2e.windows-benchmark
@@ -58,7 +58,7 @@ pipeline {
   environment {
     PLATFORM = 'tests/e2e-windows'
 
-    SQUISH_DIR = 'C:\\squish-runner-9.1.0-qt-6.9'
+    SQUISH_DIR = 'C:\\squish-runner-9.2.2-qt-6.11'
     PYTHONPATH = "${SQUISH_DIR}\\lib;${SQUISH_DIR}\\bin;${SQUISH_DIR}\\lib\\python;${PYTHONPATH}"
 
     /* To stop e2e tests using port 8545 */
@@ -183,8 +183,8 @@ pipeline {
 
 
   post {
-    always { 
-      script { 
+    always {
+      script {
         dir('test/e2e') {
           archiveArtifacts('aut/Status/bin/*.log')
 

--- a/docker-compose.waku.yml
+++ b/docker-compose.waku.yml
@@ -1,7 +1,10 @@
 services:
   boot-1:
     image: wakuorg/nwaku:v0.36.0
-    network_mode: host
+    ports:
+      - "60001:60001"
+      - "8645:8645"
+      - "49000:49000/udp"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -27,8 +30,8 @@ services:
       "--shard=64",
       "--shard=128",
       "--shard=256",
-      "--staticnode=/ip4/127.0.0.1/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
-      "--storenode=/ip4/127.0.0.1/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
+      "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
+      "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAm4y9o3GARfphq8jN1wsVhezCHPMmRuekHCCKJ1EsgzVBi",
       "--tcp-port=60001",
       "--nat=extip:127.0.0.1",
     ]
@@ -40,7 +43,10 @@ services:
 
   store:
     image: wakuorg/nwaku:v0.36.0
-    network_mode: host
+    ports:
+      - "60002:60002"
+      - "8646:8646"
+      - "49001:49001/udp"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -65,7 +71,7 @@ services:
       "--shard=64",
       "--shard=128",
       "--shard=256",
-      "--staticnode=/ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
+      "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
       "--store=true",
       "--store-message-db-url=sqlite:///tmp/store1.db",
       "--store-message-retention-policy=time:86400",
@@ -80,7 +86,10 @@ services:
 
   store-2:
     image: wakuorg/nwaku:v0.36.0
-    network_mode: host
+    ports:
+      - "60003:60003"
+      - "8647:8647"
+      - "49002:49002/udp"
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -105,7 +114,7 @@ services:
       "--shard=64",
       "--shard=128",
       "--shard=256",
-      "--staticnode=/ip4/127.0.0.1/tcp/60001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
+      "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAmMgYeJrjruJGCgL96aaP2nf85PGsRVkXLyhG2joJMH4pH",
       "--store=true",
       "--store-message-db-url=sqlite:///tmp/store2.db",
       "--store-message-retention-policy=time:86400",


### PR DESCRIPTION
- Replace network_mode:host with bridge networking and port mapping so the same compose file works on both Linux and Windows
- Use dns4 service names for inter-container communication instead of ip4/127.0.0.1
- Add local waku fleet lifecycle to Windows E2E Jenkinsfile with lock and try/finally pattern matching Linux implementation
- Update SQUISH_DIR path for benchmark e2e

- https://github.com/status-im/status-app/issues/20126