### PR TITLE
fix(browser): android snapshot colors

### DIFF
--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -296,7 +296,7 @@ if(IOS OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
       MobileWebView
 
       GIT_REPOSITORY https://github.com/status-im/mobilewebview.git
-      GIT_TAG 9b39e091f71402eb83319794367f867bf0908ff7
+      GIT_TAG 3649572f0ccf61e5fa10f7355fd291b09bb20ce8
       SOURCE_SUBDIR mobilewebview
     )
     FetchContent_MakeAvailable(MobileWebView)


### PR DESCRIPTION
* bump mobilewebview repo (https://github.com/status-im/mobilewebview/pull/8)

QImage::Format_ARGB32 format -> QImage::Format_RGBA8888

fixes #20790
