### PR TITLE
fix: getalltokens async

### DIFF
--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -17,6 +17,7 @@ type
   RefreshTokensResponse* = object
     tokensOfInterest*: seq[TokenDtoSafe]
     tokenPreferences*: JsonNode
+    allTokens*: seq[TokenDtoSafe]
     error*: string
 
   FetchAllTokenListsResponse* = object
@@ -48,6 +49,7 @@ proc asyncRefreshTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
   var output = %*{
     "tokensOfInterest": newJArray(),
     "tokenPreferences": newJArray(),
+    "allTokens": newJArray(),
     "error": ""
   }
   try:
@@ -63,6 +65,18 @@ proc asyncRefreshTokensTask*(argEncoded: string) {.gcsafe, nimcall.} =
     output["tokenPreferences"] = if prefsResponse.result.isNil: newJNull() else: prefsResponse.result
   except Exception as e:
     output["error"] = %* fmt"Error refreshing tokens: {e.msg}"
+
+  # fetch all tokens for the group-key index
+  try:
+    var allTokensResponse: JsonNode
+    let allTokensErr = status_go_tokens.getAllTokens(allTokensResponse)
+    if allTokensErr.len > 0:
+      warn "asyncRefreshTokensTask: getAllTokens failed", err = allTokensErr
+    else:
+      output["allTokens"] = if allTokensResponse.isNil: newJArray() else: allTokensResponse
+  except Exception as e:
+    warn "asyncRefreshTokensTask: getAllTokens exception", err = e.msg
+
   arg.finish(output)
 
 type

--- a/src/app_service/service/token/service_main.nim
+++ b/src/app_service/service/token/service_main.nim
@@ -31,12 +31,6 @@ proc addNewTokensToGroupsOfInterest(self: Service, tokens: seq[TokenItem]) =
 proc applyAllTokenListsData(self: Service, tokenListsDtos: seq[TokenListDto]) =
   self.allTokenLists = tokenListsDtos.map(tl => createTokenListItem(tl))
 
-proc rebuildAllTokensByGroupKeyIndex(self: Service) =
-  self.allTokensByGroupKey.clear()
-  let allTokens = getAllTokens()
-  for token in allTokens:
-    self.allTokensByGroupKey.mgetOrPut(token.groupKey, @[]).add(token)
-
 proc prefetchParaswapSupport(self: Service) =
   let chainIds = self.networkService.getEnabledChainIds()
   if chainIds.len == 0:
@@ -70,7 +64,7 @@ proc prefetchParaswapSupportRetrieved(self: Service, response: string) {.slot.} 
   except Exception as ex:
     error "prefetchParaswapSupportRetrieved", err = ex.msg
 
-proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], tokenPrefsNode: JsonNode) =
+proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], allTokenDtos: seq[TokenDtoSafe], tokenPrefsNode: JsonNode) =
   # Parse tokens of interest
   self.tokensOfInterestByKey.clear()
   self.groupsOfInterestByKey.clear()
@@ -94,9 +88,12 @@ proc applyRefreshTokensData(self: Service, tokenDtos: seq[TokenDtoSafe], tokenPr
         visible: dto.visible,
         communityId: dto.communityId)
 
+  self.allTokensByGroupKey.clear()
+  for dto in allTokenDtos:
+    let item = createTokenItem(dto)
+    self.allTokensByGroupKey.mgetOrPut(item.groupKey, @[]).add(item)
   self.rebuildMarketData()
   self.fetchTokensDetails() # TODO: if the only place where we can see these details is account's details page, we should fetch this on demand, no need to have local cache
-  self.rebuildAllTokensByGroupKeyIndex()
   # notify modules
   self.events.emit(SIGNAL_TOKENS_LIST_UPDATED, Args())
   self.events.emit(SIGNAL_TOKEN_PREFERENCES_UPDATED, Args())
@@ -107,7 +104,7 @@ proc onAsyncRefreshTokensDone(self: Service, response: string) {.slot.} =
     if env.error.len > 0:
       error "async refresh tokens failed", errDescription = env.error
       return
-    self.applyRefreshTokensData(env.tokensOfInterest, env.tokenPreferences)
+    self.applyRefreshTokensData(env.tokensOfInterest, env.allTokens, env.tokenPreferences)
   except Exception as e:
     error "error processing async refresh tokens", msg = e.msg
 


### PR DESCRIPTION
* combine `getAllTokens` into `asyncRefreshTokensTask` so it runs off the main thread.
* extend `RefreshTokensResponse` with `allTokens`; build allTokensByGroupKey in `applyRefreshTokensData` from decoded DTOs

closes #20784