### PR TITLE
fix(Search): focus the user/channel/chat search fields

### DIFF
--- a/test/e2e/gui/components/confirm_recovery_phrase.py
+++ b/test/e2e/gui/components/confirm_recovery_phrase.py
@@ -1,10 +1,23 @@
 import allure
 
+import configs
 import driver
 from gui.elements.button import Button
-from gui.elements.object import QObject
+from gui.elements.object import QObject, set_text_property_on_object
 from gui.keep_or_delete_recovery_phrase import KeepOrDeleteRecoveryPhrase
 from gui.objects_map import names
+
+_EXPECTED_SEED_VERIFY_FIELDS = 4
+
+
+def _seed_cell_object_name(cell) -> str:
+    name = getattr(cell, 'objectName', None)
+    if name:
+        return str(name)
+    try:
+        return str(cell['objectName'])
+    except (TypeError, KeyError, AttributeError):
+        return ''
 
 
 class ConfirmRecoveryPhrase(QObject):
@@ -14,17 +27,51 @@ class ConfirmRecoveryPhrase(QObject):
         self.seed_input = QObject(names.seedInput)
         self.continue_button = Button(names.continueButton)
 
+    def _wait_for_seed_verify_inputs(self, timeout_msec: int = None) -> list:
+        if timeout_msec is None:
+            timeout_msec = configs.timeouts.LOADING_LIST_TIMEOUT_MSEC
+
+        def _ready() -> bool:
+            raw = list(driver.findAllObjects(self.seed_input.real_name))
+            filtered = [c for c in raw if _seed_cell_object_name(c).startswith('seedInput_')]
+            return len(filtered) >= _EXPECTED_SEED_VERIFY_FIELDS
+
+        assert driver.waitFor(_ready, timeout_msec), (
+            f'Expected at least {_EXPECTED_SEED_VERIFY_FIELDS} SeedphraseVerifyInput fields '
+            f'with objectName seedInput_*; UI may still be loading on slow runners.'
+        )
+        raw = list(driver.findAllObjects(self.seed_input.real_name))
+        return [c for c in raw if _seed_cell_object_name(c).startswith('seedInput_')]
+
+    @staticmethod
+    def _mnemonic_index_from_cell_object_name(cell) -> int:
+        name = _seed_cell_object_name(cell)
+        suffix = name.rsplit('_', 1)[-1]
+        try:
+            return int(suffix)
+        except ValueError as e:
+            raise ValueError(f'Cannot parse mnemonic index from objectName={name!r} (cell={cell!r})') from e
+
     @allure.step('Fill in the grid and click continue')
     def fill_the_grid_and_continue(self, words):
 
-        cells_to_fill = driver.findAllObjects(self.seed_input.real_name)
+        cells_to_fill = self._wait_for_seed_verify_inputs()
+        assert len(cells_to_fill) >= _EXPECTED_SEED_VERIFY_FIELDS, (
+            f'After filtering to seedInput_*, expected at least {_EXPECTED_SEED_VERIFY_FIELDS} cells, '
+            f'got {len(cells_to_fill)}; raw findAllObjects may include unrelated overlay items.'
+        )
+        cells_to_fill.sort(key=lambda c: ConfirmRecoveryPhrase._mnemonic_index_from_cell_object_name(c))
 
         for cell in cells_to_fill:
-            word_to_confirm_index = int(str(cell['objectName']).split('_')[1])
-            word_to_put = words[word_to_confirm_index]
-            self.seed_input.real_name['objectName'] = f'seedInput_{word_to_confirm_index}'
-            self.seed_input.set_text_property(word_to_put)
+            idx = self._mnemonic_index_from_cell_object_name(cell)
+            word_to_put = words[idx]
+            set_text_property_on_object(cell, word_to_put, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
-        assert self.continue_button.is_visible
+        assert driver.waitFor(
+            lambda: self.continue_button.is_enabled,
+            configs.timeouts.UI_LOAD_TIMEOUT_MSEC,
+        ), (
+            'Continue stayed disabled'
+        )
         self.continue_button.click()
         return KeepOrDeleteRecoveryPhrase()

--- a/test/e2e/gui/elements/object.py
+++ b/test/e2e/gui/elements/object.py
@@ -11,6 +11,33 @@ from scripts.tools.image import Image
 LOG = logging.getLogger(__name__)
 
 
+def set_text_property_on_object(obj, text: str, timeout_msec: int = None) -> None:
+    if timeout_msec is None:
+        timeout_msec = configs.timeouts.UI_LOAD_TIMEOUT_MSEC
+    expected = str(text)
+    obj.forceActiveFocus()
+    obj.clear()
+    obj.text = text
+
+    def _content_matches() -> bool:
+        plain_getter = getattr(obj, 'getPlainText', None)
+        if callable(plain_getter):
+            try:
+                if str(plain_getter()) == expected:
+                    return True
+            except (RuntimeError, AttributeError, TypeError):
+                pass
+        try:
+            return str(obj.text) == expected
+        except (RuntimeError, AttributeError):
+            return False
+
+    assert driver.waitFor(_content_matches, timeout_msec), (
+        f'Text was not set on {getattr(obj, "objectName", obj)!r}; expected={expected!r} '
+        f'text={getattr(obj, "text", "")!r}'
+    )
+
+
 class QObject:
 
     def __init__(self, real_name: [str, dict] = None):
@@ -28,29 +55,7 @@ class QObject:
 
     def set_text_property(self, text):
         """Assign text without driver.type(). Verifies via plain text when available (e.g. RichText inputs)."""
-        expected = str(text)
-        obj = self.object
-        obj.forceActiveFocus()
-        obj.clear()
-        obj.text = text
-
-        def _content_matches() -> bool:
-            plain_getter = getattr(obj, 'getPlainText', None)
-            if callable(plain_getter):
-                try:
-                    if str(plain_getter()) == expected:
-                        return True
-                except (RuntimeError, AttributeError, TypeError):
-                    pass
-            try:
-                return str(obj.text) == expected
-            except (RuntimeError, AttributeError):
-                return False
-
-        assert driver.waitFor(_content_matches, configs.timeouts.UI_LOAD_TIMEOUT_MSEC), (
-            f'Text was not set; expected length={len(expected)} '
-            f'text={getattr(obj, "text", "")!r}'
-        )
+        set_text_property_on_object(self.object, text, configs.timeouts.UI_LOAD_TIMEOUT_MSEC)
 
     @property
     @allure.step('Get object exists {0}')

--- a/test/e2e/gui/objects_map/communities_names.py
+++ b/test/e2e/gui/objects_map/communities_names.py
@@ -217,8 +217,8 @@ editPermissionView_whoHoldsSwitch_StatusSwitch = {"checkable": True, "container"
 # Legacy: top-level overlay TextEdit — unreliable since HoldingsDropdown uses SearchBox + inner edit (see holdingsDropdown_*).
 edit_TextEdit = {"container": statusDesktop_mainWindow_overlay, "type": "TextEdit", "unnamed": 1, "visible": True}
 # HoldingsDropdown (Who holds +) opens ExtendedDropdownContent with SearchBox; inner TextEdit id is "edit" (StatusBaseInput).
-holdingsDropdown_SearchBox = {"container": statusDesktop_mainWindow_overlay, "type": "SearchBox", "unnamed": 1, "visible": True}
-holdingsDropdown_assetSearch_TextEdit = {"container": holdingsDropdown_SearchBox, "id": "edit", "type": "TextEdit", "unnamed": 1, "visible": True}
+holdingsDropdown_SearchBox = {"container": statusDesktop_mainWindow_overlay, "id": "searcher", "type": "SearchBox", "unnamed": 1, "visible": True}
+holdingsDropdown_assetSearch_TextEdit = {"container": statusDesktop_mainWindow_overlay, "id": "searcher", "type": "SearchBox", "unnamed": 1, "visible": True}
 inputValue_StyledTextField = {"container": statusDesktop_mainWindow_overlay, "id": "inputValue", "type": "StatusTextField", "unnamed": 1, "visible": True}
 o_TokenItem = {"container": statusDesktop_mainWindow_overlay, "index": 0, "type": "TokenItem", "unnamed": 1, "visible": True}
 add_StatusButton = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "objectName": "addButton", "type": "StatusButton", "visible": True}

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -140,6 +140,7 @@ completeAndDeleteSeedPhraseButton = {"container": statusDesktop_mainWindow_overl
 """Confirm recovery phrase modal"""
 confirmRecoveryPhraseModal = {"container": statusDesktop_mainWindow_overlay, "type": "BackupSeedphraseVerify", "unnamed": 1, "visible": True}
 seedInput = {"container": statusDesktop_mainWindow_overlay, "objectName": RegularExpression("seedInput_*"), "type": "SeedphraseVerifyInput", "visible": True}
+
 continueButton = {"container": statusDesktop_mainWindow_overlay, "text": "Continue", "type": "StatusButton", "unnamed": 1, "visible": True}
 
 """Keep or delete recovery phrase"""

--- a/test/e2e/gui/objects_map/names.py
+++ b/test/e2e/gui/objects_map/names.py
@@ -578,9 +578,7 @@ o_DropShadow = {"container": statusDesktop_mainWindow_overlay, "type": "DropShad
 # Emoji Popup
 emojiPopup = {"container": statusDesktop_mainWindow_overlay, "objectName": "StatusEmojiPopup", "type": "PopupItem",
               "visible": True}
-mainWallet_AddEditAccountPopup_AccountEmojiSearchBox = {"container": statusDesktop_mainWindow,
-                                                        "objectName": "StatusEmojiPopup_searchBox", "type": "TextEdit",
-                                                        "visible": True}
+mainWallet_AddEditAccountPopup_AccountEmojiSearchBox = {"container": statusDesktop_mainWindow_overlay, "echoMode": 0, "objectName": "StatusEmojiPopup_searchBox", "type": "SearchBox", "visible": True}
 mainWallet_AddEditAccountPopup_AccountEmoji = {"container": statusDesktop_mainWindow, "type": "StatusEmoji",
                                                "visible": True}
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
@@ -32,21 +32,18 @@ StatusTextField {
         id: d
 
         readonly property int inputTextPadding: root.Theme.defaultPadding
-        readonly property int radius: root.Theme.defaultPadding / 2
     }
 
     leftPadding: d.inputTextPadding
     rightPadding: d.inputTextPadding
-    verticalAlignment: Text.AlignVCenter
     implicitWidth: 480
     implicitHeight: 44
-    selectByMouse: true
 
     echoMode: TextInput.Password
 
     background: Rectangle {
         color: Theme.palette.baseColor2
-        radius: d.radius
+        radius: Theme.radius
         border.width: root.focus || root.hasError ? 1 : 0
         border.color: root.hasError ? Theme.palette.dangerColor1 : Theme.palette.primaryColor1
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextField.qml
@@ -10,6 +10,9 @@ import StatusQ.Popups
 
 TextField {
     id: root
+
+    property bool showBackground: true
+
     Accessible.name: Utils.formatAccessibleName(placeholderText, objectName)
 
     font.family: Fonts.baseFont.family
@@ -19,8 +22,33 @@ TextField {
     selectedTextColor: Theme.palette.directColor1
     selectionColor: Theme.palette.primaryColor2
     placeholderTextColor: Theme.palette.baseColor1
-
+    verticalAlignment: Text.AlignVCenter
     opacity: enabled ? 1 : ThemeUtils.disabledOpacity
+
+    leftPadding: Theme.defaultPadding
+    rightPadding: Theme.defaultPadding
+    topPadding: Theme.defaultHalfPadding
+    bottomPadding: Theme.defaultHalfPadding
+
+    HoverHandler {
+        id: hoverHandler
+        enabled: root.enabled
+    }
+
+    background: Rectangle {
+        implicitHeight: 44
+        color: root.showBackground ? Theme.palette.statusAppNavBar.backgroundColor : "transparent"
+        radius: Theme.radius
+
+        border.width: 1
+        border.color: {
+            if (!root.showBackground)
+                return "transparent"
+            if (root.cursorVisible)
+                return Theme.palette.primaryColor1
+            return hoverHandler.hovered ? Theme.palette.primaryColor2 : "transparent"
+        }
+    }
 
     cursorDelegate: StatusCursorDelegate {
         cursorVisible: root.cursorVisible

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -59,11 +59,10 @@ ColumnLayout {
         }
 
         StatusFlatButton {
+            id: searchBtn
             icon.name: "search"
             isRoundIcon: true
             checkable: true
-            checked: searchField.visible
-            onToggled: searchField.visible = checked
             textColor: checked || hovered ? Theme.palette.primaryColor1 : Theme.palette.directColor1
             tooltip.text: qsTr("Search")
             tooltip.orientation: StatusToolTip.Orientation.Bottom
@@ -73,14 +72,18 @@ ColumnLayout {
     SearchBox {
         id: searchField
         KeyNavigation.tab: userListView
-        Keys.onEscapePressed: visible = false
+        Keys.onEscapePressed: searchBtn.checked = false
         Layout.fillWidth: true
         Layout.leftMargin: Theme.padding
         Layout.rightMargin: Theme.padding
         placeholderText: qsTr("Search members...")
-        visible: false
-        onVisibleChanged: input.edit.clear()
-        focus: visible
+        visible: searchBtn.checked
+        onVisibleChanged: {
+            if (visible)
+                forceActiveFocus()
+            else
+                clear()
+        }
     }
 
     StatusBaseText {
@@ -118,7 +121,7 @@ ColumnLayout {
                 SQUtils.SearchFilter {
                     roleName: "preferredDisplayName"
                     searchPhrase: searchField.text
-                    enabled: !!searchPhrase
+                    enabled: searchField.visible && !!searchPhrase
                 }
             ]
             sorters: [

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -94,12 +94,11 @@ Item {
             }
 
             HeaderButton {
+                id: searchBtn
                 objectName: "searchButton"
                 icon.name: "search"
                 tooltip.text: qsTr("Search")
                 checkable: true
-                checked: searchInput.visible
-                onToggled: searchInput.visible = checked
             }
         }
 
@@ -113,11 +112,13 @@ Item {
             Layout.bottomMargin: 4
             Layout.preferredHeight: 40
             KeyNavigation.tab: channelList
-            Keys.onEscapePressed: visible = false
+            Keys.onEscapePressed: searchBtn.checked = false
             placeholderText: qsTr("Search chats...")
-            visible: false
-            onVisibleChanged: input.edit.clear()
-            focus: visible
+            visible: searchBtn.checked
+            onVisibleChanged: {
+                clear()
+                if (visible) forceActiveFocus()
+            }
         }
 
         // loading panel
@@ -147,7 +148,7 @@ Item {
                         SQUtils.SearchFilter {
                             roleName: "name"
                             searchPhrase: searchInput.text
-                            enabled: !!searchPhrase
+                            enabled: searchInput.visible && !!searchPhrase
                         }
                     ]
                     sorters: RoleSorter {

--- a/ui/app/AppLayouts/Communities/controls/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ExtendedDropdownContent.qml
@@ -437,12 +437,9 @@ Item {
             Layout.leftMargin: d.padding
             Layout.rightMargin: d.padding
             Layout.topMargin: root.state === d.depth1_ListState ? 0 : 8
+            Layout.preferredHeight: 36
 
             visible: d.availableData && !loadingIndicator.visible
-            topPadding: 0
-            bottomPadding: 0
-            minimumHeight: 36
-            maximumHeight: 36
 
             placeholderText: {
                 if (root.type === ExtendedDropdownContent.Type.Assets) {

--- a/ui/app/AppLayouts/Communities/panels/ColumnHeaderPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ColumnHeaderPanel.qml
@@ -16,11 +16,10 @@ Control {
     property url image
     property color color
     property bool amISectionAdmin
-    property bool searchActive
+    property alias searchActive: searchButton.checked
 
     signal infoButtonClicked
     signal shareOwnProfileRequested
-    signal searchRequested(bool toggled)
 
     padding: Theme.halfPadding
     rightPadding: Theme.padding
@@ -55,11 +54,11 @@ Control {
         }
 
         HeaderButton {
+            id: searchButton
             objectName: "searchButton"
             icon.name: "search"
             checkable: true
-            checked: root.searchActive
-            onToggled: root.searchRequested(checked)
+            checked: false
             tooltip.text: qsTr("Search")
         }
     }

--- a/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
@@ -42,9 +42,7 @@ ColumnLayout {
     SearchBox {
         id: filterInput
         placeholderText: qsTr("Search contacts")
-        maximumHeight: 36
-        topPadding: 0
-        bottomPadding: 0
+        Layout.preferredHeight: 36
         Layout.fillWidth: true
         Layout.topMargin: Theme.bigPadding
         Layout.bottomMargin: Theme.padding

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -82,13 +82,9 @@ Control {
 
             Layout.fillWidth: true
             Layout.topMargin: 12
+            Layout.preferredHeight: 36
 
             visible: !root.empty
-
-            topPadding: 0
-            bottomPadding: 0
-            minimumHeight: 36 // by design
-            maximumHeight: minimumHeight
 
             placeholderText: qsTr("Search hodlers")
         }

--- a/ui/app/AppLayouts/Communities/panels/TokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TokenHoldersPanel.qml
@@ -51,11 +51,8 @@ Control {
             Layout.topMargin: 12
             Layout.leftMargin: Theme.padding
             Layout.rightMargin: Theme.padding
+            Layout.preferredHeight: 36
             visible: !root.empty
-            topPadding: 0
-            bottomPadding: 0
-            minimumHeight: 36 // by design
-            maximumHeight: minimumHeight
             placeholderText: qsTr("Search hodlers")
         }
         StatusBaseText {

--- a/ui/app/AppLayouts/Communities/popups/InDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/InDropdown.qml
@@ -56,7 +56,7 @@ StatusDropdown {
     }
 
     onAboutToShow: {
-        searcher.input.edit.forceActiveFocus()
+        searcher.forceActiveFocus()
         listView.Layout.preferredHeight = Math.min(
                        listView.implicitHeight, 420)
     }
@@ -157,11 +157,7 @@ StatusDropdown {
             id: searcher
 
             Layout.fillWidth: true
-
-            topPadding: 0
-            bottomPadding: 0
-            minimumHeight: 36
-            maximumHeight: 36
+            Layout.preferredHeight: 36
         }
 
         StatusListItem {

--- a/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
@@ -67,7 +67,7 @@ StatusDropdown {
     onOpened: {
         listView.positionViewAtBeginning()
         filterInput.text = ""
-        filterInput.input.edit.forceActiveFocus()
+        filterInput.forceActiveFocus()
     }
 
     QtObject {
@@ -105,17 +105,11 @@ StatusDropdown {
             id: filterInput
 
             Layout.fillWidth: true
+            Layout.preferredHeight: 36
 
             placeholderText: qsTr("Search members")
-            maximumHeight: 36
-            topPadding: 0
-            bottomPadding: 0
 
-            input.asset.width: 15
-            input.asset.height: 15
-            input.leftPadding: 13
-            input.font.pixelSize: Theme.additionalTextSize
-            input.placeholder.font.pixelSize: Theme.additionalTextSize
+            font.pixelSize: Theme.additionalTextSize
         }
 
         StatusBaseText {

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -97,16 +97,15 @@ Item {
         spacing: Theme.halfPadding
 
         ColumnHeaderPanel {
+            id: headerPanel
             Layout.fillWidth: true
             name: communityData.name
             membersCount: root.joinedMembersCount
             image: communityData.image
             color: communityData.color
             amISectionAdmin: root.isSectionAdmin
-            searchActive: searchField.visible
             onInfoButtonClicked: root.infoButtonClicked()
             onShareOwnProfileRequested: root.shareOwnProfileRequested()
-            onSearchRequested: toggled => searchField.visible = toggled
         }
 
         Loader {
@@ -128,11 +127,15 @@ Item {
             Layout.bottomMargin: 4
             Layout.preferredHeight: 40
             KeyNavigation.tab: communityChatListAndCategories
-            Keys.onEscapePressed: visible = false
+            Keys.onEscapePressed: headerPanel.searchActive = false
             placeholderText: qsTr("Search channels...")
-            visible: false
-            onVisibleChanged: input.edit.clear()
-            focus: visible
+            visible: headerPanel.searchActive
+            onVisibleChanged: {
+                if (visible)
+                    forceActiveFocus()
+                else
+                    clear()
+            }
         }
 
         ChatsLoadingPanel {
@@ -220,7 +223,7 @@ Item {
                         SQUtils.SearchFilter {
                             roleName: "name"
                             searchPhrase: searchField.text
-                            enabled: !!searchPhrase
+                            enabled: searchField.visible && !!searchPhrase
                         }
                     ]
                 }

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -147,28 +147,9 @@ DoubleFlickableWithFolding {
                 Layout.fillWidth: true
 
                 placeholderText: root.searchPlaceholderText
-                validators: [
-                    StatusValidator {
-                        property bool isEmoji: false
-
-                        name: "check-for-no-emojis"
-                        validate: (value) => {
-                                      if (!value) {
-                                          return true
-                                      }
-
-                                      isEmoji = Constants.regularExpressions.emoji.test(value)
-                                      if (isEmoji){
-                                          return false
-                                      }
-
-                                      return Constants.regularExpressions.alphanumericalExpanded1.test(value)
-                                  }
-                        errorMessage: isEmoji ?
-                                          qsTr("Your search is too cool (use A-Z and 0-9, hyphens and underscores only)")
-                                        : qsTr("Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)")
-                    }
-                ]
+                validator: RXValidator {
+                    regularExpression: Constants.regularExpressions.alphanumericalExpanded1
+                }
 
                 Binding {
                     target: d

--- a/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/FilterComboBox.qml
@@ -53,7 +53,7 @@ ComboBox {
 
         readonly property int defaultDelegateHeight: 34
 
-        readonly property string searchTextLowerCase: searchBox.input.text
+        readonly property string searchTextLowerCase: searchBox.text
 
         readonly property SQUtils.ModelChangeTracker sourceModelTracker: SQUtils.ModelChangeTracker {
             model: root.sourceModel
@@ -210,14 +210,8 @@ ComboBox {
                 Layout.leftMargin: Theme.halfPadding
                 Layout.rightMargin: Theme.halfPadding
                 Layout.bottomMargin: 12
-                minimumHeight: d.defaultDelegateHeight
-                maximumHeight: d.defaultDelegateHeight
-                input.edit.font.pixelSize: root.font.pixelSize
-                input.placeholder.font.pixelSize: root.font.pixelSize
-                input.asset.width: 16
-                input.asset.height: 16
-                topPadding: 0
-                bottomPadding: 0
+                Layout.preferredHeight: d.defaultDelegateHeight
+                font.pixelSize: root.font.pixelSize
                 placeholderText: qsTr("Collection, community, name or #")
             }
             StatusListView {

--- a/ui/app/AppLayouts/Wallet/panels/TokenSearchBox.qml
+++ b/ui/app/AppLayouts/Wallet/panels/TokenSearchBox.qml
@@ -2,11 +2,7 @@ import shared.controls
 import StatusQ.Core.Utils
 
 SearchBox {
-    input.leftPadding: 14
-    input.rightPadding: 14
-
-    minimumHeight: 56
-    maximumHeight: 56
-    input.showBackground: false
+    implicitHeight: 56
+    showBackground: false
     focus: visible && !Utils.isMobile
 }

--- a/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityCounterpartyFilterSubMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityCounterpartyFilterSubMenu.qml
@@ -42,7 +42,7 @@ StatusMenu {
     Component.onCompleted: root.updateRecipientsModel()
 
     function resetView() {
-        searchBox.reset()
+        searchBox.clear()
     }
 
     contentItem: ColumnLayout {
@@ -66,9 +66,8 @@ StatusMenu {
             Layout.fillWidth: true
             Layout.leftMargin: 8
             Layout.rightMargin: 8
+            Layout.preferredHeight: 36
             font.pixelSize: Theme.additionalTextSize
-            placeholderFont.pixelSize: font.pixelSize
-            input.height: 36
             placeholderText: qsTr("Search name, ENS or address")
             onTextChanged: searchTimer.restart()
 

--- a/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityTokensFilterSubMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityTokensFilterSubMenu.qml
@@ -34,7 +34,7 @@ StatusMenu {
     implicitWidth: 289
 
     function resetView() {
-        tokensSearchBox.reset()
+        tokensSearchBox.clear()
         collectiblesSearchBox.reset()
     }
 
@@ -106,7 +106,7 @@ StatusMenu {
                     Layout.fillWidth: true
                     Layout.leftMargin: 8
                     Layout.rightMargin: 8
-                    input.height: 36
+                    Layout.preferredHeight: 36
                     placeholderText: qsTr("Search asset name")
                 }
 
@@ -169,7 +169,7 @@ StatusMenu {
                     Layout.fillWidth: true
                     Layout.leftMargin: 8
                     Layout.rightMargin: 8
-                    input.height: 36
+                    Layout.preferredHeight: 36
                     placeholderText: qsTr("Search collectible name")
                 }
 

--- a/ui/app/AppLayouts/Wallet/views/FollowingAddresses.qml
+++ b/ui/app/AppLayouts/Wallet/views/FollowingAddresses.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ
 import StatusQ.Components
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -59,7 +60,7 @@ Item {
 
         function reset() {
             currentSearch = ""
-            searchBox.text = ""
+            searchBox.clear()
             currentPage = 1
         }
 
@@ -77,7 +78,7 @@ Item {
         function refresh(address) {
             currentPage = 1
             currentSearch = ""
-            searchBox.text = ""
+            searchBox.clear()
             isPaginationLoading = true
             root.refreshRequested(address, "", pageSize, 0)
         }
@@ -116,28 +117,9 @@ Item {
                 searchDebounceTimer.restart()
             }
 
-            validators: [
-                StatusValidator {
-                    property bool isEmoji: false
-
-                    name: "check-for-no-emojis"
-                    validate: (value) => {
-                                  if (!value) {
-                                      return true
-                                  }
-
-                                  isEmoji = Constants.regularExpressions.emoji.test(value)
-                                  if (isEmoji){
-                                      return false
-                                  }
-
-                                  return Constants.regularExpressions.alphanumericalExpanded1.test(value)
-                              }
-                    errorMessage: isEmoji?
-                                      qsTr("Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)")
-                                    : qsTr("Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)")
-                }
-            ]
+            validator: RXValidator {
+                regularExpression: Constants.regularExpressions.alphanumericalExpanded1
+            }
         }
 
         ShapeRectangle {

--- a/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddresses.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import StatusQ
 import StatusQ.Components
 import StatusQ.Core
 import StatusQ.Core.Theme
@@ -41,28 +42,9 @@ ColumnLayout {
         visible: RootStore.savedAddresses.count > 0
         placeholderText: qsTr("Search for name, ENS or address")
 
-        validators: [
-            StatusValidator {
-                property bool isEmoji: false
-
-                name: "check-for-no-emojis"
-                validate: (value) => {
-                              if (!value) {
-                                  return true
-                              }
-
-                              isEmoji = Constants.regularExpressions.emoji.test(value)
-                              if (isEmoji){
-                                  return false
-                              }
-
-                              return Constants.regularExpressions.alphanumericalExpanded1.test(value)
-                          }
-                errorMessage: isEmoji?
-                                  qsTr("Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)")
-                                : qsTr("Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)")
-            }
-        ]
+        validator: RXValidator {
+            regularExpression: Constants.regularExpressions.alphanumericalExpanded1
+        }
     }
 
     ShapeRectangle {

--- a/ui/i18n/qml_base_en.ts
+++ b/ui/i18n/qml_base_en.ts
@@ -1012,10 +1012,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mainnet data verified by Nimbus</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Application Logs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1121,10 +1117,6 @@
     </message>
     <message>
         <source>enable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 Nimbus proxy? You need to restart the app for this change to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3943,10 +3935,6 @@ You will remain logged in, and your recovery phrase will be entirely in your han
     <name>ConfirmationDialog</name>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reject</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8079,14 +8067,6 @@ Are you sure you want to do this?</source>
     <name>FollowingAddresses</name>
     <message>
         <source>Search for name, ENS or address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14813,14 +14793,6 @@ to load</source>
 <context>
     <name>ProfileShowcasePanel</name>
     <message>
-        <source>Your search is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>In showcase</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15503,14 +15475,6 @@ to load</source>
     <name>SavedAddresses</name>
     <message>
         <source>Search for name, ENS or address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -19441,10 +19405,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     </message>
     <message>
         <source>BaseScan</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status Explorer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/qml_base_lokalise_en.ts
+++ b/ui/i18n/qml_base_lokalise_en.ts
@@ -1240,11 +1240,6 @@
       <translation>Minimize to tray icon on close</translation>
     </message>
     <message>
-      <source>Mainnet data verified by Nimbus</source>
-      <comment>AdvancedView</comment>
-      <translation>Mainnet data verified by Nimbus</translation>
-    </message>
-    <message>
       <source>Application Logs</source>
       <comment>AdvancedView</comment>
       <translation>Application Logs</translation>
@@ -1378,11 +1373,6 @@
       <source>enable</source>
       <comment>AdvancedView</comment>
       <translation>enable</translation>
-    </message>
-    <message>
-      <source>Are you sure you want to %1 Nimbus proxy? You need to restart the app for this change to take effect.</source>
-      <comment>AdvancedView</comment>
-      <translation>Are you sure you want to %1 Nimbus proxy? You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
       <source>How many log files do you want to keep archived?</source>
@@ -4812,11 +4802,6 @@
       <source>Confirm</source>
       <comment>ConfirmationDialog</comment>
       <translation>Confirm</translation>
-    </message>
-    <message>
-      <source>Reject</source>
-      <comment>ConfirmationDialog</comment>
-      <translation>Reject</translation>
     </message>
     <message>
       <source>Cancel</source>
@@ -9869,16 +9854,6 @@
       <source>Search for name, ENS or address</source>
       <comment>FollowingAddresses</comment>
       <translation>Search for name, ENS or address</translation>
-    </message>
-    <message>
-      <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-      <comment>FollowingAddresses</comment>
-      <translation>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</translation>
-    </message>
-    <message>
-      <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-      <comment>FollowingAddresses</comment>
-      <translation>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</translation>
     </message>
     <message>
       <source>No following addresses found. Check spelling or whether the address is correct.</source>
@@ -18060,16 +18035,6 @@
   <context>
     <name>ProfileShowcasePanel</name>
     <message>
-      <source>Your search is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-      <comment>ProfileShowcasePanel</comment>
-      <translation>Your search is too cool (use A-Z and 0-9, hyphens and underscores only)</translation>
-    </message>
-    <message>
-      <source>Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-      <comment>ProfileShowcasePanel</comment>
-      <translation>Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</translation>
-    </message>
-    <message>
       <source>In showcase</source>
       <comment>ProfileShowcasePanel</comment>
       <translation>In showcase</translation>
@@ -18899,16 +18864,6 @@
       <source>Search for name, ENS or address</source>
       <comment>SavedAddresses</comment>
       <translation>Search for name, ENS or address</translation>
-    </message>
-    <message>
-      <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-      <comment>SavedAddresses</comment>
-      <translation>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</translation>
-    </message>
-    <message>
-      <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-      <comment>SavedAddresses</comment>
-      <translation>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</translation>
     </message>
     <message>
       <source>Your saved addresses will appear here</source>
@@ -23664,11 +23619,6 @@
       <source>BaseScan</source>
       <comment>Utils</comment>
       <translation>BaseScan</translation>
-    </message>
-    <message>
-      <source>Status Explorer</source>
-      <comment>Utils</comment>
-      <translation>Status Explorer</translation>
     </message>
     <message>
       <source>BscScan</source>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -1015,10 +1015,6 @@
         <translation>Minimalizovat do tray ikony při zavření</translation>
     </message>
     <message>
-        <source>Mainnet data verified by Nimbus</source>
-        <translation>Data mainnetu ověřena Nimbusem</translation>
-    </message>
-    <message>
         <source>Application Logs</source>
         <translation>Logy aplikace</translation>
     </message>
@@ -1125,10 +1121,6 @@
     <message>
         <source>enable</source>
         <translation>povolit</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 Nimbus proxy? You need to restart the app for this change to take effect.</source>
-        <translation>Opravdu chcete %1 Nimbus proxy? Pro projevení této změny musíte restartovat aplikaci.</translation>
     </message>
     <message>
         <source>How many log files do you want to keep archived?</source>
@@ -3965,10 +3957,6 @@ Zůstanete přihlášeni a vaše obnovovací fráze bude zcela ve vašich rukou.
     <message>
         <source>Confirm</source>
         <translation>Potvrdit</translation>
-    </message>
-    <message>
-        <source>Reject</source>
-        <translation>Odmítnout</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -8124,14 +8112,6 @@ Opravdu to chcete udělat?</translation>
     <message>
         <source>Search for name, ENS or address</source>
         <translation>Hledat jméno, ENS nebo adresu</translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Vaše hledání je příliš cool (použijte pouze A-Z a 0-9, jednu mezeru, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Vaše hledání obsahuje neplatné znaky (použijte pouze A-Z a 0-9, jednu mezeru, pomlčky a podtržítka)</translation>
     </message>
     <message>
         <source>No following addresses found. Check spelling or whether the address is correct.</source>
@@ -14921,14 +14901,6 @@ selhalo</translation>
 <context>
     <name>ProfileShowcasePanel</name>
     <message>
-        <source>Your search is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Vaše hledání je příliš cool (použijte pouze A-Z a 0-9, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Vaše hledání obsahuje neplatné znaky (použijte pouze A-Z a 0-9, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
         <source>In showcase</source>
         <translation>Ve vitríně</translation>
     </message>
@@ -15614,14 +15586,6 @@ selhalo</translation>
     <message>
         <source>Search for name, ENS or address</source>
         <translation>Hledat jméno, ENS nebo adresu</translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Vaše hledání je příliš cool (použijte pouze A-Z a 0-9, jednu mezeru, pomlčky a podtržítka)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Vaše hledání obsahuje neplatné znaky (použijte pouze A-Z a 0-9, jednu mezeru, pomlčky a podtržítka)</translation>
     </message>
     <message>
         <source>Your saved addresses will appear here</source>
@@ -19575,10 +19539,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>BaseScan</source>
         <translation>BaseScan</translation>
-    </message>
-    <message>
-        <source>Status Explorer</source>
-        <translation>Status Explorer</translation>
     </message>
     <message>
         <source>BscScan</source>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1012,10 +1012,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mainnet data verified by Nimbus</source>
-        <translation>Datos de Mainnet verificados por Nimbus</translation>
-    </message>
-    <message>
         <source>Application Logs</source>
         <translation>Registros de la aplicación</translation>
     </message>
@@ -1122,10 +1118,6 @@
     <message>
         <source>enable</source>
         <translation>habilitar</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 Nimbus proxy? You need to restart the app for this change to take effect.</source>
-        <translation>¿Estás seguro de que quieres %1 el proxy de Nimbus? Necesitas reiniciar la aplicación para que este cambio surta efecto.</translation>
     </message>
     <message>
         <source>How many log files do you want to keep archived?</source>
@@ -3951,10 +3943,6 @@ Permanecerás conectado y tu frase de recuperación estará completamente en tus
     <message>
         <source>Confirm</source>
         <translation>Confirmar</translation>
-    </message>
-    <message>
-        <source>Reject</source>
-        <translation>Rechazar</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -8094,14 +8082,6 @@ Are you sure you want to do this?</source>
     <message>
         <source>Search for name, ENS or address</source>
         <translation type="unfinished">Buscar por nombre, ENS o dirección</translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished">Tu búsqueda es demasiado genial (usa solo A-Z y 0-9, un solo espacio en blanco, guiones y guiones bajos)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished">Tu búsqueda contiene caracteres inválidos (usa solo A-Z y 0-9, un solo espacio en blanco, guiones y guiones bajos)</translation>
     </message>
     <message>
         <source>No following addresses found. Check spelling or whether the address is correct.</source>
@@ -14831,14 +14811,6 @@ al cargar</translation>
 <context>
     <name>ProfileShowcasePanel</name>
     <message>
-        <source>Your search is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Tu búsqueda es demasiado genial (usa solo A-Z y 0-9, guiones y guiones bajos)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>Tu búsqueda contiene caracteres inválidos (usa solo A-Z y 0-9, guiones y guiones bajos)</translation>
-    </message>
-    <message>
         <source>In showcase</source>
         <translation>En la vitrina</translation>
     </message>
@@ -15522,14 +15494,6 @@ al cargar</translation>
     <message>
         <source>Search for name, ENS or address</source>
         <translation>Buscar por nombre, ENS o dirección</translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Tu búsqueda es demasiado genial (usa solo A-Z y 0-9, un solo espacio en blanco, guiones y guiones bajos)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>Tu búsqueda contiene caracteres inválidos (usa solo A-Z y 0-9, un solo espacio en blanco, guiones y guiones bajos)</translation>
     </message>
     <message>
         <source>Your saved addresses will appear here</source>
@@ -19473,10 +19437,6 @@ Si una transacción con un nonce más bajo está pendiente, las transacciones co
     <message>
         <source>BaseScan</source>
         <translation>BaseScan</translation>
-    </message>
-    <message>
-        <source>Status Explorer</source>
-        <translation></translation>
     </message>
     <message>
         <source>BscScan</source>

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1009,10 +1009,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mainnet data verified by Nimbus</source>
-        <translation>Nimbus로 검증된 Mainnet 데이터</translation>
-    </message>
-    <message>
         <source>Application Logs</source>
         <translation>애플리케이션 로그</translation>
     </message>
@@ -1119,10 +1115,6 @@
     <message>
         <source>enable</source>
         <translation>활성화</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to %1 Nimbus proxy? You need to restart the app for this change to take effect.</source>
-        <translation>정말로 Nimbus 프록시를 %1하시겠어요? 이 변경 사항을 적용하려면 앱을 다시 시작해야 합니다.</translation>
     </message>
     <message>
         <source>How many log files do you want to keep archived?</source>
@@ -3936,10 +3928,6 @@ You will remain logged in, and your recovery phrase will be entirely in your han
     <message>
         <source>Confirm</source>
         <translation>비밀번호 확인</translation>
-    </message>
-    <message>
-        <source>Reject</source>
-        <translation>거절</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -8065,14 +8053,6 @@ Are you sure you want to do this?</source>
     <message>
         <source>Search for name, ENS or address</source>
         <translation type="unfinished">이름, ENS 또는 주소 검색</translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished">검색어가 너무 쿨해요 (A-Z, 0-9, 공백 하나, 하이픈, 밑줄만 사용하세요)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation type="unfinished">검색어에 유효하지 않은 문자가 있습니다 (A-Z, 0-9, 단일 공백, 하이픈, 밑줄만 사용)</translation>
     </message>
     <message>
         <source>No following addresses found. Check spelling or whether the address is correct.</source>
@@ -14784,14 +14764,6 @@ to load</source>
 <context>
     <name>ProfileShowcasePanel</name>
     <message>
-        <source>Your search is too cool (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>검색어가 너무 힙해요 (A-Z, 0-9, 하이픈과 밑줄만 사용하세요)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, hyphens and underscores only)</source>
-        <translation>검색어에 유효하지 않은 문자가 포함되어 있습니다 (영문 대문자 A-Z, 숫자 0-9, 하이픈, 밑줄만 사용)</translation>
-    </message>
-    <message>
         <source>In showcase</source>
         <translation>쇼케이스에서</translation>
     </message>
@@ -15473,14 +15445,6 @@ to load</source>
     <message>
         <source>Search for name, ENS or address</source>
         <translation>이름, ENS 또는 주소 검색</translation>
-    </message>
-    <message>
-        <source>Your search is too cool (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>검색어가 너무 쿨해요 (A-Z, 0-9, 공백 하나, 하이픈, 밑줄만 사용하세요)</translation>
-    </message>
-    <message>
-        <source>Your search contains invalid characters (use A-Z and 0-9, single whitespace, hyphens and underscores only)</source>
-        <translation>검색어에 유효하지 않은 문자가 있습니다 (A-Z, 0-9, 단일 공백, 하이픈, 밑줄만 사용)</translation>
     </message>
     <message>
         <source>Your saved addresses will appear here</source>
@@ -19405,10 +19369,6 @@ If a transaction with a lower nonce is pending, higher nonce transactions will r
     <message>
         <source>BaseScan</source>
         <translation>BaseScan</translation>
-    </message>
-    <message>
-        <source>Status Explorer</source>
-        <translation>Status 탐색기</translation>
     </message>
     <message>
         <source>BscScan</source>

--- a/ui/imports/shared/controls/SearchBox.qml
+++ b/ui/imports/shared/controls/SearchBox.qml
@@ -1,9 +1,44 @@
 import QtQuick
 
+import StatusQ.Core
+import StatusQ.Core.Theme
 import StatusQ.Controls
 
-StatusInput {
+StatusTextField {
+    property bool showClearButton: text.length > 0
+    property string iconName: "search"
+    readonly property bool valid: acceptableInput
+
     placeholderText: qsTr("Search")
-    input.asset.name: "search"
-    input.clearable: true
+
+    leftPadding: Theme.halfPadding + searchIcon.width + searchIcon.anchors.leftMargin
+    rightPadding: Theme.halfPadding + (clearButton.visible ? clearButton.width + clearButton.anchors.rightMargin : 0)
+
+    inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData
+    EnterKey.type: Qt.EnterKeySearch
+
+    StatusIcon {
+        id: searchIcon
+        height: parent.height/2
+        width: height
+        anchors.left: parent.left
+        anchors.leftMargin: Theme.halfPadding
+        anchors.verticalCenter: parent.verticalCenter
+        icon: parent.iconName
+        color: Theme.palette.directColor1
+    }
+
+    StatusClearButton {
+        id: clearButton
+        height: parent.height/2
+        width: height
+        anchors.right: parent.right
+        anchors.rightMargin: Theme.halfPadding
+        anchors.verticalCenter: parent.verticalCenter
+        visible: parent.showClearButton && parent.cursorVisible && !!parent.text
+        onClicked: {
+            parent.forceActiveFocus()
+            parent.clear()
+        }
+    }
 }

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -96,7 +96,7 @@ StatusDropdown {
 
     onOpened: {
         if (!StatusQUtils.Utils.isMobile)
-            searchBox.input.edit.forceActiveFocus()
+            searchBox.forceActiveFocus()
         emojiGrid.positionViewAtBeginning()
     }
 
@@ -104,7 +104,7 @@ StatusDropdown {
         const recent = root.emojiModel.recentEmojis
         if (recent.length)
             root.setRecentEmojisRequested(recent)
-        searchBox.text = ""
+        searchBox.clear()
         root.emojiSize = ""
         skinToneEmoji.expandSkinColorOptions = false
     }
@@ -126,7 +126,7 @@ StatusDropdown {
             Layout.preferredHeight: searchBox.height + d.headerMargin
 
             SearchBox {
-                input.edit.objectName: "StatusEmojiPopup_searchBox"
+                objectName: "StatusEmojiPopup_searchBox"
                 id: searchBox
                 anchors.right: skinToneEmoji.left
                 anchors.rightMargin: d.headerMargin
@@ -134,10 +134,7 @@ StatusDropdown {
                 anchors.topMargin: d.headerMargin
                 anchors.left: parent.left
                 anchors.leftMargin: d.headerMargin
-                minimumHeight: 36
-                maximumHeight: 36
-                input.topPadding: 0
-                input.bottomPadding: 0
+                height: 36
             }
 
             Row {

--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -29,7 +29,7 @@ StatusDropdown {
     property var toggleCategory: function(newCategory) {
         previousCategory = currentCategory
         currentCategory = newCategory
-        searchBox.text = ""
+        searchBox.clear()
         if (currentCategory === GifPopupDefinitions.Category.Trending) {
             root.getTrendingsGifs()
         } else if(currentCategory === GifPopupDefinitions.Category.Favorite) {
@@ -79,9 +79,9 @@ StatusDropdown {
     }
 
     onAboutToShow: {
-        searchBox.text = ""
+        searchBox.clear()
         if (!SQUtils.Utils.isMobile)
-            searchBox.input.edit.forceActiveFocus()
+            searchBox.forceActiveFocus()
         if (root.gifUnfurlingEnabled) {
             root.getTrendingsGifs()
         }
@@ -123,7 +123,7 @@ StatusDropdown {
                 Layout.rightMargin: d.headerMargin
                 Layout.leftMargin: d.headerMargin
 
-                input.edit.onTextChanged: {
+                onTextChanged: {
                     if (searchBox.text === "") {
                         toggleCategory(GifPopupDefinitions.Category.Trending)
                         return

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -1114,7 +1114,6 @@ Loader {
                             root.emojiReactionLimitReached
                             return !root.emojiReactionLimitReached && !root.isViewMemberMessagesePopup
                         }
-                        anchors.verticalCenter: parent.verticalCenter
                         emojiModel: emojiPopup.fullModel
                         onToggleReaction: hexcode => root.emojiReactionToggled(root.messageId, hexcode)
                         onOpenEmojiPopup: (parent, mouse) => {


### PR DESCRIPTION
### What does the PR do

- StatusTextField: theme/style according to Status design
- SearchBox: derive from StatusTextField instead of the clunky StatusInput; we only need one-line input here anyway
- fix usages of the SearchBox, notably fixup the need to use a native validator if needed; greatly simplifies the code to use this component
- regenerate TS files

Fixes https://github.com/status-im/status-app/issues/20754

### Affected areas

UserListPanel/ContactsColumnView/CommunityColumnView

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [ ] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Screencapture of the functionality

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/3f91a35c-d778-43c8-831d-924a3caf5279" />

### Impact on end user

Better search UX on mobile

### How to test

- click the Search button in any of the affected views
- the search input field gets activated (cursor visible)
- observe the virtual keyboard shown

### Risk 

low
