### PR TITLE
fix(StatusChatInfoButton): don't open Profile dialog with pinned message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -58,7 +58,6 @@ Button {
 
     component TruncatedTextWithTooltip: StatusBaseText {
         readonly property alias hovered: truncatedHandler.hovered
-        property alias cursorShape: truncatedHandler.cursorShape
 
         elide: Text.ElideRight
 
@@ -95,7 +94,7 @@ Button {
             RowLayout {
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignLeading | Qt.AlignBottom
-                spacing: 1
+                spacing: 2
 
                 StatusIcon {
                     visible: root.type !== StatusChatInfoButton.Type.OneToOneChat && !forceHideTypeIcon && icon
@@ -199,9 +198,11 @@ Button {
                     font.underline: hovered
                     visible: root.pinnedMessagesCount
                     color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
-                    cursorShape: Qt.PointingHandCursor
-                    TapHandler {
-                        onSingleTapped: root.pinnedMessagesCountClicked()
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: parent.enabled && parent.visible
+                        cursorShape: containsMouse ? Qt.PointingHandCursor : undefined
+                        onClicked: root.pinnedMessagesCountClicked()
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

- in 1-1 chats, the TapHandler would leak the click event to the underlying MouseArea, thus invoking both the PinnedMessagesPopup and the ProfileDialog

Fixes #20658

### Affected areas

StatusChatInfoButton

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="3034" height="2028" alt="Snímek obrazovky z 2026-05-06 15-24-01" src="https://github.com/user-attachments/assets/187c41a1-b18b-4207-8264-cd808b3216ae" />

### Impact on end user

No double modal

### How to test

- enter a 1-1 chat
- click the "xxx pinned messages" link in the header button
- observe no duplicate popups

### Risk 

low
