### PR TITLE
fix(Syncing): Ensure mobile network sync is enabled by default

### DIFF
--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -63,6 +63,7 @@ QtObject:
     notifExemptionsCache: Table[string, NotificationsExemptions]
 
   # Forward declaration
+  proc saveSyncingOnMobileNetwork*(self: Service, value: bool): bool
   proc initNotificationSettings*(self: Service)
   proc getNotifSettingAllowNotifications*(self: Service): bool
   proc getNotifSettingOneToOneChats*(self: Service): string
@@ -136,6 +137,11 @@ QtObject:
       self.settings.newsNotificationsEnabled = status_newsfeed.notificationsEnabled().result.getBool
       self.settings.newsRSSEnabled = status_newsfeed.rssEnabled().result.getBool
       self.initNotificationSettings()
+      # v2.38: default to syncing on any network. Ensures status-go's
+      # CanSyncOnMobileNetwork() returns true on mobile connections.
+      # Remove this migration in v2.39 once WiFi-only behaviour is validated.
+      if not self.settings.syncingOnMobileNetwork:
+        discard self.saveSyncingOnMobileNetwork(true)
     except Exception as e:
       let errDesription = e.msg
       error "error: ", errDesription
@@ -305,10 +311,7 @@ QtObject:
     return false
 
   proc getSyncingOnMobileNetwork*(self: Service): bool =
-    # Hardcoded to true (Mobile data + Wi-Fi) for v2.38 while the feature is under review.
-    # Re-enable the line below in v2.39 once the WiFi-only behaviour is validated.
-    # self.settings.syncingOnMobileNetwork
-    true
+    self.settings.syncingOnMobileNetwork
 
   proc saveMnemonic*(self: Service, value: string): bool =
     if(self.saveSetting(KEY_MNEMONIC, value)):


### PR DESCRIPTION
Fixes #20663

### What does the PR do

Fixes `syncingOnMobileNetwork` DB value defaulting to false, causing status-go to block store node sync on mobile devices and leaving sent messages stuck in "sending" state.

### Affected areas

Syncing messages on mobile data

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

It's possible to sync messages on mobile data by default

### How to test

Send messages using mobile data

### Risk 

Low
