### PR TITLE
fix(CommunitiesPortal): community cards are cut on the right

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusCommunityTag.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCommunityTag.qml
@@ -48,14 +48,14 @@ Rectangle {
         StatusBaseText {
             anchors.verticalCenter: parent.verticalCenter
             font.pixelSize: Theme.primaryTextFontSize
-            font.weight: Font.DemiBold
+            font.weight: Font.Medium
             font.capitalization: Font.AllLowercase
             color: root.enabled ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
             text: root.name
         }
 
         StatusIcon {
-            visible: removable
+            visible: root.removable
             color: root.enabled ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
             icon: "close"
         }

--- a/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/Communities/CommunitiesPortalLayout.qml
@@ -46,10 +46,9 @@ StatusSectionLayout {
         id: d
 
         // values from the design
-        readonly property int layoutTopMargin: Theme.smallPadding
-        readonly property int layoutBottomMargin: Theme.xlPadding*2
-        readonly property int titlePixelSize: 28
-        readonly property int preventShadowClipMargin: Theme.padding
+        readonly property int layoutTopMargin: root.Theme.smallPadding
+        readonly property int layoutBottomMargin: root.Theme.xlPadding*2
+        readonly property int titlePixelSize: root.Theme.fontSize(28)
  
         readonly property bool searchMode: searcher.text.length > 0
 
@@ -95,8 +94,7 @@ StatusSectionLayout {
         anchors.fill: parent
 
         anchors.topMargin: d.layoutTopMargin
-        anchors.leftMargin: Theme.xlPadding*2
-        anchors.rightMargin: Theme.xlPadding
+        anchors.leftMargin: Theme.xlPadding
 
         ColumnLayout {
             id: column
@@ -117,6 +115,8 @@ StatusSectionLayout {
 
             ColumnLayout {
                 spacing: Theme.padding
+                Layout.fillWidth: true
+                Layout.rightMargin: Theme.xlPadding
 
                 RowLayout {
                     SearchBox {
@@ -156,6 +156,7 @@ StatusSectionLayout {
             TagsRow {
                 id: communityTags
                 Layout.fillWidth: true
+                Layout.rightMargin: Theme.xlPadding
 
                 tags: root.communitiesStore.communityTags
             }
@@ -165,12 +166,10 @@ StatusSectionLayout {
 
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.leftMargin: d.preventShadowClipMargin
-                Layout.rightMargin: d.preventShadowClipMargin
 
-                contentWidth: availableWidth
                 padding: 0
                 bottomPadding: d.layoutBottomMargin
+                compactMode: d.compactMode
 
                 model: filteredCommunitiesModel
                 searchLayout: d.searchMode
@@ -215,43 +214,44 @@ StatusSectionLayout {
         }
     }
 
-    Component {
-        id: chooseCommunityCreationTypePopupComponent
-        StatusDialog {
-            id: chooseCommunityCreationTypePopup
-            title: qsTr("Create new community")
-            horizontalPadding: 40
-            verticalPadding: 60
-            footer: null
-            onClosed: destroy()
+    // hidden as part of https://github.com/status-im/status-app/issues/17726
+    // Component {
+    //     id: chooseCommunityCreationTypePopupComponent
+    //     StatusDialog {
+    //         id: chooseCommunityCreationTypePopup
+    //         title: qsTr("Create new community")
+    //         horizontalPadding: 40
+    //         verticalPadding: 60
+    //         footer: null
+    //         onClosed: destroy()
 
-            contentItem: RowLayout {
-                spacing: 20
-                BannerPanel {
-                    objectName: "createCommunityBanner"
-                    text: qsTr("Create a new Status community")
-                    buttonText: qsTr("Create new")
-                    icon.name: "favourite"
-                    onButtonClicked: {
-                        chooseCommunityCreationTypePopup.close()
-                        Global.createCommunityPopupRequested(false /*isDiscordImport*/)
-                    }
-                }
-                BannerPanel {
-                    readonly property bool importInProgress: root.communitiesStore.discordImportInProgress && !root.communitiesStore.discordImportCancelled
-                    text: importInProgress ?
-                              qsTr("'%1' import in progress...").arg(root.communitiesStore.discordImportCommunityName || root.communitiesStore.discordImportChannelName) :
-                              qsTr("Import existing Discord community into Status")
-                    buttonText: qsTr("Import existing")
-                    icon.name: "download"
-                    buttonTooltipText: qsTr("Your current import must be finished or cancelled before a new import can be started.")
-                    buttonLoading: importInProgress
-                    onButtonClicked: {
-                        chooseCommunityCreationTypePopup.close()
-                        Global.createCommunityPopupRequested(true /*isDiscordImport*/)
-                    }
-                }
-            }
-        }
-    }
+    //         contentItem: RowLayout {
+    //             spacing: 20
+    //             BannerPanel {
+    //                 objectName: "createCommunityBanner"
+    //                 text: qsTr("Create a new Status community")
+    //                 buttonText: qsTr("Create new")
+    //                 icon.name: "favourite"
+    //                 onButtonClicked: {
+    //                     chooseCommunityCreationTypePopup.close()
+    //                     Global.createCommunityPopupRequested(false /*isDiscordImport*/)
+    //                 }
+    //             }
+    //             BannerPanel {
+    //                 readonly property bool importInProgress: root.communitiesStore.discordImportInProgress && !root.communitiesStore.discordImportCancelled
+    //                 text: importInProgress ?
+    //                           qsTr("'%1' import in progress...").arg(root.communitiesStore.discordImportCommunityName || root.communitiesStore.discordImportChannelName) :
+    //                           qsTr("Import existing Discord community into Status")
+    //                 buttonText: qsTr("Import existing")
+    //                 icon.name: "download"
+    //                 buttonTooltipText: qsTr("Your current import must be finished or cancelled before a new import can be started.")
+    //                 buttonLoading: importInProgress
+    //                 onButtonClicked: {
+    //                     chooseCommunityCreationTypePopup.close()
+    //                     Global.createCommunityPopupRequested(true /*isDiscordImport*/)
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitiesGridView.qml
@@ -24,6 +24,8 @@ StatusScrollView {
     property var assetsModel
     property var collectiblesModel
 
+    property bool compactMode
+
     readonly property bool isEmpty: !featuredRepeater.count && !root.popularCommunitiesCount
     readonly property int popularCommunitiesCount: firstPopularElementsRepeater.count + restOfPopularElementsRepeater.count
 
@@ -31,22 +33,15 @@ StatusScrollView {
 
     clip: false
     contentWidth: availableWidth
-    contentItem.scale: d.scale
-    contentItem.width: availableWidth / contentItem.scale
-    contentItem.height: availableHeight / contentItem.scale
-    contentItem.transformOrigin: Item.TopLeft
 
     QtObject {
         id: d
 
         // Values from the design
         readonly property int scrollViewTopMargin: 20
-        readonly property int subtitlePixelSize: 17
+        readonly property int subtitlePixelSize: root.Theme.fontSize(17)
         readonly property int promotionalCardPosition: Math.max(gridLayout.delegateCountPerRow - 1, 1)
-        property int delegateWidth: 335
-
-        readonly property real minWidth: d.delegateWidth + root.rightPadding + root.leftPadding + 2 * Theme.padding
-        readonly property real scale: Math.min(1, root.availableWidth / minWidth)
+        property int delegateWidth: root.compactMode ? 300 : 335
 
         Behavior on delegateWidth {
             PropertyAnimation { duration: ThemeUtils.AnimationDuration.Fast }
@@ -82,11 +77,10 @@ StatusScrollView {
                 maximumIndex: d.promotionalCardPosition - 1
             }
         ]
-
     }
 
     SortFilterProxyModel {
-        id: sfpmRestOfPopularElementsModel//popularModel
+        id: sfpmRestOfPopularElementsModel
 
         sourceModel: root.model
 
@@ -157,9 +151,7 @@ StatusScrollView {
 
     ColumnLayout {
         id: contentColumn
-        width: root.availableWidth / d.scale
-        anchors.leftMargin: root.anchors.leftMargin
-        anchors.rightMargin: root.anchors.rightMargin
+        width: root.availableWidth
 
         StatusBaseText {
             id: featuredLabel
@@ -189,12 +181,8 @@ StatusScrollView {
                 model: root.searchLayout ? root.model : featuredModel
                 delegate: communityCardDelegate
             }
-            move: Transition {
-                NumberAnimation { properties: "x,y"; }
-            }
-            add: Transition {
-                NumberAnimation { properties: "x,y"; from: 0; duration: ThemeUtils.AnimationDuration.Fast }
-            }
+            move: FastXYTransition {}
+            add: FastXYZeroTransition {}
         }
 
         StatusBaseText {
@@ -236,21 +224,24 @@ StatusScrollView {
                 model: sfpmRestOfPopularElementsModel
                 delegate: communityCardDelegate
             }
-            move: Transition {
-                NumberAnimation { properties: "x,y"; }
-            }
-            add: Transition {
-                NumberAnimation { properties: "x,y"; from: 0; duration: ThemeUtils.AnimationDuration.Fast }
-            }
+            move: FastXYTransition {}
+            add: FastXYZeroTransition {}
         }
 
         StatusBaseText {
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: Theme.xlPadding * 2
             width: d.delegateWidth
-            visible: root.model.ModelCount.count === 0
+            visible: root.model.ModelCount.empty
             text: qsTr("No communities found")
             color: Theme.palette.baseColor1
         }
+    }
+
+    component FastXYTransition: Transition {
+        NumberAnimation { properties: "x,y"; duration: ThemeUtils.AnimationDuration.Fast}
+    }
+    component FastXYZeroTransition: Transition {
+        NumberAnimation { properties: "x,y"; from: 0; duration: ThemeUtils.AnimationDuration.Fast}
     }
 }

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -3404,34 +3404,6 @@ file format</source>
         <source>Create New Community</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Create new community</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Create a new Status community</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Create new</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&apos;%1&apos; import in progress...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Import existing Discord community into Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Import existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your current import must be finished or cancelled before a new import can be started.</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>CommunitiesView</name>
@@ -17560,6 +17532,25 @@ to load</source>
     </message>
     <message>
         <source>Unpair</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextField</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -4158,41 +4158,6 @@
       <comment>CommunitiesPortalLayout</comment>
       <translation>Create New Community</translation>
     </message>
-    <message>
-      <source>Create new community</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>Create new community</translation>
-    </message>
-    <message>
-      <source>Create a new Status community</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>Create a new Status community</translation>
-    </message>
-    <message>
-      <source>Create new</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>Create new</translation>
-    </message>
-    <message>
-      <source>&#39;%1&#39; import in progress...</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>&#39;%1&#39; import in progress...</translation>
-    </message>
-    <message>
-      <source>Import existing Discord community into Status</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>Import existing Discord community into Status</translation>
-    </message>
-    <message>
-      <source>Import existing</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>Import existing</translation>
-    </message>
-    <message>
-      <source>Your current import must be finished or cancelled before a new import can be started.</source>
-      <comment>CommunitiesPortalLayout</comment>
-      <translation>Your current import must be finished or cancelled before a new import can be started.</translation>
-    </message>
   </context>
   <context>
     <name>CommunitiesView</name>
@@ -21381,6 +21346,29 @@
       <source>Unpair</source>
       <comment>StatusSyncDeviceDelegate</comment>
       <translation>Unpair</translation>
+    </message>
+  </context>
+  <context>
+    <name>StatusTextField</name>
+    <message>
+      <source>Cut</source>
+      <comment>StatusTextField</comment>
+      <translation>Cut</translation>
+    </message>
+    <message>
+      <source>Copy</source>
+      <comment>StatusTextField</comment>
+      <translation>Copy</translation>
+    </message>
+    <message>
+      <source>Paste</source>
+      <comment>StatusTextField</comment>
+      <translation>Paste</translation>
+    </message>
+    <message>
+      <source>Select All</source>
+      <comment>StatusTextField</comment>
+      <translation>Select All</translation>
     </message>
   </context>
   <context>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -3420,34 +3420,6 @@ formát souboru</translation>
         <source>Create New Community</source>
         <translation>Vytvořit novou komunitu</translation>
     </message>
-    <message>
-        <source>Create new community</source>
-        <translation>Vytvořit novou komunitu</translation>
-    </message>
-    <message>
-        <source>Create a new Status community</source>
-        <translation>Vytvořit novou Status komunitu</translation>
-    </message>
-    <message>
-        <source>Create new</source>
-        <translation>Vytvořit novou</translation>
-    </message>
-    <message>
-        <source>&apos;%1&apos; import in progress...</source>
-        <translation>Probíhá import &apos;%1&apos;...</translation>
-    </message>
-    <message>
-        <source>Import existing Discord community into Status</source>
-        <translation>Importovat existující Discord komunitu do Statusu</translation>
-    </message>
-    <message>
-        <source>Import existing</source>
-        <translation>Importovat existující</translation>
-    </message>
-    <message>
-        <source>Your current import must be finished or cancelled before a new import can be started.</source>
-        <translation>Váš aktuální import musí být dokončen nebo zrušen, než bude možné zahájit nový import.</translation>
-    </message>
 </context>
 <context>
     <name>CommunitiesView</name>
@@ -17683,6 +17655,25 @@ selhalo</translation>
     <message>
         <source>Unpair</source>
         <translation>Zrušit párování</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextField</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Kopírovat</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Vložit</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -3409,34 +3409,6 @@ no compatible</translation>
         <source>Create New Community</source>
         <translation>Crear nueva comunidad</translation>
     </message>
-    <message>
-        <source>Create new community</source>
-        <translation>Crear nueva comunidad</translation>
-    </message>
-    <message>
-        <source>Create a new Status community</source>
-        <translation>Crear una nueva comunidad de Status</translation>
-    </message>
-    <message>
-        <source>Create new</source>
-        <translation>Crear nueva</translation>
-    </message>
-    <message>
-        <source>&apos;%1&apos; import in progress...</source>
-        <translation>Importación de &apos;%1&apos; en progreso...</translation>
-    </message>
-    <message>
-        <source>Import existing Discord community into Status</source>
-        <translation>Importar comunidad de Discord existente a Status</translation>
-    </message>
-    <message>
-        <source>Import existing</source>
-        <translation>Importar existente</translation>
-    </message>
-    <message>
-        <source>Your current import must be finished or cancelled before a new import can be started.</source>
-        <translation>Tu importación actual debe finalizarse o cancelarse antes de que se pueda iniciar una nueva importación.</translation>
-    </message>
 </context>
 <context>
     <name>CommunitiesView</name>
@@ -17580,6 +17552,25 @@ al cargar</translation>
     <message>
         <source>Unpair</source>
         <translation>Desemparejar</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextField</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">Pegar</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -3397,34 +3397,6 @@ file format</source>
         <source>Create New Community</source>
         <translation>새 커뮤니티 만들기</translation>
     </message>
-    <message>
-        <source>Create new community</source>
-        <translation>새 커뮤니티 만들기</translation>
-    </message>
-    <message>
-        <source>Create a new Status community</source>
-        <translation>새 Status 커뮤니티 만들기</translation>
-    </message>
-    <message>
-        <source>Create new</source>
-        <translation>새로 만들기</translation>
-    </message>
-    <message>
-        <source>&apos;%1&apos; import in progress...</source>
-        <translation>&apos;%1&apos; 가져오는 중...</translation>
-    </message>
-    <message>
-        <source>Import existing Discord community into Status</source>
-        <translation>기존 Discord 커뮤니티를 Status로 가져오기</translation>
-    </message>
-    <message>
-        <source>Import existing</source>
-        <translation>기존 가져오기</translation>
-    </message>
-    <message>
-        <source>Your current import must be finished or cancelled before a new import can be started.</source>
-        <translation>새 가져오기를 시작하려면, 현재 가져오기를 끝내거나 취소해야 합니다.</translation>
-    </message>
 </context>
 <context>
     <name>CommunitiesView</name>
@@ -17520,6 +17492,25 @@ to load</source>
     <message>
         <source>Unpair</source>
         <translation>연결 해제</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextField</name>
+    <message>
+        <source>Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished">클립보드로 복사</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation type="unfinished">붙여넣기</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

- simplify the layout, use full width for the ScrollView
- remove the internal scaling, causes more issues than it solves
- use smaller card delegates when in compact mode
- fix some other minor responsive issues
- regenerate TS files

Fixes #20728

### Affected areas

Community Portal

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

Phone:
<img width="570" height="1280" alt="image" src="https://github.com/user-attachments/assets/e0b5a889-9650-4a4b-b1f9-bd71fdd8b71a" />

Landscape:
<img width="3224" height="2226" alt="image" src="https://github.com/user-attachments/assets/a5c662d2-4ac0-4cb8-826a-c89d0c5a0f85" />

Portrait:
<img width="964" height="2226" alt="image" src="https://github.com/user-attachments/assets/028b2acb-cd14-4727-950c-49c7b4683f2a" />

### Impact on end user

More responsive/faster layout, esp. on mobile

### How to test

- check the Community Portal on different devices (desktop/tablet/phone) and orientations

### Risk 

lowmid
