### PR TITLE
perf: Granular control qml compilation and loading of main layouts

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -105,6 +105,8 @@ type
     mainModule: main_module.AccessInterface
     keycardChannelModule: keycard_channel_module.AccessInterface
 
+    resumeLogin: bool
+
 #################################################
 # Forward declaration section
 proc load(self: AppController)
@@ -285,6 +287,11 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   # Do connections
   result.connect()
 
+  let initialAccount = result.accountsService.fetchLoggedInAccount()
+  result.resumeLogin = initialAccount.isValid()
+  if result.resumeLogin:
+    result.accountsService.setLoggedInAccount(initialAccount)
+
 proc delete*(self: AppController) =
   when defined(android):
       info "Skipping logout on AppController.delete (Android keepalive enabled)"
@@ -349,8 +356,7 @@ proc initializeQmlContext(self: AppController) =
   singletonInstance.engine.setRootContextProperty("globalUtils", self.globalUtilsVariant)
 
   # Expose a lightweight login flag that is available as soon as `main.qml` starts evaluating.
-  let resumeLogin = self.accountsService.fetchLoggedInAccount().isValid()
-  singletonInstance.engine.setRootContextProperty("skipOnboardingContextProperty", newQVariant(resumeLogin))
+  singletonInstance.engine.setRootContextProperty("skipOnboardingContextProperty", newQVariant(self.resumeLogin))
 
   # Load keycard channel module (available before login for Session API)
   self.keycardChannelModule.load()
@@ -374,8 +380,12 @@ proc start*(self: AppController) =
   self.generalService.init()
   self.accountsService.init()
   self.devicesService.init()
-
-  self.onboardingModule.load()
+  
+  if not self.resumeLogin:
+    self.onboardingModule.load()
+  else:
+    self.initializeQmlContext()
+    self.finishAppLoading()
 
 proc load(self: AppController) =
   self.settingsService.init()
@@ -455,7 +465,8 @@ proc finishAppLoading*(self: AppController) =
     self.onboardingModule.onAppLoaded(account.keyUid)
     self.onboardingModule = nil
 
-  self.mainModule.checkAndPerformProfileMigrationIfNeeded()
+  if not self.resumeLogin:
+    self.mainModule.checkAndPerformProfileMigrationIfNeeded()
 
   self.notificationsManager.onAppReady()
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1021,13 +1021,15 @@ method onChatsLoaded*[T](
 
   self.checkIfWeHaveNotifications()
 
-  self.events.emit(SIGNAL_MAIN_LOADED, Args())
-
   # Set active section if it is one of the channel sections
   if not activeSection.isEmpty():
     self.setActiveSection(activeSection)
 
   self.view.sectionsLoaded()
+
+  self.events.emit(SIGNAL_MAIN_LOADED, Args())
+  self.view.setMainLoaded(true)
+
   if self.statusDeepLinkToActivate != "":
     self.activateStatusDeepLink(self.statusDeepLinkToActivate)
 

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -21,6 +21,7 @@ QtObject:
       ephemeralNotificationModel: ephemeralNotification_model.Model
       ephemeralNotificationModelVariant: QVariant
       tmpCommunityId: string # shouldn't be used anywhere except in prepareCommunitySectionModuleForCommunityId/getCommunitySectionModule procs
+      mainLoaded: bool
 
   proc activeSectionSet*(self: View, item: SectionItem)
 
@@ -38,12 +39,26 @@ QtObject:
     result.activeSectionVariant = newQVariant(result.activeSection)
     result.ephemeralNotificationModel = ephemeralNotification_model.newModel()
     result.ephemeralNotificationModelVariant = newQVariant(result.ephemeralNotificationModel)
+    result.mainLoaded = false
 
     signalConnect(result.model, "notificationsCountChanged()", result, "onNotificationsCountChanged()", 2)
 
   proc load*(self: View) =
     # In some point, here, we will setup some exposed main module related things.
     self.delegate.viewDidLoad()
+
+  proc mainLoadedChanged*(self: View) {.signal.}
+  proc getMainLoaded(self: View): bool {.slot.} =
+    return self.mainLoaded
+  proc setMainLoaded*(self: View, mainLoaded: bool) =
+    if self.mainLoaded == mainLoaded:
+      return
+    self.mainLoaded = mainLoaded
+    self.mainLoadedChanged()
+
+  QtProperty[bool] mainLoaded:
+    read = getMainLoaded
+    notify = mainLoadedChanged
 
   proc appNetworkChanged*(self: View) {.signal.}
   proc getAppNetworkId*(self: View): int {.slot.} =

--- a/src/app/modules/onboarding/module.nim
+++ b/src/app/modules/onboarding/module.nim
@@ -96,8 +96,6 @@ method onMainLoaded*[T](self: Module[T]) =
   self.viewVariant = nil
   self.controller.delete
   self.controller = nil
-  if self.resumeLogin:
-    self.delegate.onboardingDidLoad()
 
 method onMainFailedToLoad*[T](self: Module[T]) =
   self.view.accountLoginError("Failed to load main module, please restart the app and try again.", wrongPassword = false)
@@ -105,13 +103,6 @@ method onMainFailedToLoad*[T](self: Module[T]) =
 method load*[T](self: Module[T]) =
   singletonInstance.engine.setRootContextProperty("onboardingModule", self.viewVariant)
   self.controller.init()
-  
-  let loggedInAccount = self.accountsService.fetchLoggedInAccount()
-  self.resumeLogin = loggedInAccount.isValid()
-  if (self.resumeLogin):
-    self.controller.setLoggedInAccount(loggedInAccount)    
-    self.finishAppLoading2()
-    return
 
   let openedAccounts = self.controller.getOpenedAccounts()
   if openedAccounts.len > 0:

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -26,6 +26,7 @@ QtObject:
     events: EventEmitter
     threadpool: ThreadPool
     timeoutInMilliseconds: int
+    messengerStartScheduled: bool
 
   proc delete*(self: Service)
   proc newService*(events: EventEmitter, threadpool: ThreadPool): Service =
@@ -39,6 +40,9 @@ QtObject:
       createDir(app_constants.ROOTKEYSTOREDIR)
 
   proc startMessenger*(self: Service) =
+    if self.messengerStartScheduled:
+      return
+    self.messengerStartScheduled = true
     let arg = AsyncStartMessengerTaskArg(
       tptr: asyncStartMessengerTask,
       vptr: cast[uint](self.vptr),

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -40,9 +40,9 @@ StackLayout {
     property ChatStores.RootStore rootStore
 
     // WIP: This is the new store's structure, now used, `PermissionsStore` and `CommunityAccessStore`. More stores will be added in next steps
-    property CommunityStores.CommunityRootStore newCommnityStore
-    readonly property CommunityStores.CommunityAccessStore communityAccessStore: newCommnityStore.communityAccessStore
-    readonly property CommunityStores.PermissionsStore communityPermissionsStore: newCommnityStore.communityPermissionsStore
+    property CommunityStores.CommunityRootStore newCommunityStore
+    readonly property CommunityStores.CommunityAccessStore communityAccessStore: newCommunityStore.communityAccessStore
+    readonly property CommunityStores.PermissionsStore communityPermissionsStore: newCommunityStore.communityPermissionsStore
 
     // Rest of stores references (to be reviewed)
     property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
@@ -375,62 +375,27 @@ StackLayout {
         }
     }
 
-    Loader {
+    CommunitySettingsLoader {
         id: communitySettingsLoader
+
         active: root.rootStore.chatCommunitySectionModule.isCommunity() &&
                 root.isPrivilegedUser &&
                 (root.currentIndex === 1 || !!communitySettingsLoader.item) // lazy load and preserve state after loading
-        asynchronous: false // It's false on purpose. We want to load the component synchronously
 
-        sourceComponent: CommunitySettingsView {
-            id: communitySettingsView
+        rootStore: root.rootStore
+        networksStore: root.networksStore
+        tokensStore: root.tokensStore
+        transactionStore: root.transactionStore
+        advancedStore: root.advancedStore
+        communityAccessStore: root.communityAccessStore
+        communityPermissionsStore: root.communityPermissionsStore
 
-            rootStore: root.rootStore
-            walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
-            enabledChainIds: root.networksStore.networkFilters
-            onEnableNetwork: root.networksStore.enableNetwork(chainId)
-            activeNetworks: root.networksStore.activeNetworks
-            tokensStore: root.tokensStore
-            transactionStore: root.transactionStore
-            advancedStore: root.advancedStore
+        isPendingOwnershipRequest: root.isPendingOwnershipRequest
+        sectionItemModel: root.sectionItemModel
+        communitySettingsDisabled: root.communitySettingsDisabled
+        leftPanelWidthOverride: root.leftPanelWidthOverride
 
-            isPendingOwnershipRequest: root.isPendingOwnershipRequest
-            ensCommunityPermissionsEnabled: root.advancedStore.ensCommunityPermissionsEnabled
-
-            chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
-            community: root.sectionItemModel
-            communitySettingsDisabled: root.communitySettingsDisabled
-            permissionsModel: root.communityPermissionsStore.permissionsModel
-
-            onLoadMembersRequested: rootStore.loadMembersForSectionId(root.sectionItemModel.id)
-
-            onCommunitySettingsDisabledChanged: if (communitySettingsDisabled) goTo(Constants.CommunitySettingsSections.Overview)
-
-            onBackToCommunityClicked: root.currentIndex = 0
-            onFinaliseOwnershipClicked: Global.openFinaliseOwnershipPopup(community.id)
-
-            // Permissions Related requests:
-            onCreatePermissionRequested: (holdings, permissionType, isPrivate, channels) => {
-                root.communityPermissionsStore.createPermission(holdings, permissionType, isPrivate, channels)
-            }
-            onRemovePermissionRequested: (key) => {
-                root.communityPermissionsStore.removePermission(key)
-            }
-            onEditPermissionRequested: (key, holdings, permissionType, channels, isPrivate) => {
-                root.communityPermissionsStore.editPermission(key, holdings, permissionType, channels, isPrivate)
-            }
-
-            // Communtiy access related requests:
-            onAcceptRequestToJoinCommunityRequested: (requestId, communityId) => {
-                root.communityAccessStore.acceptRequestToJoinCommunityRequested(requestId, communityId)
-            }
-            onDeclineRequestToJoinCommunityRequested: (requestId, communityId) => {
-                root.communityAccessStore.declineRequestToJoinCommunityRequested(requestId, communityId)
-            }
-
-            // Layout
-            leftPanelWidthOverride: root.leftPanelWidthOverride
-        }
+        onBackToCommunityClicked: root.currentIndex = 0
     }
 
     Component {

--- a/ui/app/AppLayouts/Chat/CommunitySettingsLoader.qml
+++ b/ui/app/AppLayouts/Chat/CommunitySettingsLoader.qml
@@ -1,0 +1,104 @@
+import QtQml
+import QtQuick
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send as SendStores
+
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStore
+import AppLayouts.stores.Messaging.Community as CommunityStores
+
+Loader {
+    id: root
+
+    required property ChatStores.RootStore rootStore
+    required property SharedStores.NetworksStore networksStore
+    required property WalletStore.TokensStore tokensStore
+    required property SendStores.TransactionStore transactionStore
+    required property ProfileStores.AdvancedStore advancedStore
+    required property CommunityStores.CommunityAccessStore communityAccessStore
+    required property CommunityStores.PermissionsStore communityPermissionsStore
+
+    required property bool isPendingOwnershipRequest
+    required property var sectionItemModel
+    required property bool communitySettingsDisabled
+
+    property real leftPanelWidthOverride: 0
+
+    // Re-emitted because ChatLayout owns its StackLayout's currentIndex.
+    signal backToCommunityClicked()
+
+    asynchronous: false
+
+    QtObject {
+        id: d
+        readonly property url url: Qt.resolvedUrl("../Communities/views/CommunitySettingsView.qml")
+    }
+
+    function loadSection() {
+        if (!active)
+            return
+        if (root.source === d.url)
+            return
+        setSource(d.url, {
+            visible:                        false,
+            rootStore:                      Qt.binding(() => root.rootStore),
+            walletAccountsModel:            Qt.binding(() => WalletStore.RootStore.nonWatchAccounts),
+            enabledChainIds:                Qt.binding(() => root.networksStore.networkFilters),
+            activeNetworks:                 Qt.binding(() => root.networksStore.activeNetworks),
+            tokensStore:                    Qt.binding(() => root.tokensStore),
+            transactionStore:               Qt.binding(() => root.transactionStore),
+            advancedStore:                  Qt.binding(() => root.advancedStore),
+            isPendingOwnershipRequest:      Qt.binding(() => root.isPendingOwnershipRequest),
+            ensCommunityPermissionsEnabled: Qt.binding(() => root.advancedStore.ensCommunityPermissionsEnabled),
+            chatCommunitySectionModule:     Qt.binding(() => root.rootStore.chatCommunitySectionModule),
+            community:                      Qt.binding(() => root.sectionItemModel),
+            communitySettingsDisabled:      Qt.binding(() => root.communitySettingsDisabled),
+            permissionsModel:               Qt.binding(() => root.communityPermissionsStore.permissionsModel),
+            leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onActiveChanged: loadSection()
+    Component.onCompleted: loadSection()
+    onLoaded: item.visible = true
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onBackToCommunityClicked() { root.backToCommunityClicked() }
+
+        function onEnableNetwork(chainId) {
+            root.networksStore.enableNetwork(chainId)
+        }
+        function onCreatePermissionRequested(holdings, permissionType, isPrivate, channels) {
+            root.communityPermissionsStore.createPermission(holdings, permissionType, isPrivate, channels)
+        }
+        function onRemovePermissionRequested(key) {
+            root.communityPermissionsStore.removePermission(key)
+        }
+        function onEditPermissionRequested(key, holdings, permissionType, channels, isPrivate) {
+            root.communityPermissionsStore.editPermission(key, holdings, permissionType, channels, isPrivate)
+        }
+        function onAcceptRequestToJoinCommunityRequested(requestId, communityId) {
+            root.communityAccessStore.acceptRequestToJoinCommunityRequested(requestId, communityId)
+        }
+        function onDeclineRequestToJoinCommunityRequested(requestId, communityId) {
+            root.communityAccessStore.declineRequestToJoinCommunityRequested(requestId, communityId)
+        }
+        function onLoadMembersRequested() {
+            root.rootStore.loadMembersForSectionId(root.sectionItemModel.id)
+        }
+        function onFinaliseOwnershipClicked() {
+            Global.openFinaliseOwnershipPopup(root.sectionItemModel.id)
+        }
+        function onCommunitySettingsDisabledChanged() {
+            if (root.item.communitySettingsDisabled)
+                root.item.goTo(Constants.CommunitySettingsSections.Overview)
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/qmldir
+++ b/ui/app/AppLayouts/Chat/qmldir
@@ -1,2 +1,3 @@
 ChatLayout 1.0 ChatLayout.qml
 ChatLayoutLoading 1.0 ChatLayoutLoading.qml
+CommunitySettingsLoader 1.0 CommunitySettingsLoader.qml

--- a/ui/app/AppLayouts/Market/MarketLayout.qml
+++ b/ui/app/AppLayouts/Market/MarketLayout.qml
@@ -31,6 +31,9 @@ StatusSectionLayout {
     /** property to enable/disable swap button **/
     property bool swapEnabled: true
 
+    /** Number of items per page **/
+    readonly property int pageSize: 100
+
     /** signal to request the launch of Swap Modal **/
     signal requestLaunchSwap()
     /** signal to request fetching tokens as per selected page and page size **/
@@ -42,15 +45,14 @@ StatusSectionLayout {
 
     QtObject {
         id: d
-        readonly property int pageSize: 100
-        property int startIndex: ((root.currentPage - 1) * d.pageSize) + 1
+        property int startIndex: ((root.currentPage - 1) * root.pageSize) + 1
 
         // Read-only flag that turns true when the component enters a “compact” layout automatically on resize.
         readonly property bool compactMode: root.width < 600
     }
 
     onCurrentPageChanged: listView.positionViewAtBeginning()
-    Component.onCompleted: root.fetchMarketTokens(1, d.pageSize)
+    Component.onCompleted: root.fetchMarketTokens(1, root.pageSize)
 
     centerPanel: ColumnLayout {
         anchors.fill: parent
@@ -99,10 +101,10 @@ StatusSectionLayout {
             footer: MarketFooter {
                 objectName: "marketFooter"
                 width: listView.width
-                pageSize: d.pageSize
+                pageSize: root.pageSize
                 totalCount: root.totalTokensCount
                 currentPage: root.currentPage
-                onSwitchPage: root.fetchMarketTokens(pageNumber, d.pageSize)
+                onSwitchPage: root.fetchMarketTokens(pageNumber, root.pageSize)
                 visible: listView.count > 0 && !root.loading
                 height: visible ? implicitHeight : 0
                 compactMode: d.compactMode
@@ -117,7 +119,7 @@ StatusSectionLayout {
 
             objectName: "loadingModel"
 
-            model: d.pageSize
+            model: root.pageSize
 
             delegate: MarketLoadingTokenDelegate {
                 width: listView.width

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -61,7 +61,7 @@ Item {
     signal manageNetworksRequested()
 
     // TODO: remove tokenType parameter from signals below
-    signal sendTokenRequested(string senderAddress, string gorupKey, int tokenType)
+    signal sendTokenRequested(string senderAddress, string groupKey, int tokenType)
 
     signal openSwapModalRequested(var swapFormData)
 
@@ -315,7 +315,7 @@ Item {
             onDappDisconnectRequested: (dappUrl) =>root.dappDisconnectRequested(dappUrl)
             onLaunchBuyCryptoModal: d.launchBuyCryptoModal()
 
-            onSendTokenRequested: (senderAddress, gorupKey, tokenType) => root.sendTokenRequested(senderAddress, gorupKey, tokenType)
+            onSendTokenRequested: (senderAddress, groupKey, tokenType) => root.sendTokenRequested(senderAddress, groupKey, tokenType)
 
             onManageNetworksRequested: root.manageNetworksRequested()
         }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -57,7 +57,7 @@ RightTabBaseView {
     signal launchShareAddressModal()
     signal launchBuyCryptoModal()
     signal launchSwapModal(string groupKey)
-    signal sendTokenRequested(string senderAddress, string gorupKey, int tokenType)
+    signal sendTokenRequested(string senderAddress, string groupKey, int tokenType)
     signal manageNetworksRequested()
 
     signal dappListRequested()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1067,7 +1067,7 @@ Item {
             if (sectionType === Constants.appSection.profile) {
                 profileLoader.settingsSubsection = subsection || Constants.settingsSubsection.profile
                 profileLoader.settingsSubSubsection = subSubsection
-                profileLoader.item.forceSubsectionNavigation = true
+                profileLoader.forceSubsectionNavigation = true
             } else if (sectionType === Constants.appSection.wallet) {
                 appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
             } else if (sectionType === Constants.appSection.swap) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -7,17 +7,11 @@ import QtQuick.Layouts
 import QtQuick.Window
 import QtQml.Models
 
-import AppLayouts.Browser
-import AppLayouts.Wallet
-import AppLayouts.Node
-import AppLayouts.Chat
+import AppLayouts.Chat 
 import AppLayouts.Chat.views
-import AppLayouts.Profile
-import AppLayouts.Communities
-import AppLayouts.Market
+import AppLayouts.Wallet
 import AppLayouts.Market.stores
 import AppLayouts.Wallet.services.dapps
-import AppLayouts.HomePage
 import AppLayouts.ActivityCenter.helpers
 import AppLayouts.ActivityCenter.panels
 import AppLayouts.ActivityCenter.adaptors
@@ -56,10 +50,10 @@ import AppLayouts.Wallet.popups.dapps as DAppsPopups
 import AppLayouts.Wallet.stores as WalletStores
 import AppLayouts.stores as AppStores
 import AppLayouts.stores.Messaging as MessagingStores
-import AppLayouts.Browser.stores as BrowserStores
 
 import mainui.adaptors
 import mainui.Handlers
+import mainui.sectionLoaders
 
 import QtModelsToolkit
 import SortFilterProxyModel
@@ -155,7 +149,7 @@ Item {
     readonly property bool isPortraitMode: appMain.width < ThemeUtils.portraitBreakpoint.width
 
     function showEnableBiometricsFlow() {
-        popupRequestsHandler.enableBiometricsPopupHandler.openPopup()
+        popupRequestsHandler.openEnableBiometricsPopup()
     }
 
     ContactDetails {
@@ -201,7 +195,7 @@ Item {
         profileStore: appMain.profileStore
         devicesStore: appMain.devicesStore
 
-        onSendRequested: popupRequestsHandler.sendModalHandler.openSend()
+        onSendRequested: popupRequestsHandler.openSend()
     }
 
     Connections {
@@ -841,8 +835,6 @@ Item {
             onConnectionTypeChanged: d.connectionChange()
         }
 
-        property bool showChatLayoutLoading: false
-
         readonly property int activeSectionType: appMain.rootStore.activeSectionType
         readonly property bool isWalletRelatedSectionType: activeSectionType === Constants.appSection.wallet ||
                                                            activeSectionType === Constants.appSection.swap || activeSectionType === Constants.appSection.market ||
@@ -850,38 +842,6 @@ Item {
         readonly property bool isBrowserEnabled: appMain.featureFlagsStore.browserEnabled &&
                                                  localAccountSensitiveSettings.isBrowserEnabled
         readonly property int syncingBadgeCount: appMain.devicesStore.totalDevicesCount - appMain.devicesStore.pairedDevicesCount
-
-        function hasChatLayoutLoader(sectionId: string): bool {
-            if (sectionId === appMain.profileStore.pubKey) {
-                return true
-            }
-
-            for (let i = 0; i < appView.children.length; i++) {
-                const child = appView.children[i]
-                if (child && child.sectionId === sectionId) {
-                    return true
-                }
-            }
-
-            return false
-        }
-
-        function isChatLayoutLoaderActive(sectionId: string) {
-            // Personal chat section is backed by a dedicated loader.
-            if (sectionId === appMain.profileStore.pubKey) {
-                return personalChatLayoutLoader.active
-            }
-
-            // Community sections are backed by repeater-created loaders.
-            for (let i = 0; i < appView.children.length; i++) {
-                const child = appView.children[i]
-                if (child && child.sectionId === sectionId) {
-                    return child.active
-                }
-            }
-
-            return false
-        }
 
         function openHomePage() {
             appMain.rootStore.setActiveSectionBySectionType(Constants.appSection.homePage)
@@ -976,7 +936,7 @@ Item {
         }
     }
 
-    Popups {
+    PopupsLoader {
         id: popups
 
         keychain: appMain.keychain
@@ -1017,12 +977,12 @@ Item {
                 Global.displaySuccessToastMessage(qsTr("%1 added to your trusted sites.").arg(domain))
             }
         }
-        onTransferOwnershipRequested: (tokenId, senderAddress) => popupRequestsHandler.sendModalHandler.transferOwnership(tokenId, senderAddress)
+        onTransferOwnershipRequested: (tokenId, senderAddress) => popupRequestsHandler.transferOwnership(tokenId, senderAddress)
         onWcUriScanned: uri => d.pairWalletConnectUri(uri)
         onNavigationEducationDialogSeenRequested: appMainGlobalSettings.newMenuEducationPopupSeen = true
     }
 
-    HandlersManager {
+    HandlersManagerLoader {
         id: popupRequestsHandler
 
         popupParent: appMain
@@ -1045,6 +1005,10 @@ Item {
         ensUsernamesStore: appMain.ensUsernamesStore
         privacyStore: appMain.privacyStore
         keychain: appMain.keychain
+
+        Component.onCompleted: {
+            Qt.callLater(() => popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup())
+        }
     }
 
     Connections {
@@ -1107,7 +1071,7 @@ Item {
             } else if (sectionType === Constants.appSection.wallet) {
                 appView.children[Constants.appViewStackIndex.wallet].item.openDesiredView(subsection, subSubsection, data)
             } else if (sectionType === Constants.appSection.swap) {
-                popupRequestsHandler.swapModalHandler.launchSwap()
+                popupRequestsHandler.launchSwap()
             } else if (sectionType === Constants.appSection.chat) {
                 appMain.rootStore.setNavToMsgDetailsFlag(true)
                 appMain.rootStore.setActiveSectionChat(appMain.profileStore.pubKey, subsection)
@@ -1139,15 +1103,6 @@ Item {
         function onCloseActivityCenterRequested() {
             if (mainLayoutItem.isPortraitMode)
                 mainLayoutItem.openACCenterPanel = false
-        }
-    }
-
-    Connections {
-        target: appMain.rootStore
-
-        function onSectionsLoadedChanged() {
-            if (!appMain.rootStore.sectionsLoaded) return
-            popupRequestsHandler.maybeDisplayEnablePushNotificationsPopup()
         }
     }
 
@@ -1210,8 +1165,6 @@ Item {
     }
 
     function changeAppSectionBySectionId(sectionId) {
-        d.showChatLayoutLoading = d.hasChatLayoutLoader(sectionId)
-                                  && !d.isChatLayoutLoaderActive(sectionId)
         // Using callLater doesn't leave ebnough time to render the loading state
         Backpressure.setTimeout(this, 1, () => {
             appMain.rootStore.setActiveSectionById(sectionId)
@@ -1312,8 +1265,8 @@ Item {
             isWalletEnabled: appMain.walletProfileStore.isWalletEnabled
             thirdpartyServicesEnabled: appMain.rootStore.thirdpartyServicesEnabled
 
-            onBuyClicked: (packId, price) => popupRequestsHandler.sendModalHandler.buyStickerPack(packId, price)
-            onEnableThirdpartyServicesRequested: popupRequestsHandler.thirdpartyServicesPopupHandler.openPopup()
+            onBuyClicked: (packId, price) => popupRequestsHandler.buyStickerPack(packId, price)
+            onEnableThirdpartyServicesRequested: popupRequestsHandler.openThirdpartyServicesPopup()
         }
     }
 
@@ -1678,18 +1631,23 @@ Item {
             ActivityCenterPanel {
                 id: acPanelItem
 
-                readonly property ActivityCenterAdaptor adaptor: ActivityCenterAdaptor {
-                    contactsModel: appMain.contactsStore.contactsModel
-                    userProfileName: appMain.profileStore.name
-                    notifications: appMain.activityCenterStore.activityCenterNotifications
-                    getCommunityDetails: function(communityId) {
-                        return appMain.rootChatStore.getCommunityDetailsAsJson(communityId)
+                Loader {
+                    id: acPanelLoader
+                    sourceComponent: ActivityCenterAdaptor {
+                        contactsModel: appMain.contactsStore.contactsModel
+                        userProfileName: appMain.profileStore.name
+                        notifications: appMain.activityCenterStore.activityCenterNotifications
+                        getCommunityDetails: function(communityId) {
+                            return appMain.rootChatStore.getCommunityDetailsAsJson(communityId)
+                        }
+                        getChatDetails: function(chatId) {
+                            return appMain.rootChatStore.getChatDetails(chatId)
+                        }
+                        onPopulateContactDetailsRequested: (contactId) => appMain.contactsStore.populateContactDetails(contactId)
                     }
-                    getChatDetails: function(chatId) {
-                        return appMain.rootChatStore.getChatDetails(chatId)
-                    }
-                    onPopulateContactDetailsRequested: (contactId) => appMain.contactsStore.populateContactDetails(contactId)
                 }
+
+                readonly property ActivityCenterAdaptor adaptor: acPanelLoader.item
 
                 backgroundColor: Theme.palette.statusAppLayout.backgroundColor
 
@@ -1704,7 +1662,7 @@ Item {
 
                 hasUnreadNotifications: appMain.activityCenterStore.unreadNotificationsCount > 0
                 readNotificationsStatus: appMain.activityCenterStore.activityCenterReadType
-                notificationsModel: adaptor.model
+                notificationsModel: adaptor?.model ?? null
                 newsSettingsStatus: appMain.notificationsStore.notificationsSettings.notifSettingStatusNews
                 newsEnabledViaRSS: appMain.privacyStore.isStatusNewsViaRSSEnabled
 
@@ -1814,15 +1772,27 @@ Item {
                         case Constants.appSection.chat:
                             return Constants.appViewStackIndex.chat
                         case Constants.appSection.community:
+                            // Track Repeater count so this binding re-evaluates when delegates
+                            // are added — Item.children has no QML-observable notifier, so without
+                            // this the lookup stays stuck on its first (empty) result if it ran
+                            // before the Repeater populated.
+                            void communityRepeater.count
                             for (let i = this.children.length - 1; i >= 0; i--) {
                                 var obj = this.children[i]
                                 if (obj && obj.sectionId && obj.sectionId === appMain.rootStore.activeSectionId) {
                                     return i
                                 }
                             }
-                            // Should never be here, correct index must be returned from the for loop above
-                            console.error("Wrong section type:", d.activeSectionType,
-                                          "or section id: ", appMain.rootStore.activeSectionId)
+                            // Repeater hasn't created the matching delegate yet — fall back; the
+                            // tracked count above will fire this binding again. If the fallback
+                            // sticks (count > 0 and still no match), it means the active section
+                            // id doesn't appear in the filtered model — surface that.
+                            if (communityRepeater.count > 0) {
+                                console.warn("AppMain: active community section",
+                                             appMain.rootStore.activeSectionId,
+                                             "not present in repeater (count=",
+                                             communityRepeater.count, ")")
+                            }
                             return Constants.appViewStackIndex.community
                         case Constants.appSection.communitiesPortal:
                             return Constants.appViewStackIndex.communitiesPortal
@@ -1855,102 +1825,32 @@ Item {
                     // If we ever change stack layout component order we need to updade
                     // Constants.appViewStackIndex accordingly
 
-                    Loader {
+                    HomePageLoader {
                         id: homePageLoader
                         focus: active
-                        active: appMain.featureFlagsStore.homePageEnabled && appView.currentIndex === Constants.appViewStackIndex.homePage
+                        active: appMain.featureFlagsStore.homePageEnabled
+                                && appView.currentIndex === Constants.appViewStackIndex.homePage
 
-                        sourceComponent: HomePage {
-                            id: homePage
+                        rootStore: appMain.rootStore
+                        rootChatStore: appMain.rootChatStore
+                        profileStore: appMain.profileStore
+                        privacyStore: appMain.privacyStore
+                        featureFlagsStore: appMain.featureFlagsStore
+                        contactsAdaptor: contactsModelAdaptor
+                        dappsServiceLoader: dAppsServiceLoader
 
-                            objectName: "homeContainer"
+                        browserEnabled: d.isBrowserEnabled
+                        syncingBadgeCount: d.syncingBadgeCount
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
-                            HomePageAdaptor {
-                                id: homePageAdaptor
-                                readonly property bool sectionsLoaded: appMain.rootStore.sectionsLoaded
-
-                                sectionsBaseModel: sectionsLoaded ? appMain.rootStore.sectionsModel : null
-                                chatsBaseModel: sectionsLoaded ? appMain.rootChatStore.chatSectionModuleModel
-                                                               : null
-                                chatsSearchBaseModel: sectionsLoaded && !!rootStore.chatSearchModel ? rootStore.chatSearchModel : null
-                                walletsBaseModel: sectionsLoaded ? WalletStores.RootStore.accounts : null
-                                dappsBaseModel: dAppsServiceLoader.active && dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
-
-                                showEnabledSectionsOnly: true
-                                marketEnabled: appMain.featureFlagsStore.marketEnabled
-                                browserEnabled: d.isBrowserEnabled
-                                showDapps: false // SEE https://github.com/status-im/status-app/issues/19580
-
-                                syncingBadgeCount: d.syncingBadgeCount
-                                messagingBadgeCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
-                                showBackUpSeed: !appMain.privacyStore.mnemonicBackedUp
-                                backUpSeedBadgeCount: appMain.profileStore.userDeclinedBackupBanner ? 0 : showBackUpSeed
-                                keycardEnabled: appMain.featureFlagsStore.keycardEnabled
-
-                                searchPhrase: homePage.searchPhrase
-
-                                profileId: appMain.profileStore.pubKey
-
-                                // no automatic propagation to QtObject, needs to be specified explicitely
-                                Theme.style: appMain.Theme.style
-                            }
-
-                            homePageEntriesModel: homePageAdaptor.homePageEntriesModel
-                            sectionsModel: homePageAdaptor.sectionsModel
-                            pinnedModel: homePageAdaptor.pinnedModel
-
-                            // Floating panel
-                            leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-
-                            onItemActivated: function(key, sectionType, itemId) {
-                                homePageAdaptor.setTimestamp(key, new Date().valueOf())
-
-                                if (sectionType === -1) { // search
-                                    const [sectionId, chatId] = key.split(";")
-                                    return rootStore.setActiveSectionChat(sectionId, chatId)
-                                } else if (sectionType === Constants.appSection.profile) {
-                                    if (itemId == Constants.settingsSubsection.backUpSeed) {
-                                        return Global.openBackUpSeedPopup()
-                                    } else if (itemId == Constants.settingsSubsection.signout) {
-                                        return Global.quitAppRequested()
-                                    }
-                                }
-
-                                let subsection = itemId
-                                let subSubsection = -1
-                                let data = {}
-
-                                if (sectionType === Constants.appSection.wallet && !!itemId) {
-                                    subsection = WalletLayout.LeftPanelSelection.Address
-                                    subSubsection = WalletLayout.RightPanelSelection.Assets
-                                    data = { address: itemId }
-                                }
-
-                                globalConns.onAppSectionBySectionTypeChanged(sectionType, subsection, subSubsection, data)
-                            }
-                            onItemPinRequested: function(key, pin) {
-                                homePageAdaptor.setPinned(key, pin)
-                                if (pin)
-                                    homePageAdaptor.setTimestamp(key, new Date().valueOf()) // update the timestamp so that the pinned dock items are sorted by their recency
-                            }
-                            onDappDisconnectRequested: function(dappUrl) {
-                                dAppsServiceLoader.dappDisconnectRequested(dappUrl)
-                            }
-                        }
+                        onAppSectionRequested: (sectionType, subsection, subSubsection, data) =>
+                            globalConns.onAppSectionBySectionTypeChanged(sectionType, subsection, subSubsection, data)
                     }
 
-                    Loader {
+                    ChatLoader {
                         id: personalChatLayoutLoader
 
                         active: false
-                        sourceComponent: personalChatLayoutComponent
-
-                        onStatusChanged: {
-                            if (status === Loader.Ready || status === Loader.Error) {
-                                d.showChatLayoutLoading = false
-                            }
-                        }
-
                         // Do not unload section data from the memory in order not
                         // to reset scroll, not send text input and etc during the
                         // sections switching
@@ -1960,159 +1860,59 @@ Item {
                             restoreMode: Binding.RestoreNone
                         }
 
-                        Component {
-                            id: personalChatLayoutComponent
+                        rootStore: appMain.rootStore
+                        contactsStore: appMain.contactsStore
+                        accountSettingsStore: appMain.accountSettingsStore
+                        featureFlagsStore: appMain.featureFlagsStore
+                        sharedRootStore: appMain.sharedRootStore
+                        currencyStore: appMain.currencyStore
+                        communityTokensStore: appMain.communityTokensStore
+                        networkConnectionStore: appMain.networkConnectionStore
+                        networksStore: appMain.networksStore
+                        transactionStore: appMain.transactionStore
+                        tokensStore: appMain.tokensStore
+                        walletAssetsStore: appMain.walletAssetsStore
+                        advancedStore: appMain.advancedStore
+                        createChatPropertiesStore: appMain.createChatPropertiesStore
+                        contactsAdaptor: contactsModelAdaptor
+                        popupHandler: popupRequestsHandler
+                        emojiPopupLoader: statusEmojiPopup
+                        stickersPopupLoader: statusStickersPopupLoader
 
-                            ChatLayout {
-                                id: chatLayoutContainer
+                        createChatViewOpened: createChatView.opened
+                        isPortraitMode: appMain.isPortraitMode
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
-                                showUsersList: appMain.accountSettingsStore.showUsersList
-                                onShowUsersListRequested:
-                                    show => appMain.accountSettingsStore.setShowUsersList(show)
-
-                                isChatView: true
-                                rootStore: ChatStores.RootStore {
-                                    contactsStore: appMain.contactsStore
-                                    currencyStore: appMain.currencyStore
-                                    communityTokensStore: appMain.communityTokensStore
-                                    openCreateChat: createChatView.opened
-                                    networkConnectionStore: appMain.networkConnectionStore
-                                    isChatSectionModule: true
-                                }
-                                createChatPropertiesStore: appMain.createChatPropertiesStore
-                                tokensStore: appMain.tokensStore
-                                transactionStore: appMain.transactionStore
-                                walletAssetsStore: appMain.walletAssetsStore
-                                currencyStore: appMain.currencyStore
-                                networksStore: appMain.networksStore
-                                advancedStore: appMain.advancedStore
-                                emojiPopup: statusEmojiPopup.item
-                                stickersPopup: statusStickersPopupLoader.item
-                                sendViaPersonalChatEnabled: featureFlagsStore.sendViaPersonalChatEnabled
-                                disabledTooltipText: !appMain.networkConnectionStore.sendBuyBridgeEnabled ?
-                                                        appMain.networkConnectionStore.sendBuyBridgeToolTipText : ""
-                                paymentRequestFeatureEnabled: featureFlagsStore.paymentRequestEnabled
-                                extraLeftPadding: appMain.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0
-
-                                mutualContactsModel: contactsModelAdaptor.mutualContacts
-
-                                // Unfurling related data:
-                                gifUnfurlingEnabled: appMain.sharedRootStore.gifUnfurlingEnabled
-                                neverAskAboutUnfurlingAgain: appMain.sharedRootStore.neverAskAboutUnfurlingAgain
-
-                                // Users related data
-                                usersModel: rootStore.usersStore.usersModel
-
-                                // Contacts related data:
-                                myPublicKey: appMain.contactsStore.myPublicKey
-
-                                // Navigation: Temporary solution that keeps ui navigation state when in-app links
-                                // are triggered and allow messaging details navigation in portrait
-                                navToMsgDetails: appMain.rootStore.navToMsgDetails
-
-                                onProfileButtonClicked: {
-                                    Global.changeAppSectionBySectionType(Constants.appSection.profile);
-                                }
-
-                                onOpenAppSearch: {
-                                    appSearch.openSearchPopup()
-                                }
-
-                                onBuyStickerPackRequested: popupRequestsHandler.sendModalHandler.buyStickerPack(packId, price)
-                                onTokenPaymentRequested: popupRequestsHandler.sendModalHandler.openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount)
-
-                                // Unfurling related requests:
-                                onSetNeverAskAboutUnfurlingAgain: appMain.sharedRootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
-
-                                onOpenGifPopupRequest: popupRequestsHandler.statusGifPopupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
-
-                                // Edit group chat members signals:
-                                onGroupMembersUpdateRequested: rootStore.usersStore.groupMembersUpdateRequested(membersPubKeysList)
-
-                                // Contacts related requests:
-                                onChangeContactNicknameRequest: appMain.contactsStore.changeContactNickname(pubKey, nickname, displayName, isEdit)
-                                onRemoveTrustStatusRequest: appMain.contactsStore.removeTrustStatus(pubKey)
-                                onDismissContactRequest: appMain.contactsStore.dismissContactRequest(chatId, contactRequestId)
-                                onAcceptContactRequest: appMain.contactsStore.acceptContactRequest(chatId, contactRequestId)
-
-                                // Navigation: Temporary solution that keeps ui navigation state when in-app links
-                                // are triggered and allow messaging details navigation in portrait
-                                onNavToMsgDetailsRequested: navigate => appMain.rootStore.setNavToMsgDetailsFlag(navigate)
-
-                                // Floating panel
-                                leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                            }
-                        }
+                        onOpenAppSearchRequested: appSearch.openSearchPopup()
                     }
 
-                    Loader {
+                    CommunitiesPortalLoader {
                         active: appView.currentIndex === Constants.appViewStackIndex.communitiesPortal
-                        sourceComponent: CommunitiesPortalLayout {
-                            anchors.fill: parent
-                            createCommunityEnabled: !SQUtils.Utils.isMobile
-                            communitiesStore: appMain.communitiesStore
-                            assetsModel: appMain.rootStore.globalAssetsModel
-                            collectiblesModel: appMain.rootStore.globalCollectiblesModel
-
-                            // Floating panel
-                            leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                        }
+                        rootStore: appMain.rootStore
+                        communitiesStore: appMain.communitiesStore
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
                     }
 
-                    Loader {
+                    WalletLoader {
                         active: appView.currentIndex === Constants.appViewStackIndex.wallet
-                        sourceComponent: appMain.rootStore.thirdpartyServicesEnabled ? walletLayout: walletPrivacyWall
 
-                        Component {
-                            id: walletPrivacyWall
+                        rootStore: appMain.rootStore
+                        contactsStore: appMain.contactsStore
+                        featureFlagsStore: appMain.featureFlagsStore
+                        sharedRootStore: appMain.sharedRootStore
+                        networkConnectionStore: appMain.networkConnectionStore
+                        networksStore: appMain.networksStore
+                        communitiesStore: appMain.communitiesStore
+                        transactionStore: appMain.transactionStore
+                        popupHandler: popupRequestsHandler
+                        dappsServiceLoader: dAppsServiceLoader
+                        emojiPopupLoader: statusEmojiPopup
 
-                            WalletPrivacyWall {
-                                onOpenThirdpartyServicesInfoPopupRequested: popupRequestsHandler.thirdpartyServicesPopupHandler.openPopup()
-                                onOpenDiscussPageRequested: Global.requestOpenLink(Constants.statusDiscussPageUrl)
-                            }
-                        }
-
-                        Component {
-                            id: walletLayout
-
-                            WalletLayout {
-                                objectName: "walletLayoutReal"
-                                walletRootStore: WalletStores.RootStore
-                                sharedRootStore: appMain.sharedRootStore
-                                store: appMain.rootStore
-                                contactsStore: appMain.contactsStore
-                                communitiesStore: appMain.communitiesStore
-                                transactionStore: appMain.transactionStore
-                                emojiPopup: statusEmojiPopup.item
-                                networkConnectionStore: appMain.networkConnectionStore
-                                networksStore: appMain.networksStore
-                                appMainVisible: appMain.visible
-                                swapEnabled: featureFlagsStore.swapEnabled
-                                buyEnabled: featureFlagsStore.buyEnabled
-                                dAppsVisible: dAppsServiceLoader.item ? dAppsServiceLoader.item.serviceAvailableToCurrentAddress : false
-                                dAppsEnabled: dAppsServiceLoader.item ? dAppsServiceLoader.item.isServiceOnline : false
-                                dAppsModel: dAppsServiceLoader.item ? dAppsServiceLoader.item.dappsModel : null
-                                isKeycardEnabled: featureFlagsStore.keycardEnabled
-                                onDappConnectRequested: {
-                                    dAppsServiceLoader.dappConnectRequested()
-                                }
-                                onDappDisconnectRequested: function(dappUrl) {
-                                    dAppsServiceLoader.dappDisconnectRequested(dappUrl)
-                                }
-                                onSendTokenRequested: (senderAddress, gorupKey, tokenType) => popupRequestsHandler.sendModalHandler.sendToken(senderAddress, gorupKey, tokenType)
-
-                                onOpenSwapModalRequested: (swapFormData) => popupRequestsHandler.swapModalHandler.launchSwapSpecific(swapFormData)
-
-                                // Floating panel
-                                leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                            }
-                        }
-                        onLoaded: {
-                            item.resetView()
-                        }
+                        appMainVisible: appMain.visible
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
                     }
 
-                    Loader {
+                    BrowserLoader {
                         id: browserLayoutContainer
 
                         // Do not unload section data from the memory once activated
@@ -2123,216 +1923,104 @@ Item {
                             restoreMode: Binding.RestoreNone
                         }
 
-                        sourceComponent: appMain.rootStore.thirdpartyServicesEnabled ? browserLayoutComp: browserPrivacyWall
+                        rootStore: appMain.rootStore
+                        featureFlagsStore: appMain.featureFlagsStore
+                        profileStore: appMain.profileStore
+                        advancedStore: appMain.advancedStore
+                        networksStore: appMain.networksStore
+                        currencyStore: appMain.currencyStore
+                        transactionStore: appMain.transactionStore
+                        popupHandler: popupRequestsHandler
 
-                        Component {
-                            id: browserPrivacyWall
-
-                            BrowserPrivacyWall {
-                                onOpenThirdpartyServicesInfoPopupRequested: popupRequestsHandler.thirdpartyServicesPopupHandler.openPopup()
-                                onOpenDiscussPageRequested: Global.openLinkWithConfirmation(
-                                                                Constants.statusDiscussPageUrl,
-                                                                SQUtils.StringUtils.extractDomainFromLink(Constants.statusDiscussPageUrl))
-                            }
-                        }
-
-                        Component {
-                            id: browserLayoutComp
-
-                            BrowserLayout {
-                                id: browserLayout
-                                isMobile: SQUtils.Utils.isMobile
-                                userUID: appMain.profileStore.pubKey
-                                thirdpartyServicesEnabled: appMain.rootStore.thirdpartyServicesEnabled
-                                dappsEnabled: featureFlagsStore.dappsEnabled
-                                bookmarksStore: BrowserStores.BookmarksStore {}
-                                downloadsStore: BrowserStores.DownloadsStore {}
-                                browserRootStore: BrowserStores.BrowserRootStore {}
-                                browserWalletStore: BrowserStores.BrowserWalletStore {}
-                                browserActivityStore: BrowserStores.BrowserActivityStore {
-                                    browserWalletStore: browserLayout.browserWalletStore
-                                }
-                                currencyStore: appMain.currencyStore
-                                networksStore: appMain.networksStore
-                                connectorController: WalletStores.RootStore.dappsConnectorController
-                                isDebugEnabled: appMain.advancedStore.isDebugEnabled
-
-                                transactionStore: appMain.transactionStore
-                                onSendToRecipientRequested: (address) => popupRequestsHandler.sendModalHandler.sendToRecipient(address)
-
-                                // Floating panel
-                                leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                            }
-                        }
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
                     }
 
-                    Loader {
+                    ProfileLoader {
                         id: profileLoader
 
-                        property int settingsSubsection: Constants.settingsSubsection.profile
-                        onSettingsSubsectionChanged: {
-                            item.settingsSubsection = settingsSubsection
-                        }
-                        property int settingsSubSubsection: -1
-                        onSettingsSubSubsectionChanged: {
-                            item.settingsSubsection = settingsSubsection
-                            item.settingsSubSubsection = settingsSubSubsection
-                        }
-
                         active: appView.currentIndex === Constants.appViewStackIndex.profile
-                        sourceComponent: ProfileLayout {
-                            isProduction: appMain.rootStore.isProduction
-                            userUID: appMain.profileStore.pubKey
 
-                            sharedRootStore: appMain.sharedRootStore
-                            utilsStore: appMain.utilsStore
-                            aboutStore: appMain.aboutStore
-                            profileStore: appMain.profileStore
-                            contactsStore: appMain.contactsStore
-                            devicesStore: appMain.devicesStore
-                            advancedStore: appMain.advancedStore
-                            privacyStore: appMain.privacyStore
-                            notificationsStore: appMain.notificationsStore
-                            languageStore: appMain.languageStore
-                            keycardStore: appMain.keycardStore
-                            keycardNewStore: appMain.keycardNewStore
-                            walletStore: appMain.walletProfileStore
-                            messagingSettingsStore: appMain.messagingSettingsStore
-                            ensUsernamesStore: appMain.ensUsernamesStore
-                            globalStore: appMain.rootStore
-                            communitiesStore: appMain.communitiesStore
-                            networkConnectionStore: appMain.networkConnectionStore
-                            tokensStore: appMain.tokensStore
-                            walletAssetsStore: appMain.walletAssetsStore
-                            collectiblesStore: appMain.walletCollectiblesStore
-                            currencyStore: appMain.currencyStore
-                            networksStore: appMain.networksStore
-                            messagingRootStore: appMain.messagingRootStore
+                        rootStore: appMain.rootStore
+                        contactsStore: appMain.contactsStore
+                        featureFlagsStore: appMain.featureFlagsStore
+                        sharedRootStore: appMain.sharedRootStore
+                        utilsStore: appMain.utilsStore
+                        networkConnectionStore: appMain.networkConnectionStore
+                        networksStore: appMain.networksStore
+                        currencyStore: appMain.currencyStore
+                        communitiesStore: appMain.communitiesStore
+                        messagingRootStore: appMain.messagingRootStore
+                        messagingSettingsStore: appMain.messagingSettingsStore
+                        aboutStore: appMain.aboutStore
+                        profileStore: appMain.profileStore
+                        devicesStore: appMain.devicesStore
+                        advancedStore: appMain.advancedStore
+                        privacyStore: appMain.privacyStore
+                        notificationsStore: appMain.notificationsStore
+                        languageStore: appMain.languageStore
+                        keycardStore: appMain.keycardStore
+                        keycardNewStore: appMain.keycardNewStore
+                        walletProfileStore: appMain.walletProfileStore
+                        ensUsernamesStore: appMain.ensUsernamesStore
+                        tokensStore: appMain.tokensStore
+                        walletAssetsStore: appMain.walletAssetsStore
+                        walletCollectiblesStore: appMain.walletCollectiblesStore
 
-                            keychain: appMain.keychain
-                            emojiPopup: statusEmojiPopup.item
+                        contactsAdaptor: contactsModelAdaptor
+                        popupHandler: popupRequestsHandler
+                        emojiPopupLoader: statusEmojiPopup
+                        keychain: appMain.keychain
 
-                            mutualContactsModel: contactsModelAdaptor.mutualContacts
-                            blockedContactsModel: contactsModelAdaptor.blockedContacts
-                            pendingContactsModel: contactsModelAdaptor.pendingContacts
-                            pendingReceivedContactsCount: contactsModelAdaptor.pendingReceivedRequestContacts.count
-                            dismissedReceivedRequestContactsModel: contactsModelAdaptor.dimissedReceivedRequestContacts
-                            isKeycardEnabled: featureFlagsStore.keycardEnabled
-                            isBrowserEnabled: featureFlagsStore.browserEnabled
-                            privacyModeFeatureEnabled: featureFlagsStore.privacyModeFeatureEnabled
-                            minimizeOnCloseOptionVisible: appMain.systemTrayIconAvailable
+                        isProduction: appMain.rootStore.isProduction
+                        systemTrayIconAvailable: appMain.systemTrayIconAvailable
+                        theme: appMainLocalSettings.theme
+                        fontSize: appMainLocalSettings.fontSize
+                        paddingFactor: appMainLocalSettings.paddingFactor
+                        whitelistedDomainsModel: appMainLocalSettings.whitelistedUnfurledDomains
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
-                            theme: appMainLocalSettings.theme
-                            fontSize: appMainLocalSettings.fontSize
-                            paddingFactor: appMainLocalSettings.paddingFactor
-
-                            whitelistedDomainsModel: appMainLocalSettings.whitelistedUnfurledDomains
-
-                            onAddressWasShownRequested: (address) => WalletStores.RootStore.addressWasShown(address)
-                            onSettingsSubsectionChanged: profileLoader.settingsSubsection = settingsSubsection
-                            onConnectUsernameRequested: (ensName, ownerAddress) => popupRequestsHandler.sendModalHandler.connectUsername(ensName, ownerAddress)
-                            onRegisterUsernameRequested: (ensName, chainId) => popupRequestsHandler.sendModalHandler.registerUsername(ensName, chainId)
-                            onReleaseUsernameRequested: (ensName, senderAddress, chainId) => popupRequestsHandler.sendModalHandler.releaseUsername(ensName, senderAddress, chainId)
-
-                            onThemeChangeRequested: function(theme) {
-                                appMainLocalSettings.theme = theme
-                                ThemeUtils.setTheme(appMain.Window.window, theme)
-                            }
-                            onFontSizeChangeRequested: function(fontSize) {
-                                appMainLocalSettings.fontSize = fontSize
-                                ThemeUtils.setFontSize(appMain.Window.window, fontSize)
-                            }
-                            onPaddingFactorChangeRequested: function(paddingFactor) {
-                                appMainLocalSettings.paddingFactor = paddingFactor
-                                ThemeUtils.setPaddingFactor(appMain.Window.window, paddingFactor)
-                            }
-                            // Communities related settings view:
-                            onLeaveCommunityRequest: communityId => appMain.communitiesStore.leaveCommunity(communityId)
-                            onSetCommunityMutedRequest: (communityId, mutedType) => appMain.communitiesStore.setCommunityMuted(communityId, mutedType)
-                            onInviteFriends: communityData => Global.openInviteFriendsToCommunityByIdPopup(communityData.id, null)
-                            onOpenThirdpartyServicesInfoPopupRequested: popupRequestsHandler.thirdpartyServicesPopupHandler.openPopup()
-                            onOpenDiscussPageRequested: Global.requestOpenLink(Constants.statusDiscussPageUrl)
-
-                            onRemoveWhitelistedDomain: function(index) {
-                                // in order to notify changes in this model, we need to re assign to this model
-                                const domainRemoved = appMainLocalSettings.whitelistedUnfurledDomains[index]
-                                const whitelistedUnfurledDomainsCpy = appMainLocalSettings.whitelistedUnfurledDomains.slice()
-                                whitelistedUnfurledDomainsCpy.splice(index, 1)
-                                appMainLocalSettings.whitelistedUnfurledDomains = whitelistedUnfurledDomainsCpy
-                                Global.displaySuccessToastMessage(qsTr("%1 was removed from your trusted sites.").arg(domainRemoved))
-                            }
-
-                            // Floating panel
-                            leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
+                        onThemeChangeRequested: (theme) => {
+                            appMainLocalSettings.theme = theme
+                            ThemeUtils.setTheme(appMain.Window.window, theme)
                         }
-                        onLoaded: {
-                            item.settingsSubsection = profileLoader.settingsSubsection
-                            item.settingsSubSubsection = profileLoader.settingsSubSubsection
+                        onFontSizeChangeRequested: (fontSize) => {
+                            appMainLocalSettings.fontSize = fontSize
+                            ThemeUtils.setFontSize(appMain.Window.window, fontSize)
+                        }
+                        onPaddingFactorChangeRequested: (paddingFactor) => {
+                            appMainLocalSettings.paddingFactor = paddingFactor
+                            ThemeUtils.setPaddingFactor(appMain.Window.window, paddingFactor)
+                        }
+                        onRemoveWhitelistedDomainRequested: (index) => {
+                            // in order to notify changes in this model, we need to re assign to this model
+                            const domainRemoved = appMainLocalSettings.whitelistedUnfurledDomains[index]
+                            const cpy = appMainLocalSettings.whitelistedUnfurledDomains.slice()
+                            cpy.splice(index, 1)
+                            appMainLocalSettings.whitelistedUnfurledDomains = cpy
+                            Global.displaySuccessToastMessage(qsTr("%1 was removed from your trusted sites.").arg(domainRemoved))
                         }
                     }
 
-                    Loader {
+                    NodeLoader {
                         active: appView.currentIndex === Constants.appViewStackIndex.node
-                        sourceComponent: NodeLayout {
-                            // Floating panel
-                            leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                        }
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
                     }
 
-                    Loader {
+                    MarketLoader {
                         active: appView.currentIndex === Constants.appViewStackIndex.market
-                        sourceComponent: appMain.rootStore.thirdpartyServicesEnabled ? marketLayout : marketPrivacyWall
 
-                        Component {
-                            id: marketPrivacyWall
+                        rootStore: appMain.rootStore
+                        featureFlagsStore: appMain.featureFlagsStore
+                        currencyStore: appMain.currencyStore
+                        marketStore: appMain.marketStore
+                        popupHandler: popupRequestsHandler
 
-                            MarketPrivacyWall {
-                                onOpenThirdpartyServicesInfoPopupRequested: popupRequestsHandler.thirdpartyServicesPopupHandler.openPopup()
-                                onOpenDiscussPageRequested: Global.requestOpenLink(Constants.statusDiscussPageUrl)
-                            }
-                        }
-
-                        Component {
-                            id: marketLayout
-
-                            MarketLayout {
-                                objectName: "marketLayout"
-
-                                tokensModel: appMain.marketStore.marketLeaderboardModel
-                                totalTokensCount: appMain.marketStore.totalLeaderboardCount
-                                loading: appMain.marketStore.marketLeaderboardLoading
-                                swapEnabled: featureFlagsStore.swapEnabled
-                                currencySymbol: {
-                                    const symbol = SQUtils.ModelUtils.getByKey(
-                                                     appMain.currencyStore.currenciesModel,
-                                                     "shortName",
-                                                     appMain.currencyStore.currentCurrency,
-                                                     "symbol")
-                                    return !!symbol ? symbol: ""
-                                }
-                                fnFormatCurrencyAmount: function(amount, options) {
-                                    return appMain.currencyStore.formatCurrencyAmount(amount, appMain.currencyStore.currentCurrency, options)
-                                }
-                                currentPage: appMain.marketStore.currentPage
-                                onRequestLaunchSwap: popupRequestsHandler.swapModalHandler.launchSwap()
-                                onFetchMarketTokens: (pageNumber, pageSize) => {
-                                                         appMain.marketStore.requestMarketTokenPage(pageNumber, pageSize)
-                                                     }
-
-                                // Floating panel
-                                leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                            }
-                        }
-
-                        onActiveChanged: {
-                            if(!active && appMain.rootStore.thirdpartyServicesEnabled) {
-                                appMain.marketStore.unsubscribeFromUpdates()
-                            }
-                        }
-                        onLoaded: item.resetView()
+                        leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
                     }
 
                     Repeater {
+                        id: communityRepeater
+
                         model: SortFilterProxyModel {
                             sourceModel: appMain.rootStore.sectionsModel
                             filters: ValueFilter {
@@ -2341,22 +2029,14 @@ Item {
                             }
                         }
 
-                        delegate: Loader {
-                            readonly property string sectionId: model.id
+                        delegate: CommunityChatLoader {
+                            required property var model
 
                             Layout.fillWidth: true
                             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                             Layout.fillHeight: true
 
                             active: false
-                            asynchronous: false
-
-                            onStatusChanged: {
-                                if (status === Loader.Ready || status === Loader.Error) {
-                                    d.showChatLayoutLoading = false
-                                }
-                            }
-
                             // Do not unload section data from the memory in order not
                             // to reset scroll, not send text input and etc during the
                             // sections switching
@@ -2366,99 +2046,35 @@ Item {
                                 restoreMode: Binding.RestoreNone
                             }
 
-                            sourceComponent: ChatLayout {
-                                id: chatLayoutComponent
+                            sectionId: model.id
+                            sectionItemModel: model
 
-                                readonly property bool isManageCommunityEnabledInAdvanced: appMain.advancedStore.isManageCommunityOnTestModeEnabled
+                            rootStore: appMain.rootStore
+                            contactsStore: appMain.contactsStore
+                            accountSettingsStore: appMain.accountSettingsStore
+                            featureFlagsStore: appMain.featureFlagsStore
+                            sharedRootStore: appMain.sharedRootStore
+                            currencyStore: appMain.currencyStore
+                            communityTokensStore: appMain.communityTokensStore
+                            networkConnectionStore: appMain.networkConnectionStore
+                            networksStore: appMain.networksStore
+                            transactionStore: appMain.transactionStore
+                            tokensStore: appMain.tokensStore
+                            walletAssetsStore: appMain.walletAssetsStore
+                            advancedStore: appMain.advancedStore
+                            communitiesStore: appMain.communitiesStore
+                            messagingRootStore: appMain.messagingRootStore
+                            createChatPropertiesStore: appMain.createChatPropertiesStore
+                            contactsAdaptor: contactsModelAdaptor
+                            popupHandler: popupRequestsHandler
+                            emojiPopupLoader: statusEmojiPopup
+                            stickersPopupLoader: statusStickersPopupLoader
 
-                                Connections {
-                                    target: Global
-                                    function onSwitchToCommunitySettings(communityId: string) {
-                                        if (communityId !== model.id)
-                                            return
-                                        chatLayoutComponent.currentIndex = 1 // Settings
-                                    }
-                                    function onSwitchToCommunityChannelsView(communityId: string) {
-                                        if (communityId !== model.id)
-                                            return
-                                        chatLayoutComponent.currentIndex = 0
-                                    }
-                                }
+                            createChatViewOpened: createChatView.opened
+                            isPortraitMode: appMain.isPortraitMode
+                            leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
 
-                                anchors.fill: parent
-                                showUsersList: appMain.accountSettingsStore.showUsersList
-                                onShowUsersListRequested:
-                                    show => appMain.accountSettingsStore.setShowUsersList(show)
-
-                                isChatView: false // This will be a community view
-                                emojiPopup: statusEmojiPopup.item
-                                stickersPopup: statusStickersPopupLoader.item
-                                sectionItemModel: model
-                                createChatPropertiesStore: appMain.createChatPropertiesStore
-                                communitiesStore: appMain.communitiesStore
-                                communitySettingsDisabled: !chatLayoutComponent.isManageCommunityEnabledInAdvanced &&
-                                                        (appMain.rootStore.isProduction && appMain.networksStore.areTestNetworksEnabled)
-
-                                newCommnityStore: appMain.messagingRootStore.createCommunityRootStore(this, model.id)
-                                rootStore: ChatStores.RootStore {
-                                    contactsStore: appMain.contactsStore
-                                    currencyStore: appMain.currencyStore
-                                    communityTokensStore: appMain.communityTokensStore
-                                    openCreateChat: createChatView.opened
-                                    isChatSectionModule: false
-                                    communityId: model.id
-                                }
-                                tokensStore: appMain.tokensStore
-                                transactionStore: appMain.transactionStore
-                                walletAssetsStore: appMain.walletAssetsStore
-                                currencyStore: appMain.currencyStore
-                                networksStore: appMain.networksStore
-                                advancedStore: appMain.advancedStore
-                                paymentRequestFeatureEnabled: featureFlagsStore.paymentRequestEnabled
-                                extraLeftPadding: appMain.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0
-
-                                mutualContactsModel: contactsModelAdaptor.mutualContacts
-
-                                // Unfurling related data:
-                                gifUnfurlingEnabled: appMain.sharedRootStore.gifUnfurlingEnabled
-                                neverAskAboutUnfurlingAgain: appMain.sharedRootStore.neverAskAboutUnfurlingAgain
-
-                                usersModel: rootStore.usersStore.usersModel
-
-                                // Contacts related data:
-                                myPublicKey: appMain.contactsStore.myPublicKey
-
-                                // Navigation:
-                                navToMsgDetails: appMain.rootStore.navToMsgDetails
-
-                                onProfileButtonClicked: {
-                                    Global.changeAppSectionBySectionType(Constants.appSection.profile);
-                                }
-
-                                onOpenAppSearch: {
-                                    appSearch.openSearchPopup()
-                                }
-
-                                onBuyStickerPackRequested: popupRequestsHandler.sendModalHandler.buyStickerPack(packId, price)
-                                onTokenPaymentRequested: popupRequestsHandler.sendModalHandler.openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount)
-
-                                // Unfurling related requests:
-                                onSetNeverAskAboutUnfurlingAgain: appMain.sharedRootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
-
-                                onOpenGifPopupRequest: popupRequestsHandler.statusGifPopupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
-
-                                // Contacts related requests:
-                                onChangeContactNicknameRequest: appMain.contactsStore.changeContactNickname(pubKey, nickname, displayName, isEdit)
-                                onRemoveTrustStatusRequest: appMain.contactsStore.removeTrustStatus(pubKey)
-                                onDismissContactRequest: appMain.contactsStore.dismissContactRequest(chatId, contactRequestId)
-                                onAcceptContactRequest: appMain.contactsStore.acceptContactRequest(chatId, contactRequestId)
-
-                                // Navigation:
-                                onNavToMsgDetailsRequested: navigate => appMain.rootStore.setNavToMsgDetailsFlag(navigate)
-
-                                // Floating panel
-                                leftPanelWidthOverride: mainLayoutItem.leftPanelWidthOverride
-                            }
+                            onOpenAppSearchRequested: appSearch.openSearchPopup()
                         }
                     }
                 }
@@ -2550,7 +2166,7 @@ Item {
                     mainLayoutItem.openACCenterPanel = false
 
                     if (sectionType === Constants.appSection.swap) {
-                        popupRequestsHandler.swapModalHandler.launchSwap()
+                        popupRequestsHandler.launchSwap()
                     } else if (sectionType === Constants.appSection.qrCodeScanner) {
                         Global.openQRScannerRequested()
                     } else {
@@ -2564,19 +2180,6 @@ Item {
                         // is shown after it's been introduced
                         d.tryOpenNavigationEducationPopup()
                     }
-                }
-            }
-
-             Loader {
-                active: d.showChatLayoutLoading
-                anchors.left: sidebar.right
-                anchors.top: parent.top
-                anchors.bottom: parent.bottom
-                anchors.right: parent.right
-
-                sourceComponent: ChatLayoutLoading {
-                    anchors.fill: parent
-                    showMembersPanel: appMain.accountSettingsStore.showUsersList
                 }
             }
         }

--- a/ui/app/mainui/Handlers/HandlersManager.qml
+++ b/ui/app/mainui/Handlers/HandlersManager.qml
@@ -298,6 +298,55 @@ QtObject {
         showEnablePushNotificationsPopup()
     }
 
+    // Flat API — delegates to the nested handler instances above. Callers should
+    // prefer these over `popupHandler.<nestedHandler>.<method>()` chains.
+    function launchSwap() {
+        swapModalHandler.launchSwap()
+    }
+    function launchSwapSpecific(data) {
+        swapModalHandler.launchSwapSpecific(data)
+    }
+
+    function openSend() {
+        sendModalHandler.openSend()
+    }
+    function transferOwnership(tokenId, senderAddress) {
+        sendModalHandler.transferOwnership(tokenId, senderAddress)
+    }
+    function buyStickerPack(packId, price) {
+        sendModalHandler.buyStickerPack(packId, price)
+    }
+    function sendToRecipient(address) {
+        sendModalHandler.sendToRecipient(address)
+    }
+    function sendToken(senderAddress, groupKey, tokenType) {
+        sendModalHandler.sendToken(senderAddress, groupKey, tokenType)
+    }
+    function connectUsername(ensName, ownerAddress) {
+        sendModalHandler.connectUsername(ensName, ownerAddress)
+    }
+    function registerUsername(ensName, chainId) {
+        sendModalHandler.registerUsername(ensName, chainId)
+    }
+    function releaseUsername(ensName, senderAddress, chainId) {
+        sendModalHandler.releaseUsername(ensName, senderAddress, chainId)
+    }
+    function openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount) {
+        sendModalHandler.openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount)
+    }
+
+    function openGifs(params, cbOnGifSelected, cbOnClose) {
+        statusGifPopupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
+    }
+
+    // Disambiguated names — both nested handlers expose `openPopup()`.
+    function openThirdpartyServicesPopup() {
+        thirdpartyServicesPopupHandler.openPopup()
+    }
+    function openEnableBiometricsPopup() {
+        enableBiometricsPopupHandler.openPopup()
+    }
+
     readonly property EnableBiometricsPopupHandler enableBiometricsPopupHandler: EnableBiometricsPopupHandler {
         popupParent: root.popupParent
         privacyStore: root.privacyStore

--- a/ui/app/mainui/Handlers/SendModalHandler.qml
+++ b/ui/app/mainui/Handlers/SendModalHandler.qml
@@ -261,23 +261,23 @@ QtObject {
         openSend(params)
     }
 
-    function sendToken(senderAddress, gorupKey, tokenType) {
+    function sendToken(senderAddress, groupKey, tokenType) {
         let sendType = Constants.SendType.Transfer
         let selectedChainId = 0
         if (tokenType === Constants.TokenType.ERC721)  {
             sendType = Constants.SendType.ERC721Transfer
             selectedChainId =
-                    SQUtils.ModelUtils.getByKey(root.collectiblesBySymbolModel, "key", gorupKey, "chainId")
+                    SQUtils.ModelUtils.getByKey(root.collectiblesBySymbolModel, "key", groupKey, "chainId")
         }
         else if(tokenType === Constants.TokenType.ERC1155) {
             sendType = Constants.SendType.ERC1155Transfer
             selectedChainId =
-                    SQUtils.ModelUtils.getByKey(root.collectiblesBySymbolModel, "key", gorupKey, "chainId")
+                    SQUtils.ModelUtils.getByKey(root.collectiblesBySymbolModel, "key", groupKey, "chainId")
         }
         else {
             let layer1chainId = SQUtils.ModelUtils.getByKey(root.filteredFlatNetworksModel, "layer", "1", "chainId")
             let networksChainIdArray = SQUtils.ModelUtils.modelToFlatArray(root.filteredFlatNetworksModel, "chainId")
-            const tokensForSelectedAsset = SQUtils.ModelUtils.getByKey(root.tokenGroupsModel, "key", gorupKey)
+            const tokensForSelectedAsset = SQUtils.ModelUtils.getByKey(root.tokenGroupsModel, "key", groupKey)
             if (!!tokensForSelectedAsset) {
                 let chainToken = SQUtils.ModelUtils.getByKey(tokensForSelectedAsset.tokens, "chainId", layer1chainId)
                 if (!chainToken) {
@@ -298,7 +298,7 @@ QtObject {
         let params = {
             sendType: sendType,
             selectedAccountAddress: senderAddress,
-            selectedGroupKey: gorupKey,
+            selectedGroupKey: groupKey,
             selectedChainId: selectedChainId,
         }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -122,62 +122,6 @@ QtObject {
         return sharedContactModelEntryLoader.item
     }
 
-    Component.onCompleted: {
-        Global.openMarkAsIDVerifiedPopup.connect(openMarkAsIDVerifiedPopup)
-        Global.openRemoveIDVerificationDialog.connect(openRemoveIDVerificationDialog)
-        Global.openInviteFriendsToCommunityPopup.connect(openInviteFriendsToCommunityPopup)
-        Global.openInviteFriendsToCommunityByIdPopup.connect(openInviteFriendsToCommunityByIdPopup)
-        Global.openContactRequestPopup.connect(openContactRequestPopup)
-        Global.openReviewContactRequestPopup.connect(openReviewContactRequestPopup)
-        Global.openDownloadModalRequested.connect(openDownloadModal)
-        Global.openImagePopup.connect(openImagePopup)
-        Global.openVideoPopup.connect(openVideoPopup)
-        Global.openProfilePopupRequested.connect(openProfilePopup)
-        Global.openNicknamePopupRequested.connect(openNicknamePopup)
-        Global.markAsUntrustedRequested.connect(openMarkAsUntrustedPopup)
-        Global.blockContactRequested.connect(openBlockContactPopup)
-        Global.unblockContactRequested.connect(openUnblockContactPopup)
-        Global.openChangeProfilePicPopup.connect(openChangeProfilePicPopup)
-        Global.openBackUpSeedPopup.connect(openBackUpSeedPopup)
-        Global.openAuthenticationPopup.connect(openAuthenticationPopup)
-        Global.openSigningPopup.connect(openSigningPopup)
-        Global.openKeycardManagementPopup.connect(openKeycardManagementPopup)
-        Global.openPinnedMessagesPopupRequested.connect(openPinnedMessagesPopup)
-        Global.openCommunityProfilePopupRequested.connect(openCommunityProfilePopup)
-        Global.createCommunityPopupRequested.connect(openCreateCommunityPopup)
-        Global.importCommunityPopupRequested.connect(openImportCommunityPopup)
-        Global.communityShareAddressesPopupRequested.connect(openCommunityShareAddressesPopup)
-        Global.communityIntroPopupRequested.connect(openCommunityIntroPopup)
-        Global.removeContactRequested.connect(openRemoveContactConfirmationPopup)
-        Global.openPopupRequested.connect(openPopup)
-        Global.closePopupRequested.connect(closePopup)
-        Global.openDeleteMessagePopup.connect(openDeleteMessagePopup)
-        Global.openDownloadImageDialog.connect(openDownloadImageDialog)
-        Global.leaveCommunityRequested.connect(openLeaveCommunityPopup)
-        Global.openTestnetPopup.connect(openTestnetPopup)
-        Global.openExportControlNodePopup.connect(openExportControlNodePopup)
-        Global.openImportControlNodePopup.connect(openImportControlNodePopup)
-        Global.openEditSharedAddressesFlow.connect(openEditSharedAddressesPopup)
-        Global.openTransferOwnershipPopup.connect(openTransferOwnershipPopup)
-        Global.openFinaliseOwnershipPopup.connect(openFinaliseOwnershipPopup)
-        Global.openDeclineOwnershipPopup.connect(openDeclineOwnershipPopup)
-        Global.openFirstTokenReceivedPopup.connect(openFirstTokenReceivedPopup)
-        Global.openConfirmHideAssetPopup.connect(openConfirmHideAssetPopup)
-        Global.openConfirmHideCollectiblePopup.connect(openConfirmHideCollectiblePopup)
-        Global.openCommunityMemberMessagesPopupRequested.connect(openCommunityMemberMessagesPopup)
-        Global.openBuyCryptoModalRequested.connect(openBuyCryptoModal)
-        Global.privacyPolicyRequested.connect(() => openPopup(privacyPolicyPopupComponent))
-        Global.openPaymentRequestModalRequested.connect(openPaymentRequestModal)
-        Global.termsOfUseRequested.connect(() => openPopup(termsOfUsePopupComponent))
-        Global.openNewsMessagePopupRequested.connect(openNewsMessagePopup)
-        Global.quitAppRequested.connect(() => openPopup(quitConfirmPopupComponent))
-        Global.openQRScannerRequested.connect(() => openPopup(qrCodeScannerDialogComponent))
-        Global.openInfoPopup.connect(openInfoPopup)
-        Global.shareProfileDialogRequested.connect(openShareProfilePopup)
-        Global.openNavigationEducationPopupRequested.connect(openNavigationEducationPopup)
-        Global.openLimitReachedPopupRequested.connect(openLimitReachedPopup)
-    }
-
     property var currentPopup
     function openPopup(popupComponent, params = {}, cb = null) {
         if (root.activePopupComponents.includes(popupComponent)) {
@@ -595,6 +539,22 @@ QtObject {
             return
         }
         openPopup(limitReachedPopupComponent, { title, contentText: content })
+    }
+
+    function openPrivacyPolicyPopup() {
+        openPopup(privacyPolicyPopupComponent)
+    }
+
+    function openTermsOfUsePopup() {
+        openPopup(termsOfUsePopupComponent)
+    }
+
+    function openQuitConfirmPopup() {
+        openPopup(quitConfirmPopupComponent)
+    }
+
+    function openQRScannerPopup() {
+        openPopup(qrCodeScannerDialogComponent)
     }
 
     readonly property list<Component> _components: [

--- a/ui/app/mainui/sectionLoaders/AppMainLoader.qml
+++ b/ui/app/mainui/sectionLoaders/AppMainLoader.qml
@@ -1,0 +1,44 @@
+import QtQml
+import QtQuick
+
+import StatusQ
+
+import shared.stores as SharedStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Profile.stores as ProfileStores
+
+Loader {
+    id: root
+
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property ProfileStores.LanguageStore languageStore
+    required property Keychain keychain
+    required property bool systemTrayIconAvailable
+
+    property SharedStores.UtilsStore utilsStore
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (root.source === QmlCompiler.appMainUrl)
+            return
+        setSource(QmlCompiler.appMainUrl, {
+            objectName:             "appMain",
+            featureFlagsStore:      Qt.binding(() => root.featureFlagsStore),
+            languageStore:          Qt.binding(() => root.languageStore),
+            keychain:               Qt.binding(() => root.keychain),
+            utilsStore:             Qt.binding(() => root.utilsStore),
+            systemTrayIconAvailable:Qt.binding(() => root.systemTrayIconAvailable),
+        })
+    }
+
+    onActiveChanged: {
+        if (root.active) {
+            loadSection()
+            return
+        }
+    }
+
+    Component.onCompleted: QmlCompiler.precompile(QmlCompiler.appMainUrl, false)
+}

--- a/ui/app/mainui/sectionLoaders/BrowserLoader.qml
+++ b/ui/app/mainui/sectionLoaders/BrowserLoader.qml
@@ -1,0 +1,137 @@
+import QtQml
+import QtQuick
+
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Browser.stores as BrowserStores
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.sectionLoaders
+
+Loader {
+    id: root
+
+    required property AppStores.RootStore rootStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property ProfileStores.ProfileStore profileStore
+    required property ProfileStores.AdvancedStore advancedStore
+    required property SharedStores.NetworksStore networksStore
+    required property SharedStores.CurrenciesStore currencyStore
+    required property TransactionStore transactionStore
+
+    required property HandlersManagerLoader popupHandler
+
+    property real leftPanelWidthOverride: 0
+
+    asynchronous: false
+
+    QtObject {
+        id: d
+
+        readonly property url realUrl: QmlCompiler.browserUrl
+        readonly property url privacyWallUrl: QmlCompiler.browserPrivacyWallUrl
+        readonly property url targetUrl: rootStore.thirdpartyServicesEnabled ? realUrl : privacyWallUrl
+
+        // Holder for the per-load store instances; rebuilt on each privacy-wall toggle.
+        property QtObject storeParent: null
+    }
+
+    Component { id: bookmarksStoreComp; BrowserStores.BookmarksStore {} }
+    Component { id: downloadsStoreComp; BrowserStores.DownloadsStore {} }
+    Component { id: browserRootStoreComp; BrowserStores.BrowserRootStore {} }
+    Component { id: browserWalletStoreComp; BrowserStores.BrowserWalletStore {} }
+    Component { id: browserActivityStoreComp; BrowserStores.BrowserActivityStore {} }
+    Component { id: storeParentComp; QtObject {} }
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(d.targetUrl))
+        loadSection()
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+
+        if (!!root.item && root.source === d.targetUrl)
+            return
+
+        if (d.storeParent) {
+            d.storeParent.destroy()
+            d.storeParent = null
+        }
+
+        if (d.targetUrl === d.privacyWallUrl) {
+            setSource(d.targetUrl, {})
+            return
+        }
+
+        d.storeParent = storeParentComp.createObject(root)
+        const browserWalletStore = browserWalletStoreComp.createObject(d.storeParent)
+        const browserActivityStore = browserActivityStoreComp.createObject(d.storeParent, {
+            browserWalletStore: browserWalletStore,
+        })
+        const bookmarksStore = bookmarksStoreComp.createObject(d.storeParent)
+        const downloadsStore = downloadsStoreComp.createObject(d.storeParent)
+        const browserRootStore = browserRootStoreComp.createObject(d.storeParent)
+
+        setSource(d.targetUrl, {
+            isMobile:                   SQUtils.Utils.isMobile,
+            visible:                    false,
+            bookmarksStore:             bookmarksStore,
+            downloadsStore:             downloadsStore,
+            browserRootStore:           browserRootStore,
+            browserWalletStore:         browserWalletStore,
+            browserActivityStore:       browserActivityStore,
+            userUID:                    Qt.binding(() => root.profileStore.pubKey),
+            thirdpartyServicesEnabled:  Qt.binding(() => root.rootStore.thirdpartyServicesEnabled),
+            dappsEnabled:               Qt.binding(() => root.featureFlagsStore.dappsEnabled),
+            currencyStore:              Qt.binding(() => root.currencyStore),
+            networksStore:              Qt.binding(() => root.networksStore),
+            connectorController:        Qt.binding(() => WalletStores.RootStore.dappsConnectorController),
+            isDebugEnabled:             Qt.binding(() => root.advancedStore.isDebugEnabled),
+            transactionStore:           Qt.binding(() => root.transactionStore),
+            leftPanelWidthOverride:     Qt.binding(() => root.leftPanelWidthOverride),
+            "anchors.fill":             root,
+        })
+    }
+
+    onActiveChanged: {
+        if (root.active) {
+            loadSection()
+            return
+        }
+        if (d.storeParent) {
+            d.storeParent.destroy()
+            d.storeParent = null
+        }
+    }
+    onLoaded: item.visible = true
+
+    Connections {
+        target: root.rootStore
+        function onThirdpartyServicesEnabledChanged() { root.loadSection() }
+    }
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onSendToRecipientRequested(address) {
+            root.popupHandler.sendToRecipient(address)
+        }
+        function onOpenThirdpartyServicesInfoPopupRequested() {
+            root.popupHandler.openThirdpartyServicesPopup()
+        }
+        function onOpenDiscussPageRequested() {
+            Global.openLinkWithConfirmation(Constants.statusDiscussPageUrl,
+                                            SQUtils.StringUtils.extractDomainFromLink(Constants.statusDiscussPageUrl))
+        }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/ChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ChatLoader.qml
@@ -1,0 +1,186 @@
+import QtQml
+import QtQuick
+
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+Loader {
+    id: root
+
+    // Stores
+    required property AppStores.RootStore rootStore
+    required property AppStores.ContactsStore contactsStore
+    required property AppStores.AccountSettingsStore accountSettingsStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property SharedStores.RootStore sharedRootStore
+    required property SharedStores.CurrenciesStore currencyStore
+    required property SharedStores.CommunityTokensStore communityTokensStore
+    required property SharedStores.NetworkConnectionStore networkConnectionStore
+    required property SharedStores.NetworksStore networksStore
+    required property TransactionStore transactionStore
+    required property WalletStores.TokensStore tokensStore
+    required property WalletStores.WalletAssetsStore walletAssetsStore
+    required property ProfileStores.AdvancedStore advancedStore
+    required property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
+
+    // Adaptors / shared loaders / handlers
+    required property ContactsModelAdaptor contactsAdaptor
+    required property HandlersManagerLoader popupHandler
+    required property Loader emojiPopupLoader
+    required property Loader stickersPopupLoader
+
+    // Inputs
+    required property bool createChatViewOpened
+    required property bool isPortraitMode
+
+    property real leftPanelWidthOverride: 0
+
+    // Re-emitted so AppMain owns the spinner toggle.
+    signal ready()
+    // Bridges the chat profile button to the global app-section navigation.
+    signal openAppSearchRequested()
+
+    asynchronous: false
+
+    onStatusChanged: {
+        if (status === Loader.Ready || status === Loader.Error)
+            ready()
+    }
+
+    Component {
+        id: chatRootStoreComp
+
+        ChatStores.RootStore {
+            contactsStore: root.contactsStore
+            currencyStore: root.currencyStore
+            communityTokensStore: root.communityTokensStore
+            openCreateChat: root.createChatViewOpened
+            networkConnectionStore: root.networkConnectionStore
+            isChatSectionModule: true
+        }
+    }
+
+    QtObject {
+        id: d
+
+        property ChatStores.RootStore chatRootStore: null
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.chatUrl))
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (!!root.item)
+            return
+        if (!d.chatRootStore)
+            d.chatRootStore = chatRootStoreComp.createObject(root)
+        setSource(QmlCompiler.chatUrl, {
+            visible: false,
+            isChatView: true,
+            showUsersList:                  Qt.binding(() => root.accountSettingsStore.showUsersList),
+            rootStore:                      Qt.binding(() => d.chatRootStore),
+            createChatPropertiesStore:      Qt.binding(() => root.createChatPropertiesStore),
+            tokensStore:                    Qt.binding(() => root.tokensStore),
+            transactionStore:               Qt.binding(() => root.transactionStore),
+            walletAssetsStore:              Qt.binding(() => root.walletAssetsStore),
+            currencyStore:                  Qt.binding(() => root.currencyStore),
+            networksStore:                  Qt.binding(() => root.networksStore),
+            advancedStore:                  Qt.binding(() => root.advancedStore),
+            emojiPopup:                     Qt.binding(() => root.emojiPopupLoader.item),
+            stickersPopup:                  Qt.binding(() => root.stickersPopupLoader.item),
+            sendViaPersonalChatEnabled:     Qt.binding(() => root.featureFlagsStore.sendViaPersonalChatEnabled),
+            disabledTooltipText:            Qt.binding(() => !root.networkConnectionStore.sendBuyBridgeEnabled
+                                                   ? root.networkConnectionStore.sendBuyBridgeToolTipText : ""),
+            paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
+            extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
+            mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),
+            gifUnfurlingEnabled:            Qt.binding(() => root.sharedRootStore.gifUnfurlingEnabled),
+            neverAskAboutUnfurlingAgain:    Qt.binding(() => root.sharedRootStore.neverAskAboutUnfurlingAgain),
+            usersModel:                     Qt.binding(() => d.chatRootStore.usersStore.usersModel),
+            myPublicKey:                    Qt.binding(() => root.contactsStore.myPublicKey),
+            navToMsgDetails:                Qt.binding(() => root.rootStore.navToMsgDetails),
+            leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onLoaded: {
+        item.visible = true
+    }
+
+    onActiveChanged: {
+        if (root.active) {
+            return
+        }
+        if (!!d.chatRootStore) {
+            d.chatRootStore.destroy()
+            d.chatRootStore = null
+        }
+    }
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onShowUsersListRequested(show) {
+            root.accountSettingsStore.setShowUsersList(show)
+        }
+        function onProfileButtonClicked() {
+            Global.changeAppSectionBySectionType(Constants.appSection.profile)
+        }
+        function onOpenAppSearch() { root.openAppSearchRequested() }
+        function onBuyStickerPackRequested(packId, price) {
+            root.popupHandler.buyStickerPack(packId, price)
+        }
+        function onTokenPaymentRequested(recipientAddress, tokenKey, rawAmount) {
+            root.popupHandler.openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount)
+        }
+        function onSetNeverAskAboutUnfurlingAgain(neverAskAgain) {
+            root.sharedRootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+        }
+        function onOpenGifPopupRequest(params, cbOnGifSelected, cbOnClose) {
+            root.popupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
+        }
+        function onGroupMembersUpdateRequested(membersPubKeysList) {
+            d.chatRootStore.usersStore.groupMembersUpdateRequested(membersPubKeysList)
+        }
+        function onChangeContactNicknameRequest(pubKey, nickname, displayName, isEdit) {
+            root.contactsStore.changeContactNickname(pubKey, nickname, displayName, isEdit)
+        }
+        function onRemoveTrustStatusRequest(pubKey) { root.contactsStore.removeTrustStatus(pubKey) }
+        function onDismissContactRequest(chatId, contactRequestId) {
+            root.contactsStore.dismissContactRequest(chatId, contactRequestId)
+        }
+        function onAcceptContactRequest(chatId, contactRequestId) {
+            root.contactsStore.acceptContactRequest(chatId, contactRequestId)
+        }
+        function onNavToMsgDetailsRequested(navigate) {
+            root.rootStore.setNavToMsgDetailsFlag(navigate)
+        }
+    }
+
+    Loader {
+        id: chatLayoutLoading
+        anchors.fill: parent
+        active: root.active && root.status !== Loader.Ready
+        sourceComponent: ChatLayoutLoading {
+            showMembersPanel: root.accountSettingsStore.showUsersList
+        }
+        onLoaded: Qt.callLater(root.loadSection)
+    }
+}

--- a/ui/app/mainui/sectionLoaders/CommunitiesPortalLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunitiesPortalLoader.qml
@@ -1,0 +1,43 @@
+import QtQml
+import QtQuick
+
+import StatusQ.Core.Utils as SQUtils
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Communities.stores
+
+Loader {
+    id: root
+
+    required property AppStores.RootStore rootStore
+    required property CommunitiesStore communitiesStore
+
+    property real leftPanelWidthOverride: 0
+
+    asynchronous: false
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.communitiesPortalUrl))
+        loadSection()
+    }
+
+    function loadSection() {
+        if (!active)
+            return
+        if (!!item)
+            return
+        if (root.source === QmlCompiler.communitiesPortalUrl)
+            return
+        setSource(QmlCompiler.communitiesPortalUrl, {
+            createCommunityEnabled: !SQUtils.Utils.isMobile,
+            visible:                false,
+            communitiesStore:       Qt.binding(() => root.communitiesStore),
+            assetsModel:            Qt.binding(() => root.rootStore.globalAssetsModel),
+            collectiblesModel:      Qt.binding(() => root.rootStore.globalCollectiblesModel),
+            leftPanelWidthOverride: Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onActiveChanged: loadSection()
+    onLoaded: item.visible = true
+}

--- a/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
+++ b/ui/app/mainui/sectionLoaders/CommunityChatLoader.qml
@@ -1,0 +1,220 @@
+import QtQml
+import QtQuick
+
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send
+
+import AppLayouts.stores as AppStores
+import AppLayouts.stores.Messaging as MessagingStores
+import AppLayouts.Communities.stores
+import AppLayouts.Chat
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+Loader {
+    id: root
+
+    // Stores
+    required property AppStores.RootStore rootStore
+    required property AppStores.ContactsStore contactsStore
+    required property AppStores.AccountSettingsStore accountSettingsStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property SharedStores.RootStore sharedRootStore
+    required property SharedStores.CurrenciesStore currencyStore
+    required property SharedStores.CommunityTokensStore communityTokensStore
+    required property SharedStores.NetworkConnectionStore networkConnectionStore
+    required property SharedStores.NetworksStore networksStore
+    required property TransactionStore transactionStore
+    required property WalletStores.TokensStore tokensStore
+    required property WalletStores.WalletAssetsStore walletAssetsStore
+    required property ProfileStores.AdvancedStore advancedStore
+    required property CommunitiesStore communitiesStore
+    required property MessagingStores.MessagingRootStore messagingRootStore
+    required property ChatStores.CreateChatPropertiesStore createChatPropertiesStore
+
+    required property ContactsModelAdaptor contactsAdaptor
+    required property HandlersManagerLoader popupHandler
+    required property Loader emojiPopupLoader
+    required property Loader stickersPopupLoader
+
+    // Per-community inputs
+    required property string sectionId
+    required property var sectionItemModel
+
+    required property bool createChatViewOpened
+    required property bool isPortraitMode
+
+    property real leftPanelWidthOverride: 0
+
+    signal ready()
+    signal openAppSearchRequested()
+
+    asynchronous: false
+
+    onStatusChanged: {
+        if (status === Loader.Ready || status === Loader.Error)
+            ready()
+    }
+
+    Component {
+        id: chatRootStoreComp
+
+        ChatStores.RootStore {
+            contactsStore: root.contactsStore
+            currencyStore: root.currencyStore
+            communityTokensStore: root.communityTokensStore
+            openCreateChat: root.createChatViewOpened
+            isChatSectionModule: false
+            communityId: root.sectionId
+        }
+    }
+
+    QtObject {
+        id: d
+
+        readonly property url url: QmlCompiler.chatUrl
+        property ChatStores.RootStore chatRootStore: null
+        property var newCommunityStore: null
+
+        function clearStores() {
+            if (d.chatRootStore) {
+                d.chatRootStore.destroy()
+                d.chatRootStore = null
+            }
+            if (d.newCommunityStore) {
+                d.newCommunityStore.destroy()
+                d.newCommunityStore = null
+            }
+        }
+
+        function createStores() {
+            if (!d.chatRootStore)
+                d.chatRootStore = chatRootStoreComp.createObject(root)
+            if (!d.newCommunityStore)
+                d.newCommunityStore = root.messagingRootStore.createCommunityRootStore(root, root.sectionId)
+        }
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (!!root.item)
+            return
+        d.createStores()
+        setSource(d.url, {
+            isChatView:                     false,
+            visible:                        false,
+            showUsersList:                  Qt.binding(() => root.accountSettingsStore.showUsersList),
+            emojiPopup:                     Qt.binding(() => root.emojiPopupLoader.item),
+            stickersPopup:                  Qt.binding(() => root.stickersPopupLoader.item),
+            sectionItemModel:               Qt.binding(() => root.sectionItemModel),
+            createChatPropertiesStore:      Qt.binding(() => root.createChatPropertiesStore),
+            communitiesStore:               Qt.binding(() => root.communitiesStore),
+            communitySettingsDisabled:      Qt.binding(() => !root.advancedStore.isManageCommunityOnTestModeEnabled
+                                                         && (root.rootStore.isProduction && root.networksStore.areTestNetworksEnabled)),
+            newCommunityStore:              Qt.binding(() => d.newCommunityStore),
+            rootStore:                      Qt.binding(() => d.chatRootStore),
+            tokensStore:                    Qt.binding(() => root.tokensStore),
+            transactionStore:               Qt.binding(() => root.transactionStore),
+            walletAssetsStore:              Qt.binding(() => root.walletAssetsStore),
+            currencyStore:                  Qt.binding(() => root.currencyStore),
+            networksStore:                  Qt.binding(() => root.networksStore),
+            advancedStore:                  Qt.binding(() => root.advancedStore),
+            paymentRequestFeatureEnabled:   Qt.binding(() => root.featureFlagsStore.paymentRequestEnabled),
+            extraLeftPadding:               Qt.binding(() => root.isPortraitMode ? SQUtils.Utils.swipeIndicatorWidth : 0),
+            mutualContactsModel:            Qt.binding(() => root.contactsAdaptor.mutualContacts),
+            gifUnfurlingEnabled:            Qt.binding(() => root.sharedRootStore.gifUnfurlingEnabled),
+            neverAskAboutUnfurlingAgain:    Qt.binding(() => root.sharedRootStore.neverAskAboutUnfurlingAgain),
+            usersModel:                     Qt.binding(() => d.chatRootStore.usersStore.usersModel),
+            myPublicKey:                    Qt.binding(() => root.contactsStore.myPublicKey),
+            navToMsgDetails:                Qt.binding(() => root.rootStore.navToMsgDetails),
+            leftPanelWidthOverride:         Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onLoaded: {
+        root.item.visible = true
+    }
+    
+    onActiveChanged: {
+        if (root.active) {
+            return
+        }
+        d.clearStores()
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.chatUrl))
+    }
+
+    Connections {
+        target: Global
+        function onSwitchToCommunitySettings(communityId) {
+            if (communityId !== root.sectionId)
+                return
+            if (root.item)
+                root.item.currentIndex = 1 // Settings
+        }
+        function onSwitchToCommunityChannelsView(communityId) {
+            if (communityId !== root.sectionId)
+                return
+            if (root.item)
+                root.item.currentIndex = 0
+        }
+    }
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onShowUsersListRequested(show) {
+            root.accountSettingsStore.setShowUsersList(show)
+        }
+        function onProfileButtonClicked() {
+            Global.changeAppSectionBySectionType(Constants.appSection.profile)
+        }
+        function onOpenAppSearch() { root.openAppSearchRequested() }
+        function onBuyStickerPackRequested(packId, price) {
+            root.popupHandler.buyStickerPack(packId, price)
+        }
+        function onTokenPaymentRequested(recipientAddress, tokenKey, rawAmount) {
+            root.popupHandler.openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount)
+        }
+        function onSetNeverAskAboutUnfurlingAgain(neverAskAgain) {
+            root.sharedRootStore.setNeverAskAboutUnfurlingAgain(neverAskAgain)
+        }
+        function onOpenGifPopupRequest(params, cbOnGifSelected, cbOnClose) {
+            root.popupHandler.openGifs(params, cbOnGifSelected, cbOnClose)
+        }
+        function onChangeContactNicknameRequest(pubKey, nickname, displayName, isEdit) {
+            root.contactsStore.changeContactNickname(pubKey, nickname, displayName, isEdit)
+        }
+        function onRemoveTrustStatusRequest(pubKey) { root.contactsStore.removeTrustStatus(pubKey) }
+        function onDismissContactRequest(chatId, contactRequestId) {
+            root.contactsStore.dismissContactRequest(chatId, contactRequestId)
+        }
+        function onAcceptContactRequest(chatId, contactRequestId) {
+            root.contactsStore.acceptContactRequest(chatId, contactRequestId)
+        }
+        function onNavToMsgDetailsRequested(navigate) {
+            root.rootStore.setNavToMsgDetailsFlag(navigate)
+        }
+    }
+    Loader {
+        id: chatLayoutLoading
+        anchors.fill: parent
+        active: root.active && root.status !== Loader.Ready
+        sourceComponent: ChatLayoutLoading {
+            showMembersPanel: root.accountSettingsStore.showUsersList
+        }
+        onLoaded: Qt.callLater(root.loadSection)
+    }
+}

--- a/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HandlersManagerLoader.qml
@@ -1,0 +1,172 @@
+import QtQml
+import QtQuick
+
+import StatusQ
+import StatusQ.Core
+
+import shared.stores as SharedStores
+import shared.stores.send as SharedSendStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Wallet.stores as WalletStores
+import AppLayouts.Profile.stores as ProfileStores
+
+Loader {
+    id: root
+
+    required property Item popupParent
+
+    required property AppStores.RootStore rootStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property AppStores.ContactsStore contactsStore
+
+    required property SharedStores.RootStore sharedRootStore
+    required property SharedStores.CurrenciesStore currencyStore
+    required property SharedStores.NetworksStore networksStore
+    required property SharedStores.NetworkConnectionStore networkConnectionStore
+    required property SharedSendStores.TransactionStore transactionStore
+
+    required property var/*TODO: Apply strong typing once it's no longer a singleton*/ walletRootStore
+    required property WalletStores.WalletAssetsStore walletAssetsStore
+    required property WalletStores.CollectiblesStore walletCollectiblesStore
+    required property WalletStores.TransactionStoreNew transactionStoreNew
+    required property WalletStores.TokensStore tokensStore
+
+    required property ChatStores.RootStore rootChatStore
+
+    required property ProfileStores.EnsUsernamesStore ensUsernamesStore
+    required property ProfileStores.PrivacyStore privacyStore
+
+    required property Keychain keychain
+
+    asynchronous: true
+    active: false // loaded on demand by section loaders, never active by default
+
+    QtObject {
+        id: d
+
+        property var pending: []
+        property bool sourceSet: false
+
+        function flushPending() {
+            const calls = pending
+            pending = []
+            for (let i = 0; i < calls.length; ++i)
+                calls[i]()
+        }
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (d.sourceSet)
+            return
+        d.sourceSet = true
+        setSource(QmlCompiler.handlersManagerUrl, {
+            popupParent:            Qt.binding(() => root.popupParent),
+            rootStore:              Qt.binding(() => root.rootStore),
+            featureFlagsStore:      Qt.binding(() => root.featureFlagsStore),
+            contactsStore:          Qt.binding(() => root.contactsStore),
+            sharedRootStore:        Qt.binding(() => root.sharedRootStore),
+            currencyStore:          Qt.binding(() => root.currencyStore),
+            networksStore:          Qt.binding(() => root.networksStore),
+            networkConnectionStore: Qt.binding(() => root.networkConnectionStore),
+            transactionStore:       Qt.binding(() => root.transactionStore),
+            walletRootStore:        Qt.binding(() => root.walletRootStore),
+            walletAssetsStore:      Qt.binding(() => root.walletAssetsStore),
+            walletCollectiblesStore:Qt.binding(() => root.walletCollectiblesStore),
+            transactionStoreNew:    Qt.binding(() => root.transactionStoreNew),
+            tokensStore:            Qt.binding(() => root.tokensStore),
+            rootChatStore:          Qt.binding(() => root.rootChatStore),
+            ensUsernamesStore:      Qt.binding(() => root.ensUsernamesStore),
+            privacyStore:           Qt.binding(() => root.privacyStore),
+            keychain:               Qt.binding(() => root.keychain),
+        })
+    }
+
+    // Triggers HandlersManager.qml to load (idempotent), then either runs `callable`
+    // immediately (if HandlersManager is loaded) or queues it to run when async
+    // load completes. Callers pass a closure that performs the actual call, e.g.
+    //     invoke(() => root.item.swapModalHandler.launchSwap())
+    // This keeps the call refactor-safe (no string method names) and preserves
+    // argument types via JS lexical capture.
+    function invoke(callable) {
+        if (!!root.item) {
+            callable()
+            return
+        }
+        if (root.active == false) {
+            root.active = true
+        }
+        d.pending.push(callable)
+        loadSection()
+    }
+
+    // Top-level forwarders mirroring HandlersManager.qml's public functions.
+    // Note: maybeDisplayEnableMessageBackupPopup() returns bool on HandlersManager;
+    // the forwarder is fire-and-forget (no return value), since invoke() may queue.
+    function maybeDisplayEnableMessageBackupPopup() {
+        invoke(() => root.item.maybeDisplayEnableMessageBackupPopup())
+    }
+    function showEnablePushNotificationsPopup() {
+        invoke(() => root.item.showEnablePushNotificationsPopup())
+    }
+    function maybeDisplayEnablePushNotificationsPopup() {
+        invoke(() => root.item.maybeDisplayEnablePushNotificationsPopup())
+    }
+
+    // Flat method forwarders — mirror HandlersManager.qml's flat API, each routed
+    // through invoke() so calls before the loader is ready get queued and the
+    // lazy loader auto-loads on first call (active: false default).
+    function launchSwap() {
+        invoke(() => root.item.launchSwap())
+    }
+    function launchSwapSpecific(data) {
+        invoke(() => root.item.launchSwapSpecific(data))
+    }
+    function openSend() {
+        invoke(() => root.item.openSend())
+    }
+    function transferOwnership(tokenId, senderAddress) {
+        invoke(() => root.item.transferOwnership(tokenId, senderAddress))
+    }
+    function buyStickerPack(packId, price) {
+        invoke(() => root.item.buyStickerPack(packId, price))
+    }
+    function sendToRecipient(address) {
+        invoke(() => root.item.sendToRecipient(address))
+    }
+    function sendToken(senderAddress, groupKey, tokenType) {
+        invoke(() => root.item.sendToken(senderAddress, groupKey, tokenType))
+    }
+    function connectUsername(ensName, ownerAddress) {
+        invoke(() => root.item.connectUsername(ensName, ownerAddress))
+    }
+    function registerUsername(ensName, chainId) {
+        invoke(() => root.item.registerUsername(ensName, chainId))
+    }
+    function releaseUsername(ensName, senderAddress, chainId) {
+        invoke(() => root.item.releaseUsername(ensName, senderAddress, chainId))
+    }
+    function openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount) {
+        invoke(() => root.item.openTokenPaymentRequest(recipientAddress, tokenKey, rawAmount))
+    }
+    function openGifs(params, cbOnGifSelected, cbOnClose) {
+        invoke(() => root.item.openGifs(params, cbOnGifSelected, cbOnClose))
+    }
+    function openThirdpartyServicesPopup() {
+        invoke(() => root.item.openThirdpartyServicesPopup())
+    }
+    function openEnableBiometricsPopup() {
+        invoke(() => root.item.openEnableBiometricsPopup())
+    }
+
+    onLoaded: d.flushPending()
+    onActiveChanged: loadSection()
+
+    Component.onCompleted: {
+        QmlCompiler.precompile(QmlCompiler.handlersManagerUrl)
+        loadSection()
+    }
+}

--- a/ui/app/mainui/sectionLoaders/HomePageLoader.qml
+++ b/ui/app/mainui/sectionLoaders/HomePageLoader.qml
@@ -1,0 +1,148 @@
+import QtQml
+import QtQuick
+
+import StatusQ.Core.Theme
+
+import utils
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.HomePage
+import AppLayouts.Wallet
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.adaptors
+
+Loader {
+    id: root
+
+    required property AppStores.RootStore rootStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property ChatStores.RootStore rootChatStore
+    required property ProfileStores.ProfileStore profileStore
+    required property ProfileStores.PrivacyStore privacyStore
+
+    required property ContactsModelAdaptor contactsAdaptor
+    required property Loader dappsServiceLoader
+
+    required property bool browserEnabled
+    required property int syncingBadgeCount
+
+    property real leftPanelWidthOverride: 0
+
+    // Routes the navigation request that was previously dispatched via globalConns.
+    signal appSectionRequested(int sectionType, int subsection, int subSubsection, var data)
+
+    asynchronous: false
+
+    Loader {
+        id: adaptor
+        active: root.active
+        sourceComponent: HomePageAdaptor {
+            id: homePageAdaptor
+
+            readonly property bool sectionsLoaded: root.rootStore.sectionsLoaded
+
+            sectionsBaseModel: sectionsLoaded ? root.rootStore.sectionsModel : null
+            chatsBaseModel: sectionsLoaded ? root.rootChatStore.chatSectionModuleModel : null
+            chatsSearchBaseModel: sectionsLoaded && !!root.rootStore.chatSearchModel ? root.rootStore.chatSearchModel : null
+            walletsBaseModel: sectionsLoaded ? WalletStores.RootStore.accounts : null
+            dappsBaseModel: root.dappsServiceLoader.active && root.dappsServiceLoader.item ? root.dappsServiceLoader.item.dappsModel : null
+
+            showEnabledSectionsOnly: true
+            marketEnabled: root.featureFlagsStore.marketEnabled
+            browserEnabled: root.browserEnabled
+            showDapps: false // SEE https://github.com/status-im/status-app/issues/19580
+
+            syncingBadgeCount: root.syncingBadgeCount
+            messagingBadgeCount: root.contactsAdaptor.pendingReceivedRequestContacts.count
+            showBackUpSeed: !root.privacyStore.mnemonicBackedUp
+            backUpSeedBadgeCount: root.profileStore.userDeclinedBackupBanner ? 0 : showBackUpSeed
+            keycardEnabled: root.featureFlagsStore.keycardEnabled
+
+            searchPhrase: root.item ? root.item.searchPhrase : ""
+
+            profileId: root.profileStore.pubKey
+
+            // no automatic propagation to QtObject, needs to be specified explicitely
+            Theme.style: root.Theme.style
+        }
+        onLoaded: loadSection()
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.homeUrl))
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (!!root.item)
+            return
+        if (source === QmlCompiler.homeUrl)
+            return
+        setSource(QmlCompiler.homeUrl, {
+            objectName:             "homeContainer",
+            visible:                false,
+            homePageEntriesModel:   Qt.binding(() => adaptor.item?.homePageEntriesModel ?? null),
+            sectionsModel:          Qt.binding(() => adaptor.item?.sectionsModel ?? null),
+            pinnedModel:            Qt.binding(() => adaptor.item?.pinnedModel ?? null),
+            leftPanelWidthOverride: Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onLoaded: {
+        root.item.visible = true
+    }
+
+    onActiveChanged: loadSection()
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onItemActivated(key, sectionType, itemId) {
+            adaptor.item.setTimestamp(key, new Date().valueOf())
+
+            if (sectionType === -1) { // search
+                const [sectionId, chatId] = key.split(";")
+                root.rootStore.setActiveSectionChat(sectionId, chatId)
+                return
+            }
+
+            if (sectionType === Constants.appSection.profile) {
+                if (itemId == Constants.settingsSubsection.backUpSeed) {
+                    Global.openBackUpSeedPopup()
+                    return
+                }
+                if (itemId == Constants.settingsSubsection.signout) {
+                    Global.quitAppRequested()
+                    return
+                }
+            }
+
+            let subsection = itemId
+            let subSubsection = -1
+            let data = {}
+
+            if (sectionType === Constants.appSection.wallet && !!itemId) {
+                subsection = WalletLayout.LeftPanelSelection.Address
+                subSubsection = WalletLayout.RightPanelSelection.Assets
+                data = { address: itemId }
+            }
+
+            root.appSectionRequested(sectionType, subsection, subSubsection, data)
+        }
+
+        function onItemPinRequested(key, pin) {
+            adaptor.item.setPinned(key, pin)
+            if (pin)
+                adaptor.item.setTimestamp(key, new Date().valueOf())
+        }
+
+        function onDappDisconnectRequested(dappUrl) {
+            root.dappsServiceLoader.dappDisconnectRequested(dappUrl)
+        }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/MarketLoader.qml
+++ b/ui/app/mainui/sectionLoaders/MarketLoader.qml
@@ -1,0 +1,111 @@
+import QtQml
+import QtQuick
+
+import StatusQ.Core.Utils as SQUtils
+
+import utils
+
+import shared.stores as SharedStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Market.stores
+
+import mainui.sectionLoaders
+
+Loader {
+    id: root
+
+    required property AppStores.RootStore rootStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property SharedStores.CurrenciesStore currencyStore
+    required property MarketStore marketStore
+
+    required property HandlersManagerLoader popupHandler
+
+    property real leftPanelWidthOverride: 0
+
+    asynchronous: false
+
+    QtObject {
+        id: d
+
+        readonly property url realUrl: QmlCompiler.marketUrl
+        readonly property url privacyWallUrl: QmlCompiler.marketPrivacyWallUrl
+        readonly property url targetUrl: root.rootStore.thirdpartyServicesEnabled ? realUrl : privacyWallUrl
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(d.targetUrl))
+        loadSection()
+    }
+
+    function loadSection() {
+        if (!active)
+            return
+        if (!!item && root.source === d.targetUrl)
+            return
+        if (d.targetUrl === d.privacyWallUrl) {
+            setSource(d.targetUrl, {})
+            return
+        }
+
+        setSource(d.targetUrl, {
+            objectName:             "marketLayout",
+            visible:                false,
+            tokensModel:            Qt.binding(() => root.marketStore.marketLeaderboardModel),
+            totalTokensCount:       Qt.binding(() => root.marketStore.totalLeaderboardCount),
+            loading:                Qt.binding(() => root.marketStore.marketLeaderboardLoading),
+            swapEnabled:            Qt.binding(() => root.featureFlagsStore.swapEnabled),
+            currentPage:            Qt.binding(() => root.marketStore.currentPage),
+            leftPanelWidthOverride: Qt.binding(() => root.leftPanelWidthOverride),
+            currencySymbol:         Qt.binding(() => {
+                const symbol = SQUtils.ModelUtils.getByKey(root.currencyStore.currenciesModel,
+                                                            "shortName",
+                                                            root.currencyStore.currentCurrency,
+                                                            "symbol")
+                return !!symbol ? symbol : ""
+            }),
+            fnFormatCurrencyAmount: function(amount, options) {
+                return root.currencyStore.formatCurrencyAmount(amount, root.currencyStore.currentCurrency, options)
+            },
+        })
+    }
+
+    onActiveChanged: {
+        if (!active && root.rootStore.thirdpartyServicesEnabled)
+            marketStore.unsubscribeFromUpdates()
+        loadSection()
+    }
+    onLoaded: {
+        item.anchors.fill = root
+        if (item.resetView)
+            item.resetView()
+
+        item.visible = true
+        
+        if (root.rootStore.thirdpartyServicesEnabled)
+            root.marketStore.requestMarketTokenPage(1, item.pageSize)
+    }
+
+    Connections {
+        target: root.rootStore
+        function onThirdpartyServicesEnabledChanged() { root.loadSection() }
+    }
+
+    Connections {
+        target: root.item
+
+        function onRequestLaunchSwap() {
+            root.popupHandler.launchSwap()
+        }
+        function onFetchMarketTokens(pageNumber, pageSize) {
+            root.marketStore.requestMarketTokenPage(pageNumber, pageSize)
+        }
+        function onOpenThirdpartyServicesInfoPopupRequested() {
+            root.popupHandler.openThirdpartyServicesPopup()
+        }
+        function onOpenDiscussPageRequested() {
+            Global.requestOpenLink(Constants.statusDiscussPageUrl)
+        }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/NodeLoader.qml
+++ b/ui/app/mainui/sectionLoaders/NodeLoader.qml
@@ -1,0 +1,25 @@
+import QtQml
+import QtQuick
+
+Loader {
+    id: root
+
+    property real leftPanelWidthOverride: 0
+
+    asynchronous: false
+
+    function loadSection() {
+        if (!active)
+            return
+        if (!!item)
+            return
+        if (source === QmlCompiler.nodeUrl)
+            return
+        setSource(QmlCompiler.nodeUrl, {
+            leftPanelWidthOverride: Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onActiveChanged: loadSection()
+    onLoaded: item.anchors.fill = root
+}

--- a/ui/app/mainui/sectionLoaders/PopupsLoader.qml
+++ b/ui/app/mainui/sectionLoaders/PopupsLoader.qml
@@ -239,8 +239,8 @@ Loader {
         function onRemoveContactRequested(publicKey) {
             root.invoke(() => root.item.openRemoveContactConfirmationPopup(publicKey))
         }
-        function onOpenPopupRequested(popupComponent, params, cb) {
-            root.invoke(() => root.item.openPopup(popupComponent, params, cb))
+        function onOpenPopupRequested(popupComponent, params) {
+            root.invoke(() => root.item.openPopup(popupComponent, params))
         }
         function onClosePopupRequested() {
             root.invoke(() => root.item.closePopup())

--- a/ui/app/mainui/sectionLoaders/PopupsLoader.qml
+++ b/ui/app/mainui/sectionLoaders/PopupsLoader.qml
@@ -1,0 +1,340 @@
+import QtQml
+import QtQuick
+
+import StatusQ
+
+import shared.stores
+
+import AppLayouts.stores as AppLayoutStores
+import AppLayouts.Chat.stores as ChatStores
+import AppLayouts.Communities.stores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+import AppLayouts.stores.Messaging as MessagingStores
+
+import utils
+
+Loader {
+    id: root
+
+    required property Item popupParent
+    required property Keychain keychain
+    required property RootStore sharedRootStore
+    required property AppLayoutStores.RootStore rootStore
+    required property CommunityTokensStore communityTokensStore
+    required property NetworksStore networksStore
+
+    property AppLayoutStores.ContactsStore contactsStore
+    property AppLayoutStores.ActivityCenterStore activityCenterStore
+    property ChatStores.RootStore chatStore
+    property UtilsStore utilsStore
+    property CommunitiesStore communitiesStore
+    property ProfileStores.ProfileStore profileStore
+    property ProfileStores.DevicesStore devicesStore
+    property CurrenciesStore currencyStore
+    property WalletStores.WalletAssetsStore walletAssetsStore
+    property WalletStores.CollectiblesStore walletCollectiblesStore
+    property NetworkConnectionStore networkConnectionStore
+    property WalletStores.BuyCryptoStore buyCryptoStore
+    property ProfileStores.AdvancedStore advancedStore
+    property ProfileStores.AboutStore aboutStore
+    property ProfileStores.PrivacyStore privacyStore
+    property MessagingStores.MessagingRootStore messagingRootStore
+
+    property var emojiPopup: null
+    property var allContactsModel
+    property var mutualContactsModel
+    property bool isDevBuild
+
+    // Signals re-emitted from the loaded Popups instance (see Popups.qml lines 95–100).
+    signal openExternalLink(string link)
+    signal saveDomainToUnfurledWhitelist(string domain)
+    signal ownershipDeclined(string communityId, string communityName)
+    signal transferOwnershipRequested(string tokenId, string senderAddress)
+    signal wcUriScanned(string uri)
+    signal navigationEducationDialogSeenRequested()
+
+    asynchronous: true
+    active: false
+
+    QtObject {
+        id: d
+
+        property var pending: []
+        property bool sourceSet: false
+
+        function flushPending() {
+            const calls = pending
+            pending = []
+            for (let i = 0; i < calls.length; ++i)
+                calls[i]()
+        }
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (d.sourceSet)
+            return
+        d.sourceSet = true
+        setSource(QmlCompiler.popupsUrl, {
+            popupParent:            Qt.binding(() => root.popupParent),
+            keychain:               Qt.binding(() => root.keychain),
+            sharedRootStore:        Qt.binding(() => root.sharedRootStore),
+            rootStore:              Qt.binding(() => root.rootStore),
+            communityTokensStore:   Qt.binding(() => root.communityTokensStore),
+            networksStore:          Qt.binding(() => root.networksStore),
+            contactsStore:          Qt.binding(() => root.contactsStore),
+            activityCenterStore:    Qt.binding(() => root.activityCenterStore),
+            chatStore:              Qt.binding(() => root.chatStore),
+            utilsStore:             Qt.binding(() => root.utilsStore),
+            communitiesStore:       Qt.binding(() => root.communitiesStore),
+            profileStore:           Qt.binding(() => root.profileStore),
+            devicesStore:           Qt.binding(() => root.devicesStore),
+            currencyStore:          Qt.binding(() => root.currencyStore),
+            walletAssetsStore:      Qt.binding(() => root.walletAssetsStore),
+            walletCollectiblesStore:Qt.binding(() => root.walletCollectiblesStore),
+            networkConnectionStore: Qt.binding(() => root.networkConnectionStore),
+            buyCryptoStore:         Qt.binding(() => root.buyCryptoStore),
+            advancedStore:          Qt.binding(() => root.advancedStore),
+            aboutStore:             Qt.binding(() => root.aboutStore),
+            privacyStore:           Qt.binding(() => root.privacyStore),
+            messagingRootStore:     Qt.binding(() => root.messagingRootStore),
+            emojiPopup:             Qt.binding(() => root.emojiPopup),
+            allContactsModel:       Qt.binding(() => root.allContactsModel),
+            mutualContactsModel:    Qt.binding(() => root.mutualContactsModel),
+            isDevBuild:             Qt.binding(() => root.isDevBuild),
+        })
+    }
+
+    // Triggers Popups.qml to load , then either runs `callable` immediately
+    // (if Popups is already loaded) or queues it to run when async load completes.
+    // Callers pass a closure that performs the actual popup invocation, e.g.
+    //     invoke(() => root.item.openInfoPopup(title, message))
+    // This keeps the popup call refactor-safe (no string method names) and preserves
+    // argument types via JS lexical capture.
+    function invoke(callable) {
+        if (!!root.item) {
+            callable()
+            return
+        }
+        if (root.active == false) {
+            root.active = true
+        }
+        d.pending.push(callable)
+        loadSection()
+    }
+
+    onLoaded: d.flushPending()
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.popupsUrl))
+    }
+
+    // Direct entry points used by AppMain.qml. Other popup paths route via Global signals
+    // (declared in the Connections block below).
+    function openProfilePopup(publicKey, parentPopup, cb) {
+        invoke(() => root.item.openProfilePopup(publicKey, parentPopup, cb))
+    }
+    function openConfirmExternalLinkPopup(link, domain) {
+        invoke(() => root.item.openConfirmExternalLinkPopup(link, domain))
+    }
+    function openBackUpSeedPopup() {
+        invoke(() => root.item.openBackUpSeedPopup())
+    }
+    function openDiscordImportProgressPopup(importingSingleChannel) {
+        invoke(() => root.item.openDiscordImportProgressPopup(importingSingleChannel))
+    }
+    function openInviteFriendsToCommunityPopup(community, communitySectionModule, cb) {
+        invoke(() => root.item.openInviteFriendsToCommunityPopup(community, communitySectionModule, cb))
+    }
+    function openCommunityProfilePopup(store, community, communitySectionModule) {
+        invoke(() => root.item.openCommunityProfilePopup(store, community, communitySectionModule))
+    }
+    function openCommunityRulesPopup(name, introMessage, image, color) {
+        invoke(() => root.item.openCommunityRulesPopup(name, introMessage, image, color))
+    }
+    function openLeaveCommunityPopup(community, communityId, outroMessage) {
+        invoke(() => root.item.openLeaveCommunityPopup(community, communityId, outroMessage))
+    }
+
+    Connections {
+        target: Global
+
+        function onOpenMarkAsIDVerifiedPopup(publicKey, cb) {
+            root.invoke(() => root.item.openMarkAsIDVerifiedPopup(publicKey, cb))
+        }
+        function onOpenRemoveIDVerificationDialog(publicKey, cb) {
+            root.invoke(() => root.item.openRemoveIDVerificationDialog(publicKey, cb))
+        }
+        function onOpenInviteFriendsToCommunityPopup(community, communitySectionModule, cb) {
+            root.invoke(() => root.item.openInviteFriendsToCommunityPopup(community, communitySectionModule, cb))
+        }
+        function onOpenInviteFriendsToCommunityByIdPopup(communityId, cb) {
+            root.invoke(() => root.item.openInviteFriendsToCommunityByIdPopup(communityId, cb))
+        }
+        function onOpenContactRequestPopup(publicKey, cb) {
+            root.invoke(() => root.item.openContactRequestPopup(publicKey, cb))
+        }
+        function onOpenReviewContactRequestPopup(publicKey, cb) {
+            root.invoke(() => root.item.openReviewContactRequestPopup(publicKey, cb))
+        }
+        function onOpenDownloadModalRequested(available, version, url) {
+            root.invoke(() => root.item.openDownloadModal(available, version, url))
+        }
+        function onOpenImagePopup(image, url, plain) {
+            root.invoke(() => root.item.openImagePopup(image, url, plain))
+        }
+        function onOpenVideoPopup(url) {
+            root.invoke(() => root.item.openVideoPopup(url))
+        }
+        function onOpenProfilePopupRequested(publicKey, parentPopup, cb) {
+            root.invoke(() => root.item.openProfilePopup(publicKey, parentPopup, cb))
+        }
+        function onOpenNicknamePopupRequested(publicKey, cb) {
+            root.invoke(() => root.item.openNicknamePopup(publicKey, cb))
+        }
+        function onMarkAsUntrustedRequested(publicKey) {
+            root.invoke(() => root.item.openMarkAsUntrustedPopup(publicKey))
+        }
+        function onBlockContactRequested(publicKey) {
+            root.invoke(() => root.item.openBlockContactPopup(publicKey))
+        }
+        function onUnblockContactRequested(publicKey) {
+            root.invoke(() => root.item.openUnblockContactPopup(publicKey))
+        }
+        function onOpenChangeProfilePicPopup(cb) {
+            root.invoke(() => root.item.openChangeProfilePicPopup(cb))
+        }
+        function onOpenBackUpSeedPopup() {
+            root.invoke(() => root.item.openBackUpSeedPopup())
+        }
+        function onOpenAuthenticationPopup(reason, keyUid) {
+            root.invoke(() => root.item.openAuthenticationPopup(reason, keyUid))
+        }
+        function onOpenSigningPopup(reason, keyUid, txHash, path, address) {
+            root.invoke(() => root.item.openSigningPopup(reason, keyUid, txHash, path, address))
+        }
+        function onOpenKeycardManagementPopup(flow, keyUid, keycardUid, cardMetadataName, cardMetadataWalletAccountsJson) {
+            root.invoke(() => root.item.openKeycardManagementPopup(flow, keyUid, keycardUid, cardMetadataName, cardMetadataWalletAccountsJson))
+        }
+        function onOpenPinnedMessagesPopupRequested(store, messageStore, pinnedMessagesModel, messageToPin, chatId) {
+            root.invoke(() => root.item.openPinnedMessagesPopup(store, messageStore, pinnedMessagesModel, messageToPin, chatId))
+        }
+        function onOpenCommunityProfilePopupRequested(store, community, communitySectionModule) {
+            root.invoke(() => root.item.openCommunityProfilePopup(store, community, communitySectionModule))
+        }
+        function onCreateCommunityPopupRequested(isDiscordImport) {
+            root.invoke(() => root.item.openCreateCommunityPopup(isDiscordImport))
+        }
+        function onImportCommunityPopupRequested() {
+            root.invoke(() => root.item.openImportCommunityPopup())
+        }
+        function onCommunityShareAddressesPopupRequested(communityId, name, imageSrc) {
+            root.invoke(() => root.item.openCommunityShareAddressesPopup(communityId, name, imageSrc))
+        }
+        function onCommunityIntroPopupRequested(communityId, name, introMessage, imageSrc, isInvitationPending) {
+            root.invoke(() => root.item.openCommunityIntroPopup(communityId, name, introMessage, imageSrc, isInvitationPending))
+        }
+        function onRemoveContactRequested(publicKey) {
+            root.invoke(() => root.item.openRemoveContactConfirmationPopup(publicKey))
+        }
+        function onOpenPopupRequested(popupComponent, params, cb) {
+            root.invoke(() => root.item.openPopup(popupComponent, params, cb))
+        }
+        function onClosePopupRequested() {
+            root.invoke(() => root.item.closePopup())
+        }
+        function onOpenDeleteMessagePopup(messageId, messageStore) {
+            root.invoke(() => root.item.openDeleteMessagePopup(messageId, messageStore))
+        }
+        function onOpenDownloadImageDialog(imageSource) {
+            root.invoke(() => root.item.openDownloadImageDialog(imageSource))
+        }
+        function onLeaveCommunityRequested(community, communityId, outroMessage) {
+            root.invoke(() => root.item.openLeaveCommunityPopup(community, communityId, outroMessage))
+        }
+        function onOpenTestnetPopup() {
+            root.invoke(() => root.item.openTestnetPopup())
+        }
+        function onOpenExportControlNodePopup(community) {
+            root.invoke(() => root.item.openExportControlNodePopup(community))
+        }
+        function onOpenImportControlNodePopup(community) {
+            root.invoke(() => root.item.openImportControlNodePopup(community))
+        }
+        function onOpenEditSharedAddressesFlow(communityId) {
+            root.invoke(() => root.item.openEditSharedAddressesPopup(communityId))
+        }
+        function onOpenTransferOwnershipPopup(communityId, communityName, communityLogo, token) {
+            root.invoke(() => root.item.openTransferOwnershipPopup(communityId, communityName, communityLogo, token))
+        }
+        function onOpenFinaliseOwnershipPopup(communityId) {
+            root.invoke(() => root.item.openFinaliseOwnershipPopup(communityId))
+        }
+        function onOpenDeclineOwnershipPopup(communityId, communityName) {
+            root.invoke(() => root.item.openDeclineOwnershipPopup(communityId, communityName))
+        }
+        function onOpenFirstTokenReceivedPopup(communityId, communityName, communityLogo, tokenSymbol, tokenName, tokenAmount, tokenType, tokenImage) {
+            root.invoke(() => root.item.openFirstTokenReceivedPopup(communityId, communityName, communityLogo, tokenSymbol, tokenName, tokenAmount, tokenType, tokenImage))
+        }
+        function onOpenConfirmHideAssetPopup(assetSymbol, assetName, assetImage, isCommunityToken) {
+            root.invoke(() => root.item.openConfirmHideAssetPopup(assetSymbol, assetName, assetImage, isCommunityToken))
+        }
+        function onOpenConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage, isCommunityToken) {
+            root.invoke(() => root.item.openConfirmHideCollectiblePopup(collectibleSymbol, collectibleName, collectibleImage, isCommunityToken))
+        }
+        function onOpenCommunityMemberMessagesPopupRequested(store, chatCommunitySectionModule, memberPubKey, displayName) {
+            root.invoke(() => root.item.openCommunityMemberMessagesPopup(store, chatCommunitySectionModule, memberPubKey, displayName))
+        }
+        function onOpenBuyCryptoModalRequested(parameters) {
+            root.invoke(() => root.item.openBuyCryptoModal(parameters))
+        }
+        function onPrivacyPolicyRequested() {
+            root.invoke(() => root.item.openPrivacyPolicyPopup())
+        }
+        function onOpenPaymentRequestModalRequested(onPaymentRequested, callback) {
+            root.invoke(() => root.item.openPaymentRequestModal(onPaymentRequested, callback))
+        }
+        function onTermsOfUseRequested() {
+            root.invoke(() => root.item.openTermsOfUsePopup())
+        }
+        function onOpenNewsMessagePopupRequested(notification, notificationId) {
+            root.invoke(() => root.item.openNewsMessagePopup(notification, notificationId))
+        }
+        function onQuitAppRequested() {
+            root.invoke(() => root.item.openQuitConfirmPopup())
+        }
+        function onOpenQRScannerRequested() {
+            root.invoke(() => root.item.openQRScannerPopup())
+        }
+        function onOpenInfoPopup(title, message) {
+            root.invoke(() => root.item.openInfoPopup(title, message))
+        }
+        function onShareProfileDialogRequested(publicKey) {
+            root.invoke(() => root.item.openShareProfilePopup(publicKey))
+        }
+        function onOpenNavigationEducationPopupRequested() {
+            root.invoke(() => root.item.openNavigationEducationPopup())
+        }
+        function onOpenLimitReachedPopupRequested(warningType) {
+            root.invoke(() => root.item.openLimitReachedPopup(warningType))
+        }
+    }
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onOpenExternalLink(link) { root.openExternalLink(link) }
+        function onSaveDomainToUnfurledWhitelist(domain) { root.saveDomainToUnfurledWhitelist(domain) }
+        function onOwnershipDeclined(communityId, communityName) {
+            root.ownershipDeclined(communityId, communityName)
+        }
+        function onTransferOwnershipRequested(tokenId, senderAddress) {
+            root.transferOwnershipRequested(tokenId, senderAddress)
+        }
+        function onWcUriScanned(uri) { root.wcUriScanned(uri) }
+        function onNavigationEducationDialogSeenRequested() { root.navigationEducationDialogSeenRequested() }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -59,9 +59,28 @@ Loader {
     required property int paddingFactor
     required property var whitelistedDomainsModel
 
-    property int settingsSubsection: Constants.settingsSubsection.profile
+    property int settingsSubsection: -1
     property int settingsSubSubsection: -1
     property real leftPanelWidthOverride: 0
+    property bool forceSubsectionNavigation: false
+
+    onSettingsSubsectionChanged: {
+        if (root.item) {
+            root.item.settingsSubsection = root.settingsSubsection
+        }
+    }
+
+    onSettingsSubSubsectionChanged: {
+        if (root.item) {
+            root.item.settingsSubSubsection = root.settingsSubSubsection
+        }
+    }
+
+    onForceSubsectionNavigationChanged: {
+        if (root.item) {
+            root.item.forceSubsectionNavigation = root.forceSubsectionNavigation
+        }
+    }
 
     // Signals re-emitted so AppMain can mutate appMainLocalSettings / Theme outside the loader
     signal themeChangeRequested(int theme)
@@ -127,6 +146,7 @@ Loader {
             leftPanelWidthOverride:                 Qt.binding(() => root.leftPanelWidthOverride),
             settingsSubsection:                     Qt.binding(() => root.settingsSubsection),
             settingsSubSubsection:                  Qt.binding(() => root.settingsSubSubsection),
+            forceSubsectionNavigation:              Qt.binding(() => root.forceSubsectionNavigation)
         })
     }
 

--- a/ui/app/mainui/sectionLoaders/ProfileLoader.qml
+++ b/ui/app/mainui/sectionLoaders/ProfileLoader.qml
@@ -1,0 +1,177 @@
+import QtQml
+import QtQuick
+
+import StatusQ
+
+import utils
+
+import shared.stores as SharedStores
+
+import AppLayouts.stores as AppStores
+import AppLayouts.stores.Messaging as MessagingStores
+import AppLayouts.Communities.stores
+import AppLayouts.Profile.stores as ProfileStores
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.adaptors
+import mainui.sectionLoaders
+
+Loader {
+    id: root
+
+    // Stores
+    required property AppStores.RootStore rootStore
+    required property AppStores.ContactsStore contactsStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property SharedStores.RootStore sharedRootStore
+    required property SharedStores.UtilsStore utilsStore
+    required property SharedStores.NetworkConnectionStore networkConnectionStore
+    required property SharedStores.NetworksStore networksStore
+    required property SharedStores.CurrenciesStore currencyStore
+    required property CommunitiesStore communitiesStore
+    required property MessagingStores.MessagingRootStore messagingRootStore
+    required property MessagingStores.MessagingSettingsStore messagingSettingsStore
+    required property ProfileStores.AboutStore aboutStore
+    required property ProfileStores.ProfileStore profileStore
+    required property ProfileStores.DevicesStore devicesStore
+    required property ProfileStores.AdvancedStore advancedStore
+    required property ProfileStores.PrivacyStore privacyStore
+    required property ProfileStores.NotificationsStore notificationsStore
+    required property ProfileStores.LanguageStore languageStore
+    required property ProfileStores.KeycardStore keycardStore
+    required property ProfileStores.KeycardNewStore keycardNewStore
+    required property ProfileStores.WalletStore walletProfileStore
+    required property ProfileStores.EnsUsernamesStore ensUsernamesStore
+    required property WalletStores.TokensStore tokensStore
+    required property WalletStores.WalletAssetsStore walletAssetsStore
+    required property WalletStores.CollectiblesStore walletCollectiblesStore
+
+    required property ContactsModelAdaptor contactsAdaptor
+    required property HandlersManagerLoader popupHandler
+    required property Loader emojiPopupLoader
+    required property Keychain keychain
+
+    // Inputs
+    required property bool isProduction
+    required property bool systemTrayIconAvailable
+    required property int theme
+    required property int fontSize
+    required property int paddingFactor
+    required property var whitelistedDomainsModel
+
+    property int settingsSubsection: Constants.settingsSubsection.profile
+    property int settingsSubSubsection: -1
+    property real leftPanelWidthOverride: 0
+
+    // Signals re-emitted so AppMain can mutate appMainLocalSettings / Theme outside the loader
+    signal themeChangeRequested(int theme)
+    signal fontSizeChangeRequested(int fontSize)
+    signal paddingFactorChangeRequested(int paddingFactor)
+    signal removeWhitelistedDomainRequested(int index)
+
+    asynchronous: false
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(QmlCompiler.profileUrl))
+        loadSection()
+    }
+
+    function loadSection() {
+        if (!root.active)
+            return
+        if (root.source === QmlCompiler.profileUrl)
+            return
+        setSource(QmlCompiler.profileUrl, {
+            visible:                                false,
+            isProduction:                           Qt.binding(() => root.isProduction),
+            userUID:                                Qt.binding(() => root.profileStore.pubKey),
+            sharedRootStore:                        Qt.binding(() => root.sharedRootStore),
+            utilsStore:                             Qt.binding(() => root.utilsStore),
+            aboutStore:                             Qt.binding(() => root.aboutStore),
+            profileStore:                           Qt.binding(() => root.profileStore),
+            contactsStore:                          Qt.binding(() => root.contactsStore),
+            devicesStore:                           Qt.binding(() => root.devicesStore),
+            advancedStore:                          Qt.binding(() => root.advancedStore),
+            privacyStore:                           Qt.binding(() => root.privacyStore),
+            notificationsStore:                     Qt.binding(() => root.notificationsStore),
+            languageStore:                          Qt.binding(() => root.languageStore),
+            keycardStore:                           Qt.binding(() => root.keycardStore),
+            keycardNewStore:                        Qt.binding(() => root.keycardNewStore),
+            walletStore:                            Qt.binding(() => root.walletProfileStore),
+            messagingSettingsStore:                 Qt.binding(() => root.messagingSettingsStore),
+            ensUsernamesStore:                      Qt.binding(() => root.ensUsernamesStore),
+            globalStore:                            Qt.binding(() => root.rootStore),
+            communitiesStore:                       Qt.binding(() => root.communitiesStore),
+            networkConnectionStore:                 Qt.binding(() => root.networkConnectionStore),
+            tokensStore:                            Qt.binding(() => root.tokensStore),
+            walletAssetsStore:                      Qt.binding(() => root.walletAssetsStore),
+            collectiblesStore:                      Qt.binding(() => root.walletCollectiblesStore),
+            currencyStore:                          Qt.binding(() => root.currencyStore),
+            networksStore:                          Qt.binding(() => root.networksStore),
+            messagingRootStore:                     Qt.binding(() => root.messagingRootStore),
+            keychain:                               Qt.binding(() => root.keychain),
+            emojiPopup:                             Qt.binding(() => root.emojiPopupLoader.item),
+            mutualContactsModel:                    Qt.binding(() => root.contactsAdaptor.mutualContacts),
+            blockedContactsModel:                   Qt.binding(() => root.contactsAdaptor.blockedContacts),
+            pendingContactsModel:                   Qt.binding(() => root.contactsAdaptor.pendingContacts),
+            pendingReceivedContactsCount:           Qt.binding(() => root.contactsAdaptor.pendingReceivedRequestContacts.count),
+            dismissedReceivedRequestContactsModel:  Qt.binding(() => root.contactsAdaptor.dimissedReceivedRequestContacts),
+            isKeycardEnabled:                       Qt.binding(() => root.featureFlagsStore.keycardEnabled),
+            isBrowserEnabled:                       Qt.binding(() => root.featureFlagsStore.browserEnabled),
+            privacyModeFeatureEnabled:              Qt.binding(() => root.featureFlagsStore.privacyModeFeatureEnabled),
+            minimizeOnCloseOptionVisible:           Qt.binding(() => root.systemTrayIconAvailable),
+            theme:                                  Qt.binding(() => root.theme),
+            fontSize:                               Qt.binding(() => root.fontSize),
+            paddingFactor:                          Qt.binding(() => root.paddingFactor),
+            whitelistedDomainsModel:                Qt.binding(() => root.whitelistedDomainsModel),
+            leftPanelWidthOverride:                 Qt.binding(() => root.leftPanelWidthOverride),
+            settingsSubsection:                     Qt.binding(() => root.settingsSubsection),
+            settingsSubSubsection:                  Qt.binding(() => root.settingsSubSubsection),
+        })
+    }
+
+    onActiveChanged: loadSection()
+    onLoaded: {
+        item.visible = true
+    }
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onSettingsSubsectionChanged() {
+            root.settingsSubsection = root.item.settingsSubsection
+        }
+        function onAddressWasShownRequested(address) {
+            WalletStores.RootStore.addressWasShown(address)
+        }
+        function onConnectUsernameRequested(ensName, ownerAddress) {
+            root.popupHandler.connectUsername(ensName, ownerAddress)
+        }
+        function onRegisterUsernameRequested(ensName, chainId) {
+            root.popupHandler.registerUsername(ensName, chainId)
+        }
+        function onReleaseUsernameRequested(ensName, senderAddress, chainId) {
+            root.popupHandler.releaseUsername(ensName, senderAddress, chainId)
+        }
+        function onThemeChangeRequested(theme) { root.themeChangeRequested(theme) }
+        function onFontSizeChangeRequested(fontSize) { root.fontSizeChangeRequested(fontSize) }
+        function onPaddingFactorChangeRequested(paddingFactor) { root.paddingFactorChangeRequested(paddingFactor) }
+        function onLeaveCommunityRequest(communityId) {
+            root.communitiesStore.leaveCommunity(communityId)
+        }
+        function onSetCommunityMutedRequest(communityId, mutedType) {
+            root.communitiesStore.setCommunityMuted(communityId, mutedType)
+        }
+        function onInviteFriends(communityData) {
+            Global.openInviteFriendsToCommunityByIdPopup(communityData.id, null)
+        }
+        function onOpenThirdpartyServicesInfoPopupRequested() {
+            root.popupHandler.openThirdpartyServicesPopup()
+        }
+        function onOpenDiscussPageRequested() {
+            Global.requestOpenLink(Constants.statusDiscussPageUrl)
+        }
+        function onRemoveWhitelistedDomain(index) { root.removeWhitelistedDomainRequested(index) }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/QmlCompiler.qml
+++ b/ui/app/mainui/sectionLoaders/QmlCompiler.qml
@@ -1,0 +1,76 @@
+pragma Singleton
+import QtQuick
+
+QtObject {
+    id: root
+
+    readonly property url appMainUrl: Qt.resolvedUrl("../AppMain.qml")
+    readonly property url browserUrl: Qt.resolvedUrl("../../AppLayouts/Browser/BrowserLayout.qml")
+    readonly property url browserPrivacyWallUrl: Qt.resolvedUrl("../../AppLayouts/Browser/BrowserPrivacyWall.qml")
+    readonly property url communitiesPortalUrl: Qt.resolvedUrl("../../AppLayouts/Communities/CommunitiesPortalLayout.qml")
+    readonly property url chatUrl: Qt.resolvedUrl("../../AppLayouts/Chat/ChatLayout.qml")
+    readonly property url handlersManagerUrl: Qt.resolvedUrl("../Handlers/HandlersManager.qml")
+    readonly property url homeUrl: Qt.resolvedUrl("../../AppLayouts/HomePage/HomePage.qml")
+    readonly property url marketUrl: Qt.resolvedUrl("../../AppLayouts/Market/MarketLayout.qml")
+    readonly property url marketPrivacyWallUrl: Qt.resolvedUrl("../../AppLayouts/Market/MarketPrivacyWall.qml")
+    readonly property url nodeUrl: Qt.resolvedUrl("../../AppLayouts/Node/NodeLayout.qml")
+    readonly property url popupsUrl: Qt.resolvedUrl("../Popups.qml")
+    readonly property url profileUrl: Qt.resolvedUrl("../../AppLayouts/Profile/ProfileLayout.qml")
+    readonly property url walletUrl: Qt.resolvedUrl("../../AppLayouts/Wallet/WalletLayout.qml")
+    readonly property url walletPrivacyWallUrl: Qt.resolvedUrl("../../AppLayouts/Wallet/WalletPrivacyWall.qml")
+
+    readonly property QtObject _d: QtObject {
+        id: d
+        property var precompiledUrls: new Set()
+        property var pinned: []
+    }
+
+    signal precompileFinished(url componentUrl, bool success)
+
+
+    function precompile(componentUrl, async = true) {
+        if (d.precompiledUrls.has(componentUrl))
+            return
+        const c = Qt.createComponent(componentUrl, async ? Component.Asynchronous : Component.Immediate)
+        d.precompiledUrls.add(componentUrl)
+        d.pinned.push(c)
+        if (c.status === Component.Error) {
+            console.error("QmlCompiler precompile error:", componentUrl, c.errorString())
+            precompileFinished(componentUrl, false)
+            return
+        }
+        if (c.status !== Component.Ready) {
+            c.statusChanged.connect(() => {
+                if (c.status === Component.Error) {
+                    console.error("QmlCompiler precompile error:", componentUrl, c.errorString())
+                    precompileFinished(componentUrl, false)
+                } else if (c.status === Component.Ready) {
+                    precompileFinished(componentUrl, true)
+                }
+            })
+        }
+    }
+
+    function precompileAll(async = true) {
+        precompile(appMainUrl, async)
+        precompile(browserUrl, async)
+        precompile(browserPrivacyWallUrl, async)
+        precompile(communitiesPortalUrl, async)
+        precompile(chatUrl, async)
+        precompile(handlersManagerUrl, async)
+        precompile(homeUrl, async)
+        precompile(marketUrl, async)
+        precompile(marketPrivacyWallUrl, async)
+        precompile(nodeUrl, async)
+        precompile(popupsUrl, async)
+        precompile(profileUrl, async)
+        precompile(walletUrl, async)
+        precompile(walletPrivacyWallUrl, async)
+    }
+
+    onPrecompileFinished: function(componentUrl, success) {
+        if (!success) {
+            Qt.quit()
+        }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/WalletLoader.qml
+++ b/ui/app/mainui/sectionLoaders/WalletLoader.qml
@@ -1,0 +1,126 @@
+import QtQml
+import QtQuick
+
+import utils
+
+import shared.stores as SharedStores
+import shared.stores.send
+
+import AppLayouts.stores as AppStores
+import AppLayouts.Communities.stores
+import AppLayouts.Wallet.stores as WalletStores
+
+import mainui.sectionLoaders
+
+Loader {
+    id: root
+
+    // Stores — only what WalletLayout / WalletPrivacyWall consume
+    required property AppStores.RootStore rootStore
+    required property AppStores.ContactsStore contactsStore
+    required property AppStores.FeatureFlagsStore featureFlagsStore
+    required property SharedStores.RootStore sharedRootStore
+    required property SharedStores.NetworkConnectionStore networkConnectionStore
+    required property SharedStores.NetworksStore networksStore
+    required property CommunitiesStore communitiesStore
+    required property TransactionStore transactionStore
+
+    // App-shell handlers / shared loaders
+    required property HandlersManagerLoader popupHandler
+    required property Loader dappsServiceLoader
+    required property Loader emojiPopupLoader
+
+    property bool appMainVisible: false
+    property real leftPanelWidthOverride: 0
+
+    asynchronous: false
+
+    QtObject {
+        id: d
+
+        readonly property url realUrl: QmlCompiler.walletUrl
+        readonly property url privacyWallUrl: QmlCompiler.walletPrivacyWallUrl
+        readonly property url targetUrl: rootStore.thirdpartyServicesEnabled ? realUrl : privacyWallUrl
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(() => QmlCompiler.precompile(d.targetUrl))
+        root.loadSection()
+    }
+
+    function loadSection() {
+         if (!root.active)
+            return
+        if (!!root.item && root.source === d.targetUrl)
+            return
+
+        if (d.targetUrl === d.privacyWallUrl) {
+            setSource(d.privacyWallUrl, {})
+            return
+        }
+
+        setSource(d.realUrl, {
+            visible:                false,
+            objectName:             "walletLayoutReal",
+            walletRootStore:        WalletStores.RootStore,
+            sharedRootStore:        Qt.binding(() => root.sharedRootStore),
+            store:                  Qt.binding(() => root.rootStore),
+            contactsStore:          Qt.binding(() => root.contactsStore),
+            communitiesStore:       Qt.binding(() => root.communitiesStore),
+            transactionStore:       Qt.binding(() => root.transactionStore),
+            emojiPopup:             Qt.binding(() => root.emojiPopupLoader.item),
+            networkConnectionStore: Qt.binding(() => root.networkConnectionStore),
+            networksStore:          Qt.binding(() => root.networksStore),
+            appMainVisible:         Qt.binding(() => root.appMainVisible),
+            swapEnabled:            Qt.binding(() => root.featureFlagsStore.swapEnabled),
+            buyEnabled:             Qt.binding(() => root.featureFlagsStore.buyEnabled),
+            dAppsVisible:           Qt.binding(() => root.dappsServiceLoader.item
+                                            ? root.dappsServiceLoader.item.serviceAvailableToCurrentAddress
+                                            : false),
+            dAppsEnabled:           Qt.binding(() => root.dappsServiceLoader.item
+                                            ? root.dappsServiceLoader.item.isServiceOnline
+                                            : false),
+            dAppsModel:             Qt.binding(() => root.dappsServiceLoader.item
+                                            ? root.dappsServiceLoader.item.dappsModel
+                                            : null),
+            isKeycardEnabled:       Qt.binding(() => root.featureFlagsStore.keycardEnabled),
+            leftPanelWidthOverride: Qt.binding(() => root.leftPanelWidthOverride),
+        })
+    }
+
+    onActiveChanged: loadSection()
+    onLoaded: {
+        if (root.item.resetView)
+            root.item.resetView()
+        root.item.visible = true
+    }
+
+    Connections {
+        target: root.rootStore
+        function onThirdpartyServicesEnabledChanged() { root.loadSection() }
+    }
+
+    Connections {
+        target: root.item
+        ignoreUnknownSignals: true
+
+        function onDappConnectRequested() {
+            root.dappsServiceLoader.dappConnectRequested()
+        }
+        function onDappDisconnectRequested(dappUrl) {
+            root.dappsServiceLoader.dappDisconnectRequested(dappUrl)
+        }
+        function onSendTokenRequested(senderAddress, gorupKey, tokenType) {
+            root.popupHandler.sendToken(senderAddress, gorupKey, tokenType)
+        }
+        function onOpenSwapModalRequested(swapFormData) {
+            root.popupHandler.launchSwapSpecific(swapFormData)
+        }
+        function onOpenThirdpartyServicesInfoPopupRequested() {
+            root.popupHandler.openThirdpartyServicesPopup()
+        }
+        function onOpenDiscussPageRequested() {
+            Global.requestOpenLink(Constants.statusDiscussPageUrl)
+        }
+    }
+}

--- a/ui/app/mainui/sectionLoaders/WalletLoader.qml
+++ b/ui/app/mainui/sectionLoaders/WalletLoader.qml
@@ -110,8 +110,8 @@ Loader {
         function onDappDisconnectRequested(dappUrl) {
             root.dappsServiceLoader.dappDisconnectRequested(dappUrl)
         }
-        function onSendTokenRequested(senderAddress, gorupKey, tokenType) {
-            root.popupHandler.sendToken(senderAddress, gorupKey, tokenType)
+        function onSendTokenRequested(senderAddress, groupKey, tokenType) {
+            root.popupHandler.sendToken(senderAddress, groupKey, tokenType)
         }
         function onOpenSwapModalRequested(swapFormData) {
             root.popupHandler.launchSwapSpecific(swapFormData)

--- a/ui/app/mainui/sectionLoaders/qmldir
+++ b/ui/app/mainui/sectionLoaders/qmldir
@@ -1,0 +1,14 @@
+singleton QmlCompiler 1.0 QmlCompiler.qml
+
+AppMainLoader 1.0 AppMainLoader.qml
+BrowserLoader 1.0 BrowserLoader.qml
+ChatLoader 1.0 ChatLoader.qml
+CommunitiesPortalLoader 1.0 CommunitiesPortalLoader.qml
+CommunityChatLoader 1.0 CommunityChatLoader.qml
+HandlersManagerLoader 1.0 HandlersManagerLoader.qml
+HomePageLoader 1.0 HomePageLoader.qml
+MarketLoader 1.0 MarketLoader.qml
+NodeLoader 1.0 NodeLoader.qml
+PopupsLoader 1.0 PopupsLoader.qml
+ProfileLoader 1.0 ProfileLoader.qml
+WalletLoader 1.0 WalletLoader.qml

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -8,6 +8,7 @@ import shared.popups
 import shared.stores
 
 import mainui
+import mainui.sectionLoaders
 import AppLayouts.stores as AppStores
 import AppLayouts.Profile.stores
 
@@ -57,9 +58,8 @@ Window {
     readonly property KeycardStateStore keycardStateStore: KeycardStateStore {}
     readonly property bool portraitLayout: height > width
     readonly property bool suppressKeyboardResize: SQUtils.Utils.isMobile
-                                                && loader.item
-                                                && loader.item.objectName === "appMain"
-                                                && loader.item.rootStore
+                                                && !!loader.item
+                                                && !!loader.item.rootStore
                                                 && loader.item.rootStore.activeSectionType === Constants.appSection.browser
     property bool biometricFlowPending: false
 
@@ -108,7 +108,8 @@ Window {
     }
 
     function contentLoaded() {
-        if (SQUtils.Utils.isAndroid) {
+        if (SQUtils.Utils.isAndroid && !d.splashDismissed) {
+            d.splashDismissed = true
             SystemUtils.setMainWindowReady()
         }
     }
@@ -176,7 +177,8 @@ Window {
 
     QtObject {
         id: d
-
+        property bool appMainTriggered: false
+        property bool splashDismissed: false
         property var mockedKeycardControllerWindow
         property double lastShakeShareMs: 0
         function runMockedKeycardControllerWindow() {
@@ -276,18 +278,63 @@ Window {
         }
     }
 
-    function moveToAppMain() {
-        Global.appIsReady = true
-        loader.setSource("app/mainui/AppMain.qml", {
-            "objectName": "appMain",
-            "utilsStore": applicationWindow.utilsStore,
-            "featureFlagsStore": applicationWindow.featureFlagsStore,
-            "languageStore": applicationWindow.languageStore,
-            "visible": Qt.binding(() => !startupOnboardingLoader.active),
-            "systemTrayIconAvailable": Qt.binding(() => systemTray.available),
-            "keychain": appKeychain
-        })
+    AppMainLoader {
+        id: loader
 
+        anchors.fill: applicationWindow.contentItem
+        anchors.topMargin: Qt.platform.os === SQUtils.Utils.mac && !applicationWindow.portraitLayout
+                           ? 0
+                           : applicationWindow.contentItem.SafeArea.margins.top
+        anchors.bottomMargin: applicationWindow.contentItem.SafeArea.margins.bottom
+        anchors.leftMargin: applicationWindow.portraitLayout
+                            ? applicationWindow.contentItem.SafeArea.margins.left
+                            : 0
+        anchors.rightMargin: applicationWindow.contentItem.SafeArea.margins.right
+
+        opacity: 0
+        visible: !startupOnboardingLoader.active
+
+        Behavior on opacity {
+            NumberAnimation { duration: 120 }
+        }
+
+        active: d.appMainTriggered && (typeof mainModule !== "undefined") && (mainModule?.mainLoaded ?? false)
+
+        featureFlagsStore: applicationWindow.featureFlagsStore
+        languageStore: applicationWindow.languageStore
+        keychain: appKeychain
+        systemTrayIconAvailable: systemTray.available
+        utilsStore: applicationWindow.utilsStore
+
+        onLoaded: {
+            Global.appIsReady = true
+            appMainFadeIn.running = true
+            startupOnboardingLoader.active = false
+            splashScreenLoader.active = false
+            applicationWindow.contentLoaded()
+            if (d.showSkippedBiometricFlow)
+                loader.item.showEnableBiometricsFlow()
+        }
+
+        onStatusChanged: {
+            if (status === Loader.Error) {
+                console.error("Failed to load AppMain.qml")
+                Qt.quit()
+            }
+        }
+    }
+
+    OpacityAnimator {
+        id: appMainFadeIn
+        target: loader
+        from: 0
+        to: 1
+        duration: 120
+        running: false
+    }
+
+    function moveToAppMain() {
+        d.appMainTriggered = true
         d.runMockedKeycardControllerWindow()
     }
 
@@ -505,41 +552,6 @@ Window {
     }
 
     Loader {
-        id: loader
-
-        anchors.fill: parent
-        anchors.topMargin: Qt.platform.os === SQUtils.Utils.mac && !applicationWindow.portraitLayout ?
-                               0 : parent.SafeArea.margins.top
-        anchors.bottomMargin: parent.SafeArea.margins.bottom
-        anchors.leftMargin: applicationWindow.portraitLayout ? parent.SafeArea.margins.left
-                                                  : 0 // the PrimaryNavSidebar is visible in landscape and already has it
-        anchors.rightMargin: parent.SafeArea.margins.right
-        opacity: active ? 1.0 : 0.0
-        visible: (opacity > 0.0001)
-        Behavior on opacity { NumberAnimation { duration: 120 }}
-        /* only unload splash screen once appmain is loaded else we see
-        an empty screen for a sec until it is loaded */
-        onLoaded: {
-            startupOnboardingLoader.active = false
-            splashScreenLoader.active = false
-            if (item) {
-                applicationWindow.contentLoaded()
-                if (d.showSkippedBiometricFlow) {
-                    // IN case of Login via syncing, request to show Biometrics Page after onboarding
-                    item.showEnableBiometricsFlow()
-                }
-            }
-        }
-
-        onStatusChanged: {
-            if (status === Loader.Error) {
-                console.error("Failed to load AppMain.qml")
-                Qt.quit()
-            }
-        }
-    }
-
-    Loader {
         id: startupOnboardingLoader
 
         anchors.fill: parent
@@ -557,23 +569,33 @@ Window {
             item.keychain = appKeychain
             item.lastSelectedProfileKeyUid = Qt.binding(() => localAppSettings.selectedProfileKeyUid)
             item.biometricFlowPending = Qt.binding(() => applicationWindow.biometricFlowPending)
-
-            item.appReady.connect(() => {
-                applicationWindow.appIsReady = true
-            })
-            item.storeAppStateRequested.connect(applicationWindow.storeAppState)
-            item.requestMoveToAppMain.connect(moveToAppMain)
-            item.biometricFlowStarted.connect(() => {
-                applicationWindow.biometricFlowPending = true
-            })
-            item.skippedBiometricFlow.connect((available) => {
-                d.showSkippedBiometricFlow = available
-            })
-            item.profileSelected.connect((keyUid) => {
-                localAppSettings.selectedProfileKeyUid = keyUid
-            })
             splashScreenLoader.active = false
             applicationWindow.contentLoaded()
+            Qt.callLater(() => QmlCompiler.precompileAll()) // precompile all components after onboarding is loaded to speed up the login flow
+        }
+    }
+
+    Connections {
+        target: startupOnboardingLoader.item
+        ignoreUnknownSignals: true
+
+        function onAppReady() {
+            applicationWindow.appIsReady = true
+        }
+        function onStoreAppStateRequested() {
+            applicationWindow.storeAppState()
+        }
+        function onRequestMoveToAppMain() {
+            applicationWindow.moveToAppMain()
+        }
+        function onBiometricFlowStarted() {
+            applicationWindow.biometricFlowPending = true
+        }
+        function onSkippedBiometricFlow(available) {
+            d.showSkippedBiometricFlow = available
+        }
+        function onProfileSelected(keyUid) {
+            localAppSettings.selectedProfileKeyUid = keyUid
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Iterates: https://github.com/status-im/status-app/issues/20228

This commit aims to split the qml compilation into smaller chunks and  schedule the compilation at the appropriate time.

Approach: Each main section lives behind a loader component that has 2 purposes - load the component at appropriate times and defer the qml compilation until the loader is created.

The same approach was applied to AppMain.qml and on top of this we'll need to make sure we're loading the AppMain at an appropriate time so that we'll avoid many intermediary states if the nim layer isn't ready for it.

For this, I've introduced a new component - QmlCompiler. It has a list of main components and can precompile the qml component or make sure to load it all if needed (e.g while the onboarding runs we can use that time to preload everything)

This approach is fully compatible with Loader.asynchronous usage and implementing loading states for the components - the community and chat loaders already implement it partially. Can be extended to preload all the sections in the background while the user is working on the current section.

- Added MarketLoader.qml to handle market-related UI loading.
- Introduced NodeLoader.qml for loading node-related UI components.
- Created PopupsLoader.qml to manage various popups within the application.
- Developed ProfileLoader.qml for loading user profile sections.
- Implemented WalletLoader.qml to manage wallet-related UI components.
- Added QmlCompiler.qml to centralize URL management for QML components.
- Updated qmldir to include new loaders for better modularity.
- Refactored main.qml to utilize the new AppMainLoader and improve loading logic.



### Affected areas

All main section (wallet, chat, home, community, node, settings)
Popups

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<!-- Gif/Video or screenshot that demonstrates the functionality, especially important if it's a bug fix. -->

### Impact on end user

4-6 seconds app start-up no matter the account size.

### How to test

This is a refactoring of the main app layouts, changing the way we're using the main layouts throughout the app, so in terms of what to test, I'd say everything..The regression would probably be all or nothing - meaning either a section or popup is not working at all or it's working fine.


But a focus testing would start with this:
App start-up with each section (cold and warm)
Launching popups throughout the app and default popups (push notifications, instructions on how to use the navbar, biometrics, etc)
Switching sections
Chat input popups
Onboarding
Browers - loading and popups

### Risk 

High