### PR TITLE
fix(iOS/FileDialog): Use native pickers for image selection

### DIFF
--- a/mobile/wrapperApp/Status.pro
+++ b/mobile/wrapperApp/Status.pro
@@ -99,6 +99,7 @@ ios {
             -framework Security \
             -framework CoreMotion \
             -framework UIKit \
+            -framework PhotosUI \
             -framework Foundation \
             -framework UserNotifications
 

--- a/ui/StatusQ/CMakeLists.txt
+++ b/ui/StatusQ/CMakeLists.txt
@@ -264,7 +264,8 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "iOS")
     find_library(WebKit WebKit)
     find_library(UserNotifications UserNotifications)
     find_library(CoreMotion CoreMotion)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${UIKit} ${Foundation} ${Security} ${LocalAuthentication} ${WebKit} ${UserNotifications} ${CoreMotion})
+    find_library(PhotosUI PhotosUI)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${UIKit} ${Foundation} ${Security} ${LocalAuthentication} ${WebKit} ${UserNotifications} ${CoreMotion} ${PhotosUI})
     target_sources(StatusQ PRIVATE
         src/ios_utils.mm
         src/shareutils_ios.mm

--- a/ui/StatusQ/include/StatusQ/systemutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/systemutilsinternal.h
@@ -40,6 +40,8 @@ public:
     Q_INVOKABLE int iosKeyboardHeight() const;
     Q_INVOKABLE bool iosKeyboardVisible() const;
     Q_INVOKABLE void setupIOSKeyboardTracking();
+    Q_INVOKABLE void openIOSDocumentPicker(bool selectMultiple, const QStringList& nameFilters) const;
+    Q_INVOKABLE void openIOSPhotoLibraryPicker(bool selectMultiple) const;
 
     // iOS native share sheet
     Q_INVOKABLE void iosShareFile(const QUrl& fileUrl) const;
@@ -68,6 +70,8 @@ signals:
     void androidKeyboardVisibleChanged();
     void iosKeyboardHeightChanged();
     void iosKeyboardVisibleChanged();
+    void iosFilePickerAccepted(const QStringList& fileUrls);
+    void iosFilePickerRejected();
     void shakeDetected();
 
 private:

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
@@ -347,6 +347,7 @@ Item {
         id: mainImage
 
         fillMode: Image.PreserveAspectFit
+        autoTransform: true
         z: windowRect.z - 1
 
         // Transform to keep the center of the image window in x and y coordinates

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
@@ -229,6 +229,7 @@ Control {
         id: fileDialog
 
         currentFolder: picturesShortcut
+        usePhotoLibrary: true
         nameFilters: [ qsTr("Supported image formats (%1)").arg(d.getExtensionsFilterText())]
         onAccepted: d.loadFile(selectedFiles)
     }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusFileDialog.qml
@@ -3,6 +3,7 @@ import QtQuick.Dialogs
 import QtCore
 
 import StatusQ
+import StatusQ.Core
 import StatusQ.Core.Utils
 import MobileUI
 
@@ -14,6 +15,7 @@ QObject {
     readonly property alias selectedFile: d.resolvedFile
     readonly property alias selectedFiles: d.resolvedFiles
     property bool selectMultiple
+    property bool usePhotoLibrary
 
     property alias modality: dlg.modality
     property alias currentFolder: dlg.currentFolder
@@ -28,10 +30,22 @@ QObject {
     signal rejected
 
     function open() {
+        if (Utils.isIOS) {
+            d.nativeSelectedFiles = []
+            d.nativeDialogOpen = true
+            if (usePhotoLibrary)
+                SystemUtils.openIOSPhotoLibraryPicker(selectMultiple)
+            else
+                SystemUtils.openIOSDocumentPicker(selectMultiple, nameFilters)
+            return
+        }
+
         dlg.open()
     }
 
     function close() {
+        if (Utils.isIOS)
+            d.nativeDialogOpen = false
         dlg.close()
     }
 
@@ -39,9 +53,11 @@ QObject {
         id: d
 
         readonly property list<url> standardPictureLocations: StandardPaths.standardLocations(StandardPaths.PicturesLocation)
+        property var nativeSelectedFiles: []
+        property bool nativeDialogOpen: false
 
-        readonly property url resolvedFile: resolveFile(dlg.selectedFile)
-        readonly property var resolvedFiles: resolveSelectedFiles(dlg.selectedFiles)
+        readonly property url resolvedFile: Utils.isIOS ? resolveFile(nativeSelectedFiles[0]) : resolveFile(dlg.selectedFile)
+        readonly property var resolvedFiles: Utils.isIOS ? resolveSelectedFiles(nativeSelectedFiles) : resolveSelectedFiles(dlg.selectedFiles)
 
         function resolveFile(file) {
             if (!file)
@@ -49,7 +65,7 @@ QObject {
 
             let resolvedLocalFile = UrlUtils.convertUrlToLocalPath(file)
             // This will reserve the access to the file for the duration of the app
-            if (Utils.isIOS && !MobileUI.startAccessingPath(resolvedLocalFile)) {
+            if (Utils.isIOS && !root.usePhotoLibrary && !MobileUI.startAccessingPath(resolvedLocalFile)) {
                 console.warn("StatusFileDialog failed to start access for selected file")
             }
             if (!resolvedLocalFile.startsWith("file:"))
@@ -62,6 +78,27 @@ QObject {
                 return []
 
             return selectedFiles.map(file => d.resolveFile(file)).filter(file => !!file)
+        }
+    }
+
+    Connections {
+        target: SystemUtils
+
+        function onIosFilePickerAccepted(fileUrls) {
+            if (!d.nativeDialogOpen)
+                return
+
+            d.nativeDialogOpen = false
+            d.nativeSelectedFiles = fileUrls
+            root.accepted()
+        }
+
+        function onIosFilePickerRejected() {
+            if (!d.nativeDialogOpen)
+                return
+
+            d.nativeDialogOpen = false
+            root.rejected()
         }
     }
 

--- a/ui/StatusQ/src/ios_utils.h
+++ b/ui/StatusQ/src/ios_utils.h
@@ -1,7 +1,14 @@
 #pragma once
 
+#include <QString>
+#include <QStringList>
+#include <QByteArray>
+#include <QUrl>
+
 
 using IOSShakeCallback = void (*)();
+using IOSFilePickerAcceptedCallback = void (*)(const QStringList&);
+using IOSFilePickerRejectedCallback = void (*)();
 
 #ifdef Q_OS_IOS
 
@@ -21,5 +28,11 @@ void setIOSShakeToEditEnabled(bool enabled);
 // Share sheet utilities
 void presentIOSShareSheetForFilePath(const QString& filePath);
 void presentIOSShareSheetForFilePaths(const QStringList& filePaths);
+
+// Document picker utilities
+void presentIOSDocumentPicker(bool selectMultiple, const QStringList& nameFilters);
+void presentIOSPhotoLibraryPicker(bool selectMultiple);
+void setIOSFilePickerCallbacks(IOSFilePickerAcceptedCallback acceptedCallback,
+                               IOSFilePickerRejectedCallback rejectedCallback);
 
 #endif // Q_OS_IOS

--- a/ui/StatusQ/src/ios_utils.mm
+++ b/ui/StatusQ/src/ios_utils.mm
@@ -2,6 +2,7 @@
 #include <QStringList>
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>
+#import <PhotosUI/PhotosUI.h>
 #import <UIKit/UIKit.h>
 #import <CoreMotion/CoreMotion.h>
 #import <objc/runtime.h>
@@ -9,6 +10,310 @@
 #include <cmath>
 #include <QString>
 #include <QUrl>
+
+static IOSFilePickerAcceptedCallback g_filePickerAcceptedCallback = nullptr;
+static IOSFilePickerRejectedCallback g_filePickerRejectedCallback = nullptr;
+
+@interface StatusQDocumentPickerDelegate : NSObject<UIDocumentPickerDelegate>
+@end
+
+@interface StatusQPhotoLibraryPickerDelegate : NSObject<UIImagePickerControllerDelegate, UINavigationControllerDelegate, PHPickerViewControllerDelegate>
+@end
+
+static UIViewController *statusqActiveRootViewController()
+{
+    UIWindow *keyWindow = nil;
+
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]])
+                continue;
+
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.activationState != UISceneActivationStateForegroundActive)
+                continue;
+
+            for (UIWindow *window in windowScene.windows) {
+                if (window.isKeyWindow) {
+                    keyWindow = window;
+                    break;
+                }
+            }
+
+            if (keyWindow)
+                break;
+        }
+    }
+
+    if (!keyWindow) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        keyWindow = [UIApplication sharedApplication].keyWindow;
+        #pragma clang diagnostic pop
+    }
+
+    if (!keyWindow)
+        return nil;
+
+    UIViewController *viewController = keyWindow.rootViewController;
+    while (viewController.presentedViewController)
+        viewController = viewController.presentedViewController;
+
+    return viewController;
+}
+
+@implementation StatusQDocumentPickerDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
+{
+    Q_UNUSED(controller);
+
+    QStringList selectedUrls;
+    selectedUrls.reserve(urls.count);
+
+    for (NSURL *url in urls) {
+        if (url.absoluteString.length > 0)
+            selectedUrls.push_back(QString::fromNSString(url.absoluteString));
+    }
+
+    if (g_filePickerAcceptedCallback)
+        g_filePickerAcceptedCallback(selectedUrls);
+}
+
+- (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller
+{
+    Q_UNUSED(controller);
+
+    if (g_filePickerRejectedCallback)
+        g_filePickerRejectedCallback();
+}
+
+@end
+
+static StatusQDocumentPickerDelegate *g_documentPickerDelegate = nil;
+static StatusQPhotoLibraryPickerDelegate *g_photoLibraryPickerDelegate = nil;
+
+void setIOSFilePickerCallbacks(IOSFilePickerAcceptedCallback acceptedCallback,
+                               IOSFilePickerRejectedCallback rejectedCallback)
+{
+    g_filePickerAcceptedCallback = acceptedCallback;
+    g_filePickerRejectedCallback = rejectedCallback;
+}
+
+void presentIOSDocumentPicker(bool selectMultiple, const QStringList& nameFilters)
+{
+    Q_UNUSED(nameFilters);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *presentingViewController = statusqActiveRootViewController();
+        if (!presentingViewController) {
+            NSLog(@"presentIOSDocumentPicker: no active root view controller");
+            if (g_filePickerRejectedCallback)
+                g_filePickerRejectedCallback();
+            return;
+        }
+
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        UIDocumentPickerViewController *picker = [[UIDocumentPickerViewController alloc] initWithDocumentTypes:@[@"public.item"] inMode:UIDocumentPickerModeOpen];
+        #pragma clang diagnostic pop
+
+        g_documentPickerDelegate = [[StatusQDocumentPickerDelegate alloc] init];
+        picker.delegate = g_documentPickerDelegate;
+        picker.allowsMultipleSelection = selectMultiple;
+        picker.modalPresentationStyle = UIModalPresentationFullScreen;
+
+        [presentingViewController presentViewController:picker animated:YES completion:nil];
+    });
+}
+
+static UIImage *statusqScaledImageForTemporaryFile(UIImage *image)
+{
+    if (!image)
+        return nil;
+
+    const CGFloat maxDimension = 4096.0;
+    const CGFloat longestSide = MAX(image.size.width, image.size.height);
+    if (longestSide <= maxDimension)
+        return image;
+
+    const CGFloat scale = maxDimension / longestSide;
+    const CGSize targetSize = CGSizeMake(image.size.width * scale, image.size.height * scale);
+    UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+    format.scale = 1.0;
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:targetSize format:format];
+
+    return [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+        Q_UNUSED(context);
+        [image drawInRect:CGRectMake(0, 0, targetSize.width, targetSize.height)];
+    }];
+}
+
+static NSURL *statusqWriteImageToTemporaryFile(UIImage *image)
+{
+    if (!image)
+        return nil;
+
+    UIImage *imageToWrite = statusqScaledImageForTemporaryFile(image);
+    if (!imageToWrite)
+        return nil;
+
+    NSData *imageData = UIImageJPEGRepresentation(imageToWrite, 0.9);
+    NSString *extension = @"jpg";
+
+    if (!imageData) {
+        imageData = UIImagePNGRepresentation(imageToWrite);
+        extension = @"png";
+    }
+
+    if (!imageData)
+        return nil;
+
+    NSString *fileName = [NSString stringWithFormat:@"%@.%@", [NSUUID UUID].UUIDString, extension];
+    NSURL *destinationUrl = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
+
+    return [imageData writeToURL:destinationUrl atomically:YES] ? destinationUrl : nil;
+}
+
+static void statusqCompletePhotoLibraryPicker(UIViewController *picker, NSArray<NSURL *> *urls)
+{
+    [picker dismissViewControllerAnimated:YES completion:^{
+        g_photoLibraryPickerDelegate = nil;
+        if (urls.count > 0 && g_filePickerAcceptedCallback) {
+            QStringList selectedUrls;
+            selectedUrls.reserve(urls.count);
+            for (NSURL *url in urls) {
+                if (url.absoluteString.length > 0)
+                    selectedUrls.push_back(QString::fromNSString(url.absoluteString));
+            }
+            g_filePickerAcceptedCallback(selectedUrls);
+        } else if (g_filePickerRejectedCallback) {
+            g_filePickerRejectedCallback();
+        }
+    }];
+}
+
+@implementation StatusQPhotoLibraryPickerDelegate
+{
+    BOOL _finished;
+}
+
+- (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<UIImagePickerControllerInfoKey, id> *)info
+{
+    if (_finished)
+        return;
+    _finished = YES;
+
+    UIImage *image = info[UIImagePickerControllerOriginalImage];
+    NSURL *selectedUrl = statusqWriteImageToTemporaryFile(image);
+    if (!selectedUrl)
+        selectedUrl = info[UIImagePickerControllerImageURL];
+
+    statusqCompletePhotoLibraryPicker(picker, selectedUrl ? @[selectedUrl] : @[]);
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
+{
+    if (_finished)
+        return;
+    _finished = YES;
+
+    statusqCompletePhotoLibraryPicker(picker, @[]);
+}
+
+- (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results API_AVAILABLE(ios(14))
+{
+    if (_finished)
+        return;
+    _finished = YES;
+
+    if (results.count == 0) {
+        statusqCompletePhotoLibraryPicker(picker, @[]);
+        return;
+    }
+
+    NSMutableArray *selectedUrls = [NSMutableArray arrayWithCapacity:results.count];
+    for (NSUInteger i = 0; i < results.count; i++)
+        [selectedUrls addObject:[NSNull null]];
+    __block NSInteger pendingResults = results.count;
+
+    void (^finishResult)(NSUInteger, NSURL *) = ^(NSUInteger index, NSURL *url) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (url)
+                selectedUrls[index] = url;
+
+            pendingResults--;
+            if (pendingResults == 0) {
+                NSMutableArray<NSURL *> *orderedUrls = [NSMutableArray arrayWithCapacity:selectedUrls.count];
+                for (id selectedUrl in selectedUrls) {
+                    if ([selectedUrl isKindOfClass:NSURL.class])
+                        [orderedUrls addObject:selectedUrl];
+                }
+                statusqCompletePhotoLibraryPicker(picker, orderedUrls);
+            }
+        });
+    };
+
+    [results enumerateObjectsUsingBlock:^(PHPickerResult *result, NSUInteger index, BOOL *stop) {
+        Q_UNUSED(stop);
+        NSItemProvider *provider = result.itemProvider;
+        if (![provider canLoadObjectOfClass:UIImage.class]) {
+            finishResult(index, nil);
+            return;
+        }
+
+        [provider loadObjectOfClass:UIImage.class completionHandler:^(id<NSItemProviderReading> object, NSError *error) {
+            Q_UNUSED(error);
+            finishResult(index, statusqWriteImageToTemporaryFile((UIImage *)object));
+        }];
+    }];
+}
+
+@end
+
+void presentIOSPhotoLibraryPicker(bool selectMultiple)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *presentingViewController = statusqActiveRootViewController();
+        if (!presentingViewController) {
+            NSLog(@"presentIOSPhotoLibraryPicker: no active root view controller");
+            if (g_filePickerRejectedCallback)
+                g_filePickerRejectedCallback();
+            return;
+        }
+
+        if (![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypePhotoLibrary]) {
+            NSLog(@"presentIOSPhotoLibraryPicker: photo library source is not available");
+            if (g_filePickerRejectedCallback)
+                g_filePickerRejectedCallback();
+            return;
+        }
+
+        if (selectMultiple) {
+            if (@available(iOS 14.0, *)) {
+                PHPickerConfiguration *configuration = [[PHPickerConfiguration alloc] init];
+                configuration.filter = [PHPickerFilter imagesFilter];
+                configuration.selectionLimit = 0;
+
+                PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
+                g_photoLibraryPickerDelegate = [[StatusQPhotoLibraryPickerDelegate alloc] init];
+                picker.delegate = g_photoLibraryPickerDelegate;
+                picker.modalPresentationStyle = UIModalPresentationFullScreen;
+
+                [presentingViewController presentViewController:picker animated:YES completion:nil];
+                return;
+            }
+        }
+
+        UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+        g_photoLibraryPickerDelegate = [[StatusQPhotoLibraryPickerDelegate alloc] init];
+        picker.delegate = g_photoLibraryPickerDelegate;
+        picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+        picker.modalPresentationStyle = UIModalPresentationFullScreen;
+
+        [presentingViewController presentViewController:picker animated:YES completion:nil];
+    });
+}
 
 void saveImageToPhotosAlbum(const QByteArray &data)
 {

--- a/ui/StatusQ/src/systemutilsinternal.cpp
+++ b/ui/StatusQ/src/systemutilsinternal.cpp
@@ -49,6 +49,8 @@ static SystemUtilsInternal* s_systemUtilsInternal = nullptr;
 
 #ifdef Q_OS_IOS
 static void iosShakeDetected();
+static void handleIOSFilePickerAccepted(const QStringList& fileUrls);
+static void handleIOSFilePickerRejected();
 #endif
 
 #ifdef Q_OS_ANDROID
@@ -104,6 +106,7 @@ SystemUtilsInternal::SystemUtilsInternal(QObject *parent)
 #ifdef Q_OS_IOS
     // Set up iOS keyboard tracking
     ::setupIOSKeyboardTracking();
+    ::setIOSFilePickerCallbacks(handleIOSFilePickerAccepted, handleIOSFilePickerRejected);
     
     // Poll iOS keyboard state and emit property change signals
     m_iosKeyboardPollTimer = new QTimer(this);
@@ -396,6 +399,25 @@ void SystemUtilsInternal::setupIOSKeyboardTracking()
 #endif
 }
 
+void SystemUtilsInternal::openIOSDocumentPicker(bool selectMultiple, const QStringList& nameFilters) const
+{
+#ifdef Q_OS_IOS
+    ::presentIOSDocumentPicker(selectMultiple, nameFilters);
+#else
+    Q_UNUSED(selectMultiple);
+    Q_UNUSED(nameFilters);
+#endif
+}
+
+void SystemUtilsInternal::openIOSPhotoLibraryPicker(bool selectMultiple) const
+{
+#ifdef Q_OS_IOS
+    ::presentIOSPhotoLibraryPicker(selectMultiple);
+#else
+    Q_UNUSED(selectMultiple);
+#endif
+}
+
 void SystemUtilsInternal::iosShareFile(const QUrl& fileUrl) const
 {
 #ifdef Q_OS_IOS
@@ -566,6 +588,22 @@ static void iosShakeDetected()
         qInfo() << "[iOS Shake] SystemUtilsInternal: shakeDetected signal emitted";
         emit s_systemUtilsInternal->shakeDetected();
     }, Qt::QueuedConnection);
+}
+
+static void handleIOSFilePickerAccepted(const QStringList& fileUrls)
+{
+    if (!s_systemUtilsInternal)
+        return;
+    QMetaObject::invokeMethod(s_systemUtilsInternal, &SystemUtilsInternal::iosFilePickerAccepted,
+                              Qt::QueuedConnection, fileUrls);
+}
+
+static void handleIOSFilePickerRejected()
+{
+    if (!s_systemUtilsInternal)
+        return;
+    QMetaObject::invokeMethod(s_systemUtilsInternal, &SystemUtilsInternal::iosFilePickerRejected,
+                              Qt::QueuedConnection);
 }
 #endif
 

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -146,7 +146,7 @@ Item {
 
                 onClicked: {
                     if (!!root.icon)
-                        Global.openMenu(editImageMenuComponent, this)
+                        Global.openMenu(editImageMenuComponent, this, {}, Qt.point(0, height + Theme.halfPadding))
                     else
                         Global.openChangeProfilePicPopup(setTempIcon);
                 }

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -41,6 +41,7 @@ Item {
 
         title: root.imageFileDialogTitle
         currentFolder: root.userSelectedImage ? imageCropper.source.substr(0, imageCropper.source.lastIndexOf("/")) : fileDialog.picturesShortcut
+        usePhotoLibrary: true
         nameFilters: [qsTr("Supported image formats (%1)").arg(UrlUtils.validImageNameFilters)]
         onAccepted: {
             if (fileDialog.selectedFiles.length > 0) {
@@ -81,25 +82,34 @@ Item {
         id: imageCropperModal
 
         headerSettings.title: root.title
+        fullScreenSheet: false
 
         width: root.roundedImage ? 480 : 580
-        StatusImageCropPanel {
-            id: imageCropper
-            objectName: "profileImageCropper"
+        topPadding: header.height
+        bottomPadding: footer.height
 
-            implicitHeight: root.roundedImage ? 350 : 370
+        contentItem: Item {
+            implicitWidth: imageCropper.implicitWidth + 2 * (Theme.bigPadding + Theme.halfPadding / 2)
+            implicitHeight: imageCropper.implicitHeight + 2 * Theme.bigPadding
 
-            anchors {
-                fill: parent
-                leftMargin: Theme.bigPadding + Theme.halfPadding / 2
-                rightMargin: Theme.bigPadding + Theme.halfPadding / 2
-                topMargin: Theme.bigPadding
-                bottomMargin: Theme.bigPadding
+            StatusImageCropPanel {
+                id: imageCropper
+                objectName: "profileImageCropper"
+
+                implicitHeight: root.roundedImage ? 350 : 370
+
+                anchors {
+                    fill: parent
+                    leftMargin: Theme.bigPadding + Theme.halfPadding / 2
+                    rightMargin: Theme.bigPadding + Theme.halfPadding / 2
+                    topMargin: Theme.bigPadding
+                    bottomMargin: Theme.bigPadding
+                }
+
+                margins: root.roundedImage ? 10 : 20
+                windowStyle: root.roundedImage ? StatusImageCrop.WindowStyle.Rounded : StatusImageCrop.WindowStyle.Rectangular
+                enableCheckers: true
             }
-
-            margins: root.roundedImage ? 10 : 20
-            windowStyle: root.roundedImage ? StatusImageCrop.WindowStyle.Rounded : StatusImageCrop.WindowStyle.Rectangular
-            enableCheckers: true
         }
 
         rightButtons: [
@@ -118,4 +128,3 @@ Item {
         onClosed: root.done()
     } // StatusModal
 } // Item
-

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -480,6 +480,7 @@ Rectangle {
         title: qsTr("Please choose an image")
         currentFolder: picturesShortcut
         selectMultiple: true
+        usePhotoLibrary: true
         nameFilters: [
             qsTr("Image files (%1)").arg(UrlUtils.validImageNameFilters)
         ]

--- a/ui/imports/shared/status/StatusChatInputNew.qml
+++ b/ui/imports/shared/status/StatusChatInputNew.qml
@@ -498,6 +498,7 @@ Control {
         title: qsTr("Please choose an image")
         currentFolder: picturesShortcut
         selectMultiple: true
+        usePhotoLibrary: true
         nameFilters: [
             qsTr("Image files (%1)").arg(UrlUtils.validImageNameFilters)
         ]


### PR DESCRIPTION
Closes #20704

### What does the PR do

Route iOS file selection through native platform pickers to avoid Qt file dialog sizing issues on mobile.

- Use `UIDocumentPickerViewController` for document-based flows such as backups and JSON imports.
- Add a photo-library mode to `StatusFileDialog` for image selection flows.
- Use the native iOS photo picker for profile picture, community logo/banner, and image selector uploads.
- Return selected files/photos through the existing `StatusFileDialog` selected file API.

### Affected areas

iOS File Dialogs

### Quality checklist

- [x] I am familiar with the [application architecture](/docs/architecture.md) and agreed good practices.
My PR is consistent with this document: [QML Architecture Guidelines](/guidelines/QML_ARCHITECTURE_GUIDE.md)
- [x] I have updated the necessary documentation if needed (eg: updated BUILDING.md if I updated dependencies)

### Impact on end user

Better UX, solved broken file system dialog layout and solved broken image cropping flows

### How to test

I.e: Try to change profile image

### Risk 

Low
