### PR TITLE
Mobile: Bottom-sheet mode improvements and related fixes

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -127,11 +127,14 @@ Dialog {
         when: root.bottomSheet
         value: d.windowWidth
     }
+
     Binding on height {
         when: root.bottomSheet && !enterTransition.running && !root.fullScreenSheet
-        value: root.fillHeightOnBottomSheet ? d.windowHeight * d.bottomSheetHeightRatio : Math.min(implicitHeight, d.windowHeight * d.bottomSheetHeightRatio)
-
+        delayed: true
+        value: root.fillHeightOnBottomSheet ? d.windowHeight * d.bottomSheetHeightRatio
+                                            : Math.min(implicitHeight, d.windowHeight * d.bottomSheetHeightRatio)
     }
+
     Binding on height {
         when: root.bottomSheet && root.fullScreenSheet
         value: d.windowHeight
@@ -141,6 +144,7 @@ Dialog {
     // Limit the height to the smaller value between the content’s implicitHeight
     // and 80% of the window height (leaving 10% margin top and bottom)
     Binding on height {
+        delayed: true
         when: !root.bottomSheet
         value: Math.min(implicitHeight, d.windowHeight * 0.8)
     }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -122,6 +122,7 @@ SettingsContentBase {
                 checked: root.advancedStore.isNimbusProxyEnabled
                 onClicked: {
                     Global.openPopup(enableNimbusProxyComponent)
+                    checked = Qt.binding(() => root.advancedStore.isNimbusProxyEnabled)
                 }
             }
 
@@ -185,7 +186,9 @@ SettingsContentBase {
                 isSwitch: true
                 checked: localAccountSensitiveSettings.isBrowserEnabled // user setting
                 onToggled: {
-                    if (checked) {
+                    checked = Qt.binding(() => localAccountSensitiveSettings.isBrowserEnabled)
+
+                    if (!checked) {
                         confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.browser
                         confirmationPopup.open()
                     } else {
@@ -200,7 +203,9 @@ SettingsContentBase {
                 isSwitch: true
                 checked: localAccountSensitiveSettings.nodeManagementEnabled
                 onToggled: {
-                    if (checked) {
+                    checked = Qt.binding(() => localAccountSensitiveSettings.nodeManagementEnabled)
+
+                    if (!checked) {
                         confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.nodeManagement
                         confirmationPopup.open()
                     } else {
@@ -369,6 +374,7 @@ SettingsContentBase {
                 checked: root.advancedStore.isDebugEnabled
 
                 onClicked: {
+                    checked = Qt.binding(() => root.advancedStore.isDebugEnabled)
                     Global.openPopup(enableDebugComponent)
                 }
 

--- a/ui/app/AppLayouts/Profile/views/SettingsLeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsLeftTabView.qml
@@ -43,15 +43,17 @@ Item {
                 return
             }
 
-            const event = { accepted: false, item: subsection };
+            if (subsection === Constants.settingsSubsection.signout) {
+                Global.quitAppRequested()
+                return
+            }
+
+            const event = { accepted: false, item: subsection }
 
             root.menuItemClicked(event)
 
             if (event.accepted)
                 return
-
-            if (subsection === Constants.settingsSubsection.signout)
-                return Global.quitAppRequested()
 
             root.settingsSubsection = subsection
         }

--- a/ui/imports/shared/popups/ConfirmationDialog.qml
+++ b/ui/imports/shared/popups/ConfirmationDialog.qml
@@ -1,135 +1,93 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQml.Models
 
 import StatusQ.Core
 import StatusQ.Core.Theme
 import StatusQ.Controls
-import StatusQ.Popups
+import StatusQ.Popups.Dialog
 
-StatusModal {
-    id: confirmationDialog
+StatusDialog {
+    id: root
 
-    property var parentPopup
-    property var value
     property var executeConfirm
-    property var executeReject
-    property var executeCancel
     property string confirmButtonObjectName: ""
     property string btnType: "warn"
     property string cancelBtnType: "warn"
     property string confirmButtonLabel: qsTr("Confirm")
-    property string rejectButtonLabel: qsTr("Reject")
     property string cancelButtonLabel: qsTr("Cancel")
     property string confirmationText: qsTr("Are you sure you want to do this?")
-    property bool showRejectButton: false
     property bool showCancelButton: false
     property alias checkbox: checkbox
 
+    property StatusModalHeaderSettings headerSettings: StatusModalHeaderSettings {
+        title: qsTr("Confirm your action")
+    }
 
-    headerSettings.title: qsTr("Confirm your action")
+    width: 480
+    margins: contentItem.Theme.padding
+
+    title: headerSettings.title
     focus: visible
-    fullScreenSheet: false
+    standardButtons: Dialog.NoButton
 
     signal confirmButtonClicked()
-    signal rejectButtonClicked()
     signal cancelButtonClicked()
 
+    contentItem: ColumnLayout {
+        spacing: Theme.padding
 
-    contentItem: Item {
-        width: confirmationDialog.width
-        implicitHeight: childrenRect.height
-        Column {
-            width: parent.width - 32
-            anchors.horizontalCenter: parent.horizontalCenter
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.topMargin: Theme.padding
+            Layout.bottomMargin: checkbox.visible ? 0: Theme.padding
 
-            Item {
-                width: parent.width
-                height: 16
-            }
+            text: root.confirmationText
+            font.pixelSize: Theme.primaryTextFontSize
+            wrapMode: Text.WordWrap
+            color: Theme.palette.directColor1
+        }
 
-            StatusBaseText {
-                text: confirmationDialog.confirmationText
-                font.pixelSize: Theme.primaryTextFontSize
-                anchors.left: parent.left
-                anchors.right: parent.right
-                wrapMode: Text.WordWrap
-                color: Theme.palette.directColor1
-            }
+        StatusCheckBox {
+            id: checkbox
+            visible: false
 
-            Item {
-                width: parent.width
-                height: 16
-            }
+            Layout.fillWidth: true
+            Layout.bottomMargin: Theme.padding
 
-            StatusCheckBox {
-                id: checkbox
-                visible: false
-                Layout.preferredWidth: parent.width
-                text: qsTr("Do not show this again")
-            }
-
-            Item {
-                width: parent.width
-                height: visible ? 16 : 0
-                visible: checkbox.visible
-            }
+            text: qsTr("Do not show this again")
         }
     }
 
-    rightButtons: [
-        StatusFlatButton {
-            id: cancelButton
-            visible: showCancelButton
-            text: confirmationDialog.cancelButtonLabel
-            type: {
-                switch (confirmationDialog.cancelBtnType) {
-                    case "warn":
-                        return StatusBaseButton.Type.Danger
-                    default:
-                        return StatusBaseButton.Type.Normal
-                }
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                id: cancelButton
+                visible: root.showCancelButton
+                text: root.cancelButtonLabel
+                type: root.cancelBtnType === "warn"
+                      ? StatusBaseButton.Type.Danger
+                      : StatusBaseButton.Type.Normal
+                onClicked: root.cancelButtonClicked()
             }
-            onClicked: {
-                if (executeCancel && typeof executeCancel === "function") {
-                    executeCancel()
+            StatusButton {
+                id: confirmButton
+                objectName: root.confirmButtonObjectName
+                Layout.maximumWidth: root.availableWidth / 2
+                type: root.btnType === "warn"
+                      ? StatusBaseButton.Type.Danger
+                      : StatusBaseButton.Type.Normal
+                text: root.confirmButtonLabel
+                focus: true
+                Keys.onReturnPressed: confirmButton.clicked()
+                onClicked: {
+                    if (root.executeConfirm
+                            && typeof root.executeConfirm === "function")
+                        root.executeConfirm()
+                    root.confirmButtonClicked()
                 }
-                confirmationDialog.cancelButtonClicked()
-            }
-        },
-        StatusFlatButton {
-            visible: showRejectButton
-            text: confirmationDialog.rejectButtonLabel
-            onClicked: {
-                if (executeReject && typeof executeReject === "function") {
-                    executeReject()
-                }
-                confirmationDialog.rejectButtonClicked()
-            }
-        },
-        StatusButton {
-            Layout.maximumWidth: confirmationDialog.availableWidth/2
-            id: confirmButton
-            objectName: confirmationDialog.confirmButtonObjectName
-            type: {
-                switch (confirmationDialog.btnType) {
-                    case "warn":
-                        return StatusBaseButton.Type.Danger
-                    default:
-                        return StatusBaseButton.Type.Normal
-                }
-            }
-            text: confirmationDialog.confirmButtonLabel
-            focus: true
-            Keys.onReturnPressed: function(event) {
-                confirmButton.clicked()
-            }
-            onClicked: {
-                if (executeConfirm && typeof executeConfirm === "function") {
-                    executeConfirm()
-                }
-                confirmationDialog.confirmButtonClicked()
             }
         }
-    ]
+    }
 }

--- a/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
+++ b/ui/imports/shared/popups/addaccount/AddAccountPopup.qml
@@ -192,7 +192,6 @@ StatusModal {
                 property string address
 
                 closePolicy: Popup.NoAutoClose
-                hasCloseButton: false
                 headerSettings.title: qsTr("Removing saved address")
                 confirmationText: qsTr("The account you're trying to add <b>%1</b> is already saved under the name <b>%2</b>.<br/><br/>Do you want to remove it from saved addresses in favour of adding it to the Wallet?")
                 .arg(address)


### PR DESCRIPTION
### What does the PR do

- Refactors `ConfirmationDialog` to be based on `StatusDialog` instead of outdated `StatusModal`
- Tweaks `StatusDialog` for proper calculation of height in bottom sheet mode
- Fixes behavior of switches in Settings->Advanced
- Fixes `Sign out & Quit` behavior - no unnecessary navigation to settings, popup only

Closes: #20625
Closes: #20646
Closes: #20314
Closes: #20745
Closes: #20744
Closes: #20493

### Affected areas
`StatusDialog`, `ConfirmationDialog`, `AdvancedView`

### Quality checklist

### Screencapture of the functionality

https://github.com/user-attachments/assets/eedad8f6-089c-49ba-b5eb-ee8ea62ac000

<img width="1116" height="2484" alt="Screenshot_2026-05-06-01-28-08-89_ba3df4632e22f9bdc86584b37550839c" src="https://github.com/user-attachments/assets/b6aea45e-52c1-4f54-9874-e35c90f724ed" />
<img width="1116" height="2484" alt="Screenshot_2026-05-06-01-32-05-06_ba3df4632e22f9bdc86584b37550839c" src="https://github.com/user-attachments/assets/c7b4796c-754c-4005-a651-887e51dfe55d" />
<img width="1116" height="2484" alt="Screenshot_2026-05-06-01-22-09-48_ba3df4632e22f9bdc86584b37550839c" src="https://github.com/user-attachments/assets/4210e8e1-25eb-44d6-838b-e7691e46e40f" />



<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

<!-- What is the impact of these changes on the end user (before/after behaviour) -->

### How to test

<!-- How should one proceed with testing this PR. -->
<!-- What kind of user flows should be checked? -->

### Risk 

<!-- Described potential risks and worst case scenarios. -->
