### PR TITLE
fix(StatusBaseInput): no placeholder with preeditText

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -468,7 +468,7 @@ Item {
 
                         StatusBaseText {
                             id: placeholder
-                            visible: (edit.length === 0)
+                            visible: edit.length === 0 && edit.preeditText === ""
                             anchors.fill: parent
                             verticalAlignment: parent.verticalAlignment
                             wrapMode: root.multiline ? Text.WrapAnywhere : Text.NoWrap


### PR DESCRIPTION
### What does the PR do

- also hide the placeholderText when there are suggestions from the native virtual keyboard on mobile

Fixes #20774

### Affected areas

StatusBaseInput

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/695c1fdf-007b-4573-b9c1-96ba5374f52e" />


### Impact on end user

- better text input on mobile

### How to test

- have a single/multiline edit
- try to enter some text

### Risk 

low
