### PR TITLE
perf: Avoid unnecessary community and chat copies

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -113,7 +113,7 @@ proc hasUnseenActivityCenterNotifications*(self: Controller): bool =
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
   return self.contactsService.getContactDetails(contactId)
 
-proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
   return self.communityService.getCommunityById(communityId)
 
 proc getActivityCenterNotifications*(self: Controller): seq[ActivityCenterNotificationDto] =
@@ -143,14 +143,14 @@ proc dismissActivityCenterNotification*(self: Controller,notificationId: string)
 proc replacePubKeysWithDisplayNames*(self: Controller, message: string): string =
   return self.messageService.replacePubKeysWithDisplayNames(message)
 
-proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
+proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: openArray[ChatDto]): string =
   return self.messageService.getRenderedText(parsedTextArray, communityChats)
 
 proc switchTo*(self: Controller, sectionId, chatId, messageId: string) =
   let data = ActiveSectionChatArgs(sectionId: sectionId, chatId: chatId, messageId: messageId)
   self.events.emit(SIGNAL_MAKE_SECTION_CHAT_ACTIVE, data)
 
-proc getChatDetails*(self: Controller, chatId: string): ChatDto =
+proc getChatDetails*(self: Controller, chatId: string): lent ChatDto =
   return self.chatService.getChatById(chatId)
 
 proc getOneToOneChatNameAndImage*(self: Controller, chatId: string):

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -259,8 +259,7 @@ method getDetails*(self: Module, sectionId: string, chatId: string): string =
     jsonObject["sColor"] = %* ""
   else:
     # Community
-    let community = self.controller.getCommunityById(sectionId)
-
+    let community {.cursor.} = self.controller.getCommunityById(sectionId)
     jsonObject["sType"] = %* ChatSectionType.Community
     jsonObject["sName"] = %* community.name
     jsonObject["sImage"] = %* community.images.thumbnail

--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -128,11 +128,12 @@ proc setSearchLocation*(self: Controller, location: string, subLocation: string)
     self.searchLocation = location
     self.searchSubLocation = subLocation
 
-proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
   return self.communityService.getCommunityById(communityId)
 
-proc getJoinedAndSpectatedCommunities*(self: Controller): seq[CommunityDto] =
-  return self.communityService.getJoinedAndSpectatedCommunities()
+iterator joinedAndSpectatedCommunities*(self: Controller): lent CommunityDto =
+  for c in self.communityService.joinedAndSpectatedCommunities():
+    yield c
 
 proc getChatsForPersonalSection*(self: Controller): seq[ChatDto] =
   return self.chatService.getChatsForPersonalSection()
@@ -140,7 +141,7 @@ proc getChatsForPersonalSection*(self: Controller): seq[ChatDto] =
 proc getChatDetailsForChatTypes*(self: Controller, types: seq[ChatType]): seq[ChatDto] =
   return self.chatService.getChatsOfChatTypes(types)
 
-proc getChatDetails*(self: Controller, communityId, chatId: string): ChatDto =
+proc getChatDetails*(self: Controller, communityId, chatId: string): lent ChatDto =
   let fullId = communityId & chatId
   return self.chatService.getChatById(fullId)
 
@@ -202,7 +203,7 @@ proc resultItemClicked*(self: Controller, itemId: string) =
     messageId: itemDetails.messageId)
   self.events.emit(SIGNAL_MAKE_SECTION_CHAT_ACTIVE, data)
 
-proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
+proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: openArray[ChatDto]): string =
   return self.messageService.getRenderedText(parsedTextArray, communityChats)
 
 proc getColorId*(self: Controller, pubkey: string): int =
@@ -214,5 +215,5 @@ proc getAllChats*(self: Controller): seq[ChatDto] =
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
   return self.contactsService.getContactDetails(contactId)
 
-proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: seq[ChatDto]): string =
+proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: openArray[ChatDto]): string =
   return self.messageService.getMessagesParsedPlainText(message, communityChats)

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -158,8 +158,7 @@ method prepareLocationMenuModel*(self: Module) =
   items.add(personalItem)
 
   # Community sections
-  let communities = self.controller.getJoinedAndSpectatedCommunities()
-  for c in communities:
+  for c in self.controller.joinedAndSpectatedCommunities():
     if c.joined:
       items.add(self.buildLocationMenuForCommunity(c))
 
@@ -252,10 +251,8 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
   var channels = personalItems
 
   # Add Communities
-  let communities = self.controller.getJoinedAndSpectatedCommunities()
-
   let searchTerm = self.controller.searchTerm().toLower
-  for community in communities:
+  for community in self.controller.joinedAndSpectatedCommunities():
     if self.controller.searchLocation().len == 0 and
         community.name.toLower.contains(searchTerm):
       let item = result_item.initItem(
@@ -294,9 +291,8 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
     if(m.`from` == singletonInstance.userProfile.getPubKey()):
       senderName = "You"
 
-    let communityChats = self.controller.getCommunityById(chatDto.communityId).chats
-
-    let renderedMessageText = self.controller.getRenderedText(m.parsedText, communityChats)
+    let community {.cursor.} = self.controller.getCommunityById(chatDto.communityId)
+    let renderedMessageText = self.controller.getRenderedText(m.parsedText, community.chats)
     let colorId = self.controller.getColorId(m.`from`)
 
     if(chatDto.communityId.len == 0):
@@ -312,12 +308,13 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
         chatDto.id, m.id)
       items.add(item)
     else:
-      let community = self.controller.getCommunityById(chatDto.communityId)
       let channelName = "#" & chatDto.name
-
       let item = result_item.initItem(m.id, renderedMessageText, $m.timestamp, m.`from`, senderName,
-        SEARCH_RESULT_MESSAGES_SECTION_NAME, senderImage, chatDto.color, community.name,
-        channelName, community.images.thumbnail, community.color, false, true, colorId)
+        SEARCH_RESULT_MESSAGES_SECTION_NAME, senderImage, chatDto.color,
+        community.name,
+        channelName,
+        community.images.thumbnail,
+        community.color, false, true, colorId)
 
       self.controller.addResultItemDetails(m.id, chatDto.communityId, chatDto.id, m.id)
       items.add(item)
@@ -333,19 +330,15 @@ method updateSearchLocationIfPointToChatWithId*(self: Module, chatId: string) =
     self.controller.setSearchLocation(self.controller.activeSectionId(), "")
 
 proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, personalChatSectionName: string): ChatSearchItem =
-  var communityChats: seq[ChatDto] = @[]
+  let isCommunity = chat.chatType == ChatType.CommunityChat and chat.communityId != ""
 
   # skip hidden chats
-  if chat.chatType == ChatType.CommunityChat and chat.communityId != "":
-    let communityDto = self.controller.getCommunityById(chat.communityId)
-    if communityDto.hasCommunityChat(chat.id):
-      let communityChat = communityDto.getCommunityChat(chat.id)
-      if communityChat.isHiddenChat:
-        return nil
-    else:
+  if isCommunity:
+    let community {.cursor.} = self.controller.getCommunityById(chat.communityId)
+    if not community.hasCommunityChat(chat.id):
       return nil
-
-    communityChats = communityDto.chats
+    if community.getCommunityChat(chat.id).isHiddenChat:
+      return nil
 
   var chatName = chat.name
   var chatImage = chat.icon
@@ -371,7 +364,12 @@ proc createChatSearchItem(self: Module, chat: ChatDto, personalChatSectionId, pe
     sectionName,
     chat.emoji,
     chat.chatType.int,
-    lastMessageText = self.controller.getMessagesParsedPlainText(chat.lastMessage, communityChats),
+    lastMessageText =
+      if isCommunity:
+        self.controller.getMessagesParsedPlainText(chat.lastMessage,
+          self.controller.getCommunityById(chat.communityId).chats)
+      else:
+        self.controller.getMessagesParsedPlainText(chat.lastMessage, []),
   )
 
 method buildChatSearchModel*(self: Module) =
@@ -436,12 +434,11 @@ method chatRemoved*(self: Module, chatId: string) =
   self.view.chatSearchModel().removeItemById(chatId)
 
 method updateLastMessage*(self: Module, chatId, communityId: string, chatType: ChatType, lastMessage: MessageDto) =
-  var communityChats: seq[ChatDto] = @[]
-  if chatType == ChatType.CommunityChat and communityId != "":
-    let communityDto = self.controller.getCommunityById(communityId)
-    communityChats = communityDto.chats
-
   self.view.chatSearchModel().updateLastMessageTextOnChatItem(
     chatId,
-    self.controller.getMessagesParsedPlainText(lastMessage, communityChats)
+    if chatType == ChatType.CommunityChat and communityId != "":
+      self.controller.getMessagesParsedPlainText(lastMessage,
+        self.controller.getCommunityById(communityId).chats)
+    else:
+      self.controller.getMessagesParsedPlainText(lastMessage, [])
   )

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -31,7 +31,7 @@ type
     messageService: message_service.Service
 
 # Forward declaration
-proc getChatDetails*(self: Controller): ChatDto
+proc getChatDetails*(self: Controller): lent ChatDto
 
 proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter, sectionId: string, chatId: string,
     belongsToCommunity: bool, isUsersListAvailable: bool, settingsService: settings_service.Service,
@@ -197,10 +197,10 @@ proc init*(self: Controller) =
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 
-proc getChatDetails*(self: Controller): ChatDto =
+proc getChatDetails*(self: Controller): lent ChatDto =
   return self.chatService.getChatById(self.chatId)
 
-proc getCommunityDetails*(self: Controller): CommunityDto =
+proc getCommunityDetails*(self: Controller): lent CommunityDto =
   return self.communityService.getCommunityById(self.sectionId)
 
 proc getOneToOneChatNameAndImage*(self: Controller): tuple[name: string, image: string, largeImage: string] =
@@ -248,7 +248,7 @@ proc getContactById*(self: Controller, contactId: string): ContactsDto =
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
   return self.contactService.getContactDetails(contactId)
 
-proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
+proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: openArray[ChatDto]): string =
   return self.messageService.getRenderedText(parsedTextArray, communityChats)
 
 proc getTransactionDetails*(self: Controller, message: MessageDto): (string,string) =

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -230,13 +230,13 @@ proc getMySectionId*(self: Controller): string =
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 
-proc getChatDetails*(self: Controller): ChatDto =
+proc getChatDetails*(self: Controller): lent ChatDto =
   return self.chatService.getChatById(self.chatId)
 
-proc getCommunityDetails*(self: Controller): CommunityDto =
+proc getCommunityDetails*(self: Controller): lent CommunityDto =
   return self.communityService.getCommunityById(self.sectionId)
 
-proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
   return self.communityService.getCommunityById(communityId)
 
 proc requestCommunityInfo*(self: Controller, communityId: string, useDatabase: bool,
@@ -279,7 +279,7 @@ proc requestContactInfo*(self: Controller, contactId: string) =
 proc getNumOfPinnedMessages*(self: Controller): int =
   return self.messageService.getNumOfPinnedMessages(self.chatId)
 
-proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
+proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: openArray[ChatDto]): string =
   return self.messageService.getRenderedText(parsedTextArray, communityChats)
 
 proc deleteMessage*(self: Controller, messageId: string) =

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -133,10 +133,7 @@ proc createMessageItemsFromMessageDtos(self: Module, messages: seq[MessageDto], 
     if(index != -1):
       self.view.model().removeItem(message.replace)
 
-    var communityChats: seq[ChatDto]
-    communityChats = self.controller.getCommunityDetails().chats
-
-    var renderedMessageText = self.controller.getRenderedText(message.parsedText, communityChats)
+    var renderedMessageText = self.controller.getRenderedText(message.parsedText, self.controller.getCommunityDetails().chats)
 
     var transactionContract = message.transactionParameters.contract
     var transactionValue = message.transactionParameters.value
@@ -157,7 +154,7 @@ proc createMessageItemsFromMessageDtos(self: Module, messages: seq[MessageDto], 
       albumMessageIds = @[],
       deletedByContactDetails,
       quotedMessageAuthorDetails,
-      self.controller.getRenderedText(message.quotedMessage.parsedText, communityChats),
+      self.controller.getRenderedText(message.quotedMessage.parsedText, self.controller.getCommunityDetails().chats),
       transactionContract,
       transactionValue,
     )
@@ -390,20 +387,17 @@ method getChatIcon*(self: Module): string =
 
 method amIChatAdmin*(self: Module): bool =
   if not self.controller.belongsToCommunity():
-    let chatDto = self.controller.getChatDetails()
-    for member in chatDto.members:
+    for member in self.controller.getChatDetails().members:
       if (member.id == singletonInstance.userProfile.getPubKey()):
         # TODO untangle this. There is no special roles for group chats
         return member.role == MemberRole.Owner or member.role == MemberRole.Admin or member.role == MemberRole.TokenMaster
     return false
   else:
-    let communityDto = self.controller.getCommunityDetails()
-    return communityDto.isPrivilegedUser
+    return self.controller.getCommunityDetails().isPrivilegedUser
 
 method pinMessageAllowedForMembers*(self: Module): bool =
   if(self.controller.belongsToCommunity()):
-    let communityDto = self.controller.getCommunityDetails()
-    return communityDto.adminSettings.pinMessageAllMembersEnabled
+    return self.controller.getCommunityDetails().adminSettings.pinMessageAllMembersEnabled
   return false
 
 method getNumberOfPinnedMessages*(self: Module): int =
@@ -428,8 +422,7 @@ method updateContactDetails*(self: Module, contactId: string) =
       item.quotedMessageAuthorAvatar = updatedContact.icon
 
     if item.messageContainsMentions and item.mentionedUsersPks.anyIt(it == contactId):
-      let communityChats = self.controller.getCommunityDetails().chats
-      item.messageText = self.controller.getRenderedText(item.parsedText, communityChats)
+      item.messageText = self.controller.getRenderedText(item.parsedText, self.controller.getCommunityDetails().chats)
 
     item.linkPreviewModel.setContactInfo(updatedContact)
 
@@ -464,14 +457,13 @@ method onMessageEdited*(self: Module, message: MessageDto) =
     return
 
   let mentionedUsersPks = itemBeforeChange.mentionedUsersPks
-  let communityChats = self.controller.getCommunityDetails().chats
 
   var updatedText = ""
   if message.contentType == ContentType.BridgeMessage:
     # message from bridge does not have any tags, we need to add them here to show correctly edited message
     updatedText = "<p>" & message.bridgeMessage.content & "</p>"
   else:
-    updatedText = self.controller.getRenderedText(message.parsedText, communityChats)
+    updatedText = self.controller.getRenderedText(message.parsedText, self.controller.getCommunityDetails().chats)
 
   self.view.model().updateEditedMsg(
     message.id,
@@ -661,8 +653,7 @@ proc updateLinkPreviewsContacts(self: Module, item: Item, requestFromMailserver:
 
 proc updateLinkPreviewsCommunities(self: Module, item: Item, requestFromMailserver: bool) =
   for communityId, url in item.linkPreviewModel.getCommunityLinks().pairs:
-    let community = self.controller.getCommunityById(communityId)
-
+    let community {.cursor.} = self.controller.getCommunityById(communityId)
     if community.id != "":
       item.linkPreviewModel.setCommunityInfo(community)
 

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -158,7 +158,6 @@ proc buildPinnedMessageItem(self: Module, message: MessageDto, actionInitiatedBy
     item: var pinned_msg_item.Item, reactions: seq[ReactionDto]):bool =
 
   let contactDetails = self.controller.getContactDetails(message.`from`)
-  let communityChats = self.controller.getCommunityDetails().chats
   var quotedMessageAuthorDetails = ContactDetails()
   if message.quotedMessage.`from` != "":
     if(message.`from` == message.quotedMessage.`from`):
@@ -179,13 +178,13 @@ proc buildPinnedMessageItem(self: Module, message: MessageDto, actionInitiatedBy
     message.communityId,
     contactDetails,
     isCurrentUser,
-    self.controller.getRenderedText(message.parsedText, communityChats),
+    self.controller.getRenderedText(message.parsedText, self.controller.getCommunityDetails().chats),
     clearText = message.text,
     albumImages = @[],
     albumMessageIds = @[],
     deletedByContactDetails = ContactDetails(),
     quotedMessageAuthorDetails,
-    self.controller.getRenderedText(message.quotedMessage.parsedText, communityChats),
+    self.controller.getRenderedText(message.quotedMessage.parsedText, self.controller.getCommunityDetails().chats),
     transactionContract,
     transactionValue,
   )
@@ -413,15 +412,13 @@ method onMadeInactive*(self: Module) =
 
 method amIChatAdmin*(self: Module): bool =
   if not self.controller.belongsToCommunity():
-    let chatDto = self.controller.getChatDetails()
-    for member in chatDto.members:
+    for member in self.controller.getChatDetails().members:
       if member.id == singletonInstance.userProfile.getPubKey():
         return member.role == MemberRole.Owner or member.role == MemberRole.Admin or member.role == MemberRole.TokenMaster
     return false
   else:
-    let communityDto = self.controller.getCommunityDetails()
-    return communityDto.memberRole == MemberRole.Owner or
-      communityDto.memberRole == MemberRole.Admin or communityDto.memberRole == MemberRole.TokenMaster
+    let role = self.controller.getCommunityDetails().memberRole
+    return role == MemberRole.Owner or role == MemberRole.Admin or role == MemberRole.TokenMaster
 
 method scrollToMessage*(self: Module, messageId: string) =
   self.messagesModule.scrollToMessage(messageId)

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -120,13 +120,13 @@ proc init*(self: Controller) =
 proc belongsToCommunity*(self: Controller): bool =
   self.belongsToCommunity
 
-proc getMyCommunity*(self: Controller): CommunityDto =
+proc getMyCommunity*(self: Controller): lent CommunityDto =
   return self.communityService.getCommunityById(self.sectionId)
 
 proc getMyChatId*(self: Controller): string =
   return self.chatId
 
-proc getMyChat*(self: Controller): ChatDto =
+proc getMyChat*(self: Controller): lent ChatDto =
   return self.chatService.getChatById(self.chatId)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -217,16 +217,15 @@ proc resolveMembersForUpdate(self: Module, membersToReset: seq[ChatMember]):
     result.members = membersToReset
     return
   if self.controller.belongsToCommunity():
-    let myCommunity = self.controller.getMyCommunity()
-
+    let community {.cursor.} = self.controller.getMyCommunity()
     if self.isSectionMemberList:
-      result.members = myCommunity.members
+      result.members = community.members
     else:
       # TODO: when a new channel is added, chat may arrive earlier and we have no up to date community yet
       # see log here: https://github.com/status-im/status-app/issues/14442#issuecomment-2120756598
       # should be resolved in https://github.com/status-im/status-app/issues/11694
       let myChatId = self.controller.getMyChatId()
-      let chat = myCommunity.getCommunityChat(myChatId)
+      let chat {.cursor.} = community.getCommunityChat(myChatId)
       if not chat.tokenGated:
         # No need to get the members, this channel is not encrypted and can use the section member list
         self.isPublicCommunityChannel = true
@@ -241,7 +240,7 @@ proc resolveMembersForUpdate(self: Module, membersToReset: seq[ChatMember]):
           result.returnEarly = true
           return
         # The channel now has a permission, but the re-eval wasn't performed yet. Show all members for now
-        result.members = myCommunity.members
+        result.members = community.members
   if result.members.len == 0:
     result.members = self.controller.getMyChat().members
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -44,7 +44,7 @@ type
     networkService: network_service.Service
 
 # Forward declarations
-proc getMyCommunity*(self: Controller): CommunityDto
+proc getMyCommunity*(self: Controller): lent CommunityDto
 
 proc newController*(delegate: io_interface.AccessInterface, sectionId: string, isCommunity: bool, events: EventEmitter,
     settingsService: settings_service.Service, nodeConfigurationService: node_configuration_service.Service,
@@ -159,20 +159,14 @@ proc init*(self: Controller) =
     var args = ChatUpdateArgs(e)
     for chat in args.chats:
       let belongsToCommunity = chat.communityId.len > 0
-      var community = CommunityDto()
-      if belongsToCommunity:
-        community = self.getMyCommunity()
-      discard self.delegate.addOrUpdateChat(chat, community, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
+      discard self.delegate.addOrUpdateChat(chat, chat.communityId, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
         self.contactService, self.chatService, self.communityService, self.messageService,
         self.mailserversService, self.sharedUrlsService, setChatAsActive = false)
 
   self.events.on(SIGNAL_CHAT_CREATED) do(e: Args):
     var args = CreatedChatArgs(e)
     let belongsToCommunity = args.chat.communityId.len > 0
-    var community = CommunityDto()
-    if belongsToCommunity:
-      community = self.getMyCommunity()
-    discard self.delegate.addOrUpdateChat(args.chat, community, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
+    discard self.delegate.addOrUpdateChat(args.chat, args.chat.communityId, belongsToCommunity, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
@@ -180,10 +174,7 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
       let belongsToCommunity = args.chat.communityId.len > 0
-      var community = CommunityDto()
-      if belongsToCommunity:
-        community = self.getMyCommunity()
-      discard self.delegate.addOrUpdateChat(args.chat, community, belongsToCommunity, self.events, self.settingsService,
+      discard self.delegate.addOrUpdateChat(args.chat, args.chat.communityId, belongsToCommunity, self.events, self.settingsService,
         self.nodeConfigurationService, self.contactService, self.chatService, self.communityService,
         self.messageService, self.mailserversService, self.sharedUrlsService, setChatAsActive = true)
 
@@ -419,8 +410,11 @@ proc init*(self: Controller) =
 proc isCommunity*(self: Controller): bool =
   return self.isCommunitySection
 
-proc getMyCommunity*(self: Controller): CommunityDto =
+proc getMyCommunity*(self: Controller): lent CommunityDto =
   return self.communityService.getCommunityById(self.sectionId)
+
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
+  return self.communityService.getCommunityById(communityId)
 
 proc getCategories*(self: Controller, communityId: string): seq[Category] =
   return self.communityService.getCategories(communityId)
@@ -433,14 +427,13 @@ proc getAllChats*(self: Controller, communityId: string): seq[ChatDto] =
 
 proc getChatsAndBuildUI*(self: Controller) =
   var chats: seq[ChatDto]
-  var community: CommunityDto
+  let communityId = if self.isCommunity(): self.getMySectionId() else: ""
   if self.isCommunity():
-    community = self.getMyCommunity()
-    let normalChats = self.chatService.getChatsForCommunity(community.id)
+    let normalChats = self.chatService.getChatsForCommunity(communityId)
 
     # TODO remove this once we do this refactor https://github.com/status-im/status-app/issues/11694
     var fullChats: seq[ChatDto] = @[]
-    for communityChat in community.chats:
+    for communityChat in self.getMyCommunity().chats:
       for chat in normalChats:
         if chat.id == communityChat.id:
           var c = chat
@@ -449,12 +442,11 @@ proc getChatsAndBuildUI*(self: Controller) =
           break
     chats = fullChats
   else:
-    community = CommunityDto()
     chats = self.chatService.getChatsForPersonalSection()
 
-  # Build chat section with the preloaded community (empty community for personal chat)
+  # Build chat section (communityId is "" for personal chat — getCommunityById returns sentinel)
   self.delegate.onChatsLoaded(
-        community,
+        communityId,
         chats,
         self.events,
         self.settingsService,
@@ -471,7 +463,7 @@ proc sectionUnreadMessagesAndMentionsCount*(self: Controller, communityId: strin
     tuple[unviewedMessagesCount: int, unviewedMentionsCount: int] =
   return self.chatService.sectionUnreadMessagesAndMentionsCount(communityId, sectionIsMuted)
 
-proc getChatDetails*(self: Controller, chatId: string): ChatDto =
+proc getChatDetails*(self: Controller, chatId: string): lent ChatDto =
   return self.chatService.getChatById(chatId)
 
 proc getChatDetailsForChatTypes*(self: Controller, types: seq[ChatType]): seq[ChatDto] =
@@ -483,7 +475,7 @@ proc getChatDetailsByIds*(self: Controller, chatIds: seq[string]): seq[ChatDto] 
 proc categoryHasUnreadMessages*(self: Controller, communityId: string, categoryId: string): bool =
   return self.communityService.categoryHasUnreadMessages(communityId, categoryId)
 
-proc getCommunityCategoryDetails*(self: Controller, communityId: string, categoryId: string): Category =
+proc getCommunityCategoryDetails*(self: Controller, communityId: string, categoryId: string): lent Category =
   return self.communityService.getCategoryById(communityId, categoryId)
 
 proc setActiveItem*(self: Controller, itemId: string) =
@@ -507,7 +499,7 @@ proc getOneToOneChatNameAndImage*(self: Controller, chatId: string):
 proc createOneToOneChat*(self: Controller, communityID: string, chatId: string, ensName: string) =
   let response = self.chatService.createOneToOneChat(communityID, chatId, ensName)
   if response.success:
-    discard self.delegate.addOrUpdateChat(response.chatDto, CommunityDto(), false, self.events, self.settingsService, self.nodeConfigurationService,
+    discard self.delegate.addOrUpdateChat(response.chatDto, "", false, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService)
 
@@ -577,7 +569,7 @@ proc makeAdmin*(self: Controller, communityID: string, chatId: string, pubKey: s
 proc createGroupChat*(self: Controller, communityID: string, groupName: string, pubKeys: seq[string]) =
   let response = self.chatService.createGroupChat(communityID, groupName, pubKeys)
   if response.success:
-    discard self.delegate.addOrUpdateChat(response.chatDto, CommunityDto(), false, self.events, self.settingsService, self.nodeConfigurationService,
+    discard self.delegate.addOrUpdateChat(response.chatDto, "", false, self.events, self.settingsService, self.nodeConfigurationService,
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.mailserversService, self.sharedUrlsService)
 
@@ -696,10 +688,10 @@ proc toggleCollapsedCommunityCategoryAsync*(self: Controller, categoryId: string
 proc reorderCommunityChat*(self: Controller, categoryId: string, chatId: string, position: int) =
   self.communityService.reorderCommunityChat(self.sectionId, categoryId, chatId, position)
 
-proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
+proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: openArray[ChatDto]): string =
   return self.messageService.getRenderedText(parsedTextArray, communityChats)
 
-proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: seq[ChatDto]): string =
+proc getMessagesParsedPlainText*(self: Controller, message: MessageDto, communityChats: openArray[ChatDto]): string =
   return self.messageService.getMessagesParsedPlainText(message, communityChats)
 
 proc getColorId*(self: Controller, pubkey: string): int =

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -26,7 +26,7 @@ method load*(self: AccessInterface, buildChats: bool = false) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onChatsLoaded*(self: AccessInterface,
-    community: CommunityDto,
+    communityId: string,
     chats: seq[ChatDto],
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,
@@ -75,7 +75,7 @@ method doesTopLevelChatExist*(self: AccessInterface, chatId: string): bool {.bas
 
 method addOrUpdateChat*(self: AccessInterface,
     chat: ChatDto,
-    community: CommunityDto,
+    communityId: string,
     belongsToCommunity: bool,
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -56,7 +56,7 @@ type
 # Forward declaration
 proc buildChatSectionUI(
   self: Module,
-  community: CommunityDto,
+  communityId: string,
   chats: seq[ChatDto],
   events: UniqueUUIDEventEmitter,
   settingsService: settings_service.Service,
@@ -75,7 +75,7 @@ method onCommunityCheckChannelPermissionsResponse*(self: Module, chatId: string,
 method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, checkAllChannelsPermissionsResponse: CheckAllChannelsPermissionsResponseDto)
 method addOrUpdateChat(self: Module,
     chat: ChatDto,
-    community: CommunityDto,
+    communityId: string,
     belongsToCommunity: bool,
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,
@@ -251,7 +251,7 @@ proc addCategoryItem(self: Module, category: Category, memberRole: MemberRole, c
 
 proc buildChatSectionUI(
     self: Module,
-    community: CommunityDto,
+    communityId: string,
     chats: seq[ChatDto],
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,
@@ -266,9 +266,10 @@ proc buildChatSectionUI(
   var selectedItemId = ""
   let sectionLastOpenChat = singletonInstance.localAccountSensitiveSettings.getSectionLastOpenChat(self.controller.getMySectionId())
   var items: seq[ChatItem] = @[]
+  let community {.cursor.} = self.controller.getCommunityById(communityId)
   for categoryDto in community.categories:
     # Add items for the categories. We use a special type to identify categories
-    items.add(self.addCategoryItem(categoryDto, community.memberRole, community.id))
+    items.add(self.addCategoryItem(categoryDto, community.memberRole, communityId))
 
   for chatDto in chats:
     # Add an empty chat item that has the category info
@@ -281,7 +282,7 @@ proc buildChatSectionUI(
 
     items.add(self.addOrUpdateChat(
       chatDto,
-      community,
+      communityId,
       belongsToCommunity = chatDto.communityId.len > 0,
       events,
       settingsService,
@@ -319,9 +320,9 @@ proc initContactRequestsModel(self: Module) =
   self.view.contactRequestsModel().addItems(contactsWhoAddedMe)
 
 proc rebuildCommunityTokenPermissionsModel(self: Module) =
-  let community = self.controller.getMyCommunity()
   var tokenPermissionsItems: seq[TokenPermissionItem] = @[]
 
+  let community {.cursor.} = self.controller.getMyCommunity()
   for _, tokenPermission in community.tokenPermissions:
     let chats = community.getCommunityChats(tokenPermission.chatIds)
     let tokenPermissionItem = buildTokenPermissionItem(tokenPermission, chats)
@@ -331,8 +332,8 @@ proc rebuildCommunityTokenPermissionsModel(self: Module) =
   self.reevaluateRequiresTokenPermissionToJoin()
 
 proc reevaluateRequiresTokenPermissionToJoin(self: Module) =
-  let community = self.controller.getMyCommunity()
   var joinPermissionsChanged = false
+  let community {.cursor.} = self.controller.getMyCommunity()
   for _, tokenPermission in community.tokenPermissions:
     if tokenPermission.`type` == TokenPermissionType.BecomeMember or
         tokenPermission.`type` == TokenPermissionType.BecomeAdmin or
@@ -359,7 +360,7 @@ method load*(self: Module, buildChats: bool = false) =
 
 method onChatsLoaded*(
     self: Module,
-    community: CommunityDto,
+    communityId: string,
     chats: seq[ChatDto],
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,
@@ -374,9 +375,9 @@ method onChatsLoaded*(
   self.chatsLoaded = true
 
   # Pre-populate the contacts cache with community members
-  contactService.seedFromChatMembers(community.members)
+  contactService.seedFromChatMembers(self.controller.getCommunityById(communityId).members)
 
-  self.buildChatSectionUI(community, chats, events, settingsService, nodeConfigurationService,
+  self.buildChatSectionUI(communityId, chats, events, settingsService, nodeConfigurationService,
     contactService, chatService, communityService, messageService, mailserversService, sharedUrlsService)
 
   # Generate members list
@@ -387,8 +388,8 @@ method onChatsLoaded*(
     # we do this only in case of chat section (not in case of communities)
     self.initContactRequestsModel()
   else:
-    self.view.setAmIMember(community.joined)
-    self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(self.controller.waitingOnNewCommunityOwnerToConfirmRequestToRejoin(community.id))
+    self.view.setAmIMember(self.controller.getCommunityById(communityId).joined)
+    self.view.setWaitingOnNewCommunityOwnerToConfirmRequestToRejoin(self.controller.waitingOnNewCommunityOwnerToConfirmRequestToRejoin(communityId))
     var requestToJoinState = RequestToJoinState.None
     if self.controller.isMyCommunityRequestPending():
       requestToJoinState = RequestToJoinState.Requested
@@ -488,8 +489,7 @@ method activeItemSet*(self: Module, itemId: string) =
   self.delegate.onDeactivateChatLoader(deactivateSectionId, deactivateChatId)
 
   if self.controller.isCommunity():
-    let community = self.controller.getMyCommunity()
-    if not community.isPrivilegedUser:
+    if not self.controller.getMyCommunity().isPrivilegedUser:
       if not chat_item.missingEncryptionKey and (not chat_item.canView or not chat_item.canPost):
         # User doesn't have full access to this channel. Check permissions to know what is missing
         self.controller.asyncCheckChannelPermissions(mySectionId, activeChatId)
@@ -516,8 +516,7 @@ method getChatContentModule*(self: Module, chatId: string): QVariant =
 proc updateParentBadgeNotifications(self: Module) =
   var sectionIsMuted = false
   if self.controller.isCommunity:
-    let myCommunity = self.controller.getMyCommunity()
-    sectionIsMuted = myCommunity.muted
+    sectionIsMuted = self.controller.getMyCommunity().muted
 
   let (unviewedMessagesCount, unviewedMentionsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
     self.controller.getMySectionId(),
@@ -549,8 +548,8 @@ proc updateBadgeNotifications(self: Module, chat: ChatDto, hasUnreadMessages: bo
       self.chatContentModules[chatId].onNotificationsUpdated(hasUnreadMessages, unviewedMentionsCount)
 
     if self.isCommunity:
-      let myCommunity = self.controller.getMyCommunity()
-      let communityChat = myCommunity.getCommunityChat(chatId)
+      let community {.cursor.} = self.controller.getMyCommunity()
+      let communityChat {.cursor.} = community.getCommunityChat(chatId)
 
       if communityChat.categoryId != "":
         let hasUnreadMessages = self.controller.categoryHasUnreadMessages(communityChat.communityId, communityChat.categoryId)
@@ -559,13 +558,13 @@ proc updateBadgeNotifications(self: Module, chat: ChatDto, hasUnreadMessages: bo
   self.updateParentBadgeNotifications()
 
 method updateLastMessage*(self: Module, chatId: string, lastMessageTimestamp: int, lastMessage: MessageDto) =
-  var communityChats: seq[ChatDto] = @[]
-  if self.controller.isCommunity():
-    let community = self.controller.getMyCommunity()
-    communityChats = community.chats
   self.view.chatsModel().updateLastMessageOnItemById(
     chatId,
-    self.controller.getMessagesParsedPlainText(lastMessage, communityChats),
+    if self.controller.isCommunity():
+      self.controller.getMessagesParsedPlainText(lastMessage,
+        self.controller.getMyCommunity().chats)
+    else:
+      self.controller.getMessagesParsedPlainText(lastMessage, []),
     lastMessageTimestamp,
   )
 
@@ -586,7 +585,7 @@ method onActiveSectionChange*(self: Module, sectionId: string) =
     self.setActiveItem(activeChatId)
 
   if self.isCommunity():
-    let community = self.controller.getMyCommunity()
+    let community {.cursor.} = self.controller.getMyCommunity()
     if not community.isPrivilegedUser:
       if not community.joined:
         self.controller.asyncCheckPermissionsToJoin()
@@ -604,7 +603,7 @@ method chatsModel*(self: Module): chats_model.Model =
 proc getChatItemFromChatDto(
     self: Module,
     chatDto: ChatDto,
-    community: CommunityDto,
+    communityId: string,
     setChatAsActive: bool = true,
     ): ChatItem =
 
@@ -638,19 +637,15 @@ proc getChatItemFromChatDto(
   var memberRole = self.getUserMemberRole(chatDto.members)
 
   if chatDto.chatType != ChatType.PrivateGroupChat:
-    memberRole = community.memberRole
+    memberRole = self.controller.getCommunityById(communityId).memberRole
 
   if memberRole == MemberRole.None and len(chatDto.communityId) != 0:
-    memberRole = community.memberRole
-    if memberRole == MemberRole.None:
-      memberRole = community.memberRole
+    memberRole = self.controller.getCommunityById(communityId).memberRole
 
   var categoryOpened = true
-  let categories = community.categories
 
   if chatDto.categoryId != "":
-    let categoryIndex = findIndexById(chatDto.categoryId, categories)
-    let category = categories[categoryIndex]
+    let category = self.controller.getCommunityCategoryDetails(communityId, chatDto.categoryId)
     if category.id == "":
       error "No category found for chat", chatName=chatDto.name, categoryId=chatDto.categoryId
     else:
@@ -666,8 +661,8 @@ proc getChatItemFromChatDto(
   var tokenGated = false
   if self.controller.isCommunity:
     # NOTE: workaround for new community chat, which is delivered in chatDto before the community will know about that
-    if community.hasCommunityChat(chatDto.id):
-      let communityChat = community.getCommunityChat(chatDto.id)
+    if self.controller.getCommunityById(communityId).hasCommunityChat(chatDto.id):
+      let communityChat = self.controller.getCommunityById(communityId).getCommunityChat(chatDto.id)
       # Some properties are only available on CommunityChat (they are useless for normal chats)
       canPost = communityChat.canPost
       canView = communityChat.canView
@@ -695,7 +690,7 @@ proc getChatItemFromChatDto(
     chatDto.chatType.int,
     memberRole,
     chatDto.timestamp.int,
-    self.controller.getMessagesParsedPlainText(chatDto.lastMessage, community.chats),
+    self.controller.getMessagesParsedPlainText(chatDto.lastMessage, self.controller.getCommunityById(communityId).chats),
     hasNotification,
     notificationsCount,
     chatDto.muted,
@@ -799,8 +794,7 @@ method onCommunityCategoryCreated*(self: Module, cat: Category, chats: seq[ChatD
   if (self.doesCatOrChatExist(cat.id)):
     return
 
-  let community = self.controller.getMyCommunity()
-  discard self.addCategoryItem(cat, community.memberRole, communityId)
+  discard self.addCategoryItem(cat, self.controller.getMyCommunity().memberRole, communityId)
   # Update chat items that now belong to that category
   self.view.chatsModel().updateItemsWithCategoryDetailsById(
     chats,
@@ -928,14 +922,14 @@ proc displayTokenPermissionChangeNotification(self: Module, title: string, messa
 method onCommunityTokenPermissionDeleted*(self: Module, communityId: string, tokenPermission: CommunityTokenPermissionDto) =
   self.view.tokenPermissionsModel.removeItemWithId(tokenPermission.id)
   self.reevaluateRequiresTokenPermissionToJoin()
-  let community = self.controller.getMyCommunity()
+  let community {.cursor.} = self.controller.getMyCommunity()
   let communityChats = community.getCommunityChats(tokenPermission.chatIds)
 
   self.updateChatsRequiredPermissions(communityChats)
   self.displayTokenPermissionChangeNotification("Community permission deleted", "A token permission has been removed", community, tokenPermission)
 
 method onCommunityTokenPermissionCreated*(self: Module, communityId: string, tokenPermission: CommunityTokenPermissionDto) =
-  let community = self.controller.getMyCommunity()
+  let community {.cursor.} = self.controller.getMyCommunity()
   let communityChats = community.getCommunityChats(tokenPermission.chatIds)
   let tokenPermissionItem = buildTokenPermissionItem(tokenPermission, communityChats)
 
@@ -945,10 +939,10 @@ method onCommunityTokenPermissionCreated*(self: Module, communityId: string, tok
   self.displayTokenPermissionChangeNotification("Community permission created", "A token permission has been added", community, tokenPermission)
 
 # Returns true if there was an update
-proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckPermissionsResultDto], community: CommunityDto): bool =
+proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckPermissionsResultDto]): bool =
   var thereWasAnUpdate = false
   for id, criteriaResult in permissions:
-    if community.tokenPermissions.hasKey(id):
+    if self.controller.getMyCommunity().tokenPermissions.hasKey(id):
       let tokenPermissionItem = self.view.tokenPermissionsModel.getItemById(id)
       if tokenPermissionItem.id == "":
         continue
@@ -993,7 +987,7 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
       )
       self.view.tokenPermissionsModel().updateItem(id, updatedTokenPermissionItem)
 
-    return thereWasAnUpdate
+  return thereWasAnUpdate
 
 proc updateCommunityPermissionsView*(self: Module) =
   let tokenPermissionsItems = self.view.tokenPermissionsModel().getItems()
@@ -1033,13 +1027,13 @@ proc updateChannelPermissionViewData*(
     chatId: string,
     viewOnlyPermissions: ViewOnlyOrViewAndPostPermissionsResponseDto,
     viewAndPostPermissions: ViewOnlyOrViewAndPostPermissionsResponseDto,
-    community: CommunityDto
   ) =
 
-  let viewOnlyUpdated = self.updateTokenPermissionModel(viewOnlyPermissions.permissions, community)
-  let viewAndPostUpdated = self.updateTokenPermissionModel(viewAndPostPermissions.permissions, community)
+  let viewOnlyUpdated = self.updateTokenPermissionModel(viewOnlyPermissions.permissions)
+  let viewAndPostUpdated = self.updateTokenPermissionModel(viewAndPostPermissions.permissions)
   if viewOnlyUpdated or viewAndPostUpdated:
-    let communityChat = community.getCommunityChat(chatId)
+    let community {.cursor.} = self.controller.getMyCommunity()
+    let communityChat {.cursor.} = community.getCommunityChat(chatId)
     self.updatePermissionsRequiredOnChat(communityChat)
     self.updateChatLocked(communityChat)
 
@@ -1047,14 +1041,13 @@ proc updateChannelPermissionViewData*(
   self.refreshHiddenBecauseNotPermittedState()
 
 method onCommunityCheckPermissionsToJoinResponse*(self: Module, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) =
-  let community = self.controller.getMyCommunity()
   self.view.setAllTokenRequirementsMet(checkPermissionsToJoinResponse.satisfied)
-  discard self.updateTokenPermissionModel(checkPermissionsToJoinResponse.permissions, community)
+  discard self.updateTokenPermissionModel(checkPermissionsToJoinResponse.permissions)
   self.updateCommunityPermissionsView()
   self.setPermissionsToJoinCheckOngoing(false)
 
 method onCommunityTokenPermissionUpdated*(self: Module, communityId: string, tokenPermission: CommunityTokenPermissionDto) =
-  let community = self.controller.getMyCommunity()
+  let community {.cursor.} = self.controller.getMyCommunity()
   let chats = community.getCommunityChats(tokenPermission.chatIds)
   let tokenPermissionItem = buildTokenPermissionItem(tokenPermission, chats)
   self.view.tokenPermissionsModel.updateItem(tokenPermission.id, tokenPermissionItem)
@@ -1081,17 +1074,15 @@ method onCommunityTokenPermissionDeletionFailed*(self: Module, communityId: stri
   singletonInstance.globalEvents.showCommunityTokenPermissionDeletionFailedNotification(communityId, "Failed to delete community permission", "Something went wrong")
 
 method onCommunityCheckChannelPermissionsResponse*(self: Module, chatId: string, checkChannelPermissionsResponse: CheckChannelPermissionsResponseDto) =
-  let community = self.controller.getMyCommunity()
-  if community.id != "":
-    self.updateChannelPermissionViewData(chatId, checkChannelPermissionsResponse.viewOnlyPermissions, checkChannelPermissionsResponse.viewAndPostPermissions, community)
+  if self.controller.getMyCommunity().id != "":
+    self.updateChannelPermissionViewData(chatId, checkChannelPermissionsResponse.viewOnlyPermissions, checkChannelPermissionsResponse.viewAndPostPermissions)
 
 method onCommunityCheckAllChannelsPermissionsResponse*(self: Module, checkAllChannelsPermissionsResponse: CheckAllChannelsPermissionsResponseDto) =
-  let community = self.controller.getMyCommunity()
-  if community.id == "":
+  if self.controller.getMyCommunity().id == "":
     return
 
   for chatId, permissionResult in checkAllChannelsPermissionsResponse.channels:
-    self.updateChannelPermissionViewData(chatId, permissionResult.viewOnlyPermissions, permissionResult.viewAndPostPermissions, community)
+    self.updateChannelPermissionViewData(chatId, permissionResult.viewOnlyPermissions, permissionResult.viewAndPostPermissions)
 
 method onKickedFromCommunity*(self: Module) =
   self.view.setAmIMember(false)
@@ -1193,9 +1184,8 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
     return
 
   let chatDetails = self.controller.getChatDetails(chatIdMsgBelongsTo)
-  let community = self.controller.getMyCommunity()
 
-  if (chatDetails.muted or community.muted):
+  if (chatDetails.muted or self.controller.getMyCommunity().muted):
     # No need to send a notification
     return
 
@@ -1215,7 +1205,7 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
     else:
       self.controller.getContactDetails(message.`from`).defaultDisplayName
 
-  let plainText = self.controller.getMessagesParsedPlainText(message, community.chats)
+  let plainText = self.controller.getMessagesParsedPlainText(message, self.controller.getMyCommunity().chats)
 
   var notificationTitle = senderDisplayName
 
@@ -1278,7 +1268,7 @@ method declineRequestToJoinCommunity*(self: Module, requestId: string, community
   self.controller.declineRequestToJoinCommunity(requestId, communityId)
 
 method onAcceptRequestToJoinFailedNoPermission*(self: Module, communityId: string, memberKey: string, requestId: string) =
-  let community = self.controller.getMyCommunity()
+  let community {.cursor.} = self.controller.getMyCommunity()
   let contact = self.controller.getContactById(memberKey)
   self.view.emitOpenNoPermissionsToJoinPopupSignal(community.name, contact.displayName,  community.id, requestId)
 
@@ -1406,7 +1396,7 @@ method setLoadingHistoryMessagesInProgress*(self: Module, isLoading: bool) =
 
 method addOrUpdateChat(self: Module,
     chat: ChatDto,
-    community: CommunityDto,
+    communityId: string,
     belongsToCommunity: bool,
     events: UniqueUUIDEventEmitter,
     settingsService: settings_service.Service,
@@ -1436,7 +1426,7 @@ method addOrUpdateChat(self: Module,
   if chat.id == activeChatId:
     self.updateActiveChatMembership()
 
-  result = self.getChatItemFromChatDto(chat, community, setChatAsActive)
+  result = self.getChatItemFromChatDto(chat, communityId, setChatAsActive)
 
   if self.doesCatOrChatExist(chat.id):
     if self.chatContentModules.contains(chat.id):

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -636,11 +636,13 @@ proc getChatItemFromChatDto(
 
   var memberRole = self.getUserMemberRole(chatDto.members)
 
+  let community {.cursor.} = self.controller.getCommunityById(communityId)
+
   if chatDto.chatType != ChatType.PrivateGroupChat:
-    memberRole = self.controller.getCommunityById(communityId).memberRole
+    memberRole = community.memberRole
 
   if memberRole == MemberRole.None and len(chatDto.communityId) != 0:
-    memberRole = self.controller.getCommunityById(communityId).memberRole
+    memberRole = community.memberRole
 
   var categoryOpened = true
 
@@ -661,8 +663,8 @@ proc getChatItemFromChatDto(
   var tokenGated = false
   if self.controller.isCommunity:
     # NOTE: workaround for new community chat, which is delivered in chatDto before the community will know about that
-    if self.controller.getCommunityById(communityId).hasCommunityChat(chatDto.id):
-      let communityChat = self.controller.getCommunityById(communityId).getCommunityChat(chatDto.id)
+    if community.hasCommunityChat(chatDto.id):
+      let communityChat {.cursor.} = community.getCommunityChat(chatDto.id)
       # Some properties are only available on CommunityChat (they are useless for normal chats)
       canPost = communityChat.canPost
       canView = communityChat.canView
@@ -690,7 +692,7 @@ proc getChatItemFromChatDto(
     chatDto.chatType.int,
     memberRole,
     chatDto.timestamp.int,
-    self.controller.getMessagesParsedPlainText(chatDto.lastMessage, self.controller.getCommunityById(communityId).chats),
+    self.controller.getMessagesParsedPlainText(chatDto.lastMessage, community.chats),
     hasNotification,
     notificationsCount,
     chatDto.muted,

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -221,8 +221,8 @@ proc getAllCommunities*(self: Controller): seq[CommunityDto] =
 proc isDisplayNameDupeOfCommunityMember*(self: Controller, displayName: string): bool =
   result = self.communityService.isDisplayNameDupeOfCommunityMember(displayName)
 
-proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
-  result = self.communityService.getCommunityById(communityId)
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
+  return self.communityService.getCommunityById(communityId)
 
 proc spectateCommunity*(self: Controller, communityId: string): string =
   self.communityService.spectateCommunity(communityId)

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -873,9 +873,9 @@ method prepareTokenModelForCommunity*(self: Module, communityId: string) =
   self.joiningCommunityDetails.communityIdForRevealedAccounts = communityId
   self.controller.asyncGetRevealedAccountsForMember(communityId, singletonInstance.userProfile.getPubKey())
 
-  let community = self.controller.getCommunityById(communityId)
   var tokenPermissionsItems: seq[TokenPermissionItem] = @[]
 
+  let community {.cursor.} = self.controller.getCommunityById(communityId)
   for id, tokenPermission in community.tokenPermissions:
     let chats = community.getCommunityChats(tokenPermission.chatIds)
     let tokenPermissionItem = buildTokenPermissionItem(tokenPermission, chats)
@@ -885,8 +885,8 @@ method prepareTokenModelForCommunity*(self: Module, communityId: string) =
   self.checkPermissions(communityId, @[])
 
 method prepareTokenModelForCommunityChat*(self: Module, communityId: string, chatId: string) =
-  let community = self.controller.getCommunityById(communityId)
   var tokenPermissionsItems: seq[TokenPermissionItem] = @[]
+  let community {.cursor.} = self.controller.getCommunityById(communityId)
   for id, tokenPermission in community.tokenPermissions:
     var containsChat = false
     for id in tokenPermission.chatIds:
@@ -904,9 +904,8 @@ method prepareTokenModelForCommunityChat*(self: Module, communityId: string, cha
   self.checkPermissions(communityId, @[])
 
 proc applyPermissionResponse*(self: Module, communityId: string, permissions: Table[string, CheckPermissionsResultDto]) =
-  let community = self.controller.getCommunityById(communityId)
   for id, criteriaResult in permissions:
-    if not community.tokenPermissions.hasKey(id):
+    if not self.controller.getCommunityById(communityId).tokenPermissions.hasKey(id):
       warn "unknown permission", id
       continue
 

--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -151,7 +151,7 @@ proc getOwnerToken*(self: Controller, communityId: string): CommunityTokenDto =
 proc getTokenMasterToken*(self: Controller, communityId: string): CommunityTokenDto =
   return self.communityTokensService.getTokenMasterToken(communityId)
 
-proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
   return self.communityService.getCommunityById(communityId)
 
 proc declineOwnership*(self: Controller, communityId: string) =

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -111,8 +111,7 @@ method load*(self: Module) =
   self.view.load()
 
 proc createOwnerAndMasterDeploymentParams(self: Module, communityId: string): (DeploymentParameters, DeploymentParameters) =
-  let communityDto = self.controller.getCommunityById(communityId)
-  let commName = communityDto.name
+  let commName = self.controller.getCommunityById(communityId).name
   let commNameShort = try: commName[0 .. 2].toUpper except: commName.toUpper
   return (
     DeploymentParameters(
@@ -463,9 +462,7 @@ method onCommunityTokenReceived*(self: Module, name: string, symbol: string, ima
   self.view.emitCommunityTokenReceived(name, symbol, image, communityId, communityName, balance, chainId, txHash, isFirst, tokenType, accountName, accountAddress)
 
 method onLostOwnership*(self: Module, communityId: string) =
-  let communityDto = self.controller.getCommunityById(communityId)
-  let communityName = communityDto.name
-  self.view.emitOwnershipLost(communityId, communityName)
+  self.view.emitOwnershipLost(communityId, self.controller.getCommunityById(communityId).name)
 
 method declineOwnership*(self: Module, communityId: string) =
   self.controller.declineOwnership(communityId)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -591,10 +591,14 @@ proc switchTo*(self: Controller, sectionId, chatId, messageId: string) =
   let data = ActiveSectionChatArgs(sectionId: sectionId, chatId: chatId, messageId: messageId)
   self.events.emit(SIGNAL_MAKE_SECTION_CHAT_ACTIVE, data)
 
-proc getJoinedAndSpectatedCommunities*(self: Controller): seq[CommunityDto] =
-  return self.communityService.getJoinedAndSpectatedCommunities()
+iterator joinedAndSpectatedCommunities*(self: Controller): lent CommunityDto =
+  for c in self.communityService.joinedAndSpectatedCommunities():
+    yield c
 
-proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+proc joinedAndSpectatedCommunityIds*(self: Controller): seq[string] =
+  return self.communityService.joinedAndSpectatedCommunityIds()
+
+proc getCommunityById*(self: Controller, communityId: string): lent CommunityDto =
   return self.communityService.getCommunityById(communityId)
 
 proc spectateCommunity*(self: Controller, communityId: string) =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -990,13 +990,12 @@ method onChatsLoaded*[T](
   # For the personal chat section we load the chats immediately
   self.chatSectionModules[myPubKey].load(buildChats = true)
 
-  let communities = self.controller.getJoinedAndSpectatedCommunities()
   # Create Community sections
-  for community in communities:
-    self.chatSectionModules[community.id] = chat_section_module.newModule(
+  for communityId in self.controller.joinedAndSpectatedCommunityIds():
+    self.chatSectionModules[communityId] = chat_section_module.newModule(
       self,
       events,
-      community.id,
+      communityId,
       isCommunity = true,
       settingsService,
       nodeConfigurationService,
@@ -1011,12 +1010,12 @@ method onChatsLoaded*[T](
       sharedUrlsService,
       networkService
     )
-    let communitySectionItem = self.createCommunitySectionItem(community)
+    let communitySectionItem = self.createCommunitySectionItem(self.controller.getCommunityById(communityId))
     items.add(communitySectionItem)
     if activeSectionId == communitySectionItem.id:
       activeSection = communitySectionItem
 
-    self.chatSectionModules[community.id].load()
+    self.chatSectionModules[communityId].load()
 
   self.view.model().addItems(items)
 
@@ -1554,8 +1553,7 @@ method onRemoteDestructed*[T](self: Module[T], communityId: string, chainId: int
     item.updateRemoteDestructedAddresses(chainId, contractAddress, addresses)
 
 method onRequestReevaluateMembersPermissionsIfRequired*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string) =
-  let communityDto = self.controller.getCommunityById(communityId)
-  for _, tokenPermission in communityDto.tokenPermissions.pairs:
+  for _, tokenPermission in self.controller.getCommunityById(communityId).tokenPermissions.pairs:
     if tokenPermission.type != TokenPermissionType.BecomeTokenOwner:
       for tokenCriteria in tokenPermission.tokenCriteria:
         if tokenCriteria.contractAddresses.hasKey(chainId):
@@ -1630,7 +1628,7 @@ method osNotificationClicked*[T](self: Module[T], details: NotificationDetails) 
 
 method newCommunityMembershipRequestReceived*[T](self: Module[T], membershipRequest: CommunityMembershipRequestDto) =
   let (contactName, _, _) = self.controller.getContactNameAndImage(membershipRequest.publicKey)
-  let community =  self.controller.getCommunityById(membershipRequest.communityId)
+  let community {.cursor.} = self.controller.getCommunityById(membershipRequest.communityId)
   singletonInstance.globalEvents.newCommunityMembershipRequestNotification("New membership request",
     fmt "{contactName} asks to join {community.name}", community.id)
 
@@ -2327,7 +2325,7 @@ method loadMembersForSectionId*[T](self: Module[T], sectionId: string) =
     error "Cannot load members for section", sectionId
     return
 
-  let community = self.controller.getCommunityById(sectionId)
+  let community {.cursor.} = self.controller.getCommunityById(sectionId)
 
   if community.memberRole == MemberRole.Owner or community.memberRole == MemberRole.TokenMaster:
     self.controller.getCommunityTokensDetailsAsync(community.id)

--- a/src/app/modules/main/profile_section/notifications/controller.nim
+++ b/src/app/modules/main/profile_section/notifications/controller.nim
@@ -106,11 +106,12 @@ proc removeNotifSettingExemptions*(self: Controller, id: string): bool =
 proc getChatsForPersonalSection*(self: Controller): seq[ChatDto] =
   return self.chatService.getChatsForPersonalSection()
 
-proc getChatDetails*(self: Controller, chatId: string): ChatDto =
+proc getChatDetails*(self: Controller, chatId: string): lent ChatDto =
   return self.chatService.getChatById(chatId)
 
 proc getContactDetails*(self: Controller, id: string): ContactDetails =
   return self.contactService.getContactDetails(id)
 
-proc getJoinedAndSpectatedCommunities*(self: Controller): seq[CommunityDto] =
-  return self.communityService.getJoinedAndSpectatedCommunities()
+iterator joinedAndSpectatedCommunities*(self: Controller): lent CommunityDto =
+  for c in self.communityService.joinedAndSpectatedCommunities():
+    yield c

--- a/src/app/modules/main/profile_section/notifications/module.nim
+++ b/src/app/modules/main/profile_section/notifications/module.nim
@@ -85,8 +85,7 @@ method initModel(self: Module) =
     items.add(item)
 
   # Add communities
-  let communities = self.controller.getJoinedAndSpectatedCommunities()
-  for community in communities:
+  for community in self.controller.joinedAndSpectatedCommunities():
     let item = self.createItem(
       community.id,
       community.name,

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -66,7 +66,7 @@ proc deleteIdentityImage*(self: Controller, address: string): bool =
 proc setDisplayName*(self: Controller, displayName: string): bool =
   self.profileService.setDisplayName(displayName)
 
-proc getCommunityById*(self: Controller, id: string): CommunityDto =
+proc getCommunityById*(self: Controller, id: string): lent CommunityDto =
   self.communityService.getCommunityById(id)
 
 proc getAccountByAddress*(self: Controller, address: string): WalletAccountDto =

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -124,6 +124,10 @@ QtObject:
     events: EventEmitter
     chats: Table[string, ChatDto] # [chat_id, ChatDto]
     contactService: contact_service.Service
+    # Read-only sentinel returned via `lent` borrow when a lookup misses.
+    # Mutation is observable across all callers and will corrupt subsequent
+    # miss results — never pass to procs that take `var T`.
+    emptyChat: ChatDto
 
   proc delete*(self: Service)
   proc newService*(
@@ -141,7 +145,7 @@ QtObject:
   # Forward declarations
   proc updateOrAddChat*(self: Service, chat: ChatDto)
   proc processMessengerResponse*(self: Service, response: RpcResponse[JsonNode]): (seq[ChatDto], seq[MessageDto])
-  proc getChatById*(self: Service, chatId: string, showWarning: bool = true): ChatDto
+  proc getChatById*(self: Service, chatId: string, showWarning: bool = true): lent ChatDto
 
   proc parseChatsInMessengerResponse*(self: Service, chatsInResponse: seq[ChatDto]) =
     var chats: seq[ChatDto] = @[]
@@ -337,11 +341,11 @@ QtObject:
   proc getChatsForCommunity*(self: Service, communityId: string): seq[ChatDto] =
     return self.getAllChats().filterIt(it.communityId == communityId)
 
-  proc getChatById*(self: Service, chatId: string, showWarning: bool = true): ChatDto =
+  proc getChatById*(self: Service, chatId: string, showWarning: bool = true): lent ChatDto =
     if(not self.chats.contains(chatId)):
       if (showWarning):
         warn "trying to get chat data for an unexisting chat id", chatId
-      return
+      return self.emptyChat
 
     return self.chats[chatId]
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -619,10 +619,15 @@ proc getCommunityChats*(self: CommunityDto, chatIds: seq[string]): seq[ChatDto] 
         break
   return chats
 
-proc getCommunityChat*(self: CommunityDto, chatId: string): ChatDto =
-  let chats = self.getCommunityChats(@[chatId])
-  if chats.len > 0:
-    return chats[0]
+# Read-only sentinel returned via `lent` borrow when getCommunityChat misses.
+# Mutation is observable across all callers — never pass to procs that take `var T`.
+let emptyCommunityChat = ChatDto()
+
+proc getCommunityChat*(self: CommunityDto, chatId: string): lent ChatDto =
+  for communityChat in self.chats:
+    if communityChat.id == chatId:
+      return communityChat
+  return emptyCommunityChat
 
 proc getCommunityChatIndex*(self: CommunityDto, chatId: string): int =
   var idx = 0

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -268,6 +268,11 @@ QtObject:
       historyArchiveDownloadTaskCommunityIds*: HashSet[string]
       communityMetrics: Table[string, CommunityMetricsDto]
       communityInfoRequests: Table[string, Time]
+      # Read-only sentinels returned via `lent` borrow when a lookup misses.
+      # Mutation is observable across all callers and will corrupt subsequent
+      # miss results — never pass these to procs that take `var T`.
+      emptyCommunity: CommunityDto
+      emptyCategory: Category
 
   # Forward declaration
   proc asyncLoadCuratedCommunities*(self: Service)
@@ -304,11 +309,24 @@ QtObject:
     result.communityMetrics = initTable[string, CommunityMetricsDto]()
     result.communityInfoRequests = initTable[string, Time]()
 
-  proc getFilteredJoinedAndSpectatedCommunities(self: Service): Table[string, CommunityDto] =
-    result = initTable[string, CommunityDto]()
-    for communityId, community in self.communities.pairs:
+  # Iterates joined/spectated communities by borrow. Cheap, but the borrow is
+  # tied to the underlying Table — any mutation of `self.communities` during
+  # iteration (including via re-entrant signal handlers triggered by the loop
+  # body) will invalidate the iterator. If the loop body may re-enter the
+  # service, use `joinedAndSpectatedCommunityIds()` and re-look-up each community
+  # by id inside the loop instead.
+  iterator joinedAndSpectatedCommunities*(self: Service): lent CommunityDto =
+    for community in self.communities.values:
       if community.joined or community.spectated:
-        result[communityId] = community
+        yield community
+
+  proc joinedAndSpectatedCommunityIds*(self: Service): seq[string] =
+    # Iterate keys + withValue to avoid the per-iteration CommunityDto copy that
+    # `Table.pairs` value-binding triggers.
+    for communityId in self.communities.keys:
+      self.communities.withValue(communityId, c):
+        if c.joined or c.spectated:
+          result.add(communityId)
 
   proc getFilteredCuratedCommunities(self: Service): Table[string, CommunityDto] =
     result = initTable[string, CommunityDto]()
@@ -872,19 +890,12 @@ QtObject:
   proc getCommunityTags*(self: Service): string =
     return self.communityTags
 
-  proc getJoinedAndSpectatedCommunities*(self: Service): seq[CommunityDto] =
-    return toSeq(self.getFilteredJoinedAndSpectatedCommunities().values)
-
   proc getAllCommunities*(self: Service): seq[CommunityDto] =
     return toSeq(self.communities.values)
 
-  proc getCommunityById*(self: Service, communityId: string): CommunityDto =
-    if communityId == "":
-      return
-
-    if not self.communities.hasKey(communityId):
-      return
-
+  proc getCommunityById*(self: Service, communityId: string): lent CommunityDto =
+    if communityId == "" or not self.communities.hasKey(communityId):
+      return self.emptyCommunity
     return self.communities[communityId]
 
   proc getCommunityIds*(self: Service): seq[string] =
@@ -936,14 +947,16 @@ QtObject:
     else:
       return 0
 
-  proc getCategoryById*(self: Service, communityId: string, categoryId: string): Category =
-    if not self.communities.contains(communityId):
-      error "trying to get community categories for an unexisting community id"
-      return
-
-    let categories = self.getCommunityById(communityId).categories
-    let categoryIndex = findIndexById(categoryId, categories)
-    return categories[categoryIndex]
+  proc getCategoryById*(self: Service, communityId: string, categoryId: string): lent Category =
+    self.communities.withValue(communityId, communityPtr):
+      let idx = findIndexById(categoryId, communityPtr[].categories)
+      if idx == -1:
+        warn "category not found in community", communityId, categoryId
+        return self.emptyCategory
+      return communityPtr[].categories[idx]
+    do:
+      error "trying to get community categories for a non-existing community id", communityId
+      return self.emptyCategory
 
   proc getCategories*(self: Service, communityId: string, order: SortOrder = SortOrder.Ascending): seq[Category] =
     if(not self.communities.contains(communityId)):
@@ -2186,8 +2199,7 @@ QtObject:
       return false
 
     let myPublicKey = singletonInstance.userProfile.getPubKey()
-    var community = self.getCommunityById(communityId)
-    for pendingRequest in community.pendingRequestsToJoin:
+    for pendingRequest in self.getCommunityById(communityId).pendingRequestsToJoin:
       if pendingRequest.publicKey == myPublicKey:
         return true
     return false
@@ -2198,8 +2210,7 @@ QtObject:
       return false
 
     let myPublicKey = singletonInstance.userProfile.getPubKey()
-    var community = self.getCommunityById(communityId)
-    for request in community.waitingForSharedAddressesRequestsToJoin:
+    for request in self.getCommunityById(communityId).waitingForSharedAddressesRequestsToJoin:
       if request.publicKey == myPublicKey:
         return true
     return false
@@ -2406,17 +2417,17 @@ QtObject:
     if communityId == "" or categoryId == "":
       return false
 
-    if not self.communities.contains(communityId):
+    self.communities.withValue(communityId, communityPtr):
+      for chat in communityPtr[].chats:
+        if chat.categoryId != categoryId:
+          continue
+        let chatDto = self.chatService.getChatById(chat.id)
+        if (not chatDto.muted and chatDto.unviewedMessagesCount > 0) or chatDto.unviewedMentionsCount > 0:
+          return true
+      return false
+    do:
       warn "unknown community", communityId
       return false
-
-    for chat in self.communities[communityId].chats:
-      if chat.categoryId != categoryId:
-        continue
-      let chatDto = self.chatService.getChatById(chat.id)
-      if (not chatDto.muted and chatDto.unviewedMessagesCount > 0) or chatDto.unviewedMentionsCount > 0:
-        return true
-    return false
 
   proc markAllReadInCommunity*(self: Service, communityId: string) =
     try:

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -138,7 +138,7 @@ QtObject:
     self.contacts[contact.dto.id] = contact
     self.contactsStatus[contact.dto.id] = StatusUpdateDto(publicKey: contact.dto.id, statusType: StatusType.Unknown)
 
-  proc seedFromChatMembers*(self: Service, members: seq[ChatMember]) =
+  proc seedFromChatMembers*(self: Service, members: openArray[ChatMember]) =
     for member in members:
       if member.id.len == 0:
         continue

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1137,7 +1137,7 @@ QtObject:
     return uuid
 
 # See render-inline in status-mobile/src/status_im/ui/screens/chat/message/message.cljs
-proc renderInline(self: Service, parsedText: ParsedText, communityChats: seq[ChatDto]): string =
+proc renderInline(self: Service, parsedText: ParsedText, communityChats: openArray[ChatDto]): string =
   let value = escape_html(parsedText.literal)
     .multiReplace(("\r\n", "<br/>"))
     .multiReplace(("\n", "<br/>"))
@@ -1182,7 +1182,7 @@ proc renderInline(self: Service, parsedText: ParsedText, communityChats: seq[Cha
       result = fmt(" {value} ")
 
 # See render-block in status-mobile/src/status_im/ui/screens/chat/message/message.cljs
-proc getRenderedText*(self: Service, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =
+proc getRenderedText*(self: Service, parsedTextArray: seq[ParsedText], communityChats: openArray[ChatDto]): string =
   for parsedText in parsedTextArray:
     case parsedText.type:
       of PARSED_TEXT_TYPE_PARAGRAPH:
@@ -1198,7 +1198,7 @@ proc getRenderedText*(self: Service, parsedTextArray: seq[ParsedText], community
 
 # Parses the message and returns the plain text representation of it.
 # If the message is a sticker or an image with no text, it returns "🖼️".
-proc getMessagesParsedPlainText*(self: Service, message: MessageDto, communityChats: seq[ChatDto]): string =
+proc getMessagesParsedPlainText*(self: Service, message: MessageDto, communityChats: openArray[ChatDto]): string =
   if message.contentType == ContentType.BridgeMessage:
     return message.bridgeMessage.content
   if message.contentType == ContentType.Sticker or (message.contentType == ContentType.Image and len(message.text) == 0):


### PR DESCRIPTION
### What does the PR do

Iterates: https://github.com/status-im/status-app/issues/20228

The nim profile trace is dominated with community and chat object copies.

There are 3 main types of changes:
- using `lent` to borrow a community from the service. It can be used as a return type only
- using openarray in favor of seq for proc args, where `lent` cannot be used.
- use "communityId" instead of full community where openarray or lent migration would cascade into lots of changes

The gain is huge on Android - other platforms will benefit as well. It improves app start-up, switching communities, switching chats (big win here), opening Home, opening Settings.

One example where the stack was almost 100% community copy and destroy

**before**
<img width="988" height="375" alt="Screenshot 2026-05-05 at 10 09 11" src="https://github.com/user-attachments/assets/4ac99f58-c610-4808-9700-91990144794f" />

**after**
<img width="929" height="413" alt="Screenshot 2026-05-05 at 10 22 19" src="https://github.com/user-attachments/assets/304a9599-4998-455f-80db-91bc1d799834" />



### Affected areas

Home Screen
Switching community
Joining community
Switching community chats
Opening settings


### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

faster app

### How to test

Test login, and warm app start-up on android
Test switching chats, navigating messages
Test switching communities, changing community settings, adding channels, removing channels, changing community shared address
Test by navigating setttings
Test the home screen

### Risk 

medium